### PR TITLE
Revert "DEV: Update checks in chat channel and thread page objects (#21875)"

### DIFF
--- a/plugins/chat/spec/system/chat_message_onebox_spec.rb
+++ b/plugins/chat/spec/system/chat_message_onebox_spec.rb
@@ -37,10 +37,7 @@ RSpec.describe "Chat message onebox", type: :system, js: true do
 
     it "is oneboxed" do
       chat_page.visit_channel(channel_1)
-      channel_page.send_message(
-        "https://en.wikipedia.org/wiki/Hyperlink",
-        check_message_presence: false,
-      )
+      channel_page.send_message("https://en.wikipedia.org/wiki/Hyperlink")
 
       expect(page).to have_content("This is a test", wait: 20)
     end

--- a/plugins/chat/spec/system/edited_message_spec.rb
+++ b/plugins/chat/spec/system/edited_message_spec.rb
@@ -39,12 +39,7 @@ RSpec.describe "Edited message", type: :system, js: true do
       message_1 = Fabricate(:chat_message, chat_channel: channel_1, user: current_user)
       chat_page.visit_channel(channel_1)
 
-      channel_page.edit_message(
-        message_1,
-        '[date=2025-03-10 timezone="Europe/Paris"]',
-        check_message_presence: false,
-      )
-
+      channel_page.edit_message(message_1, '[date=2025-03-10 timezone="Europe/Paris"]')
       expect(page).to have_css(".cooked-date")
     end
   end

--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Message errors", type: :system, js: true do
       sign_in(current_user)
       chat_page.visit_channel(channel)
 
-      channel_page.send_message("atoolongmessage" + "a" * max_length, check_message_presence: false)
+      channel_page.send_message("atoolongmessage" + "a" * max_length)
 
       expect(page).to have_no_content("atoolongmessage")
       expect(page).to have_content(I18n.t("chat.errors.message_too_long", count: max_length))

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -120,19 +120,19 @@ module PageObjects
         find("[data-value='edit']").click
       end
 
-      def edit_message(message, text = nil, check_message_presence: true)
+      def edit_message(message, text = nil)
         open_edit_message(message)
-        send_message(text, check_message_presence:) if text
+        send_message(text) if text
       end
 
-      def send_message(text = nil, check_message_presence: true)
+      def send_message(text = nil)
         text ||= Faker::Lorem.characters(number: SiteSetting.chat_minimum_message_length)
         text = text.chomp if text.present? # having \n on the end of the string counts as an Enter keypress
         composer.fill_in(with: text)
         click_send_message
-        expect(messages).to have_message(text: text, persisted: true) if check_message_presence
+        messages.has_message?(text: text, persisted: true)
         click_composer
-        expect(self).to have_no_loading_skeleton
+        has_no_loading_skeleton?
         text
       end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -62,7 +62,7 @@ module PageObjects
         text = text.chomp if text.present? # having \n on the end of the string counts as an Enter keypress
         composer.fill_in(with: text)
         click_send_message
-        expect(messages).to have_message(text: text, persisted: true)
+        messages.has_message?(text: text, persisted: true)
         click_composer
         text
       end

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
 
         clip_text = copy_messages_to_clipboard(message_1)
         click_selection_button("cancel")
-        chat_channel_page.send_message(clip_text, check_message_presence: false)
+        chat_channel_page.send_message(clip_text)
 
         expect(page).to have_selector(".chat-message", count: 2)
         expect(page).to have_css(".chat-transcript")


### PR DESCRIPTION
This reverts commit ddf4ecba04f3c6396615506ec595650f14986758.

Causing a flaky test to appear:

```
main $ LOAD_PLUGINS=1 rspec plugins/chat/spec/system/chat/composer/shortcuts/channel_spec.rb

Randomized with seed 17765
.....F..

Failures:

  1) Chat | composer | shortcuts | channel when using ArrowUp when last message is staged does not edit a message
     Failure/Error: channel_page.send_message
       expected `#<PageObjects::Components::Chat::Messages:0x00007fe823ac1710 @context=".chat-channel">.has_message?({:persisted=>true, :text=>"2"})` to be truthy, got false

     [Screenshot Image]: /home/tgxworld/work/discourse/tmp/capybara/failures_r_spec_example_groups_chat_composer_shortcuts_channel_when_using_arrow_up_when_last_message_is_staged_does_not_edit_a_message_148.png
```