### PR TITLE
FIX: flakey spec in sidebar with new font size

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -289,6 +289,7 @@ RSpec.configure do |config|
           options.add_argument("--no-sandbox")
           options.add_argument("--disable-dev-shm-usage")
           options.add_argument("--mute-audio")
+          options.add_argument("--force-device-scale-factor=1")
         end
 
     Capybara.register_driver :selenium_chrome do |app|
@@ -310,6 +311,7 @@ RSpec.configure do |config|
           options.add_argument("--disable-dev-shm-usage")
           options.add_emulation(device_name: "iPhone 12 Pro")
           options.add_argument("--mute-audio")
+          options.add_argument("--force-device-scale-factor=1")
         end
 
     Capybara.register_driver :selenium_mobile_chrome do |app|

--- a/spec/system/page_objects/components/sidebar_header_dropdown.rb
+++ b/spec/system/page_objects/components/sidebar_header_dropdown.rb
@@ -42,8 +42,8 @@ module PageObjects
       end
 
       def click_outside
-        dropdown = page.find(SIDEBAR_HAMBURGER_DROPDOWN)
-        dropdown.click(x: dropdown.rect.width + 1, y: 1)
+        width = page.evaluate_script("document.body.clientWidth")
+        page.find("body").click(x: width - 1, y: 1)
       end
     end
   end


### PR DESCRIPTION
This commit also includes two changes to the rails helper which make tests more consistent on different devices. With this change the failure was reproducible locally and not only on CI:

```
options.add_argument("--force-device-scale-factor=1")
```

The fix itself is quite simple and attempts to find safe click coordinates, the previous solution could fail depending on the size of the sidebar.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
