### PR TITLE
FIX: Don't show duplicates in styleguide

### DIFF
--- a/plugins/styleguide/assets/javascripts/discourse/components/styleguide-icons.js
+++ b/plugins/styleguide/assets/javascripts/discourse/components/styleguide-icons.js
@@ -19,7 +19,7 @@ export default Component.extend({
     if (symbols.length > 0) {
       let ids = Array.from(symbols).mapBy("id");
       ids.push(...Object.keys(REPLACEMENTS));
-      this.set("iconIds", ids.sort());
+      this.set("iconIds", [...new Set(ids.sort())]);
     } else {
       // Let's try again a short time later if there are no svgs loaded yet
       discourseLater(this, this.setIconIds, 1500);


### PR DESCRIPTION
Adding in the replacements was not deduplicating them. Issue was introduced in ef62c85. 

Before

<img width="815" alt="image" src="https://github.com/discourse/discourse/assets/368961/214ca926-00a2-4580-a9f9-15d083e1307f">

After

<img width="832" alt="image" src="https://github.com/discourse/discourse/assets/368961/2a7c2db0-807e-4b68-9a1e-9378bd575ecb">
