### PR TITLE
DEV: Amend suggested topics when user has experimental new new view

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -235,17 +235,27 @@ class TopicQuery
           builder.add_results(unread_messages(pm_params.merge(count: builder.results_left)))
         end
       else
-        builder.add_results(
-          unread_results(
-            topic: topic,
-            per_page: builder.results_left,
-            max_age: SiteSetting.suggested_topics_unread_max_days_old,
-          ),
-          :high,
-        )
+        if @user.new_new_view_enabled?
+          builder.add_results(
+            new_and_unread_results(
+              topic:,
+              per_page: builder.results_left,
+              max_age: SiteSetting.suggested_topics_unread_max_days_old,
+            ),
+          )
+        else
+          builder.add_results(
+            unread_results(
+              topic: topic,
+              per_page: builder.results_left,
+              max_age: SiteSetting.suggested_topics_unread_max_days_old,
+            ),
+            :high,
+          )
 
-        unless builder.full?
-          builder.add_results(new_results(topic: topic, per_page: builder.category_results_left))
+          unless builder.full?
+            builder.add_results(new_results(topic: topic, per_page: builder.category_results_left))
+          end
         end
       end
     end
@@ -581,6 +591,7 @@ class TopicQuery
         base,
         treat_as_new_topic_start_date: @user.user_option.treat_as_new_topic_start_date,
       )
+
     new_results = remove_muted(new_results, @user, options)
     new_results = remove_dismissed(new_results, @user)
 


### PR DESCRIPTION
What does this change do?

Suggested topics by default are ordered in the following way:

1. Unread topics in current category of topic that is being viewed
2. Unread topics in other categories
3. New topics in current category of topics that is being viewed
4. New topics in other categories
5. Random topics

With the experimental new new view, we want to remove the concept of
read and new so that new order is as such:

1. Topics created by the current user with posts that the user has not
   read ordered by topic's bumped date
2. Topics in current category of topic with posts that the user has not
   read ordered by topic's bumped date
3. Topics in other categories with posts that the user has not read
   ordered by topic's bumped date
4. Random topics ordered by topic's bumped date