### PR TITLE
FIX: adjust chat window in RTL mode

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
@@ -120,7 +120,7 @@
   @include ellipsis;
   font-size: var(--font-0);
   color: var(--primary);
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
 }
 
 .channel-info {

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -110,6 +110,11 @@ html.rtl {
   display: flex;
   height: 2rem;
   margin-left: auto;
+
+  .rtl & {
+    margin-left: unset;
+    margin-right: auto;
+  }
 }
 
 .chat-drawer-header__top-line {

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -60,11 +60,23 @@
     &:first-child {
       border-bottom-left-radius: 0.25em;
       border-top-left-radius: 0.25em;
+
+      .rtl & {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0.25em;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0.25em;
+      }
     }
 
     &:first-child:not(:hover) {
       border-color: var(--primary-300);
       border-right-color: transparent;
+
+      .rtl & {
+        border-color: var(--primary-300);
+        border-left-color: transparent;
+      }
     }
 
     .d-icon {
@@ -85,6 +97,12 @@
       padding: 0.5em 0;
       width: 2.5em;
       transition: background 0.2s, border-color 0.2s;
+
+      .rtl & {
+        border: 1px solid var(--primary-300);
+        border-right-color: transparent;
+        border-radius: 0.25em 0 0 0.25em;
+      }
 
       &:focus {
         border-color: var(--primary-300);

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -74,7 +74,6 @@
       border-right-color: transparent;
 
       .rtl & {
-        border-color: var(--primary-300);
         border-left-color: transparent;
       }
     }

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -74,6 +74,7 @@
       border-right-color: transparent;
 
       .rtl & {
+        border-color: var(--primary-300);
         border-left-color: transparent;
       }
     }

--- a/plugins/chat/assets/stylesheets/common/chat-message-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-info.scss
@@ -10,7 +10,7 @@
 
   & + .chat-message-info__bot-indicator,
   & + .chat-message-info__date {
-    margin-left: 0.25em;
+    margin-inline-start: 0.25em;
   }
 }
 
@@ -29,7 +29,7 @@
   font-size: var(--font-down-2);
 
   & + .chat-message-info__date {
-    margin-left: 0.25em;
+    margin-inline-start: 0.25em;
   }
 }
 
@@ -45,7 +45,7 @@
   }
 
   & + .chat-message-info__flag {
-    margin-left: 0.25em;
+    margin-inline-start: 0.25em;
   }
 }
 
@@ -58,7 +58,7 @@
   .d-icon-bookmark {
     color: var(--primary-low-mid);
     font-size: var(--font-down-2);
-    margin-left: 0.5em;
+    margin-inline-start: 0.5em;
   }
 }
 

--- a/plugins/chat/assets/stylesheets/common/chat-reply.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-reply.scss
@@ -52,4 +52,8 @@
   @include ellipsis;
   font-weight: 700;
   padding: 0 0.5em 0 0;
+
+  .rtl & {
+    padding: 0 0 0 0.5em;
+  }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-retention-reminder.scss
@@ -13,8 +13,12 @@
   z-index: 10;
   min-width: 280px;
 
+  .rtl & {
+    padding: 0.5em 1em 0.5em 0;
+  }
+
   .btn-flat.dismiss-btn {
-    margin-left: 0.25em;
+    margin-inline-end: 0.25em;
     color: var(--primary-medium);
 
     &:hover,


### PR DESCRIPTION
**PR Summary**:
The PR includes UI modifications for the chat window in RTL mode. The specific changes are as follows: 
- Chat window header: The button has been relocated to the left side, and the margin between the title and icon has been adjusted to the opposite side. 
- Chat window popup message: The message and exit button have been aligned differently to accommodate RTL mode. 
- Chat window body: The margin between the username and the date has been moved to the opposite side. 
- Chat window referred message: The margin between the username and the message has been adjusted for RTL mode. 

You can visualize these changes in the image provided below:

![image](https://github.com/discourse/discourse/assets/35470921/e3edacf8-af1e-4c46-b2dd-4ed72513a518)

LTR mode remines the same:

![image](https://github.com/discourse/discourse/assets/35470921/4a22d406-4de1-4e64-aced-9af528680aba)

