### PR TITLE
FEATURE: admin can edit community section

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -23,6 +23,13 @@
             dragMove=link.dragMove
           }}
         />
+      {{else if link.action}}
+        <Sidebar::SectionButton
+          @action={{link.action}}
+          @content={{link.text}}
+          @prefixType="icon"
+          @prefixValue={{link.prefixValue}}
+        />
       {{else}}
         <Sidebar::SectionLink
           @shouldDisplay={{link.shouldDisplay}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
@@ -1,15 +1,37 @@
-<Sidebar::SectionLink
-  @shouldDisplay={{@sectionLink.shouldDisplay}}
-  @linkName={{@sectionLink.name}}
-  @route={{@sectionLink.route}}
-  @href={{@sectionLink.href}}
-  @query={{@sectionLink.query}}
-  @title={{@sectionLink.title}}
-  @content={{@sectionLink.text}}
-  @currentWhen={{@sectionLink.currentWhen}}
-  @badgeText={{@sectionLink.badgeText}}
-  @model={{@sectionLink.model}}
-  @models={{@sectionLink.models}}
-  @prefixType={{@sectionLink.prefixType}}
-  @prefixValue={{@sectionLink.prefixValue}}
-/>
+{{#if @sectionLink.shouldDisplay}}
+  {{#if @sectionLink.external}}
+    <Sidebar::SectionLink
+      @linkName={{@sectionLink.name}}
+      @content={{replace-emoji @sectionLink.text}}
+      @prefixType="icon"
+      @prefixValue={{@sectionLink.prefixValue}}
+      @href={{@sectionLink.value}}
+    />
+  {{else if @sectionLink.action}}
+    <Sidebar::SectionButton
+      @action={{@sectionLink.action}}
+      @content={{@sectionLink.text}}
+      @prefixType="icon"
+      @prefixValue={{@sectionLink.prefixValue}}
+    />
+  {{else}}
+    <Sidebar::SectionLink
+      @shouldDisplay={{@sectionLink.shouldDisplay}}
+      @href={{@sectionLink.href}}
+      @title={{@sectionLink.title}}
+      @linkName={{@sectionLink.name}}
+      @route={{@sectionLink.route}}
+      @model={{@sectionLink.model}}
+      @models={{@sectionLink.models}}
+      @query={{@sectionLink.query}}
+      @content={{replace-emoji @sectionLink.text}}
+      @badgeText={{@sectionLink.badgeText}}
+      @prefixType="icon"
+      @prefixValue={{@sectionLink.prefixValue}}
+      @suffixCSSClass={{@sectionLink.suffixCSSClass}}
+      @suffixValue={{@sectionLink.suffixValue}}
+      @suffixType={{@sectionLink.suffixType}}
+      @currentWhen={{@sectionLink.currentWhen}}
+    />
+  {{/if}}
+{{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-button.hbs
@@ -1,0 +1,6 @@
+<DButton
+  @icon={{@prefixValue}}
+  @action={{@action}}
+  @class="btn-flat sidebar-button"
+  @translatedLabel={{@content}}
+/>

--- a/app/assets/javascripts/discourse/app/components/sidebar/sidebar-section-form-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/sidebar-section-form-link.hbs
@@ -1,0 +1,62 @@
+<div
+  class={{concat-class "row-wrapper" this.dragCssClass}}
+  draggable="true"
+  {{on "dragstart" this.dragHasStarted}}
+  {{on "dragover" this.dragOver}}
+  {{on "dragleave" this.dragLeave}}
+  {{on "dragend" this.dragEnd}}
+  {{on "drop" this.dropItem}}
+>
+  <div class="draggable" data-link-name={{@link.name}}>
+    {{d-icon "grip-lines"}}
+  </div>
+  <div class="input-group">
+    <IconPicker
+      @name="icon"
+      @value={{@link.icon}}
+      @options={{hash maximum=1}}
+      class={{@link.iconCssClass}}
+      @onlyAvailable={{true}}
+      @onChange={{action (mut @link.icon)}}
+    />
+    {{#if @link.invalidIconMessage}}
+      <div class="icon warning">
+        {{@link.invalidIconMessage}}
+      </div>
+    {{/if}}
+  </div>
+  <div class="input-group">
+    <Input
+      name="link-name"
+      @type="text"
+      @value={{@link.name}}
+      class={{@link.nameCssClass}}
+      {{on "input" (action (mut @link.name) value="target.value")}}
+    />
+    {{#if @link.invalidNameMessage}}
+      <div class="name warning">
+        {{@link.invalidNameMessage}}
+      </div>
+    {{/if}}
+  </div>
+  <div class="input-group">
+    <Input
+      name="link-url"
+      @type="text"
+      @value={{@link.value}}
+      class={{@link.valueCssClass}}
+      {{on "input" (action (mut @link.value) value="target.value")}}
+    />
+    {{#if @link.invalidValueMessage}}
+      <div class="value warning">
+        {{@link.invalidValueMessage}}
+      </div>
+    {{/if}}
+  </div>
+  <DButton
+    @icon="trash-alt"
+    @action={{action @deleteLink @link}}
+    @class="btn-flat delete-link"
+    @title="sidebar.sections.custom.links.delete"
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/sidebar-section-form-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/sidebar-section-form-link.js
@@ -1,0 +1,62 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+
+export default class SidebarSectionFormLink extends Component {
+  @tracked dragCssClass;
+
+  constructor() {
+    super(...arguments);
+    this.link = this.args.link;
+    this.reorderCallback = this.args.reorderCallback;
+    this.deleteLink = this.args.deleteLink;
+  }
+
+  isAboveElement(event) {
+    event.preventDefault();
+    const target = event.currentTarget;
+    const domRect = target.getBoundingClientRect();
+    return event.offsetY < domRect.height / 2;
+  }
+
+  @action
+  dragHasStarted(event) {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("linkId", this.link.objectId);
+    this.dragCssClass = "dragging";
+  }
+  @action
+  dragOver(event) {
+    event.preventDefault();
+    if (!this.dragCssClass) {
+      if (this.isAboveElement(event)) {
+        this.dragCssClass = "drag-above";
+      } else {
+        this.dragCssClass = "drag-below";
+      }
+    }
+  }
+  @action
+  dragLeave() {
+    if (
+      this.dragCssClass === "drag-above" ||
+      this.dragCssClass === "drag-below"
+    ) {
+      this.dragCssClass = null;
+    }
+  }
+  @action
+  dropItem(event) {
+    event.stopPropagation();
+    this.reorderCallback(
+      parseInt(event.dataTransfer.getData("linkId"), 10),
+      this.link.objectId,
+      this.isAboveElement(event)
+    );
+    this.dragCssClass = null;
+  }
+  @action
+  dragEnd() {
+    this.dragCssClass = null;
+  }
+}

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -375,6 +375,9 @@ export default Controller.extend(ModalFunctionality, {
 
   @bind
   reorder(linkIdFrom, linkIdTo, above) {
+    if (linkIdFrom === linkIdTo) {
+      return;
+    }
     let fromLink = this.model.links.find(
       (link) => link.objectId === linkIdFrom
     );

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
@@ -9,6 +9,8 @@ export default class BaseCommunitySectionLink {
     router,
     siteSettings,
     inMoreDrawer,
+    overridenName,
+    overridenIcon,
   } = {}) {
     this.router = router;
     this.topicTrackingState = topicTrackingState;
@@ -16,6 +18,8 @@ export default class BaseCommunitySectionLink {
     this.appEvents = appEvents;
     this.siteSettings = siteSettings;
     this.inMoreDrawer = inMoreDrawer;
+    this.overridenName = overridenName;
+    this.overridenIcon = overridenIcon;
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/about-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/about-section-link.js
@@ -16,10 +16,13 @@ export default class AboutSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.about.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get prefixValue() {
-    return "info-circle";
+    return this.overridenIcon || "info-circle";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
@@ -24,6 +24,6 @@ export default class BadgesSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "certificate";
+    return this.overridenIcon || "certificate";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
@@ -44,7 +44,10 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.everything.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get currentWhen() {
@@ -93,7 +96,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "layer-group";
+    return this.overridenIcon || "layer-group";
   }
 
   get suffixCSSClass() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/faq-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/faq-section-link.js
@@ -20,10 +20,13 @@ export default class FAQSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.faq.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get prefixValue() {
-    return "question-circle";
+    return this.overridenIcon || "question-circle";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/groups-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/groups-section-link.js
@@ -24,6 +24,6 @@ export default class GroupsSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "user-friends";
+    return this.overridenIcon || "user-friends";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/users-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/users-section-link.js
@@ -16,7 +16,10 @@ export default class UsersSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.users.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get shouldDisplay() {
@@ -27,6 +30,6 @@ export default class UsersSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "users";
+    return this.overridenIcon || "users";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/admin-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/admin-section-link.js
@@ -16,7 +16,10 @@ export default class AdminSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.admin.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get shouldDisplay() {
@@ -24,6 +27,6 @@ export default class AdminSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "wrench";
+    return this.overridenIcon || "wrench";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -69,9 +69,17 @@ export default class MyPostsSectionLink extends BaseSectionLink {
 
   get text() {
     if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
-      return I18n.t("sidebar.sections.community.links.my_posts.content_drafts");
+      return I18n.t(
+        `sidebar.sections.community.links.my_posts.content_drafts`,
+        { defaultValue: "My Drafts" }
+      );
     } else {
-      return I18n.t("sidebar.sections.community.links.my_posts.content");
+      return I18n.t(
+        `sidebar.sections.community.links.${this.overridenName
+          .toLowerCase()
+          .replace(" ", "/")}.content`,
+        { defaultValue: this.overridenName }
+      );
     }
   }
 
@@ -94,7 +102,7 @@ export default class MyPostsSectionLink extends BaseSectionLink {
     if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
       return "pencil-alt";
     }
-    return "user";
+    return this.overridenIcon || "user";
   }
 
   get suffixCSSClass() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/new-topic-section-button.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/new-topic-section-button.js
@@ -1,0 +1,66 @@
+import Composer from "discourse/models/composer";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { next } from "@ember/runloop";
+import PermissionType from "discourse/models/permission-type";
+import I18n from "I18n";
+import { bind } from "discourse-common/utils/decorators";
+
+export default class NewTopicSectionButton {
+  constructor({
+    topicTrackingState,
+    currentUser,
+    appEvents,
+    router,
+    siteSettings,
+    inMoreDrawer,
+    overridenName,
+    overridenIcon,
+  } = {}) {
+    this.router = router;
+    this.topicTrackingState = topicTrackingState;
+    this.currentUser = currentUser;
+    this.appEvents = appEvents;
+    this.siteSettings = siteSettings;
+    this.inMoreDrawer = inMoreDrawer;
+    this.overridenName = overridenName;
+    this.overridenIcon = overridenIcon;
+  }
+
+  get name() {
+    return "new-topic";
+  }
+
+  get prefixValue() {
+    return this.overridenIcon || "plus";
+  }
+
+  get text() {
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
+  }
+
+  get shouldDisplay() {
+    return this.currentUser;
+  }
+
+  @bind
+  action() {
+    const composerArgs = {
+      action: Composer.CREATE_TOPIC,
+      draftKey: Composer.NEW_TOPIC_KEY,
+    };
+
+    const controller = getOwner(this).lookup("controller:navigation/category");
+    const category = controller.category;
+
+    if (category && category.permission === PermissionType.FULL) {
+      composerArgs.categoryId = category.id;
+    }
+
+    next(() => {
+      getOwner(this).lookup("controller:composer").open(composerArgs);
+    });
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
@@ -53,7 +53,10 @@ export default class ReviewSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.review.content");
+    return I18n.t(
+      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      { defaultValue: this.overridenName }
+    );
   }
 
   get shouldDisplay() {
@@ -71,6 +74,6 @@ export default class ReviewSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
-    return "flag";
+    return this.overridenIcon || "flag";
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -22,67 +22,30 @@
         </div>
       {{/if}}
     </div>
-    {{#each this.activeLinks as |link|}}
-      <div class="row-wrapper">
-        <div class="input-group">
-          <label for="link-name">{{i18n
-              "sidebar.sections.custom.links.icon.label"
-            }}</label>
-          <IconPicker
-            @name="icon"
-            @value={{link.icon}}
-            @options={{hash maximum=1}}
-            class={{link.iconCssClass}}
-            @onlyAvailable={{true}}
-            @onChange={{action (mut link.icon)}}
-          />
-          {{#if link.invalidIconMessage}}
-            <div class="icon warning">
-              {{link.invalidIconMessage}}
-            </div>
-          {{/if}}
-        </div>
-        <div class="input-group">
-          <label for="link-name">{{i18n
-              "sidebar.sections.custom.links.name.label"
-            }}</label>
-          <Input
-            name="link-name"
-            @type="text"
-            @value={{link.name}}
-            class={{link.nameCssClass}}
-            {{on "input" (action (mut link.name) value="target.value")}}
-          />
-          {{#if link.invalidNameMessage}}
-            <div class="name warning">
-              {{link.invalidNameMessage}}
-            </div>
-          {{/if}}
-        </div>
-        <div class="input-group">
-          <label for="link-url">{{i18n
-              "sidebar.sections.custom.links.value.label"
-            }}</label>
-          <Input
-            name="link-url"
-            @type="text"
-            @value={{link.value}}
-            class={{link.valueCssClass}}
-            {{on "input" (action (mut link.value) value="target.value")}}
-          />
-          {{#if link.invalidValueMessage}}
-            <div class="value warning">
-              {{link.invalidValueMessage}}
-            </div>
-          {{/if}}
-        </div>
-        <DButton
-          @icon="trash-alt"
-          @action={{action "deleteLink" link}}
-          @class="btn-flat delete-link"
-          @title="sidebar.sections.custom.links.delete"
-        />
+    <div class="row-wrapper header">
+      <div class="input-group link-name">
+        <label for="link-name">{{i18n
+            "sidebar.sections.custom.links.icon.label"
+          }}</label>
       </div>
+      <div class="input-group">
+        <label for="link-name">{{i18n
+            "sidebar.sections.custom.links.name.label"
+          }}</label>
+      </div>
+      <div class="input-group">
+        <label for="link-url">{{i18n
+            "sidebar.sections.custom.links.value.label"
+          }}</label>
+      </div>
+      <div></div>
+    </div>
+    {{#each this.activeLinks as |link|}}
+      <Sidebar::SidebarSectionFormLink
+        @link={{link}}
+        @deleteLink={{this.deleteLink}}
+        @reorderCallback={{this.reorder}}
+      />
     {{/each}}
     <DButton
       @action={{action "addLink"}}
@@ -91,8 +54,37 @@
       @icon="plus"
       @label="sidebar.sections.custom.links.add"
     />
-    {{#if this.currentUser.staff}}
-      <div class="row-wrapper">
+    {{#if this.activeSecondaryLinks}}
+      <hr />
+      <h3>{{I18n "sidebar.sections.custom.more_menu"}}</h3>
+      {{#each this.activeSecondaryLinks as |link|}}
+        <Sidebar::SidebarSectionFormLink
+          @link={{link}}
+          @deleteLink={{this.deleteLink}}
+          @reorderCallback={{this.reorder}}
+        />
+      {{/each}}
+      <DButton
+        @action={{action "addSecondaryLink"}}
+        @class="btn-flat btn-text add-link"
+        @title="sidebar.sections.custom.links.add"
+        @icon="plus"
+        @label="sidebar.sections.custom.links.add"
+      />
+
+      {{#if this.model.sectionType}}
+        <DButton
+          @action={{action "resetToDefault"}}
+          @class="btn-flat btn-text reset-link"
+          @icon="undo"
+          @title="sidebar.sections.custom.links.reset"
+          @label="sidebar.sections.custom.links.reset"
+        />
+      {{/if}}
+
+    {{/if}}
+    {{#if (and this.currentUser.staff (not this.model.sectionType))}}
+      <div class="row-wrapper mark-public-wrapper">
         <label class="checkbox-label">
           <Input
             @type="checkbox"
@@ -114,7 +106,7 @@
     @label="sidebar.sections.custom.save"
     @disabled={{not this.model.valid}}
   />
-  {{#if this.model.id}}
+  {{#if this.canDelete}}
     <DButton
       @icon="trash-alt"
       @id="delete-section"

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -55,10 +55,10 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     assert.ok(exists("#reply-control"), "it opens the composer");
   });
 
-  test("clicking on section header button while viewing a category", async function (assert) {
+  test("clicking on new topic button while viewing a category", async function (assert) {
     await visit("/c/bug");
     await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-header-button"
+      ".sidebar-section[data-section-name='community'] .sidebar-button"
     );
 
     assert.ok(exists("#reply-control"), "it opens the composer");

--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -75,7 +75,7 @@ export default {
             },
             {
               id: 331,
-              name: "Info",
+              name: "About",
               value: "/about",
               icon: "info-circle",
               external: false,
@@ -110,6 +110,14 @@ export default {
               name: "Admin",
               value: "/admin",
               icon: "wrench",
+              external: false,
+              segment: "primary",
+            },
+            {
+              id: 338,
+              name: "New Topic",
+              value: "/new-topic",
+              icon: "plus",
               external: false,
               segment: "primary",
             },

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -723,7 +723,7 @@ export default {
             },
             {
               id: 331,
-              name: "Info",
+              name: "About",
               value: "/about",
               icon: "info-circle",
               external: false,

--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -43,11 +43,54 @@
       }
     }
   }
+  .sidebar-section-btn {
+    background: none;
+    width: 100%;
+    justify-content: left;
+    color: var(--primary-high);
+    &:hover {
+      background: var(--d-sidebar-highlight-color);
+      color: var(--primary-high);
+      .d-icon {
+        color: var(--primary-high);
+      }
+    }
+  }
 }
 .discourse-touch {
   .sidebar-custom-sections {
     a:hover {
       background: none !important;
     }
+  }
+}
+.sidebar-more-section-links-details-content-main {
+  .btn-flat.sidebar-button {
+    padding-left: 0.5em;
+  }
+}
+.btn-flat.sidebar-button {
+  &:focus-within,
+  &:active,
+  &:hover {
+    background: var(--d-sidebar-highlight-color);
+    svg.d-icon {
+      color: var(--primary-medium);
+    }
+  }
+  height: var(--d-sidebar-row-height);
+  color: var(--primary-high);
+  display: flex;
+  width: 100%;
+  padding: var(--d-sidebar-row-vertical-padding)
+    var(--d-sidebar-row-horizontal-padding);
+  font-size: var(--d-sidebar-row-font-size);
+  justify-content: left;
+
+  svg.d-icon {
+    width: var(--d-sidebar-section-link-prefix-width);
+    margin-right: var(--d-sidebar-section-link-prefix-margin-right);
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
   }
 }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -119,6 +119,20 @@
 }
 
 .sidebar-section-form-modal {
+  .draggable {
+    cursor: move;
+    align-self: center;
+    margin-left: auto;
+    margin-right: auto;
+    -webkit-user-drag: element;
+    -khtml-user-drag: element;
+    -moz-user-drag: element;
+    -o-user-drag: element;
+    user-drag: element;
+  }
+  .dragging {
+    opacity: 0.4;
+  }
   .modal-inner-container {
     width: var(--modal-max-width);
   }
@@ -133,9 +147,38 @@
   }
   .row-wrapper {
     display: grid;
-    grid-template-columns: auto auto auto 2em;
+    grid-template-columns: 25px 220px auto auto 2em;
     gap: 1em;
-    margin-top: 1em;
+    padding: 0.5em 1px;
+    -webkit-user-drag: none;
+    -khtml-user-drag: none;
+    -moz-user-drag: none;
+    -o-user-drag: none;
+    user-drag: none;
+    cursor: default;
+
+    &.header {
+      padding-bottom: 0;
+      padding-top: 1em;
+    }
+
+    &.drag-above {
+      border-top: 1px dotted #666;
+      padding-top: calc(0.5em - 1px);
+    }
+    &.drag-below {
+      border-bottom: 1px dotted #666;
+      padding-bottom: calc(0.5em - 1px);
+    }
+    .link-name {
+      grid-column: 1 / span 2;
+      padding-left: calc(25px + 1em);
+    }
+    &.mark-public-wrapper {
+      label {
+        grid-column: 1 / -1;
+      }
+    }
   }
   .delete-link {
     height: 1em;
@@ -143,7 +186,8 @@
     margin-bottom: 0.75em;
     margin-right: 1em;
   }
-  .btn-flat.add-link {
+  .btn-flat.add-link,
+  .btn-flat.reset-link {
     margin-top: 1em;
     margin-left: -0.65em;
     &:active,
@@ -158,6 +202,9 @@
     &:hover svg {
       color: var(--tertiary-hover);
     }
+  }
+  .btn-flat.reset-link {
+    float: right;
   }
   .modal-footer {
     display: flex;

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -35,6 +35,18 @@ class SidebarSectionsController < ApplicationController
     ActiveRecord::Base.transaction do
       sidebar_section.update!(section_params.merge(sidebar_urls_attributes: links_params))
       sidebar_section.sidebar_section_links.update_all(user_id: sidebar_section.user_id)
+      order =
+        sidebar_section
+          .sidebar_urls
+          .sort_by do |url|
+            links_params.index { |link| link["name"] == url.name && link["value"] == url.value } ||
+              -1
+          end
+          .each_with_index
+          .map { |url, index| [url.id, index] }
+          .to_h
+
+      set_order(sidebar_section, order)
     end
 
     if sidebar_section.public?
@@ -43,11 +55,22 @@ class SidebarSectionsController < ApplicationController
       Site.clear_anon_cache!
     end
 
-    render json: SidebarSectionSerializer.new(sidebar_section)
+    render json: SidebarSectionSerializer.new(sidebar_section.reload)
   rescue ActiveRecord::RecordInvalid => e
     render_json_error(e.record.errors.full_messages.first)
   rescue Discourse::InvalidAccess
     render json: failed_json, status: 403
+  end
+
+  def reset
+    sidebar_section = SidebarSection.find(params[:id])
+    @guardian.ensure_can_edit!(sidebar_section)
+
+    case sidebar_section.section_type
+    when "community"
+      reset_community(sidebar_section)
+    end
+    render json: SidebarSectionSerializer.new(sidebar_section.reload)
   end
 
   def reorder
@@ -55,16 +78,8 @@ class SidebarSectionsController < ApplicationController
     @guardian.ensure_can_edit!(sidebar_section)
 
     order = reorder_params["links_order"].map(&:to_i).each_with_index.to_h
-    position_generator =
-      (0..sidebar_section.sidebar_section_links.count * 2).excluding(
-        sidebar_section.sidebar_section_links.map(&:position),
-      ).each
-    links =
-      sidebar_section
-        .sidebar_section_links
-        .sort_by { |link| order[link.linkable_id] }
-        .map { |link| link.attributes.merge(position: position_generator.next) }
-    sidebar_section.sidebar_section_links.upsert_all(links, update_only: [:position])
+
+    set_order(sidebar_section, order)
     render json: sidebar_section
   rescue Discourse::InvalidAccess
     render json: failed_json, status: 403
@@ -91,7 +106,7 @@ class SidebarSectionsController < ApplicationController
   end
 
   def links_params
-    params.permit(links: %i[icon name value id _destroy])["links"]
+    params.permit(links: %i[icon name value id _destroy segment])["links"]
   end
 
   def reorder_params
@@ -99,6 +114,45 @@ class SidebarSectionsController < ApplicationController
   end
 
   private
+
+  def reset_community(community_section)
+    community_section.update!(title: "Community")
+    community_section.sidebar_section_links.destroy_all
+    community_urls =
+      SidebarUrl::COMMUNITY_SECTION_LINKS.map do |url_data|
+        "('#{url_data[:name]}', '#{url_data[:path]}', '#{url_data[:icon]}', '#{url_data[:segment]}', false, now(), now())"
+      end
+
+    result = DB.query <<~SQL
+      INSERT INTO sidebar_urls(name, value, icon, segment, external, created_at, updated_at)
+      VALUES #{community_urls.join(",")}
+      RETURNING sidebar_urls.id
+    SQL
+
+    sidebar_section_links =
+      result.map.with_index do |url, index|
+        "(-1, #{url.id}, 'SidebarUrl', #{community_section.id}, #{index},  now(), now())"
+      end
+
+    DB.query <<~SQL
+      INSERT INTO sidebar_section_links(user_id, linkable_id, linkable_type, sidebar_section_id, position, created_at, updated_at)
+      VALUES #{sidebar_section_links.join(",")}
+    SQL
+  end
+
+  def set_order(sidebar_section, order)
+    position_generator =
+      (0..sidebar_section.sidebar_section_links.count * 2).excluding(
+        sidebar_section.sidebar_section_links.map(&:position),
+      ).each
+
+    links =
+      sidebar_section
+        .sidebar_section_links
+        .sort_by { |link| order[link.linkable_id] }
+        .map { |link| link.attributes.merge(position: position_generator.next) }
+    sidebar_section.sidebar_section_links.upsert_all(links, update_only: [:position])
+  end
 
   def check_access_if_public
     return true if !params[:public]

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -1,20 +1,53 @@
 # frozen_string_literal: true
 
 class SidebarUrl < ActiveRecord::Base
+  enum :segment, { primary: 0, secondary: 1 }, scopes: false, suffix: true
+
   FULL_RELOAD_LINKS_REGEX = [%r{\A/my/[a-z_\-/]+\z}, %r{\A/safe-mode\z}]
   MAX_ICON_LENGTH = 40
   MAX_NAME_LENGTH = 80
   MAX_VALUE_LENGTH = 200
   COMMUNITY_SECTION_LINKS = [
-    { name: "Everything", path: "/latest", icon: "layer-group", segment: "primary" },
-    { name: "My Posts", path: "/my/activity", icon: "user", segment: "primary" },
-    { name: "Review", path: "/review", icon: "flag", segment: "primary" },
-    { name: "Admin", path: "/admin", icon: "wrench", segment: "primary" },
-    { name: "Users", path: "/u", icon: "users", segment: "secondary" },
-    { name: "About", path: "/about", icon: "info-circle", segment: "secondary" },
-    { name: "FAQ", path: "/faq", icon: "question-circle", segment: "secondary" },
-    { name: "Groups", path: "/g", icon: "user-friends", segment: "secondary" },
-    { name: "Badges", path: "/badges", icon: "certificate", segment: "secondary" },
+    {
+      name: "Everything",
+      path: "/latest",
+      icon: "layer-group",
+      segment: SidebarUrl.segments["primary"],
+    },
+    {
+      name: "My Posts",
+      path: "/my/activity",
+      icon: "user",
+      segment: SidebarUrl.segments["primary"],
+    },
+    { name: "Review", path: "/review", icon: "flag", segment: SidebarUrl.segments["primary"] },
+    { name: "Admin", path: "/admin", icon: "wrench", segment: SidebarUrl.segments["primary"] },
+    {
+      name: "New topic",
+      path: "/new-topic",
+      icon: "plus",
+      segment: SidebarUrl.segments["primary"],
+    },
+    { name: "Users", path: "/u", icon: "users", segment: SidebarUrl.segments["secondary"] },
+    {
+      name: "About",
+      path: "/about",
+      icon: "info-circle",
+      segment: SidebarUrl.segments["secondary"],
+    },
+    {
+      name: "FAQ",
+      path: "/faq",
+      icon: "question-circle",
+      segment: SidebarUrl.segments["secondary"],
+    },
+    { name: "Groups", path: "/g", icon: "user-friends", segment: SidebarUrl.segments["secondary"] },
+    {
+      name: "Badges",
+      path: "/badges",
+      icon: "certificate",
+      segment: SidebarUrl.segments["secondary"],
+    },
   ]
 
   validates :icon, presence: true, length: { maximum: MAX_ICON_LENGTH }
@@ -24,8 +57,6 @@ class SidebarUrl < ActiveRecord::Base
   validate :path_validator
 
   before_validation :remove_internal_hostname, :set_external
-
-  enum :segment, { primary: 0, secondary: 1 }, scopes: false, suffix: true
 
   def path_validator
     return true if !external?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4416,10 +4416,13 @@ en:
           save: "Save"
           delete: "Delete"
           delete_confirm: "Are you sure you want to delete this section?"
+          reset_confirm: "Are you sure you want to reset this section to default?"
           public: "Make this section public and visible to everyone"
+          more_menu: "More menu"
           links:
             add: "Add another link"
             delete: "Delete link"
+            reset: "Reset to default"
             icon:
               label: "Icon"
               validation:
@@ -4476,8 +4479,10 @@ en:
           configure_defaults: "Configure defaults"
         community:
           header_link_text: "Community"
-          header_action_title: "Create a topic"
           links:
+            new_topic:
+              content: "New topic"
+              title: "Create a topic"
             about:
               content: "About"
               title: "More details about this site"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4481,7 +4481,7 @@ en:
           header_link_text: "Community"
           links:
             new_topic:
-              content: "New topic"
+              content: "New Topic"
               title: "Create a topic"
             about:
               content: "About"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1594,6 +1594,7 @@ Discourse::Application.routes.draw do
 
     resources :sidebar_sections, only: %i[index create update destroy]
     post "/sidebar_sections/reorder" => "sidebar_sections#reorder"
+    put "/sidebar_sections/reset/:id" => "sidebar_sections#reset"
 
     get "*url", to: "permalinks#show", constraints: PermalinkConstraint.new
   end

--- a/db/migrate/20230502235832_insert_new_topic_to_community_section.rb
+++ b/db/migrate/20230502235832_insert_new_topic_to_community_section.rb
@@ -20,21 +20,6 @@ class InsertNewTopicToCommunitySection < ActiveRecord::Migration[7.0]
   end
 
   def down
-    community_section_query = DB.query <<~SQL
-      SELECT id FROM sidebar_sections WHERE section_type = 0
-    SQL
-    community_section_id = community_section_query.last&.id
-
-    result = DB.query <<~SQL
-      DELETE FROM sidebar_section_links
-      WHERE id IN (SELECT id from sidebar_section_links WHERE sidebar_section_id = #{community_section_id} ORDER BY POSITION DESC LIMIT 1)
-        RETURNING sidebar_section_links.linkable_id
-    SQL
-    sidebar_url_ids = result.map(&:linkable_id)
-
-    DB.query <<~SQL
-      DELETE FROM sidebar_urls
-      WHERE id IN (#{sidebar_url_ids.join(",")})
-    SQL
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20230502235832_insert_new_topic_to_community_section.rb
+++ b/db/migrate/20230502235832_insert_new_topic_to_community_section.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class InsertNewTopicToCommunitySection < ActiveRecord::Migration[7.0]
+  def up
+    community_section_query = DB.query <<~SQL
+      SELECT id FROM sidebar_sections WHERE section_type = 0
+    SQL
+
+    result = DB.query <<~SQL
+      INSERT INTO sidebar_urls(name, value, icon, segment, external, created_at, updated_at)
+      VALUES ('New Topic', '/new-topic','plus', 0, false, now(), now())
+      RETURNING sidebar_urls.id
+    SQL
+
+    result = DB.query <<~SQL
+      INSERT INTO sidebar_section_links(user_id, linkable_id, linkable_type, sidebar_section_id, position, created_at, updated_at)
+      SELECT -1, #{result[0].id}, 'SidebarUrl', #{community_section_query.first.id}, MAX(position) + 1, now(), now() FROM sidebar_section_links
+      WHERE sidebar_section_id = #{community_section_query.first.id}
+    SQL
+  end
+
+  def down
+    community_section_query = DB.query <<~SQL
+      SELECT id FROM sidebar_sections WHERE section_type = 0
+    SQL
+    community_section_id = community_section_query.last&.id
+
+    result = DB.query <<~SQL
+      DELETE FROM sidebar_section_links
+      WHERE id IN (SELECT id from sidebar_section_links WHERE sidebar_section_id = #{community_section_id} ORDER BY POSITION DESC LIMIT 1)
+        RETURNING sidebar_section_links.linkable_id
+    SQL
+    sidebar_url_ids = result.map(&:linkable_id)
+
+    DB.query <<~SQL
+      DELETE FROM sidebar_urls
+      WHERE id IN (#{sidebar_url_ids.join(",")})
+    SQL
+  end
+end

--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -7,10 +7,12 @@ module SidebarGuardian
 
   def can_edit_sidebar_section?(sidebar_section)
     return @user.staff? if sidebar_section.public?
+    return @user.staff? if sidebar_section.section_type
     is_my_own?(sidebar_section)
   end
 
   def can_delete_sidebar_section?(sidebar_section)
+    return false if sidebar_section.section_type.present?
     return @user.staff? if sidebar_section.public?
     is_my_own?(sidebar_section)
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Category do
 
       expect { category_sidebar_section_link.linkable.destroy! }.to change {
         SidebarSectionLink.count
-      }.from(12).to(10)
+      }.from(13).to(11)
       expect(SidebarSectionLink.last).to eq(tag_sidebar_section_link)
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Tag do
 
       expect { tag_sidebar_section_link.linkable.destroy! }.to change {
         SidebarSectionLink.count
-      }.from(12).to(10)
+      }.from(13).to(11)
       expect(SidebarSectionLink.last).to eq(category_sidebar_section_link)
     end
   end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -135,6 +135,9 @@ RSpec.describe SidebarSectionsController do
     fab!(:section_link_2) do
       Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_2)
     end
+    let(:community_section) do
+      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+    end
 
     it "allows user to update their own section and links" do
       sign_in(user)
@@ -164,9 +167,20 @@ RSpec.describe SidebarSectionsController do
           params: {
             title: "custom section edited",
             links: [
+              {
+                icon: "link",
+                name: "meta",
+                value: "https://meta.discourse.org",
+                segment: "primary",
+              },
               { icon: "link", id: sidebar_url_1.id, name: "latest", value: "/latest" },
               { icon: "link", id: sidebar_url_2.id, name: "tags", value: "/tags", _destroy: "1" },
-              { icon: "link", name: "homepage", value: "https://discourse.org" },
+              {
+                icon: "link",
+                name: "homepage",
+                value: "https://discourse.org",
+                segment: "secondary",
+              },
             ],
           }
 
@@ -178,17 +192,21 @@ RSpec.describe SidebarSectionsController do
       expect { section_link_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { sidebar_url_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
-      expect(sidebar_section.sidebar_section_links.last.position).to eq(2)
-      expect(sidebar_section.sidebar_section_links.last.linkable.name).to eq("homepage")
-      expect(sidebar_section.sidebar_section_links.last.linkable.value).to eq(
-        "https://discourse.org",
-      )
+      urls = sidebar_section.sidebar_urls
+      expect(urls[0].name).to eq("meta")
+      expect(urls[0].value).to eq("https://meta.discourse.org")
+      expect(urls[0].segment).to eq("primary")
+      expect(urls[1].name).to eq("latest")
+      expect(urls[1].value).to eq("/latest")
+      expect(urls[2].name).to eq("homepage")
+      expect(urls[2].value).to eq("https://discourse.org")
+      expect(urls[2].segment).to eq("secondary")
 
       user_history = UserHistory.last
       expect(user_history.action).to eq(UserHistory.actions[:update_public_sidebar_section])
       expect(user_history.subject).to eq("custom section edited")
       expect(user_history.details).to eq(
-        "links: latest - /latest, homepage - https://discourse.org",
+        "links: latest - /latest, meta - https://meta.discourse.org, homepage - https://discourse.org",
       )
     end
 
@@ -237,6 +255,48 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(404)
 
       expect(sidebar_url_3.reload.name).to eq("other_tags")
+    end
+
+    it "doesn't allow users to edit community section" do
+      sign_in(user)
+      put "/sidebar_sections/#{community_section.id}.json",
+          params: {
+            title: "custom section edited",
+            links: [],
+          }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "allows admin to edit community section" do
+      sign_in(admin)
+      everything_link = community_section.sidebar_urls.find_by(name: "Everything")
+      my_posts_link = community_section.sidebar_urls.find_by(name: "My Posts")
+      community_section
+        .sidebar_section_links
+        .where.not(linkable_id: [everything_link.id, my_posts_link.id])
+        .destroy_all
+      put "/sidebar_sections/#{community_section.id}.json",
+          params: {
+            title: "community section edited",
+            links: [
+              { icon: "link", id: my_posts_link.id, name: "my posts edited", value: "/my_posts" },
+              {
+                icon: "link",
+                id: everything_link.id,
+                name: "everything edited",
+                value: "/everything",
+              },
+            ],
+          }
+
+      expect(response.status).to eq(200)
+
+      expect(community_section.reload.title).to eq("community section edited")
+      expect(community_section.sidebar_urls[0].reload.name).to eq("my posts edited")
+      expect(community_section.sidebar_urls[0].value).to eq("/my_posts")
+      expect(community_section.sidebar_urls[1].reload.name).to eq("everything edited")
+      expect(community_section.sidebar_urls[1].value).to eq("/everything")
     end
   end
 
@@ -333,6 +393,30 @@ RSpec.describe SidebarSectionsController do
       delete "/sidebar_sections/#{sidebar_section.id}.json"
 
       expect(response.status).to eq(403)
+    end
+  end
+
+  describe "#reset" do
+    let(:community_section) do
+      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+    end
+    let(:everything_link) { community_section.sidebar_section_links.first }
+
+    it "doesn't allow user to reset community section" do
+      sign_in(user)
+      put "/sidebar_sections/reset/#{community_section.id}.json"
+      expect(response.status).to eq(403)
+    end
+
+    it "allows admins to reset community section to default" do
+      community_section.update!(title: "test")
+      everything_link.linkable.update!(name: "everything edited")
+
+      sign_in(admin)
+      put "/sidebar_sections/reset/#{community_section.id}.json"
+
+      expect(community_section.reload.title).to eq("Community")
+      expect(community_section.sidebar_section_links.first.linkable.name).to eq("Everything")
     end
   end
 end

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -191,6 +191,39 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar).to have_no_section("Edited public section")
   end
 
+  it "allows admin to edit community section and reset to default" do
+    sign_in admin
+    visit("/latest")
+
+    sidebar.edit_custom_section("Community")
+    section_modal.fill_name("Edited community section")
+    everything_link = find(".draggable[data-link-name='Everything']")
+    my_posts_link = find(".draggable[data-link-name='Review']")
+    everything_link.drag_to(my_posts_link, delay: 0.4)
+    section_modal.save
+
+    expect(sidebar).to have_section("Edited community section")
+    within(
+      "[data-section-name='edited-community-section'] .sidebar-section-link-wrapper:nth-child(1)",
+    ) { expect(sidebar).to have_section_link("My Posts") }
+
+    within(
+      "[data-section-name='edited-community-section'] .sidebar-section-link-wrapper:nth-child(2)",
+    ) { expect(sidebar).to have_section_link("Everything") }
+
+    sidebar.edit_custom_section("Edited community section")
+    section_modal.reset
+
+    expect(sidebar).to have_section("Community")
+    within("[data-section-name='community'] .sidebar-section-link-wrapper:nth-child(1)") do
+      expect(sidebar).to have_section_link("Everything")
+    end
+
+    within("[data-section-name='community'] .sidebar-section-link-wrapper:nth-child(2)") do
+      expect(sidebar).to have_section_link("My Posts")
+    end
+  end
+
   it "shows anonymous public sections" do
     sidebar_section = Fabricate(:sidebar_section, title: "Public section", public: true)
     sidebar_url_1 = Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags")

--- a/spec/system/page_objects/components/sidebar_header_dropdown.rb
+++ b/spec/system/page_objects/components/sidebar_header_dropdown.rb
@@ -23,10 +23,10 @@ module PageObjects
         page.has_no_css?(".sidebar-footer-actions-keyboard-shortcuts")
       end
 
-      def click_community_header_button
+      def click_new_topic_button
         page.click_button(
-          I18n.t("js.sidebar.sections.community.header_action_title"),
-          class: "sidebar-section-header-button",
+          I18n.t("js.sidebar.sections.community.links.new_topic.content"),
+          class: "sidebar-button",
         )
       end
 

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -28,6 +28,11 @@ module PageObjects
         find(".dialog-container .btn-primary").click
       end
 
+      def reset
+        find(".reset-link").click
+        find(".dialog-footer .btn-primary").click
+      end
+
       def save
         find("#save-section").click
       end

--- a/spec/system/viewing_sidebar_mobile_spec.rb
+++ b/spec/system/viewing_sidebar_mobile_spec.rb
@@ -46,14 +46,14 @@ describe "Viewing sidebar mobile", type: :system, js: true, mobile: true do
     expect(sidebar_dropdown).to be_hidden
   end
 
-  it "collapses the sidebar when clicking on a button in the sidebar" do
+  it "collapses the sidebar when clicking on a new topic button in the sidebar" do
     visit("/latest")
 
     sidebar_dropdown.click
 
     expect(sidebar_dropdown).to be_visible
 
-    sidebar_dropdown.click_community_header_button
+    sidebar_dropdown.click_new_topic_button
 
     expect(composer).to be_opened
     expect(sidebar_dropdown).to be_hidden


### PR DESCRIPTION
New feature to allow admins to edit community section:
- admin can add/update/remove links
- admin can reorder links
- admin can reset section to default

Demo

https://github.com/discourse/discourse/assets/72780/82239960-01fd-4279-8c70-c9b3bb053923

