### PR TITLE
FIX: correctly set last message bus ids on resync

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -54,15 +54,6 @@ export default class ChatSubscriptionsManager extends Service {
     this._channelSubscriptions.delete(channel.id);
   }
 
-  restartChannelsSubscriptions(messageBusIds) {
-    this.stopChannelsSubscriptions();
-    this.startChannelsSubscriptions(messageBusIds);
-
-    (this.chatChannelsManager.channels || []).forEach((channel) => {
-      this.startChannelSubscription(channel);
-    });
-  }
-
   startChannelsSubscriptions(messageBusIds) {
     this._startNewChannelSubscription(messageBusIds.new_channel);
     this._startChannelArchiveStatusSubscription(messageBusIds.archive_status);

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -115,14 +115,10 @@ export default class Chat extends Service {
     if (present) {
       // NOTE: channels is more than a simple array, it also contains
       // tracking and membership data, see Chat::StructuredChannelSerializer
-      this.chatApi.listCurrentUserChannels().then((channels) => {
-        this.chatSubscriptionsManager.restartChannelsSubscriptions(
-          channels.meta.message_bus_last_ids
-        );
-
+      this.chatApi.listCurrentUserChannels().then((channelView) => {
         [
-          ...channels.public_channels,
-          ...channels.direct_message_channels,
+          ...channelView.public_channels,
+          ...channelView.direct_message_channels,
         ].forEach((channelObject) => {
           this.chatChannelsManager
             .find(channelObject.id, { fetchIfNotFound: false })
@@ -135,10 +131,11 @@ export default class Chat extends Service {
               // endpoint that gives you all channel tracking state and the
               // thread tracking state for the current channel.
               if (channel) {
+                channel.meta.message_bus_last_ids =
+                  channelObject.meta.message_bus_last_ids;
                 channel.updateMembership(channelObject.current_user_membership);
-
                 const channelTrackingState =
-                  channels.tracking.channel_tracking[channel.id];
+                  channelView.tracking.channel_tracking[channel.id];
                 channel.tracking.unreadCount =
                   channelTrackingState.unread_count;
                 channel.tracking.mentionCount =

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -115,10 +115,10 @@ export default class Chat extends Service {
     if (present) {
       // NOTE: channels is more than a simple array, it also contains
       // tracking and membership data, see Chat::StructuredChannelSerializer
-      this.chatApi.listCurrentUserChannels().then((channelView) => {
+      this.chatApi.listCurrentUserChannels().then((channelsView) => {
         [
-          ...channelView.public_channels,
-          ...channelView.direct_message_channels,
+          ...channelsView.public_channels,
+          ...channelsView.direct_message_channels,
         ].forEach((channelObject) => {
           this.chatChannelsManager
             .find(channelObject.id, { fetchIfNotFound: false })
@@ -135,7 +135,7 @@ export default class Chat extends Service {
                   channelObject.meta.message_bus_last_ids;
                 channel.updateMembership(channelObject.current_user_membership);
                 const channelTrackingState =
-                  channelView.tracking.channel_tracking[channel.id];
+                  channelsView.tracking.channel_tracking[channel.id];
                 channel.tracking.unreadCount =
                   channelTrackingState.unread_count;
                 channel.tracking.mentionCount =


### PR DESCRIPTION
Replaces `channel.meta.message_bust_last_ids` on full resync instead of restarting the subscriptions, which was moreover not using a correct id.