### PR TITLE
DEV: Allow plugins to send additional fields when user preferences are saved

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -13,6 +13,7 @@ import { inject as service } from "@ember/service";
 import { next } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
 import { exportUserArchive } from "discourse/lib/export-csv";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend(CanCheckEmails, {
   dialog: service(),
@@ -181,7 +182,11 @@ export default Controller.extend(CanCheckEmails, {
       });
 
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("account")
+          )
+        )
         .then(() => this.set("saved", true))
         .catch(popupAjaxError);
     },

--- a/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
@@ -2,6 +2,7 @@ import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { or } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend({
   @discourseComputed("siteSettings.mute_all_categories_by_default")
@@ -57,7 +58,11 @@ export default Controller.extend({
     save() {
       this.set("saved", false);
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("categories")
+          )
+        )
         .then(() => {
           this.set("saved", true);
         })

--- a/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
@@ -3,6 +3,7 @@ import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { equal } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 const EMAIL_LEVELS = {
   ALWAYS: 0,
@@ -94,7 +95,11 @@ export default Controller.extend({
     save() {
       this.set("saved", false);
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("emails")
+          )
+        )
         .then(() => {
           this.set("saved", true);
         })

--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -15,6 +15,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { reload } from "discourse/helpers/page-reloader";
 import { propertyEqual } from "discourse/lib/computed";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 const USER_HOMES = {
   1: "latest",
@@ -303,7 +304,11 @@ export default Controller.extend({
       }
 
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("interface")
+          )
+        )
         .then(() => {
           this.set("saved", true);
 

--- a/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
@@ -1,6 +1,7 @@
 import Controller from "@ember/controller";
 import I18n from "I18n";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend({
   subpageTitle: I18n.t("user.preferences_nav.notifications"),
@@ -34,7 +35,11 @@ export default Controller.extend({
     save() {
       this.set("saved", false);
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("notifications")
+          )
+        )
         .then(() => {
           this.set("saved", true);
         })

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -9,6 +9,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { readOnly } from "@ember/object/computed";
 import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend({
   dialog: service(),
@@ -124,7 +125,11 @@ export default Controller.extend({
       this.send("_updateUserFields");
 
       return model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("profile")
+          )
+        )
         .then(() => {
           cookAsync(model.get("bio_raw"))
             .then(() => {

--- a/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
@@ -4,6 +4,7 @@ import { tracked } from "@glimmer/tracking";
 import I18n from "I18n";
 
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export const DEFAULT_LIST_DESTINATION = "default";
 export const UNREAD_LIST_DESTINATION = "unread_new";
@@ -49,7 +50,11 @@ export default class extends Controller {
     );
 
     this.model
-      .save(this.saveAttrNames)
+      .save(
+        this.saveAttrNames.concat(
+          getSaveAttributeForPreferencesController("sidebar")
+        )
+      )
       .then((result) => {
         if (result.user.sidebar_tags) {
           this.model.set("sidebar_tags", result.user.sidebar_tags);

--- a/app/assets/javascripts/discourse/app/controllers/preferences/tags.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tags.js
@@ -1,6 +1,7 @@
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend({
   init() {
@@ -28,7 +29,11 @@ export default Controller.extend({
     save() {
       this.set("saved", false);
       return this.model
-        .save(this.saveAttrNames)
+        .save(
+          this.saveAttrNames.concat(
+            getSaveAttributeForPreferencesController("tags")
+          )
+        )
         .then(() => {
           this.set("saved", true);
         })

--- a/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
@@ -5,6 +5,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { action, computed } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default class extends Controller {
   @service currentUser;
@@ -166,7 +167,11 @@ export default class extends Controller {
     this.saved = false;
 
     return this.model
-      .save(this.saveAttrNames)
+      .save(
+        this.saveAttrNames.concat(
+          getSaveAttributeForPreferencesController("tracking")
+        )
+      )
       .then(() => {
         this.saved = true;
       })

--- a/app/assets/javascripts/discourse/app/controllers/preferences/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/users.js
@@ -4,6 +4,7 @@ import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { makeArray } from "discourse-common/lib/helpers";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getSaveAttributeForPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export default Controller.extend({
   ignoredUsernames: alias("model.ignored_usernames"),
@@ -78,7 +79,11 @@ export default Controller.extend({
     this.set("saved", false);
 
     return this.model
-      .save(this.saveAttrNames)
+      .save(
+        this.saveAttrNames.concat(
+          getSaveAttributeForPreferencesController("users")
+        )
+      )
       .then(() => this.set("saved", true))
       .catch(popupAjaxError);
   },

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -118,6 +118,7 @@ import { registerModelTransformer } from "discourse/lib/model-transformers";
 import { registerCustomUserNavMessagesDropdownRow } from "discourse/controllers/user-private-messages";
 import { registerFullPageSearchType } from "discourse/controllers/full-page-search";
 import { registerHashtagType } from "discourse/lib/hashtag-autocomplete";
+import { addSaveAttributeToPreferencesController } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 // If you add any methods to the API ensure you bump up the version number
 // based on Semantic Versioning 2.0.0. Please update the changelog at
@@ -2264,6 +2265,38 @@ class PluginApi {
    */
   registerHashtagType(type, typeClassInstance) {
     registerHashtagType(type, typeClassInstance);
+  }
+
+  /**
+   * Indicates that the given attribute can be included in the request payload
+   * when a preferences section (i.e. controller) is saved. Example of
+   * preferences sections are `emails`, `interface` and `profile`.
+   *
+   * For example, if you have a attribute named `subscribe_to_newsletter` that
+   * you want to include in the request payload when a user saves their Emails
+   * preferences (`/my/preferences/emails`), you can use this API to signal to
+   * the `emails` preferences controller that it should treat your attribute as
+   * saveable, like so:
+   *
+   * ```
+   * api.addSaveAttributeToPreferencesController("emails", "subscribe_to_newsletter");
+   * ```
+   *
+   * There's an additional step required to include your attribute in the
+   * request payload which is to call the `addSaveableUserField` or
+   * `addSaveableUserOptionField` APIs to teach the User model where it should
+   * retrieve the value of your attribute from. If your attribute is a direct
+   * property of the user object, then use the `addSaveableUserField` API. But
+   * if it's a property of the user_options object, then you need to use the
+   * `addSaveableUserOptionField` API.
+   *
+   * @param {string} controllerName - The name of the preferences controller
+   *   that should treat the attribute as saveable. E.g., `profile`, `interface`,
+   *   `emails`.
+   * @param {string} attribute - The attribute name.
+   */
+  addSaveAttributeToPreferencesController(controllerName, attribute) {
+    addSaveAttributeToPreferencesController(controllerName, attribute);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/preferences-controllers-save-attrs-register.js
+++ b/app/assets/javascripts/discourse/app/lib/preferences-controllers-save-attrs-register.js
@@ -1,0 +1,18 @@
+let saveAttrsForControllerMap = null;
+
+export function resetPreferencesControllersSaveAttrs() {
+  saveAttrsForControllerMap = null;
+}
+
+export function addSaveAttributeToPreferencesController(
+  controllerName,
+  attribute
+) {
+  saveAttrsForControllerMap ||= {};
+  saveAttrsForControllerMap[controllerName] ||= [];
+  saveAttrsForControllerMap[controllerName].push(attribute);
+}
+
+export function getSaveAttributeForPreferencesController(controllerName) {
+  return (saveAttrsForControllerMap || {})[controllerName] || [];
+}

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -99,9 +99,14 @@ let userFields = [
   "sidebar_tag_names",
   "status",
 ];
+const customUserFields = [];
 
 export function addSaveableUserField(fieldName) {
-  userFields.push(fieldName);
+  customUserFields.push(fieldName);
+}
+
+export function resetSaveableUserField() {
+  customUserFields.clear();
 }
 
 let userOptionFields = [
@@ -139,9 +144,14 @@ let userOptionFields = [
   "bookmark_auto_delete_preference",
   "sidebar_list_destination",
 ];
+const customUserOptionFields = [];
 
 export function addSaveableUserOptionField(fieldName) {
-  userOptionFields.push(fieldName);
+  customUserOptionFields.push(fieldName);
+}
+
+export function resetSaveableUserOptionField() {
+  customUserOptionFields.clear();
 }
 
 function userOption(userOptionKey) {
@@ -439,12 +449,16 @@ const User = RestModel.extend({
 
   save(fields) {
     const data = this.getProperties(
-      userFields.filter((uf) => !fields || fields.includes(uf))
+      userFields
+        .concat(customUserFields)
+        .filter((uf) => !fields || fields.includes(uf))
     );
 
     const filteredUserOptionFields = fields
-      ? userOptionFields.filter((uo) => fields.includes(uo))
-      : userOptionFields;
+      ? userOptionFields
+          .concat(customUserOptionFields)
+          .filter((uo) => fields.includes(uo))
+      : userOptionFields.concat(customUserOptionFields);
 
     filteredUserOptionFields.forEach((s) => {
       data[s] = this.get(`user_option.${s}`);

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -21,7 +21,10 @@ import { getOwner } from "discourse-common/lib/get-owner";
 import { run } from "@ember/runloop";
 import { setupApplicationTest } from "ember-qunit";
 import Site from "discourse/models/site";
-import User from "discourse/models/user";
+import User, {
+  resetSaveableUserField,
+  resetSaveableUserOptionField,
+} from "discourse/models/user";
 import { _clearSnapshots } from "select-kit/components/composer-actions";
 import { clearHTMLCache } from "discourse/helpers/custom-html";
 import deprecated from "discourse-common/lib/deprecated";
@@ -84,6 +87,7 @@ import { reset as resetLinkLookup } from "discourse/lib/link-lookup";
 import { resetMentions } from "discourse/lib/link-mentions";
 import { resetModelTransformers } from "discourse/lib/model-transformers";
 import { cleanupTemporaryModuleRegistrations } from "./temporary-module-helper";
+import { resetPreferencesControllersSaveAttrs } from "discourse/lib/preferences-controllers-save-attrs-register";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -219,6 +223,9 @@ export function testCleanup(container, app) {
   resetMentions();
   cleanupTemporaryModuleRegistrations();
   cleanupCssGeneratorTags();
+  resetPreferencesControllersSaveAttrs();
+  resetSaveableUserField();
+  resetSaveableUserOptionField();
 }
 
 function cleanupCssGeneratorTags() {


### PR DESCRIPTION
This PR introduces a new JS API to add custom attributes to the request payload when a preferences section is saved. For more details, see the description above the API method in the `plugin-api.js` file.

Another somewhat related change that's included in this PR is "reset" methods for the existing `addSaveableUserField` and `addSaveableUserOptionField` APIs. Currently, they can cause state leak if they're called in tests because there's nothing that undoes their effects between tests.

----

New API is used in https://github.com/discourse/discourse-mailinglist-integration/pull/1.