### PR TITLE
DEV: Deprecate `modify_user_params` method in `UsersController`

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2014,12 +2014,25 @@ class UsersController < ApplicationController
       result.merge!(params.permit(:active, :staged, :approved))
     end
 
+    deprecate_modify_user_params_method
     modify_user_params(result)
   end
 
   # Plugins can use this to modify user parameters
   def modify_user_params(attrs)
     attrs
+  end
+
+  def deprecate_modify_user_params_method
+    # only issue a deprecation warning if the method is overriden somewhere
+    if method(:modify_user_params).source_location[0] !=
+         "#{Rails.root}/app/controllers/users_controller.rb"
+      Discourse.deprecate(
+        "`UsersController#modify_user_params` method is deprecated. Please use the `users_controller_update_user_params` modifier instead.",
+        since: "3.1.0.beta4",
+        drop_from: "3.2.0",
+      )
+    end
   end
 
   def fail_with(key)


### PR DESCRIPTION
This PR deprecates the `modify_user_params` method in `UsersController` and adds a new modifier to replace that method whose entire purpose is to allow plugins to monkey-patch it to permit custom params in the controller. We now have the "modifier" system which can achieve the same results but in a safer and easier way, see https://github.com/discourse/discourse/pull/21737.