### PR TITLE
UI: removes thread margins

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -19,8 +19,6 @@
   &__body {
     overflow-y: scroll;
     @include chat-scrollbar();
-    margin: 2px;
-    padding-right: 2px;
     box-sizing: border-box;
     flex-grow: 1;
     overscroll-behavior: contain;


### PR DESCRIPTION
Before:

<img width="341" alt="Screenshot 2023-05-16 at 21 09 14" src="https://github.com/discourse/discourse/assets/339945/664f02a7-cacd-48f8-bba7-6bb358a96c07">

After:

<img width="265" alt="Screenshot 2023-05-16 at 21 09 34" src="https://github.com/discourse/discourse/assets/339945/9e6c3f39-6223-427e-858d-3f9b1859cb48">

