### PR TITLE
FEATURE: apply hashtag styles to autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -239,6 +239,12 @@ function _searchRequest(term, contextualHashtagConfiguration, resultFunc) {
       response.results?.forEach((result) => {
         // Convert :emoji: in the result text to HTML safely.
         result.text = htmlSafe(emojiUnescape(escapeExpression(result.text)));
+
+        const hashtagType = getHashtagTypeClasses()[result.type];
+        result.icon = hashtagType.generateIconHTML({
+          icon: result.icon,
+          id: result.id,
+        });
       });
       resultFunc(response.results || CANCELLED_STATUS);
     })

--- a/app/assets/javascripts/discourse/app/templates/hashtag-autocomplete.hbr
+++ b/app/assets/javascripts/discourse/app/templates/hashtag-autocomplete.hbr
@@ -3,7 +3,7 @@
     <ul>
       {{#each options as |option|}}
         <li class="hashtag-autocomplete__option">
-          <a class="hashtag-autocomplete__link" title="{{option.description}}" href>{{d-icon option.icon}}<span class="hashtag-autocomplete__text">{{option.text}}{{#if option.secondary_text}}<span class="hashtag-autocomplete__meta-text">({{option.secondary_text}}){{/if}}</span></span>
+          <a class="hashtag-autocomplete__link" title="{{option.description}}" href>{{{option.icon}}}<span class="hashtag-autocomplete__text">{{option.text}}{{#if option.secondary_text}}<span class="hashtag-autocomplete__meta-text">({{option.secondary_text}}){{/if}}</span></span>
           </a>
         </li>
       {{/each}}

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -90,8 +90,15 @@ a.hashtag-cooked {
     }
 
     .d-icon {
-      color: var(--primary-medium);
       margin-right: 0.25em;
+    }
+
+    .hashtag-category-badge {
+      flex: 0 0 auto;
+      width: 15px;
+      height: 15px;
+      margin-right: 5px;
+      display: inline-block;
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/hashtag-types/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/hashtag-types/channel.js
@@ -20,7 +20,7 @@ export default class ChannelHashtagType extends HashtagTypeBase {
 
   generateColorCssClasses(channel) {
     return [
-      `.hashtag-cooked .d-icon.hashtag-color--${this.type}-${channel.id} { color: var(--category-${channel.chatable.id}-color); }`,
+      `.d-icon.hashtag-color--${this.type}-${channel.id} { color: var(--category-${channel.chatable.id}-color); }`,
     ];
   }
 

--- a/plugins/chat/test/javascripts/acceptance/hashtag-css-generator-test.js
+++ b/plugins/chat/test/javascripts/acceptance/hashtag-css-generator-test.js
@@ -59,7 +59,7 @@ acceptance("Chat | Hashtag CSS Generator", function (needs) {
     assert.equal(
       cssTag.innerHTML,
 
-      ".hashtag-color--category-1 {\n  background: linear-gradient(90deg, var(--category-1-color) 50%, var(--category-1-color) 50%);\n}\n.hashtag-color--category-2 {\n  background: linear-gradient(90deg, var(--category-2-color) 50%, var(--category-2-color) 50%);\n}\n.hashtag-color--category-4 {\n  background: linear-gradient(90deg, var(--category-4-color) 50%, var(--category-1-color) 50%);\n}\n.hashtag-cooked .d-icon.hashtag-color--channel-44 { color: var(--category-1-color); }\n.hashtag-cooked .d-icon.hashtag-color--channel-74 { color: var(--category-2-color); }\n.hashtag-cooked .d-icon.hashtag-color--channel-88 { color: var(--category-4-color); }"
+      ".hashtag-color--category-1 {\n  background: linear-gradient(90deg, var(--category-1-color) 50%, var(--category-1-color) 50%);\n}\n.hashtag-color--category-2 {\n  background: linear-gradient(90deg, var(--category-2-color) 50%, var(--category-2-color) 50%);\n}\n.hashtag-color--category-4 {\n  background: linear-gradient(90deg, var(--category-4-color) 50%, var(--category-1-color) 50%);\n}\n.d-icon.hashtag-color--channel-44 { color: var(--category-1-color); }\n.d-icon.hashtag-color--channel-74 { color: var(--category-2-color); }\n.d-icon.hashtag-color--channel-88 { color: var(--category-4-color); }"
     );
   });
 });


### PR DESCRIPTION
This commit uses improvements done in https://github.com/discourse/discourse/commit/0b3cf83e3c7d03c2dcd54f86de60efe32f385a44 to apply these styles to the autocomplete in composer.

<img width="301" alt="Screenshot 2023-05-24 at 20 28 31" src="https://github.com/discourse/discourse/assets/339945/24ea7728-c140-4250-962f-23631630c95c">