### PR TITLE
FIX: moves chat height computation to a mixin

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel.scss
@@ -7,21 +7,7 @@
   grid-area: main;
   width: 100%;
   min-width: 250px;
-  height: calc(
-    var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-      var(--composer-height, 0px) - var(--chat-draft-header-height, 0px) -
-      var(--chat-direct-message-creator-height, 0px) -
-      env(safe-area-inset-bottom)
-  );
-
-  .footer-nav-ipad & {
-    height: calc(
-      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
-        var(--chat-direct-message-creator-height, 0px) -
-        env(safe-area-inset-bottom)
-    );
-  }
+  @include chat-height;
 
   .open-drawer-btn,
   .open-thread-list-btn {

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -1,0 +1,39 @@
+@mixin chat-height {
+  // desktop and mobile
+  height: calc(
+    var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+      var(--chat-draft-header-height, 0px) -
+      var(--chat-direct-message-creator-height, 0px) -
+      env(safe-area-inset-bottom)
+  );
+
+  // mobile with keyboard opened
+  .keyboard-visible & {
+    height: calc(
+      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+        var(--chat-draft-header-height, 0px) -
+        var(--chat-direct-message-creator-height, 0px)
+    );
+  }
+
+  // ipad
+  .footer-nav-ipad & {
+    height: calc(
+      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+        var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
+        var(--chat-direct-message-creator-height, 0px) -
+        env(safe-area-inset-bottom)
+    );
+  }
+
+  // ipad with keyboard opened
+  .keyboard-visible & {
+    .footer-nav-ipad & {
+      height: calc(
+        var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+          var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
+          var(--chat-direct-message-creator-height, 0px)
+      );
+    }
+  }
+}

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -2,22 +2,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-
-  height: calc(
-    var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-      var(--composer-height, 0px) - var(--chat-draft-header-height, 0px) -
-      var(--chat-direct-message-creator-height, 0px) -
-      env(safe-area-inset-bottom)
-  );
-
-  .footer-nav-ipad & {
-    height: calc(
-      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
-        var(--chat-direct-message-creator-height, 0px) -
-        env(safe-area-inset-bottom)
-    );
-  }
+  @include chat-height;
 
   &__header {
     height: var(--chat-header-offset);

--- a/plugins/chat/assets/stylesheets/common/chat-threads-list.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-threads-list.scss
@@ -2,22 +2,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-
-  height: calc(
-    var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-      var(--composer-height, 0px) - var(--chat-draft-header-height, 0px) -
-      var(--chat-direct-message-creator-height, 0px) -
-      env(safe-area-inset-bottom)
-  );
-
-  .footer-nav-ipad & {
-    height: calc(
-      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
-        var(--chat-direct-message-creator-height, 0px) -
-        env(safe-area-inset-bottom)
-    );
-  }
+  @include chat-height;
 
   &__items {
     overflow-y: scroll;

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -1,3 +1,4 @@
+@import "chat-height-mixin";
 @import "base-common";
 @import "sidebar-extensions";
 @import "chat-browse";


### PR DESCRIPTION
This commit also removes safe-area-inset-bottom when keyboard is displayed to avoid having a taller than needed space between composer and replying indicator.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
