### PR TITLE
UX: Fix post history raw view

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -35,7 +35,7 @@
     .row:first-of-type {
       margin-top: 10px;
     }
-    table {
+    .revision-content table {
       thead {
         th {
           padding-bottom: 2px;


### PR DESCRIPTION
The post history raw view was broken by my previous PR. This commit fixes it.

Before:
![image](https://github.com/discourse/discourse/assets/5654300/40568077-8b48-4570-a147-ab6b3aa44771)

After:
![image](https://github.com/discourse/discourse/assets/5654300/061de355-c875-4d3f-af44-9b2ff20b3eec)