### PR TITLE
FIX: consider users.created_at for inactive cleanup

### DIFF
--- a/app/jobs/scheduled/clean_up_inactive_users.rb
+++ b/app/jobs/scheduled/clean_up_inactive_users.rb
@@ -14,6 +14,7 @@ module Jobs
           admin: false,
           moderator: false,
         )
+        .where("users.created_at < ?", SiteSetting.clean_up_inactive_users_after_days.days.ago)
         .where(
           "users.last_seen_at < ? OR users.last_seen_at IS NULL",
           SiteSetting.clean_up_inactive_users_after_days.days.ago,

--- a/spec/jobs/clean_up_inactive_users_spec.rb
+++ b/spec/jobs/clean_up_inactive_users_spec.rb
@@ -4,18 +4,35 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
   it "should clean up new users that have been inactive" do
     SiteSetting.clean_up_inactive_users_after_days = 0
 
-    user = Fabricate(:user, last_seen_at: 5.days.ago, trust_level: TrustLevel.levels[:newuser])
+    user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
 
     Fabricate(:active_user)
 
     Fabricate(
       :post,
-      user: Fabricate(:user, trust_level: TrustLevel.levels[:newuser], last_seen_at: 5.days.ago),
+      user:
+        Fabricate(
+          :user,
+          trust_level: TrustLevel.levels[:newuser],
+          created_at: 5.days.ago,
+          last_seen_at: 5.days.ago,
+        ),
     ).user
 
-    Fabricate(:user, trust_level: TrustLevel.levels[:newuser], last_seen_at: 2.days.ago)
+    Fabricate(
+      :user,
+      trust_level: TrustLevel.levels[:newuser],
+      created_at: 5.days.ago,
+      last_seen_at: 2.days.ago,
+    )
 
-    Fabricate(:user, trust_level: TrustLevel.levels[:basic])
+    Fabricate(:user, trust_level: TrustLevel.levels[:basic], created_at: 5.days.ago)
 
     expect { described_class.new.execute({}) }.to_not change { User.count }
 
@@ -28,7 +45,13 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
 
   it "doesn't delete inactive admins" do
     SiteSetting.clean_up_inactive_users_after_days = 4
-    admin = Fabricate(:admin, last_seen_at: 5.days.ago, trust_level: TrustLevel.levels[:newuser])
+    admin =
+      Fabricate(
+        :admin,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
 
     expect { described_class.new.execute({}) }.to_not change { User.count }
     expect(User.exists?(admin.id)).to eq(true)
@@ -37,7 +60,12 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
   it "doesn't delete inactive mods" do
     SiteSetting.clean_up_inactive_users_after_days = 4
     moderator =
-      Fabricate(:moderator, last_seen_at: 5.days.ago, trust_level: TrustLevel.levels[:newuser])
+      Fabricate(
+        :moderator,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
 
     expect { described_class.new.execute({}) }.to_not change { User.count }
     expect(User.exists?(moderator.id)).to eq(true)
@@ -50,7 +78,13 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
 
     Fabricate(
       :post,
-      user: Fabricate(:user, trust_level: TrustLevel.levels[:newuser], last_seen_at: 5.days.ago),
+      user:
+        Fabricate(
+          :user,
+          trust_level: TrustLevel.levels[:newuser],
+          created_at: 5.days.ago,
+          last_seen_at: 2.days.ago,
+        ),
       # ensuring that topic author is a different user as the topic is non-deleted
       topic: Fabricate(:topic, user: Fabricate(:user)),
       deleted_at: Time.now,
@@ -66,7 +100,13 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
 
     Fabricate(
       :topic,
-      user: Fabricate(:user, trust_level: TrustLevel.levels[:newuser], last_seen_at: 5.days.ago),
+      user:
+        Fabricate(
+          :user,
+          trust_level: TrustLevel.levels[:newuser],
+          created_at: 2.days.ago,
+          last_seen_at: 2.days.ago,
+        ),
       deleted_at: Time.now,
     ).user
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
