### PR TITLE
FIX: Improve chat membership update on deleted message

### DIFF
--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -127,11 +127,12 @@ module Chat
     SQL
     end
 
-    def latest_not_deleted_message_id
-      DB.query_single(<<~SQL, channel_id: self.id).first
+    def latest_not_deleted_message_id(anchor_message_id: nil)
+      DB.query_single(<<~SQL, channel_id: self.id, anchor_message_id: anchor_message_id).first
         SELECT id FROM chat_messages
         WHERE chat_channel_id = :channel_id
         AND deleted_at IS NULL
+        #{anchor_message_id ? "AND id < :anchor_message_id" : ""}
         ORDER BY created_at DESC, id DESC
         LIMIT 1
       SQL

--- a/plugins/chat/app/models/chat/thread.rb
+++ b/plugins/chat/app/models/chat/thread.rb
@@ -52,15 +52,21 @@ module Chat
       original_message.rich_excerpt(max_length: EXCERPT_LENGTH)
     end
 
-    def latest_not_deleted_message_id
-      DB.query_single(<<~SQL, channel_id: self.channel_id, thread_id: self.id).first
+    def latest_not_deleted_message_id(anchor_message_id: nil)
+      DB.query_single(
+        <<~SQL,
         SELECT id FROM chat_messages
         WHERE chat_channel_id = :channel_id
         AND thread_id = :thread_id
         AND deleted_at IS NULL
+        #{anchor_message_id ? "AND id < :anchor_message_id" : ""}
         ORDER BY created_at DESC, id DESC
         LIMIT 1
       SQL
+        channel_id: self.channel_id,
+        thread_id: self.id,
+        anchor_message_id: anchor_message_id,
+      ).first
     end
 
     def self.grouped_messages(thread_ids: nil, message_ids: nil, include_original_message: true)

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -140,9 +140,9 @@ module Chat
       latest_not_deleted_message_id =
         if chat_message.thread_reply? && chat_channel.threading_enabled &&
              SiteSetting.enable_experimental_chat_threaded_discussions
-          chat_message.thread.latest_not_deleted_message_id
+          chat_message.thread.latest_not_deleted_message_id(anchor_message_id: chat_message.id)
         else
-          chat_channel.latest_not_deleted_message_id
+          chat_channel.latest_not_deleted_message_id(anchor_message_id: chat_message.id)
         end
       publish_to_targets!(
         message_bus_targets,

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe "Deleted message", type: :system, js: true do
       channel_page.delete_message(message)
       expect(channel_page).to have_deleted_message(message, count: 1)
       sidebar_component.click_link(channel_2.name)
+      expect(channel_page).to have_no_loading_skeleton
+
       sidebar_component.click_link(channel_1.name)
       expect(channel_page).to have_deleted_message(message, count: 1)
     end


### PR DESCRIPTION
Followup to c908eeacc96e947025176c1744ee4071ee252b91

Instead of using the latest message ID in the channel, which
could cause issues if you have an earlier last read message ID
that matches the deleted one, instead we use the first non-deleted
message that comes before the deleted message by ID.
