### PR TITLE
FIX: composer should be sending metaData

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -925,7 +925,6 @@ const Composer = RestModel.extend({
         if (!this.canEditTopicFeaturedLink) {
           this.set("featuredLink", null);
         }
-
         return this.editingPost ? this.editPost(opts) : this.createPost(opts);
       }
     });
@@ -1065,6 +1064,7 @@ const Composer = RestModel.extend({
       wiki: false,
       typingTime: this.typingTime,
       composerTime: this.composerTime,
+      metaData: this.metaData,
     });
 
     this.serialize(_create_serializer, createdPost);

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -9,6 +9,10 @@ import AppEvents from "discourse/services/app-events";
 import { module, test } from "qunit";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
+import pretender, {
+  parsePostData,
+  response,
+} from "discourse/tests/helpers/create-pretender";
 
 function createComposer(opts = {}) {
   opts.user ??= currentUser();
@@ -439,5 +443,42 @@ module("Unit | Model | composer", function (hooks) {
       { name: "staff", type: "group" },
       { name: "foo@bar.com", type: "email" },
     ]);
+  });
+
+  test("can add meta_data", async function (assert) {
+    let saved = false;
+    pretender.post("/posts", function (request) {
+      const data = parsePostData(request.requestBody);
+
+      assert.equal(data.meta_data.some_custom_field, "some_value");
+      saved = true;
+
+      return response(200, {
+        success: true,
+        action: "create_post",
+        post: {
+          id: 12345,
+          topic_id: 280,
+          topic_slug: "internationalization-localization",
+        },
+      });
+    });
+    const composer = createComposer.call(this, {});
+
+    await composer.open({
+      action: CREATE_TOPIC,
+      title: "some topic title here",
+      categoryId: 1,
+      reply: "some reply here some reply here some reply here",
+      draftKey: "abcd",
+      draftSequence: 1,
+    });
+
+    assert.equal(composer.loading, false);
+
+    composer.metaData = { some_custom_field: "some_value" };
+    await composer.save({});
+
+    assert.equal(saved, true);
   });
 });


### PR DESCRIPTION
An extensibility point we support server side is setting meta_data
(topic / post custom fields) with the composer payload.

Previous to this change even though we had a lot of setup code we never
actually sent the payload.

This ensures that on create we send meta_data.
