### PR TITLE
FIX: do not attempt to mark as read a staged message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -459,7 +459,7 @@ export default class ChatLivePane extends Component {
       const lastReadId =
         this.args.channel.currentUserMembership?.lastReadMessageId;
       let lastUnreadVisibleMessage = this.args.channel.visibleMessages.findLast(
-        (message) => !lastReadId || message.id > lastReadId
+        (message) => !message.staged && (!lastReadId || message.id > lastReadId)
       );
 
       // all intersecting messages are read


### PR DESCRIPTION
This has not much impact as it would just be a silent 404 server side, but this is unnecessary work.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
