### PR TITLE
FEATURE: Fuzzy search in site settings and raise limit to 100 matches

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -49,8 +49,15 @@ export default class AdminSiteSettingsController extends Controller {
     };
 
     const matchesGroupedByCategory = [all];
-
     const matches = [];
+
+    const strippedQuery = filter.replace(/[^a-z0-9]/gi, "");
+    let fuzzyRegex;
+
+    if (strippedQuery.length > 2) {
+      fuzzyRegex = new RegExp(strippedQuery.split("").join(".*"), "i");
+    }
+
     allSiteSettings.forEach((settingsCategory) => {
       let fuzzyMatches = [];
 
@@ -68,7 +75,7 @@ export default class AdminSiteSettingsController extends Controller {
             setting.replace(/_/g, " ").includes(filter) ||
             item.get("description").toLowerCase().includes(filter) ||
             (item.get("value") || "").toString().toLowerCase().includes(filter);
-          if (!filterResult && this.fuzzySearch(filter, setting)) {
+          if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
             fuzzyMatches.push(item);
           }
           return filterResult;
@@ -135,17 +142,6 @@ export default class AdminSiteSettingsController extends Controller {
       "adminSiteSettingsCategory",
       category || "all_results"
     );
-  }
-
-  fuzzySearch(query, item) {
-    const strippedQuery = query.replace(/[^a-z0-9]/gi, "");
-
-    if (strippedQuery.length > 2) {
-      const regex = new RegExp(strippedQuery.split("").join(".*"), "i");
-      return regex.test(item);
-    }
-
-    return false;
   }
 
   @observes("filter", "onlyOverridden", "model")

--- a/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
@@ -7,7 +7,7 @@
       />
     {{/each}}
     {{#if this.category.hasMore}}
-      <p class="warning">{{i18n "admin.site_settings.more_than_30_results"}}</p>
+      <p class="warning">{{i18n "admin.site_settings.more_site_setting_results" count=this.category.maxResults}}</p>
     {{/if}}
   </DSection>
 {{else}}

--- a/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
@@ -7,7 +7,10 @@
       />
     {{/each}}
     {{#if this.category.hasMore}}
-      <p class="warning">{{i18n "admin.site_settings.more_site_setting_results" count=this.category.maxResults}}</p>
+      <p class="warning">{{i18n
+          "admin.site_settings.more_site_setting_results"
+          count=this.category.maxResults
+        }}</p>
     {{/if}}
   </DSection>
 {{else}}

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -1,0 +1,42 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import SiteSetting from "admin/models/site-setting";
+
+module("Unit | Controller | admin-site-settings", function (hooks) {
+  setupTest(hooks);
+
+  test("can perform fuzzy search", async function (assert) {
+    const controller = this.owner.lookup("controller:admin-site-settings");
+    const settings = await SiteSetting.findAll();
+
+    let results = controller.performSearch("top_menu", settings);
+    assert.deepEqual(results[0].siteSettings.length, 1);
+
+    results = controller.performSearch("tmenu", settings);
+    assert.deepEqual(results[0].siteSettings.length, 1);
+
+    const settings2 = [
+      {
+        name: "Required",
+        nameKey: "required",
+        siteSettings: [
+          SiteSetting.create({
+            description: "",
+            value: "",
+            setting: "hpello world",
+          }),
+          SiteSetting.create({
+            description: "",
+            value: "",
+            setting: "hello world",
+          }),
+        ],
+      },
+    ];
+
+    results = controller.performSearch("hello world", settings2);
+    assert.deepEqual(results[0].siteSettings.length, 2);
+    // ensures hello world shows up before fuzzy hpello world
+    assert.deepEqual(results[0].siteSettings[0].setting, "hello world");
+  });
+});

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6050,7 +6050,7 @@ en:
         title: "Settings"
         no_results: "No results found."
         more_site_setting_results:
-          one: "There is more than 1 result. Please refine your search or select a category."
+          one: "There is more than %{count} result. Please refine your search or select a category."
           other: "There are more than %{count} results. Please refine your search or select a category."
         clear_filter: "Clear"
         add_url: "add URL"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6049,7 +6049,9 @@ en:
             label: "Add Emoji"
         title: "Settings"
         no_results: "No results found."
-        more_than_30_results: "There are more than 30 results. Please refine your search or select a category."
+        more_site_setting_results:
+          one: "There is more than 1 result. Please refine your search or select a category."
+          other: "There are more than %{count} results. Please refine your search or select a category."
         clear_filter: "Clear"
         add_url: "add URL"
         add_host: "add host"


### PR DESCRIPTION
We have been struggling lately finding site settings due to 30 setting limit

This was introduced for performance reasons a while back but is no longer as
needed give that ember is faster.

Additionally searching is hard, so allow people to use fuzzy search against
setting name.