### PR TITLE
PERF: N+1 query for chat message serializer on mentions

### DIFF
--- a/plugins/chat/app/queries/chat/messages_query.rb
+++ b/plugins/chat/app/queries/chat/messages_query.rb
@@ -76,10 +76,14 @@ module Chat
           .includes(:uploads)
           .includes(chat_channel: :chatable)
           .includes(:thread)
-          .includes(:chat_mentions)
           .where(chat_channel_id: channel.id)
 
-      query = query.includes(user: :user_status) if SiteSetting.enable_user_status
+      if SiteSetting.enable_user_status
+        query = query.includes(user: :user_status)
+        query = query.includes(chat_mentions: { user: :user_status })
+      else
+        query = query.includes(chat_mentions: :user)
+      end
 
       query
     end

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -27,9 +27,10 @@ module Chat
     has_many :uploads, serializer: ::UploadSerializer, embed: :objects
 
     def mentioned_users
-      User
-        .where(id: object.chat_mentions.pluck(:user_id))
-        .order("users.id ASC")
+      object
+        .chat_mentions
+        .map(&:user)
+        .sort_by(&:id)
         .map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
         .as_json
     end

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -451,7 +451,7 @@ describe Chat::Message do
       notification = Fabricate(:notification)
       mention_1 = Fabricate(:chat_mention, chat_message: message_1, notification: notification)
 
-      message_1.destroy!
+      message_1.reload.destroy!
 
       expect { mention_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
Followup to d4a5b79592a79201076fb02845d2da7db1df1646,
this introduced an N1 because every message in the list
we had to query users for the mentions and then the user's
status too. Instead we can just include both in Chat::MessagesQuery.
