### PR TITLE
DEV: Bump the limits on group request text fields

### DIFF
--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -375,7 +375,7 @@ const Group = RestModel.extend({
   },
 
   requestMembership(reason) {
-    return ajax(`/groups/${this.name}/request_membership`, {
+    return ajax(`/groups/${this.name}/request_membership.json`, {
       type: "POST",
       data: { reason },
     });

--- a/app/assets/javascripts/discourse/app/templates/modal/request-group-membership-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/request-group-membership-form.hbs
@@ -5,7 +5,7 @@
         {{i18n "groups.membership_request.reason"}}
       </label>
 
-      <ExpandingTextArea @value={{this.reason}} @maxlength="280" />
+      <ExpandingTextArea @value={{this.reason}} @maxlength="5000" />
     </div>
   </DModalBody>
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -10,7 +10,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
 function setupGroupPretender(server, helper) {
-  server.post("/groups/Macdonald/request_membership", () => {
+  server.post("/groups/Macdonald/request_membership.json", () => {
     return helper.response({
       relative_url: "/t/internationalization-localization/280",
     });

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -91,7 +91,7 @@ class Group < ActiveRecord::Base
   validate :validate_grant_trust_level, if: :will_save_change_to_grant_trust_level?
   validates :automatic_membership_email_domains, length: { maximum: 1000 }
   validates :bio_raw, length: { maximum: 3000 }
-  validates :membership_request_template, length: { maximum: 500 }
+  validates :membership_request_template, length: { maximum: 5000 }
   validates :full_name, length: { maximum: 100 }
 
   AUTO_GROUPS = {

--- a/app/models/group_request.rb
+++ b/app/models/group_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GroupRequest < ActiveRecord::Base
-  REASON_CHARACTER_LIMIT = 280
+  REASON_CHARACTER_LIMIT = 5000
 
   belongs_to :group
   belongs_to :user

--- a/spec/models/group_request_spec.rb
+++ b/spec/models/group_request_spec.rb
@@ -3,8 +3,5 @@
 RSpec.describe GroupRequest do
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :group }
-
-  it do
-    is_expected.to validate_length_of(:reason).is_at_most(described_class::REASON_CHARACTER_LIMIT)
-  end
+  it { is_expected.to validate_length_of(:reason).is_at_most(5000) }
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Group do
       is_expected.not_to allow_value("#{"a" * 997}.com").for(:automatic_membership_email_domains)
     end
     it { is_expected.to validate_length_of(:bio_raw).is_at_most(3000) }
-    it { is_expected.to validate_length_of(:membership_request_template).is_at_most(500) }
+    it { is_expected.to validate_length_of(:membership_request_template).is_at_most(5000) }
     it { is_expected.to validate_length_of(:full_name).is_at_most(100) }
 
     describe "#grant_trust_level" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2208,7 +2208,7 @@ RSpec.describe GroupsController do
 
       expect(response.status).to eq(422)
       expect(response.parsed_body["errors"]).to contain_exactly(
-        "Reason is too long (maximum is 280 characters)",
+        "Reason is too long (maximum is 5000 characters)",
       )
     end
 


### PR DESCRIPTION
Users submitting requests to join groups were not receiving errors when the character limit for the request was exceeded. This also affects the UX when admin-created group request templates are inserted into the request.

This PR bumps the limits.

- https://meta.discourse.org/t/group-membership-requests-suddenly-limited-to-274-characters/265127
- https://github.com/discourse/discourse/pull/19993