### PR TITLE
FIX: Include more_topic_url in the response to /categories_and_{latest}

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -327,11 +327,16 @@ class CategoriesController < ApplicationController
 
     if topics_filter == :latest
       result.topic_list = TopicQuery.new(current_user, topic_options).list_latest
+      result.topic_list.more_topics_url =
+        url_for(
+          public_send("latest_path", sort: topic_options[:order] == "created" ? :created : nil),
+        )
     elsif topics_filter == :top
       result.topic_list =
         TopicQuery.new(current_user, topic_options).list_top_for(
           SiteSetting.top_page_default_timeframe.to_sym,
         )
+      result.topic_list.more_topics_url = url_for(public_send("top_path"))
     end
 
     render_serialized(result, CategoryAndTopicListsSerializer, root: false)


### PR DESCRIPTION
The field more_topic_url is already included in the response preloaded in categories#index

However, this field was missing if a request was subsequently made to update the page using the end-points /categories_and_latest or /categories_and_top. This could lead the client app to display incorrect information if it relied on this information to update the UI.

