### PR TITLE
FEATURE: Chat thread header indicator improvements

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/right-actions.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/right-actions.hbs
@@ -1,6 +1,6 @@
 <div class="chat-drawer-header__right-actions">
   <div class="chat-drawer-header__top-line">
-    {{#if this.chat.activeChannel.threadingEnabled}}
+    {{#if this.showThreadsListButton}}
       <Chat::Thread::ThreadsListButton @channel={{this.chat.activeChannel}} />
     {{/if}}
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/right-actions.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/right-actions.js
@@ -3,5 +3,10 @@ import { inject as service } from "@ember/service";
 
 export default class ChatDrawerHeaderRightActions extends Component {
   @service chat;
+  @service router;
   @service chatStateManager;
+
+  get showThreadsListButton() {
+    return this.chat.activeChannel?.threadingEnabled;
+  }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.hbs
@@ -40,7 +40,7 @@
             />
           {{/if}}
 
-          {{#if @channel.threadingEnabled}}
+          {{#if this.showThreadsListButton}}
             <Chat::Thread::ThreadsListButton @channel={{@channel}} />
           {{/if}}
         </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.js
@@ -4,8 +4,17 @@ import Component from "@glimmer/component";
 export default class ChatFullPageHeader extends Component {
   @service site;
   @service chatStateManager;
+  @service router;
 
   get displayed() {
     return this.args.displayed ?? true;
+  }
+
+  get showThreadsListButton() {
+    return (
+      this.args.channel.threadingEnabled &&
+      this.router.currentRoute.name !== "chat.channel.threads" &&
+      this.router.currentRoute.name !== "chat.channel.thread"
+    );
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.js
@@ -8,10 +8,6 @@ export default class ChatHeaderIcon extends Component {
   @service chatStateManager;
   @service router;
 
-  get currentUserInDnD() {
-    return this.currentUser.isInDoNotDisturb();
-  }
-
   get href() {
     if (this.chatStateManager.isFullPageActive) {
       if (this.site.mobileView) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header-unread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header-unread-indicator.hbs
@@ -1,5 +1,9 @@
 {{#if this.showUnreadIndicator}}
-  <div class="chat-thread-header-unread-indicator">
+  <div
+    class="chat-thread-header-unread-indicator"
+    aria-label={{i18n "chat.unread_threads_count" count=this.unreadCountLabel}}
+    title={{i18n "chat.unread_threads_count" count=this.unreadCountLabel}}
+  >
     <div class="chat-thread-header-unread-indicator__number-wrap">
       <div
         class="chat-thread-header-unread-indicator__number"

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header-unread-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header-unread-indicator.js
@@ -1,12 +1,19 @@
 import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
 export default class ChatThreadHeaderUnreadIndicator extends Component {
+  @service currentUser;
+
+  get currentUserInDnD() {
+    return this.currentUser.isInDoNotDisturb();
+  }
+
   get unreadCount() {
     return this.args.channel.unreadThreadCount;
   }
 
   get showUnreadIndicator() {
-    return this.unreadCount > 0;
+    return !this.currentUserInDnD && this.unreadCount > 0;
   }
 
   get unreadCountLabel() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
@@ -1,4 +1,18 @@
 <div class="chat-thread-header">
+  <div class="chat-thread-header__left-buttons">
+    {{#if @thread}}
+      <LinkTo
+        class="chat-thread__back-to-index btn-flat btn btn-icon no-text"
+        @route="chat.channel.threads"
+        @models={{@channel.routeModels}}
+        title={{i18n "chat.return_to_threads_list"}}
+      >
+        <Chat::Thread::HeaderUnreadIndicator @channel={{@channel}} />
+        {{d-icon "chevron-left"}}
+      </LinkTo>
+    {{/if}}
+  </div>
+
   <span class="chat-thread-header__label overflow-ellipsis">
     {{replace-emoji this.label}}
   </span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/threads-list-button.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/threads-list-button.hbs
@@ -9,7 +9,5 @@
 >
   {{d-icon "discourse-threads"}}
 
-  {{#unless this.currentUserInDnD}}
-    <Chat::Thread::HeaderUnreadIndicator @channel={{@channel}} />
-  {{/unless}}
+  <Chat::Thread::HeaderUnreadIndicator @channel={{@channel}} />
 </LinkTo>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/threads-list-button.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/threads-list-button.js
@@ -1,10 +1,3 @@
-import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 
-export default class ChatThreadsListButton extends Component {
-  @service currentUser;
-
-  get currentUserInDnD() {
-    return this.currentUser.isInDoNotDisturb();
-  }
-}
+export default class ChatThreadsListButton extends Component {}

--- a/plugins/chat/assets/stylesheets/common/chat-thread-header-button.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-header-button.scss
@@ -2,14 +2,20 @@
   position: relative;
   display: flex;
   align-items: center;
-  border: 1px solid var(--blend-primary-secondary-5);
   border-radius: 5px;
+  padding: 0.5em 0;
 
   @include chat-channel-header-button;
 
   &.-has-unreads {
     .d-icon {
       color: var(--tertiary-med-or-tertiary);
+    }
+
+    &:hover {
+      .d-icon {
+        color: var(--tertiary-med-or-tertiary);
+      }
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-thread-header.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-header.scss
@@ -6,10 +6,21 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding-inline: 1rem;
+  padding-inline: 0.5rem;
+
+  .chat-thread__back-to-index {
+    padding: 0.5rem 0;
+    margin-right: 0.5rem;
+  }
 
   &__buttons {
     display: flex;
+    margin-left: auto;
+  }
+
+  &__left-buttons {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
 }

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -251,6 +251,9 @@ en:
       select: "Select"
       return_to_list: "Return to channels list"
       return_to_threads_list: "Return to ongoing discussions"
+      unread_threads_count:
+        one: "You have %{count} unread discussion"
+        other: "You have %{count} unread discussions"
       scroll_to_bottom: "Scroll to bottom"
       scroll_to_new_messages: "See new messages"
       sound:


### PR DESCRIPTION
This changes the thread header positioning of the
unread indicator to match the designs based on the route:

1. When the channel is open, show the indicator of # unread
   threads with the icon
2. When the threads list is open, show no indicator since
   you are on the list and can see which threads are unread
3. When a single thread is open, show the unread threads
   indicator along with a left < back button, with a label
   to show that this goes back to ongoing discussions

Drawer changes to come in another PR.
