### PR TITLE
FIX: correct replying indicator padding

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -18,6 +18,10 @@
     .drop-a-file {
       display: none;
     }
+
+    .chat-replying-indicator {
+      padding-inline: 1rem;
+    }
   }
 
   .chat-composer-button,


### PR DESCRIPTION
Before:
<img width="234" alt="Screenshot 2023-05-22 at 17 48 36" src="https://github.com/discourse/discourse/assets/339945/65bfd397-a375-4301-9ede-5673b2d70bff">

After:
<img width="242" alt="Screenshot 2023-05-22 at 17 48 31" src="https://github.com/discourse/discourse/assets/339945/96a55d62-9c26-4da1-a696-d3f7f55fc257">

