### PR TITLE
FIX: Ensure modal alert is hidden when empty

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -68,7 +68,7 @@
             )
           }}
         >
-          {{this.flash.text}}
+          {{~this.flash.text~}}
         </div>
 
         {{yield}}


### PR DESCRIPTION
We use the `:empty` css selector on `#modal-alert`, so we need to strip any whitespace from the contents to ensure the selector functions correctly. Followup to ad431ab03ab2d15d0613827183937c643be0c2cd

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
