### PR TITLE
FIX: ensure sidepanel size is correctly applied when showing

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
@@ -1,7 +1,7 @@
 {{#if this.chatStateManager.isSidePanelExpanded}}
   <div
     class="chat-side-panel"
-    {{did-insert this.setSidePanel}}
+    {{did-insert this.setupSize}}
     {{chat/resizable-node
       ".chat-side-panel-resizer"
       this.didResize

--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
@@ -11,12 +11,11 @@ export default class ChatSidePanel extends Component {
   @service chatSidePanelSize;
   @service site;
 
-  @tracked sidePanel;
   @tracked widthStyle;
 
   @action
-  setSidePanel(element) {
-    this.sidePanel = element;
+  setupSize() {
+    this.widthStyle = htmlSafe(`width:${this.chatSidePanelSize.width}px`);
   }
 
   @action
@@ -28,7 +27,7 @@ export default class ChatSidePanel extends Component {
     const parentWidth = element.parentElement.getBoundingClientRect().width;
     const mainPanelWidth = parentWidth - size.width;
 
-    if (mainPanelWidth > MIN_CHAT_CHANNEL_WIDTH) {
+    if (mainPanelWidth >= MIN_CHAT_CHANNEL_WIDTH) {
       this.chatSidePanelSize.width = size.width;
       element.style.width = size.width + "px";
       this.widthStyle = htmlSafe(`width:${size.width}px`);

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/resizable-node.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/resizable-node.js
@@ -68,7 +68,7 @@ export default class ResizableNode extends Modifier {
 
   @bind
   _resize(event) {
-    throttle(this, this._resizeThrottled, event, 24);
+    throttle(this, this._resizeThrottled, event, 50);
   }
 
   /*


### PR DESCRIPTION
We were not correctly setting the widthStyle on insert.

Note this commit also changes throttling from 24ms to 50ms. 24ms was probably overkill.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
