### PR TITLE
FIX: ensures chat-thread is not overflowing

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
@@ -8,7 +8,6 @@
 
 .chat-side-panel {
   grid-area: threads;
-  min-height: 100%;
   box-sizing: border-box;
   border-left: 1px solid var(--primary-low);
   position: relative;


### PR DESCRIPTION
Before this fix the sidepanel containing the thread would have an height superior at the viewport.

<img width="811" alt="Screenshot 2023-05-27 at 16 02 37" src="https://github.com/discourse/discourse/assets/339945/e37c6e2a-00c7-4178-b13f-4ae93aae36ef">

