### PR TITLE
DEV: more reliable toggle_setting spec helper

### DIFF
--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -31,7 +31,7 @@ module PageObjects
       end
 
       def toggle_setting(setting, text = "")
-        find(".edit-category-tab .#{setting} label.checkbox-label", text: text).click
+        find(".edit-category-tab .#{setting} label.checkbox-label", text: text, visible: :all).click
         self
       end
 


### PR DESCRIPTION
Page settings can be very long and the setting can be way out of viewport. This should ensure the setting can be found and clicked.

This was for example causing this flakey in discourse-topic-voting:

```
Failures:

  1) Voting enables voting in category topics and votes
     Failure/Error: find(".edit-category-tab .#{setting} label.checkbox-label", text: text).click

     Capybara::ElementNotFound:
       Unable to find css ".edit-category-tab .enable-topic-voting label.checkbox-label"

     [Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_voting_enables_voting_in_category_topics_and_votes_873.png

     ~~~~~~~ JS LOGS ~~~~~~~
     http://localhost:31341/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
     ~~~~~ END JS LOGS ~~~~~

     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/base.rb:84:in `synchronize'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:60:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/session.rb:773:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `call'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `find'
     # ./spec/system/page_objects/pages/category.rb:34:in `toggle_setting'
     # ./plugins/discourse-topic-voting/spec/system/voting_spec.rb:39:in `block (2 levels) in <main>'
     # ./spec/rails_helper.rb:368:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:189:in `block in timeout'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `block in catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:198:in `timeout'
     # ./spec/rails_helper.rb:364:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:356:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 7 minutes 18 seconds (files took 0 seconds to load)
445 examples, 1 failure, 17 pending, 1 error occurred outside of examples

Failed examples:

rspec ./plugins/discourse-topic-voting/spec/system/voting_spec.rb:27 # Voting enables voting in category topics and votes
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
