### PR TITLE
DEV: fix flakey spec in handle_category_udpated

### DIFF
--- a/plugins/chat/spec/services/auto_remove/handle_category_updated_spec.rb
+++ b/plugins/chat/spec/services/auto_remove/handle_category_updated_spec.rb
@@ -66,8 +66,6 @@ RSpec.describe Chat::AutoRemove::HandleCategoryUpdated do
       end
 
       context "when the category still has category_group records" do
-        let(:action) { UserHistory.where(custom_type: "chat_auto_remove_membership").last }
-
         before do
           [user_1, user_2, admin_1, admin_2].each do |user|
             channel_1.add(user)
@@ -142,10 +140,24 @@ RSpec.describe Chat::AutoRemove::HandleCategoryUpdated do
 
         it "logs a staff action" do
           result
-          expect(action).to have_attributes(
-            details: "users_removed: 1\nchannel_id: #{channel_2.id}\nevent: category_updated",
-            acting_user_id: Discourse.system_user.id,
-            custom_type: "chat_auto_remove_membership",
+
+          changes =
+            UserHistory
+              .where(custom_type: "chat_auto_remove_membership")
+              .all
+              .map { |uh| uh.slice(:details, :acting_user_id) }
+
+          expect(changes).to match_array(
+            [
+              {
+                details: "users_removed: 1\nchannel_id: #{channel_1.id}\nevent: category_updated",
+                acting_user_id: Discourse.system_user.id,
+              },
+              {
+                details: "users_removed: 1\nchannel_id: #{channel_2.id}\nevent: category_updated",
+                acting_user_id: Discourse.system_user.id,
+              },
+            ],
           )
         end
       end


### PR DESCRIPTION
We were checking on the last UserHistory object when we actually do two changes, there was a chance the order wouldn't be what we expected. The spec now just check we get the two expected changes in whatever order.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
