### PR TITLE
UX: iPad footer nav now included in header offset

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -540,13 +540,6 @@
   }
 }
 
-body.footer-nav-ipad {
-  .hamburger-panel .revamped,
-  .menu-panel.slide-in {
-    margin-top: var(--footer-nav-height);
-  }
-}
-
 .hamburger-panel .menu-panel.slide-in {
   left: 0;
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -42,10 +42,8 @@
   );
 
   .footer-nav-ipad & {
-    top: calc(var(--header-offset) + var(--footer-nav-height));
     height: calc(
-      var(--composer-vh, var(--1dvh)) * 100 - var(--header-offset, 0px) -
-        var(--footer-nav-height, 0px)
+      var(--composer-vh, var(--1dvh)) * 100 - var(--header-offset, 0px)
     );
   }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -50,9 +50,6 @@ $topic-progress-height: 42px;
       align-self: start;
       @include sticky;
       top: calc(var(--header-offset, 60px) + 2em);
-      .footer-nav-ipad & {
-        top: calc(var(--header-offset, 60px) + var(--footer-nav-height) + 2em);
-      }
       margin-left: 1em;
       z-index: z("timeline");
 

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -20,7 +20,7 @@
   .footer-nav-ipad & {
     height: calc(
       var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
+        var(--chat-draft-header-height, 0px) -
         var(--chat-direct-message-creator-height, 0px) -
         var(--composer-height, 0px)
     );
@@ -31,7 +31,7 @@
     .footer-nav-ipad & {
       height: calc(
         var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-          var(--footer-nav-height, 0px) - var(--chat-draft-header-height, 0px) -
+          var(--chat-draft-header-height, 0px) -
           var(--chat-direct-message-creator-height, 0px)
       );
     }


### PR DESCRIPTION
As of https://github.com/discourse/discourse/commit/14ad0b39f11bff0929dfc2346fbbf7b5adf491a7, custom header content is included in the `--header-offset` calculation, so we no longer need `var(--footer-nav-height)` for iPads. 

This solves some spacing issues like this with the sidebar:

![Screenshot 2023-05-23 at 12 19 52 PM](https://github.com/discourse/discourse/assets/1681963/1caef8f3-1739-4b81-8185-2c46deb95c7f)

as well as:

* extra space in "dropdown" mode of the sidebar
* extra space below the chat composer in full screen chat
* extra space above the topic timeline 

