### PR TITLE
UX: Remove welcome topic admin tip and tweak copy

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -149,14 +149,6 @@
                 class="edit-topic"
                 title={{i18n "edit"}}
               >{{d-icon "pencil-alt"}}</a>
-
-              {{#if (eq this.siteSettings.welcome_topic_id this.model.id)}}
-                <UserTip
-                  @id="welcome_topic"
-                  @selector=".edit-topic"
-                  @placement="bottom"
-                />
-              {{/if}}
             {{/if}}
 
             <PluginOutlet

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -355,7 +355,6 @@ class User < ActiveRecord::Base
         post_menu: 3,
         topic_notification_levels: 4,
         suggested_topics: 5,
-        welcome_topic: 6,
       )
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1931,10 +1931,6 @@ en:
         title: "Keep reading!"
         content: "Here are some topics we think you might like to read next."
 
-      welcome_topic:
-        title: "Edit the welcome topic"
-        content: "Help new members feel at home by customizing this topic to suit your community's needs."
-
     loading: "Loading..."
     errors:
       prev_page: "while trying to load"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -680,8 +680,12 @@ en:
   discourse_welcome_topic:
     title: "Welcome to %{site_title}! :wave:"
     body: |
-      We are so glad you joined us. %{site_description}
-      
+      We are so glad you joined us.
+
+      > ## %{site_title}
+      >
+      > %{site_description}
+
       Here are some things you can do to get started:
 
       :speaking_head: **Introduce yourself** by adding your picture and information about yourself and your interests to [your profile](%{base_path}/my/preferences/account). What is one thing you’d like to be asked about?

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2493,7 +2493,6 @@ uncategorized:
   welcome_topic_id:
     default: -1
     hidden: true
-    client: true
   admin_quick_start_topic_id:
     default: -1
     hidden: true

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -241,9 +241,6 @@
         },
         "suggested_topics": {
           "type": "integer"
-        },
-        "welcome_topic": {
-          "type": "integer"
         }
       },
       "required": [


### PR DESCRIPTION
The welcome topic user tip was for admins only, but in general, user tips should be used for guiding new users through the features that Discourse offers. For this reason, we decided to remove the user tip.

This commit also includes a few more copy tweaks to the welcome topic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
