### PR TITLE
FIX: correctly resubscribe after restart

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -57,6 +57,10 @@ export default class ChatSubscriptionsManager extends Service {
   restartChannelsSubscriptions(messageBusIds) {
     this.stopChannelsSubscriptions();
     this.startChannelsSubscriptions(messageBusIds);
+
+    (this.chatChannelsManager.channels || []).forEach((channel) => {
+      this.startChannelSubscription(channel);
+    });
   }
 
   startChannelsSubscriptions(messageBusIds) {


### PR DESCRIPTION
Few weeks ago we implemented `onPresenceChangeCallback` to re-sync chat channels state when going back to a long time inactive tab. This codepath however contained a bug as we were reseting all subscriptions but only restarting global subscriptions and not per channel subscriptions.

This commit should correctly ensure we correctly do so. It's sadly very hard to test time related changes in system specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
