### PR TITLE
FIX: adds missing margin on desktop draft message

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
@@ -37,9 +37,7 @@
     }
   }
 
-  .ios-device.keyboard-visible & {
-    .chat-composer__wrapper {
-      padding-bottom: 1rem;
-    }
+  .chat-composer__wrapper {
+    padding-bottom: 1rem;
   }
 }


### PR DESCRIPTION
Before:

<img width="1060" alt="Screenshot 2023-05-18 at 13 56 42" src="https://github.com/discourse/discourse/assets/339945/d6502c4a-1f74-4532-aaed-5fd78d7adacf">

After:

<img width="1046" alt="Screenshot 2023-05-18 at 13 56 14" src="https://github.com/discourse/discourse/assets/339945/9e62bf75-3e8c-4d54-b3c9-de3eb8e461d2">
