### PR TITLE
FIX: Do not error if admin/owner checks target message

### DIFF
--- a/plugins/chat/app/services/chat/channel_view_builder.rb
+++ b/plugins/chat/app/services/chat/channel_view_builder.rb
@@ -65,9 +65,12 @@ module Chat
       guardian.can_preview_chat_channel?(channel)
     end
 
-    def target_message_exists(contract:, **)
+    def target_message_exists(contract:, guardian:, **)
       return true if contract.target_message_id.blank?
-      Chat::Message.exists?(id: contract.target_message_id)
+      target_message = Chat::Message.unscoped.find_by(id: contract.target_message_id)
+      return false if target_message.blank?
+      return true if !target_message.trashed?
+      target_message.user_id == guardian.user.id || guardian.is_staff?
     end
 
     def determine_threads_enabled(channel:, **)

--- a/plugins/chat/spec/services/chat/channel_view_builder_spec.rb
+++ b/plugins/chat/spec/services/chat/channel_view_builder_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe Chat::ChannelViewBuilder do
         before { message.trash! }
 
         it { is_expected.to fail_a_policy(:target_message_exists) }
+
+        context "when the user is the owner of the trashed message" do
+          before { message.update!(user: current_user) }
+
+          it { is_expected.not_to fail_a_policy(:target_message_exists) }
+        end
+
+        context "when the user is admin" do
+          before { current_user.update!(admin: true) }
+
+          it { is_expected.not_to fail_a_policy(:target_message_exists) }
+        end
       end
     end
   end


### PR DESCRIPTION
In the ChannelViewBuilder, we introduced a check to see if
the target message exists, which errors if the message has
been trashed. However if the user is the creator of the message
or admin then they are able to see trashed messages, so
we need to take this into account.
