### PR TITLE
DEV: Increase number of parallel process for system test to 5 on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,11 +194,11 @@ jobs:
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
-        run: PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --profile=50 --verbose --format documentation spec/system
+        run: PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation spec/system
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --profile=50 --verbose --format documentation plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots


### PR DESCRIPTION
4dd053a69c073e7662f1718f70160b67deb4fd49 addressed most of the
instability we were seeing with system tests on CI and locally. Let's
try pushing the number of parallel processes up to squeeze as much time
savings as possible from the runner.

## Before 

![Screenshot from 2023-06-01 10-26-02](https://github.com/discourse/discourse/assets/4335742/15fbec24-f27b-4348-8289-086e5e46124b)

## After

![Screenshot from 2023-06-01 10-25-57](https://github.com/discourse/discourse/assets/4335742/1f286c7b-f566-4c9b-857a-a867441f3900)
