### PR TITLE
DEV: Disable splash screen in system tests

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -27,6 +27,7 @@ module SystemHelpers
     SiteSetting.external_system_avatars_enabled = false
     SiteSetting.disable_avatar_education_message = true
     SiteSetting.enable_user_tips = false
+    SiteSetting.splash_screen = false
   end
 
   def try_until_success(timeout: 2, frequency: 0.01)


### PR DESCRIPTION
Why is this change required?

We had a system test failed right after visiting a URL because an
element that was supposed to be on screen isn't. In the screenshot
captured, the app was still stuck on the splash screen. We're not sure
if this has been causing flakiness in our system tests but there is no
good reason to enable splash screen which adds some overhead to each
page load.