### PR TITLE
DEV: endpoint to reset community community-section

### DIFF
--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -58,7 +58,7 @@ class SidebarSectionsController < ApplicationController
     when "community"
       reset_community(sidebar_section)
     end
-    render json: SidebarSectionSerializer.new(sidebar_section.reload)
+    render_serialized(sidebar_section.reload, SidebarSectionSerializer)
   end
 
   def reorder

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -50,6 +50,17 @@ class SidebarSectionsController < ApplicationController
     render json: failed_json, status: 403
   end
 
+  def reset
+    sidebar_section = SidebarSection.find(params[:id])
+    @guardian.ensure_can_edit!(sidebar_section)
+
+    case sidebar_section.section_type
+    when "community"
+      reset_community(sidebar_section)
+    end
+    render json: SidebarSectionSerializer.new(sidebar_section.reload)
+  end
+
   def reorder
     sidebar_section = SidebarSection.find_by(id: reorder_params["sidebar_section_id"])
     @guardian.ensure_can_edit!(sidebar_section)
@@ -99,6 +110,31 @@ class SidebarSectionsController < ApplicationController
   end
 
   private
+
+  def reset_community(community_section)
+    community_section.update!(title: "Community")
+    community_section.sidebar_section_links.destroy_all
+    community_urls =
+      SidebarUrl::COMMUNITY_SECTION_LINKS.map do |url_data|
+        "('#{url_data[:name]}', '#{url_data[:path]}', '#{url_data[:icon]}', '#{url_data[:segment]}', false, now(), now())"
+      end
+
+    result = DB.query <<~SQL
+      INSERT INTO sidebar_urls(name, value, icon, segment, external, created_at, updated_at)
+      VALUES #{community_urls.join(",")}
+      RETURNING sidebar_urls.id
+    SQL
+
+    sidebar_section_links =
+      result.map.with_index do |url, index|
+        "(-1, #{url.id}, 'SidebarUrl', #{community_section.id}, #{index},  now(), now())"
+      end
+
+    DB.query <<~SQL
+      INSERT INTO sidebar_section_links(user_id, linkable_id, linkable_type, sidebar_section_id, position, created_at, updated_at)
+      VALUES #{sidebar_section_links.join(",")}
+    SQL
+  end
 
   def check_access_if_public
     return true if !params[:public]

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -1,20 +1,53 @@
 # frozen_string_literal: true
 
 class SidebarUrl < ActiveRecord::Base
+  enum :segment, { primary: 0, secondary: 1 }, scopes: false, suffix: true
+
   FULL_RELOAD_LINKS_REGEX = [%r{\A/my/[a-z_\-/]+\z}, %r{\A/safe-mode\z}]
   MAX_ICON_LENGTH = 40
   MAX_NAME_LENGTH = 80
   MAX_VALUE_LENGTH = 200
   COMMUNITY_SECTION_LINKS = [
-    { name: "Everything", path: "/latest", icon: "layer-group", segment: "primary" },
-    { name: "My Posts", path: "/my/activity", icon: "user", segment: "primary" },
-    { name: "Review", path: "/review", icon: "flag", segment: "primary" },
-    { name: "Admin", path: "/admin", icon: "wrench", segment: "primary" },
-    { name: "Users", path: "/u", icon: "users", segment: "secondary" },
-    { name: "About", path: "/about", icon: "info-circle", segment: "secondary" },
-    { name: "FAQ", path: "/faq", icon: "question-circle", segment: "secondary" },
-    { name: "Groups", path: "/g", icon: "user-friends", segment: "secondary" },
-    { name: "Badges", path: "/badges", icon: "certificate", segment: "secondary" },
+    {
+      name: "Everything",
+      path: "/latest",
+      icon: "layer-group",
+      segment: SidebarUrl.segments["primary"],
+    },
+    {
+      name: "My Posts",
+      path: "/my/activity",
+      icon: "user",
+      segment: SidebarUrl.segments["primary"],
+    },
+    { name: "Review", path: "/review", icon: "flag", segment: SidebarUrl.segments["primary"] },
+    { name: "Admin", path: "/admin", icon: "wrench", segment: SidebarUrl.segments["primary"] },
+    {
+      name: "New topic",
+      path: "/new-topic",
+      icon: "plus",
+      segment: SidebarUrl.segments["primary"],
+    },
+    { name: "Users", path: "/u", icon: "users", segment: SidebarUrl.segments["secondary"] },
+    {
+      name: "About",
+      path: "/about",
+      icon: "info-circle",
+      segment: SidebarUrl.segments["secondary"],
+    },
+    {
+      name: "FAQ",
+      path: "/faq",
+      icon: "question-circle",
+      segment: SidebarUrl.segments["secondary"],
+    },
+    { name: "Groups", path: "/g", icon: "user-friends", segment: SidebarUrl.segments["secondary"] },
+    {
+      name: "Badges",
+      path: "/badges",
+      icon: "certificate",
+      segment: SidebarUrl.segments["secondary"],
+    },
   ]
 
   validates :icon, presence: true, length: { maximum: MAX_ICON_LENGTH }
@@ -24,8 +57,6 @@ class SidebarUrl < ActiveRecord::Base
   validate :path_validator
 
   before_validation :remove_internal_hostname, :set_external
-
-  enum :segment, { primary: 0, secondary: 1 }, scopes: false, suffix: true
 
   def path_validator
     return true if !external?

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -22,12 +22,6 @@ class SidebarUrl < ActiveRecord::Base
     },
     { name: "Review", path: "/review", icon: "flag", segment: SidebarUrl.segments["primary"] },
     { name: "Admin", path: "/admin", icon: "wrench", segment: SidebarUrl.segments["primary"] },
-    {
-      name: "New topic",
-      path: "/new-topic",
-      icon: "plus",
-      segment: SidebarUrl.segments["primary"],
-    },
     { name: "Users", path: "/u", icon: "users", segment: SidebarUrl.segments["secondary"] },
     {
       name: "About",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1594,6 +1594,7 @@ Discourse::Application.routes.draw do
 
     resources :sidebar_sections, only: %i[index create update destroy]
     post "/sidebar_sections/reorder" => "sidebar_sections#reorder"
+    put "/sidebar_sections/reset/:id" => "sidebar_sections#reset"
 
     get "*url", to: "permalinks#show", constraints: PermalinkConstraint.new
   end

--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -7,6 +7,7 @@ module SidebarGuardian
 
   def can_edit_sidebar_section?(sidebar_section)
     return @user.staff? if sidebar_section.public?
+    return @user.staff? if sidebar_section.section_type
     is_my_own?(sidebar_section)
   end
 

--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -2,17 +2,17 @@
 
 module SidebarGuardian
   def can_create_public_sidebar_section?
-    @user.staff?
+    @user.admin?
   end
 
   def can_edit_sidebar_section?(sidebar_section)
-    return @user.staff? if sidebar_section.public?
-    return @user.staff? if sidebar_section.section_type
+    return @user.admin? if sidebar_section.public?
+    return @user.admin? if sidebar_section.section_type
     is_my_own?(sidebar_section)
   end
 
   def can_delete_sidebar_section?(sidebar_section)
-    return @user.staff? if sidebar_section.public?
+    return @user.admin? if sidebar_section.public?
     is_my_own?(sidebar_section)
   end
 end

--- a/spec/models/sidebar_section_spec.rb
+++ b/spec/models/sidebar_section_spec.rb
@@ -3,10 +3,36 @@
 RSpec.describe SidebarSection do
   fab!(:user) { Fabricate(:user) }
   fab!(:sidebar_section) { Fabricate(:sidebar_section, user: user) }
+  let(:community_section) do
+    SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
+  end
 
   it "uses system user for public sections" do
     expect(sidebar_section.user_id).to eq(user.id)
     sidebar_section.update!(public: true)
     expect(sidebar_section.user_id).to eq(Discourse.system_user.id)
+  end
+
+  it "resets Community section to the default state" do
+    community_section.update!(title: "test")
+    community_section.sidebar_section_links.first.linkable.update!(name: "everything edited")
+    community_section.sidebar_section_links.last.destroy!
+
+    community_section.reset_community!
+    expect(community_section.reload.title).to eq("Community")
+    expect(community_section.sidebar_section_links.all.map { |link| link.linkable.name }).to eq(
+      [
+        "Everything",
+        "My Posts",
+        "Review",
+        "Admin",
+        "New topic",
+        "Users",
+        "About",
+        "FAQ",
+        "Groups",
+        "Badges",
+      ],
+    )
   end
 end

--- a/spec/models/sidebar_section_spec.rb
+++ b/spec/models/sidebar_section_spec.rb
@@ -21,18 +21,7 @@ RSpec.describe SidebarSection do
     community_section.reset_community!
     expect(community_section.reload.title).to eq("Community")
     expect(community_section.sidebar_section_links.all.map { |link| link.linkable.name }).to eq(
-      [
-        "Everything",
-        "My Posts",
-        "Review",
-        "Admin",
-        "New topic",
-        "Users",
-        "About",
-        "FAQ",
-        "Groups",
-        "Badges",
-      ],
+      ["Everything", "My Posts", "Review", "Admin", "Users", "About", "FAQ", "Groups", "Badges"],
     )
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -384,6 +384,8 @@ RSpec.describe SidebarSectionsController do
       SidebarSection.any_instance.expects(:reset_community!).once
       put "/sidebar_sections/reset/#{community_section.id}.json"
       expect(response.status).to eq(200)
+      expect(response.parsed_body["sidebar_section"]["id"]).to eq(community_section.id)
+      expect(response.parsed_body["sidebar_section"]["title"]).to eq(community_section.title)
     end
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(403)
     end
 
-    it "does not allow staff to create public section" do
+    it "does not allow moderator to create public section" do
       sign_in(moderator)
       post "/sidebar_sections.json",
            params: {

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(403)
     end
 
-    it "doesn't allow staff to delete public sidebar section" do
+    it "doesn't allow moderator to delete public sidebar section" do
       sign_in(moderator)
       sidebar_section.update!(public: true)
       delete "/sidebar_sections/#{sidebar_section.id}.json"

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -367,25 +367,23 @@ RSpec.describe SidebarSectionsController do
 
     it "doesn't allow user to reset community section" do
       sign_in(user)
+      SidebarSection.any_instance.expects(:reset_community!).never
       put "/sidebar_sections/reset/#{community_section.id}.json"
       expect(response.status).to eq(403)
     end
 
     it "doesn't allow staff to reset community section" do
       sign_in(moderator)
+      SidebarSection.any_instance.expects(:reset_community!).never
       put "/sidebar_sections/reset/#{community_section.id}.json"
       expect(response.status).to eq(403)
     end
 
     it "allows admins to reset community section to default" do
-      community_section.update!(title: "test")
-      everything_link.linkable.update!(name: "everything edited")
-
       sign_in(admin)
+      SidebarSection.any_instance.expects(:reset_community!).once
       put "/sidebar_sections/reset/#{community_section.id}.json"
-
-      expect(community_section.reload.title).to eq("Community")
-      expect(community_section.sidebar_section_links.first.linkable.name).to eq("Everything")
+      expect(response.status).to eq(200)
     end
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe SidebarSectionsController do
       Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_2)
     end
     let(:community_section) do
-      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+      SidebarSection.find(section_type: SidebarSection.section_types[:community])
     end
 
     it "allows user to update their own section and links" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe SidebarSectionsController do
 
   describe "#reset" do
     let(:community_section) do
-      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+      SidebarSection.find(section_type: SidebarSection.section_types[:community])
     end
     let(:everything_link) { community_section.sidebar_section_links.first }
 


### PR DESCRIPTION
In upcoming PRs, admins will be able to edit the Community section. We need an endpoint which allows resetting it to the default state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
