### PR TITLE
FIX: prevents admins to be silenced

### DIFF
--- a/plugins/chat/lib/chat/review_queue.rb
+++ b/plugins/chat/lib/chat/review_queue.rb
@@ -87,6 +87,7 @@ module Chat
       return if reviewable.score <= Chat::ReviewableMessage.score_to_silence_user
 
       user = reviewable.target_created_by
+      return if user.admin?
       return unless user
       return if user.silenced?
 

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -369,6 +369,18 @@ describe Chat::ReviewQueue do
 
         expect(message_poster.reload.silenced?).to eq(false)
       end
+
+      context "when the target is an admin" do
+        it "does not silence the user" do
+          SiteSetting.chat_auto_silence_from_flags_duration = 1
+          flagger.update!(trust_level: TrustLevel[4]) # Increase Score due to TL Bonus.
+          message_poster.update!(admin: true)
+
+          queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+          expect(message_poster.reload.silenced?).to eq(false)
+        end
+      end
     end
 
     context "when flagging a DM" do


### PR DESCRIPTION
Currently in chat it was possible to have TL4 users to flag admins and silence them through the auto silence feature of chat, this change should ensure it's never possible.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
