### PR TITLE
FIX: followups to composer notch adjustments

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -592,7 +592,6 @@ html.has-full-page-chat {
       .full-page-chat {
         height: 100%;
         min-height: 0;
-        padding-bottom: env(safe-area-inset-bottom);
       }
 
       .main-chat-outlet {

--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -1,7 +1,7 @@
 .chat-browse-view {
   position: relative;
   box-sizing: border-box;
-  padding: 1rem;
+  padding: 1rem 1rem env(safe-area-inset-bottom) 1rem;
 
   &__header {
     display: flex;

--- a/plugins/chat/assets/stylesheets/common/chat-tabs.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-tabs.scss
@@ -8,6 +8,7 @@
 .chat-tabs__tabpanel {
   height: 100%;
   min-height: 1px;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .chat-tabs-list {


### PR DESCRIPTION
We had safe-area-inset-bottom still set at a wrong place which was causing issues but was also useful to some cases. This commit removes it and ensures the affected cases are corrected.