### PR TITLE
FIX: change Community icons and new link

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
@@ -51,7 +51,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get currentWhen() {
-    return "discovery.latest discovery.new discovery.unread discovery.top";
+    return `${this.route} discovery.top`;
   }
 
   get badgeText() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
@@ -26,7 +26,6 @@ const LINKS_IN_BOTH_SEGMENTS = ["/review"];
 
 const SPECIAL_LINKS_MAP = {
   "/latest": EverythingSectionLink,
-  "/new": EverythingSectionLink,
   "/about": AboutSectionLink,
   "/u": UsersSectionLink,
   "/faq": FAQSectionLink,
@@ -116,7 +115,7 @@ export default class CommunitySection {
         sectionLinkClass,
         inMoreDrawer,
         link.name,
-        link.scon
+        link.icon
       );
     } else {
       return new SectionLink(link, this, this.router);

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -197,7 +197,10 @@ describe "Custom sidebar sections", type: :system, js: true do
     sign_in admin
     visit("/latest")
 
+    expect(sidebar.primary_section_icons("community")).to eq(%w[layer-group user wrench ellipsis-v])
+
     sidebar.edit_custom_section("Community")
+    section_modal.fill_link("Everything", "/latest", "paper-plane")
     section_modal.fill_name("Edited community section")
     section_modal.everything_link.drag_to(section_modal.review_link, delay: 0.4)
     section_modal.save
@@ -205,6 +208,9 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar).to have_section("Edited community section")
     expect(sidebar.primary_section_links("edited-community-section")).to eq(
       ["My Posts", "Everything", "Admin", "More"],
+    )
+    expect(sidebar.primary_section_icons("edited-community-section")).to eq(
+      %w[user paper-plane wrench ellipsis-v],
     )
 
     sidebar.edit_custom_section("Edited community section")
@@ -214,6 +220,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar.primary_section_links("community")).to eq(
       ["Everything", "My Posts", "Admin", "More"],
     )
+    expect(sidebar.primary_section_icons("community")).to eq(%w[layer-group user wrench ellipsis-v])
   end
 
   it "shows anonymous public sections" do

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -67,6 +67,12 @@ module PageObjects
         all("[data-section-name='#{slug}'] .sidebar-section-link-wrapper").map(&:text)
       end
 
+      def primary_section_icons(slug)
+        all("[data-section-name='#{slug}'] .sidebar-section-link-wrapper use").map do |icon|
+          icon[:href].delete_prefix("#")
+        end
+      end
+
       private
 
       def section_link_present?(name, href: nil, active: false, present:)

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -7,9 +7,12 @@ module PageObjects
         fill_in "section-name", with: name
       end
 
-      def fill_link(name, url)
+      def fill_link(name, url, icon = "link")
         fill_in "link-name", with: name, match: :first
         fill_in "link-url", with: url, match: :first
+        find(".sidebar-section-form-link .select-kit summary", match: :first).click
+        fill_in "filter-input-search", with: icon, match: :first
+        find(".select-kit-row.is-highlighted", match: :first).click
       end
 
       def mark_as_public


### PR DESCRIPTION
Fix two bugs in edit community section form:
- Because of typo, icon could not be changed;
- We treated /new and /latest path as "Everything". Users would like to have two separate links in section, Everything and New.

<img width="252" alt="Screenshot 2023-06-02 at 10 19 00 am" src="https://github.com/discourse/discourse/assets/72780/40c15899-0083-4cdc-9441-595c1f304cff">

