### PR TITLE
DEV: Add experimental registerCustomCategorySectionLinkPrefix api

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -106,6 +106,7 @@ import { addSectionLink as addCustomCommunitySectionLink } from "discourse/lib/s
 import { addSidebarSection } from "discourse/lib/sidebar/custom-sections";
 import {
   registerCustomCategoryLockIcon,
+  registerCustomCategorySectionLinkPrefix,
   registerCustomCountable as registerUserCategorySectionLinkCountable,
 } from "discourse/lib/sidebar/user/categories-section/category-section-link";
 import { REFRESH_COUNTS_APP_EVENT_NAME as REFRESH_USER_SIDEBAR_CATEGORIES_SECTION_COUNTS_APP_EVENT_NAME } from "discourse/components/sidebar/user/categories-section";
@@ -1922,6 +1923,45 @@ class PluginApi {
    */
   registerCustomCategorySectionLinkLockIcon(icon) {
     return registerCustomCategoryLockIcon(icon);
+  }
+
+  /**
+   * EXPERIMENTAL. Do not use.
+   * Register a custom prefix for a sidebar category section link.
+   *
+   * Example:
+   *
+   * ```
+   * api.registerCustomCategorySectionLinkPrefix({
+   *   categoryId: category.id,
+   *   prefixType: "icon",
+   *   prefixValue: "wrench",
+   *   prefixColor: "FF0000"
+   * })
+   * ```
+   *
+   * @params {Object} arg - An object
+   * @params {string} arg.categoryId - The id of the category
+   * @params {string} arg.prefixType - The type of prefix to use. Can be "icon", "image", "text" or "span".
+   * @params {string} arg.prefixValue - The value of the prefix to use.
+   *                                    For "icon", pass in the name of a FontAwesome 5 icon.
+   *                                    For "image", pass in the src of the image.
+   *                                    For "text", pass in the text to display.
+   *                                    For "span", pass in an array containing two hex color values. Example: `[FF0000, 000000]`.
+   * @params {string} arg.prefixColor - The color of the prefix to use. Example: "FF0000".
+   */
+  registerCustomCategorySectionLinkPrefix({
+    categoryId,
+    prefixType,
+    prefixValue,
+    prefixColor,
+  }) {
+    registerCustomCategorySectionLinkPrefix({
+      categoryId,
+      prefixType,
+      prefixValue,
+      prefixColor,
+    });
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -82,6 +82,29 @@ export function resetCustomCategoryLockIcon() {
   customCategoryLockIcon = null;
 }
 
+let customCategoryPrefixes = {};
+
+export function registerCustomCategorySectionLinkPrefix({
+  categoryId,
+  prefixValue,
+  prefixType,
+  prefixColor,
+}) {
+  customCategoryPrefixes[categoryId] = {
+    prefixValue,
+    prefixType,
+    prefixColor,
+  };
+}
+
+export function resetCustomCategorySectionLinkPrefix() {
+  for (let key in customCategoryPrefixes) {
+    if (customCategoryPrefixes.hasOwnProperty(key)) {
+      delete customCategoryPrefixes[key];
+    }
+  }
+}
+
 export default class CategorySectionLink {
   @tracked activeCountable;
 
@@ -166,10 +189,17 @@ export default class CategorySectionLink {
   }
 
   get prefixType() {
-    return "span";
+    return customCategoryPrefixes[this.category.id]?.prefixType || "span";
   }
 
   get prefixValue() {
+    const customPrefixValue =
+      customCategoryPrefixes[this.category.id]?.prefixValue;
+
+    if (customPrefixValue) {
+      return customPrefixValue;
+    }
+
     if (this.category.parentCategory?.color) {
       return [this.category.parentCategory?.color, this.category.color];
     } else {
@@ -178,7 +208,10 @@ export default class CategorySectionLink {
   }
 
   get prefixColor() {
-    return this.category.color;
+    return (
+      customCategoryPrefixes[this.category.id]?.prefixColor ||
+      this.category.color
+    );
   }
 
   get prefixBadge() {


### PR DESCRIPTION
This commit adds the experimental `registerCustomCategorySectionLinkPrefix` client side
plugin API that allows themes or plugins to override the prefix of a
category section link.

This is marked experimental because we might be introducing a core
feature where category icons are supported. This is currently use as a
bridge for the https://github.com/discourse/discourse-category-icons
theme component.