### PR TITLE
FEATURE: Allow admins to backfill seen_popups

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/site-setting-user-tips.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/site-setting-user-tips.js
@@ -1,0 +1,8 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+import ModalUpdateExistingUsers from "discourse/mixins/modal-update-existing-users";
+
+export default class SiteSettingUserTipsController extends Controller.extend(
+  ModalFunctionality,
+  ModalUpdateExistingUsers
+) {}

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -68,6 +68,7 @@ const DEFAULT_USER_PREFERENCES = [
   "default_title_count_mode",
   "default_sidebar_categories",
   "default_sidebar_tags",
+  "enable_user_tips",
 ];
 
 export default Mixin.create({

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -190,7 +190,12 @@ export default Mixin.create({
     const count = result.user_count;
 
     if (count > 0) {
-      const controller = showModal("site-setting-default-categories", {
+      let modalName = "site-setting-default-categories";
+      if (key === "enable_user_tips") {
+        modalName = "site-setting-user-tips";
+      }
+
+      const controller = showModal(modalName, {
         model: { count, key: key.replaceAll("_", " ") },
         admin: true,
       });

--- a/app/assets/javascripts/admin/addon/templates/modal/site-setting-user-tips.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/site-setting-user-tips.hbs
@@ -1,0 +1,18 @@
+<DModalBody @class="incoming-emails" @rawTitle={{this.model.key}}>
+  {{i18n
+    "admin.site_settings.skip_new_user_tips.modal_description"
+    count=this.model.count
+  }}
+</DModalBody>
+
+<div class="modal-footer">
+  <DButton
+    @action={{action "updateExistingUsers"}}
+    @class="btn-primary"
+    @label="admin.site_settings.skip_new_user_tips.modal_yes"
+  />
+  <DButton
+    @action={{action "cancel"}}
+    @label="admin.site_settings.skip_new_user_tips.modal_no"
+  />
+</div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6102,6 +6102,10 @@ en:
           modal_description: "Would you like to apply this change historically? This will change preferences for %{count} existing users."
           modal_yes: "Yes"
           modal_no: "No, only apply change going forward"
+        skip_new_user_tips:
+          modal_description: "Do you want to hide user tips for existing users? This will change preferences for %{count} users who have not seen all user tips. Users signing up now or those who have less than 10 posts will still see new user tips."
+          modal_yes: "Yes"
+          modal_no: "No, do not hide user tips for any user"
         simple_list:
           add_item: "Add item..."
         json_schema:


### PR DESCRIPTION
When enabling user tips, admins can decide whether they want to hide seen popups for all existing users.

<img width="718" alt="image" src="https://github.com/discourse/discourse/assets/23153890/efc72e1a-bb64-4426-8938-9c17149b75a9">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
