### PR TITLE
FIX: keyboard on android

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -11,16 +11,16 @@ export default class ChatVh extends Component {
   didInsertElement() {
     this._super(...arguments);
 
+    this.setVHFromVisualViewPort();
+
     if ("virtualKeyboard" in navigator) {
-      this.setVHFromKeyboard();
+      navigator.virtualKeyboard.overlaysContent = true;
 
       navigator.virtualKeyboard.addEventListener(
         "geometrychange",
         this.setVHFromKeyboard
       );
     } else {
-      this.setVHFromVisualViewPort();
-
       (window?.visualViewport || window).addEventListener(
         "resize",
         this.setVHFromVisualViewPort
@@ -62,8 +62,9 @@ export default class ChatVh extends Component {
 
     pendingUpdate = true;
 
+    const { height } = event.target.boundingClientRect;
+
     requestAnimationFrame(() => {
-      const { height } = event.target.boundingRect;
       const vhInPixels =
         ((window.visualViewport?.height || window.innerHeight) - height) * 0.01;
       document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);

--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -3,7 +3,6 @@ import Component from "@ember/component";
 import isZoomed from "discourse/plugins/chat/discourse/lib/zoom-check";
 
 const CSS_VAR = "--chat-vh";
-let pendingUpdate = false;
 
 export default class ChatVh extends Component {
   tagName = "";
@@ -42,16 +41,10 @@ export default class ChatVh extends Component {
         this.setVHFromVisualViewPort
       );
     }
-
-    pendingUpdate = false;
   }
 
   @bind
   setVHFromKeyboard(event) {
-    if (pendingUpdate) {
-      return;
-    }
-
     if (this.isDestroying || this.isDestroyed) {
       return;
     }
@@ -60,25 +53,20 @@ export default class ChatVh extends Component {
       return;
     }
 
-    pendingUpdate = true;
-
-    const { height } = event.target.boundingRect;
-
     requestAnimationFrame(() => {
-      const vhInPixels =
-        ((window.visualViewport?.height || window.innerHeight) - height) * 0.01;
-      document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);
+      requestAnimationFrame(() => {
+        const keyboardHeight = event.target.boundingRect.height;
+        const viewportHeight =
+          window.visualViewport?.height || window.innerHeight;
 
-      pendingUpdate = false;
+        const vhInPixels = (viewportHeight - keyboardHeight) * 0.01;
+        document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);
+      });
     });
   }
 
   @bind
   setVHFromVisualViewPort() {
-    if (pendingUpdate) {
-      return;
-    }
-
     if (this.isDestroying || this.isDestroyed) {
       return;
     }
@@ -87,14 +75,10 @@ export default class ChatVh extends Component {
       return;
     }
 
-    pendingUpdate = true;
-
     requestAnimationFrame(() => {
       const vhInPixels =
         (window.visualViewport?.height || window.innerHeight) * 0.01;
       document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);
-
-      pendingUpdate = false;
     });
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -62,7 +62,7 @@ export default class ChatVh extends Component {
 
     pendingUpdate = true;
 
-    const { height } = event.target.boundingClientRect;
+    const { height } = event.target.boundingRect;
 
     requestAnimationFrame(() => {
       const vhInPixels =


### PR DESCRIPTION
`geometry` change event is not called when `overlaysContent` is not set to true. This is a bug of chromium tracked in this ticket: https://bugs.chromium.org/p/chromium/issues/detail?id=1433640

Moreover, it will now set a default VH on load.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
