### PR TITLE
PERF: Preload user information when visiting user messages routes

### DIFF
--- a/app/controllers/user_actions_controller.rb
+++ b/app/controllers/user_actions_controller.rb
@@ -36,11 +36,6 @@ class UserActionsController < ApplicationController
     render_serialized(UserAction.stream_item(params[:id], guardian), UserActionSerializer)
   end
 
-  def private_messages
-    # DO NOT REMOVE
-    # TODO should preload messages to avoid extra http req
-  end
-
   private
 
   def user_actions_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -521,29 +521,28 @@ Discourse::Application.routes.draw do
            :constraints => {
              token: /[0-9a-f]+/,
            }
-      get "#{root_path}/:username/private-messages" => "user_actions#private_messages",
+      get "#{root_path}/:username/private-messages" => "users#show",
           :constraints => {
             username: RouteFormat.username,
           }
-      get "#{root_path}/:username/private-messages/:filter" => "user_actions#private_messages",
+      get "#{root_path}/:username/private-messages/:filter" => "users#show",
           :constraints => {
             username: RouteFormat.username,
           }
-      get "#{root_path}/:username/messages" => "user_actions#private_messages",
+      get "#{root_path}/:username/messages" => "users#show",
           :constraints => {
             username: RouteFormat.username,
           }
-      get "#{root_path}/:username/messages/:filter" => "user_actions#private_messages",
+      get "#{root_path}/:username/messages/:filter" => "users#show",
           :constraints => {
             username: RouteFormat.username,
           }
-      get "#{root_path}/:username/messages/group/:group_name" => "user_actions#private_messages",
+      get "#{root_path}/:username/messages/group/:group_name" => "users#show",
           :constraints => {
             username: RouteFormat.username,
             group_name: RouteFormat.username,
           }
-      get "#{root_path}/:username/messages/group/:group_name/:filter" =>
-            "user_actions#private_messages",
+      get "#{root_path}/:username/messages/group/:group_name/:filter" => "users#show",
           :constraints => {
             username: RouteFormat.username,
             group_name: RouteFormat.username,


### PR DESCRIPTION
What is the problem?

The user messages routes are currently routed by the server to
`UserActionsController#private_messages`. However, the method is
essentially a no-op and does not do any preloading. As a result, when we
load the user private messages routes, the client ends up having to
issue another request to the server to get more information about the
user profile currently being viewed. This extra request is triggered by
the `user` model's `findDetails` method that is called from the `user`
route in the `afterModel` hook.

What is the solution?

The `user` model's `findDetails` method actually checks the preload
store to see if the `user_${username}` key is present in the store and
if it is, it will use the preloaded data instead of triggering another
request. Since the user private messages routes are nested under the
user route on the client side, we have to rely on the
`UsersController#show` controller action on the server side for the user private
messages route as the `UsersController#show` controller action preloads
the required user information for the client side.