### PR TITLE
FIX: ensures replying indicator has limited height

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
@@ -3,6 +3,10 @@
   display: inline-flex;
   font-size: var(--font-down-2);
 
+  &-container {
+    display: flex;
+  }
+
   &:before {
     // unicode zero width space character
     // Ensures the span height is consistent even when empty


### PR DESCRIPTION
Before:

<img width="469" alt="Screenshot 2023-05-17 at 17 58 25" src="https://github.com/discourse/discourse/assets/339945/9e6aa90d-0044-4bf6-a506-32a78d532909">

After:

<img width="465" alt="Screenshot 2023-05-17 at 17 58 21" src="https://github.com/discourse/discourse/assets/339945/f03e48f7-08bd-4c21-bd04-5ddf37f09bbb">
