### PR TITLE
FIX: Hide d-modal during page load

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/modal.js
+++ b/app/assets/javascripts/discourse/app/controllers/modal.js
@@ -2,5 +2,5 @@ import Controller from "@ember/controller";
 import { tracked } from "@glimmer/tracking";
 
 export default class ModalController extends Controller {
-  @tracked hidden;
+  @tracked hidden = true;
 }


### PR DESCRIPTION
Followup to 4bc769cac083dd90c2c312e691dca91c65725ee7

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
