### PR TITLE
DEV: Replace `HideModalTrigger` with JS logic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/hide-modal-trigger.js
+++ b/app/assets/javascripts/discourse/app/components/hide-modal-trigger.js
@@ -1,7 +1,0 @@
-import Component from "@ember/component";
-export default Component.extend({
-  didInsertElement() {
-    this._super(...arguments);
-    $(".d-modal.fixed-modal").modal("hide");
-  },
-});

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -168,6 +168,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       }
 
       this.render("hide-modal", { into: "modal", outlet: "modalBody" });
+      $(".d-modal.fixed-modal").modal("hide");
 
       if (controllerName) {
         const controller = getOwner(this).lookup(

--- a/app/assets/javascripts/discourse/app/templates/hide-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/hide-modal.hbs
@@ -1,1 +1,0 @@
-<HideModalTrigger />


### PR DESCRIPTION
No need to set up a whole component here - we can just call the necessary JS directly from the `closeModal` function. For now, the empty `hide-modal` template is still required in order to clean up the named outlet when a modal is closed.

(extracted from https://github.com/discourse/discourse/pull/21304)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
