### PR TITLE
FIX: correctly uses getURL to open full page

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
@@ -1,3 +1,4 @@
+import getURL from "discourse-common/lib/get-url";
 import Component from "@ember/component";
 import { bind, observes } from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
@@ -191,7 +192,9 @@ export default Component.extend({
     this.chatStateManager.prefersFullPage();
     this.chat.activeChannel = null;
 
-    return this.router.transitionTo(this.chatStateManager.lastKnownChatURL);
+    return this.router.transitionTo(
+      getURL(this.chatStateManager.lastKnownChatURL)
+    );
   },
 
   @action


### PR DESCRIPTION
I will followup tomorrow with a more global solution to this problem.