### PR TITLE
FIX: hides global notice on chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -1,4 +1,5 @@
 .has-full-page-chat {
+  .global-notice,
   .create-topics-notice,
   .bootstrap-mode-notice {
     display: none;


### PR DESCRIPTION
It's not necessary and we already hide create-topics-notice and bootstrap mode, and it's also annoying to get correct chat's height.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
