### PR TITLE
DEV: ensures thread list has finished loading

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -225,6 +225,7 @@ module PageObjects
 
       def open_thread_list
         find(thread_list_button_selector).click
+        PageObjects::Components::Chat::ThreadList.new.has_loaded?
       end
 
       def has_unread_thread_indicator?(count:)

--- a/plugins/chat/spec/system/page_objects/chat/components/thread_list.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_list.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    module Chat
+      class ThreadList < PageObjects::Components::Base
+        SELECTOR = ".chat-thread-list"
+
+        def component
+          find(SELECTOR)
+        end
+
+        def has_loaded?
+          component.has_css?(".spinner", wait: 0)
+          component.has_no_css?(".spinner")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should fix this failure:

```
Failures:

  1) Thread list in side panel | full page when there are no threads that the user is participating in shows a message
     Failure/Error: measurement = Benchmark.measure { example.run }
       expected to find text "You are not participating in any threads in this channel." in "Community\nEverything\nMy Posts\nMore\nMessages\nInbox\nChannels\nRandom 25\nPersonal chat\nRandom 25\nShowing all messages\nOngoing discussions"
```

The screenshot failure was clearly showing the spinner still being present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
