### PR TITLE
UX: opens side panel early to avoid jitter

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
@@ -59,5 +59,7 @@ export default class ChatChannelThread extends DiscourseRoute {
         return;
       }
     }
+
+    this.chatStateManager.openSidePanel();
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
@@ -1,6 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
+
 export default class ChatChannelThreads extends DiscourseRoute {
   @service router;
   @service chatChannelThreadListPane;
@@ -19,8 +20,10 @@ export default class ChatChannelThreads extends DiscourseRoute {
   }
 
   @action
-  willTransition() {
-    this.chatChannelThreadListPane.close();
+  willTransition(transition) {
+    if (transition.targetName !== "chat.channel.thread") {
+      this.chatChannelThreadListPane.close();
+    }
   }
 
   activate() {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 export default class ChatChannelThreads extends DiscourseRoute {
   @service router;
   @service chatChannelThreadListPane;
+  @service chatStateManager;
 
   beforeModel(transition) {
     const channel = this.modelFor("chat.channel");
@@ -13,6 +14,8 @@ export default class ChatChannelThreads extends DiscourseRoute {
       this.router.transitionTo("chat.channel", ...channel.routeModels);
       return;
     }
+
+    this.chatStateManager.openSidePanel();
   }
 
   @action


### PR DESCRIPTION
Hard to write a test for this behavior, this is a micro optimisation which doesn’t change the behavior but only makes it smoother by happening right before async request.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
