### PR TITLE
DEV: ensures preview button is enabled

### DIFF
--- a/spec/system/page_objects/pages/form_template.rb
+++ b/spec/system/page_objects/pages/form_template.rb
@@ -48,7 +48,7 @@ module PageObjects
       end
 
       def click_preview_button
-        find(".form-templates__preview-button").click
+        find(".form-templates__preview-button:enabled").click
       end
 
       def has_input_field?(type)


### PR DESCRIPTION
In tests we could attempt to click the preview button when it was not enabled yet, causing a noop and a future failure. This fix ensures we try to find (and wait) for an enabled button.

This should help with this specific flakey:

```
Failures:

  1) Admin Customize Form Templates when visiting the page to create a new form template should render all the input field types in the preview
     Failure/Error: find(".form-template-field__#{type}").present?

     Capybara::ElementNotFound:
       Unable to find css ".form-template-field__input"

     [Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_admin_customize_form_templates_when_visiting_the_page_to_create_a_new_form_template_should_render_all_the_input_field_types_in_the_preview_277.png

     ~~~~~~~ JS LOGS ~~~~~~~
     http://localhost:31339/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
     ~~~~~ END JS LOGS ~~~~~

     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/base.rb:84:in `synchronize'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:60:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/session.rb:773:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `call'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `find'
     # ./spec/system/page_objects/pages/form_template.rb:55:in `has_input_field?'
     # ./spec/system/admin_customize_form_templates_spec.rb:114:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:368:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:189:in `block in timeout'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `block in catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:198:in `timeout'
     # ./spec/rails_helper.rb:364:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:356:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
