### PR TITLE
DEV: `.quick-access-profile` no longer exists

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -537,42 +537,6 @@
     }
     /* as a big ol' click target, don't let text inside be selected */
     @include unselectable;
-
-    &.quick-access-profile {
-      display: inline;
-      li:not(.show-all) a {
-        color: var(--primary);
-        display: flex;
-      }
-      ul button {
-        line-height: 1.4; // match 'ul a' link height
-        width: 100%;
-        display: flex;
-      }
-      @media screen and (max-height: 360px) {
-        // two column grid to avoid scroll
-        ul {
-          display: grid;
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-          grid-gap: 0 1em;
-          a {
-            @include ellipsis;
-            > div {
-              display: block;
-            }
-          }
-          button {
-            span:not(.relative-date) {
-              @include ellipsis;
-            }
-          }
-        }
-        li:not(.show-all) a {
-          color: var(--primary);
-          display: flex;
-        }
-      }
-    }
   }
 }
 

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -1,19 +1,3 @@
-.user-menu .quick-access-panel.quick-access-profile li:not(.show-all) {
-  border-bottom: 1px solid var(--primary-low);
-
-  a,
-  button {
-    // accounts for menu "ears" 4px + border 1px
-    padding: 0.75em calc(0.5em + 4px + 1px);
-    margin: 0.25em;
-    @media screen and (max-height: 500px) {
-      // reduce padding to avoid scroll
-      padding-top: 0.25em;
-      padding-bottom: 0.25em;
-    }
-  }
-}
-
 .panel-body-contents {
   // 2em padding very useful for iOS Safari's overlayed bottom nav
   // padding-bottom: calc(env(safe-area-inset-bottom) + 2em);


### PR DESCRIPTION
This PR removes some lingering CSS styles using the class `.quick-access-profile` which no longer exists and was removed in https://github.com/discourse/discourse/commit/082821c754ce95aefdc5c69e6d0eea4057bcd5b5