### PR TITLE
PERF: Strict loading for SidebarSection queries

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -359,11 +359,12 @@ export default Controller.extend(ModalFunctionality, {
           return ajax(`/sidebar_sections/${this.model.id}`, {
             type: "DELETE",
           })
-            .then((data) => {
+            .then(() => {
               const newSidebarSections =
                 this.currentUser.sidebar_sections.filter((section) => {
-                  return section.id !== data["sidebar_section"].id;
+                  return section.id !== this.model.id;
                 });
+
               this.currentUser.set("sidebar_sections", newSidebarSections);
               this.send("closeModal");
             })

--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -5,6 +5,7 @@ class SidebarSection < ActiveRecord::Base
 
   belongs_to :user
   has_many :sidebar_section_links, -> { order("position") }, dependent: :destroy
+
   has_many :sidebar_urls,
            through: :sidebar_section_links,
            source: :linkable,

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -79,7 +79,7 @@ class CurrentUserSerializer < BasicUserSerializer
     SidebarSection
       .public_sections
       .or(SidebarSection.where(user_id: object.id))
-      .includes(sidebar_section_links: :linkable)
+      .includes(:sidebar_urls)
       .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
       .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end

--- a/app/serializers/sidebar_section_serializer.rb
+++ b/app/serializers/sidebar_section_serializer.rb
@@ -4,7 +4,7 @@ class SidebarSectionSerializer < ApplicationSerializer
   attributes :id, :title, :links, :slug, :public, :section_type
 
   def links
-    object.sidebar_section_links.map { |link| SidebarUrlSerializer.new(link.linkable, root: false) }
+    object.sidebar_urls.map { |sidebar_url| SidebarUrlSerializer.new(sidebar_url, root: false) }
   end
 
   def slug

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -260,7 +260,7 @@ class SiteSerializer < ApplicationSerializer
   def anonymous_sidebar_sections
     SidebarSection
       .public_sections
-      .includes(sidebar_section_links: :linkable)
+      .includes(:sidebar_urls)
       .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
       .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,4 +71,6 @@ Discourse::Application.configure do
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
   end
+
+  config.active_record.action_on_strict_loading_violation = :log
 end

--- a/spec/models/sidebar_section_spec.rb
+++ b/spec/models/sidebar_section_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe SidebarSection do
     community_section.update!(title: "test")
     community_section.sidebar_section_links.first.linkable.update!(name: "everything edited")
     community_section.sidebar_section_links.last.destroy!
-
     community_section.reset_community!
+
     expect(community_section.reload.title).to eq("Community")
+
     expect(community_section.sidebar_section_links.all.map { |link| link.linkable.name }).to eq(
       ["Everything", "My Posts", "Review", "Admin", "Users", "About", "FAQ", "Groups", "Badges"],
     )


### PR DESCRIPTION
What is this change required?

I noticed that actions in `SidebarSectionsController` resulted in
lots of N+1 queries problem and I wanted a solution to
prevent such problems without having to write N+1 queries tests. I have
also used strict loading for `SidebarSection` queries in performance
sensitive spots.

Note that in this commit, I have also set `config.active_record.action_on_strict_loading_violation = :log`
for the production environment so that we have more visibility of
potential N+1 queries problem in the logs. In development and test
environment, we're sticking with the default of raising an error.