### PR TITLE
DEV: Remove unnecessary wait for chat transcript system test

### DIFF
--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
   fab!(:current_user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
   fab!(:chat_channel_1) { Fabricate(:chat_channel) }
 
   let(:cdp) { PageObjects::CDP.new }
@@ -10,13 +11,13 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
-    chat_system_bootstrap(Fabricate(:admin), [chat_channel_1])
+    chat_system_bootstrap(admin, [chat_channel_1])
     chat_channel_1.add(current_user)
     sign_in(current_user)
   end
 
   def select_message_desktop(message)
-    if page.has_css?(".chat-message-container.selecting-messages")
+    if page.has_css?(".chat-message-container.selecting-messages", wait: 0)
       chat_channel_page.message_by_id(message.id).find(".chat-message-selector").click
     else
       chat_channel_page.message_by_id(message.id).hover


### PR DESCRIPTION
What is this change required?

In the `chat/spec/system/transcript_spec.rb` test, there is a helper
method that uses `page.has_css?` in a conditional but it do not
specify a wait time and hence the default Capybara default max wait
time is used. However, there is no need for us to be waiting here so
we specify the `wait: 0` option.