### PR TITLE
FIX: Miscellaneous tagging errors

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -38,9 +38,11 @@ const Category = RestModel.extend({
   @discourseComputed("required_tag_groups", "minimum_required_tags")
   minimumRequiredTags() {
     if (this.required_tag_groups?.length > 0) {
-      return this.required_tag_groups.reduce(
-        (sum, rtg) => sum + rtg.min_count,
-        0
+      // it should require the max between the bare minimum set in the category and the sum of the min_count of the
+      // required_tag_groups
+      return Math.max(
+        this.required_tag_groups.reduce((sum, rtg) => sum + rtg.min_count, 0),
+        this.minimum_required_tags || 0
       );
     } else {
       return this.minimum_required_tags > 0 ? this.minimum_required_tags : null;

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -263,6 +263,27 @@ module("Unit | Model | category", function (hooks) {
     });
 
     assert.strictEqual(quux.minimumRequiredTags, null);
+
+    const foobar = store.createRecord("category", {
+      id: 1,
+      slug: "foo",
+      minimum_required_tags: 2,
+      required_tag_groups: [{ name: "bar", min_count: 1 }],
+    });
+
+    assert.strictEqual(foobar.minimumRequiredTags, 2);
+
+    const barfoo = store.createRecord("category", {
+      id: 1,
+      slug: "foo",
+      minimum_required_tags: 2,
+      required_tag_groups: [
+        { name: "foo", min_count: 1 },
+        { name: "bar", min_count: 2 },
+      ],
+    });
+
+    assert.strictEqual(barfoo.minimumRequiredTags, 3);
   });
 
   test("search with category name", function (assert) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4917,7 +4917,7 @@ en:
     required_tags_from_group:
       one: "You must include at least %{count} %{tag_group_name} tag. The tags in this group are: %{tags}."
       other: "You must include at least %{count} %{tag_group_name} tags. The tags in this group are: %{tags}."
-    limited_to_one_tag_from_group: "The tags %{tags} cannot be used at the same time. Please include only one of them."
+    limited_to_one_tag_from_group: "The tags %{tags} cannot be used simultaneously. Please include only one of them."
     invalid_target_tag: "cannot be a synonym of a synonym"
     synonyms_exist: "is not allowed while synonyms exist"
   rss_by_tag: "Topics tagged %{tag}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -652,8 +652,8 @@ en:
           attributes:
             value:
               invalid_interpolation_keys:
-                one: 'The following interpolation key is invalid: %{keys}'
-                other: 'The following interpolation keys are invalid: %{keys}'
+                one: "The following interpolation key is invalid: %{keys}"
+                other: "The following interpolation keys are invalid: %{keys}"
         watched_word:
           attributes:
             word:
@@ -2416,7 +2416,7 @@ en:
     default_sidebar_tags: "Selected tags will be displayed under Sidebar's Tags section by default."
     enable_new_notifications_menu: "Enables the new notifications menu. Disabling this setting is deprecated. The new notifications menu is always used for non-legacy 'navigation menu' choices. <a href='https://meta.discourse.org/t/260358'>Learn more</a>"
     enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
-    experimental_new_new_view_groups: "EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the \"Everything\" link in the sidebar link to it."
+    experimental_new_new_view_groups: 'EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
     enable_custom_sidebar_sections: "EXPERIMENTAL: Enable custom sidebar sections"
     experimental_topics_filter: "EXPERIMENTAL: Enables the experimental topics filter route at /filter"
 
@@ -4917,6 +4917,7 @@ en:
     required_tags_from_group:
       one: "You must include at least %{count} %{tag_group_name} tag. The tags in this group are: %{tags}."
       other: "You must include at least %{count} %{tag_group_name} tags. The tags in this group are: %{tags}."
+    limited_to_one_tag_from_group: "The tags %{tags} cannot be used at the same time. Please include only one of them."
     invalid_target_tag: "cannot be a synonym of a synonym"
     synonyms_exist: "is not allowed while synonyms exist"
   rss_by_tag: "Topics tagged %{tag}"

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -163,6 +163,18 @@ module DiscourseTagging
     false
   end
 
+  def self.validate_category_tags(guardian, model, category, tags = [])
+    existing_tags = tags.present? ? Tag.where(name: tags) : []
+    valid_tags = guardian.can_create_tag? ? tags : existing_tags
+
+    # all add to model (topic) errors
+    valid = validate_min_required_tags_for_category(guardian, model, category, valid_tags)
+    valid &&= validate_required_tags_from_group(guardian, model, category, existing_tags)
+    valid &&= validate_category_restricted_tags(guardian, model, category, valid_tags)
+
+    valid
+  end
+
   def self.validate_min_required_tags_for_category(guardian, model, category, tags = [])
     if !guardian.is_staff? && category && category.minimum_required_tags > 0 &&
          tags.length < category.minimum_required_tags

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -457,7 +457,7 @@ module DiscourseTagging
 
       if !one_tag_per_group_ids.empty?
         builder.where(
-          "tag_group_id IS NULL OR tag_group_id NOT IN (?) OR id IN (:selected_tag_ids)",
+          "t.id NOT IN (SELECT DISTINCT tag_id FROM tag_group_restrictions WHERE tag_group_id IN (?)) OR id IN (:selected_tag_ids)",
           one_tag_per_group_ids,
         )
       end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -90,12 +90,7 @@ class PostRevisor
     elsif new_category.nil? || tc.guardian.can_move_topic_to_category?(new_category_id)
       tags = fields[:tags] || tc.topic.tags.map(&:name)
       if new_category &&
-           !DiscourseTagging.validate_min_required_tags_for_category(
-             tc.guardian,
-             tc.topic,
-             new_category,
-             tags,
-           )
+           !DiscourseTagging.validate_category_tags(tc.guardian, tc.topic, new_category, tags)
         tc.check_result(false)
         next
       end

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -28,18 +28,9 @@ class TopicCreator
     category = find_category
     if category.present? && guardian.can_tag?(topic)
       tags = @opts[:tags].presence || []
-      existing_tags = tags.present? ? Tag.where(name: tags) : []
-      valid_tags = guardian.can_create_tag? ? tags : existing_tags
 
-      # all add to topic.errors
-      DiscourseTagging.validate_min_required_tags_for_category(
-        guardian,
-        topic,
-        category,
-        valid_tags,
-      )
-      DiscourseTagging.validate_required_tags_from_group(guardian, topic, category, existing_tags)
-      DiscourseTagging.validate_category_restricted_tags(guardian, topic, category, valid_tags)
+      # adds topic.errors
+      DiscourseTagging.validate_category_tags(guardian, topic, category, tags)
     end
 
     DiscourseEvent.trigger(:after_validate_topic, topic, self)

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -164,293 +164,212 @@ RSpec.describe DiscourseTagging do
   describe "#filter_tags_violating_one_tag_from_group_per_topic" do
     fab!(:tag_group) { Fabricate(:tag_group, tags: [tag1, tag2, tag3], one_per_topic: true) }
 
-    it "returns and empty array if the topic doesn't belong to a category" do
-      invalid_tags =
-        DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(nil, [tag1, tag2])
-      expect(invalid_tags).to be_empty
-    end
+    context "when the topic doesn't belong to a category" do
+      it "does not return tags that are not violating the one tag from group per topic rule" do
+        tag4 = Fabricate(:tag, name: "fun4")
+        tag5 = Fabricate(:tag, name: "fun5")
 
-    context "when the category only allows tags from some tag groups" do
+        invalid_tags =
+          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(nil, [tag4, tag5])
+        expect(invalid_tags).to be_empty
+      end
+
       it "returns tags that are violating the one tag from group per topic rule when there is only one group" do
-        category = Fabricate(:category, allowed_tag_groups: [tag_group.name])
-
         invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2],
-          ).first
+          DiscourseTagging
+            .filter_tags_violating_one_tag_from_group_per_topic(nil, [tag1, tag2])
+            .values
+            .first
+            .map(&:name)
         expect(invalid_tags).to contain_exactly(tag1.name, tag2.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name, tag3.name)
-      end
-
-      it "returns tags that are violating the one tag from group per topic rule when there are multiple groups" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
-
-        tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
-
-        category = Fabricate(:category, allowed_tag_groups: [tag_group.name, tag_group2.name])
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag4, tag5],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag4.name, tag5.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2, tag4, tag5],
-          )
-        expect(invalid_tags[0]).to contain_exactly(tag1.name, tag2.name)
-        expect(invalid_tags[1]).to contain_exactly(tag4.name, tag5.name)
-      end
-
-      it "returns an empty array when only one tag is provided" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
-
-        tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
-
-        category = Fabricate(:category, allowed_tag_groups: [tag_group.name, tag_group2.name])
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag1])
-        expect(invalid_tags).to be_empty
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag2])
-        expect(invalid_tags).to be_empty
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag3])
-        expect(invalid_tags).to be_empty
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag4])
-        expect(invalid_tags).to be_empty
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag5])
-        expect(invalid_tags).to be_empty
-      end
-
-      it "returns and empty array if the tags don't belong to a tag group" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
-
-        category = Fabricate(:category, allowed_tag_groups: [tag_group.name])
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag4, tag5],
-          )
-        expect(invalid_tags).to be_empty
       end
     end
 
-    context "when some tag groups are required in the category" do
-      it "returns tags that are violating the one tag from group per topic rule when there is only one group" do
-        category =
-          Fabricate(
-            :category,
-            category_required_tag_groups: [
-              CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
-            ],
-          )
+    context "when the topic belongs to a category" do
+      context "when the category only allows tags from some tag groups" do
+        it "returns tags that are violating the one tag from group per topic rule when there is only one group" do
+          category = Fabricate(:category, allowed_tag_groups: [tag_group.name])
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
+          [[tag1, tag2], [tag1, tag3], [tag2, tag3], [tag1, tag2, tag3]].each do |test_values|
+            invalid_tags =
+              DiscourseTagging
+                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .values
+                .first
+                .map(&:name)
+            expect(invalid_tags).to contain_exactly(*test_values.map(&:name))
+          end
+        end
+
+        it "returns tags that are violating the one tag from group per topic rule when there are multiple groups" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
+
+          tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
+
+          category = Fabricate(:category, allowed_tag_groups: [tag_group.name, tag_group2.name])
+
+          [
             [tag1, tag2],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag1, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag1, tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name, tag3.name)
+            [tag4, tag5],
+          ].each do |test_values|
+            invalid_tags =
+              DiscourseTagging
+                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .values
+                .first
+                .map(&:name)
+            expect(invalid_tags).to contain_exactly(*test_values.map(&:name))
+          end
+
+          invalid_tags =
+            DiscourseTagging
+              .filter_tags_violating_one_tag_from_group_per_topic(
+                category,
+                [tag1, tag2, tag4, tag5],
+              )
+              .values
+              .map { |tags| tags.map(&:name) }
+          expect(invalid_tags).to contain_exactly([tag1.name, tag2.name], [tag4.name, tag5.name])
+        end
+
+        it "returns an empty array when only one tag is provided" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
+
+          tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
+
+          category = Fabricate(:category, allowed_tag_groups: [tag_group.name, tag_group2.name])
+
+          [tag1, tag2, tag3, tag4, tag5].each do |tag|
+            invalid_tags =
+              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag])
+            expect(invalid_tags).to be_empty
+          end
+        end
+
+        it "returns and empty array if the tags don't belong to a tag group" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
+
+          category = Fabricate(:category, allowed_tag_groups: [tag_group.name])
+
+          invalid_tags =
+            DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+              category,
+              [tag4, tag5],
+            )
+          expect(invalid_tags).to be_empty
+        end
       end
 
-      it "returns tags that are violating the one tag from group per topic rule when there are multiple groups" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
+      context "when some tag groups are required in the category" do
+        it "returns tags that are violating the one tag from group per topic rule when there is only one group" do
+          category =
+            Fabricate(
+              :category,
+              category_required_tag_groups: [
+                CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
+              ],
+            )
 
-        tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
+          [[tag1, tag2], [tag1, tag3], [tag2, tag3], [tag1, tag2, tag3]].each do |test_values|
+            invalid_tags =
+              DiscourseTagging
+                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .values
+                .first
+                .map(&:name)
+            expect(invalid_tags).to contain_exactly(*test_values.map(&:name))
+          end
+        end
 
-        category =
-          Fabricate(
-            :category,
-            category_required_tag_groups: [
-              CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
-              CategoryRequiredTagGroup.new(tag_group: tag_group2, min_count: 1),
-            ],
-          )
+        it "returns tags that are violating the one tag from group per topic rule when there are multiple groups" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
+          tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
+
+          category =
+            Fabricate(
+              :category,
+              category_required_tag_groups: [
+                CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
+                CategoryRequiredTagGroup.new(tag_group: tag_group2, min_count: 1),
+              ],
+            )
+
+          [
             [tag1, tag2],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag1, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag1, tag2, tag3],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag1.name, tag2.name, tag3.name)
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
             [tag4, tag5],
-          ).first
-        expect(invalid_tags).to contain_exactly(tag4.name, tag5.name)
+          ].each do |test_values|
+            invalid_tags =
+              DiscourseTagging
+                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .values
+                .first
+                .map(&:name)
+            expect(invalid_tags).to contain_exactly(*test_values.map(&:name))
+          end
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag1, tag2, tag4, tag5],
-          )
-        expect(invalid_tags[0]).to contain_exactly(tag1.name, tag2.name)
-        expect(invalid_tags[1]).to contain_exactly(tag4.name, tag5.name)
-      end
+          invalid_tags =
+            DiscourseTagging
+              .filter_tags_violating_one_tag_from_group_per_topic(
+                category,
+                [tag1, tag2, tag4, tag5],
+              )
+              .values
+              .map { |tags| tags.map(&:name) }
+          expect(invalid_tags).to contain_exactly([tag1.name, tag2.name], [tag4.name, tag5.name])
+        end
 
-      it "returns an empty array when only one tag is provided" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
+        it "returns an empty array when only one tag is provided" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
 
-        tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
+          tag_group2 = Fabricate(:tag_group, tags: [tag4, tag5], one_per_topic: true)
 
-        category =
-          Fabricate(
-            :category,
-            category_required_tag_groups: [
-              CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
-              CategoryRequiredTagGroup.new(tag_group: tag_group2, min_count: 1),
-            ],
-          )
+          category =
+            Fabricate(
+              :category,
+              category_required_tag_groups: [
+                CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
+                CategoryRequiredTagGroup.new(tag_group: tag_group2, min_count: 1),
+              ],
+            )
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag1])
-        expect(invalid_tags).to be_empty
+          [tag1, tag2, tag3, tag4, tag5].each do |tag|
+            invalid_tags =
+              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag])
+            expect(invalid_tags).to be_empty
+          end
+        end
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag2])
-        expect(invalid_tags).to be_empty
+        it "returns and empty array if the tags don't belong to a tag group" do
+          tag4 = Fabricate(:tag, name: "fun4")
+          tag5 = Fabricate(:tag, name: "fun5")
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag3])
-        expect(invalid_tags).to be_empty
+          category =
+            Fabricate(
+              :category,
+              category_required_tag_groups: [
+                CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
+              ],
+            )
 
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag4])
-        expect(invalid_tags).to be_empty
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag5])
-        expect(invalid_tags).to be_empty
-      end
-
-      it "returns and empty array if the tags don't belong to a tag group" do
-        tag4 = Fabricate(:tag, name: "fun4")
-        tag5 = Fabricate(:tag, name: "fun5")
-
-        category =
-          Fabricate(
-            :category,
-            category_required_tag_groups: [
-              CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1),
-            ],
-          )
-
-        invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
-            category,
-            [tag4, tag5],
-          )
-        expect(invalid_tags).to be_empty
+          invalid_tags =
+            DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+              category,
+              [tag4, tag5],
+            )
+          expect(invalid_tags).to be_empty
+        end
       end
     end
   end

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -103,15 +103,18 @@ RSpec.describe DiscourseTagging do
     fab!(:category) { Fabricate(:category, allowed_tag_groups: [tag_group.name]) }
 
     it "returns true if the topic doesn't belong to a category" do
-      result = DiscourseTagging.validate_one_tag_from_group_per_topic(nil, topic, nil, [tag1, tag2])
+      result =
+        DiscourseTagging.validate_one_tag_from_group_per_topic(guardian, topic, nil, [tag1, tag2])
       expect(result).to eq(true)
     end
 
     it "returns true if only one tag is provided" do
-      result = DiscourseTagging.validate_one_tag_from_group_per_topic(nil, topic, category, [tag1])
+      result =
+        DiscourseTagging.validate_one_tag_from_group_per_topic(guardian, topic, category, [tag1])
       expect(result).to eq(true)
 
-      result = DiscourseTagging.validate_one_tag_from_group_per_topic(nil, topic, category, [tag2])
+      result =
+        DiscourseTagging.validate_one_tag_from_group_per_topic(guardian, topic, category, [tag2])
       expect(result).to eq(true)
     end
 
@@ -119,14 +122,24 @@ RSpec.describe DiscourseTagging do
       tag4 = Fabricate(:tag, name: "fun4")
 
       result =
-        DiscourseTagging.validate_one_tag_from_group_per_topic(nil, topic, category, [tag1, tag4])
+        DiscourseTagging.validate_one_tag_from_group_per_topic(
+          guardian,
+          topic,
+          category,
+          [tag1, tag4],
+        )
       expect(result).to eq(true)
     end
 
     context "when it fails" do
       it "returns false if more than one tag from the group is provided" do
         result =
-          DiscourseTagging.validate_one_tag_from_group_per_topic(nil, topic, category, [tag1, tag2])
+          DiscourseTagging.validate_one_tag_from_group_per_topic(
+            guardian,
+            topic,
+            category,
+            [tag1, tag2],
+          )
 
         expect(topic.errors[:base]&.first).to eq(
           I18n.t(
@@ -145,7 +158,7 @@ RSpec.describe DiscourseTagging do
 
         result =
           DiscourseTagging.validate_one_tag_from_group_per_topic(
-            nil,
+            guardian,
             topic,
             category2,
             [tag1, tag2, tag4, tag5],
@@ -170,14 +183,18 @@ RSpec.describe DiscourseTagging do
         tag5 = Fabricate(:tag, name: "fun5")
 
         invalid_tags =
-          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(nil, [tag4, tag5])
+          DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+            guardian,
+            nil,
+            [tag4, tag5],
+          )
         expect(invalid_tags).to be_empty
       end
 
       it "returns tags that are violating the one tag from group per topic rule when there is only one group" do
         invalid_tags =
           DiscourseTagging
-            .filter_tags_violating_one_tag_from_group_per_topic(nil, [tag1, tag2])
+            .filter_tags_violating_one_tag_from_group_per_topic(guardian, nil, [tag1, tag2])
             .values
             .first
             .map(&:name)
@@ -193,7 +210,7 @@ RSpec.describe DiscourseTagging do
           [[tag1, tag2], [tag1, tag3], [tag2, tag3], [tag1, tag2, tag3]].each do |test_values|
             invalid_tags =
               DiscourseTagging
-                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .filter_tags_violating_one_tag_from_group_per_topic(guardian, category, test_values)
                 .values
                 .first
                 .map(&:name)
@@ -218,7 +235,7 @@ RSpec.describe DiscourseTagging do
           ].each do |test_values|
             invalid_tags =
               DiscourseTagging
-                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .filter_tags_violating_one_tag_from_group_per_topic(guardian, category, test_values)
                 .values
                 .first
                 .map(&:name)
@@ -228,6 +245,7 @@ RSpec.describe DiscourseTagging do
           invalid_tags =
             DiscourseTagging
               .filter_tags_violating_one_tag_from_group_per_topic(
+                guardian,
                 category,
                 [tag1, tag2, tag4, tag5],
               )
@@ -246,7 +264,11 @@ RSpec.describe DiscourseTagging do
 
           [tag1, tag2, tag3, tag4, tag5].each do |tag|
             invalid_tags =
-              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag])
+              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+                guardian,
+                category,
+                [tag],
+              )
             expect(invalid_tags).to be_empty
           end
         end
@@ -259,6 +281,7 @@ RSpec.describe DiscourseTagging do
 
           invalid_tags =
             DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+              guardian,
               category,
               [tag4, tag5],
             )
@@ -279,7 +302,7 @@ RSpec.describe DiscourseTagging do
           [[tag1, tag2], [tag1, tag3], [tag2, tag3], [tag1, tag2, tag3]].each do |test_values|
             invalid_tags =
               DiscourseTagging
-                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .filter_tags_violating_one_tag_from_group_per_topic(guardian, category, test_values)
                 .values
                 .first
                 .map(&:name)
@@ -311,7 +334,7 @@ RSpec.describe DiscourseTagging do
           ].each do |test_values|
             invalid_tags =
               DiscourseTagging
-                .filter_tags_violating_one_tag_from_group_per_topic(category, test_values)
+                .filter_tags_violating_one_tag_from_group_per_topic(guardian, category, test_values)
                 .values
                 .first
                 .map(&:name)
@@ -321,6 +344,7 @@ RSpec.describe DiscourseTagging do
           invalid_tags =
             DiscourseTagging
               .filter_tags_violating_one_tag_from_group_per_topic(
+                guardian,
                 category,
                 [tag1, tag2, tag4, tag5],
               )
@@ -346,7 +370,11 @@ RSpec.describe DiscourseTagging do
 
           [tag1, tag2, tag3, tag4, tag5].each do |tag|
             invalid_tags =
-              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(category, [tag])
+              DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+                guardian,
+                category,
+                [tag],
+              )
             expect(invalid_tags).to be_empty
           end
         end
@@ -365,6 +393,7 @@ RSpec.describe DiscourseTagging do
 
           invalid_tags =
             DiscourseTagging.filter_tags_violating_one_tag_from_group_per_topic(
+              guardian,
               category,
               [tag4, tag5],
             )

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe PostRevisor do
 
       tag1 = Fabricate(:tag)
       tag2 = Fabricate(:tag)
-      tag_group = Fabricate(:tag_group, tags: [tag1], one_per_topic: true)
-      tag_group2 = Fabricate(:tag_group, tags: [tag2], one_per_topic: true)
+      tag_group = Fabricate(:tag_group, tags: [tag1])
+      tag_group2 = Fabricate(:tag_group, tags: [tag2])
 
       old_category = Fabricate(:category, tag_groups: [tag_group])
       new_category = Fabricate(:category, tag_groups: [tag_group2])
@@ -168,7 +168,7 @@ RSpec.describe PostRevisor do
       SiteSetting.min_trust_level_to_tag_topics = 0
 
       tag1 = Fabricate(:tag)
-      tag_group = Fabricate(:tag_group, tags: [tag1], one_per_topic: true)
+      tag_group = Fabricate(:tag_group, tags: [tag1])
 
       old_category = Fabricate(:category)
       new_category =


### PR DESCRIPTION
# FIX: Displaying the wrong number of minimum tags in the composer

When the minimum number of tags set for the category is larger than the minimum number of tags set in the category tag-groups, the composer was displaying the wrong value.

This commit fixes the value displayed in the composer to show the max value between the required for the category and the tag-groups set for the category.

This bug was reported on Meta in https://meta.discourse.org/t/tags-from-multiple-tag-groups-required-only-suggest-select-at-least-one-tag/263817

# FIX: Limiting tags to categories not working as expected
When a category was restricted to a tag group A, which was set to only allow
one tag from the group per topic, selecting a tag belonging only to A returned
other tags from A that also belonged to other group/s (if any).

Example:

Tag group A: alpha, beta, gamma, epsilon, delta
Tag group B: alpha, beta, gamma

Both tag groups set to only allow one tag from the group per topic.

If Category 1 was set to only allow tags from the tag group A, and the first tag
selected was epsilon, then, because they also belonged to tag group B, the tags
alpha, beta, and gamma were still returned as valid options when they should not be.

This commit ensures that once a tag from a tag group that restricts its tags to
one per topic is selected, no other tag from this group is returned.

This bug was reported on Meta in https://meta.discourse.org/t/limiting-tags-to-categories-not-working-as-expected/263143.

# FIX: Moving topics does not prompt to add required tag for new category
When a topic was moved from a category to another, the tag requirements
of the new category were not being checked.

This allowed a topic to be created and moved to a category:

- that limited the tags to a tag group, with the topic containing tags
not allowed.
- that required n tags from a tag group, with the topic not containing
the required tags.

This bug was reported on Meta in https://meta.discourse.org/t/moving-tagged-topics-does-not-prompt-to-add-required-tag-for-new-category/264138.

# FIX: Editing topics with tag groups from parents allows incorrect tagging

When there was a combination between parent tags defined in a tag group
set to allow only one tag from the group per topic, and other tag groups
relying on this restriction to combine the children tag types with the
parent tag, editing a topic could allow the user to insert an invalid
combination of these tags.

Example:

Automakers tag group: landhover, toyota
  - group set to limit one tag from the group per topic

Toyota models group: land-cruiser, hilux, corolla

Landhover models group: evoque, defender, discovery

If a topic was initially setup with the tags toyota, land-cruiser it was
possible to edit it removing the tag toyota and adding the tag landhover
and other landhover model tag like evoque for example.

In this case the topic would end up with the tags toyota, land-cruiser,
landhover, evoque because Discourse will automatically insert the
missing parent tag toyota when it detects the tag land-cruiser.

This combination of tags would violate the restriction specified in
the Automakers tag group resulting in an invalid combination of tags.

This commit enforces that the "one tag from the group per topic"
restriction is verified before updating the topic tags and also
make sure the verification check the compatibility of parent tags that
would be automatically inserted.

After the changes the user will receive an error similar to:
The tags land-cruiser, landhover cannot be used simultaneously.
Please include only one of them.

This bug was reported on Meta in https://meta.discourse.org/t/editing-topics-with-tag-groups-from-parents-allows-incorrect-tagging/263968.