### PR TITLE
DEV: Improve performance of system tests by disabling GPU in chrome

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -650,6 +650,7 @@ def apply_base_chrome_options(options)
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--mute-audio")
   options.add_argument("--force-device-scale-factor=1")
+  options.add_argument("--disable-gpu")
 end
 
 class SpecSecureRandom


### PR DESCRIPTION
It seems like the overhead of GPU acceleration is not worth it and is
slowing down our system tests. Locally the following command completes
in `2 minutes 8.6 seconds` with GPU disabled as compared to `2 minutes 45.4 seconds` with GPU enabled.

`LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=8 CAPYBARA_DEFAULT_MAX_WAIT_TIME=10 bin/turbo_rspec --seed=34908 --profile --verbose --format documentation plugins/chat/spec/system/`