### PR TITLE
dev/status on mentions edge cases

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1436,6 +1436,10 @@ User.reopen(Evented, {
     this._subscribersCount--;
   },
 
+  isTrackingStatus() {
+    return this._subscribersCount > 0;
+  },
+
   _statusChanged(sender, key) {
     this.trigger("status-changed");
 

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -39,6 +39,10 @@ export function success() {
   return response({ success: true });
 }
 
+export function OK(resp = {}, headers = {}) {
+  return [200, headers, resp];
+}
+
 const loggedIn = () => !!User.current();
 const helpers = { response, success, parsePostData };
 

--- a/plugins/chat/app/controllers/chat/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat/chat_controller.rb
@@ -412,6 +412,7 @@ module Chat
           .includes(:uploads)
           .includes(chat_channel: :chatable)
           .includes(:thread)
+          .includes(:chat_mentions)
 
       query = query.includes(user: :user_status) if SiteSetting.enable_user_status
 

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -30,6 +30,7 @@ module Chat
       User
         .where(id: object.chat_mentions.pluck(:user_id))
         .map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
+        .as_json
     end
 
     def channel

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -18,12 +18,19 @@ module Chat
                :thread_id,
                :thread_reply_count,
                :thread_title,
-               :chat_channel_id
+               :chat_channel_id,
+               :mentioned_users
 
     has_one :user, serializer: Chat::MessageUserSerializer, embed: :objects
     has_one :chat_webhook_event, serializer: Chat::WebhookEventSerializer, embed: :objects
     has_one :in_reply_to, serializer: Chat::InReplyToSerializer, embed: :objects
     has_many :uploads, serializer: ::UploadSerializer, embed: :objects
+
+    def mentioned_users
+      User
+        .where(id: object.chat_mentions.pluck(:user_id))
+        .map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
+    end
 
     def channel
       @channel ||= @options.dig(:chat_channel) || object.chat_channel

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -19,6 +19,7 @@ import { setupHashtagAutocomplete } from "discourse/lib/hashtag-autocomplete";
 import { isEmpty, isPresent } from "@ember/utils";
 import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 import { Promise } from "rsvp";
+import User from "discourse/models/user";
 
 export default class ChatComposer extends Component {
   @service capabilities;
@@ -412,7 +413,11 @@ export default class ChatComposer extends Component {
       width: "100%",
       treatAsTextarea: true,
       autoSelectFirstSuggestion: true,
-      transformComplete: (v) => v.username || v.name,
+      transformComplete: (userData) => {
+        const user = User.create(userData);
+        this.currentMessage.mentionedUsers.set(user.id, user);
+        return user.username || user.name;
+      },
       dataSource: (term) => {
         return userSearch({ term, includeGroups: true }).then((result) => {
           if (result?.users?.length > 0) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -13,7 +13,6 @@
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
     {{did-update this.refreshStatusOnMentions @message.version}}
-    {{did-update this.initt @message.version}}
     {{on "touchmove" this.handleTouchMove passive=true}}
     {{on "touchstart" this.handleTouchStart passive=true}}
     {{on "touchend" this.handleTouchEnd passive=true}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -62,6 +62,7 @@
         </div>
       {{else}}
         <div
+          {{did-insert this.refreshStatusOnMentions}}
           class={{concat-class
             "chat-message"
             (if @message.staged "chat-message-staged")

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -9,6 +9,7 @@
   <div
     {{will-destroy this.teardownChatMessage}}
     {{did-insert this.decorateCookedMessage}}
+    {{did-insert this.refreshStatusOnMentions}}
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
     {{on "touchmove" this.handleTouchMove passive=true}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -13,6 +13,7 @@
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
     {{did-update this.refreshStatusOnMentions @message.version}}
+    {{did-update this.initt @message.version}}
     {{on "touchmove" this.handleTouchMove passive=true}}
     {{on "touchstart" this.handleTouchStart passive=true}}
     {{on "touchend" this.handleTouchEnd passive=true}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -12,6 +12,7 @@
     {{did-insert this.refreshStatusOnMentions}}
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
+    {{did-update this.refreshStatusOnMentions @message.version}}
     {{on "touchmove" this.handleTouchMove passive=true}}
     {{on "touchstart" this.handleTouchStart passive=true}}
     {{on "touchend" this.handleTouchEnd passive=true}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -61,6 +61,7 @@
         <div
           {{did-insert this.refreshStatusOnMentions}}
           {{did-update this.refreshStatusOnMentions @message.version}}
+          {{did-update this.initMentionedUsers @message.version}}
           class={{concat-class
             "chat-message"
             (if @message.staged "chat-message-staged")

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -9,10 +9,8 @@
   <div
     {{will-destroy this.teardownChatMessage}}
     {{did-insert this.decorateCookedMessage}}
-    {{did-insert this.refreshStatusOnMentions}}
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
-    {{did-update this.refreshStatusOnMentions @message.version}}
     {{on "touchmove" this.handleTouchMove passive=true}}
     {{on "touchstart" this.handleTouchStart passive=true}}
     {{on "touchend" this.handleTouchEnd passive=true}}
@@ -62,6 +60,7 @@
       {{else}}
         <div
           {{did-insert this.refreshStatusOnMentions}}
+          {{did-update this.refreshStatusOnMentions @message.version}}
           class={{concat-class
             "chat-message"
             (if @message.staged "chat-message-staged")

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -110,6 +110,9 @@ export default class ChatMessage extends Component {
     };
 
     this.args.message.expanded = true;
+    schedule("afterRender", () => {
+      this.refreshStatusOnMentions();
+    });
 
     recursiveExpand(this.args.message);
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -430,6 +430,10 @@ export default class ChatMessage extends Component {
 
   #initMentionedUsers() {
     this.args.message.mentionedUsers.forEach((user) => {
+      if (user.isTrackingStatus()) {
+        return;
+      }
+
       user.trackStatus();
       user.on("status-changed", this, "refreshStatusOnMentions");
     });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -46,11 +46,7 @@ export default class ChatMessage extends Component {
 
   constructor() {
     super(...arguments);
-
-    this.args.message.mentionedUsers.forEach((user) => {
-      user.trackStatus();
-      user.on("status-changed", this, "refreshStatusOnMentions");
-    });
+    this.#initMentionedUsers();
   }
 
   get pane() {
@@ -130,11 +126,7 @@ export default class ChatMessage extends Component {
   @action
   teardownChatMessage() {
     cancel(this._invitationSentTimer);
-
-    this.args.message.mentionedUsers.forEach((user) => {
-      user.stopTrackingStatus();
-      user.off("status-changed", this, "refreshStatusOnMentions");
-    });
+    this.#teardownMentionedUsers();
   }
 
   @action
@@ -434,5 +426,19 @@ export default class ChatMessage extends Component {
   @action
   dismissMentionWarning() {
     this.args.message.mentionWarning = null;
+  }
+
+  #initMentionedUsers() {
+    this.args.message.mentionedUsers.forEach((user) => {
+      user.trackStatus();
+      user.on("status-changed", this, "refreshStatusOnMentions");
+    });
+  }
+
+  #teardownMentionedUsers() {
+    this.args.message.mentionedUsers.forEach((user) => {
+      user.stopTrackingStatus();
+      user.off("status-changed", this, "refreshStatusOnMentions");
+    });
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -46,7 +46,7 @@ export default class ChatMessage extends Component {
 
   constructor() {
     super(...arguments);
-    this.#initMentionedUsers();
+    this.initMentionedUsers();
   }
 
   get pane() {
@@ -153,6 +153,18 @@ export default class ChatMessage extends Component {
       _chatMessageDecorators.forEach((decorator) => {
         decorator.call(this, this.messageContainer, this.args.message.channel);
       });
+    });
+  }
+
+  @action
+  initMentionedUsers() {
+    this.args.message.mentionedUsers.forEach((user) => {
+      if (user.isTrackingStatus()) {
+        return;
+      }
+
+      user.trackStatus();
+      user.on("status-changed", this, "refreshStatusOnMentions");
     });
   }
 
@@ -426,17 +438,6 @@ export default class ChatMessage extends Component {
   @action
   dismissMentionWarning() {
     this.args.message.mentionWarning = null;
-  }
-
-  #initMentionedUsers() {
-    this.args.message.mentionedUsers.forEach((user) => {
-      if (user.isTrackingStatus()) {
-        return;
-      }
-
-      user.trackStatus();
-      user.on("status-changed", this, "refreshStatusOnMentions");
-    });
   }
 
   #teardownMentionedUsers() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -12,6 +12,7 @@ import { getOwner } from "discourse-common/lib/get-owner";
 import ChatMessageInteractor from "discourse/plugins/chat/discourse/lib/chat-message-interactor";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
+import { updateUserStatusOnMention } from "discourse/lib/update-user-status-on-mention";
 
 let _chatMessageDecorators = [];
 
@@ -42,6 +43,15 @@ export default class ChatMessage extends Component {
   @service router;
 
   @optionalService adminTools;
+
+  constructor() {
+    super(...arguments);
+
+    this.args.message.mentionedUsers.forEach((user) => {
+      user.trackStatus();
+      user.on("status-changed", this, "refreshStatusOnMentions");
+    });
+  }
 
   get pane() {
     return this.args.context === MESSAGE_CONTEXT_THREAD
@@ -120,6 +130,25 @@ export default class ChatMessage extends Component {
   @action
   teardownChatMessage() {
     cancel(this._invitationSentTimer);
+
+    this.args.message.mentionedUsers.forEach((user) => {
+      user.stopTrackingStatus();
+      user.off("status-changed", this, "refreshStatusOnMentions");
+    });
+  }
+
+  @action
+  refreshStatusOnMentions() {
+    this.args.message.mentionedUsers.forEach((user) => {
+      const href = `/u/${user.username.toLowerCase()}`;
+      const mentions = this.messageContainer.querySelectorAll(
+        `a.mention[href="${href}"]`
+      );
+
+      mentions.forEach((mention) => {
+        updateUserStatusOnMention(mention, user.status, this.currentUser);
+      });
+    });
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -134,6 +134,10 @@ export default class ChatMessage extends Component {
 
   @action
   refreshStatusOnMentions() {
+    if (!this.messageContainer) {
+      return;
+    }
+
     this.args.message.mentionedUsers.forEach((user) => {
       const href = `/u/${user.username.toLowerCase()}`;
       const mentions = this.messageContainer.querySelectorAll(

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -88,6 +88,7 @@ export default class ChatMessage {
     this.uploads = new TrackedArray(args.uploads || []);
     this.user = this.#initUserModel(args.user);
     this.bookmark = args.bookmark ? Bookmark.create(args.bookmark) : null;
+    this.mentionedUsers = this.#initMentionedUsers(args.mentioned_users);
   }
 
   duplicate() {
@@ -309,6 +310,17 @@ export default class ChatMessage {
 
   #initChatMessageReactionModel(reactions = []) {
     return reactions.map((reaction) => ChatMessageReaction.create(reaction));
+  }
+
+  #initMentionedUsers(mentionedUsers) {
+    const map = new Map();
+    if (mentionedUsers) {
+      mentionedUsers.forEach((userData) => {
+        const user = User.create(userData);
+        map.set(user.id, user);
+      });
+    }
+    return map;
   }
 
   #initUserModel(user) {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -66,8 +66,10 @@ export default class ChatRoute extends DiscourseRoute {
   }
 
   deactivate(transition) {
-    const url = this.router.urlFor(transition.from.name);
-    this.chatStateManager.storeChatURL(url);
+    if (transition) {
+      const url = this.router.urlFor(transition.from.name);
+      this.chatStateManager.storeChatURL(url);
+    }
 
     this.chat.activeChannel = null;
     this.chat.updatePresence();

--- a/plugins/chat/assets/javascripts/discourse/services/chat-tracking-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-tracking-state-manager.js
@@ -24,7 +24,7 @@ export default class ChatTrackingStateManager extends Service {
   // NOTE: In future, we may want to preload some thread tracking state
   // as well, but for now we do that on demand when the user opens a channel,
   // to avoid having to load all the threads across all channels into memory at once.
-  setupWithPreloadedState({ channel_tracking = {} }) {
+  setupWithPreloadedState(channel_tracking = {}) {
     this.chatChannelsManager.channels.forEach((channel) => {
       if (channel_tracking[channel.id.toString()]) {
         this.#setState(channel, channel_tracking[channel.id.toString()]);

--- a/plugins/chat/spec/components/chat/message_updater_spec.rb
+++ b/plugins/chat/spec/components/chat/message_updater_spec.rb
@@ -124,6 +124,23 @@ describe Chat::MessageUpdater do
     expect(events.map { _1[:event_name] }).to include(:chat_message_edited)
   end
 
+  it "publishes updated message to message bus" do
+    chat_message = create_chat_message(user1, "This will be changed", public_chat_channel)
+    new_content = "New content"
+    messages =
+      MessageBus.track_publish("/chat/#{public_chat_channel.id}") do
+        described_class.update(
+          guardian: guardian,
+          chat_message: chat_message,
+          new_content: new_content,
+        )
+      end
+
+    expect(messages.count).to be(1)
+    message = messages[0].data
+    expect(message["chat_message"]["message"]).to eq(new_content)
+  end
+
   context "with mentions" do
     it "sends notifications if a message was updated with new mentions" do
       message = create_chat_message(user1, "Mentioning @#{user2.username}", public_chat_channel)
@@ -226,6 +243,56 @@ describe Chat::MessageUpdater do
       mention = user1.chat_mentions.where(chat_message: chat_message).first
       expect(mention).to be_present
       expect(mention.notification).to be_nil
+    end
+
+    it "adds mentioned user and their status to the message bus message" do
+      SiteSetting.enable_user_status = true
+      status = { description: "dentist", emoji: "tooth" }
+      user2.set_status!(status[:description], status[:emoji])
+      chat_message = create_chat_message(user1, "This will be updated", public_chat_channel)
+      new_content = "Hey @#{user2.username}"
+
+      messages =
+        MessageBus.track_publish("/chat/#{public_chat_channel.id}") do
+          described_class.update(
+            guardian: guardian,
+            chat_message: chat_message,
+            new_content: new_content,
+          )
+        end
+
+      expect(messages.count).to be(1)
+      message = messages[0].data
+      expect(message["chat_message"]["mentioned_users"].count).to be(1)
+      mentioned_user = message["chat_message"]["mentioned_users"][0]
+
+      expect(mentioned_user["id"]).to eq(user2.id)
+      expect(mentioned_user["username"]).to eq(user2.username)
+      expect(mentioned_user["status"]).to be_present
+      expect(mentioned_user["status"].slice(:description, :emoji)).to eq(status)
+    end
+
+    it "doesn't add mentioned user's status to the message bus message when status is disabled" do
+      SiteSetting.enable_user_status = false
+      user2.set_status!("dentist", "tooth")
+      chat_message = create_chat_message(user1, "This will be updated", public_chat_channel)
+      new_content = "Hey @#{user2.username}"
+
+      messages =
+        MessageBus.track_publish("/chat/#{public_chat_channel.id}") do
+          described_class.update(
+            guardian: guardian,
+            chat_message: chat_message,
+            new_content: new_content,
+          )
+        end
+
+      expect(messages.count).to be(1)
+      message = messages[0].data
+      expect(message["chat_message"]["mentioned_users"].count).to be(1)
+      mentioned_user = message["chat_message"]["mentioned_users"][0]
+
+      expect(mentioned_user["status"]).to be_blank
     end
 
     context "when updating a mentioned user" do

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -133,16 +133,18 @@ RSpec.describe "Chat channel", type: :system, js: true do
 
   context "when a message contains mentions" do
     fab!(:other_user) { Fabricate(:user) }
-
-    before do
-      channel_1.add(other_user)
-      channel_1.add(current_user)
+    fab!(:message) do
       Fabricate(
         :chat_message,
         chat_channel: channel_1,
         message: "hello @here @all @#{current_user.username} @#{other_user.username} @unexisting",
         user: other_user,
       )
+    end
+
+    before do
+      channel_1.add(other_user)
+      channel_1.add(current_user)
       sign_in(current_user)
     end
 
@@ -157,6 +159,18 @@ RSpec.describe "Chat channel", type: :system, js: true do
       )
       expect(page).to have_selector(".mention", text: "@#{other_user.username}")
       expect(page).to have_selector(".mention", text: "@unexisting")
+    end
+
+    it "renders user status on mentions" do
+      SiteSetting.enable_user_status = true
+      other_user.set_status!("surfing", "surfing_man")
+      Fabricate(:chat_mention, user: other_user, chat_message: message)
+
+      chat.visit_channel(channel_1)
+
+      expect(page).to have_selector(
+        ".mention .user-status[title=#{other_user.user_status.description}]",
+      )
     end
   end
 

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -171,10 +171,10 @@ RSpec.describe "Chat channel", type: :system, js: true do
       chat.visit_channel(channel_1)
 
       expect(page).to have_selector(
-        ".mention .user-status[title=#{current_user.user_status.description}]",
+        ".mention .user-status[title='#{current_user.user_status.description}']",
       )
       expect(page).to have_selector(
-        ".mention .user-status[title=#{other_user.user_status.description}]",
+        ".mention .user-status[title='#{other_user.user_status.description}']",
       )
     end
   end

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -163,11 +163,16 @@ RSpec.describe "Chat channel", type: :system, js: true do
 
     it "renders user status on mentions" do
       SiteSetting.enable_user_status = true
+      current_user.set_status!("off to dentist", "tooth")
       other_user.set_status!("surfing", "surfing_man")
+      Fabricate(:chat_mention, user: current_user, chat_message: message)
       Fabricate(:chat_mention, user: other_user, chat_message: message)
 
       chat.visit_channel(channel_1)
 
+      expect(page).to have_selector(
+        ".mention .user-status[title=#{current_user.user_status.description}]",
+      )
       expect(page).to have_selector(
         ".mention .user-status[title=#{other_user.user_status.description}]",
       )

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -1,0 +1,187 @@
+import {
+  acceptance,
+  loggedInUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import {
+  click,
+  fillIn,
+  triggerKeyEvent,
+  visit,
+  waitFor,
+} from "@ember/test-helpers";
+import pretender from "discourse/tests/helpers/create-pretender";
+
+acceptance("Chat | User status on mentions", function (needs) {
+  const channelId = 1;
+  const mentionedUser1 = {
+    id: 1000,
+    username: "user1",
+    status: {
+      description: "surfing",
+      emoji: "surfing_man",
+    },
+  };
+  const messagesResponse = {
+    meta: {
+      channel_id: channelId,
+    },
+    chat_messages: [
+      {
+        id: 1891,
+        message: `Hey @${mentionedUser1.username}`,
+        cooked: `<p>Hey <a class="mention" href="/u/${mentionedUser1.username}">@${mentionedUser1.username}</a></p>`,
+        mentioned_users: [mentionedUser1],
+        user: {
+          id: 1,
+          username: "jesse",
+        },
+      },
+    ],
+  };
+  const mentionedUser2 = {
+    id: 2000,
+    username: "user2",
+    status: {
+      description: "vacation",
+      emoji: "desert_island",
+    },
+  };
+
+  needs.settings({ chat_enabled: true });
+
+  needs.user({
+    has_chat_enabled: true,
+    chat_channels: {
+      public_channels: [
+        {
+          id: channelId,
+          chatable_id: 1,
+          chatable_type: "Category",
+          meta: { message_bus_last_ids: {} },
+          current_user_membership: { following: true },
+          chatable: { id: 1 },
+        },
+      ],
+      direct_message_channels: [],
+      meta: { message_bus_last_ids: {} },
+    },
+  });
+
+  needs.hooks.beforeEach(function () {
+    pretender.get("/chat/1/messages", () => {
+      return [200, {}, messagesResponse];
+    });
+    pretender.post("/chat/1", () => {
+      return [200, {}, {}];
+    });
+    pretender.post("/chat/drafts", () => {
+      return [200, {}, {}];
+    });
+
+    setupAutocompleteResponses([mentionedUser2]);
+  });
+
+  test("it shows status on mentions on just posted messages", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+
+    assert
+      .dom(`.mention[href='/u/${mentionedUser2.username}'] .user-status`)
+      .exists("status is rendered")
+      .hasAttribute(
+        "title",
+        mentionedUser2.status.description,
+        "status description is correct"
+      )
+      .hasAttribute(
+        "src",
+        new RegExp(`${mentionedUser2.status.emoji}.png`),
+        "status emoji is updated"
+      );
+  });
+
+  test("it updates status on mentions on just posted messages", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+
+    const newStatus = {
+      description: "working remotely",
+      emoji: "house",
+    };
+
+    loggedInUser().appEvents.trigger("user-status:changed", {
+      [mentionedUser2.id]: newStatus,
+    });
+
+    const selector = `.mention[href='/u/${mentionedUser2.username}'] .user-status`;
+    await waitFor(selector);
+    assert
+      .dom(selector)
+      .exists("status is rendered")
+      .hasAttribute(
+        "title",
+        newStatus.description,
+        "status description is updated"
+      )
+      .hasAttribute(
+        "src",
+        new RegExp(`${newStatus.emoji}.png`),
+        "status emoji is updated"
+      );
+  });
+
+  test("it deletes status on mentions on just posted messages", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+
+    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+
+    loggedInUser().appEvents.trigger("user-status:changed", {
+      [mentionedUser2.id]: null,
+    });
+
+    const selector = `.mention[href='/u/${mentionedUser2.username}'] .user-status`;
+    await waitFor(selector, { count: 0 });
+    assert.dom(selector).doesNotExist("status is deleted");
+  });
+
+  async function emulateAutocomplete(inputSelector, text) {
+    await triggerKeyEvent(inputSelector, "keydown", "Backspace");
+    await fillIn(inputSelector, `${text} `);
+    await triggerKeyEvent(inputSelector, "keyup", "Backspace");
+
+    await triggerKeyEvent(inputSelector, "keydown", "Backspace");
+    await fillIn(inputSelector, text);
+    await triggerKeyEvent(inputSelector, "keyup", "Backspace");
+  }
+
+  async function typeAndApplyAutocompleteSuggestion(text) {
+    await emulateAutocomplete(".chat-composer__input", text);
+    await click(".autocomplete.ac-user .selected");
+    await triggerKeyEvent(".chat-composer__input", "keydown", "Enter");
+  }
+
+  function setupAutocompleteResponses(results) {
+    pretender.get("/u/search/users", () => {
+      return [
+        200,
+        {},
+        {
+          users: results,
+        },
+      ];
+    });
+
+    pretender.get("/chat/api/mentions/groups.json", () => {
+      return [
+        200,
+        {},
+        {
+          unreachable: [],
+          over_members_limit: [],
+          invalid: ["and"],
+        },
+      ];
+    });
+  }
+});

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -13,6 +13,10 @@ import {
 import pretender from "discourse/tests/helpers/create-pretender";
 
 acceptance("Chat | User status on mentions", function (needs) {
+  const actingUser = {
+    id: 1,
+    username: "acting_user",
+  };
   const channelId = 1;
   const mentionedUser1 = {
     id: 1000,
@@ -32,10 +36,7 @@ acceptance("Chat | User status on mentions", function (needs) {
         message: `Hey @${mentionedUser1.username}`,
         cooked: `<p>Hey <a class="mention" href="/u/${mentionedUser1.username}">@${mentionedUser1.username}</a></p>`,
         mentioned_users: [mentionedUser1],
-        user: {
-          id: 1,
-          username: "jesse",
-        },
+        user: actingUser,
       },
     ],
   };
@@ -51,6 +52,7 @@ acceptance("Chat | User status on mentions", function (needs) {
   needs.settings({ chat_enabled: true });
 
   needs.user({
+    ...actingUser,
     has_chat_enabled: true,
     chat_channels: {
       public_channels: [

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -20,6 +20,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     username: "acting_user",
   };
   const channelId = 1;
+  const messageId = 1891;
   const mentionedUser1 = {
     id: 1000,
     username: "user1",
@@ -28,20 +29,6 @@ acceptance("Chat | User status on mentions", function (needs) {
       emoji: "surfing_man",
     },
   };
-  const messagesResponse = {
-    meta: {
-      channel_id: channelId,
-    },
-    chat_messages: [
-      {
-        id: 1891,
-        message: `Hey @${mentionedUser1.username}`,
-        cooked: `<p>Hey <a class="mention" href="/u/${mentionedUser1.username}">@${mentionedUser1.username}</a></p>`,
-        mentioned_users: [mentionedUser1],
-        user: actingUser,
-      },
-    ],
-  };
   const mentionedUser2 = {
     id: 2000,
     username: "user2",
@@ -49,6 +36,28 @@ acceptance("Chat | User status on mentions", function (needs) {
       description: "vacation",
       emoji: "desert_island",
     },
+  };
+  const mentionedUser3 = {
+    id: 3000,
+    username: "user3",
+    status: {
+      description: "off to dentist",
+      emoji: "tooth",
+    },
+  };
+  const messagesResponse = {
+    meta: {
+      channel_id: channelId,
+    },
+    chat_messages: [
+      {
+        id: messageId,
+        message: `Hey @${mentionedUser1.username}`,
+        cooked: `<p>Hey <a class="mention" href="/u/${mentionedUser1.username}">@${mentionedUser1.username}</a></p>`,
+        mentioned_users: [mentionedUser1],
+        user: actingUser,
+      },
+    ],
   };
 
   needs.settings({ chat_enabled: true });
@@ -79,16 +88,19 @@ acceptance("Chat | User status on mentions", function (needs) {
     pretender.post("/chat/1", () => {
       return [200, {}, {}];
     });
+    pretender.put(`/chat/1/edit/${messageId}`, () => {
+      return [200, {}, {}];
+    });
     pretender.post("/chat/drafts", () => {
       return [200, {}, {}];
     });
 
-    setupAutocompleteResponses([mentionedUser2]);
+    setupAutocompleteResponses([mentionedUser2, mentionedUser3]);
   });
 
   test("it shows status on mentions on just posted messages", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
-    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+    await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
     assert
       .dom(`.mention[href='/u/${mentionedUser2.username}'] .user-status`)
@@ -107,7 +119,7 @@ acceptance("Chat | User status on mentions", function (needs) {
 
   test("it updates status on mentions on just posted messages", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
-    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+    await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
     const newStatus = {
       description: "working remotely",
@@ -138,7 +150,7 @@ acceptance("Chat | User status on mentions", function (needs) {
   test("it deletes status on mentions on just posted messages", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
-    await typeAndApplyAutocompleteSuggestion("mentioning @u");
+    await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
     loggedInUser().appEvents.trigger("user-status:changed", {
       [mentionedUser2.id]: null,
@@ -152,26 +164,31 @@ acceptance("Chat | User status on mentions", function (needs) {
   test("it shows status on mentions on updated messages", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
-    await editMessage(".chat-message-content");
+    await editMessage(
+      ".chat-message-content",
+      `mentioning @${mentionedUser3.username}`
+    );
 
     assert
-      .dom(`.mention[href='/u/${mentionedUser2.username}'] .user-status`)
+      .dom(`.mention[href='/u/${mentionedUser3.username}'] .user-status`)
       .exists("status is rendered")
       .hasAttribute(
         "title",
-        mentionedUser2.status.description,
+        mentionedUser3.status.description,
         "status description is correct"
       )
       .hasAttribute(
         "src",
-        new RegExp(`${mentionedUser2.status.emoji}.png`),
+        new RegExp(`${mentionedUser3.status.emoji}.png`),
         "status emoji is updated"
       );
   });
 
-  async function editMessage(messageSelector) {
+  async function editMessage(messageSelector, text) {
     await triggerEvent(query(messageSelector), "mouseenter");
-    await click(".more-buttons");
+    await click(".more-buttons .select-kit-header-wrapper");
+    await click(".select-kit-collection .select-kit-row[data-value='edit']");
+    await typeWithAutocompleteAndSend(text);
   }
 
   async function emulateAutocomplete(inputSelector, text) {
@@ -184,7 +201,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     await triggerKeyEvent(inputSelector, "keyup", "Backspace");
   }
 
-  async function typeAndApplyAutocompleteSuggestion(text) {
+  async function typeWithAutocompleteAndSend(text) {
     await emulateAutocomplete(".chat-composer__input", text);
     await click(".autocomplete.ac-user .selected");
     await triggerKeyEvent(".chat-composer__input", "keydown", "Enter");

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -1,11 +1,13 @@
 import {
   acceptance,
   loggedInUser,
+  query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import {
   click,
   fillIn,
+  triggerEvent,
   triggerKeyEvent,
   visit,
   waitFor,
@@ -146,6 +148,31 @@ acceptance("Chat | User status on mentions", function (needs) {
     await waitFor(selector, { count: 0 });
     assert.dom(selector).doesNotExist("status is deleted");
   });
+
+  test("it shows status on mentions on updated messages", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+
+    await editMessage(".chat-message-content");
+
+    assert
+      .dom(`.mention[href='/u/${mentionedUser2.username}'] .user-status`)
+      .exists("status is rendered")
+      .hasAttribute(
+        "title",
+        mentionedUser2.status.description,
+        "status description is correct"
+      )
+      .hasAttribute(
+        "src",
+        new RegExp(`${mentionedUser2.status.emoji}.png`),
+        "status emoji is updated"
+      );
+  });
+
+  async function editMessage(messageSelector) {
+    await triggerEvent(query(messageSelector), "mouseenter");
+    await click(".more-buttons");
+  }
 
   async function emulateAutocomplete(inputSelector, text) {
     await triggerKeyEvent(inputSelector, "keydown", "Backspace");

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -5,7 +5,7 @@ import {
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import {
   click,
   triggerEvent,
@@ -151,7 +151,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
-  skip("edited messages | it updates status on mentions", async function (assert) {
+  test("edited messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await editMessage(
       ".chat-message-content",
@@ -167,7 +167,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assertStatusIsRendered(assert, selector, newStatus);
   });
 
-  skip("edited messages | it deletes status on mentions", async function (assert) {
+  test("edited messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  emulateAutocomplete,
   loggedInUser,
   publishToMessageBus,
   query,
@@ -7,7 +8,6 @@ import {
 import { skip, test } from "qunit";
 import {
   click,
-  fillIn,
   triggerEvent,
   triggerKeyEvent,
   visit,
@@ -312,16 +312,6 @@ acceptance("Chat | User status on mentions", function (needs) {
       type: "restore",
       chat_message: message,
     });
-  }
-
-  async function emulateAutocomplete(inputSelector, text) {
-    await triggerKeyEvent(inputSelector, "keydown", "Backspace");
-    await fillIn(inputSelector, `${text} `);
-    await triggerKeyEvent(inputSelector, "keyup", "Backspace");
-
-    await triggerKeyEvent(inputSelector, "keydown", "Backspace");
-    await fillIn(inputSelector, text);
-    await triggerKeyEvent(inputSelector, "keyup", "Backspace");
   }
 
   async function typeWithAutocompleteAndSend(text) {

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -313,41 +313,6 @@ acceptance("Chat | User status on mentions", function (needs) {
       type: "restore",
       chat_message: message,
     });
-
-    // data: {
-    //   chat_message: {
-    //     id: 2137,
-    //     message: "test",
-    //     cooked: "<p>test</p>",
-    //     created_at: "2023-05-17T22:15:38.972Z",
-    //     excerpt: "test",
-    //     available_flags: [],
-    //     thread_title: null,
-    //     chat_channel_id: 1,
-    //     mentioned_users: [],
-    //     user: {
-    //       id: 1,
-    //       username: "admin1",
-    //       name: null,
-    //       avatar_template:
-    //         "/letter_avatar_proxy/v4/letter/a/bbce88/{size}.png",
-    //       status: {
-    //         description: "test",
-    //         emoji: "hole",
-    //         ends_at: null,
-    //         message_bus_last_id: 29,
-    //       },
-    //       moderator: false,
-    //       admin: true,
-    //       staff: true,
-    //       new_user: false,
-    //       primary_group_name: null,
-    //     },
-    //     chat_webhook_event: null,
-    //     uploads: [],
-    //   },
-    //   type: "restore",
-    // },
   }
 
   async function emulateAutocomplete(inputSelector, text) {

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -105,7 +105,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
     assertStatusIsRendered(
       assert,
-      `.mention[href='/u/${mentionedUser2.username}'] .user-status`,
+      statusSelector(mentionedUser2.username),
       mentionedUser2.status
     );
   });
@@ -118,7 +118,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser2.id]: newStatus,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser2.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser2.username);
     await waitFor(selector);
     assertStatusIsRendered(assert, selector, newStatus);
   });
@@ -132,7 +132,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser2.id]: null,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser2.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser2.username);
     await waitFor(selector, { count: 0 });
     assert.dom(selector).doesNotExist("status is deleted");
   });
@@ -147,7 +147,7 @@ acceptance("Chat | User status on mentions", function (needs) {
 
     assertStatusIsRendered(
       assert,
-      `.mention[href='/u/${mentionedUser3.username}'] .user-status`,
+      statusSelector(mentionedUser3.username),
       mentionedUser3.status
     );
   });
@@ -163,7 +163,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser3.id]: newStatus,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser3.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser3.username);
     await waitFor(selector);
     assertStatusIsRendered(assert, selector, newStatus);
   });
@@ -180,7 +180,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser3.id]: null,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser3.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser3.username);
     await waitFor(selector, { count: 0 });
     assert.dom(selector).doesNotExist("status is deleted");
   });
@@ -193,7 +193,7 @@ acceptance("Chat | User status on mentions", function (needs) {
 
     assertStatusIsRendered(
       assert,
-      `.mention[href='/u/${mentionedUser1.username}'] .user-status`,
+      statusSelector(mentionedUser1.username),
       mentionedUser1.status
     );
   });
@@ -208,7 +208,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser1.id]: newStatus,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser1.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser1.username);
     await waitFor(selector);
     assertStatusIsRendered(assert, selector, newStatus);
   });
@@ -223,7 +223,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       [mentionedUser1.id]: null,
     });
 
-    const selector = `.mention[href='/u/${mentionedUser1.username}'] .user-status`;
+    const selector = statusSelector(mentionedUser1.username);
     await waitFor(selector, { count: 0 });
     assert.dom(selector).doesNotExist("status is deleted");
   });
@@ -236,7 +236,7 @@ acceptance("Chat | User status on mentions", function (needs) {
 
     assertStatusIsRendered(
       assert,
-      `.mention[href='/u/${mentionedUser1.username}'] .user-status`,
+      statusSelector(mentionedUser1.username),
       mentionedUser1.status
     );
   });
@@ -358,6 +358,10 @@ acceptance("Chat | User status on mentions", function (needs) {
         },
       ];
     });
+  }
+
+  function statusSelector(username) {
+    return `.mention[href='/u/${username}'] .user-status`;
   }
 
   const OK = [200, {}, {}];

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -13,7 +13,7 @@ import {
   visit,
   waitFor,
 } from "@ember/test-helpers";
-import pretender from "discourse/tests/helpers/create-pretender";
+import pretender, { OK } from "discourse/tests/helpers/create-pretender";
 
 acceptance("Chat | User status on mentions", function (needs) {
   const actingUser = {
@@ -356,9 +356,5 @@ acceptance("Chat | User status on mentions", function (needs) {
 
   function statusSelector(username) {
     return `.mention[href='/u/${username}'] .user-status`;
-  }
-
-  function OK(response = {}, headers = {}) {
-    return [200, headers, response];
   }
 });

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -16,12 +16,12 @@ import {
 import pretender, { OK } from "discourse/tests/helpers/create-pretender";
 
 acceptance("Chat | User status on mentions", function (needs) {
+  const channelId = 1;
+  const messageId = 1;
   const actingUser = {
     id: 1,
     username: "acting_user",
   };
-  const channelId = 1;
-  const messageId = 1891;
   const mentionedUser1 = {
     id: 1000,
     username: "user1",

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -232,7 +232,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     await visit(`/chat/c/-/${channelId}`);
 
     await deleteMessage(".chat-message-content");
-    await restoreMessage(".chat-message-content");
+    await restoreMessage(".chat-message-deleted");
 
     assertStatusIsRendered(
       assert,

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -241,6 +241,36 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
+  test("restored messages | it updates status on mentions", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+
+    await deleteMessage(".chat-message-content");
+    await restoreMessage(".chat-message-deleted");
+
+    loggedInUser().appEvents.trigger("user-status:changed", {
+      [mentionedUser1.id]: newStatus,
+    });
+
+    const selector = statusSelector(mentionedUser1.username);
+    await waitFor(selector);
+    assertStatusIsRendered(assert, selector, newStatus);
+  });
+
+  test("restored messages | it deletes status on mentions", async function (assert) {
+    await visit(`/chat/c/-/${channelId}`);
+
+    await deleteMessage(".chat-message-content");
+    await restoreMessage(".chat-message-deleted");
+
+    loggedInUser().appEvents.trigger("user-status:changed", {
+      [mentionedUser1.id]: null,
+    });
+
+    const selector = statusSelector(mentionedUser1.username);
+    await waitFor(selector, { count: 0 });
+    assert.dom(selector).doesNotExist("status is deleted");
+  });
+
   function assertStatusIsRendered(assert, selector, status) {
     assert
       .dom(selector)

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -98,7 +98,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     setupAutocompleteResponses([mentionedUser2, mentionedUser3]);
   });
 
-  test("it shows status on mentions on just posted messages", async function (assert) {
+  test("just posted messages | it shows status on mentions ", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
@@ -117,7 +117,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       );
   });
 
-  test("it updates status on mentions on just posted messages", async function (assert) {
+  test("just posted messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
@@ -147,7 +147,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       );
   });
 
-  test("it deletes status on mentions on just posted messages", async function (assert) {
+  test("just posted messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
@@ -161,7 +161,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assert.dom(selector).doesNotExist("status is deleted");
   });
 
-  test("it shows status on mentions on edited messages", async function (assert) {
+  test("edited messages | it shows status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(
@@ -184,7 +184,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       );
   });
 
-  skip("it updates status on mentions on edited messages", async function (assert) {
+  skip("edited messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await editMessage(
       ".chat-message-content",
@@ -216,7 +216,7 @@ acceptance("Chat | User status on mentions", function (needs) {
       );
   });
 
-  skip("it deletes status on mentions on edited messages", async function (assert) {
+  skip("edited messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -87,14 +87,13 @@ acceptance("Chat | User status on mentions", function (needs) {
   });
 
   needs.hooks.beforeEach(function () {
-    pretender.get(`/chat/1/messages`, () => [200, {}, messagesResponse]);
-    pretender.post(`/chat/1`, () => OK);
-    pretender.put(`/chat/1/edit/${messageId}`, () => OK);
-    pretender.post(`/chat/drafts`, () => OK);
-    pretender.delete(`/chat/api/channels/1/messages/${messageId}`, () => OK);
-    pretender.put(
-      `/chat/api/channels/1/messages/${messageId}/restore`,
-      () => OK
+    pretender.get(`/chat/1/messages`, () => OK(messagesResponse));
+    pretender.post(`/chat/1`, () => OK());
+    pretender.put(`/chat/1/edit/${messageId}`, () => OK());
+    pretender.post(`/chat/drafts`, () => OK());
+    pretender.delete(`/chat/api/channels/1/messages/${messageId}`, () => OK());
+    pretender.put(`/chat/api/channels/1/messages/${messageId}/restore`, () =>
+      OK()
     );
 
     setupAutocompleteResponses([mentionedUser2, mentionedUser3]);
@@ -359,5 +358,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     return `.mention[href='/u/${username}'] .user-status`;
   }
 
-  const OK = [200, {}, {}];
+  function OK(response = {}, headers = {}) {
+    return [200, headers, response];
+  }
 });

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -1,0 +1,118 @@
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import fabricators from "../helpers/fabricators";
+import { render, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import pretender from "discourse/tests/helpers/create-pretender";
+
+module(
+  "Discourse Chat | Component | chat-channel | mentions",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    const channelId = 1;
+    const mentionedUser = {
+      id: 1000,
+      username: "user1",
+      status: {
+        description: "surfing",
+        emoji: "surfing_man",
+      },
+    };
+    const messagesResponse = {
+      meta: {
+        channel_id: channelId,
+      },
+      chat_messages: [
+        {
+          id: 1891,
+          message: `Hey @${mentionedUser.username}`,
+          cooked: `<p>Hey <a class="mention" href="/u/${mentionedUser.username}">@${mentionedUser.username}</a></p>`,
+          mentioned_users: [mentionedUser],
+          user: {
+            id: 1,
+            username: "jesse",
+          },
+        },
+      ],
+    };
+
+    hooks.beforeEach(function () {
+      this.channel = fabricators.chatChannel({
+        id: channelId,
+        currentUserMembership: { following: true },
+      });
+
+      pretender.get(`/chat/${channelId}/messages`, () => {
+        return [200, {}, messagesResponse];
+      });
+      pretender.post(`/chat/${channelId}`, () => {
+        return [200, {}, {}];
+      });
+      pretender.post("/chat/drafts", () => {
+        return [200, {}, {}];
+      });
+
+      this.appEvents = this.container.lookup("service:appEvents");
+    });
+
+    test("it shows status on mentions", async function (assert) {
+      await render(hbs`<ChatChannel @channel={{this.channel}} />`);
+
+      assert
+        .dom(".mention .user-status")
+        .exists("status is rendered")
+        .hasAttribute(
+          "title",
+          mentionedUser.status.description,
+          "status description is correct"
+        )
+        .hasAttribute(
+          "src",
+          new RegExp(`${mentionedUser.status.emoji}.png`),
+          "status emoji is updated"
+        );
+    });
+
+    test("it updates status on mentions", async function (assert) {
+      await render(hbs`<ChatChannel @channel={{this.channel}} />`);
+
+      const newStatus = {
+        description: "off to dentist",
+        emoji: "tooth",
+      };
+
+      this.appEvents.trigger("user-status:changed", {
+        [mentionedUser.id]: newStatus,
+      });
+
+      const selector = ".mention .user-status";
+      await waitFor(selector);
+      assert
+        .dom(selector)
+        .exists("status is rendered")
+        .hasAttribute(
+          "title",
+          newStatus.description,
+          "status description is updated"
+        )
+        .hasAttribute(
+          "src",
+          new RegExp(`${newStatus.emoji}.png`),
+          "status emoji is updated"
+        );
+    });
+
+    test("it deletes status on mentions", async function (assert) {
+      await render(hbs`<ChatChannel @channel={{this.channel}} />`);
+
+      this.appEvents.trigger("user-status:changed", {
+        [mentionedUser.id]: null,
+      });
+
+      const selector = ".mention .user-status";
+      await waitFor(selector, { count: 0 });
+      assert.dom(selector).doesNotExist("status is deleted");
+    });
+  }
+);

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -41,6 +41,7 @@ module(
       this.channel = fabricators.channel({
         id: channelId,
         currentUserMembership: { following: true },
+        meta: { can_join_chat_channel: false },
       });
 
       pretender.get(`/chat/${channelId}/messages`, () => {

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -1,6 +1,6 @@
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import hbs from "htmlbars-inline-precompile";
-import fabricators from "../helpers/fabricators";
+import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 import { render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import pretender from "discourse/tests/helpers/create-pretender";
@@ -38,7 +38,7 @@ module(
     };
 
     hooks.beforeEach(function () {
-      this.channel = fabricators.chatChannel({
+      this.channel = fabricators.channel({
         id: channelId,
         currentUserMembership: { following: true },
       });

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -123,6 +123,40 @@ module(
       );
     });
 
+    test("it updates status on mentions on messages that came from Message Bus", async function (assert) {
+      await render(hbs`<ChatChannel @channel={{this.channel}} />`);
+      await receiveMessageViaMessageBus();
+
+      const newStatus = {
+        description: "off to meeting",
+        emoji: "calendar",
+      };
+      this.appEvents.trigger("user-status:changed", {
+        [mentionedUser2.id]: newStatus,
+      });
+
+      const selector = statusSelector(mentionedUser2.username);
+      await waitFor(selector);
+      assertStatusIsRendered(
+        assert,
+        statusSelector(mentionedUser2.username),
+        newStatus
+      );
+    });
+
+    test("it deletes status on mentions on messages that came from Message Bus", async function (assert) {
+      await render(hbs`<ChatChannel @channel={{this.channel}} />`);
+      await receiveMessageViaMessageBus();
+
+      this.appEvents.trigger("user-status:changed", {
+        [mentionedUser2.id]: null,
+      });
+
+      const selector = statusSelector(mentionedUser2.username);
+      await waitFor(selector, { count: 0 });
+      assert.dom(selector).doesNotExist("status is deleted");
+    });
+
     function assertStatusIsRendered(assert, selector, status) {
       assert
         .dom(selector)

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -7,7 +7,7 @@ import pretender from "discourse/tests/helpers/create-pretender";
 import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 
 module(
-  "Discourse Chat | Component | chat-channel | mentions",
+  "Discourse Chat | Component | chat-channel | status on mentions",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -71,19 +71,11 @@ module(
     test("it shows status on mentions", async function (assert) {
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
 
-      assert
-        .dom(statusSelector(mentionedUser.username))
-        .exists("status is rendered")
-        .hasAttribute(
-          "title",
-          mentionedUser.status.description,
-          "status description is correct"
-        )
-        .hasAttribute(
-          "src",
-          new RegExp(`${mentionedUser.status.emoji}.png`),
-          "status emoji is updated"
-        );
+      assertStatusIsRendered(
+        assert,
+        statusSelector(mentionedUser.username),
+        mentionedUser.status
+      );
     });
 
     test("it updates status on mentions", async function (assert) {
@@ -100,19 +92,11 @@ module(
 
       const selector = statusSelector(mentionedUser.username);
       await waitFor(selector);
-      assert
-        .dom(selector)
-        .exists("status is rendered")
-        .hasAttribute(
-          "title",
-          newStatus.description,
-          "status description is updated"
-        )
-        .hasAttribute(
-          "src",
-          new RegExp(`${newStatus.emoji}.png`),
-          "status emoji is updated"
-        );
+      assertStatusIsRendered(
+        assert,
+        statusSelector(mentionedUser.username),
+        newStatus
+      );
     });
 
     test("it deletes status on mentions", async function (assert) {
@@ -132,20 +116,28 @@ module(
 
       await receiveMessageViaMessageBus();
 
+      assertStatusIsRendered(
+        assert,
+        statusSelector(mentionedUser2.username),
+        mentionedUser2.status
+      );
+    });
+
+    function assertStatusIsRendered(assert, selector, status) {
       assert
-        .dom(statusSelector(mentionedUser2.username))
+        .dom(selector)
         .exists("status is rendered")
         .hasAttribute(
           "title",
-          mentionedUser2.status.description,
-          "status description is correct"
+          status.description,
+          "status description is updated"
         )
         .hasAttribute(
           "src",
-          new RegExp(`${mentionedUser2.status.emoji}.png`),
+          new RegExp(`${status.emoji}.png`),
           "status emoji is updated"
         );
-    });
+    }
 
     async function receiveMessageViaMessageBus() {
       await publishToMessageBus(`/chat/${channelId}`, {

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -107,7 +107,7 @@ module(
     test("it shows status on mentions on messages that came from Message Bus", async function (assert) {
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
 
-      await receiveMessageViaMessageBus();
+      await receiveChatMessageViaMessageBus();
 
       assertStatusIsRendered(
         assert,
@@ -118,7 +118,7 @@ module(
 
     test("it updates status on mentions on messages that came from Message Bus", async function (assert) {
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
-      await receiveMessageViaMessageBus();
+      await receiveChatMessageViaMessageBus();
 
       const newStatus = {
         description: "off to meeting",
@@ -139,7 +139,7 @@ module(
 
     test("it deletes status on mentions on messages that came from Message Bus", async function (assert) {
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
-      await receiveMessageViaMessageBus();
+      await receiveChatMessageViaMessageBus();
 
       this.appEvents.trigger("user-status:changed", {
         [mentionedUser2.id]: null,
@@ -166,7 +166,7 @@ module(
         );
     }
 
-    async function receiveMessageViaMessageBus() {
+    async function receiveChatMessageViaMessageBus() {
       await publishToMessageBus(`/chat/${channelId}`, {
         chat_message: {
           id: 2138,

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -3,7 +3,7 @@ import hbs from "htmlbars-inline-precompile";
 import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 import { render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import pretender from "discourse/tests/helpers/create-pretender";
+import pretender, { OK } from "discourse/tests/helpers/create-pretender";
 import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 
 module(
@@ -188,10 +188,6 @@ module(
 
     function statusSelector(username) {
       return `.mention[href='/u/${username}'] .user-status`;
-    }
-
-    function OK(response = {}, headers = {}) {
-      return [200, headers, response];
     }
   }
 );

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -57,16 +57,13 @@ module(
         meta: { can_join_chat_channel: false },
       });
 
-      pretender.get(`/chat/${channelId}/messages`, () => {
-        return [200, {}, messagesResponse];
-      });
-      pretender.post(`/chat/${channelId}`, () => {
-        return [200, {}, {}];
-      });
-      pretender.post("/chat/drafts", () => {
-        return [200, {}, {}];
-      });
-      pretender.put(`/chat/api/channels/1/read/2138`, () => [200, {}, {}]);
+      pretender.get(`/chat/${channelId}/messages`, () => [
+        200,
+        {},
+        messagesResponse,
+      ]);
+      pretender.post(`/chat/${channelId}`, () => OK);
+      pretender.post("/chat/drafts", () => OK);
 
       this.appEvents = this.container.lookup("service:appEvents");
     });
@@ -130,7 +127,7 @@ module(
       assert.dom(selector).doesNotExist("status is deleted");
     });
 
-    test("it shows status on mentions on a message that came from Message Bus", async function (assert) {
+    test("it shows status on mentions on messages that came from Message Bus", async function (assert) {
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
 
       await receiveMessageViaMessageBus();
@@ -167,21 +164,13 @@ module(
           uploads: [],
         },
         type: "sent",
-        staged_id: "07d40475-3ea7-4be9-a05f-c4df7b79ff3c",
-        staged_thread_id: null,
-      });
-
-      await publishToMessageBus(`/chat/${channelId}/new-messages`, {
-        channel_id: channelId,
-        message_id: 2138,
-        user_id: 2,
-        username: "andrei1",
-        thread_id: null,
       });
     }
 
     function statusSelector(username) {
       return `.mention[href='/u/${username}'] .user-status`;
     }
+
+    const OK = [200, {}, {}];
   }
 );

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -72,7 +72,7 @@ module(
       await render(hbs`<ChatChannel @channel={{this.channel}} />`);
 
       assert
-        .dom(".mention .user-status")
+        .dom(statusSelector(mentionedUser.username))
         .exists("status is rendered")
         .hasAttribute(
           "title",
@@ -98,7 +98,7 @@ module(
         [mentionedUser.id]: newStatus,
       });
 
-      const selector = ".mention .user-status";
+      const selector = statusSelector(mentionedUser.username);
       await waitFor(selector);
       assert
         .dom(selector)
@@ -122,7 +122,7 @@ module(
         [mentionedUser.id]: null,
       });
 
-      const selector = ".mention .user-status";
+      const selector = statusSelector(mentionedUser.username);
       await waitFor(selector, { count: 0 });
       assert.dom(selector).doesNotExist("status is deleted");
     });

--- a/plugins/chat/test/javascripts/components/chat-channel-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.js
@@ -51,20 +51,13 @@ module(
     };
 
     hooks.beforeEach(function () {
+      pretender.get(`/chat/${channelId}/messages`, () => OK(messagesResponse));
+
       this.channel = fabricators.channel({
         id: channelId,
         currentUserMembership: { following: true },
         meta: { can_join_chat_channel: false },
       });
-
-      pretender.get(`/chat/${channelId}/messages`, () => [
-        200,
-        {},
-        messagesResponse,
-      ]);
-      pretender.post(`/chat/${channelId}`, () => OK);
-      pretender.post("/chat/drafts", () => OK);
-
       this.appEvents = this.container.lookup("service:appEvents");
     });
 
@@ -197,6 +190,8 @@ module(
       return `.mention[href='/u/${username}'] .user-status`;
     }
 
-    const OK = [200, {}, {}];
+    function OK(response = {}, headers = {}) {
+      return [200, headers, response];
+    }
   }
 );


### PR DESCRIPTION
- SERVER: return mentions from the server
- Avoid N + 1 when loading chat mentions
- CLIENT: show live status
- Server specs
- A system spec
- Client specs
- Transition can be null in route.deactivate
- Extract methods for initializing and tearing down mentioned users
- Show status on messages that are coming from Message Bus
- Refresh status when updating the message
- Do not enable status tracking for a mentioned user twice
- Make status live on updated messages too
- Tests: add acting user, so it's possible to edit a message
- Draft a test
- Show live status on expanded deleted messages
- Show live status on restored deleted messages
- Fix
- Fix 3
- Import fabricators from the new file
- Fix 4
- Test for updated message
- More tests for updated message (skipped for now)
- Test for self-mentions
- Better test names
- Tests for deleted messages
- Simplify tests + test for restored messages
- Refactor tests
- Make the test pass
- More tests for restored messages
- Drop commented code
- A test for messages that came from MessageBus
- Simplify tests
- Refactor
- Refactor
- More test cases
- Correct the system spec
- Avoid exceptions on deleted messages
- Move status related modifiers
- Refactor tests
- Refactor tests
- Refactor tests
- Refactor tests

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
