### PR TITLE
UX: adjust frequent poster size in topic map

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -684,14 +684,14 @@ aside.quote {
     }
 
     .avatar {
-      width: 2.5em;
-      height: 2.5em;
+      width: 2.15em;
+      height: 2.15em;
     }
     .post-count {
       position: absolute;
       right: 0;
       border-radius: 100px;
-      padding: 3px 5px;
+      padding: 0.15em 0.4em 0.2em;
       text-align: center;
       font-weight: normal;
       font-size: var(--font-down-2);


### PR DESCRIPTION
after c2332d7 these ended up a little too large, this gets us back to where we were before

Before:
![Screenshot 2023-06-05 at 4 10 15 PM](https://github.com/discourse/discourse/assets/1681963/847b1669-84e1-4b32-8189-4403ac909b0f)


After:
![Screenshot 2023-06-05 at 4 10 02 PM](https://github.com/discourse/discourse/assets/1681963/ced58ab8-f9c6-405b-816d-8bb5d2c64555)
