### PR TITLE
FIX: ensures chat composer docks to topic composer

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -3,7 +3,8 @@
   height: calc(
     var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
       var(--chat-draft-header-height, 0px) -
-      var(--chat-direct-message-creator-height, 0px) - $inset
+      var(--chat-direct-message-creator-height, 0px) -
+      var(--composer-height, 0px) - $inset
   );
 
   // mobile with keyboard opened
@@ -20,7 +21,8 @@
     height: calc(
       var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
         var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
-        var(--chat-direct-message-creator-height, 0px)
+        var(--chat-direct-message-creator-height, 0px) -
+        var(--composer-height, 0px)
     );
   }
 


### PR DESCRIPTION
Before:

<img width="1396" alt="Screenshot 2023-05-17 at 11 08 22" src="https://github.com/discourse/discourse/assets/339945/b75ed3ed-a9fe-498e-be02-62c9c7f9c9fb">

After:

<img width="1554" alt="Screenshot 2023-05-17 at 10 23 58" src="https://github.com/discourse/discourse/assets/339945/02b56c0a-011e-4218-9613-972f041aa5d0">
