### PR TITLE
FIX: Chat deleted last read message and tracking state issues

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -68,15 +68,24 @@ class Chat::Api::ChannelsController < Chat::ApiController
   end
 
   def show
-    if params[:target_message_id].present? || params[:include_messages].present?
+    if params[:target_message_id].present? || params[:include_messages].present? ||
+         params[:fetch_from_last_read].present?
       with_service(
         Chat::ChannelViewBuilder,
-        **params.permit(:channel_id, :target_message_id, :thread_id, :page_size, :direction).slice(
+        **params.permit(
           :channel_id,
           :target_message_id,
           :thread_id,
           :page_size,
           :direction,
+          :fetch_from_last_read,
+        ).slice(
+          :channel_id,
+          :target_message_id,
+          :thread_id,
+          :page_size,
+          :direction,
+          :fetch_from_last_read,
         ),
       ) do
         on_success { render_serialized(result.view, Chat::ViewSerializer, root: false) }

--- a/plugins/chat/app/models/chat/tracking_state_report.rb
+++ b/plugins/chat/app/models/chat/tracking_state_report.rb
@@ -11,8 +11,8 @@ module Chat
       attr_accessor :unread_count, :mention_count
 
       def initialize(info)
-        @unread_count = info[:unread_count]
-        @mention_count = info[:mention_count]
+        @unread_count = info.present? ? info[:unread_count] : 0
+        @mention_count = info.present? ? info[:mention_count] : 0
       end
 
       def to_hash

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -300,6 +300,7 @@ module Chat
           guardian: user.guardian,
           thread_ids: [message.thread_id],
           include_threads: true,
+          include_missing_memberships: true,
         ).find_thread(message.thread_id)
       end
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -166,10 +166,13 @@ export default class ChatLivePane extends Component {
 
     const findArgs = { pageSize: PAGE_SIZE, includeMessages: true };
     const fetchingFromLastRead = !options.fetchFromLastMessage;
+    let scrollToMessageId = null;
     if (this.requestedTargetMessageId) {
       findArgs.targetMessageId = this.requestedTargetMessageId;
+      scrollToMessageId = this.requestedTargetMessageId;
     } else if (fetchingFromLastRead) {
-      findArgs.targetMessageId =
+      findArgs.fetchFromLastRead = true;
+      scrollToMessageId =
         this.args.channel.currentUserMembership.lastReadMessageId;
     }
 
@@ -199,7 +202,7 @@ export default class ChatLivePane extends Component {
         }
 
         if (this.requestedTargetMessageId) {
-          this.scrollToMessage(findArgs["targetMessageId"], {
+          this.scrollToMessage(scrollToMessageId, {
             highlight: true,
           });
           return;
@@ -208,9 +211,9 @@ export default class ChatLivePane extends Component {
         if (
           fetchingFromLastRead &&
           messages.length &&
-          findArgs["targetMessageId"] !== messages[messages.length - 1].id
+          scrollToMessageId !== messages[messages.length - 1].id
         ) {
-          this.scrollToMessage(findArgs["targetMessageId"]);
+          this.scrollToMessage(scrollToMessageId);
           return;
         }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -27,6 +27,8 @@ export default class ChatApi extends Service {
 
     if (data.targetMessageId) {
       args.target_message_id = data.targetMessageId;
+    } else if (data.fetchFromLastRead) {
+      args.fetch_from_last_read = true;
     } else {
       args.page_size = data.pageSize;
 

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -47,6 +47,34 @@ RSpec.describe "Deleted message", type: :system, js: true do
       sidebar_component.click_link(channel_1.name)
       expect(channel_page).to have_deleted_message(message, count: 1)
     end
+
+    context "when the current user is not admin" do
+      fab!(:current_user) { Fabricate(:user) }
+
+      it "does not error when coming back to the channel from another channel" do
+        message = Fabricate(:chat_message, chat_channel: channel_1)
+        channel_2 = Fabricate(:category_channel, name: "other channel")
+        channel_2.add(current_user)
+        channel_1
+          .user_chat_channel_memberships
+          .find_by(user: current_user)
+          .update!(last_read_message_id: message.id)
+        chat_page.visit_channel(channel_1)
+        sidebar_component.click_link(channel_2.name)
+
+        other_user = Fabricate(:admin)
+        chat_system_user_bootstrap(user: other_user, channel: channel_1)
+        using_session(:tab_2) do |session|
+          sign_in(other_user)
+          chat_page.visit_channel(channel_1)
+          channel_page.delete_message(message)
+          session.quit
+        end
+
+        sidebar_component.click_link(channel_1.name)
+        expect(channel_page).to have_no_message(id: message.id)
+      end
+    end
   end
 
   context "when deleting multiple messages" do


### PR DESCRIPTION
#### FIX: Do not use client lastReadMessageId when fetching channel messages

We had an issue where the following happened:

1. User opened channel and saw the last message, and we set the
   lastReadMessageId on the server and the client
2. User navigated to another channel
3. Another user deleted the message in the original channel
4. The first user navigated back to the original channel before
   the MessageBus event for the deleted message arrived, and got
   a 404 error because we were sending the deleted lastReadMessageId as
   target_message_id to the channel controller.

Instead of this which is a bit flaky and is hard to cover all
the issues for, instead we can pass a fetch_from_last_read boolean
param to the channels controller, and just get the user's
last_read_message_id straight from the database to use for the
target_message_id. This gets rid of any sources of race conditions
or lack of updates from MessageBus.

#### FIX: Include missing memberships for thread tracking publish

When we publish the channel/message tracking state for a
user and that message was a thread reply the publisher
was erroring because we were not telling Chat::TrackingStateReportQuery
to return missing memberships (which have zeroed out unread counts)
as well, which is what we do for the channel tracking state here.
Also just make sure that the TrackingStateReport does not error
when passed an ID it doesn't have data for.
