### PR TITLE
DEV: prevents flakey in autocomplete hashtag

### DIFF
--- a/spec/system/hashtag_autocomplete_spec.rb
+++ b/spec/system/hashtag_autocomplete_spec.rb
@@ -77,10 +77,13 @@ describe "Using #hashtag autocompletion to search for and lookup categories and 
 
   it "cooks the hashtags for tag and category correctly serverside when the post is saved to the database" do
     topic_page.visit_topic_and_open_composer(topic)
+
     expect(topic_page).to have_expanded_composer
-    topic_page.type_in_composer("this is a #cool-cat category and a #cooltag tag")
-    topic_page.send_reply
+
+    topic_page.send_reply("this is a #cool-cat category and a #cooltag tag")
+
     expect(topic_page).to have_post_number(2)
+
     cooked_hashtags = page.all(".hashtag-cooked", count: 2)
 
     expect(cooked_hashtags[0]["outerHTML"]).to eq(<<~HTML.chomp)

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -119,7 +119,8 @@ module PageObjects
         @composer_component.has_popup_content?(content)
       end
 
-      def send_reply
+      def send_reply(content = nil)
+        fill_in_composer(content) if content
         find("#reply-control .save-or-cancel .create").click
       end
 


### PR DESCRIPTION
Watching screenshots of failures it appears that sometimes the reply was stuck at: `this is a #` due to the autocomplete showing, given we only need to send a reply here? I think fill_in + click send should be more reliable here.

Note I also tweaked `send_reply` to accept a content param and use it to fill composer when given.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
