### PR TITLE
FIX: Refresh site when enable_user_tips changes

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/user-tips.js
+++ b/app/assets/javascripts/discourse/app/initializers/user-tips.js
@@ -30,6 +30,10 @@ export default {
 
   @bind
   onMessage(seenUserTips) {
+    if (!this.site.user_tips) {
+      return;
+    }
+
     this.currentUser.set("seen_popups", seenUserTips);
 
     if (!this.currentUser.user_option) {

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -386,6 +386,7 @@ basic:
   enable_user_tips:
     client: true
     default: true
+    refresh: true
 
 login:
   invite_only:


### PR DESCRIPTION
Without refresh, no user tip will be shown and Site.user_tips is not
properly populated either.

The other commit fixes the MessageBus handler until page is refreshed.