### PR TITLE
FIX: Clear topic list cache after archiving a PM

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -6,6 +6,7 @@ import discourseComputed, {
   bind,
   observes,
 } from "discourse-common/utils/decorators";
+import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
 import { isEmpty, isPresent } from "@ember/utils";
 import { next, schedule } from "@ember/runloop";
 import discourseLater from "discourse-common/lib/later";
@@ -579,7 +580,10 @@ export default Controller.extend(bufferedProperty("model"), {
         return;
       }
 
-      const backToInbox = () => this.gotoInbox(topic.get("inboxGroupName"));
+      const backToInbox = () => {
+        resetCachedTopicList(this.session);
+        this.gotoInbox(topic.get("inboxGroupName"));
+      };
 
       if (topic.get("message_archived")) {
         topic.moveToInbox().then(backToInbox);

--- a/app/assets/javascripts/discourse/app/lib/cached-topic-list.js
+++ b/app/assets/javascripts/discourse/app/lib/cached-topic-list.js
@@ -1,13 +1,25 @@
+export function setCachedTopicList(session, topicList) {
+  session.set("topicList", topicList);
+}
+
+export function getCachedTopicList(session) {
+  session.get("topicList");
+}
+
+export function resetCachedTopicList(session) {
+  session.setProperties({
+    topicList: null,
+    topicListScrollPosition: null,
+  });
+}
+
 export function findOrResetCachedTopicList(session, filter) {
   const lastTopicList = session.get("topicList");
 
   if (lastTopicList && lastTopicList.filter === filter) {
     return lastTopicList;
   } else {
-    session.setProperties({
-      topicList: null,
-      topicListScrollPosition: null,
-    });
+    resetCachedTopicList(session);
     return false;
   }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, currentURL, visit } from "@ember/test-helpers";
 import DiscourseURL from "discourse/lib/url";
 import {
   acceptance,
@@ -8,6 +8,11 @@ import {
 import I18n from "I18n";
 import { test } from "qunit";
 import sinon from "sinon";
+import {
+  getCachedTopicList,
+  setCachedTopicList,
+} from "discourse/lib/cached-topic-list";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 acceptance("Personal Message", function (needs) {
   needs.user();
@@ -19,6 +24,17 @@ acceptance("Personal Message", function (needs) {
       query("#suggested-topics .suggested-topics-title").innerText.trim(),
       I18n.t("suggested_topics.pm_title")
     );
+  });
+
+  test("redirects to inbox after topic is archived and clears topicList cache", async function (assert) {
+    const session = getOwner(this).lookup("service:session");
+    setCachedTopicList(session, {});
+
+    await visit("/t/pm-for-testing/12");
+    await click(".archive-topic");
+
+    assert.strictEqual(currentURL(), "/u/eviltrout/messages");
+    assert.notOk(getCachedTopicList(session), "topic list cached is cleared");
   });
 });
 


### PR DESCRIPTION
Context of the problem

When viewing the topic list for either the personal inbox or the group
PM inbox, we store a cache of the topic list if the user has loaded more
topics in the topic list. This cache is used to improve the experience
for users so that navigating to a topic and then back would not make
them lose their "last read" position in the topic list. Without this
cache, users will have to start from the top of the topic list each time
they navigate back after reading a topic.

What is the problem?

After archiving a PM, the user is redirected to either the personal
inbox or the group PM inbox. The problem is that if a topic list cache
exists, we will render the topic list using the cache. However, this
means that the archived PM will still appear in the list leading to
confusion for our users.

What is the fix?

To fix this, we will simply clear the topic list cache after a user
archives a topic.