### PR TITLE
DEV: Unskip system tests that were previously marked as flaky

### DIFF
--- a/plugins/chat/spec/system/archive_channel_spec.rb
+++ b/plugins/chat/spec/system/archive_channel_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Archive channel", type: :system, js: true do
           )
         end
 
-        xit "can be retried" do
+        it "can be retried" do
           Jobs.run_immediately!
 
           chat.visit_channel(channel_1)

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Chat composer", type: :system, js: true do
   end
 
   context "when adding an emoji through the picker" do
-    xit "adds the emoji to the composer" do
+    it "adds the emoji to the composer" do
       chat_page.visit_channel(channel_1)
       channel_page.open_action_menu
       channel_page.click_action_button("emoji")
@@ -131,7 +131,7 @@ RSpec.describe "Chat composer", type: :system, js: true do
   end
 
   context "when opening emoji picker through more button of the autocomplete" do
-    xit "prefills the emoji picker filter input" do
+    it "prefills the emoji picker filter input" do
       chat_page.visit_channel(channel_1)
       find(".chat-composer__input").fill_in(with: ":gri")
 
@@ -140,7 +140,7 @@ RSpec.describe "Chat composer", type: :system, js: true do
       expect(find(".chat-emoji-picker .dc-filter-input").value).to eq("gri")
     end
 
-    xit "filters with the prefilled input" do
+    it "filters with the prefilled input" do
       chat_page.visit_channel(channel_1)
       find(".chat-composer__input").fill_in(with: ":fr")
 

--- a/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "Message notifications - with sidebar", type: :system, js: true d
         end
 
         context "when messages are created" do
-          xit "correctly renders notifications" do
+          it "correctly renders notifications" do
             using_session(:current_user) { visit("/") }
 
             using_session(:user_1) { create_message(channel: channel_1, creator: user_1) }

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -51,7 +51,7 @@ describe "Uploading files in chat messages", type: :system, js: true do
       expect(Chat::Message.last.uploads.count).to eq(2)
     end
 
-    xit "allows uploading a huge image file with preprocessing" do
+    it "allows uploading a huge image file with preprocessing" do
       SiteSetting.composer_media_optimization_image_bytes_optimization_threshold = 200.kilobytes
       chat.visit_channel(channel_1)
       file_path = file_from_fixtures("huge.jpg", "images").path

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
 
         before { group.add(current_user) }
 
-        xit "shows a group mention notification" do
+        it "shows a group mention notification" do
           message =
             Chat::MessageCreator.create(
               chat_channel: channel_1,
@@ -157,7 +157,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
       end
 
       context "when @all" do
-        xit "shows a mention notification" do
+        it "shows a mention notification" do
           message =
             Chat::MessageCreator.create(
               chat_channel: channel_1,
@@ -191,7 +191,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
 
     before { channel_1.add(current_user) }
 
-    xit "shows an invitation notification" do
+    it "shows an invitation notification" do
       Jobs.run_immediately!
 
       chat.visit_channel(channel_1)

--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -8,7 +8,6 @@ describe "Composer using review_media", type: :system, js: true do
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
-    skip("Currently flaky on CI")
     SiteSetting.review_media_unless_trust_level = 3
     sign_in user
   end

--- a/spec/system/emojis/emoji_deny_list_spec.rb
+++ b/spec/system/emojis/emoji_deny_list_spec.rb
@@ -47,7 +47,7 @@ describe "Emoji deny list", type: :system, js: true do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: topic) }
 
-    xit "should remove denied emojis from emoji picker" do
+    it "should remove denied emojis from emoji picker" do
       topic_page.visit_topic_and_open_composer(topic)
       expect(composer).to be_opened
 


### PR DESCRIPTION
We believe the system tests were flaky due to the problem identified in 4dd053a69c073e7662f1718f70160b67deb4fd49