### PR TITLE
DEV: Marking `registerCustomCategorySectionLinkLockIcon` as experimental

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -1917,6 +1917,7 @@ class PluginApi {
   }
 
   /**
+   * EXPERIMENTAL. Do not use.
    * Changes the lock icon used for a sidebar category section link to indicate that a category is read restricted.
    *
    * @param {String} Name of a FontAwesome 5 icon

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,13 +7,6 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-
-### Added
-
-- Adds `registerCustomCategorySectionLinkLockIcon` which allows plugins or themes to customize the FontAwesome 5 icon used to indicate
-  that a category is read restricted when the category is displayed in the sidebar.
-
 ## [1.6.0] - 2022-12-13
 
 ### Added


### PR DESCRIPTION
This might soon become a first class feature in Discourse core in the
short term  so marking it as experimental for now to bridge
certain Discourse own-ed plugins and themes.