### PR TITLE
DEV: Disable animation in system tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -251,7 +251,7 @@ RSpec.configure do |config|
     end
 
     Capybara.threadsafe = true
-    Capybara.disable_animation = false
+    Capybara.disable_animation = true
 
     # Click offsets is calculated from top left of element
     Capybara.w3c_click_offset = false


### PR DESCRIPTION
What is this change?

This change is an attempt to avoid flakiness in our tests due to
animations being enabled in our tests. An example of flakiness caused by
animations is when the `find(selector).click` pattern is used. When
`find(selector)` returns the node, its position may have changed if the
element is still moving. However, the `click` method will end up
clicking on the old position.

Either way, there is no need for us to make system tests even more
complicated by enabling animations.