### PR TITLE
DEV: When deleting a chat message, do not delete mention records

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,7 +5,6 @@ class Notification < ActiveRecord::Base
   belongs_to :topic
 
   has_one :shelved_notification
-  has_many :chat_mentions, dependent: :nullify, class_name: "Chat::Mention"
 
   MEMBERSHIP_REQUEST_CONSOLIDATION_WINDOW_HOURS = 24
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,6 +5,7 @@ class Notification < ActiveRecord::Base
   belongs_to :topic
 
   has_one :shelved_notification
+  has_many :chat_mentions, dependent: :nullify, class_name: "Chat::Mention"
 
   MEMBERSHIP_REQUEST_CONSOLIDATION_WINDOW_HOURS = 24
 

--- a/plugins/chat/app/services/chat/trash_message.rb
+++ b/plugins/chat/app/services/chat/trash_message.rb
@@ -22,7 +22,7 @@ module Chat
     policy :invalid_access
     transaction do
       step :trash_message
-      step :destroy_mentions
+      step :destroy_notifications
       step :update_tracking_state
       step :update_thread_reply_cache
     end
@@ -53,8 +53,9 @@ module Chat
       message.trash!
     end
 
-    def destroy_mentions(message:, **)
-      Chat::Mention.where(chat_message: message).destroy_all
+    def destroy_notifications(message:, **)
+      ids = Chat::Mention.where(chat_message: message).pluck(:notification_id)
+      Notification.where(id: ids).destroy_all
     end
 
     def update_tracking_state(message:, **)

--- a/plugins/chat/app/services/chat/trash_message.rb
+++ b/plugins/chat/app/services/chat/trash_message.rb
@@ -56,6 +56,7 @@ module Chat
     def destroy_notifications(message:, **)
       ids = Chat::Mention.where(chat_message: message).pluck(:notification_id)
       Notification.where(id: ids).destroy_all
+      Chat::Mention.where(chat_message: message).update_all(notification_id: nil)
     end
 
     def update_tracking_state(message:, **)

--- a/plugins/chat/spec/services/chat/trash_message_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_message_spec.rb
@@ -43,10 +43,13 @@ RSpec.describe Chat::TrashMessage do
           expect(Chat::Message.find_by(id: message.id)).to be_nil
         end
 
-        it "destroys associated mentions" do
+        it "destroys notifications for mentions" do
           mention = Fabricate(:chat_mention, chat_message: message)
           result
-          expect(Chat::Mention.find_by(id: mention.id)).to be_nil
+
+          mention = Chat::Mention.find_by(id: mention.id)
+          expect(mention).to be_present
+          expect(mention.notification).to be_nil
         end
 
         it "publishes associated Discourse and MessageBus events" do

--- a/plugins/chat/spec/services/chat/trash_message_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_message_spec.rb
@@ -44,12 +44,14 @@ RSpec.describe Chat::TrashMessage do
         end
 
         it "destroys notifications for mentions" do
-          mention = Fabricate(:chat_mention, chat_message: message)
+          notification = Fabricate(:notification)
+          mention = Fabricate(:chat_mention, chat_message: message, notification: notification)
+
           result
 
           mention = Chat::Mention.find_by(id: mention.id)
           expect(mention).to be_present
-          expect(mention.notification).to be_nil
+          expect(mention.notification_id).to be_nil
         end
 
         it "publishes associated Discourse and MessageBus events" do


### PR DESCRIPTION
A chat message may be restored later, so we shouldn't be deleting `chat_mentions` records for it.

But we still have to remove notifications (see 082cd139)