### PR TITLE
DEV: Fix flaky test

### DIFF
--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1246,13 +1246,13 @@ RSpec.describe TopicsFilter do
         end
 
         describe "when query string is `order:#{order}-invalid`" do
-          it "should return topics ordered by the default order" do
+          it "should return topics ordered by the database's default order" do
             expect(
               TopicsFilter
                 .new(guardian: Guardian.new)
                 .filter_from_query_string("order:#{order}-invalid")
                 .pluck(:id),
-            ).to eq(Topic.all.order(:id).pluck(:id))
+            ).to contain_exactly(*Topic.all.pluck(:id))
           end
         end
       end


### PR DESCRIPTION
```
  1) TopicsFilter#filter_from_query_string ordering topics filter when ordering topics by creation date when query string is `order:created-invalid` should return topics ordered by the default order
     Failure/Error:
       expect(
         TopicsFilter
           .new(guardian: Guardian.new)
           .filter_from_query_string("order:#{order}-invalid")
           .pluck(:id),
       ).to eq(Topic.all.order(:id).pluck(:id))

       expected: [484, 485, 486]
            got: [486, 484, 485]
```