### PR TITLE
UX: minor active state fix for sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -26,7 +26,7 @@
       background: var(--d-sidebar-highlight-color);
 
       .sidebar-section-link-prefix {
-        &.icon svg {
+        &.icon {
           color: var(--primary-medium);
         }
       }


### PR DESCRIPTION
Prior to this change the active state for a chat channel will change the icon color. Follow-up to 442b553

Before
![Screenshot 2023-05-25 at 3 47 58 PM](https://github.com/discourse/discourse/assets/1681963/326c0e94-9985-4b1b-9067-f3c4ffabf32f)


After
![Screenshot 2023-05-25 at 3 47 53 PM](https://github.com/discourse/discourse/assets/1681963/ebb487a4-577a-4d83-be8e-55fe88896647)
