### PR TITLE
FIX: Remove obsolete references to lounge category

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -869,7 +869,7 @@ class Category < ActiveRecord::Base
 
   def seeded?
     [
-      SiteSetting.lounge_category_id,
+      SiteSetting.general_category_id,
       SiteSetting.meta_category_id,
       SiteSetting.staff_category_id,
       SiteSetting.uncategorized_category_id,

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe SeedData::Categories do
     end
 
     it "does not override permissions of existing category when not forced" do
-      create_category("lounge_category_id")
+      create_category("general_category_id")
 
       category = Category.last
       category.set_permissions(trust_level_2: :full)
@@ -143,7 +143,7 @@ RSpec.describe SeedData::Categories do
 
       expect(category.category_groups.first).to have_attributes(permissions(:trust_level_2, :full))
 
-      expect { create_category("lounge_category_id") }.not_to change { CategoryGroup.count }
+      expect { create_category("general_category_id") }.not_to change { CategoryGroup.count }
 
       category.reload
       expect(category.category_groups.first).to have_attributes(permissions(:trust_level_2, :full))


### PR DESCRIPTION
### What is this change?

The lounge category was replaced with the general category in https://github.com/discourse/discourse/pull/18097.

However, there are still a few references to the lounge category in code. In particular, `Category#seeded?` is erroring out in production looking for `SiteSetting.lounge_category_id`.