### PR TITLE
DEV: Use `@cached` decorator for `sidebar/user/sections.js`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/sections.js
@@ -2,20 +2,15 @@ import Component from "@glimmer/component";
 import { customSections as sidebarCustomSections } from "discourse/lib/sidebar/custom-sections";
 import { getOwner, setOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
+import { cached } from "@glimmer/tracking";
 
 export default class SidebarUserSections extends Component {
   @service siteSettings;
   @service currentUser;
   @service site;
 
-  customSections;
-
-  constructor() {
-    super(...arguments);
-    this.customSections = this._customSections;
-  }
-
-  get _customSections() {
+  @cached
+  get customSections() {
     return sidebarCustomSections.map((customSection) => {
       const section = new customSection({ sidebar: this });
       setOwner(section, getOwner(this));


### PR DESCRIPTION
Achieves the same thing as the old manual caching

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
