### PR TITLE
DEV: Update call sites using BaseStore#download but expecting exceptions

### DIFF
--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -146,7 +146,7 @@ class OptimizedImage < ActiveRecord::Base
       if local?
         Discourse.store.path_for(self)
       else
-        Discourse.store.download(self).path
+        Discourse.store.download!(self).path
       end
     File.size(path)
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -144,7 +144,7 @@ class Upload < ActiveRecord::Base
     external_copy = nil
 
     if original_path.blank?
-      external_copy = Discourse.store.download(self)
+      external_copy = Discourse.store.download!(self)
       original_path = external_copy.path
     end
 
@@ -268,14 +268,14 @@ class Upload < ActiveRecord::Base
   def fix_dimensions!
     return if !FileHelper.is_supported_image?("image.#{extension}")
 
-    path =
-      if local?
-        Discourse.store.path_for(self)
-      else
-        Discourse.store.download(self).path
-      end
-
     begin
+      path =
+        if local?
+          Discourse.store.path_for(self)
+        else
+          Discourse.store.download!(self).path
+        end
+
       if extension == "svg"
         w, h =
           begin

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -363,7 +363,7 @@ module Email
             if attached_upload.local?
               Discourse.store.path_for(attached_upload)
             else
-              Discourse.store.download(attached_upload).path
+              Discourse.store.download!(attached_upload).path
             end
 
           @message_attachments_index[original_upload.sha1] = @message.attachments.size

--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -105,7 +105,7 @@ module FileStore
     end
 
     def download(object, max_file_size_kb: nil, print_deprecation: true)
-      Discourse.deprecate(<<~MESSAGE, output_in_test: true) if print_deprecation
+      Discourse.deprecate(<<~MESSAGE) if print_deprecation
           In a future version `FileStore#download` will no longer raise an error when the
           download fails, and will instead return `nil`. If you need a method that raises
           an error, use `FileStore#download!`, which raises a `FileStore::DownloadError`.


### PR DESCRIPTION
### Background

In https://github.com/discourse/discourse/pull/21498, we split `BaseStore#download` into a "safe" version which returns `nil` on errors, and an "unsafe" version which raises an exception, which was the old behaviour of `#download`.

### What is this change?

This change updates call sites that used the old `#download`, which raised exceptions, to use the new `#download!` to preserve behaviour (and silence deprecation warnings.)

It also silences the deprecation warning in tests.