### PR TITLE
FIX: Allow integer group_ids for create invite api

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -686,7 +686,7 @@ class Group < ActiveRecord::Base
 
   def self.lookup_groups(group_ids: [], group_names: [])
     if group_ids.present?
-      group_ids = group_ids.split(",") if group_ids.is_a?(String)
+      group_ids = group_ids.to_s.split(",") if !group_ids.is_a?(Array)
       group_ids.map!(&:to_i)
       groups = Group.where(id: group_ids) if group_ids.present?
     end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -579,6 +579,23 @@ RSpec.describe Group do
     expect(group.id).to eq Group[group.name.to_sym].id
   end
 
+  it "allows you to lookup a group by integer id" do
+    group = Fabricate(:group)
+    expect(group.id).to eq Group.lookup_groups(group_ids: group.id).first.id
+  end
+
+  it "allows you to lookup groups by comma separated string" do
+    group1 = Fabricate(:group)
+    group2 = Fabricate(:group)
+    expect([group1, group2]).to eq Group.lookup_groups(group_ids: "#{group1.id},#{group2.id}")
+  end
+
+  it "allows you to lookup groups by array" do
+    group1 = Fabricate(:group)
+    group2 = Fabricate(:group)
+    expect([group1, group2]).to eq Group.lookup_groups(group_ids: [group1.id, group2.id])
+  end
+
   it "can find desired groups correctly" do
     expect(Group.desired_trust_level_groups(2).sort).to eq [10, 11, 12]
   end


### PR DESCRIPTION
This fixes a bug in the create invite API where if you passed in an
integer for the group_ids field it would fail to add the user to the
specified group.
