### PR TITLE
FIX: skip iframe URLs with relative paths in pretty text sanitizer.

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/sanitizer.js
+++ b/app/assets/javascripts/pretty-text/addon/sanitizer.js
@@ -127,6 +127,7 @@ export function sanitize(text, allowLister) {
             hrefAllowed(value, extraHrefMatchers)) ||
           (tag === "iframe" &&
             name === "src" &&
+            !value.match(/\/\.+\//) &&
             allowedIframes.some((i) => {
               return value.toLowerCase().startsWith((i || "").toLowerCase());
             }))

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2367,6 +2367,21 @@ HTML
     expect(cooked).to eq(html.strip)
   end
 
+  it "can skip relative paths in allowlist iframes" do
+    SiteSetting.allowed_iframes = "https://bob.com/abc/def"
+    raw = <<~HTML
+      <iframe src='https://bob.com/abc/def'></iframe>
+      <iframe src='https://bob.com/abc/def/../ghi'></iframe>
+      <iframe src='https://bob.com/abc/def/ghi/../../jkl'></iframe>
+    HTML
+
+    html = <<~HTML
+      <iframe src="https://bob.com/abc/def"></iframe>
+    HTML
+
+    expect(PrettyText.cook(raw).strip).to eq(html.strip)
+  end
+
   it "You can disable linkify" do
     md = "www.cnn.com test.it http://test.com https://test.ab https://a"
     cooked = PrettyText.cook(md)


### PR DESCRIPTION
This commit prevents unallowed URLs in iframe src by adding a relative path like `https://bob.com/abc/def/../ghi`. Currently, the iframe linking to site uses the current_user, not the post's author, so users who have no access to a certain path **are not** be able to view anything they shouldn't.