### PR TITLE
DEV: Implement staff logs for user columns edits

### DIFF
--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -24,7 +24,6 @@ class EditDirectoryColumnsController < ApplicationController
       raise Discourse::InvalidParameters, "Must have at least one column enabled"
     end
 
-    changes = ""
     new_values = ""
     previous_values = ""
     staff_action_logger = StaffActionLogger.new(current_user)
@@ -35,10 +34,9 @@ class EditDirectoryColumnsController < ApplicationController
            existing_column.enabled != ActiveModel::Type::Boolean.new.cast(column_data[:enabled]) ||
              existing_column.position != column_data[:position].to_i
          )
-        change, new_value, previous_value =
+        new_value, previous_value =
           staff_action_logger.edit_directory_columns_details(column_data, existing_column)
 
-        changes += change
         new_values += new_value
         previous_values += previous_value
 
@@ -49,12 +47,7 @@ class EditDirectoryColumnsController < ApplicationController
       end
     end
 
-    details =
-      if changes.empty?
-        { Detail: "Nothing was changed" }
-      else
-        { Changes: changes }
-      end
+    details = {}
 
     details.merge!({ previous_value: previous_values, new_value: new_values })
     staff_action_logger.log_custom("update_directory_columns", details = details)

--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -25,6 +25,7 @@ class EditDirectoryColumnsController < ApplicationController
     end
 
     changes = "\n"
+
     directory_column_params[:directory_columns].values.each do |column_data|
       existing_column = directory_columns.detect { |c| c.id == column_data[:id].to_i }
       if (
@@ -32,7 +33,7 @@ class EditDirectoryColumnsController < ApplicationController
              existing_column.position != column_data[:position].to_i
          )
         changes +=
-          "#{existing_column.name} - enabled: #{existing_column.enabled} -> #{column_data[:enabled]} , position: #{existing_column.position} -> #{column_data[:position]}\n"
+          "#{existing_column.name} - enabled: #{existing_column.enabled} -> #{column_data[:enabled]}, position: #{existing_column.position} -> #{column_data[:position]}\n"
         existing_column.update(
           enabled: column_data[:enabled],
           position: column_data[:position].to_i,

--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -49,8 +49,10 @@ class EditDirectoryColumnsController < ApplicationController
 
     details = {}
 
-    details.merge!({ previous_value: previous_values, new_value: new_values })
-    staff_action_logger.log_custom("update_directory_columns", details = details)
+    staff_action_logger.log_custom(
+      "update_directory_columns",
+      { previous_value: previous_values, new_value: new_values },
+    )
     render json: success_json
   end
 

--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -43,7 +43,7 @@ class EditDirectoryColumnsController < ApplicationController
 
     details =
       if changes.empty?
-        { Detail: "Nothing was changed" }
+        { Detail: "" }
       else
         { Changes: changes }
       end

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -129,7 +129,7 @@ class UserHistory < ActiveRecord::Base
 
   # Staff actions is a subset of all actions, used to audit actions taken by staff users.
   def self.staff_actions
-    @staff_actions ||= %i[
+    actions = %i[
       delete_user
       change_trust_level
       change_site_setting
@@ -223,7 +223,18 @@ class UserHistory < ActiveRecord::Base
       update_public_sidebar_section
       destroy_public_sidebar_section
       reset_bounce_score
+      update_directory_columns
+      deleted_unused_tags
+      renamed_tag
+      deleted_tag
+      chat_channel_status_change
+      chat_auto_remove_membership
     ]
+
+    actions_constants = [Chat::TrashChannel::DELETE_CHANNEL_LOG_KEY.to_sym]
+    actions.concat(actions_constants)
+
+    @staff_actions ||= actions
   end
 
   def self.staff_action_ids

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -129,7 +129,7 @@ class UserHistory < ActiveRecord::Base
 
   # Staff actions is a subset of all actions, used to audit actions taken by staff users.
   def self.staff_actions
-    actions = %i[
+    @staff_actions ||= %i[
       delete_user
       change_trust_level
       change_site_setting
@@ -230,11 +230,6 @@ class UserHistory < ActiveRecord::Base
       chat_channel_status_change
       chat_auto_remove_membership
     ]
-
-    actions_constants = [Chat::TrashChannel::DELETE_CHANNEL_LOG_KEY.to_sym]
-    actions.concat(actions_constants)
-
-    @staff_actions ||= actions
   end
 
   def self.staff_action_ids

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -46,6 +46,26 @@ class StaffActionLogger
     UserHistory.create!(attrs)
   end
 
+  def edit_directory_columns_details(column_data, directory_column)
+    changes = "\n#{directory_column.name} - "
+
+    directory_column = directory_column.attributes.transform_values(&:to_s)
+    previous_value = directory_column
+    new_value = directory_column.clone
+
+    directory_column.each do |key, value|
+      if column_data[key] != value && column_data[key].present?
+        changes += "#{key}: #{value} -> #{column_data[key]}, "
+        new_value[key] = column_data[key]
+      elsif key != "name"
+        previous_value.delete key
+        new_value.delete key
+      end
+    end
+
+    [changes.chomp!(", "), previous_value.to_json, new_value.to_json]
+  end
+
   def log_post_deletion(deleted_post, opts = {})
     unless deleted_post && deleted_post.is_a?(Post)
       raise Discourse::InvalidParameters.new(:deleted_post)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -47,15 +47,12 @@ class StaffActionLogger
   end
 
   def edit_directory_columns_details(column_data, directory_column)
-    changes = "\n#{directory_column.name} - "
-
     directory_column = directory_column.attributes.transform_values(&:to_s)
     previous_value = directory_column
     new_value = directory_column.clone
 
     directory_column.each do |key, value|
       if column_data[key] != value && column_data[key].present?
-        changes += "#{key}: #{value} -> #{column_data[key]}, "
         new_value[key] = column_data[key]
       elsif key != "name"
         previous_value.delete key
@@ -63,7 +60,7 @@ class StaffActionLogger
       end
     end
 
-    [changes.chomp!(", "), previous_value.to_json, new_value.to_json]
+    [previous_value.to_json, new_value.to_json]
   end
 
   def log_post_deletion(deleted_post, opts = {})

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5452,6 +5452,7 @@ en:
             revoke_moderation: "revoke moderation"
             backup_create: "create backup"
             deleted_tag: "deleted tag"
+            update_directory_columns: "update directory columns"
             deleted_unused_tags: "deleted unused tags"
             renamed_tag: "renamed tag"
             revoke_email: "revoke email"

--- a/spec/requests/edit_directory_columns_controller_spec.rb
+++ b/spec/requests/edit_directory_columns_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rspec"
+
+RSpec.describe EditDirectoryColumnsController do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:normal_user) { Fabricate(:user) }
+  let!(:payload) do
+    {
+      directory_columns: {
+        "0": {
+          id: "1",
+          enabled: "true",
+          position: "2",
+        },
+        "1": {
+          id: "2",
+          enabled: "true",
+          position: "1",
+        },
+      },
+      format: "json",
+    }
+  end
+
+  describe "#update" do
+    describe "when user is an admin or moderator" do
+      before { sign_in(admin) }
+      describe "user saves a new configuration" do
+        it "logs the new information using StaffActionLogger" do
+          put edit_directory_columns_path(params: payload)
+          staff_log = UserHistory.last
+
+          expect(staff_log.custom_type).to eq("update_directory_columns")
+        end
+      end
+    end
+
+    describe "when user is not an admin or moderator" do
+      before { sign_in(normal_user) }
+      describe "user saves a new configuration" do
+        it "does not allow saving" do
+          put edit_directory_columns_path(params: payload)
+
+          expect(response.status).to eq(403)
+        end
+      end
+    end
+  end
+
+  describe "#index" do
+    describe "when user is not an admin or moderator" do
+      before { sign_in(normal_user) }
+      describe "user checks current configuration" do
+        it "does not allow the configuration to load" do
+          get edit_directory_columns_path << ".json"
+
+          expect(response.status).to eq(403)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Context**
User directory columns are used to change what can be seen on the `Users` page at the relative URL `/u`

**Problem**
Currently, we can't see changes to edits in the user directory columns. This has caused, in at least one instance, confusion when a moderator made changes thinking it was a personal change and not a site-wide change, leading a customer to believe it was an error in the code, having logs could have solved this easily.

**Solution**
Implement Staff logging so that these kinds of actions can be tracked 
