### PR TITLE
FIX: improves draft for channels

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -43,6 +43,7 @@ export default class ChatLivePane extends Component {
   @service appEvents;
   @service messageBus;
   @service site;
+  @service chatDraftsManager;
 
   @tracked loading = false;
   @tracked loadingMorePast = false;
@@ -116,11 +117,6 @@ export default class ChatLivePane extends Component {
     if (this._loadedChannelId !== this.args.channel?.id) {
       this.unsubscribeToUpdates(this._loadedChannelId);
       this.chatChannelPane.selectingMessages = false;
-
-      if (this.args.channel.draft) {
-        this.chatChannelComposer.message = this.args.channel.draft;
-      }
-
       this._loadedChannelId = this.args.channel?.id;
     }
 
@@ -642,6 +638,7 @@ export default class ChatLivePane extends Component {
       .editMessage(this.args.channel.id, message.id, data)
       .catch(popupAjaxError)
       .finally(() => {
+        this.chatDraftsManager.remove({ channelId: this.args.channel.id });
         this.chatChannelPane.sending = false;
       });
   }
@@ -704,7 +701,7 @@ export default class ChatLivePane extends Component {
           return;
         }
 
-        this.args.channel.draft = null;
+        this.chatDraftsManager.remove({ channelId: this.args.channel.id });
         this.chatChannelPane.sending = false;
       });
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
@@ -1,4 +1,8 @@
-<div class="chat-composer-message-details" data-id={{@message.id}}>
+<div
+  class="chat-composer-message-details"
+  data-id={{@message.id}}
+  data-action={{if @message.editing "edit" "reply"}}
+>
   <div class="chat-reply">
     {{d-icon (if @message.editing "pencil-alt" "reply")}}
     <ChatUserAvatar @user={{@message.user}} />

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
@@ -26,6 +26,8 @@
     {{did-update this.didUpdateMessage this.currentMessage}}
     {{did-update this.didUpdateInReplyTo this.currentMessage.inReplyTo}}
     {{did-insert this.setup}}
+    {{did-insert this.didUpdateChannel}}
+    {{did-update this.didUpdateChannel @channel.id}}
     {{will-destroy this.teardown}}
     {{will-destroy this.cancelPersistDraft}}
   >

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
@@ -7,6 +7,7 @@ import { action } from "@ember/object";
 export default class ChatComposerChannel extends ChatComposer {
   @service("chat-channel-composer") composer;
   @service("chat-channel-pane") pane;
+  @service chatDraftsManager;
 
   context = "channel";
 
@@ -22,6 +23,8 @@ export default class ChatComposerChannel extends ChatComposer {
     if (this.args.channel?.isDraft) {
       return;
     }
+
+    this.chatDraftsManager.add(this.currentMessage);
 
     this._persistHandler = discourseDebounce(
       this,

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -81,7 +81,6 @@ export default class ChatChannel {
   @tracked canFlag;
   @tracked canModerate;
   @tracked userSilenced;
-  @tracked draft = null;
   @tracked meta;
   @tracked chatableType;
   @tracked chatableUrl;

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -247,6 +247,12 @@ export default class ChatMessage {
       };
     }
 
+    if (this.editing) {
+      data.editing = true;
+      data.id = this.id;
+      data.excerpt = this.excerpt;
+    }
+
     return JSON.stringify(data);
   }
 

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -137,8 +137,12 @@ export default class ChatMessage {
   }
 
   cook() {
+    const site = getOwner(this).lookup("service:site");
+
     next(() => {
-      const site = getOwner(this).lookup("service:site");
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
 
       const markdownOptions = {
         featuresOverride:

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
@@ -1,10 +1,18 @@
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 import ChatComposer from "./chat-composer";
+import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 
 export default class ChatChannelComposer extends ChatComposer {
   @service chat;
   @service router;
+
+  @action
+  reset(channel) {
+    this.message = ChatMessage.createDraftMessage(channel, {
+      user: this.currentUser,
+    });
+  }
 
   @action
   replyTo(message) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-composer.js
@@ -7,7 +7,7 @@ export default class ChatChannelThreadComposer extends ChatComposer {
   reset(channel, thread) {
     this.message = ChatMessage.createDraftMessage(channel, {
       user: this.currentUser,
+      thread,
     });
-    this.message.thread = thread;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-composer.js
@@ -1,13 +1,12 @@
 import { tracked } from "@glimmer/tracking";
 import Service, { inject as service } from "@ember/service";
 import { action } from "@ember/object";
-import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 
 export default class ChatComposer extends Service {
   @service chat;
   @service currentUser;
 
-  @tracked _message;
+  @tracked message;
 
   @action
   cancel() {
@@ -16,13 +15,6 @@ export default class ChatComposer extends Service {
     } else if (this.message.inReplyTo) {
       this.message.inReplyTo = null;
     }
-  }
-
-  @action
-  reset(channel) {
-    this.message = ChatMessage.createDraftMessage(channel, {
-      user: this.currentUser,
-    });
   }
 
   @action
@@ -40,13 +32,5 @@ export default class ChatComposer extends Service {
   @action
   onCancelEditing() {
     this.reset();
-  }
-
-  get message() {
-    return this._message;
-  }
-
-  set message(message) {
-    this._message = message;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
@@ -1,0 +1,17 @@
+import Service from "@ember/service";
+
+export default class ChatDraftsManager extends Service {
+  drafts = {};
+
+  add(message) {
+    this.drafts[message.channel.id] = message;
+  }
+
+  get({ channelId }) {
+    return this.drafts[channelId];
+  }
+
+  remove({ channelId }) {
+    delete this.drafts[channelId];
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
@@ -1,10 +1,14 @@
 import Service from "@ember/service";
-
+import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 export default class ChatDraftsManager extends Service {
   drafts = {};
 
   add(message) {
-    this.drafts[message.channel.id] = message;
+    if (message instanceof ChatMessage) {
+      this.drafts[message.channel.id] = message;
+    } else {
+      throw new Error("message must be an instance of ChatMessage");
+    }
   }
 
   get({ channelId }) {
@@ -13,5 +17,9 @@ export default class ChatDraftsManager extends Service {
 
   remove({ channelId }) {
     delete this.drafts[channelId];
+  }
+
+  reset() {
+    this.drafts = {};
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -27,6 +27,7 @@ export default class Chat extends Service {
   @service chatNotificationManager;
   @service chatSubscriptionsManager;
   @service chatStateManager;
+  @service chatDraftsManager;
   @service presence;
   @service router;
   @service site;
@@ -167,19 +168,18 @@ export default class Chat extends Service {
     [...channels.public_channels, ...channels.direct_message_channels].forEach(
       (channelObject) => {
         const channel = this.chatChannelsManager.store(channelObject);
+        const storedDraft = (this.currentUser?.chat_drafts || []).find(
+          (draft) => draft.channel_id === channel.id
+        );
 
-        if (this.currentUser.chat_drafts) {
-          const storedDraft = this.currentUser.chat_drafts.find(
-            (draft) => draft.channel_id === channel.id
-          );
-
-          channel.draft = ChatMessage.createDraftMessage(
-            channel,
-            Object.assign(
-              {
-                user: this.currentUser,
-              },
-              storedDraft ? JSON.parse(storedDraft.data) : {}
+        if (storedDraft) {
+          this.chatDraftsManager.add(
+            ChatMessage.createDraftMessage(
+              channel,
+              Object.assign(
+                { user: this.currentUser },
+                JSON.parse(storedDraft.data)
+              )
             )
           );
         }

--- a/plugins/chat/spec/system/chat_composer_draft_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_draft_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat composer draft", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+
+  before { chat_system_bootstrap }
+
+  context "when loading a channel with a draft" do
+    fab!(:draft_1) do
+      Chat::Draft.create!(
+        chat_channel: channel_1,
+        user: current_user,
+        data: { message: "draft" }.to_json,
+      )
+    end
+
+    before do
+      channel_1.add(current_user)
+      sign_in(current_user)
+    end
+
+    it "loads the draft" do
+      chat_page.visit_channel(channel_1)
+
+      expect(channel_page.composer.value).to eq("draft")
+    end
+
+    context "when loading another channel and back" do
+      fab!(:channel_2) { Fabricate(:chat_channel) }
+
+      fab!(:draft_2) do
+        Chat::Draft.create!(
+          chat_channel: channel_2,
+          user: current_user,
+          data: { message: "draft2" }.to_json,
+        )
+      end
+
+      before { channel_2.add(current_user) }
+
+      it "loads the correct drafts" do
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.composer.value).to eq("draft")
+
+        chat_page.visit_channel(channel_2)
+
+        expect(channel_page.composer.value).to eq("draft2")
+
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.composer.value).to eq("draft")
+      end
+    end
+
+    context "with editing" do
+      fab!(:draft_1) do
+        Chat::Draft.create!(
+          chat_channel: channel_1,
+          user: current_user,
+          data: { message: message_1.message, id: message_1.id, editing: true }.to_json,
+        )
+      end
+
+      it "loads the draft with the editing state" do
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.composer).to be_editing_message(message_1)
+      end
+    end
+
+    context "with uploads" do
+      fab!(:upload_1) do
+        Fabricate(
+          :upload,
+          url: "/images/logo-dark.png",
+          original_filename: "logo_dark.png",
+          width: 400,
+          height: 300,
+          extension: "png",
+        )
+      end
+
+      fab!(:draft_1) do
+        Chat::Draft.create!(
+          chat_channel: channel_1,
+          user: current_user,
+          data: { message: "draft", uploads: [upload_1] }.to_json,
+        )
+      end
+
+      it "loads the draft with the upload" do
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.composer.value).to eq("draft")
+        expect(page).to have_selector(".chat-composer-upload--image", count: 1)
+      end
+    end
+
+    context "when replying" do
+      fab!(:draft_1) do
+        Chat::Draft.create!(
+          chat_channel: channel_1,
+          user: current_user,
+          data: {
+            message: "draft",
+            replyToMsg: {
+              id: message_1.id,
+              excerpt: message_1.excerpt,
+              user: {
+                id: message_1.user.id,
+                name: nil,
+                avatar_template: message_1.user.avatar_template,
+                username: message_1.user.username,
+              },
+            },
+          }.to_json,
+        )
+      end
+
+      it "loads the draft with replied to mesage" do
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.composer.value).to eq("draft")
+        expect(page).to have_selector(".chat-reply__username", text: message_1.user.username)
+        expect(page).to have_selector(".chat-reply__excerpt", text: message_1.excerpt)
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/system/page_objects/chat/components/composer.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/composer.rb
@@ -12,6 +12,10 @@ module PageObjects
           @context = context
         end
 
+        def message_details
+          @message_details ||= PageObjects::Components::Chat::ComposerMessageDetails.new(context)
+        end
+
         def input
           find(context).find(SELECTOR).find(".chat-composer__input")
         end
@@ -30,6 +34,10 @@ module PageObjects
 
         def open_emoji_picker
           find(context).find(SELECTOR).find(".chat-composer-button__btn.emoji").click
+        end
+
+        def editing_message?(message)
+          value == message.message && message_details.editing_message?(message)
         end
       end
     end

--- a/plugins/chat/spec/system/page_objects/chat/components/composer_message_details.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/composer_message_details.rb
@@ -12,12 +12,18 @@ module PageObjects
           @context = context
         end
 
-        def has_message?(message)
-          find(context).find(SELECTOR + "[data-id=\"#{message.id}\"]")
+        def has_message?(message, action: nil)
+          data_attributes = "[data-id=\"#{message.id}\"]"
+          data_attributes << "[data-action=\"#{action}\"]" if action
+          find(context).find(SELECTOR + data_attributes)
         end
 
         def has_no_message?
           find(context).has_no_css?(SELECTOR)
+        end
+
+        def editing_message?(message)
+          has_message?(message, action: :edit)
         end
       end
     end

--- a/plugins/chat/test/javascripts/unit/services/chat-drafts-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-drafts-manager-test.js
@@ -16,7 +16,7 @@ module(
       this.subject.reset();
     });
 
-    test("storing and retrivieng messsage", function (assert) {
+    test("storing and retrieving message", function (assert) {
       const message1 = fabricators.message();
       this.subject.add(message1);
 

--- a/plugins/chat/test/javascripts/unit/services/chat-drafts-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-drafts-manager-test.js
@@ -1,0 +1,53 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
+import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module(
+  "Discourse Chat | Unit | Service | chat-drafts-manager",
+  function (hooks) {
+    setupTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.subject = getOwner(this).lookup("service:chat-drafts-manager");
+    });
+
+    hooks.afterEach(function () {
+      this.subject.reset();
+    });
+
+    test("storing and retrivieng messsage", function (assert) {
+      const message1 = fabricators.message();
+      this.subject.add(message1);
+
+      assert.strictEqual(
+        this.subject.get({ channelId: message1.channel.id }),
+        message1
+      );
+
+      const message2 = fabricators.message();
+      this.subject.add(message2);
+
+      assert.strictEqual(
+        this.subject.get({ channelId: message2.channel.id }),
+        message2
+      );
+    });
+
+    test("stores only chat messages", function (assert) {
+      assert.throws(function () {
+        this.subject.add({ foo: "bar" });
+      }, /instance of ChatMessage/);
+    });
+
+    test("#reset", function (assert) {
+      this.subject.add(fabricators.message());
+
+      assert.strictEqual(Object.keys(this.subject.drafts).length, 1);
+
+      this.subject.reset();
+
+      assert.strictEqual(Object.keys(this.subject.drafts).length, 0);
+    });
+  }
+);


### PR DESCRIPTION
This commit attempts to correctly change draft when the channel changes. It moves responsibility to the composer instead of the channel.

A new service `chatDraftsManager` is being introduced here to allow finer control and pave the way for future thread draft support.

These changes also now allow an editing message to be stored as a draft.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
