### PR TITLE
FIX: recover by showing drawer index on 404

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -75,12 +75,6 @@ export default class ChatDrawerRouter extends Service {
     }
 
     this.drawerRoute = ROUTES[route.name];
-
-    if (!this.drawerRoute) {
-      // TODO (joffrey) maybe we should implement the equivalent of a 404 here?
-      return;
-    }
-
     this.params = this.drawerRoute?.extractParams?.(route) || route.params;
     this.component = this.drawerRoute?.name || ChatDrawerIndex;
 


### PR DESCRIPTION
If the drawer receives an unexpected route, attempt to show the index. This is probably a more serious issue with subfolder but should limit the effects.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
