### PR TITLE
DEV: attempts to increase wait for a flakey spec

### DIFF
--- a/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
+++ b/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Unfollow dm channel", type: :system, js: true do
         session.quit
       end
 
-      expect(page).to have_css(".channel-#{dm_channel_1.id} .urgent")
+      expect(page).to have_css(".channel-#{dm_channel_1.id} .urgent", wait: 25)
     end
   end
 end


### PR DESCRIPTION
This spec is working very reliably locally. Increasing the time might offer us some resilience here.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
