### PR TITLE
FIX: close panel earlier

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
@@ -1,5 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
 
 export default class ChatChannelThread extends DiscourseRoute {
   @service router;
@@ -24,7 +25,8 @@ export default class ChatChannelThread extends DiscourseRoute {
     this.chatChannelThreadPane.open(model);
   }
 
-  deactivate() {
+  @action
+  willTransition() {
     this.chatChannelThreadPane.close();
   }
 

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
@@ -1,13 +1,9 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { inject as service } from "@ember/service";
-
+import { action } from "@ember/object";
 export default class ChatChannelThreads extends DiscourseRoute {
   @service router;
   @service chatChannelThreadListPane;
-
-  deactivate() {
-    this.chatChannelThreadListPane.close();
-  }
 
   beforeModel(transition) {
     const channel = this.modelFor("chat.channel");
@@ -17,6 +13,11 @@ export default class ChatChannelThreads extends DiscourseRoute {
       this.router.transitionTo("chat.channel", ...channel.routeModels);
       return;
     }
+  }
+
+  @action
+  willTransition() {
+    this.chatChannelThreadListPane.close();
   }
 
   activate() {


### PR DESCRIPTION
deactivate was happening too late and sometimes after we did reopen for next panel causing the panel to stay effectively closed

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
