### PR TITLE
UX: Drop display of `short_site_description` site settings in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -5,7 +5,6 @@
   @headerActions={{this.section.headerActions}}
   @headerActionsIcon={{this.section.headerActionIcon}}
   @class={{this.section.dragCss}}
-  @sectionDescription={{this.section.description}}
 >
   {{#each this.section.links as |link|}}
     {{#if link.shouldDisplay}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
@@ -44,12 +44,6 @@
       {{/if}}
     </div>
 
-    {{#if @sectionDescription}}
-      <Sidebar::SectionMessage>
-        {{@sectionDescription}}
-      </Sidebar::SectionMessage>
-    {{/if}}
-
     {{#if this.displaySectionContent}}
       <ul class="sidebar-section-content" id={{this.sidebarSectionContentID}}>
         {{yield}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
@@ -131,14 +131,6 @@ export default class CommunitySection {
     });
   }
 
-  get description() {
-    if (!this.currentUser && !!this.siteSettings.short_site_description) {
-      return this.siteSettings.short_site_description;
-    } else {
-      return "";
-    }
-  }
-
   get decoratedTitle() {
     return I18n.t(
       `sidebar.sections.${this.section.title.toLowerCase()}.header_link_text`

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -5,7 +5,6 @@ import { test } from "qunit";
 import {
   acceptance,
   exists,
-  query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
@@ -15,22 +14,8 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
     navigation_menu: "sidebar",
     faq_url: "https://discourse.org",
   });
+
   needs.site({});
-
-  test("display short site description site setting when it is set", async function (assert) {
-    this.siteSettings.short_site_description =
-      "This is a short description about the site";
-
-    await visit("/");
-
-    assert.strictEqual(
-      query(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-message"
-      ).textContent.trim(),
-      this.siteSettings.short_site_description,
-      "displays the short site description under the community section"
-    );
-  });
 
   test("everything section link is shown by default ", async function (assert) {
     await visit("/");


### PR DESCRIPTION
Why are we making this change?

Currently, we are displaying the value of the `short_site_description`
site setting in the sidebar only for anonymous user. However, the
display of the description seems out of place in both the `sidebar` and
`header dropdown` navigation menu and do not think the sidebar is the
right place to display it anymore.