### PR TITLE
FIX: Incorrect `PLUGIN_NAME` for "poll"

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -20,7 +20,7 @@ hide_plugin
 
 after_initialize do
   module ::DiscoursePoll
-    PLUGIN_NAME ||= "discourse_poll"
+    PLUGIN_NAME ||= "poll"
     DATA_PREFIX ||= "data-poll-"
     HAS_POLLS ||= "has_polls"
     DEFAULT_POLL_NAME ||= "poll"


### PR DESCRIPTION
This resulted in `Required plugin 'discourse_poll' not found` warnings in logs

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
