### PR TITLE
FIX: Fix for Default to subcategory when parent category does not allow posting

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/open-composer.js
+++ b/app/assets/javascripts/discourse/app/mixins/open-composer.js
@@ -7,11 +7,15 @@ export default Mixin.create({
   openComposer(controller) {
     let categoryId = controller.get("category.id");
 
-    if (
-      !controller.canCreateTopicOnCategory &&
-      this.siteSettings.default_subcategory_on_read_only_category
-    ) {
-      categoryId = controller.get("defaultSubcategory.id");
+    if (this.siteSettings.default_subcategory_on_read_only_category) {
+      if (
+        !controller.canCreateTopicOnCategory &&
+        controller.canCreateTopicOnSubCategory
+      ) {
+        categoryId = controller.get("defaultSubcategory.id");
+      } else {
+        categoryId = this.siteSettings.default_composer_category;
+      }
     }
 
     if (

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -163,7 +163,8 @@ export default (filterArg, params) => {
 
       if (
         !canCreateTopicOnCategory &&
-        this.siteSettings.default_subcategory_on_read_only_category
+        this.siteSettings.default_subcategory_on_read_only_category &&
+        category.subcategories
       ) {
         defaultSubcategory = category.subcategories.find((subcategory) => {
           return subcategory.get("permission") === PermissionType.FULL;

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -157,27 +157,24 @@ export default (filterArg, params) => {
 
       let canCreateTopicOnCategory =
         canCreateTopic && category.get("permission") === PermissionType.FULL;
-
+      let cannotCreateTopicOnCategory = !canCreateTopicOnCategory;
       let defaultSubcategory;
       let canCreateTopicOnSubCategory;
 
-      if (
-        !canCreateTopicOnCategory &&
-        this.siteSettings.default_subcategory_on_read_only_category &&
-        category.subcategories
-      ) {
-        defaultSubcategory = category.subcategories.find((subcategory) => {
-          return subcategory.get("permission") === PermissionType.FULL;
-        });
+      if (this.siteSettings.default_subcategory_on_read_only_category) {
+        cannotCreateTopicOnCategory = false;
 
-        canCreateTopicOnSubCategory = !!defaultSubcategory;
+        if (!canCreateTopicOnCategory && category.subcategories) {
+          defaultSubcategory = category.subcategories.find((subcategory) => {
+            return subcategory.get("permission") === PermissionType.FULL;
+          });
+          canCreateTopicOnSubCategory = !!defaultSubcategory;
+        }
       }
 
       this.controllerFor("navigation/category").setProperties({
         canCreateTopicOnCategory,
-        cannotCreateTopicOnCategory: !(
-          canCreateTopicOnCategory || canCreateTopicOnSubCategory
-        ),
+        cannotCreateTopicOnCategory,
         canCreateTopic,
         canCreateTopicOnSubCategory,
         defaultSubcategory,

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -8,7 +8,7 @@ end
 
 Fabricator(:category_with_definition, from: :category) { skip_category_definition false }
 
-Fabricator(:private_category, from: :category) do
+Fabricator(:category_with_group_and_permission, from: :category) do
   transient :group
   transient :permission_type
 
@@ -17,12 +17,15 @@ Fabricator(:private_category, from: :category) do
   user
 
   after_build do |cat, transients|
-    cat.update!(read_restricted: true)
     cat.category_groups.build(
       group_id: transients[:group].id,
       permission_type: transients[:permission_type] || CategoryGroup.permission_types[:full],
     )
   end
+end
+
+Fabricator(:private_category, from: :category_with_group_and_permission) do
+  after_build { |cat, transients| cat.update!(read_restricted: true) }
 end
 
 Fabricator(:private_category_with_definition, from: :private_category) do

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -10,19 +10,29 @@ describe "Default to Subcategory when parent Category doesn't allow posting",
   fab!(:subcategory) do
     Fabricate(:private_category, parent_category_id: category.id, group: group, permission_type: 1)
   end
+  fab!(:category_with_no_subcategory) do
+    Fabricate(:private_category, group: group, permission_type: 3)
+  end
   let(:category_page) { PageObjects::Pages::Category.new }
   before { sign_in(user) }
 
   describe "Setting enabled and can't post on parent category" do
     before { SiteSetting.default_subcategory_on_read_only_category = true }
-
-    it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
-      category_page.visit(category)
-      expect(category_page).to have_button("New Topic", disabled: false)
-      category_page.new_topic_button.click
-      select_kit =
-        PageObjects::Components::SelectKit.new(page.find("#reply-control.open .category-chooser"))
-      expect(select_kit).to have_selected_value(subcategory.id)
+    describe "Category has subcategory" do
+      it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
+        category_page.visit(category)
+        expect(category_page).to have_button("New Topic", disabled: false)
+        category_page.new_topic_button.click
+        select_kit =
+          PageObjects::Components::SelectKit.new(page.find("#reply-control.open .category-chooser"))
+        expect(select_kit).to have_selected_value(subcategory.id)
+      end
+    end
+  end
+  describe "Category does not have subcategory" do
+    it "should have the 'New Topic' button disabled" do
+      category_page.visit(category_with_no_subcategory)
+      expect(category_page).to have_button("New Topic", disabled: true)
     end
   end
 

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -12,10 +12,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting",
     Fabricate(:private_category, parent_category_id: category.id, group: group, permission_type: 1)
   end
   fab!(:category_with_no_subcategory) do
-    category_with_no_subcategory = Fabricate(:private_category, group: group, permission_type: 3)
-    category_with_no_subcategory.read_restricted = false
-    category_with_no_subcategory.save
-    category_with_no_subcategory
+    Fabricate(:category_with_group_and_permission, group: group, permission_type: 3)
   end
   let(:category_page) { PageObjects::Pages::Category.new }
 
@@ -29,7 +26,7 @@ describe "Default to Subcategory when parent Category doesn't allow posting",
 
   describe "logged in user" do
     before { sign_in(user) }
-    describe "Setting enabled and can't post on parent category" do
+    describe "default_subcategory_on_read_only_category setting enabled and can't post on parent category" do
       before do
         SiteSetting.default_subcategory_on_read_only_category = true
         SiteSetting.default_composer_category = default_latest_category.id

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -6,42 +6,66 @@ describe "Default to Subcategory when parent Category doesn't allow posting",
   fab!(:user) { Fabricate(:user) }
   fab!(:group) { Fabricate(:group) }
   fab!(:group_user) { Fabricate(:group_user, user: user, group: group) }
+  fab!(:default_latest_category) { Fabricate(:category) }
   fab!(:category) { Fabricate(:private_category, group: group, permission_type: 3) }
   fab!(:subcategory) do
     Fabricate(:private_category, parent_category_id: category.id, group: group, permission_type: 1)
   end
   fab!(:category_with_no_subcategory) do
-    Fabricate(:private_category, group: group, permission_type: 3)
+    category_with_no_subcategory = Fabricate(:private_category, group: group, permission_type: 3)
+    category_with_no_subcategory.read_restricted = false
+    category_with_no_subcategory.save
+    category_with_no_subcategory
   end
   let(:category_page) { PageObjects::Pages::Category.new }
-  before { sign_in(user) }
 
-  describe "Setting enabled and can't post on parent category" do
-    before { SiteSetting.default_subcategory_on_read_only_category = true }
-    describe "Category has subcategory" do
-      it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
-        category_page.visit(category)
-        expect(category_page).to have_button("New Topic", disabled: false)
-        category_page.new_topic_button.click
-        select_kit =
-          PageObjects::Components::SelectKit.new(page.find("#reply-control.open .category-chooser"))
-        expect(select_kit).to have_selected_value(subcategory.id)
+  describe "anon user" do
+    it "can visit the category" do
+      category_page.visit(category_with_no_subcategory)
+      select_kit = PageObjects::Components::SelectKit.new(page.find(".navigation-container"))
+      expect(select_kit).to have_selected_value(category_with_no_subcategory.id)
+    end
+  end
+
+  describe "logged in user" do
+    before { sign_in(user) }
+    describe "Setting enabled and can't post on parent category" do
+      before do
+        SiteSetting.default_subcategory_on_read_only_category = true
+        SiteSetting.default_composer_category = default_latest_category.id
+      end
+      describe "Category has subcategory" do
+        it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
+          category_page.visit(category)
+          expect(category_page).to have_button("New Topic", disabled: false)
+          category_page.new_topic_button.click
+          select_kit =
+            PageObjects::Components::SelectKit.new(
+              page.find("#reply-control.open .category-chooser"),
+            )
+          expect(select_kit).to have_selected_value(subcategory.id)
+        end
+      end
+      describe "Category does not have subcategory" do
+        it "should have the 'New Topic' button enabled and default Subcategory set to latest default subcategory" do
+          category_page.visit(category_with_no_subcategory)
+          expect(category_page).to have_button("New Topic", disabled: false)
+          category_page.new_topic_button.click
+          select_kit =
+            PageObjects::Components::SelectKit.new(
+              page.find("#reply-control.open .category-chooser"),
+            )
+          expect(select_kit).to have_selected_value(default_latest_category.id)
+        end
       end
     end
-  end
-  describe "Category does not have subcategory" do
-    it "should have the 'New Topic' button disabled" do
-      category_page.visit(category_with_no_subcategory)
-      expect(category_page).to have_button("New Topic", disabled: true)
-    end
-  end
 
-  describe "Setting disabled and can't post on parent category" do
-    before { SiteSetting.default_subcategory_on_read_only_category = false }
-
-    it "should have 'New Topic' button disabled" do
-      category_page.visit(category)
-      expect(category_page).to have_button("New Topic", disabled: true)
+    describe "Setting disabled and can't post on parent category" do
+      before { SiteSetting.default_subcategory_on_read_only_category = false }
+      it "should have 'New Topic' button disabled" do
+        category_page.visit(category)
+        expect(category_page).to have_button("New Topic", disabled: true)
+      end
     end
   end
 end


### PR DESCRIPTION
**Context**
 We want the New Topic button to be enabled on read-only categories. When the category has subcategories the user can post on, then the composer will default to those categories. When the category doesn't have subcategories the user can post or there are no subcategories at all, then the composer will default to the latest page default.

**Problem**
 When anon user tries to see a category without subcategories the category information wouldn't load.
 Behavior wasn't implemented correctly when there were no subcategories the user could post on.

**Solution**
 Implemented checks for anon users
 Used SiteSettings to grab the correct default latest category when the user can't create a topic on a category