### PR TITLE
FEATURE:  Allow watched words to be created and managed as  group

### DIFF
--- a/app/assets/javascripts/admin/addon/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/components/watched-word-form.hbs
@@ -1,14 +1,13 @@
 <div class="watched-word-input">
   <label for="watched-word">{{i18n "admin.watched_words.form.label"}}</label>
-  <TextField
-    @id="watched-word"
-    @value={{this.word}}
-    @disabled={{this.formSubmitted}}
-    @class="watched-word-input-field"
-    @autocorrect="off"
-    @autocapitalize="off"
-    @placeholderKey={{this.placeholderKey}}
-    @title={{i18n this.placeholderKey}}
+  <WatchedWords
+    @id="watched-words"
+    @value={{this.words}}
+    @onChange={{action (mut this.words)}}
+    @options={{hash
+      filterPlaceholder=this.placeholderKey
+      disabled=this.formSubmitted
+    }}
   />
 </div>
 

--- a/app/assets/javascripts/admin/addon/models/watched-word.js
+++ b/app/assets/javascripts/admin/addon/models/watched-word.js
@@ -34,7 +34,7 @@ export default class WatchedWord extends EmberObject {
       {
         type: this.id ? "PUT" : "POST",
         data: {
-          word: this.word,
+          words: this.words,
           replacement: this.replacement,
           action_key: this.action,
           case_sensitive: this.isCaseSensitive,

--- a/app/assets/javascripts/select-kit/addon/components/watched-words.js
+++ b/app/assets/javascripts/select-kit/addon/components/watched-words.js
@@ -1,0 +1,20 @@
+import MultiSelectComponent from "select-kit/components/multi-select";
+import { makeArray } from "discourse-common/lib/helpers";
+import { computed } from "@ember/object";
+
+export default MultiSelectComponent.extend({
+  pluginApiIdentifiers: ["watched-words"],
+  classNames: ["watched-word-input-field"],
+
+  selectKitOptions: {
+    autoInsertNoneItem: false,
+    fullWidthOnMobile: true,
+    allowAny: true,
+    none: "admin.watched_words.form.words_or_phrases",
+  },
+
+  @computed("value.[]")
+  get content() {
+    return makeArray(this.value).map((x) => this.defaultItem(x, x));
+  },
+});

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -344,6 +344,7 @@ table.screened-ip-addresses {
   }
   .select-kit.multi-select.watched-word-input-field {
     width: 300px;
+    margin-bottom: 9px;
   }
 
   + .btn-primary {

--- a/app/controllers/admin/watched_word_groups_controller.rb
+++ b/app/controllers/admin/watched_word_groups_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class Admin::WatchedWordGroupsController < Admin::StaffController
+  before_action :find_watched_word_group, only: %i[update destroy]
+
+  def create
+    group = WatchedWordGroup.create_membership(watched_word_group_params)
+
+    # TODO: use valid?
+    if group.errors.empty?
+      StaffActionLogger.new(current_user).log_create_watched_word_group(group)
+
+      render json: { id: group.id, words: group.watched_words }, root: false
+    else
+      render_json_error(group)
+    end
+  end
+
+  def update
+    group = @watched_word_group.update_membership(watched_word_group_params.except(:id))
+    current_words = @watched_word_group.watched_words
+
+    # TODO: use valid?
+    if group.errors.empty?
+      StaffActionLogger.new(current_user).log_update_watched_word_group(
+        group.reload,
+        old_members: current_words,
+      )
+
+      render json: { id: group.id, words: group.watched_words }, root: false
+    else
+      render_json_error(group)
+    end
+  end
+
+  def destroy
+    current_words = @watched_word_group.watched_words
+    @watched_word_group.destroy!
+
+    StaffActionLogger.new(current_user).log_delete_watched_word_group(
+      @watched_word_group,
+      deleted_members: current_words,
+    )
+
+    render json: success_json
+  end
+
+  private
+
+  def find_watched_word_group
+    @watched_word_group = WatchedWordGroup.includes(:watched_words).find_by(id: params[:id])
+
+    raise Discourse::NotFound unless @watched_word_group
+  end
+
+  def watched_word_group_params
+    params[:action_key] = params[:action_key].to_sym
+    params.permit(:id, :replacement, :action_key, :case_sensitive, words: [])
+  end
+end

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -124,6 +124,9 @@ class UserHistory < ActiveRecord::Base
         update_public_sidebar_section: 102,
         destroy_public_sidebar_section: 103,
         reset_bounce_score: 104,
+        create_watched_word_group: 105,
+        update_watched_word_group: 106,
+        delete_watched_word_group: 107,
       )
   end
 
@@ -223,6 +226,9 @@ class UserHistory < ActiveRecord::Base
       update_public_sidebar_section
       destroy_public_sidebar_section
       reset_bounce_score
+      create_watched_word_group
+      update_watched_word_group
+      delete_watched_word_group
     ]
   end
 

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -74,6 +74,7 @@ class WatchedWord < ActiveRecord::Base
     w.action_key = params[:action_key] if params[:action_key]
     w.action = params[:action] if params[:action]
     w.case_sensitive = params[:case_sensitive] if !params[:case_sensitive].nil?
+    w.watched_word_group_id = params[:watched_word_group_id]
     w.save
     w
   end

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -37,6 +37,8 @@ class WatchedWord < ActiveRecord::Base
     end
   end
 
+  belongs_to :watched_word_group
+
   after_save :clear_cache
   after_destroy :clear_cache
 
@@ -101,15 +103,17 @@ end
 #
 # Table name: watched_words
 #
-#  id             :integer          not null, primary key
-#  word           :string           not null
-#  action         :integer          not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  replacement    :string
-#  case_sensitive :boolean          default(FALSE), not null
+#  id                    :integer          not null, primary key
+#  word                  :string           not null
+#  action                :integer          not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  replacement           :string
+#  case_sensitive        :boolean          default(FALSE), not null
+#  watched_word_group_id :bigint
 #
 # Indexes
 #
-#  index_watched_words_on_action_and_word  (action,word) UNIQUE
+#  index_watched_words_on_action_and_word        (action,word) UNIQUE
+#  index_watched_words_on_watched_word_group_id  (watched_word_group_id)
 #

--- a/app/models/watched_word_group.rb
+++ b/app/models/watched_word_group.rb
@@ -4,6 +4,49 @@ class WatchedWordGroup < ActiveRecord::Base
   validates :action, presence: true
 
   has_many :watched_words, dependent: :destroy
+
+  def self.create_membership(params)
+    words = params.delete(:words)
+    action = params[:action] || WatchedWord.actions[params[:action_key]]
+    group = self.new(action: action)
+
+    group.create_or_update_members(words, params) { group.save! }
+
+    group
+  end
+
+  def update_membership(params)
+    words = params.delete(:words)
+    action = params[:action] || WatchedWord.actions[params[:action_key]] || self.action
+    removed_members = self.watched_words.where.not(word: words)
+
+    self.create_or_update_members(words, params) do
+      self.update!(action: action) if self.action != action
+      removed_members.destroy_all
+    end
+
+    self
+  end
+
+  def create_or_update_members(words, params)
+    WatchedWordGroup.transaction do
+      yield if block_given?
+
+      words.each do |word|
+        watched_word =
+          WatchedWord.create_or_update_word(
+            params.merge(word: word, watched_word_group_id: self.id),
+          )
+
+        unless watched_word.valid?
+          # TODO: Properly bubble up error
+          self.errors.merge!(watched_word.errors)
+
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/watched_word_group.rb
+++ b/app/models/watched_word_group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class WatchedWordGroup < ActiveRecord::Base
+  validates :action, presence: true
+
+  has_many :watched_words, dependent: :destroy
+end
+
+# == Schema Information
+#
+# Table name: watched_word_groups
+#
+#  id         :bigint           not null, primary key
+#  action     :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WatchedWordSerializer < ApplicationSerializer
-  attributes :id, :word, :regexp, :replacement, :action, :case_sensitive
+  attributes :id, :word, :regexp, :replacement, :action, :case_sensitive, :watched_word_group_id
 
   def regexp
     WordWatcher.word_to_regexp(word)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -940,6 +940,55 @@ class StaffActionLogger
     )
   end
 
+  def log_create_watched_word_group(watched_word_group)
+    raise Discourse::InvalidParameters.new(:watched_word_group) unless watched_word_group
+
+    member_log_details = watched_word_group.watched_words.map(&:action_log_details)
+
+    UserHistory.create!(
+      action: UserHistory.actions[:create_watched_word_group],
+      acting_user_id: @admin.id,
+      details: "id: #{watched_word_group.id}\n#{member_log_details.join("\n")}",
+      context: WatchedWord.actions[watched_word_group.action],
+    )
+  end
+
+  def log_update_watched_word_group(watched_word_group, opts = {})
+    raise Discourse::InvalidParameters.new(:watched_word_group) unless watched_word_group
+
+    member_log_details = watched_word_group.watched_words.map(&:action_log_details)
+    old_member_log_details = opts[:old_members].map(&:action_log_details) if opts[:old_members]
+
+    details = [
+      "id: #{watched_word_group.id}",
+      "#{old_member_log_details.join("\n")}",
+      "\n-----\n",
+      "#{member_log_details.join("\n")}",
+    ]
+
+    UserHistory.create!(
+      action: UserHistory.actions[:update_watched_word_group],
+      acting_user_id: @admin.id,
+      details: details.join("\n"),
+      context: WatchedWord.actions[watched_word_group.action],
+    )
+  end
+
+  def log_delete_watched_word_group(watched_word_group, opts = {})
+    raise Discourse::InvalidParameters.new(:watched_word_group) unless watched_word_group
+
+    deleted_member_log_details = opts[:deleted_members].map(&:action_log_details) if opts[
+      :deleted_members
+    ]
+
+    UserHistory.create!(
+      action: UserHistory.actions[:delete_watched_word_group],
+      acting_user_id: @admin.id,
+      details: "id: #{watched_word_group.id}\n#{deleted_member_log_details.join("\n")}",
+      context: WatchedWord.actions[watched_word_group.action],
+    )
+  end
+
   def log_group_deletetion(group)
     raise Discourse::InvalidParameters.new(:group) if group.nil?
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5569,9 +5569,9 @@ en:
           silence: "Silence new accounts if their very first post contains any of these words. The post will be automatically hidden until staff approves it."
           link: "Replace words in posts with links."
         form:
-          label: "Has word or phrase"
-          placeholder: "Enter word or phrase (* is a wildcard)"
-          placeholder_regexp: "regular expression"
+          label: "Has words or phrases"
+          placeholder: "words or phrases (* is a wildcard)"
+          placeholder_regexp: "regular expressions"
           replace_label: "Replacement"
           replace_placeholder: "example"
           tag_label: "Tag"
@@ -5584,6 +5584,7 @@ en:
           upload_successful: "Upload successful. Words have been added."
           case_sensitivity_label: "Is case-sensitive"
           case_sensitivity_description: "Only words with matching character casing"
+          words_or_phrases: "words or phrases"
         test:
           button_label: "Test"
           modal_title: "%{action}: Test Watched Words"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,8 @@ Discourse::Application.routes.draw do
           end
         end
         post "watched_words/upload" => "watched_words#upload"
+
+        resources :watched_word_groups, only: %i[create update destroy]
       end
 
       get "version_check" => "versions#show"

--- a/db/migrate/20230515103515_create_watched_word_groups.rb
+++ b/db/migrate/20230515103515_create_watched_word_groups.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateWatchedWordGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :watched_word_groups do |t|
+      t.integer :action, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230515131111_add_watched_word_group_id_to_watched_words.rb
+++ b/db/migrate/20230515131111_add_watched_word_group_id_to_watched_words.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddWatchedWordGroupIdToWatchedWords < ActiveRecord::Migration[7.0]
+  def change
+    add_column :watched_words, :watched_word_group_id, :bigint
+    add_index :watched_words, :watched_word_group_id
+  end
+end

--- a/spec/fabricators/watched_word_group_fabricator.rb
+++ b/spec/fabricators/watched_word_group_fabricator.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Fabricator(:watched_word_group) { action WatchedWord.actions[:block] }

--- a/spec/models/watched_word_group_spec.rb
+++ b/spec/models/watched_word_group_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe WatchedWordGroup do
+  fab!(:watched_word_group) { Fabricate(:watched_word_group) }
+
+  pending "add test cases"
+end

--- a/spec/models/watched_word_group_spec.rb
+++ b/spec/models/watched_word_group_spec.rb
@@ -2,6 +2,131 @@
 
 RSpec.describe WatchedWordGroup do
   fab!(:watched_word_group) { Fabricate(:watched_word_group) }
+  fab!(:watched_word_1) { Fabricate(:watched_word, watched_word_group_id: watched_word_group.id) }
+  fab!(:watched_word_2) { Fabricate(:watched_word, watched_word_group_id: watched_word_group.id) }
 
-  pending "add test cases"
+  describe "#update_membership" do
+    it "adds new words to group" do
+      words = [watched_word_1.word, watched_word_2.word, "Sssh", "hack3r"]
+      old_action = watched_word_group.action
+      watched_words_before_update = watched_word_group.watched_words
+
+      expect(watched_words_before_update.size).to eq(2)
+      expect(watched_words_before_update.map(&:word)).to contain_exactly(
+        watched_word_1.word,
+        watched_word_2.word,
+      )
+      expect(watched_words_before_update.map(&:action).uniq).to contain_exactly(old_action)
+
+      group =
+        watched_word_group.update_membership(
+          words: words,
+          action_key: WatchedWord.actions[watched_word_group.action],
+        )
+
+      expect(group.errors).to be_empty
+
+      watched_words = watched_word_group.reload.watched_words
+
+      expect(watched_word_group.action).to eq(old_action)
+      expect(watched_words.size).to eq(4)
+      expect(watched_words.map(&:word)).to contain_exactly(*words)
+      expect(watched_words.map(&:action).uniq).to contain_exactly(old_action)
+    end
+
+    it "removes deleted words from group" do
+      words = [watched_word_1.word]
+      old_action = watched_word_group.action
+      watched_words_before_update = watched_word_group.watched_words
+
+      expect(watched_words_before_update.size).to eq(2)
+      expect(watched_words_before_update.map(&:word)).to contain_exactly(
+        watched_word_1.word,
+        watched_word_2.word,
+      )
+      expect(watched_words_before_update.map(&:action).uniq).to contain_exactly(old_action)
+
+      group =
+        watched_word_group.update_membership(
+          words: words,
+          action_key: WatchedWord.actions[watched_word_group.action],
+        )
+
+      expect(group.errors).to be_empty
+
+      watched_words = watched_word_group.reload.watched_words
+
+      expect(watched_words.size).to eq(1)
+      expect(watched_words.map(&:word)).to contain_exactly(*words)
+      expect(watched_words.map(&:action).uniq).to contain_exactly(old_action)
+    end
+
+    it "updates watched word action" do
+      words = [watched_word_1.word, watched_word_2.word, "damn", "4sale"]
+      old_action = watched_word_group.action
+      watched_words_before_update = watched_word_group.watched_words
+
+      expect(old_action).to eq(WatchedWord.actions[:block])
+      expect(watched_words_before_update.map(&:action).uniq).to contain_exactly(old_action)
+
+      group = watched_word_group.update_membership(words: words, action_key: :censor)
+
+      expect(group.errors).to be_empty
+
+      watched_words = watched_word_group.reload.watched_words
+
+      expect(watched_words.size).to eq(4)
+      expect(watched_words.map(&:word)).to contain_exactly(*words)
+      expect(watched_words.map(&:action).uniq).to contain_exactly(WatchedWord.actions[:censor])
+      expect(watched_word_group.action).to eq(WatchedWord.actions[:censor])
+    end
+
+    it "leaves membership intact if update fails" do
+      words = [watched_word_1.word, watched_word_2.word, "a" * 120]
+      old_action = watched_word_group.action
+      watched_words_before_update = watched_word_group.watched_words
+
+      expect(watched_words_before_update.size).to eq(2)
+      expect(watched_words_before_update.map(&:word)).to contain_exactly(
+        watched_word_1.word,
+        watched_word_2.word,
+      )
+      expect(watched_words_before_update.map(&:action).uniq).to contain_exactly(old_action)
+
+      group =
+        watched_word_group.update_membership(
+          words: words,
+          action_key: WatchedWord.actions[watched_word_group.action],
+        )
+
+      expect(group.errors).not_to be_empty
+
+      watched_words = watched_word_group.reload.watched_words
+
+      expect(watched_word_group.action).to eq(old_action)
+      expect(watched_words.size).to eq(2)
+      expect(watched_words.map(&:word)).to contain_exactly(watched_word_1.word, watched_word_2.word)
+      expect(watched_words.map(&:action).uniq).to contain_exactly(old_action)
+    end
+  end
+
+  describe ".create_membership" do
+    it "creates and groups words" do
+      expect do
+        words = %w[damn darn]
+        group = described_class.create_membership(words: words, action_key: :block)
+        expect(group.watched_words.map(&:word)).to contain_exactly(*words)
+      end.to change { described_class.count }.by(1)
+    end
+
+    it "does not create group with invalid words" do
+      expect do
+        words = ["damn", "d" * 120]
+        group = described_class.create_membership(words: words, action_key: :block)
+
+        expect(group.new_record?).to eq(true)
+        expect(WatchedWord.where(word: words)).to be_empty
+      end.not_to change { described_class.count }
+    end
+  end
 end

--- a/spec/requests/admin/watched_word_groups_controller_spec.rb
+++ b/spec/requests/admin/watched_word_groups_controller_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::WatchedWordGroupsController do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:watched_word_group) { Fabricate(:watched_word_group) }
+  fab!(:watched_word_1) { Fabricate(:watched_word, watched_word_group_id: watched_word_group.id) }
+  fab!(:watched_word_2) { Fabricate(:watched_word, watched_word_group_id: watched_word_group.id) }
+
+  describe "#create" do
+    let(:valid_word_list) { %w[Fr33 Deals] }
+    let(:invalid_word_list) { valid_word_list + ["bad" * 120] }
+
+    context "when logged in as a non-staff user" do
+      before { sign_in(user) }
+
+      it "does not create a watched word group" do
+        expect do
+          post "/admin/customize/watched_word_groups.json",
+               params: {
+                 action_key: "flag",
+                 words: valid_word_list,
+               }
+
+          expect(response.status).to eq(404)
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+
+    context "when logged in as a staff user" do
+      before { sign_in(admin) }
+
+      it "creates and groups watched words" do
+        expect do
+          post "/admin/customize/watched_word_groups.json",
+               params: {
+                 action_key: "flag",
+                 words: valid_word_list,
+               }
+
+          expect(response.status).to eq(200)
+
+          response_body = response.parsed_body
+          group = WatchedWordGroup.find(response_body["id"])
+
+          expect(response_body["words"].count).to eq(2)
+          expect(group.watched_words.pluck(:word)).to contain_exactly(*valid_word_list)
+          expect(response_body["words"]).to match(
+            [
+              hash_including(
+                "word" => valid_word_list[0],
+                "watched_word_group_id" => group.id,
+                "case_sensitive" => false,
+                "replacement" => nil,
+                "action" => WatchedWord.actions[:flag],
+              ),
+              hash_including(
+                "word" => valid_word_list[1],
+                "watched_word_group_id" => group.id,
+                "case_sensitive" => false,
+                "replacement" => nil,
+                "action" => WatchedWord.actions[:flag],
+              ),
+            ],
+          )
+
+          expect(
+            UserHistory.where(action: UserHistory.actions[:create_watched_word_group]).count,
+          ).to eq(1)
+        end.to change { WatchedWordGroup.count }.by(1)
+      end
+
+      it "creates and groups case-sensitive watched words" do
+        expect do
+          post "/admin/customize/watched_word_groups.json",
+               params: {
+                 action_key: "flag",
+                 words: valid_word_list,
+                 case_sensitive: true,
+               }
+
+          response_body = response.parsed_body
+          group = WatchedWordGroup.find(response_body["id"])
+
+          expect(response.status).to eq(200)
+          expect(response_body["words"].count).to eq(2)
+          expect(group.watched_words.pluck(:case_sensitive)).to contain_exactly(true, true)
+        end.to change { WatchedWordGroup.count }.by(1)
+      end
+
+      it "neither creates nor groups watched words with an invalid word" do
+        expect do
+          expect(WatchedWord.count).to eq(2)
+
+          post "/admin/customize/watched_word_groups.json",
+               params: {
+                 action_key: "flag",
+                 words: invalid_word_list,
+               }
+
+          expect(WatchedWord.count).to eq(2)
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to be_present
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when logged in as a non-staff user" do
+      before { sign_in(user) }
+
+      it "does not update watched word group membership" do
+        expect do
+          put "/admin/customize/watched_word_groups/#{watched_word_group.id}.json",
+              params: {
+                action_key: "flag",
+                words: [watched_word_1.word, "Fr33"],
+              }
+
+          expect(response.status).to eq(404)
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+
+    context "when logged in as a staff user" do
+      before { sign_in(admin) }
+
+      it "updates watched word group membership" do
+        expect do
+          expect(watched_word_group.watched_words.map(&:word)).to contain_exactly(
+            watched_word_1.word,
+            watched_word_2.word,
+          )
+
+          put "/admin/customize/watched_word_groups/#{watched_word_group.id}.json",
+              params: {
+                action_key: WatchedWord.actions[watched_word_group.action],
+                words: [watched_word_1.word, "Fr33"],
+              }
+
+          expect(response.status).to eq(200)
+          expect(
+            WatchedWord.where(watched_word_group_id: watched_word_group.id).map(&:word),
+          ).to contain_exactly(watched_word_1.word, "Fr33")
+          expect(response.parsed_body["words"]).to match(
+            [
+              hash_including(
+                "word" => watched_word_1.word,
+                "watched_word_group_id" => watched_word_group.id,
+                "case_sensitive" => false,
+                "replacement" => nil,
+                "action" => watched_word_group.action,
+              ),
+              hash_including(
+                "word" => "Fr33",
+                "watched_word_group_id" => watched_word_group.id,
+                "case_sensitive" => false,
+                "replacement" => nil,
+                "action" => watched_word_group.action,
+              ),
+            ],
+          )
+          expect(
+            UserHistory.where(action: UserHistory.actions[:update_watched_word_group]).count,
+          ).to eq(1)
+        end.not_to change { WatchedWordGroup.count }
+      end
+
+      it "does not update membership with an invalid word" do
+        expect do
+          expect(watched_word_group.watched_words.pluck(:word)).to contain_exactly(
+            watched_word_1.word,
+            watched_word_2.word,
+          )
+
+          put "/admin/customize/watched_word_groups/#{watched_word_group.id}.json",
+              params: {
+                action_key: WatchedWord.actions[watched_word_group.action],
+                words: [watched_word_1.word, "Fr33" * 120],
+              }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to be_present
+          expect(
+            WatchedWord.where(watched_word_group_id: watched_word_group.id).pluck(:word),
+          ).to contain_exactly(watched_word_1.word, watched_word_2.word)
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "when logged in as a non-staff user" do
+      before { sign_in(user) }
+
+      it "does not delete watched word group membership" do
+        expect do
+          delete "/admin/customize/watched_word_groups/#{watched_word_group.id}.json"
+
+          expect(response.status).to eq(404)
+          expect(
+            WatchedWord.where(watched_word_group: watched_word_group.id).pluck(:word),
+          ).to contain_exactly(watched_word_1.word, watched_word_2.word)
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+
+    context "when logged in as a staff user" do
+      before { sign_in(admin) }
+
+      it "deletes group and members" do
+        expect do
+          delete "/admin/customize/watched_word_groups/#{watched_word_group.id}.json"
+
+          expect(response.status).to eq(200)
+          expect(
+            UserHistory.where(action: UserHistory.actions[:delete_watched_word_group]).count,
+          ).to eq(1)
+        end.to change { WatchedWordGroup.count }.by(-1).and change { WatchedWord.count }.by(-2)
+      end
+
+      it "does nothing with an invalid id" do
+        expect do
+          delete "/admin/customize/watched_word_groups/-100.json"
+
+          expect(response.status).to eq(404)
+        end.not_to change { WatchedWordGroup.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
At the moment, there is no way to create and manage a group of related watched words together.  If a user needed a set of words to be created and managed together, they'll have to create/delete/recreate them individually one at a time.

This change attempts to allow related watched words to be created, updated and deleted as a group. The idea here is to have a list of words be tied together via a common `WatchedWordGroup` record.  Given a list of words, a `WatchedWordGroup` record is created and assigned to each `WatchedWord` record. The existing WatchedWord
creation/update behaviour remains largely unchanged.

### Before
<img width="646" alt="Screenshot 2023-05-25 at 8 12 00 AM" src="https://github.com/discourse/discourse/assets/849886/3a29cd39-2b89-4bb4-ba95-f0906d7c66b7">

### After 

<img width="664" alt="Screenshot 2023-05-25 at 8 09 49 AM" src="https://github.com/discourse/discourse/assets/849886/8a2ff568-eaf8-4c1b-8d19-1df7ed25ac7b">
