### PR TITLE
FIX: compensate for lack of replying indicator on draft

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
@@ -37,7 +37,9 @@
     }
   }
 
-  .chat-composer__wrapper {
-    padding-bottom: 0.5em;
+  .ios-device.keyboard-visible & {
+    .chat-composer__wrapper {
+      padding-bottom: 1rem;
+    }
   }
 }


### PR DESCRIPTION
As we don't have the spacing generated by the replying indicator, we need to manually add spacing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
