### PR TITLE
FIX: always listen on window resize

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -12,17 +12,17 @@ export default class ChatVh extends Component {
 
     this.setVHFromVisualViewPort();
 
+    (window?.visualViewport || window).addEventListener(
+      "resize",
+      this.setVHFromVisualViewPort
+    );
+
     if ("virtualKeyboard" in navigator) {
       navigator.virtualKeyboard.overlaysContent = true;
 
       navigator.virtualKeyboard.addEventListener(
         "geometrychange",
         this.setVHFromKeyboard
-      );
-    } else {
-      (window?.visualViewport || window).addEventListener(
-        "resize",
-        this.setVHFromVisualViewPort
       );
     }
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -1,84 +1,52 @@
 import { bind } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
-import isZoomed from "discourse/plugins/chat/discourse/lib/zoom-check";
+import { inject as service } from "@ember/service";
 
 const CSS_VAR = "--chat-vh";
+let lastVH;
 
 export default class ChatVh extends Component {
+  @service capabilities;
+
   tagName = "";
 
   didInsertElement() {
     this._super(...arguments);
 
-    this.setVHFromVisualViewPort();
-
-    (window?.visualViewport || window).addEventListener(
-      "resize",
-      this.setVHFromVisualViewPort
-    );
-
     if ("virtualKeyboard" in navigator) {
-      navigator.virtualKeyboard.overlaysContent = true;
-
-      navigator.virtualKeyboard.addEventListener(
-        "geometrychange",
-        this.setVHFromKeyboard
-      );
+      navigator.virtualKeyboard.overlaysContent = false;
     }
+
+    this.activeWindow = window.visualViewport || window;
+    this.activeWindow.addEventListener("resize", this.setVH);
+    this.setVH();
   }
 
   willDestroyElement() {
     this._super(...arguments);
 
-    if ("virtualKeyboard" in navigator) {
-      navigator.virtualKeyboard.removeEventListener(
-        "geometrychange",
-        this.setVHFromKeyboard
-      );
-    } else {
-      (window?.visualViewport || window).removeEventListener(
-        "resize",
-        this.setVHFromVisualViewPort
-      );
-    }
+    this.activeWindow?.removeEventListener("resize", this.setVH);
+    lastVH = null;
   }
 
   @bind
-  setVHFromKeyboard(event) {
-    if (this.isDestroying || this.isDestroyed) {
+  setVH() {
+    const vh = (this.activeWindow?.height || window.innerHeight) * 0.01;
+
+    if (lastVH === vh) {
       return;
+    } else if (this.capabilities.touch && lastVH < vh && vh - lastVH > 1) {
+      this.#blurActiveElement();
     }
 
-    if (isZoomed()) {
-      return;
-    }
+    lastVH = vh;
 
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const keyboardHeight = event.target.boundingRect.height;
-        const viewportHeight =
-          window.visualViewport?.height || window.innerHeight;
-
-        const vhInPixels = (viewportHeight - keyboardHeight) * 0.01;
-        document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);
-      });
-    });
+    document.documentElement.style.setProperty(CSS_VAR, `${vh}px`);
   }
 
-  @bind
-  setVHFromVisualViewPort() {
-    if (this.isDestroying || this.isDestroyed) {
-      return;
+  #blurActiveElement() {
+    if (document.activeElement?.blur) {
+      document.activeElement.blur();
     }
-
-    if (isZoomed()) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      const vhInPixels =
-        (window.visualViewport?.height || window.innerHeight) * 0.01;
-      document.documentElement.style.setProperty(CSS_VAR, `${vhInPixels}px`);
-    });
   }
 }


### PR DESCRIPTION
Without this the keyboard change would trigger a resize on mobile, but resizing a window on desktop wouldn't work.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
