### PR TITLE
FEATURE: chat-replying indicator for threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
@@ -93,7 +93,9 @@
 
   {{#if this.shouldRenderReplyingIndicator}}
     <div class="chat-replying-indicator-container">
-      <ChatReplyingIndicator @channel={{@channel}} />
+      <ChatReplyingIndicator
+        @presenceChannelName={{this.presenceChannelName}}
+      />
     </div>
   {{/if}}
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -35,9 +35,10 @@ export default class ChatComposer extends Component {
 
   @tracked isFocused = false;
   @tracked inProgressUploadsCount = 0;
+  @tracked presenceChannelName;
 
   get shouldRenderReplyingIndicator() {
-    return this.context === "channel" && !this.args.channel?.isDraft;
+    return !this.args.channel?.isDraft;
   }
 
   get shouldRenderMessageDetails() {
@@ -248,7 +249,7 @@ export default class ChatComposer extends Component {
     }
 
     this.chatComposerPresenceManager.notifyState(
-      this.args.channel.id,
+      this.presenceChannelName,
       !this.currentMessage.editing && this.hasContent
     );
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.hbs
@@ -1,11 +1,11 @@
-{{#if @channel}}
+{{#if @presenceChannelName}}
   <div
     class={{concat-class
       "chat-replying-indicator"
       (if this.presenceChannel.subscribed "is-subscribed")
     }}
     {{did-insert this.subscribe}}
-    {{did-update this.updateSubscription @channel.id}}
+    {{did-update this.updateSubscription @presenceChannelName}}
     {{will-destroy this.unsubscribe}}
   >
     {{#if this.shouldRender}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -10,7 +10,6 @@ export default class ChatReplyingIndicator extends Component {
   @service presence;
 
   @tracked presenceChannel = null;
-  @tracked users = [];
 
   @action
   async updateSubscription() {
@@ -20,31 +19,29 @@ export default class ChatReplyingIndicator extends Component {
 
   @action
   async subscribe() {
-    this.presenceChannel = this.presence.getChannel(this.channelName);
+    this.presenceChannel = this.presence.getChannel(
+      this.args.presenceChannelName
+    );
     await this.presenceChannel.subscribe();
-    this.users = this.presenceChannel.users || [];
-    this.presenceChannel.on("change", this.handlePresenceChange);
   }
 
   @action
   async unsubscribe() {
-    this.users = [];
-
-    if (this.presenceChannel.subscribed) {
-      this.presenceChannel.off("change", this.handlePresenceChange);
+    if (this.presenceChannel?.subscribed) {
       await this.presenceChannel.unsubscribe();
     }
   }
 
-  @action
-  handlePresenceChange(presenceChannel) {
-    this.users = presenceChannel.users || [];
+  get users() {
+    return (
+      this.presenceChannel
+        ?.get("users")
+        ?.filter((u) => u.id !== this.currentUser.id) || []
+    );
   }
 
   get usernames() {
-    return this.users
-      .filter((u) => u.id !== this.currentUser.id)
-      .mapBy("username");
+    return this.users.mapBy("username");
   }
 
   get text() {
@@ -76,9 +73,5 @@ export default class ChatReplyingIndicator extends Component {
 
   get shouldRender() {
     return isPresent(this.usernames);
-  }
-
-  get channelName() {
-    return `/chat-reply/${this.args.channel.id}`;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
@@ -60,6 +60,7 @@
   {{else}}
     <Chat::Composer::Thread
       @channel={{this.channel}}
+      @thread={{this.thread}}
       @onSendMessage={{this.onSendMessage}}
       @uploadDropZone={{this.uploadDropZone}}
     />

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
@@ -12,6 +12,11 @@ export default class ChatComposerChannel extends ChatComposer {
 
   composerId = "channel-composer";
 
+  get presenceChannelName() {
+    const channel = this.args.channel;
+    return `/chat-reply/${channel.id}`;
+  }
+
   @action
   persistDraft() {
     if (this.args.channel?.isDraft) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
@@ -2,6 +2,7 @@ import ChatComposer from "../../chat-composer";
 import { inject as service } from "@ember/service";
 import I18n from "I18n";
 import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
 
 export default class ChatComposerThread extends ChatComposer {
   @service("chat-channel-thread-composer") composer;
@@ -9,9 +10,15 @@ export default class ChatComposerThread extends ChatComposer {
   @service("chat-channel-thread-pane") pane;
   @service router;
 
+  @tracked thread;
+
   context = "thread";
 
   composerId = "thread-composer";
+
+  get presenceChannelName() {
+    return `/chat-reply/${this.args.channel.id}/thread/${this.args.thread.id}`;
+  }
 
   get placeholder() {
     return I18n.t("chat.placeholder_thread");

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
@@ -2,15 +2,12 @@ import ChatComposer from "../../chat-composer";
 import { inject as service } from "@ember/service";
 import I18n from "I18n";
 import { action } from "@ember/object";
-import { tracked } from "@glimmer/tracking";
 
 export default class ChatComposerThread extends ChatComposer {
   @service("chat-channel-thread-composer") composer;
   @service("chat-channel-composer") channelComposer;
   @service("chat-channel-thread-pane") pane;
   @service router;
-
-  @tracked thread;
 
   context = "thread";
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-composer-presence-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-composer-presence-manager.js
@@ -2,7 +2,6 @@ import Service, { inject as service } from "@ember/service";
 import { cancel, debounce } from "@ember/runloop";
 import { isTesting } from "discourse-common/config/environment";
 
-const CHAT_PRESENCE_CHANNEL_PREFIX = "/chat-reply";
 const KEEP_ALIVE_DURATION_SECONDS = 10;
 
 // This service is loosely based on discourse-presence's ComposerPresenceManager service
@@ -16,15 +15,15 @@ export default class ChatComposerPresenceManager extends Service {
     this.leave();
   }
 
-  notifyState(chatChannelId, replying) {
+  notifyState(channelName, replying) {
     if (!replying) {
       this.leave();
       return;
     }
 
-    if (this._chatChannelId !== chatChannelId) {
-      this._enter(chatChannelId);
-      this._chatChannelId = chatChannelId;
+    if (this._channelName !== channelName) {
+      this._enter(channelName);
+      this._channelName = channelName;
     }
 
     if (!isTesting()) {
@@ -39,17 +38,16 @@ export default class ChatComposerPresenceManager extends Service {
   leave() {
     this._presentChannel?.leave();
     this._presentChannel = null;
-    this._chatChannelId = null;
+    this._channelName = null;
     if (this._autoLeaveTimer) {
       cancel(this._autoLeaveTimer);
       this._autoLeaveTimer = null;
     }
   }
 
-  _enter(chatChannelId) {
+  _enter(channelName) {
     this.leave();
 
-    let channelName = `${CHAT_PRESENCE_CHANNEL_PREFIX}/${chatChannelId}`;
     this._presentChannel = this.presence.getChannel(channelName);
     this._presentChannel.enter();
   }

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -27,8 +27,4 @@
     display: flex;
     flex-direction: column;
   }
-
-  .chat-composer__wrapper {
-    padding-bottom: 27px;
-  }
 }


### PR DESCRIPTION
This feature adds the replying indicator in threads, it uses the same `/chat-reply/CHANNEL_ID` prefix than the channel composer replying indicator as we don't have specific right on threads ATM (if you can access channel, you can access thread). Thread will however use a presence channel name of the following format: `/chat-reply/CHANNEL_ID/thread/THREAD_ID`

This commit also simplifies the computation of `users` to eventually avoid a race-condition leading to a leak of the indicator in another channel/thread.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
