### PR TITLE
FIX: Prevent undefined on isSafari capabilities test

### DIFF
--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -29,7 +29,7 @@ export default class Capabilities extends Service {
     this.isChrome = !!window.chrome && !this.isOpera;
     this.isSafari =
       /Constructor/.test(window.HTMLElement) ||
-      window.safari?.pushNotification.toString() ===
+      window.safari?.pushNotification?.toString() ===
         "[object SafariRemoteNotification]";
 
     this.hasContactPicker =


### PR DESCRIPTION
Added a null coalesce operator on the field `isSafari` on the capabilities service to prevent an error in case `pushNotifications` is `undefined`

