### PR TITLE
FIX: Hide delete button to invite as user are unable to delete anyway

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -184,24 +184,26 @@
                       {{/if}}
                     </td>
 
-                    <td class="invite-actions">
-                      <DButton
-                        @class="btn-default"
-                        @icon="pencil-alt"
-                        @action={{action "editInvite" invite}}
-                        @title="user.invited.edit"
-                      />
-                      <DButton
-                        @icon="trash-alt"
-                        @class="cancel"
-                        @action={{action "destroyInvite" invite}}
-                        @title={{if
-                          invite.destroyed
-                          "user.invited.removed"
-                          "user.invited.remove"
-                        }}
-                      />
-                    </td>
+                    {{#if invite.can_delete_invite}}
+                      <td class="invite-actions">
+                        <DButton
+                          @class="btn-default"
+                          @icon="pencil-alt"
+                          @action={{action "editInvite" invite}}
+                          @title="user.invited.edit"
+                        />
+                        <DButton
+                          @icon="trash-alt"
+                          @class="cancel"
+                          @action={{action "destroyInvite" invite}}
+                          @title={{if
+                            invite.destroyed
+                            "user.invited.removed"
+                            "user.invited.remove"
+                          }}
+                        />
+                      </td>
+                    {{/if}}
                   </tr>
                 {{/each}}
               </tbody>

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -1,7 +1,6 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import {
   acceptance,
-  count,
   exists,
   fakeTime,
   loggedInUser,
@@ -57,15 +56,15 @@ acceptance("Invites - Create & Edit Invite Modal", function (needs) {
     await visit("/u/eviltrout/invited/pending");
     await click(".user-invite-buttons .btn:first-child");
 
-    assert.ok(!exists("tbody tr"), "does not show invite before saving");
+    assert
+      .dom("table.user-invite-list tbody tr")
+      .exists({ count: 2 }, "is seeded with two rows");
 
     await click(".btn-primary");
 
-    assert.strictEqual(
-      count("tbody tr"),
-      1,
-      "adds invite to list after saving"
-    );
+    assert
+      .dom("table.user-invite-list tbody tr")
+      .exists({ count: 3 }, "gets added to the list");
   });
 
   test("copying saves invite", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -224,7 +224,40 @@ export function applyDefaultHandlers(pretender) {
 
   pretender.get("/u/eviltrout/invited.json", () => {
     return response({
-      invites: [],
+      invites: [
+        {
+          id: 8,
+          invite_key: "hMFT8G1oKP",
+          link: "http://localhost:3000/invites/hMFT8G1oKP",
+          email: "steak@cat.com",
+          domain: null,
+          emailed: false,
+          can_delete_invite: true,
+          custom_message: null,
+          created_at: "2023-06-01T04:47:13.195Z",
+          updated_at: "2023-06-01T04:47:13.195Z",
+          expires_at: "2023-08-30T04:47:00.000Z",
+          expired: false,
+          topics: [],
+          groups: [],
+        },
+        {
+          id: 9,
+          invite_key: "hMFT8G1WHA",
+          link: "http://localhost:3000/invites/hMFT8G1WHA",
+          email: "tomtom@cat.com",
+          domain: null,
+          emailed: false,
+          can_delete_invite: false,
+          custom_message: null,
+          created_at: "2023-06-01T04:47:13.195Z",
+          updated_at: "2023-06-01T04:47:13.195Z",
+          expires_at: "2023-08-30T04:47:00.000Z",
+          expired: false,
+          topics: [],
+          groups: [],
+        },
+      ],
       can_see_invite_details: true,
       counts: {
         pending: 0,

--- a/app/assets/javascripts/discourse/tests/integration/components/user-invited-show-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-invited-show-test.js
@@ -1,18 +1,5 @@
-import { cloneJSON } from "discourse-common/lib/object";
-import userFixtures from "discourse/tests/fixtures/user-fixtures";
-import {
-  acceptance,
-  count,
-  exists,
-  loggedInUser,
-  publishToMessageBus,
-  query,
-  queryAll,
-  visible,
-} from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
-import I18n from "I18n";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { visit } from "@ember/test-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
 acceptance("User invites", function (needs) {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-invited-show-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-invited-show-test.js
@@ -1,0 +1,32 @@
+import { cloneJSON } from "discourse-common/lib/object";
+import userFixtures from "discourse/tests/fixtures/user-fixtures";
+import {
+  acceptance,
+  count,
+  exists,
+  loggedInUser,
+  publishToMessageBus,
+  query,
+  queryAll,
+  visible,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
+import I18n from "I18n";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { test } from "qunit";
+
+acceptance("User invites", function (needs) {
+  needs.user();
+
+  test("hides delete button based on can_delete_invite", async function (assert) {
+    await visit("/u/eviltrout/invited");
+
+    assert.dom("table.user-invite-list tbody tr").exists({ count: 2 });
+    assert
+      .dom("table.user-invite-list tbody tr:nth-child(1) button.cancel")
+      .exists();
+    assert
+      .dom("table.user-invite-list tbody tr:nth-child(2) button.cancel")
+      .doesNotExist();
+  });
+});

--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -7,6 +7,7 @@ class InviteSerializer < ApplicationSerializer
              :email,
              :domain,
              :emailed,
+             :can_delete_invite,
              :max_redemptions_allowed,
              :redemption_count,
              :custom_message,
@@ -28,6 +29,10 @@ class InviteSerializer < ApplicationSerializer
 
   def emailed
     object.emailed_status != Invite.emailed_status_types[:not_required]
+  end
+
+  def can_delete_invite
+    scope.is_admin? || object.invited_by_id == scope.current_user.id
   end
 
   def include_custom_message?

--- a/spec/serializers/invite_serializer_spec.rb
+++ b/spec/serializers/invite_serializer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe InviteSerializer do
+  describe "#can_delete_invite" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:admin) { Fabricate(:admin) }
+    fab!(:moderator) { Fabricate(:moderator) }
+    fab!(:invite_from_user) { Fabricate(:invite, invited_by: user) }
+    fab!(:invite_from_moderator) { Fabricate(:invite, invited_by: moderator) }
+
+    it "returns true for admin" do
+      serializer = InviteSerializer.new(invite_from_user, scope: Guardian.new(admin), root: false)
+
+      expect(serializer.as_json[:can_delete_invite]).to eq(true)
+    end
+
+    it "returns false for moderator" do
+      serializer =
+        InviteSerializer.new(invite_from_user, scope: Guardian.new(moderator), root: false)
+
+      expect(serializer.as_json[:can_delete_invite]).to eq(false)
+    end
+
+    it "returns true for inviter" do
+      serializer = InviteSerializer.new(invite_from_user, scope: Guardian.new(user), root: false)
+
+      expect(serializer.as_json[:can_delete_invite]).to eq(true)
+    end
+
+    it "returns false for plain user" do
+      serializer =
+        InviteSerializer.new(invite_from_moderator, scope: Guardian.new(user), root: false)
+
+      expect(serializer.as_json[:can_delete_invite]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
There is a bug now when a moderator visits /u/not-themself/invited page, they see the delete button to the invite, but are not actually able to delete it.

<img width="782" alt="Screenshot 2023-06-01 at 5 20 37 PM" src="https://github.com/discourse/discourse/assets/1555215/266537c2-6b70-402d-9ecf-b5dbbb0f7cfc">

This PR removes the button if they are not the creator of the invite, but keeps it if they are an admin.