### PR TITLE
DEV: Correct Capybara default max wait time setting in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       PGUSER: discourse
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' || matrix.build_type == 'system' }}
-      CABPYARA_DEFAULT_MAX_WAIT_TIME: 10
+      CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We were not setting capybara's default max wait time correctly in CI due
to a spelling error.

This regressd in fc17045876bc31f8bf8018f10b1f90e6736b461b