### PR TITLE
PERF: creating a post would cause an N+1

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -570,7 +570,7 @@ class PostSerializer < BasicPostSerializer
       if @topic_view && (mentioned_users = @topic_view.mentioned_users[object.id])
         mentioned_users
       else
-        User.where(username: object.mentions)
+        User.includes(:user_status).where(username: object.mentions)
       end
 
     users.map { |user| BasicUserWithStatusSerializer.new(user, root: false) }


### PR DESCRIPTION
In the case where the `@topic_view` is not present we were fetching users without including `:user_status`, which would cause an N+1

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
