### PR TITLE
UX: long unstyled category names need truncation

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -142,6 +142,9 @@
   &.none {
     color: var(--primary-high);
     margin-right: 5px;
+    .badge-category {
+      overflow: hidden;
+    }
   }
 }
 


### PR DESCRIPTION
This is specifically for the `category_style: none` site setting, other styles truncate fine

Before:
![Screenshot 2023-05-25 at 4 21 11 PM](https://github.com/discourse/discourse/assets/1681963/5a851b7a-ce7d-41a5-848f-2dd32198288f)


After:
![Screenshot 2023-05-25 at 4 19 49 PM](https://github.com/discourse/discourse/assets/1681963/938c2b7e-78b0-407d-89dc-b5b3beba6798)
