### PR TITLE
DEV: `PostRevisor` helper methods to track topic title and raw revisions

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -762,4 +762,17 @@ class PostRevisor
   def guardian
     @guardian ||= Guardian.new(@editor)
   end
+
+  def raw_changed?
+    @fields.has_key?(:raw) && @fields[:raw] != cached_original_raw && @post_successfully_saved
+  end
+
+  def topic_title_changed?
+    topic_changed? && @fields.has_key?(:title) && topic_diff.has_key?(:title) &&
+      !@topic_changes.errored?
+  end
+
+  def reviewable_content_changed?
+    raw_changed? || topic_title_changed?
+  end
 end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -322,6 +322,7 @@ RSpec.describe PostRevisor do
       subject.revise!(admin, raw: "new post body", tags: ["new-tag"])
       expect(post.topic.reload.tags.map(&:name)).to contain_exactly("new-tag")
       expect(post.post_revisions.reload.size).to eq(1)
+      expect(subject.raw_changed?).to eq(true)
 
       subject.revise!(admin, raw: old_raw, tags: [])
       expect(post.topic.reload.tags.map(&:name)).to be_empty
@@ -968,6 +969,8 @@ RSpec.describe PostRevisor do
       post.reload
       expect(post.topic.title).to eq(new_title)
       expect(post.revisions.first.modifications["title"][1]).to eq(new_title)
+      expect(subject.topic_title_changed?).to eq(true)
+      expect(subject.raw_changed?).to eq(false)
     end
 
     it "revises and tracks changes of topic archetypes" do
@@ -983,17 +986,21 @@ RSpec.describe PostRevisor do
       post.reload
       expect(post.topic.archetype).to eq(new_archetype)
       expect(post.revisions.first.modifications["archetype"][1]).to eq(new_archetype)
+      expect(subject.raw_changed?).to eq(false)
     end
 
     it "revises and tracks changes of topic tags" do
       subject.revise!(admin, tags: ["new-tag"])
       expect(post.post_revisions.last.modifications).to eq("tags" => [[], ["new-tag"]])
+      expect(subject.raw_changed?).to eq(false)
 
       subject.revise!(admin, tags: %w[new-tag new-tag-2])
       expect(post.post_revisions.last.modifications).to eq("tags" => [[], %w[new-tag new-tag-2]])
+      expect(subject.raw_changed?).to eq(false)
 
       subject.revise!(admin, tags: ["new-tag-3"])
       expect(post.post_revisions.last.modifications).to eq("tags" => [[], ["new-tag-3"]])
+      expect(subject.raw_changed?).to eq(false)
     end
 
     describe "#publish_changes" do


### PR DESCRIPTION
Not all revisions involve changes to the actual post/topic content. We may want to know if a revisions includes the topic title or post raw.

Specifically introducing these for use in the Akismet plugin to conditionally queue checks.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
