### PR TITLE
PERF: Avoid rendering a component that isn't required most of the time

### DIFF
--- a/app/assets/javascripts/discourse/app/components/offline-indicator.js
+++ b/app/assets/javascripts/discourse/app/components/offline-indicator.js
@@ -4,13 +4,9 @@ import { inject as service } from "@ember/service";
 
 export default class OfflineIndicator extends Component {
   @service messageBusConnectivity;
-  @service siteSettings;
 
   get showing() {
-    return (
-      this.siteSettings.enable_offline_indicator &&
-      !this.messageBusConnectivity.connected
-    );
+    return !this.messageBusConnectivity.connected;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/services/message-bus-connectivity.js
+++ b/app/assets/javascripts/discourse/app/services/message-bus-connectivity.js
@@ -8,6 +8,7 @@ export default class MessageBusConnectivity extends Service {
 
   setConnectivity(connected) {
     this.connected = connected;
+
     document.documentElement.classList.toggle(
       CONNECTIVITY_ERROR_CLASS,
       !connected

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -24,7 +24,10 @@
   {{/if}}
 
   <SoftwareUpdatePrompt />
-  <OfflineIndicator />
+
+  {{#if this.siteSettings.enable_offline_indicator}}
+    <OfflineIndicator />
+  {{/if}}
 
   <PluginOutlet
     @name="below-site-header"


### PR DESCRIPTION
What is this change required?

The `enable_offline_indicator` site setting is disabled by default so
there is no need for us to be rendering an extra Ember component when
the site setting is not enabled.