### PR TITLE
FIX: Drawer styles for chat thread icon

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/thread-list-button.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/thread-list-button.hbs
@@ -2,7 +2,7 @@
   @route="chat.channel.threads"
   @models={{this.chat.activeChannel.routeModels}}
   title={{i18n "chat.threads.list"}}
-  class="open-thread-list-btn btn btn-flat"
+  class="open-thread-list-btn btn btn-link btn-flat chat-drawer-header__thread-list-btn"
   {{on "click" this.stopPropagation}}
 >
   {{d-icon "discourse-threads"}}

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -208,6 +208,7 @@ a.chat-drawer-header__title {
   &__close-btn,
   &__back-btn,
   &__full-screen-btn,
+  &__thread-list-btn,
   &__expand-btn {
     height: 30px;
     width: 30px;
@@ -222,6 +223,7 @@ a.chat-drawer-header__title {
 
     .d-icon {
       color: var(--primary-low-mid);
+      margin-right: 0;
     }
 
     &:visited {


### PR DESCRIPTION
The spacing was not correct for this icon
in the drawer.
