### PR TITLE
FEATURE: allow searching for oldest topics

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1124,11 +1124,23 @@ class Search
       else
         posts = posts.reorder("posts.created_at DESC")
       end
+    elsif @order == :oldest
+      if aggregate_search
+        posts = posts.order("MAX(posts.created_at) ASC")
+      else
+        posts = posts.reorder("posts.created_at ASC")
+      end
     elsif @order == :latest_topic
       if aggregate_search
         posts = posts.order("MAX(topics.created_at) DESC")
       else
         posts = posts.order("topics.created_at DESC")
+      end
+    elsif @order == :oldest_topic
+      if aggregate_search
+        posts = posts.order("MAX(topics.created_at) ASC")
+      else
+        posts = posts.order("topics.created_at ASC")
       end
     elsif @order == :views
       if aggregate_search

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2009,6 +2009,7 @@ RSpec.describe Search do
       topic2 = Fabricate(:topic, title: "I do not like that Sam I am 2", created_at: 5.minutes.ago)
       post2 = Fabricate(:post, topic: topic2, created_at: 5.minutes.ago)
 
+      expect(Search.execute("sam").posts.map(&:id)).to eq([post1.id, post2.id])
       expect(Search.execute("sam ORDER:oldest").posts.map(&:id)).to eq([post2.id, post1.id])
     end
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1991,7 +1991,7 @@ RSpec.describe Search do
       expect(Search.execute("with:images").posts.map(&:id)).to contain_exactly(post_uploaded.id)
     end
 
-    it "can find by latest and oldest" do
+    it "can find by latest" do
       topic1 = Fabricate(:topic, title: "I do not like that Sam I am")
       post1 = Fabricate(:post, topic: topic1, created_at: 10.minutes.ago)
       post2 = Fabricate(:post, raw: "that Sam I am, that Sam I am", created_at: 5.minutes.ago)


### PR DESCRIPTION
In some cases reverse chronological can be very important.

- Oldest post by sam
- Oldest topic by sam

Prior to these new filters we had no way of searching for them.

Now the 2 new orders `order:oldest` and `order:oldest_topic` can be used
to find oldest topics and posts
