### PR TITLE
FIX: Create original message user thread membership

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
@@ -1,5 +1,9 @@
 <div
-  class={{concat-class "chat-thread" (if this.loading "loading")}}
+  class={{concat-class
+    "chat-thread"
+    (if this.loading "loading")
+    (if this.thread.staged "staged")
+  }}
   data-id={{this.thread.id}}
   {{did-insert this.setUploadDropZone}}
   {{did-insert this.subscribeToUpdates}}

--- a/plugins/chat/lib/chat/message_creator.rb
+++ b/plugins/chat/lib/chat/message_creator.rb
@@ -233,6 +233,13 @@ module Chat
       return if resolved_thread.blank?
       resolved_thread.increment_replies_count_cache
       Chat::UserChatThreadMembership.find_or_create_by!(user: @user, thread: resolved_thread)
+
+      if resolved_thread.original_message_user != @user
+        Chat::UserChatThreadMembership.find_or_create_by!(
+          user: resolved_thread.original_message_user,
+          thread: resolved_thread,
+        )
+      end
     end
   end
 end

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Reply to message - channel - full page", type: :system, js: true
         thread_page.click_send_message
 
         expect(thread_page).to have_message(text: "reply to message")
+        expect(channel_page).to have_thread_indicator(original_message)
 
         refresh
 


### PR DESCRIPTION
When a thread is created / a new message is created in the
thread, we want to make sure that the original message user
has a membership for that thread, otherwise they will not
receive unread indicators for messages in the thread.
