### PR TITLE
DEV: Bump CAPYBARA_DEFAULT_MAX_WAIT_TIME to 10 seconds on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       PGUSER: discourse
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' || matrix.build_type == 'system' }}
-      CABPYARA_DEFAULT_MAX_WAIT_TIME: 4
+      CABPYARA_DEFAULT_MAX_WAIT_TIME: 10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We're running on pretty crappy hardware on Github's CI and this has an
impact on the stability of our system tests on CI. Therefore, we are
bumping `CABPYARA_DEFAULT_MAX_WAIT_TIME` to 10 seconds to account for
the less than ideal hardware we're running the system tests on.

This change trades off speed for stability but speed is already bad on
CI so stability is more important for our case.