### PR TITLE
DEV: Speed up slow system tests

### DIFF
--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -27,7 +27,7 @@ module PageObjects
       end
 
       def is_collapsed?
-        has_css?(context + ":not(.is-expanded)")
+        has_css?(context + ":not(.is-expanded)", wait: 0)
       end
 
       def has_selected_value?(value)


### PR DESCRIPTION
What is the problem?

Prior to this change, we had a `has_css?(context + ":not(.is-expanded)"`
check when using the select-kit component page object. The problem here
is that this check will end up waiting the full capybara default wait
time if the select-kit has already been expanded. It turns out that we
were calling this check alot of times when the select-kit has already
been expanded resulting in many tests waiting the full default wait
time. An example of this can be seen in https://github.com/discourse/discourse/actions/runs/5107901738/jobs/9181236540, where a test timeout after 30 seconds because the test was running `has_css?(context + ":not(.is-expanded)"`
multiple times and waiting up to the full Capybara default wait time of 10 seconds in CI each time.

What is the fix?

The fix here is to specify the `wait: 0` option such that we do not wait
and fundamentally, there is no need for us to wait at all here.