### PR TITLE
UX: add support for flagged chat message in reviewqueue

### DIFF
--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -232,8 +232,9 @@
       color: var(--secondary);
       border-radius: 8px;
       background-color: var(--secondary-high);
-      &.-flagged-post {
-        background-color: var(--danger-medium);
+      &.-flagged-post,
+      &.-flagged-chat-message {
+        background-color: var(--danger);
       }
       &.-queued-post,
       &.-queued-topic,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -630,6 +630,8 @@ en:
           title: "User"
         reviewable_post:
           title: "Post"
+        reviewable_chat_message:
+          title: "Flagged chat message"
       approval:
         title: "Post Needs Approval"
         description: "We've received your new post but it needs to be approved by a moderator before it will appear. Please be patient."

--- a/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
@@ -1,15 +1,14 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { cached } from "@glimmer/tracking";
+import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 
 export default class ReviewableChatMessage extends Component {
   @service store;
+  @service chatChannelsManager;
 
   @cached
   get chatChannel() {
-    return this.store.createRecord(
-      "chat-channel",
-      this.args.reviewable.chat_channel
-    );
+    return ChatChannel.create(this.args.reviewable.chat_channel);
   }
 }


### PR DESCRIPTION
Fixing
![image](https://github.com/discourse/discourse/assets/101828855/ff088f3e-1d22-4885-8102-bee1c5ea9376)

so it matches all the other flags

<img width="696" alt="image" src="https://github.com/discourse/discourse/assets/101828855/bf658eff-fb4c-4de6-a59a-b7fab64adda2">

