### PR TITLE
DEV: Make `attachWidgetAction` fail gracefully when widget is missing

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -573,7 +573,17 @@ class PluginApi {
   attachWidgetAction(widget, actionName, fn) {
     const widgetClass =
       queryRegistry(widget) ||
-      this.container.factoryFor(`widget:${widget}`).class;
+      this.container.factoryFor(`widget:${widget}`)?.class;
+
+    if (!widgetClass) {
+      // eslint-disable-next-line no-console
+      console.error(
+        consolePrefix(),
+        `attachWidgetAction: Could not find widget ${widget} in registry`
+      );
+      return;
+    }
+
     widgetClass.prototype[actionName] = fn;
   }
 

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -23,6 +23,7 @@ import { deepMerge } from "discourse-common/lib/object";
 import { get } from "@ember/object";
 import { h } from "virtual-dom";
 import { isProduction } from "discourse-common/config/environment";
+import { consolePrefix } from "discourse/lib/source-identifier";
 
 const _registry = {};
 
@@ -106,7 +107,10 @@ export function reopenWidget(name, opts) {
   let existing = _registry[name];
   if (!existing) {
     // eslint-disable-next-line no-console
-    console.error(`Could not find widget ${name} in registry`);
+    console.error(
+      consolePrefix(),
+      `reopenWidget: Could not find widget ${name} in registry`
+    );
     return;
   }
 


### PR DESCRIPTION
This brings the behaviour in line with our other widget-related APIs like `decorateWidget` and `reopenWidget`. This commit also adds a theme/plugin prefix to the console messages.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
