### PR TITLE
DEV: Allow to see hidden posts for members of specified groups

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -57,6 +57,7 @@ export function transformBasicPost(post) {
     canPermanentlyDelete: false,
     showFlagDelete: false,
     canRecover: post.can_recover,
+    canSeeHiddenPost: post.can_see_hidden_post,
     canEdit: post.can_edit,
     canFlag: !post.get("topic.deleted") && !isEmpty(post.get("flagsAvailable")),
     canReviewTopic: false,

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -497,10 +497,7 @@ createWidget("post-contents", {
 
     result = result.concat(applyDecorators(this, "after-cooked", attrs, state));
 
-    if (
-      attrs.cooked_hidden &&
-      (this.currentUser?.isLeader || attrs.user_id === this.currentUser?.id)
-    ) {
+    if (attrs.cooked_hidden && attrs.canSeeHiddenPost) {
       result.push(this.attach("expand-hidden", attrs));
     }
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -43,6 +43,7 @@ class PostSerializer < BasicPostSerializer
              :can_delete,
              :can_permanently_delete,
              :can_recover,
+             :can_see_hidden_post,
              :can_wiki,
              :link_counts,
              :read,
@@ -178,6 +179,10 @@ class PostSerializer < BasicPostSerializer
 
   def can_recover
     scope.can_recover_post?(object)
+  end
+
+  def can_see_hidden_post
+    scope.can_see_hidden_post?(object)
   end
 
   def can_wiki

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1700,6 +1700,7 @@ en:
     enable_badges: "Enable the badge system"
     max_favorite_badges: "Maximum number of badges that user can select"
     whispers_allowed_groups: "Allow private communication within topics for members of specified groups."
+    hidden_post_visible_groups: "Allow to see hidden posts for members of specified groups."
 
     allow_index_in_robots_txt: "Specify in robots.txt that this site is allowed to be indexed by web search engines. In exceptional cases you can permanently <a href='%{base_path}/admin/customize/robots'>override robots.txt</a>."
     blocked_email_domains: "A pipe-delimited list of email domains that users are not allowed to register accounts with. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported. Example: mailinator.com|trashmail.net"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -336,6 +336,12 @@ basic:
     default: ""
     allow_any: false
     refresh: true
+  hidden_post_visible_groups:
+    type: group_list
+    list_type: compact
+    default: "3|14"
+    allow_any: false
+    refresh: true  
   enable_bookmarks_with_reminders:
     client: true
     default: true

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -284,8 +284,12 @@ module PostGuardian
   end
 
   def can_see_hidden_post?(post)
+    if SiteSetting.hidden_post_visible_groups_map.include?(Group::AUTO_GROUPS[:everyone])
+      return true
+    end
     return false if anonymous?
-    post.user_id == @user.id || @user.has_trust_level_or_staff?(TrustLevel[4])
+    return true if is_admin?
+    post.user_id == @user.id || @user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
   end
 
   def can_view_edit_history?(post)

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -12,20 +12,7 @@ RSpec.describe PostGuardian do
   fab!(:hidden_post) { Fabricate(:post, topic: topic, hidden: true) }
 
   describe "#can_see_hidden_post?" do
-    it "returns false for anonymous users" do
-      expect(Guardian.new(anon).can_see_hidden_post?(hidden_post)).to eq(false)
-    end
-
-    it "returns false for TL3 users" do
-      expect(Guardian.new(tl3_user).can_see_hidden_post?(hidden_post)).to eq(false)
-    end
-
-    it "returns true for TL4 users" do
-      expect(Guardian.new(tl4_user).can_see_hidden_post?(hidden_post)).to eq(true)
-    end
-
-    it "returns true for staff users" do
-      expect(Guardian.new(moderator).can_see_hidden_post?(hidden_post)).to eq(true)
+    it "returns true for admin users" do
       expect(Guardian.new(admin).can_see_hidden_post?(hidden_post)).to eq(true)
     end
   end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

This commit adds a new site_setting to discourse, allowing custom groups to view hidden posts instead of TL4 users.

https://meta.discourse.org/t/allows-configuring-which-groups-can-view-posts-hidden-by-flags/266433/6?u=lhc_fl