### PR TITLE
FIX: Show Privacy Policy or ToS when they exist

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -18,7 +18,6 @@ import { ajax } from "discourse/lib/ajax";
 import { emailValid } from "discourse/lib/utilities";
 import { findAll } from "discourse/models/login-method";
 import discourseDebounce from "discourse-common/lib/debounce";
-import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { notEmpty } from "@ember/object/computed";
 import { setting } from "discourse/lib/computed";
@@ -129,11 +128,12 @@ export default Controller.extend(
 
     @discourseComputed
     disclaimerHtml() {
-      return I18n.t("create_account.disclaimer", {
-        tos_link: this.siteSettings.tos_url || getURL("/tos"),
-        privacy_link:
-          this.siteSettings.privacy_policy_url || getURL("/privacy"),
-      });
+      if (this.site.tos_url && this.site.privacy_policy_url) {
+        return I18n.t("create_account.disclaimer", {
+          tos_link: this.site.tos_url,
+          privacy_link: this.site.privacy_policy_url,
+        });
+      }
     },
 
     // Check the email address

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -271,11 +271,12 @@ export default Controller.extend(
 
     @discourseComputed
     disclaimerHtml() {
-      return I18n.t("create_account.disclaimer", {
-        tos_link: this.siteSettings.tos_url || getUrl("/tos"),
-        privacy_link:
-          this.siteSettings.privacy_policy_url || getUrl("/privacy"),
-      });
+      if (this.site.tos_url && this.site.privacy_policy_url) {
+        return I18n.t("create_account.disclaimer", {
+          tos_link: this.site.tos_url,
+          privacy_link: this.site.privacy_policy_url,
+        });
+      }
     },
 
     @discourseComputed("authOptions.associate_url", "authOptions.auth_provider")

--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -18,12 +18,12 @@
                 "faq"
               }}</LinkTo></li>
         {{/if}}
-        {{#if (gt this.siteSettings.tos_topic_id 0)}}
+        {{#if this.site.tos_url}}
           <li class="nav-item-tos"><LinkTo @route="tos">{{i18n
                 "tos"
               }}</LinkTo></li>
         {{/if}}
-        {{#if (gt this.siteSettings.privacy_topic_id 0)}}
+        {{#if this.site.privacy_policy_url}}
           <li class="nav-item-privacy"><LinkTo @route="privacy">{{i18n
                 "privacy"
               }}</LinkTo></li>

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -41,6 +41,8 @@ class SiteSerializer < ApplicationSerializer
     :anonymous_sidebar_sections,
     :whispers_allowed_groups_names,
     :denied_emojis,
+    :tos_url,
+    :privacy_policy_url,
   )
 
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
@@ -283,6 +285,30 @@ class SiteSerializer < ApplicationSerializer
 
   def include_denied_emojis?
     denied_emojis.present?
+  end
+
+  def tos_url
+    if SiteSetting.tos_url.present?
+      SiteSetting.tos_url
+    elsif SiteSetting.tos_topic_id > 0 && Topic.exists?(id: SiteSetting.tos_topic_id)
+      "#{Discourse.base_path}/tos"
+    end
+  end
+
+  def include_tos_url?
+    tos_url.present?
+  end
+
+  def privacy_policy_url
+    if SiteSetting.privacy_policy_url.present?
+      SiteSetting.privacy_policy_url
+    elsif SiteSetting.privacy_topic_id > 0 && Topic.exists?(id: SiteSetting.privacy_topic_id)
+      "#{Discourse.base_path}/privacy"
+    end
+  end
+
+  def include_privacy_policy_url?
+    privacy_policy_url.present?
   end
 
   private

--- a/app/views/layouts/_noscript_footer.html.erb
+++ b/app/views/layouts/_noscript_footer.html.erb
@@ -16,16 +16,20 @@
           <a href='<%= path "/guidelines" %>' itemprop="url"><%= t 'guidelines_topic.title' %> </a>
         </span>
       </li>
-      <li itemscope itemtype='http://schema.org/SiteNavigationElement'>
-        <span itemprop='name'>
-          <a href='<%= path "/tos" %>' itemprop="url"><%= t 'tos_topic.title' %> </a>
-        </span>
-      </li>
-      <li itemscope itemtype='http://schema.org/SiteNavigationElement'>
-        <span itemprop='name'>
-          <a href='<%= path "/privacy" %>' itemprop="url"><%= t 'privacy_topic.title' %> </a>
-        </span>
-      </li>
+      <% if path = tos_path.presence %>
+        <li itemscope itemtype='http://schema.org/SiteNavigationElement'>
+          <span itemprop='name'>
+            <a href='<%= path %>' itemprop="url"><%= t 'tos_topic.title' %> </a>
+          </span>
+        </li>
+      <% end %>
+      <% if path = privacy_path.presence %>
+        <li itemscope itemtype='http://schema.org/SiteNavigationElement'>
+          <span itemprop='name'>
+            <a href='<%= path %>' itemprop="url"><%= t 'privacy_topic.title' %> </a>
+          </span>
+        </li>
+      <% end %>
     </ul>
   </nav>
   <p class='powered-by-link'><%= t 'powered_by_html' %></p>

--- a/app/views/static/show.html.erb
+++ b/app/views/static/show.html.erb
@@ -10,11 +10,11 @@
         <li class='nav-item-faq'><a class='<%= @page == 'faq' ? 'active' : '' %>' href='<%=faq_path%>'><%= t 'js.faq' %></a></li>
       <% end %>
     <% end %>
-    <% if SiteSetting.tos_topic_id > 0 %>
-      <li class='nav-item-tos'><a href='<%= tos_path %>' class='<%= @page == 'tos' ? 'active' : '' %>'><%= t 'js.tos' %></a></li>
+    <% if path = tos_path.presence %>
+      <li class='nav-item-tos'><a href='<%= path %>' class='<%= @page == 'tos' ? 'active' : '' %>'><%= t 'js.tos' %></a></li>
     <% end %>
-    <% if SiteSetting.privacy_topic_id > 0 %>
-      <li class='nav-item-privacy'><a href='<%= privacy_path %>' class='<%= @page == 'privacy' ? 'active' : '' %>'><%= t 'js.privacy' %></a></li>
+    <% if path = privacy_path.presence %>
+      <li class='nav-item-privacy'><a href='<%= path %>' class='<%= @page == 'privacy' ? 'active' : '' %>'><%= t 'js.privacy' %></a></li>
     <% end %>
   </ul>
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2477,14 +2477,12 @@ uncategorized:
   tos_topic_id:
     default: -1
     hidden: true
-    client: true
   guidelines_topic_id:
     default: -1
     hidden: true
   privacy_topic_id:
     default: -1
     hidden: true
-    client: true
   welcome_topic_id:
     default: -1
     hidden: true

--- a/lib/configurable_urls.rb
+++ b/lib/configurable_urls.rb
@@ -6,14 +6,18 @@ module ConfigurableUrls
   end
 
   def tos_path
-    SiteSetting.tos_url.blank? ? "#{Discourse.base_path}/tos" : SiteSetting.tos_url
+    if SiteSetting.tos_url.present?
+      SiteSetting.tos_url
+    elsif SiteSetting.tos_topic_id > 0 && Topic.exists?(id: SiteSetting.tos_topic_id)
+      "#{Discourse.base_path}/tos"
+    end
   end
 
   def privacy_path
-    if SiteSetting.privacy_policy_url.blank?
-      "#{Discourse.base_path}/privacy"
-    else
+    if SiteSetting.privacy_policy_url.present?
       SiteSetting.privacy_policy_url
+    elsif SiteSetting.privacy_topic_id > 0 && Topic.exists?(id: SiteSetting.privacy_topic_id)
+      "#{Discourse.base_path}/privacy"
     end
   end
 end


### PR DESCRIPTION
Privacy Policy and Terms of Service topics are no longer created by default for communities that have not set a company name. For this reason, some URLs were pointing to 404 page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
