### PR TITLE
FIX: use fixed dimensions for user card avatar

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -150,8 +150,8 @@
       max-height: var(--avatar-width);
     }
     .avatar {
-      width: 100%;
-      height: 100%;
+      width: var(--avatar-width);
+      height: var(--avatar-width);
     }
     .new-user a {
       color: var(--primary-low-mid);


### PR DESCRIPTION
Follow-up to 1d9f195, avatar sizes on my dev instance were wrong... these values actually need to be fixed and not a percentage (width being used for height is intentional because they're square). 