### PR TITLE
FIX: correctly nullifies active message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
@@ -2,6 +2,7 @@
   <div
     {{did-insert this.setup}}
     {{did-update this.setup this.chat.activeMessage.model.id}}
+    {{on "mouseleave" this.onMouseleave}}
     {{will-destroy this.teardown}}
     class={{concat-class
       "chat-message-actions-container"

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -45,6 +45,21 @@ export default class ChatMessageActionsDesktop extends Component {
   }
 
   @action
+  onMouseleave(event) {
+    // if the mouse is leaving the actions menu for the actual menu, don't close it
+    // this will avoid the menu rerendering
+    if (
+      (event.toElement || event.relatedTarget)?.closest(
+        ".chat-message-container"
+      )
+    ) {
+      return;
+    }
+
+    this.chat.activeMessage = null;
+  }
+
+  @action
   setup(element) {
     this.popper?.destroy();
 


### PR DESCRIPTION
Very fast or specific mouse moves could allow to leave a message actions menu without reseting the active message. This commit should ensure we correctly catch this event.

No test as it's hard and not reliable to reproduce these in a test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
