### PR TITLE
DEV: Avoid leaking new site setting states in test environment

### DIFF
--- a/spec/integrity/i18n_spec.rb
+++ b/spec/integrity/i18n_spec.rb
@@ -31,7 +31,7 @@ end
 RSpec.describe "i18n integrity checks" do
   it "has an i18n key for each Site Setting" do
     SiteSetting.all_settings.each do |s|
-      next if s[:setting][/^test_/]
+      next if s[:plugin] == SiteSetting::SAMPLE_TEST_PLUGIN.name
       expect(s[:description]).not_to match(/translation missing/)
     end
   end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -289,9 +289,9 @@ RSpec.describe StaticController do
         Discourse::Application.routes.send(:eval_block, routes)
 
         topic_id = Fabricate(:post, cooked: "contact info").topic_id
-        SiteSetting.setting(:test_contact_topic_id, topic_id)
+        SiteSetting.test_some_topic_id = topic_id
 
-        Plugin::Instance.new.add_topic_static_page("contact", topic_id: "test_contact_topic_id")
+        Plugin::Instance.new.add_topic_static_page("contact", topic_id: "test_some_topic_id")
 
         get "/contact"
 
@@ -301,14 +301,15 @@ RSpec.describe StaticController do
 
       it "replaces existing topic-backed pages" do
         topic_id = Fabricate(:post, cooked: "Regular FAQ").topic_id
-        SiteSetting.setting(:test_faq_topic_id, topic_id)
+        SiteSetting.test_some_topic_id = topic_id
+
         polish_topic_id = Fabricate(:post, cooked: "Polish FAQ").topic_id
-        SiteSetting.setting(:test_polish_faq_topic_id, polish_topic_id)
+        SiteSetting.test_some_other_topic_id = polish_topic_id
 
         Plugin::Instance
           .new
           .add_topic_static_page("faq") do
-            current_user&.locale == "pl" ? "test_polish_faq_topic_id" : "test_faq_topic_id"
+            current_user&.locale == "pl" ? "test_some_other_topic_id" : "test_some_topic_id"
           end
 
         get "/faq"

--- a/spec/support/sample_plugin_site_settings.yml
+++ b/spec/support/sample_plugin_site_settings.yml
@@ -1,0 +1,7 @@
+site_settings:
+  plugin_setting:
+    default: "some value"
+  test_some_topic_id:
+    default: 0
+  test_some_other_topic_id:
+    default: 0

--- a/spec/support/site_settings_helpers.rb
+++ b/spec/support/site_settings_helpers.rb
@@ -8,6 +8,10 @@ module SiteSettingsHelpers
       # so we set listen_for_changes to false
       self.listen_for_changes = false
       self.provider = provider
+
+      def self.setting(*args)
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
What is the problem?

In the test environment, we were calling `SiteSetting.setting` directly
to introduce new site settings. However, this leads to changes in state of the site settings
hash that is stored in memory while the tests run. Changing or leaking states
when running tests is one of the major contributors of test flakiness.

An example of how this resulted in test flakiness is our `spec/integrity/i18n_spec.rb` spec which
had a test case that would fail because a new "plugin_setting" site
setting was registered in another test case but the site setting did not
have translations for the site setting set.

What is the fix?

There are a couple of changes being introduced in this commit:

1. Make `SiteSetting.setting` a private method as it is not safe to be
   exposed as a public method of the `SiteSetting` class

2. Change test cases to use existing site settings in Discourse instead
   of creating custom site settings. Existing site settings are not
   removed often so we don't really need to dynamically add new site
   settings in test cases. Even if the site settings being used in test
   cases are removed, updating the test cases to rely on other site
   settings is a very easy change.

3. Set up a plugin instance in the test environment as a "fixture"
   instead of having each test create its own plugin instance.