### PR TITLE
FIX: Searching for svg sprite icons connecting to default database

### DIFF
--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -32,27 +32,23 @@ class SvgSpriteController < ApplicationController
   end
 
   def search
-    RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
-      keyword = params.require(:keyword)
-      data = SvgSprite.search(keyword)
+    keyword = params.require(:keyword)
+    data = SvgSprite.search(keyword)
 
-      if data.blank?
-        render body: nil, status: 404
-      else
-        render plain: data.inspect, disposition: nil, content_type: "text/plain"
-      end
+    if data.blank?
+      render body: nil, status: 404
+    else
+      render plain: data.inspect, disposition: nil, content_type: "text/plain"
     end
   end
 
   def icon_picker_search
-    RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
-      params.permit(:filter, :only_available)
-      filter = params[:filter] || ""
-      only_available = params[:only_available]
+    params.permit(:filter, :only_available)
+    filter = params[:filter] || ""
+    only_available = params[:only_available]
 
-      icons = SvgSprite.icon_picker_search(filter, only_available)
-      render json: icons.take(200), root: false
-    end
+    icons = SvgSprite.icon_picker_search(filter, only_available)
+    render json: icons.take(200), root: false
   end
 
   def svg_icon

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe SvgSpriteController do
   end
 
   describe "#icon_picker_search" do
+    it "should return 403 for anonymous users" do
+      get "/svg-sprite/picker-search"
+
+      expect(response.status).to eq(403)
+    end
+
     it "should work with no filter and max out at 200 results" do
       user = sign_in(Fabricate(:user))
       get "/svg-sprite/picker-search"


### PR DESCRIPTION
## What is the problem?

In `SvgSpriteController#search` and `SvgSpriteController#icon_picker_search`, the controller actions
were using the `RailsMultisite::ConnectionManagement.with_hostname` API
but `params[:hostname]` was always `nil` because the routes do not
have a `:hostname` param component and the client does not ever pass the
`:hostname` param when making the request. When `RailsMultisite::ConnectionManagement.with_hostname` is
used with a `nil` argument, it ends up connecting to the default
multisite database. Usually this would be bad because we're allowing a
site in a multisite setup to connect to another site but thankfully no
private data is being leaked here.

## What is the fix?

Since `SvgSpriteController#search` and `SvgSpriteController#icon_picker_search` are login required route,
there is no need for us to switch database connections. The fix here is
to simply remove the use of `RailsMultisite::ConnectionManagement.with_hostname`.

## Reviewer Notes

Note that there isn't really a meaningful test we can write to protect us here because we're simply removing code that shouldn't have been written in the first place. 