### PR TITLE
DEV: Unskip supposedly flaky test

### DIFF
--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -8,7 +8,6 @@ describe "Composer using review_media", type: :system, js: true do
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
-    skip("Currently flaky on CI")
     SiteSetting.review_media_unless_trust_level = 3
     sign_in user
   end


### PR DESCRIPTION
We believe the system tests were flaky due to the problem identified in
4dd053av