### PR TITLE
DEV: Reinstate Chat::MessageCreator skipped thread specs

### DIFF
--- a/plugins/chat/spec/components/chat/message_creator_spec.rb
+++ b/plugins/chat/spec/components/chat/message_creator_spec.rb
@@ -726,7 +726,13 @@ describe Chat::MessageCreator do
         end
 
         it "creates a thread and updates all the messages in the chain" do
-          skip "TODO: a recent spec regression"
+          # This must be done since the fabricator uses Chat::MessageCreator
+          # under the hood and it creates the thread already.
+          old_message_1.update!(thread_id: nil)
+          old_message_2.update!(thread_id: nil)
+          old_message_3.update!(thread_id: nil)
+          reply_message.update!(thread_id: nil)
+
           thread_count = Chat::Thread.count
           message =
             described_class.create(
@@ -851,11 +857,11 @@ describe Chat::MessageCreator do
 
           before do
             old_message_1.update!(thread: old_thread)
+            old_message_2.update!(thread: old_thread)
             old_message_3.update!(thread: incorrect_thread)
           end
 
           it "does not change any messages in the chain, assumes they have the correct thread ID" do
-            skip "TODO: a recent spec regression"
             thread_count = Chat::Thread.count
             message =
               described_class.create(


### PR DESCRIPTION
Followup to 7f85624a01a08ae46f9759b1aee90c6c6ab79ed7

Fixes the specs that were skipped and reinstates them
