### PR TITLE
FIX: Avoid double-encoding featured topic title in user profile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -180,8 +180,8 @@
                     this.model.featured_topic.slug
                     this.model.featured_topic.id
                   }}
-                >{{html-safe
-                    (replace-emoji this.model.featured_topic.fancy_title)
+                >{{replace-emoji
+                    (html-safe this.model.featured_topic.fancy_title)
                   }}</LinkTo>
               </div>
             {{/if}}


### PR DESCRIPTION
a373bf2 updated the behavior of replace-emoji so that the input is treated as unsafe-by-default. fancy_title is already escaped, so we need to mark it as html-safe to avoid it being double-escaped.

There is no need to html-safe the result of replace-emoji - it's already done as part of the helper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
