### PR TITLE
UX: improve tags spacing

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -260,7 +260,6 @@
       padding-top: 0;
       padding-bottom: 0;
     }
-    .discourse-tag.simple:after,
     .discourse-tag.box {
       margin-right: 0.25em;
     }

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -323,13 +323,6 @@
       min-height: 3em; // for situations when there are no categories/tags
     }
 
-    .topic-title {
-      .d-icon {
-        color: var(--text-color);
-        margin: 0;
-      }
-    }
-
     .fancy-title {
       display: inline-block;
       width: 100%;
@@ -342,6 +335,10 @@
       align-items: baseline;
       color: var(--text-color);
       font-size: var(--font-up-1);
+      .d-icon {
+        color: var(--text-color);
+        margin: 0;
+      }
     }
 
     .topic-statuses {

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -114,7 +114,7 @@
 .list-tags,
 .search-category {
   .discourse-tag.simple:not(:last-child):after {
-    content: ", ";
+    content: ",\00a0";
     margin-left: 1px;
   }
 }
@@ -160,7 +160,7 @@ header .discourse-tag {
 }
 
 #topic-title {
-  .discourse-tags .discourse-tag {
+  .discourse-tags .discourse-tag.box {
     margin-right: 0.35em;
   }
 }


### PR DESCRIPTION
Improves tags spacing overall and fixes it on the "reply-where" modal.
Also adds spaces after the category icons in this modal.

Before:
![image](https://github.com/discourse/discourse/assets/5654300/8d0a718e-a422-4940-9667-c9eebb2f5548)

After:
![image](https://github.com/discourse/discourse/assets/5654300/15f45760-900d-4043-a570-45df508208bb)
