### PR TITLE
DEV: Eliminate flakiness in specs that depend on plugins from fixtures

### DIFF
--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -243,8 +243,7 @@ RSpec.describe Plugin::Instance do
     end
 
     it "can activate plugins correctly" do
-      plugin = Plugin::Instance.new
-      plugin.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+      plugin = plugin_from_fixtures("my_plugin")
       junk_file = "#{plugin.auto_generated_path}/junk"
 
       plugin.ensure_directory(junk_file)
@@ -260,8 +259,7 @@ RSpec.describe Plugin::Instance do
     end
 
     it "registers auth providers correctly" do
-      plugin = Plugin::Instance.new
-      plugin.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+      plugin = plugin_from_fixtures("my_plugin")
       plugin.activate!
       expect(DiscoursePluginRegistry.auth_providers.count).to eq(0)
       plugin.notify_before_auth
@@ -271,8 +269,7 @@ RSpec.describe Plugin::Instance do
     end
 
     it "finds all the custom assets" do
-      plugin = Plugin::Instance.new
-      plugin.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+      plugin = plugin_from_fixtures("my_plugin")
 
       plugin.register_asset("test.css")
       plugin.register_asset("test2.scss")
@@ -397,8 +394,8 @@ RSpec.describe Plugin::Instance do
   end
 
   describe "locales" do
-    let(:plugin_path) { "#{Rails.root}/spec/fixtures/plugins/custom_locales" }
-    let!(:plugin) { Plugin::Instance.new(nil, "#{plugin_path}/plugin.rb") }
+    let!(:plugin) { plugin_from_fixtures("custom_locales") }
+    let(:plugin_path) { File.dirname(plugin.path) }
     let(:plural) do
       {
         keys: %i[one few other],

--- a/spec/lib/stylesheet/compiler_spec.rb
+++ b/spec/lib/stylesheet/compiler_spec.rb
@@ -56,15 +56,13 @@ RSpec.describe Stylesheet::Compiler do
 
     context "with a plugin" do
       let :plugin1 do
-        plugin1 = Plugin::Instance.new
-        plugin1.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+        plugin1 = plugin_from_fixtures("my_plugin")
         plugin1.register_css "body { background: $primary }"
         plugin1
       end
 
       let :plugin2 do
-        plugin2 = Plugin::Instance.new
-        plugin2.path = "#{Rails.root}/spec/fixtures/plugins/scss_plugin/plugin.rb"
+        plugin2 = plugin_from_fixtures("scss_plugin")
         plugin2
       end
 
@@ -183,8 +181,7 @@ RSpec.describe Stylesheet::Compiler do
 
     context "with a plugin" do
       before do
-        plugin = Plugin::Instance.new
-        plugin.path = "#{Rails.root}/spec/fixtures/plugins/color_definition/plugin.rb"
+        plugin = plugin_from_fixtures("color_definition")
         Discourse.plugins << plugin
         plugin.activate!
       end

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -1014,15 +1014,13 @@ RSpec.describe Stylesheet::Manager do
 
     context "when there are enabled plugins" do
       let(:plugin1) do
-        plugin1 = Plugin::Instance.new
-        plugin1.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+        plugin1 = plugin_from_fixtures("my_plugin")
         plugin1.register_css "body { padding: 1px 2px 3px 4px; }"
         plugin1
       end
 
       let(:plugin2) do
-        plugin2 = Plugin::Instance.new
-        plugin2.path = "#{Rails.root}/spec/fixtures/plugins/scss_plugin/plugin.rb"
+        plugin2 = plugin_from_fixtures("scss_plugin")
         plugin2
       end
 

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -238,8 +238,7 @@ RSpec.describe SvgSprite do
 
     context "with a plugin" do
       let :plugin1 do
-        plugin1 = Plugin::Instance.new
-        plugin1.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+        plugin1 = plugin_from_fixtures("my_plugin")
         plugin1
       end
 

--- a/spec/requests/bootstrap_controller_spec.rb
+++ b/spec/requests/bootstrap_controller_spec.rb
@@ -93,8 +93,7 @@ RSpec.describe BootstrapController do
 
   context "with a plugin asset filter" do
     let :plugin do
-      plugin = Plugin::Instance.new
-      plugin.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+      plugin = plugin_from_fixtures("my_plugin")
       plugin.register_asset_filter do |type, request|
         next true if request.path == "/mypluginroute"
         false

--- a/spec/requests/stylesheets_controller_spec.rb
+++ b/spec/requests/stylesheets_controller_spec.rb
@@ -64,8 +64,7 @@ RSpec.describe StylesheetsController do
     fab!(:user) { Fabricate(:user) }
 
     let(:plugin) do
-      plugin = Plugin::Instance.new
-      plugin.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
+      plugin = plugin_from_fixtures("my_plugin")
       plugin.register_css "body { padding: 1px 2px 3px 4px; }"
       plugin
     end


### PR DESCRIPTION
When tests are executed in parallel (using `bin/turbo_rspec`), it's currently possible for a race condition to occur where 2 test cases, that load/activate the same plugin from the fixtures directory, to delete auto generated assets files (which are kept in an `auto_generated` directory inside the plugin) that belong to the other test case, causing one or both cases to fail when they attempt to read the now-deleted asset files.

Example failure:

```
1) Stylesheet::Manager.precompile_css when there are enabled plugins generates LTR and RTL CSS for plugins
     Failure/Error: file += File.read src
     
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /__w/discourse/discourse/spec/fixtures/plugins/my_plugin/auto_generated/plugin_80bc76c8fb1b52d77c435c9ea0cec39c38dede7c.css
     # ./lib/stylesheet/compiler.rb:21:in `read'
     # ./lib/stylesheet/compiler.rb:21:in `block in compile_asset'
     # ./lib/stylesheet/compiler.rb:20:in `compile_asset'
     # ./lib/stylesheet/manager/builder.rb:41:in `block in compile'
     # ./lib/stylesheet/manager/builder.rb:171:in `with_load_paths'
     # ./lib/stylesheet/manager/builder.rb:40:in `compile'
     # ./lib/stylesheet/manager.rb:65:in `block in precompile_css'
     # ./lib/stylesheet/manager.rb:62:in `each'
     # ./lib/stylesheet/manager.rb:62:in `precompile_css'
     # ./spec/lib/stylesheet/manager_spec.rb:1046:in `block (5 levels) in <main>'
     # ./spec/support/helpers.rb:138:in `capture_output'
     # ./spec/lib/stylesheet/manager_spec.rb:1046:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:372:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:189:in `block in timeout'
     # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.3.2/lib/timeout.rb:196:in `timeout'
     # ./spec/rails_helper.rb:367:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:356:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

Relevant code:

https://github.com/discourse/discourse/blob/95a51b7d8aae5c613ea6155886beab2e3985ebb7/lib/plugin/instance.rb#L463-L476

https://github.com/discourse/discourse/blob/95a51b7d8aae5c613ea6155886beab2e3985ebb7/lib/plugin/instance.rb#L490-L500

This PR eliminates this race condition by making test cases that need a plugin from the fixtures to copy the plugin from the fixtures directory into a temporary directory that's unique per process and load/activate the plugin from the temporary directory instead of the original copy in the fixtures directory. 