### PR TITLE
FIX: Move thread storage out of chatApi.thread() call

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-threads-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-threads-manager.js
@@ -16,6 +16,7 @@ import { TrackedObject } from "@ember-compat/tracked-built-ins";
 export default class ChatThreadsManager {
   @service chatSubscriptionsManager;
   @service chatTrackingStateManager;
+  @service chatChannelsManager;
   @service chatApi;
   @service chat;
   @service currentUser;
@@ -83,7 +84,11 @@ export default class ChatThreadsManager {
   }
 
   async #find(channelId, threadId) {
-    return this.chatApi.thread(channelId, threadId);
+    return this.chatApi.thread(channelId, threadId).then((result) => {
+      return this.chatChannelsManager.find(channelId).then((channel) => {
+        return channel.threadsManager.store(channel, result.thread);
+      });
+    });
   }
 
   #cache(thread) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -62,13 +62,7 @@ export default class ChatApi extends Service {
    *    this.chatApi.thread(5, 1).then(thread => { ... })
    */
   thread(channelId, threadId) {
-    return this.#getRequest(`/channels/${channelId}/threads/${threadId}`).then(
-      (result) =>
-        this.chat.activeChannel.threadsManager.store(
-          this.chat.activeChannel,
-          result.thread
-        )
-    );
+    return this.#getRequest(`/channels/${channelId}/threads/${threadId}`);
   }
 
   /**


### PR DESCRIPTION
In some cases activeChannel can be null so this will error,
also it is limiting to have this code in chatApi. Instead
move to the threads manager, and also lean on channelsManager.find
to get the channel from the cache instead, which will not error.
