### PR TITLE
UX: better copy for generic error msg

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -207,8 +207,8 @@ en:
       invalid_site_setting: "No setting named '%{name}' exists"
       invalid_category_id: "You specified a category that does not exist"
       invalid_choice:
-        one: "You specified the invalid choice %{name}"
-        other: "You specified the invalid choices %{name}"
+        one: "%{name} is an invalid choice."
+        other: "%{name} are invalid choices."
       default_categories_already_selected: "You cannot select a category used in another list."
       default_tags_already_selected: "You cannot select a tag used in another list."
       s3_upload_bucket_is_required: "You cannot enable uploads to S3 unless you've provided the 's3_upload_bucket'."
@@ -652,8 +652,8 @@ en:
           attributes:
             value:
               invalid_interpolation_keys:
-                one: 'The following interpolation key is invalid: %{keys}'
-                other: 'The following interpolation keys are invalid: %{keys}'
+                one: "The following interpolation key is invalid: %{keys}"
+                other: "The following interpolation keys are invalid: %{keys}"
         watched_word:
           attributes:
             word:
@@ -2093,7 +2093,7 @@ en:
     pop3_polling_password: "The password for the POP3 account to poll for email."
     pop3_polling_delete_from_server: "Delete emails from server. NOTE: If you disable this you should manually clean your mail inbox"
     log_mail_processing_failures: "Log all email processing failures to <a href='%{base_path}/logs' target='_blank'>/logs</a>"
-    email_in: 'Allow users to post new topics via email. After enabling this setting, you will be able to configure incoming email addresses for groups and categories.'
+    email_in: "Allow users to post new topics via email. After enabling this setting, you will be able to configure incoming email addresses for groups and categories."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."
     email_in_authserv_id: "The identifier of the service doing authentication checks on incoming emails. See <a href='https://meta.discourse.org/t/134358'>https://meta.discourse.org/t/134358</a> for instructions on how to configure this."
     email_in_spam_header: "The email header to detect spam."
@@ -2415,7 +2415,7 @@ en:
     default_sidebar_tags: "Selected tags will be displayed under Sidebar's Tags section by default."
     enable_new_notifications_menu: "Enables the new notifications menu. Disabling this setting is deprecated. The new notifications menu is always used for non-legacy 'navigation menu' choices. <a href='https://meta.discourse.org/t/260358'>Learn more</a>"
     enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
-    experimental_new_new_view_groups: "EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the \"Everything\" link in the sidebar link to it."
+    experimental_new_new_view_groups: 'EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
     enable_custom_sidebar_sections: "EXPERIMENTAL: Enable custom sidebar sections"
     experimental_topics_filter: "EXPERIMENTAL: Enables the experimental topics filter route at /filter"
 


### PR DESCRIPTION
I wanted to fix this error msg to make it less vague:
![image](https://github.com/discourse/discourse/assets/101828855/a9c23ab4-453f-455a-8094-85de641a0a4c)

but turns out it's a generic one so can't be specified. But at least the copy can be improved a bit.

