### PR TITLE
FIX: Removing arbitrary limit in a Discuz importer script query

### DIFF
--- a/script/import_scripts/discuz_x.rb
+++ b/script/import_scripts/discuz_x.rb
@@ -429,7 +429,6 @@ class ImportScripts::DiscuzX < ImportScripts::Base
               FROM #{posts_table} p
               JOIN #{posts_table} p2 ON p2.first AND p2.tid = p.tid
               JOIN #{topics_table} t ON t.tid = p.tid
-              where t.tid < 10000
              ORDER BY id ASC, topic_id ASC
              LIMIT #{BATCH_SIZE}
             OFFSET #{offset};


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
