### PR TITLE
DEV: attempts to fix flakey spec

### DIFF
--- a/plugins/chat/spec/system/navigating_to_message_spec.rb
+++ b/plugins/chat/spec/system/navigating_to_message_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Navigating to message", type: :system, js: true do
 
         click_button(class: "chat-scroll-to-bottom")
 
-        expect(page).to have_content(link)
+        expect(page).to have_content(link, visible: :all)
 
         click_link(link)
 


### PR DESCRIPTION
A screenshot of the failure shows the message is on screen while the error is:

```
     Failure/Error: example.run
       expected to find text "My favorite message" in "Community\nEverything\nMy Posts\nMore\nMessages\nInbox\nChannels\nPolitics 1\nPersonal chat\nPolitics 1". (However, it was found 1 time including non-visible text.)
```

I expect the arrow element might e slightly hiding the link, but not 100% sure of this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
