### PR TITLE
DEV: Add a timeout for cache step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -264,6 +264,8 @@ jobs:
       - name: Yarn cache
         uses: actions/cache@v3
         id: yarn-cache
+        timeout-minutes: 3
+        continue-on-error: true
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
There's a known issue when using self-hosted runners that downloading the cache from Github can be slow.