### PR TITLE
FIX: keeps panel size when changing content

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
@@ -9,7 +9,7 @@
     }}
     style={{if
       (and this.site.desktopView this.chatStateManager.isFullPageActive)
-      this.width
+      this.widthStyle
     }}
   >
     {{yield}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
@@ -12,23 +12,11 @@ export default class ChatSidePanel extends Component {
   @service site;
 
   @tracked sidePanel;
+  @tracked widthStyle;
 
   @action
   setSidePanel(element) {
     this.sidePanel = element;
-  }
-
-  get width() {
-    if (!this.sidePanel) {
-      return;
-    }
-
-    const maxWidth = Math.min(
-      this.#maxWidth(this.sidePanel),
-      this.chatSidePanelSize.width
-    );
-
-    return htmlSafe(`width:${maxWidth}px`);
   }
 
   @action
@@ -43,6 +31,7 @@ export default class ChatSidePanel extends Component {
     if (mainPanelWidth > MIN_CHAT_CHANNEL_WIDTH) {
       this.chatSidePanelSize.width = size.width;
       element.style.width = size.width + "px";
+      this.widthStyle = htmlSafe(`width:${size.width}px`);
     }
   }
 


### PR DESCRIPTION
Before this commit the following actions would have shown the issue:
- visit a thread
- changes the width of the side panel
- open threads list
- the size has reverted to previous state

This was caused by the width change to not correctly be tracked.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
