### PR TITLE
UX: increase sidebar font-size

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -4,14 +4,13 @@
   }
   .sidebar-section-header {
     position: relative;
-  }
-  .d-icon-globe {
-    position: absolute;
-    left: -0.75em;
-    height: 0.75em;
-    width: 0.75em;
-    margin-top: 0.15em;
-    align-items: center;
+    .d-icon-globe {
+      position: absolute;
+      left: -0.75em;
+      align-self: stretch;
+      width: 0.6em;
+      height: 100%;
+    }
   }
 
   .sidebar-section-link-prefix.icon {

--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -13,9 +13,7 @@
   list-style: none;
   box-sizing: border-box;
   width: 100%;
-  padding: var(--d-sidebar-row-vertical-padding)
-    var(--d-sidebar-row-horizontal-padding);
-  font-size: var(--d-sidebar-row-font-size);
+  padding: 0 var(--d-sidebar-row-horizontal-padding);
   justify-content: left;
 
   svg.d-icon {

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -1,5 +1,5 @@
 :root {
-  --d-sidebar-section-link-prefix-margin-right: 0.4rem;
+  --d-sidebar-section-link-prefix-margin-right: 0.5rem;
   --d-sidebar-section-link-prefix-width: 20px;
 }
 

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -35,6 +35,7 @@
     .sidebar-section-link-content-badge {
       @include ellipsis;
       padding-left: 0.5em;
+      padding-right: 0.1em; // avoids some overflow cropping
       text-align: right;
       color: var(--primary-700);
       font-size: var(--font-down-1);
@@ -146,8 +147,8 @@
       }
     }
     .prefix-span {
-      width: 0.9em;
-      height: 0.9em;
+      width: 0.87em;
+      height: 0.87em;
     }
   }
 

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -36,14 +36,14 @@
       @include ellipsis;
       padding-left: 0.5em;
       text-align: right;
-      color: var(--primary-high);
+      color: var(--primary-700);
       font-size: var(--font-down-1);
       font-weight: normal;
       margin-left: auto;
     }
 
     .sidebar-section-link-suffix {
-      margin-left: 0.25rem;
+      margin-left: 1em;
       font-size: var(--font-down-4);
       color: var(--tertiary-medium);
     }
@@ -119,6 +119,7 @@
         background: rgba(var(--primary-rgb), 0.1);
         width: calc(var(--d-sidebar-section-link-prefix-width) - 2px);
         height: calc(var(--d-sidebar-section-link-prefix-width) - 2px);
+        font-size: var(--font-down-1);
       }
     }
 

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -16,15 +16,23 @@
 
   .sidebar-section-header-wrapper {
     display: flex;
+    font-size: var(--d-sidebar-section-header-text-font-size);
 
     .discourse-no-touch & {
       &:hover {
         background: var(--d-sidebar-highlight-color);
+        .d-icon-globe {
+          color: var(--primary-medium);
+        }
       }
     }
 
     &:focus-within {
       background: var(--d-sidebar-highlight-color);
+    }
+
+    .sidebar-section-header-button {
+      font-size: var(--font-down-1);
     }
 
     .btn.dropdown-select-box-header,
@@ -86,9 +94,9 @@
   }
 
   .sidebar-section-header-text {
+    display: flex;
     line-height: normal;
     margin-right: 0.25em;
-    font-size: var(--d-sidebar-section-header-text-font-size);
     @include ellipsis;
   }
 
@@ -133,7 +141,7 @@
   }
 
   .sidebar-section-content {
-    padding-bottom: 1em;
+    padding-bottom: 1.25em;
     margin: 0;
     hr {
       margin: 0em 1.5em;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -5,20 +5,17 @@
   }
   --d-sidebar-animation-time: 0.25s;
   --d-sidebar-animation-ease: ease-in-out;
-  --d-sidebar-row-height: 30px;
   // 1.25rem gets text left-aligned with the hamburger icon
   --d-sidebar-row-horizontal-padding: 1.25rem;
-  --d-sidebar-row-vertical-padding: 0.33rem;
-  --d-sidebar-row-font-size: var(--font-down-1);
+  // ems so height is variable along with font size
+  --d-sidebar-row-height: 2.15em;
 }
 
 .sidebar-row {
   box-sizing: border-box;
   height: var(--d-sidebar-row-height);
-  padding: var(--d-sidebar-row-vertical-padding)
-    var(--d-sidebar-row-horizontal-padding);
+  padding: 0 var(--d-sidebar-row-horizontal-padding);
   align-items: center;
-  font-size: var(--d-sidebar-row-font-size);
 }
 
 .sidebar-wrapper {
@@ -69,7 +66,7 @@
     flex-direction: column;
     box-sizing: border-box;
     flex: 1;
-    padding: 1.5em 0 1em;
+    padding: 1.35em 0 1em;
     overflow-x: hidden;
     overflow-y: overlay;
 

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -17,7 +17,7 @@ $topic-body-width-padding: 11px;
 $topic-avatar-width: 45px;
 $reply-area-max-width: 1475px !default;
 
-$d-sidebar-width: 16em !default;
+$d-sidebar-width: 17em !default;
 $d-sidebar-narrow-width: 14em !default;
 
 // Brand color variables

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -16,7 +16,6 @@
   --d-sidebar-row-height: 30px;
   // 1.25rem gets text left-aligned with the hamburger icon
   --d-sidebar-row-horizontal-padding: 0.66rem;
-  --d-sidebar-row-vertical-padding: 0.33rem;
 
   .panel-body-content {
     width: 100%;
@@ -41,8 +40,13 @@
     &.sidebar-section {
       padding-top: 0.5em;
       .sidebar-section-header-wrapper {
-        margin: 0 0 var(--d-sidebar-row-vertical-padding);
+        margin: 0 0 0.5em;
+        padding-bottom: 0.25em;
         border-bottom: 1px solid var(--primary-low);
+        .d-icon-globe {
+          font-size: var(--font-down-2);
+          color: var(--primary-medium);
+        }
       }
       ul {
         display: grid;
@@ -56,12 +60,6 @@
     .sidebar-section-message {
       padding: 0;
     }
-  }
-
-  .sidebar-custom-sections .d-icon-globe {
-    left: -0.9em;
-    top: 0.35em;
-    font-size: 0.7em;
   }
 
   .sidebar-section-link-wrapper

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -16,6 +16,7 @@
   --d-sidebar-row-height: 30px;
   // 1.25rem gets text left-aligned with the hamburger icon
   --d-sidebar-row-horizontal-padding: 0.66rem;
+  width: 360px;
 
   .panel-body-content {
     width: 100%;

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -16,9 +16,6 @@
 .hamburger-panel .revamped {
   --d-sidebar-row-horizontal-padding: 1rem;
   --d-sidebar-highlight-color: var(--primary-low);
-  --d-sidebar-row-font-size: var(--font-0);
-  --d-sidebar-row-height: 32px;
-  --d-sidebar-section-header-text-font-size: var(--font-0);
   box-sizing: border-box;
   padding: 0;
 
@@ -65,5 +62,12 @@
 
   .sidebar-section-content {
     padding-bottom: 0;
+  }
+
+  .sidebar-section-header-wrapper {
+    .d-icon-globe {
+      color: var(--primary-medium);
+      font-size: var(--font-down-1);
+    }
   }
 }


### PR DESCRIPTION
This bumps up the sidebar font-size by 1 step in our font scale (from 13 to 15px). This means each item is 15px by default, and headings are 17px. This gets us a more legible default size that's better aligned with the rest of the app. 

This also:

* Normalizes the globe icon alignment for custom sections, and makes it less finicky
* Increases the default sidebar width by 1em `$d-sidebar-width`. This is a small increase to grant text a little more space at its larger size.
* Removes `--d-sidebar-row-vertical-padding` — since we set a static height with `--d-sidebar-row-height` there's not much point to this padding 
* Removes some mobile-specific overrides for more consistent styling across devices   
* Increases the default width of the revamped dropdown hamburger menu 

before|after
![Screenshot 2023-05-23 at 3 08 00 PM](https://github.com/discourse/discourse/assets/1681963/e93a6b9e-5503-4c15-a0bd-67344e5a4915) ![Screenshot 2023-05-23 at 3 07 49 PM](https://github.com/discourse/discourse/assets/1681963/b1ffa725-8ae1-42f4-a097-6816a5ae2421) 

before|after
![Screenshot 2023-05-23 at 3 14 21 PM](https://github.com/discourse/discourse/assets/1681963/9d825492-a6f0-40fa-9cd6-2dcce3171644) ![Screenshot 2023-05-23 at 3 18 35 PM](https://github.com/discourse/discourse/assets/1681963/57fc5804-0c9c-4653-b150-731af61781e6)
