### PR TITLE
Revert "PERF: Client side triggering multiple requests when opening composer (#21823)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -170,7 +170,20 @@ export default Component.extend(KeyEnterEscape, {
 
   didInsertElement() {
     this._super(...arguments);
+
     this.setupComposerResizeEvents();
+
+    const triggerOpen = () => {
+      if (this.get("composer.composeState") === Composer.OPEN) {
+        this.appEvents.trigger("composer:opened");
+      }
+    };
+    triggerOpen();
+
+    this.element.addEventListener("transitionend", () => {
+      triggerOpen();
+    });
+
     positioningWorkaround(this.element);
   },
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -5,7 +5,6 @@ import discourseComputed, {
   observes,
   on,
 } from "discourse-common/utils/decorators";
-import discourseLater from "discourse-common/lib/later";
 import {
   emailValid,
   escapeExpression,
@@ -226,12 +225,6 @@ const Composer = RestModel.extend({
     if (this.composeState === OPEN) {
       this.set("composerOpened", oldOpen || new Date());
       elem.classList.add("composer-open");
-
-      // If the duration changes here, it must also be changed in `stylesheets/common/base/compose.scss` which is where
-      // the transition duration is defined. A delay is added here as we only want to fire the event after the transition ends.
-      discourseLater(() => {
-        this.appEvents.trigger("composer:opened");
-      }, 250);
     } else {
       if (oldOpen) {
         const oldTotal = this.composerTotalOpened || 0;

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
@@ -138,6 +138,9 @@ acceptance("Composer - Messages - Duplicate links", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("button.create");
 
+    // Work around the lack of CSS transitions in the test env
+    query("#reply-control").dispatchEvent(new Event("transitionend"));
+
     assert
       .dom(".composer-popup")
       .doesNotExist("composer warning is not shown by default");

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -23,11 +23,8 @@ html.composer-open {
     min-width: 0;
   }
   z-index: z("composer", "content");
-
-  // If the transition duration is changed here, it must also be changed in the `composeStateChanged` function of models/composer.js
   transition: height 250ms ease, background 250ms ease, transform 250ms ease,
     max-width 250ms ease, padding-bottom 250ms ease;
-
   background-color: var(--secondary);
   box-shadow: shadow("composer");
 

--- a/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
+++ b/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
@@ -12,6 +12,10 @@ describe "Composer don't feed the trolls popup", type: :system, js: true do
   before { sign_in user }
 
   it "shows a popup when about to reply to a troll" do
+    skip(
+      "TGX: This does not work when Capybara.disable_animation is set to true. We're in the midst of fixing this.",
+    )
+
     SiteSetting.educate_until_posts = 0
 
     topic_page.visit_topic(topic)


### PR DESCRIPTION
This reverts commit e1ba4c6b73b9a26ccfd43499c223ce865bdf79a3.

Tests are flaky. See https://github.com/discourse/discourse/actions/runs/5133211966/jobs/9235502848?pr=21857