### PR TITLE
DEV: refactor calls to message.cook when sending messages

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -647,6 +647,7 @@ export default class ChatLivePane extends Component {
 
   @action
   async onSendMessage(message) {
+    await message.cook();
     if (message.editing) {
       await this.#sendEditMessage(message);
     } else {
@@ -660,7 +661,6 @@ export default class ChatLivePane extends Component {
   }
 
   async #sendEditMessage(message) {
-    await message.cook();
     this.pane.sending = true;
 
     const data = {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -228,6 +228,7 @@ export default class ChatThreadPanel extends Component {
   async onSendMessage(message) {
     resetIdle();
 
+    await message.cook();
     if (message.editing) {
       await this.#sendEditMessage(message);
     } else {
@@ -281,7 +282,6 @@ export default class ChatThreadPanel extends Component {
   }
 
   async #sendEditMessage(message) {
-    await message.cook();
     this.chatThreadPane.sending = true;
 
     const data = {

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -292,7 +292,6 @@ export default class ChatChannel {
     message.draft = false;
     message.createdAt ??= moment.utc().format();
     message.channel = this;
-    await message.cook();
 
     if (message.inReplyTo) {
       if (!this.threadingEnabled) {

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
@@ -69,7 +69,6 @@ export default class ChatThread {
     message.draft = false;
     message.createdAt ??= moment.utc().format();
     message.thread = this;
-    await message.cook();
 
     this.messagesManager.addMessages([message]);
   }


### PR DESCRIPTION
When editing a message, we call `message.cook()` in the beginning of `#sendEditMessage` methods, but when sending a new message the call to `message.cook()` is hidden in the `stageMessage` method.

We can just call `message.cook()` before sending the message, no matter whether this is a new message or an edited message.
