### PR TITLE
DEV: ensures save button is visible and enabled

### DIFF
--- a/spec/system/page_objects/pages/form_template.rb
+++ b/spec/system/page_objects/pages/form_template.rb
@@ -36,7 +36,7 @@ module PageObjects
       end
 
       def click_save_button
-        find(".form-templates__form .footer-buttons .btn-primary").click
+        find(".form-templates__form .footer-buttons .btn-primary:enabled", visible: :all).click
       end
 
       def click_quick_insert(field_type)


### PR DESCRIPTION
In tests we could attempt to click the button before it was enabled and it could also not be visible on screen. This commits attempts to solve both problems.

It should solve this failure:

```
Failures:

  1) Admin Customize Form Templates when visiting the page to create a new form template should allow admin to create a new form template
     Failure/Error: find(".form-templates__table tbody tr td", text: name).present?

     Capybara::ElementNotFound:
       Unable to find css ".form-templates__table tbody tr td"

     [Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_admin_customize_form_templates_when_visiting_the_page_to_create_a_new_form_template_should_allow_admin_to_create_a_new_form_template_911.png

     ~~~~~~~ JS LOGS ~~~~~~~
     http://localhost:31339/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
     ~~~~~ END JS LOGS ~~~~~

     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/base.rb:84:in `synchronize'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/node/finders.rb:60:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/session.rb:773:in `find'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `call'
     # ./vendor/bundle/ruby/3.2.0/gems/capybara-3.39.1/lib/capybara/dsl.rb:52:in `find'
     # ./spec/system/page_objects/pages/form_template.rb:21:in `has_form_template?'
     # ./spec/system/admin_customize_form_templates_spec.rb:71:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:381:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:189:in `block in timeout'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `block in catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:36:in `catch'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:198:in `timeout'
     # ./spec/rails_helper.rb:377:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:369:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
