### PR TITLE
FIX: Sync channel tracking state properly on presence change

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -108,6 +108,8 @@ export default class Chat extends Service {
   @bind
   onPresenceChangeCallback(present) {
     if (present) {
+      // NOTE: channels is more than a simple array, it also contains
+      // tracking and membership data, see Chat::StructuredChannelSerializer
       this.chatApi.listCurrentUserChannels().then((channels) => {
         this.chatSubscriptionsManager.restartChannelsSubscriptions(
           channels.meta.message_bus_last_ids
@@ -122,6 +124,13 @@ export default class Chat extends Service {
             .then((channel) => {
               if (channel) {
                 channel.updateMembership(channelObject.current_user_membership);
+
+                const channelTrackingState =
+                  channels.tracking.channel_tracking[channel.id];
+                channel.tracking.unreadCount =
+                  channelTrackingState.unread_count;
+                channel.tracking.mentionCount =
+                  channelTrackingState.mention_count;
               }
             });
         });


### PR DESCRIPTION
Followup from 9953a6edd92654845bb34773550d14cb7850240e,
which broke an issue fixed in e8d6277062e711b8c33829b1d708100822cca167.

In the refactor we did not update the place where we resync
channel tracking based on onPresenceChange to use the new
tracking object we added to the serializer, and to directly
update channel.tracking
