### PR TITLE
DEV: Rescue the timeout error for a better spec cleanup

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -178,9 +178,7 @@ module TurboTests
         env["DISCOURSE_RSPEC_PROFILE_EACH_EXAMPLE"] = "1" if @profile
 
         if @verbose
-          command_str =
-            [env.map { |k, v| "#{k}=#{v}" }.join(" "), command.join(" ")].select { |x| x.size > 0 }
-              .join(" ")
+          command_str = [env.map { |k, v| "#{k}=#{v}" }.join(" "), command.join(" ")].join(" ")
 
           STDOUT.puts "::group::[#{process_id}] Run RSpec" if ENV["GITHUB_ACTIONS"]
           STDOUT.puts "Process #{process_id}: #{command_str}"

--- a/plugins/chat/spec/system/browse_page_spec.rb
+++ b/plugins/chat/spec/system/browse_page_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Browse page", type: :system, js: true do
       end
     end
 
-    context "when filtering resuls" do
+    context "when filtering results" do
       fab!(:category_channel_1) { Fabricate(:chat_channel, name: "foo") }
       fab!(:category_channel_2) { Fabricate(:chat_channel, name: "bar") }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -360,12 +360,18 @@ RSpec.configure do |config|
   end
 
   if ENV["CI"]
+    class SpecTimeoutError < StandardError
+    end
+
     config.around do |example|
       Timeout.timeout(
         PER_SPEC_TIMEOUT_SECONDS,
-        nil,
+        SpecTimeoutError,
         "Spec timed out after #{PER_SPEC_TIMEOUT_SECONDS} seconds",
-      ) { example.run }
+      ) do
+        example.run
+      rescue SpecTimeoutError
+      end
     end
   end
 


### PR DESCRIPTION
Rescuing them still makes timing-out tests fail but doesn't break `after` spec cleanup (which could trigger more errors) Using custom error class to avoid any other possible timeout-catching code.

Also:
* remove an unnecessary `.select { |x| x.size > 0 }`
* fix a typo in a test title