### PR TITLE
DEV: Added modifier to change mentions extracted from cooked text

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -457,6 +457,9 @@ module PrettyText
           end
         end
 
+    mentions =
+      DiscoursePluginRegistry.apply_modifier(:pretty_text_extract_mentions, mentions, cooked)
+
     mentions.compact!
     mentions.uniq!
     mentions


### PR DESCRIPTION
Added a new modifier hook to allow plugins to modify the @mentions
extracted from a cooked text.

Use case: Some plugins may change how the mentions are cooked to prevent
them from being confused with user or group mentions and display the user
card. 

This modifier hook allows the plugin to filter the mentions detected or add new ways 
to add mentions into cooked text.