### PR TITLE
FIX: more resilient bottom of message check

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -1000,7 +1000,7 @@ export default class ChatLivePane extends Component {
   #isBottomOfMessageVisible(element, container) {
     const rect = element.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
-    // - 1.0 to account for rounding errors, especially on firefox
-    return rect.bottom - 1.0 <= containerRect.bottom;
+    // - 5.0 to account for rounding errors, especially on firefox
+    return rect.bottom - 5.0 <= containerRect.bottom;
   }
 }


### PR DESCRIPTION
1.0 lenience might not be enough in rare cases and there are no real consequences to slightly increase it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
