### PR TITLE
DEV: Use `has_no_css?` instead of `!has_css?`

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -18,14 +18,11 @@ module PageObjects
       end
 
       def has_drawer?(channel_id: nil, expanded: true)
-        selector = ".chat-drawer"
-        selector += ".is-expanded" if expanded
-        selector += "[data-chat-channel-id=\"#{channel_id}\"]" if channel_id
-        has_css?(selector)
+        drawer?(expectation: true, channel_id: channel_id, expanded: expanded)
       end
 
-      def has_no_drawer?(**args)
-        !has_drawer?(**args)
+      def has_no_drawer?(channel_id: nil, expanded: true)
+        drawer?(expectation: false, channel_id: channel_id, expanded: expanded)
       end
 
       def visit_channel(channel, message_id: nil)
@@ -84,6 +81,15 @@ module PageObjects
 
       def has_no_new_channel_button?
         has_no_css?(NEW_CHANNEL_BUTTON_SELECTOR)
+      end
+
+      private
+
+      def drawer?(expectation:, channel_id: nil, expanded: true)
+        selector = ".chat-drawer"
+        selector += ".is-expanded" if expanded
+        selector += "[data-chat-channel-id=\"#{channel_id}\"]" if channel_id
+        expectation ? has_css?(selector) : has_no_css?(selector)
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
@@ -12,7 +12,7 @@ module PageObjects
       end
 
       def has_no_open_thread?
-        !has_css?(".chat-side-panel .chat-thread")
+        has_no_css?(".chat-side-panel .chat-thread")
       end
 
       def has_open_thread_list?


### PR DESCRIPTION
If we're asserting that something is missing, we want to use
`has_no_css?` instead of `!has_css?` since `has_css?` will wait the full
capybara default wait time before return if the selector is not present.