### PR TITLE
DEV: Added modifier hooks to allow plugins to tweak how categories and groups are fetched

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -80,6 +80,11 @@ class GroupsController < ApplicationController
       type_filters = type_filters - %i[my owner]
     end
 
+    modifiers = []
+    # some plugins may need to change the query
+    DiscourseEvent.trigger(:query_groups_list, modifiers, groups, @guardian, params)
+    modifiers.each { |mod| groups = mod.call(groups) }
+
     type_filters.delete(:non_automatic)
 
     # count the total before doing pagination

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -129,6 +129,11 @@ class CategoryList
 
     @categories = self.class.order_categories(@categories)
 
+    modifiers = []
+    # some plugins may need to change the categories cached on site load
+    DiscourseEvent.trigger(:query_categories_list, modifiers, @categories, @guardian, @options)
+    modifiers.each { |mod| @categories = mod.call(@categories) }
+
     @categories = @categories.to_a
 
     include_subcategories = @options[:include_subcategories] == true

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -657,14 +657,17 @@ class Group < ActiveRecord::Base
     groups ||= Group
 
     relation =
-      groups.where("name ILIKE :term_like OR full_name ILIKE :term_like", term_like: "%#{name}%")
+      groups.where(
+        "groups.name ILIKE :term_like OR groups.full_name ILIKE :term_like",
+        term_like: "%#{name}%",
+      )
 
     if sort == :auto
       prefix = "#{name.gsub("_", "\\_")}%"
       relation =
         relation.reorder(
           DB.sql_fragment(
-            "CASE WHEN name ILIKE :like OR full_name ILIKE :like THEN 0 ELSE 1 END ASC, name ASC",
+            "CASE WHEN groups.name ILIKE :like OR groups.full_name ILIKE :like THEN 0 ELSE 1 END ASC, groups.name ASC",
             like: prefix,
           ),
         )

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -71,20 +71,29 @@ class Site
       .cache
       .fetch(categories_cache_key, expires_in: 30.minutes) do
         categories =
-          Category
-            .includes(
-              :uploaded_logo,
-              :uploaded_logo_dark,
-              :uploaded_background,
-              :tags,
-              :tag_groups,
-              :form_templates,
-              category_required_tag_groups: :tag_group,
-            )
-            .joins("LEFT JOIN topics t on t.id = categories.topic_id")
-            .select("categories.*, t.slug topic_slug")
-            .order(:position)
-            .to_a
+          begin
+            query =
+              Category
+                .includes(
+                  :uploaded_logo,
+                  :uploaded_logo_dark,
+                  :uploaded_background,
+                  :tags,
+                  :tag_groups,
+                  :form_templates,
+                  category_required_tag_groups: :tag_group,
+                  )
+                .joins("LEFT JOIN topics t on t.id = categories.topic_id")
+                .select("categories.*, t.slug topic_slug")
+                .order(:position)
+
+            modifiers = []
+            # some plugins may need to change the categories cached on site load
+            DiscourseEvent.trigger(:site_query_categories, modifiers, query, @guardian)
+            modifiers.each { |mod| query = mod.call(query) }
+
+            query.to_a
+          end
 
         if preloaded_category_custom_fields.present?
           Category.preload_custom_fields(categories, preloaded_category_custom_fields)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -630,7 +630,7 @@ class Search
       Group
         .visible_groups(@guardian.user)
         .members_visible_groups(@guardian.user)
-        .where("groups.name ILIKE ? OR (id = ? AND id > 0)", match, match.to_i)
+        .where("groups.name ILIKE ? OR (groups.id = ? AND groups.id > 0)", match, match.to_i)
 
     DiscoursePluginRegistry.search_groups_set_query_callbacks.each do |cb|
       group_query = cb.call(group_query, @term, @guardian)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -157,6 +157,32 @@ RSpec.describe Site do
 
       expect(site.categories.map { |c| c[:can_edit] }).to contain_exactly(true, true)
     end
+
+    describe "site_all_categories_cache_query modifier" do
+      fab!(:cool_category) { Fabricate(:category, name: "Cool category") }
+      fab!(:boring_category) { Fabricate(:category, name: "Boring category") }
+
+      it "allows changing the query" do
+        prefetched_categories = Site.new(Guardian.new(user)).categories.map { |c| c[:id] }
+        expect(prefetched_categories).to include(cool_category.id, boring_category.id)
+
+        # we need to clear the cache to ensure that the categories list will be updated
+        Site.clear_cache
+
+        Plugin::Instance
+          .new
+          .register_modifier(:site_all_categories_cache_query) do |query|
+            query.where("categories.name LIKE 'Cool%'")
+          end
+
+        prefetched_categories = Site.new(Guardian.new(user)).categories.map { |c| c[:id] }
+
+        expect(prefetched_categories).to include(cool_category.id)
+        expect(prefetched_categories).not_to include(boring_category.id)
+      ensure
+        DiscoursePluginRegistry.clear_modifiers!
+      end
+    end
   end
 
   it "omits groups user can not see" do
@@ -172,6 +198,31 @@ RSpec.describe Site do
     admin = Fabricate(:admin)
     site = Site.new(Guardian.new(admin))
     expect(site.groups.pluck(:name)).to include(staff_group.name, public_group.name, "everyone")
+  end
+
+  describe "site_groups_query modifier" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:cool_group) { Fabricate(:group, name: "cool-group") }
+    fab!(:boring_group) { Fabricate(:group, name: "boring-group") }
+
+    it "allows changing the query" do
+      prefetched_groups = Site.new(Guardian.new(user)).groups.map { |c| c[:id] }
+      expect(prefetched_groups).to include(cool_group.id, boring_group.id)
+
+      # we need to clear the cache to ensure that the groups list will be updated
+      Site.clear_cache
+
+      Plugin::Instance
+        .new
+        .register_modifier(:site_groups_query) { |query| query.where("groups.name LIKE 'cool%'") }
+
+      prefetched_groups = Site.new(Guardian.new(user)).groups.map { |c| c[:id] }
+
+      expect(prefetched_groups).to include(cool_group.id)
+      expect(prefetched_groups).not_to include(boring_group.id)
+    ensure
+      DiscoursePluginRegistry.clear_modifiers!
+    end
   end
 
   it "includes all enabled authentication providers" do


### PR DESCRIPTION
This commit adds modifiers that allow plugins to change how categories and groups are prefetched into the application and listed in the respective controllers.

Possible use cases: 

- prevent some categories/groups from being prefetched when the application loads for performance reasons.
- prevent some categories/groups from being listed in their respective index pages
