### PR TITLE
DEV: Update checks in chat channel and thread page objects

### DIFF
--- a/plugins/chat/spec/system/chat_message_onebox_spec.rb
+++ b/plugins/chat/spec/system/chat_message_onebox_spec.rb
@@ -37,7 +37,10 @@ RSpec.describe "Chat message onebox", type: :system, js: true do
 
     it "is oneboxed" do
       chat_page.visit_channel(channel_1)
-      channel_page.send_message("https://en.wikipedia.org/wiki/Hyperlink")
+      channel_page.send_message(
+        "https://en.wikipedia.org/wiki/Hyperlink",
+        check_message_presence: false,
+      )
 
       expect(page).to have_content("This is a test", wait: 20)
     end

--- a/plugins/chat/spec/system/edited_message_spec.rb
+++ b/plugins/chat/spec/system/edited_message_spec.rb
@@ -39,7 +39,12 @@ RSpec.describe "Edited message", type: :system, js: true do
       message_1 = Fabricate(:chat_message, chat_channel: channel_1, user: current_user)
       chat_page.visit_channel(channel_1)
 
-      channel_page.edit_message(message_1, '[date=2025-03-10 timezone="Europe/Paris"]')
+      channel_page.edit_message(
+        message_1,
+        '[date=2025-03-10 timezone="Europe/Paris"]',
+        check_message_presence: false,
+      )
+
       expect(page).to have_css(".cooked-date")
     end
   end

--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Message errors", type: :system, js: true do
       sign_in(current_user)
       chat_page.visit_channel(channel)
 
-      channel_page.send_message("atoolongmessage" + "a" * max_length)
+      channel_page.send_message("atoolongmessage" + "a" * max_length, check_message_presence: false)
 
       expect(page).to have_no_content("atoolongmessage")
       expect(page).to have_content(I18n.t("chat.errors.message_too_long", count: max_length))

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -120,19 +120,19 @@ module PageObjects
         find("[data-value='edit']").click
       end
 
-      def edit_message(message, text = nil)
+      def edit_message(message, text = nil, check_message_presence: true)
         open_edit_message(message)
-        send_message(text) if text
+        send_message(text, check_message_presence:) if text
       end
 
-      def send_message(text = nil)
+      def send_message(text = nil, check_message_presence: true)
         text ||= Faker::Lorem.characters(number: SiteSetting.chat_minimum_message_length)
         text = text.chomp if text.present? # having \n on the end of the string counts as an Enter keypress
         composer.fill_in(with: text)
         click_send_message
-        messages.has_message?(text: text, persisted: true)
+        expect(messages).to have_message(text: text, persisted: true) if check_message_presence
         click_composer
-        has_no_loading_skeleton?
+        expect(self).to have_no_loading_skeleton
         text
       end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -62,7 +62,7 @@ module PageObjects
         text = text.chomp if text.present? # having \n on the end of the string counts as an Enter keypress
         composer.fill_in(with: text)
         click_send_message
-        messages.has_message?(text: text, persisted: true)
+        expect(messages).to have_message(text: text, persisted: true)
         click_composer
         text
       end

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
 
         clip_text = copy_messages_to_clipboard(message_1)
         click_selection_button("cancel")
-        chat_channel_page.send_message(clip_text)
+        chat_channel_page.send_message(clip_text, check_message_presence: false)
 
         expect(page).to have_selector(".chat-message", count: 2)
         expect(page).to have_css(".chat-transcript")


### PR DESCRIPTION
What is the problem?
    
We were calling out to methods that calls `has_css?` or `has_selector?`
which returns a boolean. Since we are not using the return value, it
means the methods can be deemed unnecessary. However, we do want those
checks and this commit adds the necessarily assertions to make use of
 he return values.