### PR TITLE
DEV: ensures __optInput is initialized

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -257,6 +257,8 @@ module PrettyText
   # leaving this here, cause it invokes v8, don't want to implement twice
   def self.avatar_img(avatar_template, size)
     protect { v8.eval(<<~JS) }
+        __optInput = {};
+        __optInput.avatar_sizes = #{SiteSetting.avatar_sizes.to_json};
         __paths = #{paths_json};
         __utils.avatarImg({size: #{size.inspect}, avatarTemplate: #{avatar_template.inspect}}, __getURL);
       JS


### PR DESCRIPTION
Test were sometimes failing with similar error to the following:

```
  1) UsernameChanger#override when unicode_usernames is off overrides the username if a new name has different case
     Failure/Error:
           protect { v8.eval(<<~JS) }
               __paths = #{paths_json};
               __utils.avatarImg({size: #{size.inspect}, avatarTemplate: #{avatar_template.inspect}}, __getURL);
             JS

     MiniRacer::RuntimeError:
       ReferenceError: __optInput is not defined
     # JavaScript at exports.helperContext (<anonymous>:21:17)
     # JavaScript at getRawAvatarSize (<anonymous>:108:49)
     # JavaScript at avatarUrl (<anonymous>:102:21)
     # JavaScript at Object.avatarImg (<anonymous>:129:15)
     # JavaScript at <anonymous>:2:9
     # ./lib/pretty_text.rb:259:in `block in avatar_img'
     # ./lib/pretty_text.rb:661:in `block in protect'
     # ./lib/pretty_text.rb:661:in `synchronize'
     # ./lib/pretty_text.rb:661:in `protect'
     # ./lib/pretty_text.rb:259:in `avatar_img'
     # ./app/jobs/regular/update_username.rb:14:in `execute'
```

This should not be needed as it should already have been initialised but that should stop the flakey-ness for now while being a safe change.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
