### PR TITLE
FIX: Markdown preview should look the same as cooked post

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -26,7 +26,7 @@ class CookedPostProcessor
     @category_id = @post&.topic&.category_id
 
     cooked = post.cook(post.raw, @cooking_options)
-    @doc = Loofah.fragment(cooked)
+    @doc = Loofah.html5_fragment(cooked)
     @has_oneboxes = post.post_analyzer.found_oneboxes?
     @size_cache = {}
 

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -206,14 +206,14 @@ module Oneboxer
 
   def self.apply(string_or_doc, extra_paths: nil)
     doc = string_or_doc
-    doc = Loofah.fragment(doc) if doc.is_a?(String)
+    doc = Loofah.html5_fragment(doc) if doc.is_a?(String)
     changed = false
 
     each_onebox_link(doc, extra_paths: extra_paths) do |url, element|
       onebox, _ = yield(url, element)
       next if onebox.blank?
 
-      parsed_onebox = Loofah.fragment(onebox)
+      parsed_onebox = Loofah.html5_fragment(onebox)
       next if parsed_onebox.children.blank?
 
       changed = true

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -311,7 +311,7 @@ module PrettyText
     add_mentions(doc, user_id: opts[:user_id]) if SiteSetting.enable_mentions
 
     scrubber = Loofah::Scrubber.new { |node| node.remove if node.name == "script" }
-    loofah_fragment = Loofah.fragment(doc.to_html)
+    loofah_fragment = Loofah.html5_fragment(doc.to_html)
     loofah_fragment.scrub!(scrubber).to_html
   end
 

--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -12,7 +12,7 @@ module Chat
       @opts = {}
 
       cooked = Chat::Message.cook(chat_message.message, user_id: chat_message.last_editor_id)
-      @doc = Loofah.fragment(cooked)
+      @doc = Loofah.html5_fragment(cooked)
     end
 
     def run!

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -788,7 +788,8 @@ RSpec.describe Oneboxer do
     it "does keeps SVGs valid" do
       raw = "Onebox\n\nhttps://example.com"
       cooked = PrettyText.cook(raw)
-      cooked = Oneboxer.apply(Loofah.fragment(cooked)) { "<div><svg><path></path></svg></div>" }
+      cooked =
+        Oneboxer.apply(Loofah.html5_fragment(cooked)) { "<div><svg><path></path></svg></div>" }
       doc = Nokogiri::HTML5.fragment(cooked.to_html)
       expect(doc.to_html).to match_html <<~HTML
         <p>Onebox</p>


### PR DESCRIPTION
https://meta.discourse.org/t/markdown-preview-and-result-differ/263878

The result of this markdown had different results in the composer preview and the post. This is solved by updating Loofah to the latest version and using html5 fragments like our user had reported. While the change was only needed in [cooked_post_processor.rb](https://github.com/discourse/discourse/pull/21500/files#diff-67de7f44aa04f02ceba9770e5d83b4465add3bd4297be871f94a2233cd4831a7), I've updated the other areas of our codebase to also use the html5 fragment.

> <strike>
> 
> Additionally, how come
> 
> ```qml
> import QtQuick
> import QtQuick.Controls 2.15 as QQC2
> import QtQuick.Layouts
> import QtPositioning
> ```
> 
> and prepension of `QQC2` before `Action`, `Button`, `ApplicationWindow`, and `Frame` doesn't work, whereas
> 
> ```qml
> import QtQuick
> import QtQuick.Controls
> import QtQuick.Layouts
> import QtPositioning
> import QtQuick.Controls 2.15 as QQC2
> ```
> 
> and addition of `QQC2.Button` (per https://discuss.kde.org/t/qml-pyqt6-cant-get-native-control-appearance/1240/2?u=rokejulianlockhart) does?
> 
> </strike>


<img width="643" alt="Screenshot 2023-05-11 at 3 15 36 PM" src="https://github.com/discourse/discourse/assets/1555215/e7087502-b0a1-4219-be0b-ad3904cc6a6f">

