### PR TITLE
DEV: do not rely on checking DB state

### DIFF
--- a/spec/system/discovery_breadcrumb_navigation_spec.rb
+++ b/spec/system/discovery_breadcrumb_navigation_spec.rb
@@ -39,7 +39,7 @@ describe "Navigating with breadcrumbs", type: :system, js: true do
 
     expect(discovery.subcategory_drop).to have_selected_value("") # all
 
-    discovery.subcategory_drop.select_row_by_value("no-categories")
+    discovery.subcategory_drop.select_row_by_name("none")
     expect(discovery.topic_list).to have_topic(c3_topic)
     expect(discovery.topic_list).to have_topics(count: 1)
 

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -34,6 +34,10 @@ module PageObjects
         component.find(".select-kit-header[data-value='#{value}']")
       end
 
+      def has_selected_index?(index)
+        component.find(".select-kit-header[data-index='#{index}']")
+      end
+
       def has_selected_name?(name)
         component.find(".select-kit-header[data-name='#{name}']")
       end

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -62,14 +62,17 @@ module PageObjects
 
       def select_row_by_value(value)
         expanded_component.find(".select-kit-row[data-value='#{value}']").click
+        has_selected_value?(value)
       end
 
       def select_row_by_name(name)
         expanded_component.find(".select-kit-row[data-name='#{name}']").click
+        has_selected_name?(name)
       end
 
       def select_row_by_index(index)
         expanded_component.find(".select-kit-row[data-index='#{index}']").click
+        has_selected_index?(index)
       end
 
       def expand_if_needed

--- a/spec/system/page_objects/pages/user_preferences.rb
+++ b/spec/system/page_objects/pages/user_preferences.rb
@@ -9,7 +9,7 @@ module PageObjects
       end
 
       def click_interface_tab
-        click_link "Interface"
+        click_link(I18n.t("js.user.preferences_nav.interface"))
         self
       end
 

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -9,14 +9,11 @@ module PageObjects
       end
 
       def has_bookmark_after_notification_mode?(value)
-        page.has_css?(
-          "#bookmark-after-notification-mode .select-kit-header[data-value=\"#{value}\"]",
-        )
+        bookmark_after_notification_mode_dropdown.has_selected_value?(value)
       end
 
       def select_bookmark_after_notification_mode(value)
-        page.find("#bookmark-after-notification-mode").click
-        page.find(".select-kit-row[data-value=\"#{value}\"]").click
+        bookmark_after_notification_mode_dropdown.select_row_by_value(value)
         self
       end
 
@@ -24,6 +21,11 @@ module PageObjects
         find("button", exact_text: I18n.t("js.save"), visible: :all).click
         find(".saved", exact_text: I18n.t("js.saved"))
         self
+      end
+
+      def bookmark_after_notification_mode_dropdown
+        @bookmark_after_notification_mode_dropdown ||=
+          PageObjects::Components::SelectKit.new("#bookmark-after-notification-mode")
       end
     end
   end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -18,7 +18,7 @@ module PageObjects
       end
 
       def save_changes
-        find("button", text: I18n.t("js.save").click
+        find("button", text: I18n.t("js.save")).click
         find(".saved", text: I18n.t("js.saved"))
         self
       end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -18,7 +18,7 @@ module PageObjects
       end
 
       def save_changes
-        find("button", text: I18n.t("js.save")).click
+        click_button("Save Changes")
         find(".saved", text: I18n.t("js.saved"))
         self
       end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -21,8 +21,8 @@ module PageObjects
       end
 
       def save_changes
-        click_button "Save Changes"
-        expect(page).to have_content(I18n.t("js.saved"))
+        click_button(I18n.t("js.save"))
+        find(".saved", exact_text: I18n.t("js.saved"))
         self
       end
     end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -19,7 +19,7 @@ module PageObjects
 
       def save_changes
         find("button", exact_text: I18n.t("js.save"), visible: :all).click
-        find(".saved", exact_text: I18n.t("js.saved"))
+        find(".saved", exact_text: I18n.t("js.saved"), visible: :all)
         self
       end
 

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -18,8 +18,8 @@ module PageObjects
       end
 
       def save_changes
-        click_button("Save Changes")
-        find(".saved", text: I18n.t("js.saved"))
+        click_button(I18n.t("js.save"))
+        expect(page).to have_content(I18n.t("js.saved"))
         self
       end
 

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -18,8 +18,8 @@ module PageObjects
       end
 
       def save_changes
-        find("button", exact_text: I18n.t("js.save"), visible: :all).click
-        find(".saved", exact_text: I18n.t("js.saved"), visible: :all)
+        find("button", text: I18n.t("js.save").click
+        find(".saved", text: I18n.t("js.saved")
         self
       end
 

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -21,7 +21,7 @@ module PageObjects
       end
 
       def save_changes
-        click_button(I18n.t("js.save"))
+        find("button", exact_text: I18n.t("js.save"), visible: :all).click
         find(".saved", exact_text: I18n.t("js.saved"))
         self
       end

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -19,7 +19,7 @@ module PageObjects
 
       def save_changes
         find("button", text: I18n.t("js.save").click
-        find(".saved", text: I18n.t("js.saved")
+        find(".saved", text: I18n.t("js.saved"))
         self
       end
 

--- a/spec/system/user_preferences_interface_spec.rb
+++ b/spec/system/user_preferences_interface_spec.rb
@@ -2,33 +2,25 @@
 
 describe "User preferences for Interface", type: :system, js: true do
   fab!(:user) { Fabricate(:user) }
+
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
   let(:user_preferences_interface_page) { PageObjects::Pages::UserPreferencesInterface.new }
 
   before { sign_in(user) }
 
   describe "Bookmarks" do
+    let(:preferences) { Bookmark.auto_delete_preferences }
+    let(:dropdown) { PageObjects::Components::SelectKit.new("#bookmark-after-notification-mode") }
+
     it "changes the bookmark after notification preference" do
       user_preferences_page.visit(user)
-      click_link(I18n.t("js.user.preferences_nav.interface"))
-
-      dropdown = PageObjects::Components::SelectKit.new("#bookmark-after-notification-mode")
+      user_preferences_page.click_interface_tab
 
       # preselects the default user_option.bookmark_auto_delete_preference value of 3 (clear_reminder)
-      expect(dropdown).to have_selected_value(Bookmark.auto_delete_preferences[:clear_reminder])
+      expect(dropdown).to have_selected_value(preferences[:clear_reminder])
 
-      dropdown.select_row_by_value(Bookmark.auto_delete_preferences[:when_reminder_sent])
-      click_button(I18n.t("js.save"))
-
-      # the preference page reloads after saving, so we need to poll the db
-      try_until_success(timeout: 20) do
-        expect(
-          UserOption.exists?(
-            user_id: user.id,
-            bookmark_auto_delete_preference: Bookmark.auto_delete_preferences[:when_reminder_sent],
-          ),
-        ).to be_truthy
-      end
+      dropdown.select_row_by_value(preferences[:when_reminder_sent])
+      user_preferences_interface_page.save_changes
     end
   end
 end

--- a/spec/system/user_preferences_interface_spec.rb
+++ b/spec/system/user_preferences_interface_spec.rb
@@ -10,7 +10,7 @@ describe "User preferences for Interface", type: :system, js: true do
 
   describe "Bookmarks" do
     let(:preferences) { Bookmark.auto_delete_preferences }
-    let(:dropdown) { PageObjects::Components::SelectKit.new("#bookmark-after-notification-mode") }
+    let(:dropdown) { user_preferences_interface_page.bookmark_after_notification_mode_dropdown }
 
     it "changes the bookmark after notification preference" do
       user_preferences_page.visit(user)


### PR DESCRIPTION
I understand the appeal of checking DB to ensure an action has gone from end to end but generally speaking I think we should always only try to check UI state.

This case is a little bit special as it's one of  these cases where UI state doesn’t change much and especially it doesn’t create a new "object" on screen, like creating a post would do for example.

---

This commit also removes one expectation from the page object, while there are debates on wether expectations should be in page objects or not, we generally have not been doing it so far. Checking for presence of the object will fail just like an expectation if the object is not present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
