### PR TITLE
DEV: Avoid waiting full capybara default wait time

### DIFF
--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -88,7 +88,7 @@ describe "Composer Form Templates", type: :system, js: true do
   it "shows a form when a form template is assigned to the category" do
     category_page.visit(category_with_template_1)
     category_page.new_topic_button.click
-    expect(composer).not_to have_composer_input
+    expect(composer).to have_no_composer_input
     expect(composer).to have_form_template
     expect(composer).to have_form_template_field("checkbox")
   end
@@ -115,7 +115,7 @@ describe "Composer Form Templates", type: :system, js: true do
   it "does not show form template chooser when a category only has form template" do
     category_page.visit(category_with_template_1)
     category_page.new_topic_button.click
-    expect(composer).not_to have_form_template_chooser
+    expect(composer).to have_no_form_template_chooser
   end
 
   it "shows form template chooser when a category has multiple form templates" do

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -103,8 +103,14 @@ module PageObjects
         page.has_no_css?(emoji_preview_selector(emoji))
       end
 
+      COMPOSER_INPUT_SELECTOR = "#{COMPOSER_ID} .d-editor-input"
+
+      def has_no_composer_input?
+        page.has_no_css?(COMPOSER_INPUT_SELECTOR)
+      end
+
       def has_composer_input?
-        page.has_css?("#{COMPOSER_ID} .d-editor .d-editor-input")
+        page.has_css?(COMPOSER_INPUT_SELECTOR)
       end
 
       def has_form_template?
@@ -115,8 +121,14 @@ module PageObjects
         page.has_css?(".form-template-field[data-field-type='#{field}']")
       end
 
+      FORM_TEMPLATE_CHOOSER_SELECTOR = ".composer-select-form-template"
+
+      def has_no_form_template_chooser?
+        page.has_no_css?(FORM_TEMPLATE_CHOOSER_SELECTOR)
+      end
+
       def has_form_template_chooser?
-        page.has_css?(".composer-select-form-template")
+        page.has_css?(FORM_TEMPLATE_CHOOSER_SELECTOR)
       end
 
       def composer_input


### PR DESCRIPTION
Avoid using negated matchers with custom RSpec matchers that rely on
`has_css?` as it'll result in Capybara waiting the full default wait
time.