### PR TITLE
DEV: Fix double Chat:: module usage in chat models

### DIFF
--- a/plugins/chat/app/models/chat/user_chat_channel_membership.rb
+++ b/plugins/chat/app/models/chat/user_chat_channel_membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Chat
-  class Chat::UserChatChannelMembership < ActiveRecord::Base
+  class UserChatChannelMembership < ActiveRecord::Base
     self.table_name = "user_chat_channel_memberships"
 
     NOTIFICATION_LEVELS = { never: 0, mention: 1, always: 2 }

--- a/plugins/chat/app/models/chat/user_chat_thread_membership.rb
+++ b/plugins/chat/app/models/chat/user_chat_thread_membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Chat
-  class Chat::UserChatThreadMembership < ActiveRecord::Base
+  class UserChatThreadMembership < ActiveRecord::Base
     self.table_name = "user_chat_thread_memberships"
 
     belongs_to :user


### PR DESCRIPTION
We don't need to prepend Chat:: to these classes since
they are already in the Chat module.