### PR TITLE
FIX: rely only on one keyboard computation solution

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -11,17 +11,19 @@ export default class ChatVh extends Component {
   didInsertElement() {
     this._super(...arguments);
 
-    this.setVHFromVisualViewPort();
-
-    (window?.visualViewport || window).addEventListener(
-      "resize",
-      this.setVHFromVisualViewPort
-    );
-
     if ("virtualKeyboard" in navigator) {
+      this.setVHFromKeyboard();
+
       navigator.virtualKeyboard.addEventListener(
         "geometrychange",
         this.setVHFromKeyboard
+      );
+    } else {
+      this.setVHFromVisualViewPort();
+
+      (window?.visualViewport || window).addEventListener(
+        "resize",
+        this.setVHFromVisualViewPort
       );
     }
   }


### PR DESCRIPTION
We were combining both solutions which was apparently causing issues from chrome 113 on Android at least.

The commit will now use `geometrychange` (android) only when available and fallback to `visualViewport` otherwise (iOS).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
