### PR TITLE
DEV: Add policy objects to services

### DIFF
--- a/plugins/chat/app/controllers/chat/api_controller.rb
+++ b/plugins/chat/app/controllers/chat/api_controller.rb
@@ -19,12 +19,8 @@ module Chat
         on_success { render(json: success_json) }
         on_failure { render(json: failed_json, status: 422) }
         on_failed_policy(:invalid_access) { raise Discourse::InvalidAccess }
-        on_failed_contract do
-          render(
-            json:
-              failed_json.merge(errors: result[:"result.contract.default"].errors.full_messages),
-            status: 400,
-          )
+        on_failed_contract do |contract|
+          render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
         end
       end
     end

--- a/plugins/chat/app/policies/policy_base.rb
+++ b/plugins/chat/app/policies/policy_base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PolicyBase
+  attr_reader :context
+
+  delegate :guardian, to: :context
+
+  def initialize(context)
+    @context = context
+  end
+
+  def call
+    raise "Not implemented"
+  end
+
+  def reason
+    raise "Not implemented"
+  end
+end

--- a/plugins/chat/lib/chat/steps_inspector.rb
+++ b/plugins/chat/lib/chat/steps_inspector.rb
@@ -80,6 +80,9 @@ module Chat
 
     # @!visibility private
     class Policy < Step
+      def error
+        step_result.reason
+      end
     end
 
     # @!visibility private

--- a/plugins/chat/lib/service_runner.rb
+++ b/plugins/chat/lib/service_runner.rb
@@ -12,12 +12,20 @@
 #
 # * +on_success+: will execute the provided block if the service succeeds
 # * +on_failure+: will execute the provided block if the service fails
+# * +on_failed_step(name)+: will execute the provided block if the step named
+#   `name` fails
 # * +on_failed_policy(name)+: will execute the provided block if the policy
 #   named `name` fails
 # * +on_failed_contract(name)+: will execute the provided block if the contract
 #   named `name` fails
-# * +on_model_not_found(name)+: will execute the provided block if the service
-#   fails and its model is not present
+# * +on_model_not_found(name)+: will execute the provided block if the model
+#   named `name` is not present
+# * +on_model_errors(name)+: will execute the provided block if the model named
+#   `name` contains validation errors
+#
+# All the specialized steps receive the failing step result object as an
+# argument to their block. `on_model_errors` receives the actual model so it’s
+# easier to inspect it.
 #
 # Default actions for each of these are defined in [Chat::ApiController#default_actions_for_service]
 #
@@ -28,7 +36,7 @@
 #         flash[:notice] = "Success!"
 #         redirect_to a_path
 #       end
-#       on_failed_policy(:a_named_policy) { redirect_to root_path }
+#       on_failed_policy(:a_named_policy) { |policy| redirect_to root_path, alert: policy.reason }
 #       on_failure { render :new }
 #     end
 #   end
@@ -50,20 +58,41 @@
 
 class ServiceRunner
   # @!visibility private
-  NULL_RESULT = OpenStruct.new(failure?: false)
-  # @!visibility private
   AVAILABLE_ACTIONS = {
-    on_success: -> { result.success? },
-    on_failure: -> { result.failure? },
-    on_failed_step: ->(name) { failure_for?("result.step.#{name}") },
-    on_failed_policy: ->(name = "default") { failure_for?("result.policy.#{name}") },
-    on_failed_contract: ->(name = "default") { failure_for?("result.contract.#{name}") },
-    on_model_not_found: ->(name = "model") do
-      failure_for?("result.model.#{name}") && result[name].blank?
-    end,
-    on_model_errors: ->(name = "model") do
-      failure_for?("result.model.#{name}") && result["result.model.#{name}"].invalid
-    end,
+    on_success: {
+      condition: -> { result.success? },
+      key: [],
+    },
+    on_failure: {
+      condition: -> { result.failure? },
+      key: [],
+    },
+    on_failed_step: {
+      condition: ->(name) { failure_for?("result.step.#{name}") },
+      key: %w[result step],
+    },
+    on_failed_policy: {
+      condition: ->(name = "default") { failure_for?("result.policy.#{name}") },
+      key: %w[result policy],
+      default_name: "default",
+    },
+    on_failed_contract: {
+      condition: ->(name = "default") { failure_for?("result.contract.#{name}") },
+      key: %w[result contract],
+      default_name: "default",
+    },
+    on_model_not_found: {
+      condition: ->(name = "model") { failure_for?("result.model.#{name}") && result[name].blank? },
+      key: %w[result model],
+      default_name: "model",
+    },
+    on_model_errors: {
+      condition: ->(name = "model") do
+        failure_for?("result.model.#{name}") && result["result.model.#{name}"].invalid
+      end,
+      key: [],
+      default_name: "model",
+    },
   }.with_indifferent_access.freeze
 
   # @!visibility private
@@ -104,13 +133,19 @@ class ServiceRunner
   attr_reader :actions
 
   def failure_for?(key)
-    (object.result[key] || NULL_RESULT).failure?
+    object.result[key]&.failure?
   end
 
   def add_action(name, *args, &block)
+    action = AVAILABLE_ACTIONS[name]
     actions[[name, *args].join("_").to_sym] = [
-      -> { instance_exec(*args, &AVAILABLE_ACTIONS[name]) },
-      -> { object.instance_eval(&block) },
+      -> { instance_exec(*args, &action[:condition]) },
+      -> do
+        object.instance_exec(
+          result[[*action[:key], args.first || action[:default_name]].join(".")],
+          &block
+        )
+      end,
     ]
   end
 

--- a/plugins/chat/spec/lib/chat/steps_inspector_spec.rb
+++ b/plugins/chat/spec/lib/chat/steps_inspector_spec.rb
@@ -221,6 +221,30 @@ RSpec.describe Chat::StepsInspector do
       end
     end
 
+    context "when the policy step is failing" do
+      before do
+        class DummyService
+          def policy
+            false
+          end
+        end
+      end
+
+      context "when there is no reason provided" do
+        it "returns nothing" do
+          expect(error).to be_blank
+        end
+      end
+
+      context "when a reason is provided" do
+        before { result["result.policy.policy"].reason = "failed" }
+
+        it "returns the reason" do
+          expect(error).to eq "failed"
+        end
+      end
+    end
+
     context "when a common step is failing" do
       before { result["result.step.final_step"].fail(error: "my error") }
 

--- a/plugins/chat/spec/lib/service_runner_spec.rb
+++ b/plugins/chat/spec/lib/service_runner_spec.rb
@@ -210,8 +210,22 @@ RSpec.describe ServiceRunner do
       context "when the service policy fails" do
         let(:service) { FailedPolicyService }
 
-        it "runs the provided block" do
-          expect(runner).to eq :policy_failure
+        context "when not using the block argument" do
+          it "runs the provided block" do
+            expect(runner).to eq :policy_failure
+          end
+        end
+
+        context "when using the block argument" do
+          let(:actions) { <<-BLOCK }
+              proc do
+                on_failed_policy(:test) { |policy| policy == result["result.policy.test"] }
+              end
+            BLOCK
+
+          it "runs the provided block" do
+            expect(runner).to be true
+          end
         end
       end
 
@@ -234,8 +248,22 @@ RSpec.describe ServiceRunner do
       context "when the service contract fails" do
         let(:service) { FailedContractService }
 
-        it "runs the provided block" do
-          expect(runner).to eq :contract_failure
+        context "when not using the block argument" do
+          it "runs the provided block" do
+            expect(runner).to eq :contract_failure
+          end
+        end
+
+        context "when using the block argument" do
+          let(:actions) { <<-BLOCK }
+              proc do
+                on_failed_contract { |contract| contract == result["result.contract.default"] }
+              end
+            BLOCK
+
+          it "runs the provided block" do
+            expect(runner).to be true
+          end
         end
       end
 
@@ -250,7 +278,7 @@ RSpec.describe ServiceRunner do
 
     context "when using the on_model_not_found action" do
       let(:actions) { <<-BLOCK }
-          ->(*) do
+          proc do
             on_model_not_found(:fake_model) { :no_model }
           end
         BLOCK
@@ -259,8 +287,22 @@ RSpec.describe ServiceRunner do
         context "when the service fails without a model" do
           let(:service) { FailureWithModelService }
 
-          it "runs the provided block" do
-            expect(runner).to eq :no_model
+          context "when not using the block argument" do
+            it "runs the provided block" do
+              expect(runner).to eq :no_model
+            end
+          end
+
+          context "when using the block argument" do
+            let(:actions) { <<-BLOCK }
+                proc do
+                  on_model_not_found(:fake_model) { |model| model == result["result.model.fake_model"] }
+                end
+              BLOCK
+
+            it "runs the provided block" do
+              expect(runner).to be true
+            end
           end
         end
 
@@ -294,7 +336,7 @@ RSpec.describe ServiceRunner do
 
     context "when using the on_model_errors action" do
       let(:actions) { <<-BLOCK }
-          ->(*) do
+          proc do
             on_model_errors(:fake_model) { :model_errors }
           end
         BLOCK
@@ -302,8 +344,22 @@ RSpec.describe ServiceRunner do
       context "when the service fails with a model containing errors" do
         let(:service) { FailureWithModelErrorsService }
 
-        it "runs the provided block" do
-          expect(runner).to eq :model_errors
+        context "when not using the block argument" do
+          it "runs the provided block" do
+            expect(runner).to eq :model_errors
+          end
+        end
+
+        context "when using the block argument" do
+          let(:actions) { <<-BLOCK }
+              proc do
+                on_model_errors(:fake_model) { |model| model == OpenStruct.new(invalid?: true) }
+              end
+            BLOCK
+
+          it "runs the provided block" do
+            expect(runner).to be true
+          end
         end
       end
 


### PR DESCRIPTION
This PR introduces policy objects to chat services. It allows putting more complex logic in a dedicated class, which will make services thinner. It also allows providing a reason why the policy failed.

Some change has been made to the service runner too to use more easily these new policy objects: when matching a failing policy (or any failing step actually), the result object is now provided to the block. This way, instead of having to access the reason why the policy failed by doing `result["result.policy.policy_name"].reason` inside the block, this one can be simply written like this:
```ruby
  on_failed_policy(:policy_name) { |policy| policy.reason }
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
