### PR TITLE
DEV: Allow color scheme loading to be used async

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
+++ b/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
@@ -54,7 +54,7 @@ export function loadColorSchemeStylesheet(
   darkMode = false
 ) {
   const themeId = theme_id ? `/${theme_id}` : "";
-  ajax(`/color-scheme-stylesheet/${colorSchemeId}${themeId}.json`).then(
+  return ajax(`/color-scheme-stylesheet/${colorSchemeId}${themeId}.json`).then(
     (result) => {
       if (result && result.new_href) {
         const elementId = darkMode ? "cs-preview-dark" : "cs-preview-light";


### PR DESCRIPTION
In a theme component, I'm looking to use this via: 

```
loadColorSchemeStylesheet(colorSchemeId, this.themeId, true).then(...)
```