### PR TITLE
DEV: attempts to make deleted spec not flakey

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -62,7 +62,7 @@
         <div
           class={{concat-class
             "chat-message"
-            (if @message.staged "chat-message-staged")
+            (if @message.staged "chat-message-staged" "chat-message-persisted")
             (if @message.deletedAt "deleted")
             (if (and @message.inReplyTo (not this.hideReplyToInfo)) "is-reply")
             (if this.showThreadIndicator "is-threaded")

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe "Deleted message", type: :system, js: true do
     it "shows as deleted" do
       chat_page.visit_channel(channel_1)
       channel_page.send_message("aaaaaaaaaaaaaaaaaaaa")
-      expect(page).to have_no_css(".chat-message-staged")
+
+      expect(page).to have_css(".chat-message-persisted")
+
       last_message = find(".chat-message-container:last-child")
       channel_page.delete_message(OpenStruct.new(id: last_message["data-id"]))
 


### PR DESCRIPTION
It easier to check for presence in this case that to check for something not present, as depending on performance of the machine running the test this could take sometime to be changed and the test would fail.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
