### PR TITLE
FIX: Hashtag CSS class color specificity

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -14,7 +14,7 @@ a.hashtag {
   }
 }
 
-a.hashtag-cooked {
+.hashtag-cooked {
   @include mention;
 
   &:visited,
@@ -23,7 +23,6 @@ a.hashtag-cooked {
   }
 
   .d-icon {
-    color: var(--primary-high);
     font-size: var(--font-down-1);
     margin: 0 0.2em 0 0.1em;
   }


### PR DESCRIPTION
Followup to eae47d82e22189646ce1b29ea2f3b5b2f8b64312,
we removed some specificity from the hashtag color
CSS classes, but now the color is being overridden
by the base hashtag-cooked.d-icon color. This color
is no longer needed, so we just remove that and
the specificity.
