### PR TITLE
FIX: rename everything link to topics

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -15,6 +15,7 @@ const FULL_RELOAD_LINKS_REGEX = [
   /^\/my\/[a-z_\-\/]+$/,
   /^\/pub\/[a-z_\-\/]+$/,
   /^\/safe-mode$/,
+  /^\/topics$/,
 ];
 
 class Section {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/topics-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/topics-section-link.js
@@ -32,7 +32,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get name() {
-    return "everything";
+    return "topics";
   }
 
   get query() {
@@ -40,7 +40,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.everything.title");
+    return I18n.t("sidebar.sections.community.links.topics.title");
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
@@ -7,7 +7,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
 import PermissionType from "discourse/models/permission-type";
-import EverythingSectionLink from "discourse/lib/sidebar/common/community-section/everything-section-link";
+import TopicsSectionLink from "discourse/lib/sidebar/common/community-section/topics-section-link";
 import MyPostsSectionLink from "discourse/lib/sidebar/user/community-section/my-posts-section-link";
 import AdminSectionLink from "discourse/lib/sidebar/user/community-section/admin-section-link";
 import AboutSectionLink from "discourse/lib/sidebar/common/community-section/about-section-link";
@@ -23,8 +23,7 @@ import {
 import showModal from "discourse/lib/show-modal";
 
 const SPECIAL_LINKS_MAP = {
-  "/latest": EverythingSectionLink,
-  "/new": EverythingSectionLink,
+  "/topics": TopicsSectionLink,
   "/about": AboutSectionLink,
   "/u": UsersSectionLink,
   "/faq": FAQSectionLink,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -17,7 +17,7 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
 
   needs.site({});
 
-  test("everything section link is shown by default ", async function (assert) {
+  test("topics section link is shown by default ", async function (assert) {
     await visit("/");
 
     const sectionLinks = queryAll(
@@ -26,8 +26,8 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
 
     assert.strictEqual(
       sectionLinks[0].textContent.trim(),
-      I18n.t("sidebar.sections.community.links.everything.content"),
-      "displays the everything section link first"
+      I18n.t("sidebar.sections.community.links.topics.content"),
+      "displays the topics section link first"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -151,10 +151,10 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
-  test("clicking on everything link", async function (assert) {
+  test("clicking on topics link", async function (assert) {
     await visit("/t/280");
     await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
     );
 
     assert.strictEqual(
@@ -173,20 +173,20 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
-  test("clicking on everything link - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
+  test("clicking on topics link - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
     updateCurrentUser({
       sidebar_list_destination: "unread_new",
     });
 
     await visit("/t/280");
     await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
     );
     assert.strictEqual(
       currentURL(),
@@ -204,13 +204,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
-  test("clicking on everything link - sidebar_list_destination set to unread/new with new topics", async function (assert) {
+  test("clicking on topics link - sidebar_list_destination set to unread/new with new topics", async function (assert) {
     const topicTrackingState = this.container.lookup(
       "service:topic-tracking-state"
     );
@@ -226,7 +226,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     });
     await visit("/t/280");
     await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
     );
 
     assert.strictEqual(
@@ -245,13 +245,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
-  test("clicking on everything link - sidebar_list_destination set to unread/new with new and unread topics", async function (assert) {
+  test("clicking on topics link - sidebar_list_destination set to unread/new with new and unread topics", async function (assert) {
     const topicTrackingState = this.container.lookup(
       "service:topic-tracking-state"
     );
@@ -275,7 +275,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     });
     await visit("/t/280");
     await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
     );
 
     assert.strictEqual(
@@ -294,9 +294,9 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
@@ -712,9 +712,9 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
@@ -731,9 +731,9 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
@@ -750,13 +750,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'].active"
+        ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'].active"
       ),
-      "the everything link is marked as active"
+      "the topics link is marked as active"
     );
   });
 
-  test("show suffix indicator for unread and new content on everything link", async function (assert) {
+  test("show suffix indicator for unread and new content on topics link", async function (assert) {
     updateCurrentUser({
       sidebar_list_destination: "default",
     });
@@ -788,9 +788,9 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-suffix"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-suffix"
       ),
-      "shows suffix indicator for unread posts on everything link"
+      "shows suffix indicator for unread posts on topics link"
     );
 
     const topicTrackingState = this.container.lookup(
@@ -814,7 +814,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-suffix"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-suffix"
       ),
       "shows suffix indicator for new topics on categories link"
     );
@@ -838,13 +838,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       !exists(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-suffix"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-suffix"
       ),
       "it removes the suffix indicator when all topics are read"
     );
   });
 
-  test("new and unread count for everything link", async function (assert) {
+  test("new and unread count for topics link", async function (assert) {
     updateCurrentUser({
       sidebar_list_destination: "unread_new",
     });
@@ -896,7 +896,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.strictEqual(
       query(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-content-badge"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-content-badge"
       ).textContent.trim(),
       "3 unread",
       "it displays the right unread count"
@@ -915,7 +915,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.strictEqual(
       query(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-content-badge"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-content-badge"
       ).textContent.trim(),
       "2 unread",
       "it updates the unread count"
@@ -945,7 +945,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.strictEqual(
       query(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-content-badge"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-content-badge"
       ).textContent.trim(),
       "1 new",
       "it displays the new count once there are no unread topics"
@@ -963,7 +963,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.ok(
       !exists(
-        ".sidebar-section-link[data-link-name='everything'] .sidebar-section-link-content-badge"
+        ".sidebar-section-link[data-link-name='topics'] .sidebar-section-link-content-badge"
       ),
       "it removes new count once there are no new topics"
     );
@@ -1187,7 +1187,7 @@ acceptance(
       navigation_menu: "sidebar",
     });
 
-    test("count shown next to the everything link", async function (assert) {
+    test("count shown next to the topics link", async function (assert) {
       this.container.lookup("service:topic-tracking-state").loadStates([
         {
           topic_id: 1,
@@ -1225,14 +1225,14 @@ acceptance(
 
       assert.strictEqual(
         query(
-          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything'] .sidebar-section-link-content-badge"
+          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics'] .sidebar-section-link-content-badge"
         ).textContent.trim(),
         "2",
         "count is 2 because there's 1 unread topic and 1 new topic"
       );
     });
 
-    test("everything link href", async function (assert) {
+    test("topics link href", async function (assert) {
       this.container.lookup("service:topic-tracking-state").loadStates([
         {
           topic_id: 1,
@@ -1260,7 +1260,7 @@ acceptance(
 
       assert.true(
         query(
-          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
         ).href.endsWith("/new"),
         "links to /new because there are 1 new and 1 unread topics"
       );
@@ -1276,7 +1276,7 @@ acceptance(
 
       assert.true(
         query(
-          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
         ).href.endsWith("/new"),
         "links to /new because there is 1 unread topic"
       );
@@ -1292,7 +1292,7 @@ acceptance(
 
       assert.true(
         query(
-          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
         ).href.endsWith("/latest"),
         "links to /latest because there are no unread or new topics"
       );
@@ -1308,7 +1308,7 @@ acceptance(
 
       assert.true(
         query(
-          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='everything']"
+          ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='topics']"
         ).href.endsWith("/new"),
         "links to /new because there is 1 new topic"
       );

--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -59,8 +59,8 @@ export default {
           links: [
             {
               id: 329,
-              name: "Everything",
-              value: "/latest",
+              name: "Topics",
+              value: "/topics",
               icon: "layer-group",
               external: false,
               segment: "primary",

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -707,8 +707,8 @@ export default {
           links: [
             {
               id: 329,
-              name: "Everything",
-              value: "/latest",
+              name: "Topics",
+              value: "/topics",
               icon: "layer-group",
               external: false,
               segment: "primary",

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -9,8 +9,8 @@ class SidebarUrl < ActiveRecord::Base
   MAX_VALUE_LENGTH = 200
   COMMUNITY_SECTION_LINKS = [
     {
-      name: "Everything",
-      path: "/latest",
+      name: "Topics",
+      path: "/topics",
       icon: "layer-group",
       segment: SidebarUrl.segments["primary"],
     },

--- a/config/locales/client.ar.yml
+++ b/config/locales/client.ar.yml
@@ -4818,7 +4818,7 @@ ar:
             badges:
               content: "الشارات"
               title: "كل الشارات الممكن منحها لك"
-            everything:
+            topics:
               content: "كل شيء"
               title: "كل الموضوعات"
             faq:

--- a/config/locales/client.bg.yml
+++ b/config/locales/client.bg.yml
@@ -3442,7 +3442,7 @@ bg:
               content: "Администратор"
             badges:
               content: "Значки"
-            everything:
+            topics:
               content: "Всичко"
             faq:
               content: "FAQ"

--- a/config/locales/client.bs_BA.yml
+++ b/config/locales/client.bs_BA.yml
@@ -3074,7 +3074,7 @@ bs_BA:
               content: "Admin"
             badges:
               content: "Bedž"
-            everything:
+            topics:
               content: "Sve"
             faq:
               content: "Česta pitanja"

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -2910,7 +2910,7 @@ ca:
               content: "Administració"
             badges:
               content: "Insígnies"
-            everything:
+            topics:
               content: "Qualsevol cosa"
             faq:
               content: "PMF"

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -3170,7 +3170,7 @@ cs:
               content: "Administrace"
             badges:
               content: "Odznaky"
-            everything:
+            topics:
               content: "Vše"
             faq:
               content: "FAQ"

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -3617,7 +3617,7 @@ da:
               content: "Admin"
             badges:
               content: "Emblemer"
-            everything:
+            topics:
               content: "Alting"
             faq:
               content: "OSS"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -4147,7 +4147,7 @@ de:
             badges:
               content: "Abzeichen"
               title: "Alle Abzeichen, die es zu verdienen gibt"
-            everything:
+            topics:
               content: "Alles"
               title: "Alle Themen"
             faq:

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -3348,7 +3348,7 @@ el:
               content: "Διαχείριση"
             badges:
               content: "Παράσημα"
-            everything:
+            topics:
               content: "Τα πάνΤα"
               title: "Όλα τα θέματα"
             faq:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4503,8 +4503,8 @@ en:
             badges:
               content: "Badges"
               title: "All the badges available to earn"
-            everything:
-              content: "Everything"
+            topics:
+              content: "Topics"
               title: "All topics"
             faq:
               content: "FAQ"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -4033,7 +4033,7 @@ es:
             badges:
               content: "Insignias"
               title: "Todas las insignias disponibles para ganar"
-            everything:
+            topics:
               content: "Todo"
               title: "Todos los temas"
             faq:

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -3413,7 +3413,7 @@ fa_IR:
               title: "تنظیمات و گزارش‌های سایت"
             badges:
               content: "نشان‌ها"
-            everything:
+            topics:
               content: "همه چیز"
               title: "همه موضوعات"
             faq:

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -4067,7 +4067,7 @@ fi:
             badges:
               content: "Kunniamerkit"
               title: "Kaikki ansaittavissa olevat kunniamerkit"
-            everything:
+            topics:
               content: "Kaikki"
               title: "Kaikki ketjut"
             faq:

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -4037,7 +4037,7 @@ fr:
             badges:
               content: "Badges"
               title: "Tous les badges disponibles à gagner"
-            everything:
+            topics:
               content: "Tout"
               title: "Tous les sujets"
             faq:

--- a/config/locales/client.gl.yml
+++ b/config/locales/client.gl.yml
@@ -3352,7 +3352,7 @@ gl:
               content: "Administración"
             badges:
               content: "Insignias"
-            everything:
+            topics:
               content: "Todo"
             faq:
               content: "PMF"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -4525,7 +4525,7 @@ he:
             badges:
               content: "עיטורים"
               title: "כל העיטורים שאפשר לקבל"
-            everything:
+            topics:
               content: "הכול"
               title: "כל הנושאים"
             faq:

--- a/config/locales/client.hr.yml
+++ b/config/locales/client.hr.yml
@@ -4226,7 +4226,7 @@ hr:
             badges:
               content: "Značke"
               title: "Sve značke dostupne za osvajanje"
-            everything:
+            topics:
               content: "Sve"
               title: "Sve teme"
             faq:

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -3714,7 +3714,7 @@ hu:
             badges:
               content: "Jelvények"
               title: "Az összes megszerezhető jelvény"
-            everything:
+            topics:
               content: "Összes"
               title: "Minden téma"
             faq:

--- a/config/locales/client.hy.yml
+++ b/config/locales/client.hy.yml
@@ -2885,7 +2885,7 @@ hy:
               content: "Ադմին"
             badges:
               content: "Կրծքանշաններ"
-            everything:
+            topics:
               content: "Բոլորը"
             faq:
               content: "ՀՏՀ"

--- a/config/locales/client.id.yml
+++ b/config/locales/client.id.yml
@@ -1944,7 +1944,7 @@ id:
               content: "Tentang"
             admin:
               content: "Admin"
-            everything:
+            topics:
               content: "Semuanya"
             faq:
               content: "FAQ"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -4018,7 +4018,7 @@ it:
             badges:
               content: "Distintivi"
               title: "Tutti i distintivi disponibili"
-            everything:
+            topics:
               content: "Tutti"
               title: "Tutti gli argomenti"
             faq:

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -3827,7 +3827,7 @@ ja:
             badges:
               content: "バッジ"
               title: "獲得可能なすべてのバッジ"
-            everything:
+            topics:
               content: "すべて"
               title: "すべてのトピック"
             faq:

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -3568,7 +3568,7 @@ ko:
               content: "관리자"
             badges:
               content: "배지"
-            everything:
+            topics:
               content: "모두"
               title: "모든 글"
             faq:

--- a/config/locales/client.lt.yml
+++ b/config/locales/client.lt.yml
@@ -3568,7 +3568,7 @@ lt:
               content: "Adminas"
             badges:
               content: "Trofėjai"
-            everything:
+            topics:
               content: "Viskas"
               title: "Visos temos"
             faq:

--- a/config/locales/client.lv.yml
+++ b/config/locales/client.lv.yml
@@ -2813,7 +2813,7 @@ lv:
               content: "Administrators"
             badges:
               content: "Žetoni"
-            everything:
+            topics:
               content: "Viss"
             faq:
               content: "BUJ"

--- a/config/locales/client.nb_NO.yml
+++ b/config/locales/client.nb_NO.yml
@@ -3411,7 +3411,7 @@ nb_NO:
               content: "Administrator"
             badges:
               content: "Merker"
-            everything:
+            topics:
               content: "Alt"
             faq:
               content: "O-S-S"

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -4030,7 +4030,7 @@ nl:
             badges:
               content: "Badges"
               title: "Alle beschikbare badges om te verdienen"
-            everything:
+            topics:
               content: "Alles"
               title: "Alle topics"
             faq:

--- a/config/locales/client.pl_PL.yml
+++ b/config/locales/client.pl_PL.yml
@@ -4524,7 +4524,7 @@ pl_PL:
             badges:
               content: "Odznaki"
               title: "Wszystkie odznaki dostępne do zdobycia"
-            everything:
+            topics:
               content: "Wszystko"
               title: "Wszystkie tematy"
             faq:

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -3497,7 +3497,7 @@ pt:
               content: "Administrador"
             badges:
               content: "Crachás"
-            everything:
+            topics:
               content: "Tudo"
             faq:
               content: "FAQ"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -4068,7 +4068,7 @@ pt_BR:
             badges:
               content: "Emblemas"
               title: "Todos os emblemas disponíveis para ganhar"
-            everything:
+            topics:
               content: "Tudo"
               title: "Todos os Tópicos"
             faq:

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -2955,7 +2955,7 @@ ro:
               content: "Administrator"
             badges:
               content: "Ecusoane"
-            everything:
+            topics:
               content: "Totul"
             faq:
               content: "Întrebări frecvente"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -4434,7 +4434,7 @@ ru:
             badges:
               content: "Награды"
               title: "Все награды, которые можно получить"
-            everything:
+            topics:
               content: "Все"
               title: "Все темы"
             faq:

--- a/config/locales/client.sk.yml
+++ b/config/locales/client.sk.yml
@@ -2325,7 +2325,7 @@ sk:
               content: "Administrátor"
             badges:
               content: "Odznaky"
-            everything:
+            topics:
               content: "Všetko"
             faq:
               content: "Časté otázky"

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -3391,7 +3391,7 @@ sl:
               content: "Admin"
             badges:
               content: "Značke"
-            everything:
+            topics:
               content: "Vse"
             faq:
               content: "Pravila skupnosti"

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -4119,7 +4119,7 @@ sv:
             badges:
               content: "Utmärkelser"
               title: "Alla utmärkelser som kan förtjänas"
-            everything:
+            topics:
               content: "Allting"
               title: "Alla ämnen"
             faq:

--- a/config/locales/client.th.yml
+++ b/config/locales/client.th.yml
@@ -2455,7 +2455,7 @@ th:
               content: "แอดมิน"
             badges:
               content: "เหรียญ"
-            everything:
+            topics:
               content: "ทุกสิ่ง"
             faq:
               content: "คำถามที่พบบ่อย"

--- a/config/locales/client.tr_TR.yml
+++ b/config/locales/client.tr_TR.yml
@@ -4061,7 +4061,7 @@ tr_TR:
             badges:
               content: "Rozetler"
               title: "Kazanılabilecek tüm rozetler"
-            everything:
+            topics:
               content: "Her şey"
               title: "Tüm konular"
             faq:

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -4473,7 +4473,7 @@ uk:
             badges:
               content: "Нагороди"
               title: "Всі значки доступні для отримання"
-            everything:
+            topics:
               content: "Усе"
               title: "Всі теми"
             faq:

--- a/config/locales/client.ur.yml
+++ b/config/locales/client.ur.yml
@@ -3624,7 +3624,7 @@ ur:
               content: "ایڈمن"
             badges:
               content: "بَیج"
-            everything:
+            topics:
               content: "تمام"
             faq:
               content: "عمومی سوالات"

--- a/config/locales/client.vi.yml
+++ b/config/locales/client.vi.yml
@@ -3583,7 +3583,7 @@ vi:
               content: "Quản trị"
             badges:
               content: "Huy hiệu"
-            everything:
+            topics:
               content: "Mọi thứ"
               title: "Tất cả các chủ đề"
             faq:

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -3928,7 +3928,7 @@ zh_CN:
             badges:
               content: "徽章"
               title: "所有可获得的徽章"
-            everything:
+            topics:
               content: "一切"
               title: "所有话题"
             faq:

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -2907,7 +2907,7 @@ zh_TW:
               content: "管理員"
             badges:
               content: "徽章"
-            everything:
+            topics:
               content: "所有"
               title: "所有話題"
             faq:

--- a/db/migrate/20230602034711_rename_everything_to_topics_link.rb
+++ b/db/migrate/20230602034711_rename_everything_to_topics_link.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class RenameEverythingToTopicsLink < ActiveRecord::Migration[7.0]
+  def up
+    DB.exec <<~SQL
+      UPDATE sidebar_urls su1
+      SET name = 'Topics', value = '/topics'
+      FROM sidebar_urls su2
+      INNER JOIN sidebar_section_links ON sidebar_section_links.linkable_id = su2.id
+      INNER JOIN sidebar_sections ON sidebar_sections.id = sidebar_section_links.sidebar_section_id AND sidebar_sections.section_type = 0
+      WHERE su1.id = su2.id AND su2.value = '/latest'
+    SQL
+  end
+
+  def down
+    DB.exec <<~SQL
+      UPDATE sidebar_urls su1
+      SET name = 'Everything', value = '/latest'
+      FROM sidebar_urls su2
+      INNER JOIN sidebar_section_links ON sidebar_section_links.linkable_id = su2.id
+      INNER JOIN sidebar_sections ON sidebar_sections.id = sidebar_section_links.sidebar_section_id AND sidebar_sections.section_type = 0
+      WHERE su1.id = su2.id AND su2.value = '/topics'
+    SQL
+  end
+end

--- a/db/migrate/20230602034711_rename_everything_to_topics_link.rb
+++ b/db/migrate/20230602034711_rename_everything_to_topics_link.rb
@@ -7,7 +7,7 @@ class RenameEverythingToTopicsLink < ActiveRecord::Migration[7.0]
       FROM sidebar_urls su2
       INNER JOIN sidebar_section_links ON sidebar_section_links.linkable_id = su2.id
       INNER JOIN sidebar_sections ON sidebar_sections.id = sidebar_section_links.sidebar_section_id AND sidebar_sections.section_type = 0
-      WHERE su1.id = su2.id AND su2.value = '/latest'
+      WHERE su1.id = su2.id AND su2.value = '/latest' AND su2.name = 'Everything'
     SQL
   end
 
@@ -18,7 +18,7 @@ class RenameEverythingToTopicsLink < ActiveRecord::Migration[7.0]
       FROM sidebar_urls su2
       INNER JOIN sidebar_section_links ON sidebar_section_links.linkable_id = su2.id
       INNER JOIN sidebar_sections ON sidebar_sections.id = sidebar_section_links.sidebar_section_id AND sidebar_sections.section_type = 0
-      WHERE su1.id = su2.id AND su2.value = '/topics'
+      WHERE su1.id = su2.id AND su2.value = '/topics' AND su2.name = 'Topics'
     SQL
   end
 end

--- a/spec/models/sidebar_section_spec.rb
+++ b/spec/models/sidebar_section_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SidebarSection do
     expect(community_section.reload.title).to eq("Community")
 
     expect(community_section.sidebar_section_links.all.map { |link| link.linkable.name }).to eq(
-      ["Everything", "My Posts", "Review", "Admin", "Users", "About", "FAQ", "Groups", "Badges"],
+      ["Topics", "My Posts", "Review", "Admin", "Users", "About", "FAQ", "Groups", "Badges"],
     )
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -303,12 +303,12 @@ RSpec.describe SidebarSectionsController do
     it "allows admin to edit community section" do
       sign_in(admin)
 
-      everything_link = community_section.sidebar_urls.find_by(name: "Everything")
+      topics_link = community_section.sidebar_urls.find_by(name: "Topics")
       my_posts_link = community_section.sidebar_urls.find_by(name: "My Posts")
 
       community_section
         .sidebar_section_links
-        .where.not(linkable_id: [everything_link.id, my_posts_link.id])
+        .where.not(linkable_id: [topics_link.id, my_posts_link.id])
         .destroy_all
 
       put "/sidebar_sections/#{community_section.id}.json",
@@ -316,12 +316,7 @@ RSpec.describe SidebarSectionsController do
             title: "community section edited",
             links: [
               { icon: "link", id: my_posts_link.id, name: "my posts edited", value: "/my_posts" },
-              {
-                icon: "link",
-                id: everything_link.id,
-                name: "everything edited",
-                value: "/everything",
-              },
+              { icon: "link", id: topics_link.id, name: "topics edited", value: "/latest" },
             ],
           }
 
@@ -330,8 +325,8 @@ RSpec.describe SidebarSectionsController do
       expect(community_section.reload.title).to eq("community section edited")
       expect(community_section.sidebar_urls[0].name).to eq("my posts edited")
       expect(community_section.sidebar_urls[0].value).to eq("/my_posts")
-      expect(community_section.sidebar_urls[1].name).to eq("everything edited")
-      expect(community_section.sidebar_urls[1].value).to eq("/everything")
+      expect(community_section.sidebar_urls[1].name).to eq("topics edited")
+      expect(community_section.sidebar_urls[1].value).to eq("/latest")
     end
   end
 
@@ -461,7 +456,7 @@ RSpec.describe SidebarSectionsController do
     let(:community_section) do
       SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
     end
-    let(:everything_link) { community_section.sidebar_section_links.first }
+    let(:topics_link) { community_section.sidebar_section_links.first }
 
     it "doesn't allow user to reset community section" do
       sign_in(user)

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -202,14 +202,14 @@ describe "Custom sidebar sections", type: :system do
     )
 
     sidebar.edit_custom_section("Community")
-    section_modal.fill_link("Everything", "/latest", "paper-plane")
+    section_modal.fill_link("Topics", "/topics", "paper-plane")
     section_modal.fill_name("Edited community section")
-    section_modal.everything_link.drag_to(section_modal.review_link, delay: 0.4)
+    section_modal.topics_link.drag_to(section_modal.review_link, delay: 0.4)
     section_modal.save
 
     expect(sidebar).to have_section("Edited community section")
     expect(sidebar.primary_section_links("edited-community-section")).to eq(
-      ["My Posts", "Everything", "Review", "Admin", "More"],
+      ["My Posts", "Topics", "Review", "Admin", "More"],
     )
     expect(sidebar.primary_section_icons("edited-community-section")).to eq(
       %w[user paper-plane flag wrench ellipsis-v],
@@ -220,7 +220,7 @@ describe "Custom sidebar sections", type: :system do
 
     expect(sidebar).to have_section("Community")
     expect(sidebar.primary_section_links("community")).to eq(
-      ["Everything", "My Posts", "Review", "Admin", "More"],
+      ["Topics", "My Posts", "Review", "Admin", "More"],
     )
     expect(sidebar.primary_section_icons("community")).to eq(
       %w[layer-group user flag wrench ellipsis-v],

--- a/spec/system/page_objects/components/sidebar_header_dropdown.rb
+++ b/spec/system/page_objects/components/sidebar_header_dropdown.rb
@@ -30,8 +30,8 @@ module PageObjects
         )
       end
 
-      def click_everything_link
-        find(".sidebar-section-link[data-link-name='everything']").click
+      def click_topics_link
+        find(".sidebar-section-link[data-link-name='topics']").click
       end
 
       def click_toggle_to_desktop_view_button

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -52,8 +52,8 @@ module PageObjects
         find_button("Save", disabled: false)
       end
 
-      def everything_link
-        find(".draggable[data-link-name='Everything']")
+      def topics_link
+        find(".draggable[data-link-name='Topics']")
       end
 
       def review_link

--- a/spec/system/viewing_sidebar_mobile_spec.rb
+++ b/spec/system/viewing_sidebar_mobile_spec.rb
@@ -41,7 +41,7 @@ describe "Viewing sidebar mobile", type: :system, mobile: true do
 
     expect(sidebar_dropdown).to be_visible
 
-    sidebar_dropdown.click_everything_link
+    sidebar_dropdown.click_topics_link
 
     expect(sidebar_dropdown).to be_hidden
   end


### PR DESCRIPTION
Rename everything link in community sidebar section to topics which is a bit more descriptive.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
