### PR TITLE
DEV: Gracefully handle user avatar download SSRF errors

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -144,8 +144,8 @@ class UserAvatar < ActiveRecord::Base
         user.update!(uploaded_avatar_id: upload.id)
       end
     end
-  rescue Net::ReadTimeout, OpenURI::HTTPError
-    # skip saving, we are not connected to the net
+  rescue Net::ReadTimeout, OpenURI::HTTPError, FinalDestination::SSRFError
+    # Skip saving. We are not connected to the net, or SSRF checks failed.
   ensure
     tempfile.close! if tempfile && tempfile.respond_to?(:close!)
   end

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -8,6 +8,9 @@ require "url_helper"
 
 # Determine the final endpoint for a Web URI, following redirects
 class FinalDestination
+  class SSRFError < SocketError
+  end
+
   MAX_REQUEST_TIME_SECONDS = 10
   MAX_REQUEST_SIZE_BYTES = 5_242_880 # 1024 * 1024 * 5
 

--- a/lib/final_destination/ssrf_detector.rb
+++ b/lib/final_destination/ssrf_detector.rb
@@ -2,9 +2,9 @@
 
 class FinalDestination
   module SSRFDetector
-    class DisallowedIpError < SocketError
+    class DisallowedIpError < SSRFError
     end
-    class LookupFailedError < SocketError
+    class LookupFailedError < SSRFError
     end
 
     # This is a list of private IPv4 IP ranges that are not allowed to be globally reachable as given by

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -9,7 +9,7 @@ module RetrieveTitle
       max_redirects: max_redirects,
       initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit,
     )
-  rescue Net::ReadTimeout, FinalDestination::SSRFDetector::LookupFailedError
+  rescue Net::ReadTimeout, FinalDestination::SSRFError
     # do nothing for Net::ReadTimeout errors
   end
 

--- a/spec/models/user_avatar_spec.rb
+++ b/spec/models/user_avatar_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe UserAvatar do
         expect(user.user_avatar.custom_upload_id).to eq(nil)
       end
     end
+
+    it "doesn't error out if the remote request fails" do
+      FileHelper.stubs(:download).raises(FinalDestination::SSRFDetector::LookupFailedError.new)
+
+      expect { UserAvatar.import_url_for_user(anything, user) }.not_to raise_error
+    end
   end
 
   describe "ensure_consistency!" do


### PR DESCRIPTION
### Background

When SSRF detection fails, the exception bubbles all the way up, causing a log alert. This isn't actionable, and should instead be ignored. The existing `rescue` does already ignore network errors, but fails to account for SSRF exceptions coming from `FinalDestination`.

### What is this change?

This PR does two things.

---

Firstly, it introduces a common root exception class, `FinalDestination::SSRFError` for SSRF errors. This serves two functions: 1) it makes it easier to rescue both errors at once, which is generally what one wants to do and 2) prevents having to dig deep into the class hierarchy for the constant.

**Before:**

<img width="683" alt="Screenshot 2023-05-12 at 1 30 04 PM" src="https://github.com/discourse/discourse/assets/5259935/ffe3b63a-612f-4df6-9844-76c2f602999d">

**After:**

<img width="670" alt="Screenshot 2023-05-12 at 1 29 43 PM" src="https://github.com/discourse/discourse/assets/5259935/89114404-3343-4c86-bdf6-5dc2e413b112">

This change is fully backwards compatible thanks to how inheritance and exception handling works.

---

Secondly, it rescues this new exception in `UserAvatar.import_url_for_user`, which is causing sporadic errors to be logged in production. After this SSRF errors are handled the same as network errors.