### PR TITLE
Clarify "disable tags/category notification" settings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2200,9 +2200,9 @@ en:
 
     disable_system_edit_notifications: "Disables edit notifications by the system user when 'download_remote_images_to_local' is active."
 
-    disable_category_edit_notifications: "Disable category edit notifications on topics."
+    disable_category_edit_notifications: "Disable notifications when editing topic category."
 
-    disable_tags_edit_notifications: "Disable tags edit notifications on topics."
+    disable_tags_edit_notifications: "Disable notifications when editing topic tags."
 
     notification_consolidation_threshold: "Number of liked or membership request notifications received before the notifications are consolidated into a single one. Set to 0 to disable."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2200,9 +2200,9 @@ en:
 
     disable_system_edit_notifications: "Disables edit notifications by the system user when 'download_remote_images_to_local' is active."
 
-    disable_category_edit_notifications: "Disable notifications when editing topic category."
+    disable_category_edit_notifications: "Disable notifications for topic category edits."
 
-    disable_tags_edit_notifications: "Disable notifications when editing topic tags."
+    disable_tags_edit_notifications: "Disable notifications for topic tag edits."
 
     notification_consolidation_threshold: "Number of liked or membership request notifications received before the notifications are consolidated into a single one. Set to 0 to disable."
 


### PR DESCRIPTION
Slightly improved wordings here that — to my understanding — are more accurate and no longer just parrot the setting id.

Cf. https://meta.discourse.org/t/bulk-editing-topic-categories-should-not-trigger-thousands-of-email-notifications/265269/4

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
