### PR TITLE
FIX: Correctly make d-modal hidden by default

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -71,6 +71,8 @@ export default class DModal extends Component {
 
   @action
   setupListeners(element) {
+    element.classList.add("hidden");
+
     this.appEvents.on("modal:body-shown", this._modalBodyShown);
     this.appEvents.on("modal-body:flash", this._flash);
     this.appEvents.on("modal-body:clearFlash", this._clearFlash);

--- a/app/assets/javascripts/discourse/app/templates/modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal.hbs
@@ -8,7 +8,6 @@
   @onSelectPanel={{this.onSelectPanel}}
   @errors={{this.errors}}
   @closeModal={{route-action "closeModal"}}
-  class="hidden"
 >
   {{outlet "modalBody"}}
 </DModal>

--- a/app/assets/javascripts/discourse/app/templates/modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal.hbs
@@ -6,9 +6,9 @@
   @panels={{this.panels}}
   @selectedPanel={{this.selectedPanel}}
   @onSelectPanel={{this.onSelectPanel}}
-  @class="hidden"
   @errors={{this.errors}}
   @closeModal={{route-action "closeModal"}}
+  class="hidden"
 >
   {{outlet "modalBody"}}
 </DModal>


### PR DESCRIPTION
This regressed during glimmerification of d-modal

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
