### PR TITLE
FIX: Thread reply indicator overflow

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -15,8 +15,6 @@
   &__replies-count {
     color: var(--primary-medium);
     font-size: var(--font-down-1);
-    max-width: 60px;
-    flex: 1;
   }
 
   &__view-thread {


### PR DESCRIPTION
In some cases the thread reply count indicator
(e.g. 433 replies) would wrap to the next line.
