### PR TITLE
DEV: Ensure `maxminddb:fetch` works as standalone task

### DIFF
--- a/lib/tasks/maxminddb.rake
+++ b/lib/tasks/maxminddb.rake
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 desc "downloads MaxMind's GeoLite2-City database"
-task "maxminddb:get" do
-  require "discourse_ip_info"
-
+task "maxminddb:get" => "environment" do
   puts "Downloading MaxMindDb's GeoLite2-City..."
   DiscourseIpInfo.mmdb_download("GeoLite2-City")
 


### PR DESCRIPTION
`DiscourseIpInfo` expects zeitwerk auto-loading to be available, so we need to ensure the rake task loads the full rails environment. Normally we run this task as part of assets:precompile, so the app is already initialized. This commit only affects the case where the maxmind task is run directly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
