### PR TITLE
DEV: Allow plugins to hook into user preferences update process on the server

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2015,7 +2015,13 @@ class UsersController < ApplicationController
     end
 
     deprecate_modify_user_params_method
-    modify_user_params(result)
+    result = modify_user_params(result)
+    DiscoursePluginRegistry.apply_modifier(
+      :users_controller_update_user_params,
+      result,
+      current_user,
+      params,
+    )
   end
 
   # Plugins can use this to modify user parameters

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -237,6 +237,7 @@ class UserUpdater
           attributes.fetch(:name) { "" },
         )
       end
+      DiscourseEvent.trigger(:user_updater_commit_updates, user, attributes)
     rescue Addressable::URI::InvalidURIError => e
       # Prevent 500 for crazy url input
       return saved

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -237,7 +237,7 @@ class UserUpdater
           attributes.fetch(:name) { "" },
         )
       end
-      DiscourseEvent.trigger(:user_updater_commit_updates, user, attributes)
+      DiscourseEvent.trigger(:within_user_updater_transaction, user, attributes)
     rescue Addressable::URI::InvalidURIError => e
       # Prevent 500 for crazy url input
       return saved

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -46,6 +46,42 @@ RSpec.describe UserUpdater do
       expect(user.reload.name).to eq "Jim Tom"
     end
 
+    describe "the user_updater_commit_updates event" do
+      it "allows plugins to perform additional updates" do
+        update_attributes = { name: "Jimmmy Johnny" }
+        handler =
+          Proc.new do |user, attrs|
+            user.user_profile.update!(bio_raw: "hello world I'm Jimmmy")
+            expect(attrs).to eq(update_attributes)
+          end
+        DiscourseEvent.on(:user_updater_commit_updates, &handler)
+
+        updater = UserUpdater.new(user, user)
+        updater.update(update_attributes)
+
+        expect(user.reload.name).to eq("Jimmmy Johnny")
+        expect(user.user_profile.bio_raw).to eq("hello world I'm Jimmmy")
+      ensure
+        DiscourseEvent.off(:user_updater_commit_updates, &handler)
+      end
+
+      it "can cancel the whole update transaction if a handler raises" do
+        error_class = Class.new(StandardError)
+        handler = Proc.new { raise error_class.new }
+
+        DiscourseEvent.on(:user_updater_commit_updates, &handler)
+
+        old_name = user.name
+        updater = UserUpdater.new(user, user)
+
+        expect { updater.update(name: "Failure McClario") }.to raise_error(error_class)
+
+        expect(user.reload.name).to eq(old_name)
+      ensure
+        DiscourseEvent.off(:user_updater_commit_updates, &handler)
+      end
+    end
+
     it "can update categories and tags" do
       updater = UserUpdater.new(user, user)
       updater.update(watched_tags: "#{tag.name},#{tag2.name}", muted_category_ids: [category.id])


### PR DESCRIPTION
This PR introduces a new `user_updater_commit_updates` event that's triggered inside the transaction that saves user updates in `UserUpdater`. Plugins can hook into the transaction using the event to include custom changes in the transaction. Callbacks for this event receive 2 arguments:

1. the user being saved
2. the changed attributes that are passed to `UserUpdater`.

-----

New API is used in https://github.com/discourse/discourse-mailinglist-integration/pull/1.