### PR TITLE
FIX: prevents saving draft in incorrect channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -146,8 +146,11 @@ export default class ChatComposer extends Component {
 
   @action
   didUpdateChannel() {
+    this.cancelPersistDraft();
+
     if (!this.args.channel) {
       this.composer.message = null;
+      return;
     }
 
     this.composer.message =

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
@@ -29,16 +29,15 @@ export default class ChatComposerChannel extends ChatComposer {
     this._persistHandler = discourseDebounce(
       this,
       this._debouncedPersistDraft,
+      this.args.channel.id,
+      this.currentMessage.toJSONDraft(),
       2000
     );
   }
 
   @action
-  _debouncedPersistDraft() {
-    this.chatApi.saveDraft(
-      this.args.channel.id,
-      this.currentMessage.toJSONDraft()
-    );
+  _debouncedPersistDraft(channelId, jsonDraft) {
+    this.chatApi.saveDraft(channelId, jsonDraft);
   }
 
   get placeholder() {


### PR DESCRIPTION
This commit regroups 3 changes
- serializes channel ID and json draft when calling the debouncer instead of inside the debounced function, it seems very unlikely to happen, but in a case where the debouncing wouldn't be canceled and the new message not set yet, we could save the draft on an invalid channel
- cancel persist draft handler when changing channel
- ensures we exit early when channel is not set

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
