### PR TITLE
DEV: prevents `rake emoji:update` to run on prod

### DIFF
--- a/lib/tasks/emoji.rake
+++ b/lib/tasks/emoji.rake
@@ -277,6 +277,8 @@ end
 
 desc "update emoji images"
 task "emoji:update" do
+  abort("This task can't be run on production.") if Rails.env.production?
+
   copy_emoji_db
 
   json_db = File.read(File.join(GENERATED_PATH, "db.json"))


### PR DESCRIPTION
This task is only designed to help generate a pull request to update official emoji images. It should never be run directly on production.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
