### PR TITLE
FIX: Non-Interfering Backdrop Clicks

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.hbs
@@ -9,7 +9,7 @@
     <div
       role="button"
       class="collapse-area"
-      {{on "touchstart" this.collapseMenu passive=true}}
+      {{on "touchstart" this.collapseMenu}}
     >
     </div>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
@@ -48,7 +48,7 @@ export default class ChatMessageActionsMobile extends Component {
 
   @action
   collapseMenu(event) {
-    event.stopPropagation();
+    event.preventDefault();
     this.#onCloseMenu();
   }
 


### PR DESCRIPTION
Previously, there was an issue where closing the message actions menu on mobile would unintentionally trigger a click event on an element below it, such as a thread indicator or a reaction. With this fix, when you close the menu, it will no longer interfere with or activate any elements positioned underneath it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
