### PR TITLE
UX: Remove title and description block if blank

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -683,9 +683,7 @@ en:
     body: |
       We are so glad you joined us.
 
-      > ## %{site_title}
-      >
-      > %{site_description}
+      %{site_info_quote}
 
       Here are some things you can do to get started:
 

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -98,6 +98,17 @@ module SeedData
       if include_welcome_topics
         # Welcome Topic
         if general_category = Category.find_by(id: SiteSetting.general_category_id)
+          site_info_quote =
+            if SiteSetting.title.present? && SiteSetting.site_description.present?
+              <<~RAW
+              > ## #{SiteSetting.title}
+              >
+              > #{SiteSetting.site_description}
+              RAW
+            else
+              ""
+            end
+
           topics << {
             site_setting_name: "welcome_topic_id",
             title: I18n.t("discourse_welcome_topic.title", site_title: SiteSetting.title),
@@ -107,6 +118,7 @@ module SeedData
                 base_path: Discourse.base_path,
                 site_title: SiteSetting.title,
                 site_description: SiteSetting.site_description,
+                site_info_quote: site_info_quote,
               ),
             category: general_category,
             after_create: proc { |post| post.topic.update_pinned(true, true) },

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe SeedData::Topics do
           base_path: Discourse.base_path,
           site_title: SiteSetting.title,
           site_description: SiteSetting.site_description,
+          site_info_quote: "",
         ).rstrip,
       )
       expect(topic.category_id).to eq(SiteSetting.general_category_id)
@@ -78,6 +79,27 @@ RSpec.describe SeedData::Topics do
       expect(SiteSetting.tos_topic_id).to eq(-1)
     end
 
+    it "creates a welcome topic without site title" do
+      SiteSetting.title = "My Awesome Community"
+      SiteSetting.site_description = ""
+
+      create_topic
+
+      post = Post.find_by(topic_id: SiteSetting.welcome_topic_id, post_number: 1)
+      expect(post.raw).not_to include("> ## My Awesome Community")
+    end
+
+    it "creates a welcome topic with site title and description" do
+      SiteSetting.title = "My Awesome Community"
+      SiteSetting.site_description = "The best community"
+
+      create_topic
+
+      post = Post.find_by(topic_id: SiteSetting.welcome_topic_id, post_number: 1)
+      expect(post.raw).to include("> ## My Awesome Community")
+      expect(post.raw).to include("> The best community")
+    end
+
     it "creates a legal topic if company_name is set" do
       SiteSetting.company_name = "Company Name"
       subject.create(site_setting_names: ["tos_topic_id"])
@@ -110,6 +132,7 @@ RSpec.describe SeedData::Topics do
           base_path: Discourse.base_path,
           site_title: SiteSetting.title,
           site_description: SiteSetting.site_description,
+          site_info_quote: "",
         ).rstrip,
       )
     end


### PR DESCRIPTION
If the description is empty then it does not make sense to keep the quote block that contains just the title.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
