### PR TITLE
DEV: specs to ensure that only admin can edit Community section

### DIFF
--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -13,6 +13,7 @@ module SidebarGuardian
 
   def can_delete_sidebar_section?(sidebar_section)
     return @user.admin? if sidebar_section.public?
+    return false if sidebar_section.section_type.present?
     is_my_own?(sidebar_section)
   end
 end

--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -12,8 +12,8 @@ module SidebarGuardian
   end
 
   def can_delete_sidebar_section?(sidebar_section)
-    return @user.admin? if sidebar_section.public?
     return false if sidebar_section.section_type.present?
+    return @user.admin? if sidebar_section.public?
     is_my_own?(sidebar_section)
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe SidebarSectionsController do
       Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_2)
     end
     let(:community_section) do
-      SidebarSection.find(section_type: SidebarSection.section_types[:community])
+      SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
     end
 
     it "allows user to update their own section and links" do
@@ -291,6 +291,7 @@ RSpec.describe SidebarSectionsController do
         .sidebar_section_links
         .where.not(linkable_id: [everything_link.id, my_posts_link.id])
         .destroy_all
+
       put "/sidebar_sections/#{community_section.id}.json",
           params: {
             title: "community section edited",
@@ -369,7 +370,7 @@ RSpec.describe SidebarSectionsController do
   describe "#destroy" do
     fab!(:sidebar_section) { Fabricate(:sidebar_section, user: user) }
     let(:community_section) do
-      SidebarSection.find(section_type: SidebarSection.section_types[:community])
+      SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
     end
 
     it "allows user to delete their own section" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -150,6 +150,9 @@ RSpec.describe SidebarSectionsController do
     fab!(:section_link_2) do
       Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_2)
     end
+    let(:community_section) do
+      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+    end
 
     it "allows user to update their own section and links" do
       sign_in(user)
@@ -268,6 +271,48 @@ RSpec.describe SidebarSectionsController do
 
       expect(sidebar_url_3.reload.name).to eq("other_tags")
     end
+
+    it "doesn't allow users to edit community section" do
+      sign_in(user)
+      put "/sidebar_sections/#{community_section.id}.json",
+          params: {
+            title: "custom section edited",
+            links: [],
+          }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "allows admin to edit community section" do
+      sign_in(admin)
+      everything_link = community_section.sidebar_urls.find_by(name: "Everything")
+      my_posts_link = community_section.sidebar_urls.find_by(name: "My Posts")
+      community_section
+        .sidebar_section_links
+        .where.not(linkable_id: [everything_link.id, my_posts_link.id])
+        .destroy_all
+      put "/sidebar_sections/#{community_section.id}.json",
+          params: {
+            title: "community section edited",
+            links: [
+              { icon: "link", id: my_posts_link.id, name: "my posts edited", value: "/my_posts" },
+              {
+                icon: "link",
+                id: everything_link.id,
+                name: "everything edited",
+                value: "/everything",
+              },
+            ],
+          }
+
+      expect(response.status).to eq(200)
+
+      expect(community_section.reload.title).to eq("community section edited")
+      expect(community_section.sidebar_urls[0].reload.name).to eq("my posts edited")
+      expect(community_section.sidebar_urls[0].value).to eq("/my_posts")
+      expect(community_section.sidebar_urls[1].reload.name).to eq("everything edited")
+      expect(community_section.sidebar_urls[1].value).to eq("/everything")
+    end
   end
 
   describe "#reorder" do
@@ -323,6 +368,9 @@ RSpec.describe SidebarSectionsController do
 
   describe "#destroy" do
     fab!(:sidebar_section) { Fabricate(:sidebar_section, user: user) }
+    let(:community_section) do
+      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+    end
 
     it "allows user to delete their own section" do
       sign_in(user)
@@ -401,6 +449,13 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["sidebar_section"]["id"]).to eq(community_section.id)
       expect(response.parsed_body["sidebar_section"]["title"]).to eq(community_section.title)
+    end
+
+    it "doesn't allow admin to delete community sidebar section" do
+      sign_in(admin)
+      delete "/sidebar_sections/#{community_section.id}.json"
+
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe SidebarSectionsController do
       Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_2)
     end
     let(:community_section) do
-      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+      SidebarSection.find(section_type: SidebarSection.section_types[:community])
     end
 
     it "allows user to update their own section and links" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe SidebarSectionsController do
   describe "#destroy" do
     fab!(:sidebar_section) { Fabricate(:sidebar_section, user: user) }
     let(:community_section) do
-      SidebarSection.where(section_type: SidebarSection.section_types[:community]).first
+      SidebarSection.find(section_type: SidebarSection.section_types[:community])
     end
 
     it "allows user to delete their own section" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -308,9 +308,9 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(200)
 
       expect(community_section.reload.title).to eq("community section edited")
-      expect(community_section.sidebar_urls[0].reload.name).to eq("my posts edited")
+      expect(community_section.sidebar_urls[0].name).to eq("my posts edited")
       expect(community_section.sidebar_urls[0].value).to eq("/my_posts")
-      expect(community_section.sidebar_urls[1].reload.name).to eq("everything edited")
+      expect(community_section.sidebar_urls[1].name).to eq("everything edited")
       expect(community_section.sidebar_urls[1].value).to eq("/everything")
     end
   end


### PR DESCRIPTION
In addition, add lock that even admin can not delete Community section

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
