### PR TITLE
DEV: Add support for array params in topic-list finder

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -2,39 +2,37 @@ import PreloadStore from "discourse/lib/preload-store";
 import RestAdapter from "discourse/adapters/rest";
 import { ajax } from "discourse/lib/ajax";
 
-export function finderFor(filter, params) {
-  return function () {
-    let url = `/${filter}.json`;
+export default RestAdapter.extend({
+  find(store, type, { filter, params }) {
+    return PreloadStore.getAndRemove("topic_list", () => {
+      let url = `/${filter}.json`;
 
-    if (params) {
-      const urlSearchParams = new URLSearchParams();
+      if (params) {
+        const urlSearchParams = new URLSearchParams();
 
-      for (const [key, value] of Object.entries(params)) {
-        if (typeof value !== "undefined") {
-          urlSearchParams.set(key, value);
+        for (const [key, value] of Object.entries(params)) {
+          if (typeof value === "undefined") {
+            continue;
+          }
+
+          if (Array.isArray(value)) {
+            for (const arrayValue of value) {
+              urlSearchParams.append(`${key}[]`, arrayValue);
+            }
+          } else {
+            urlSearchParams.set(key, value);
+          }
+        }
+
+        const queryString = urlSearchParams.toString();
+
+        if (queryString) {
+          url += `?${queryString}`;
         }
       }
 
-      const queryString = urlSearchParams.toString();
-
-      if (queryString) {
-        url += `?${queryString}`;
-      }
-    }
-
-    return ajax(url);
-  };
-}
-
-export default RestAdapter.extend({
-  find(store, type, findArgs) {
-    const filter = findArgs.filter;
-    const params = findArgs.params;
-
-    return PreloadStore.getAndRemove(
-      "topic_list",
-      finderFor(filter, params)
-    ).then(function (result) {
+      return ajax(url);
+    }).then((result) => {
       result.filter = filter;
       result.params = params;
       return result;

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -7,6 +7,7 @@ import { ajax } from "discourse/lib/ajax";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { isEmpty } from "@ember/utils";
 import { notEmpty } from "@ember/object/computed";
+import deprecated from "discourse-common/lib/deprecated";
 
 function extractByKey(collection, klass) {
   const retval = {};
@@ -195,6 +196,16 @@ TopicList.reopenClass({
   },
 
   find(filter, params) {
+    deprecated(
+      `TopicList.find is deprecated. Use \`findFiltered("topicList")\` on the \`store\` service instead.`,
+      {
+        id: "topic-list-find",
+        since: "3.1.0.beta5",
+        dropFrom: "3.2.0.beta1",
+        raiseError: true,
+      }
+    );
+
     const store = getOwner(this).lookup("service:store");
     return store.findFiltered("topicList", { filter, params });
   },

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -202,7 +202,6 @@ TopicList.reopenClass({
         id: "topic-list-find",
         since: "3.1.0.beta5",
         dropFrom: "3.2.0.beta1",
-        raiseError: true,
       }
     );
 


### PR DESCRIPTION
It wasn't possible (at least in any reasonable way) to pass params like `tags`. Also removes the export and inlines the function as that was used only to test the function and the test is gone.