### PR TITLE
FIX: Elements floating away on overscroll in Safari

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -432,6 +432,10 @@ export default SiteHeaderComponent.extend({
   updateHeaderOffset() {
     let headerWrapTop = this.headerWrap.getBoundingClientRect().top;
 
+    if (headerWrapTop !== 0) {
+      headerWrapTop -= Math.max(0, document.body.getBoundingClientRect().top);
+    }
+
     if (DEBUG && isTesting()) {
       headerWrapTop -= document
         .getElementById("ember-testing-container")


### PR DESCRIPTION
This issue:
<img src="https://github.com/discourse/discourse/assets/66961/9f791114-748d-42b5-932e-efa22d8c7687" width="300">
(notice the sidebar detaching from the header on overscroll)

The bug also affected e.g. mini_profiler widget