### PR TITLE
FIX: Anonymizing a user clears the user status

### DIFF
--- a/app/services/user_anonymizer.rb
+++ b/app/services/user_anonymizer.rb
@@ -60,6 +60,8 @@ class UserAnonymizer
         )
       end
 
+      @user.clear_status!
+
       @user.user_avatar&.destroy!
       @user.single_sign_on_record&.destroy!
       @user.oauth2_user_infos.destroy_all

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe UserAnonymizer do
       end
     end
 
+    it "clears existing user status" do
+      user_status = Fabricate(:user_status, user: user)
+
+      expect do
+        make_anonymous
+        user.reload
+      end.to change { user.user_status }.from(user_status).to(nil)
+    end
+
     context "when Site Settings require full name" do
       before { SiteSetting.full_name_required = true }
 


### PR DESCRIPTION
As explained in this topic https://meta.discourse.org/t/when-the-user-is-anoned-their-user-status-remains/265717, when a user is anonymized, the user status is currently not cleared.

![image](https://github.com/discourse/discourse/assets/1555215/1f6dab3d-9676-44b1-9d43-7abec6e99683)

This fix ensures that the status is cleared as well.