### PR TITLE
DEV: Remove skipped form template system spec

### DIFF
--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -10,10 +10,6 @@ describe "Admin Customize Form Templates", type: :system, js: true do
   end
 
   before do
-    skip(<<~TEXT) if ENV["CI"]
-    The specs here are extremely flaky on CI for some reason.
-    TEXT
-
     SiteSetting.experimental_form_templates = true
     sign_in(admin)
   end

--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -3,11 +3,10 @@
 describe "Admin Customize Form Templates", type: :system, js: true do
   let(:form_template_page) { PageObjects::Pages::FormTemplate.new }
   let(:ace_editor) { PageObjects::Components::AceEditor.new }
+
   fab!(:admin) { Fabricate(:admin) }
   fab!(:form_template) { Fabricate(:form_template) }
-  fab!(:category) do
-    Fabricate(:category, name: "Cool Category", slug: "cool-cat", topic_count: 3234)
-  end
+  fab!(:category) { Fabricate(:category) }
 
   before do
     SiteSetting.experimental_form_templates = true
@@ -15,7 +14,7 @@ describe "Admin Customize Form Templates", type: :system, js: true do
   end
 
   describe "when visiting the page to customize form templates" do
-    before { category.update(form_template_ids: [form_template.id]) }
+    before { category.update!(form_template_ids: [form_template.id]) }
 
     it "should show the existing form templates in a table" do
       visit("/admin/customize/form-templates")

--- a/spec/system/page_objects/pages/form_template.rb
+++ b/spec/system/page_objects/pages/form_template.rb
@@ -31,7 +31,7 @@ module PageObjects
 
       # Form Template new/edit form related
       def type_in_template_name(input)
-        find(".form-templates__form-name-input").send_keys(input)
+        find(".form-templates__form-name-input").fill_in(with: input)
         self
       end
 


### PR DESCRIPTION
This PR removes the `skip` for the `admin_customize_form_templates_spec`