### PR TITLE
FIX: Do not add mentioned groups as mentioned users

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -415,6 +415,11 @@ export default class ChatComposer extends Component {
     }
   }
 
+  #addMentionedUser(userData) {
+    const user = User.create(userData);
+    this.currentMessage.mentionedUsers.set(user.id, user);
+  }
+
   #applyUserAutocomplete($textarea) {
     if (!this.siteSettings.enable_mentions) {
       return;
@@ -426,10 +431,9 @@ export default class ChatComposer extends Component {
       width: "100%",
       treatAsTextarea: true,
       autoSelectFirstSuggestion: true,
-      transformComplete: (userData) => {
-        const user = User.create(userData);
-        this.currentMessage.mentionedUsers.set(user.id, user);
-        return user.username || user.name;
+      transformComplete: (obj) => {
+        this.#addMentionedUser(obj);
+        return obj.username || obj.name;
       },
       dataSource: (term) => {
         return userSearch({ term, includeGroups: true }).then((result) => {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -432,7 +432,10 @@ export default class ChatComposer extends Component {
       treatAsTextarea: true,
       autoSelectFirstSuggestion: true,
       transformComplete: (obj) => {
-        this.#addMentionedUser(obj);
+        if (obj.isUser) {
+          this.#addMentionedUser(obj);
+        }
+
         return obj.username || obj.name;
       },
       dataSource: (term) => {


### PR DESCRIPTION
When a user type a message with mentions, the autocomplete popup may suggest users or groups. Here it suggests a group:

<img width="459" alt="Screenshot 2023-06-01 at 00 30 08" src="https://github.com/discourse/discourse/assets/1274517/e956e746-0547-4aea-9dfc-b694d8793e4a">

We were adding all these object to the `currentMessage.mentionedUsers` collection, while we should have been adding only users. A group added to that collection led to the error later when trying to update user status on mentions:

<img width="528" alt="Screenshot 2023-06-01 at 00 33 50" src="https://github.com/discourse/discourse/assets/1274517/66e306e0-969d-4e24-a487-4c85b99c183b">

This PR makes sure we add only users to the collection.







