### PR TITLE
FIX: do not set VH while zooming

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-vh.js
@@ -1,6 +1,7 @@
 import { bind } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { inject as service } from "@ember/service";
+import isZoomed from "discourse/plugins/chat/discourse/lib/zoom-check";
 
 const CSS_VAR = "--chat-vh";
 let lastVH;
@@ -31,6 +32,10 @@ export default class ChatVh extends Component {
 
   @bind
   setVH() {
+    if (isZoomed()) {
+      return;
+    }
+
     const vh = (this.activeWindow?.height || window.innerHeight) * 0.01;
 
     if (lastVH === vh) {


### PR DESCRIPTION
This was an optimisation I mistakenly removed from https://github.com/discourse/discourse/commit/4cfa78c3f3fbaebb33bfd14488606879ae3c2a45

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
