### PR TITLE
DEV: Fix preview sanitization test

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { fillIn, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import { query } from "discourse/tests/helpers/qunit-helpers";
 
 module("Integration | Component | ComposerEditor", function (hooks) {
   setupRenderingTest(hooks);
@@ -42,5 +43,23 @@ module("Integration | Component | ComposerEditor", function (hooks) {
     `);
 
     await fillIn("textarea", "@user-no @user-ok @user-nope");
+  });
+
+  test("preview sanitizes HTML", async function (assert) {
+    this.set("model", {});
+    this.set("noop", () => {});
+
+    await render(hbs`
+      <ComposerEditor
+        @composer={{this.model}}
+        @afterRefresh={{this.noop}}
+      />
+    `);
+
+    await fillIn(".d-editor-input", `"><svg onload="prompt(/xss/)"></svg>`);
+    assert.strictEqual(
+      query(".d-editor-preview").innerHTML.trim(),
+      '<p>"&gt;<svg></svg></p>'
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -45,16 +45,6 @@ module("Integration | Component | d-editor", function (hooks) {
     );
   });
 
-  test("preview sanitizes HTML", async function (assert) {
-    await render(hbs`<DEditor @value={{this.value}} />`);
-
-    await fillIn(".d-editor-input", `"><svg onload="prompt(/xss/)"></svg>`);
-    assert.strictEqual(
-      query(".d-editor-preview").innerHTML.trim(),
-      '<p>"&gt;</p>'
-    );
-  });
-
   test("updating the value refreshes the preview", async function (assert) {
     this.set("value", "evil trout");
 


### PR DESCRIPTION
This test was passing, but the environment it was testing was incorrect. The `image-controls` markdown rule allowlists several svgs when previewing. But since `previewing: true` is only set on the parent `ComposerEditor` component, the test in `DEditor` wasn't aware of that context and therefore the output was excluding SVG elements altogether.

This moves the test one level higher to `ComposerEditor`, and because now `previewing: true` is present in that context, the test needs to be updated to include the SVG element, but exclude the `onload` attribute.
