### PR TITLE
DEV: Don't pass in extra, ignored parameters when rendering sass

### DIFF
--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -55,10 +55,6 @@ module Stylesheet
           style: :compressed,
           source_map_file: source_map_file,
           source_map_contents: true,
-          theme_id: options[:theme_id],
-          theme: options[:theme],
-          theme_field: options[:theme_field],
-          color_scheme_id: options[:color_scheme_id],
           load_paths: load_paths,
           validate_source_map_path: false,
         )


### PR DESCRIPTION
As far as I can tell, these parameters do nothing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
