### PR TITLE
FIX: allow admin to change topic notification level via API

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -806,7 +806,7 @@ class TopicsController < ApplicationController
     user =
       if is_api? && @guardian.is_admin?
         begin
-          fetch_user_from_params
+          fetch_user_from_params if (params[:username].present? || params[:external_id].present?)
         rescue Discourse::NotFound
           current_user
         end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -806,11 +806,7 @@ class TopicsController < ApplicationController
     user =
       if is_api? && @guardian.is_admin? &&
            (params[:username].present? || params[:external_id].present?)
-        begin
-          fetch_user_from_params
-        rescue Discourse::NotFound
-          current_user
-        end
+        fetch_user_from_params
       else
         current_user
       end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -805,7 +805,11 @@ class TopicsController < ApplicationController
   def set_notifications
     user =
       if is_api? && @guardian.is_admin?
-        fetch_user_from_params
+        begin
+          fetch_user_from_params
+        rescue Discourse::NotFound
+          current_user
+        end
       else
         current_user
       end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -803,8 +803,15 @@ class TopicsController < ApplicationController
   end
 
   def set_notifications
+    user =
+      if is_api? && @guardian.is_admin?
+        fetch_user_from_params
+      else
+        current_user
+      end
+
     topic = Topic.find(params[:topic_id].to_i)
-    TopicUser.change(current_user, topic.id, notification_level: params[:notification_level].to_i)
+    TopicUser.change(user, topic.id, notification_level: params[:notification_level].to_i)
     render json: success_json
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -804,9 +804,10 @@ class TopicsController < ApplicationController
 
   def set_notifications
     user =
-      if is_api? && @guardian.is_admin?
+      if is_api? && @guardian.is_admin? &&
+           (params[:username].present? || params[:external_id].present?)
         begin
-          fetch_user_from_params if (params[:username].present? || params[:external_id].present?)
+          fetch_user_from_params
         rescue Discourse::NotFound
           current_user
         end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4844,7 +4844,7 @@ RSpec.describe TopicsController do
 
   describe "#set_notifications" do
     describe "initiated by admin" do
-      it "allows fetches user from params if the request is_api? " do
+      it "admins can update another user's notification level via API" do
         api_key = Fabricate(:api_key, user: admin)
         post "/t/#{topic.id}/notifications",
              params: {

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4844,7 +4844,7 @@ RSpec.describe TopicsController do
 
   describe "#set_notifications" do
     describe "initiated by admin" do
-      it "admins can update another user's notification level via API" do
+      it "can update another user's notification level via API" do
         api_key = Fabricate(:api_key, user: admin)
         post "/t/#{topic.id}/notifications",
              params: {
@@ -4856,6 +4856,21 @@ RSpec.describe TopicsController do
                HTTP_API_USERNAME: admin.username,
              }
         expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(
+          NotificationLevels.topic_levels[:watching],
+        )
+      end
+
+      it "can update own notification level via API" do
+        api_key = Fabricate(:api_key, user: admin)
+        post "/t/#{topic.id}/notifications",
+             params: {
+               notification_level: NotificationLevels.topic_levels[:watching],
+             },
+             headers: {
+               HTTP_API_KEY: api_key.key,
+               HTTP_API_USERNAME: admin.username,
+             }
+        expect(TopicUser.find_by(user: admin, topic: topic).notification_level).to eq(
           NotificationLevels.topic_levels[:watching],
         )
       end
@@ -4879,6 +4894,22 @@ RSpec.describe TopicsController do
           NotificationLevels.topic_levels[:watching],
         )
         expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
+      end
+
+      it "can update own notification level via API" do
+        api_key = Fabricate(:api_key, user: user)
+        post "/t/#{topic.id}/notifications",
+             params: {
+               notification_level: NotificationLevels.topic_levels[:watching],
+             },
+             headers: {
+               HTTP_API_KEY: api_key.key,
+               HTTP_API_USERNAME: user.username,
+             }
+
+        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(
+          NotificationLevels.topic_levels[:watching],
+        )
       end
     end
   end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
