### PR TITLE
UI: minor spacing adjustment in message details

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -191,7 +191,7 @@
 }
 
 .chat-composer-message-details {
-  padding: 0 0.75rem 0.5rem;
+  margin: 0 1rem 0.5rem 1rem;
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
Before:

<img width="580" alt="Screenshot 2023-05-26 at 08 44 58" src="https://github.com/discourse/discourse/assets/339945/78d45a08-0201-4ea8-b5f4-7727d0ba7376">

After:

<img width="572" alt="Screenshot 2023-05-26 at 08 45 13" src="https://github.com/discourse/discourse/assets/339945/2a3193c0-f995-4efd-bef1-42f88ad30276">


