### PR TITLE
FIX: Don’t run validations when invalidating invites

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -274,10 +274,12 @@ class Invite < ActiveRecord::Base
   end
 
   def self.invalidate_for_email(email)
-    invite = Invite.find_by(email: Email.downcase(email))
-    invite.update!(invalidated_at: Time.zone.now) if invite
+    Invite.find_by(email: Email.downcase(email))&.invalidate!
+  end
 
-    invite
+  def invalidate!
+    update_attribute(:invalidated_at, Time.current)
+    self
   end
 
   def resend_invite

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe Invite do
     end
   end
 
-  describe "#invalidate_for_email" do
+  describe ".invalidate_for_email" do
     it "returns nil if there is no invite for the given email" do
       invite = Invite.invalidate_for_email("test@example.com")
       expect(invite).to eq(nil)
@@ -597,6 +597,31 @@ RSpec.describe Invite do
 
       it "returns true if email does match user email" do
         expect(invite.can_be_redeemed_by?(user)).to eq(true)
+      end
+    end
+  end
+
+  describe "#invalidate!" do
+    subject(:invalidate) { invite.invalidate! }
+
+    fab!(:invite) { Fabricate(:invite) }
+
+    before { freeze_time }
+
+    it "invalidates the invite" do
+      expect { invalidate }.to change { invite.invalidated_at }.to Time.current
+    end
+
+    it "returns the invite" do
+      expect(invalidate).to eq invite
+    end
+
+    context "when the invite is in an invalid state" do
+      before { invite.update_attribute(:custom_message, "a" * 2000) }
+
+      it "still invalidates the invite" do
+        expect(invite).to be_invalid
+        expect { invalidate }.to change { invite.invalidated_at }.to Time.current
       end
     end
   end


### PR DESCRIPTION
This PR is a followup of
https://github.com/discourse/discourse/pull/21504 where limits on custom message for an invite were introduced.

This had a side effect of making some existing invites invalid and with the current code, they can’t be invalidated anymore.

This PR takes the approach of skipping the validations when invites are invalidated since the important thing here is to mark the invite as invalidated regardless of its actual state in the DB. (no other attributes are updated at the same time anyway)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
