### PR TITLE
FIX: allow published pages to be added to sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -10,7 +10,11 @@ import { tracked } from "@glimmer/tracking";
 import { A } from "@ember/array";
 import { SIDEBAR_SECTION, SIDEBAR_URL } from "discourse/lib/constants";
 
-const FULL_RELOAD_LINKS_REGEX = [/^\/my\/[a-z_\-\/]+$/, /^\/safe-mode$/];
+const FULL_RELOAD_LINKS_REGEX = [
+  /^\/my\/[a-z_\-\/]+$/,
+  /^\/pub\/[a-z_\-\/]+$/,
+  /^\/safe-mode$/,
+];
 
 class Section {
   @tracked title;

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -3,7 +3,7 @@
 class SidebarUrl < ActiveRecord::Base
   enum :segment, { primary: 0, secondary: 1 }, scopes: false, suffix: true
 
-  FULL_RELOAD_LINKS_REGEX = [%r{\A/my/[a-z_\-/]+\z}, %r{\A/safe-mode\z}]
+  FULL_RELOAD_LINKS_REGEX = [%r{\A/my/[a-z_\-/]+\z}, %r{\A/pub/[a-z_\-/]+\z}, %r{\A/safe-mode\z}]
   MAX_ICON_LENGTH = 40
   MAX_NAME_LENGTH = 80
   MAX_VALUE_LENGTH = 200

--- a/spec/models/sidebar_url_spec.rb
+++ b/spec/models/sidebar_url_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe SidebarUrl do
         value: "https://www.test.com/discourse-test",
       ).valid?,
     ).to eq(true)
+    expect(
+      SidebarUrl.new(
+        icon: "link",
+        name: "categories",
+        value: "http://#{Discourse.current_hostname}/pub/test",
+      ).valid?,
+    ).to eq(true)
   end
 
   it "sets external flag" do

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -33,17 +33,10 @@ describe "Custom sidebar sections", type: :system, js: true do
   it "allows the user to create custom section with /my link" do
     sign_in user
     visit("/latest")
+
     sidebar.click_add_section_button
-
-    expect(section_modal).to be_visible
-    expect(section_modal).to have_disabled_save
-    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
-
     section_modal.fill_name("My section")
-
     section_modal.fill_link("My preferences", "/my/preferences")
-    expect(section_modal).to have_enabled_save
-
     section_modal.save
 
     expect(sidebar).to have_section("My section")
@@ -53,17 +46,10 @@ describe "Custom sidebar sections", type: :system, js: true do
   it "allows the user to create custom section with /pub link" do
     sign_in user
     visit("/latest")
+
     sidebar.click_add_section_button
-
-    expect(section_modal).to be_visible
-    expect(section_modal).to have_disabled_save
-    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
-
     section_modal.fill_name("My section")
-
     section_modal.fill_link("Published Page", "/pub/test")
-    expect(section_modal).to have_enabled_save
-
     section_modal.save
 
     expect(sidebar).to have_section("My section")

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -50,6 +50,26 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar).to have_section_link("My preferences")
   end
 
+  it "allows the user to create custom section with /pub link" do
+    sign_in user
+    visit("/latest")
+    sidebar.click_add_section_button
+
+    expect(section_modal).to be_visible
+    expect(section_modal).to have_disabled_save
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
+
+    section_modal.fill_name("My section")
+
+    section_modal.fill_link("Published Page", "/pub/test")
+    expect(section_modal).to have_enabled_save
+
+    section_modal.save
+
+    expect(sidebar).to have_section("My section")
+    expect(sidebar).to have_section_link("Published Page")
+  end
+
   it "allows the user to create custom section with external link" do
     sign_in user
     visit("/latest")


### PR DESCRIPTION
Custom sidebar sections should accept publish pages with URL `/pub/*`. Similarly to `/my/activity` links.
