### PR TITLE
DEV: Speed chat channel system test

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -12,16 +12,25 @@ module PageObjects
           @context = context
         end
 
+        def does_not_exist?(**args)
+          exists?(**args, does_not_exist: true)
+        end
+
         def exists?(**args)
           selectors = SELECTOR
           selectors += "[data-id=\"#{args[:id]}\"]" if args[:id]
           selectors += ".is-persisted" if args[:persisted]
           selectors += ".is-staged" if args[:staged]
+          selector_method = args[:does_not_exist] ? :has_no_selector? : :has_selector?
 
           if args[:text]
-            find(context).has_selector?(selectors + " " + ".chat-message-text", text: args[:text])
+            find(context).send(
+              selector_method,
+              selectors + " " + ".chat-message-text",
+              text: args[:text],
+            )
           else
-            find(context).has_selector?(selectors)
+            find(context).send(selector_method, selectors)
           end
         end
       end

--- a/plugins/chat/spec/system/page_objects/chat/components/messages.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/messages.rb
@@ -21,7 +21,7 @@ module PageObjects
         end
 
         def has_no_message?(**args)
-          !has_message?(**args)
+          PageObjects::Components::Chat::Message.new(".chat-channel").does_not_exist?(**args)
         end
 
         def has_x_messages?(count)


### PR DESCRIPTION
Why is this change required?

In the `PageObjects::Components::Chat::Messages#has_no_message?` method,
it ended up calling `has_selector` when trying to assert that the
selector is not present. This is an anti-pattern which results in us
waiting the full Capybara default wait time