### PR TITLE
FEATURE: display PM participant group names in the topics list.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/participant-groups.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/participant-groups.hbr
@@ -1,0 +1,8 @@
+<div class="participant-groups" role="list" aria-label="Groups">
+{{#each groups as |group|}}
+  <a class="user-group trigger-group-card" href="/g/{{group.name}}" data-group-card="{{group.name}}">
+    {{d-icon 'users'}}
+    {{group.name}}
+  </a>
+{{/each}}
+</div>

--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -40,6 +40,9 @@
       {{/unless}}
     {{/unless}}
     {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
+    {{#if topic.participant_groups}}
+      {{raw "list/participant-groups" groups=topic.participant_groups}}
+    {{/if}}
     {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
   </div>
   {{#if expandPinned}}

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -264,6 +264,19 @@
     .discourse-tag.box {
       margin-right: 0.25em;
     }
+    .participant-groups {
+      margin-left: 0.5em;
+      font-weight: normal;
+      font-size: var(--font-down-1);
+
+      > a {
+        color: var(--primary-medium);
+        border: solid 1px var(--primary-low);
+        padding: 0 0.3em 0.07em;
+        border-radius: 0.6em;
+        margin-right: 0.25em;
+      }
+    }
   }
 
   .topic-featured-link {

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -28,7 +28,7 @@ class Topic < ActiveRecord::Base
   def_delegator :notifier, :mute!, :notify_muted!
   def_delegator :notifier, :toggle_mute, :toggle_mute
 
-  attr_accessor :allowed_user_ids, :tags_changed, :includes_destination_category
+  attr_accessor :allowed_user_ids, :allowed_group_ids, :tags_changed, :includes_destination_category
 
   def self.max_fancy_title_length
     400
@@ -293,6 +293,7 @@ class Topic < ActiveRecord::Base
 
   attr_accessor :posters # TODO: can replace with posters_summary once we remove old list code
   attr_accessor :participants
+  attr_accessor :participant_groups
   attr_accessor :topic_list
   attr_accessor :meta_data
   attr_accessor :include_last_poster
@@ -1268,6 +1269,10 @@ class Topic < ActiveRecord::Base
 
   def participants_summary(options = {})
     @participants_summary ||= TopicParticipantsSummary.new(self, options).summary
+  end
+
+  def participant_groups_summary(options = {})
+    @participant_groups_summary ||= TopicParticipantGroupsSummary.new(self, options).summary
   end
 
   def make_banner!(user, bannered_until = nil)

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -97,12 +97,19 @@ class TopicList
 
     # Create a lookup for all the user ids we need
     user_ids = []
+    group_ids = []
     @topics.each do |ft|
       user_ids << ft.user_id << ft.last_post_user_id << ft.featured_user_ids << ft.allowed_user_ids
+      group_ids << ft.allowed_group_ids
     end
 
     user_ids = TopicList.preload_user_ids(@topics, user_ids, self)
     user_lookup = UserLookup.new(user_ids)
+
+    if group_ids.present?
+      group_ids = group_ids.flatten.uniq
+      group_lookup = GroupLookup.new(group_ids)
+    end
 
     @topics.each do |ft|
       ft.user_data = @topic_lookup[ft.id] if @topic_lookup.present?
@@ -120,6 +127,8 @@ class TopicList
       ft.posters = ft.posters_summary(user_lookup: user_lookup)
 
       ft.participants = ft.participants_summary(user_lookup: user_lookup, user: @current_user)
+      ft.participant_groups =
+        ft.participant_groups_summary(group_lookup: group_lookup, group: @opts[:group])
       ft.topic_list = self
     end
 

--- a/app/models/topic_participant_groups_summary.rb
+++ b/app/models/topic_participant_groups_summary.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# This is used on a topic page
+class TopicParticipantGroupsSummary
+  attr_reader :topic, :options
+
+  def initialize(topic, options = {})
+    @topic = topic
+    @options = options
+    @group = options[:group]
+  end
+
+  def summary
+    group_participants.compact
+  end
+
+  def group_participants
+    group_ids.map { |id| group_lookup[id] }
+  end
+
+  def group_ids
+    ids = topic.allowed_group_ids
+    ids = ids - [@group.id] if @group.present?
+    ids
+  end
+
+  def group_lookup
+    @group_lookup ||= options[:group_lookup] || GroupLookup.new(group_ids)
+  end
+end

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -18,6 +18,11 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
   has_many :participants, serializer: TopicPosterSerializer, embed: :objects
+  has_many :participant_groups, serializer: TopicParticipantGroupSerializer, embed: :objects
+
+  def include_participant_groups?
+    object.private_message?
+  end
 
   def posters
     object.posters || object.posters_summary || []

--- a/app/serializers/topic_participant_group_serializer.rb
+++ b/app/serializers/topic_participant_group_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TopicParticipantGroupSerializer < ApplicationSerializer
+  attributes :id, :name, :title, :full_name, :display_name
+
+  def include_display_name?
+    object.automatic
+  end
+
+  def display_name
+    if auto_group_name = Group::AUTO_GROUP_IDS[object.id]
+      I18n.t("groups.default_names.#{auto_group_name}")
+    end
+  end
+end

--- a/lib/group_lookup.rb
+++ b/lib/group_lookup.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GroupLookup
+  def self.lookup_columns
+    @group_lookup_columns ||= %i[id name title full_name automatic]
+  end
+
+  def initialize(group_ids = [])
+    @group_ids = group_ids.tap(&:compact!).tap(&:uniq!).tap(&:flatten!)
+  end
+
+  # Lookup a group by id
+  def [](group_id)
+    groups[group_id]
+  end
+
+  private
+
+  def groups
+    @groups ||= Group.where(id: @group_ids).select(self.class.lookup_columns).index_by(&:id)
+  end
+end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -498,7 +498,13 @@ class TopicQuery
     end
 
     topics.each do |t|
-      t.allowed_user_ids = filter == :private_messages ? t.allowed_users.map { |u| u.id } : []
+      if filter == :private_messages
+        t.allowed_user_ids = t.allowed_users.map { |u| u.id }
+        t.allowed_group_ids = t.allowed_groups.map { |g| g.id }
+      else
+        t.allowed_user_ids = []
+        t.allowed_group_ids = []
+      end
     end
 
     list = TopicList.new(filter, @user, topics, options.merge(@options))

--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -71,7 +71,7 @@ class TopicQuery
       list = list.where("gm.id IS NULL")
       publish_read_state = !!group.publish_read_state
       list = append_read_state(list, group) if publish_read_state
-      create_list(:private_messages, { publish_read_state: publish_read_state }, list)
+      create_list(:private_messages, { publish_read_state: publish_read_state, group: group }, list)
     end
 
     def list_private_messages_group_archive(user)
@@ -84,7 +84,7 @@ class TopicQuery
 
       publish_read_state = !!group.publish_read_state
       list = append_read_state(list, group) if publish_read_state
-      create_list(:private_messages, { publish_read_state: publish_read_state }, list)
+      create_list(:private_messages, { publish_read_state: publish_read_state, group: group }, list)
     end
 
     def list_private_messages_group_new(user)
@@ -92,14 +92,14 @@ class TopicQuery
       list = remove_dismissed(list, user)
       publish_read_state = !!group.publish_read_state
       list = append_read_state(list, group) if publish_read_state
-      create_list(:private_messages, { publish_read_state: publish_read_state }, list)
+      create_list(:private_messages, { publish_read_state: publish_read_state, group: group }, list)
     end
 
     def list_private_messages_group_unread(user)
       list = filter_private_messages_unread(user, :group)
       publish_read_state = !!group.publish_read_state
       list = append_read_state(list, group) if publish_read_state
-      create_list(:private_messages, { publish_read_state: publish_read_state }, list)
+      create_list(:private_messages, { publish_read_state: publish_read_state, group: group }, list)
     end
 
     def list_private_messages_warnings(user)
@@ -259,6 +259,7 @@ class TopicQuery
         Topic
           .private_messages
           .includes(:allowed_users)
+          .includes(:allowed_groups)
           .joins(
             "LEFT OUTER JOIN topic_users AS tu ON (topics.id = tu.topic_id AND tu.user_id = #{user.id.to_i})",
           )


### PR DESCRIPTION
After this change, we can view all the participant group names in the topic list page itself.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
