### PR TITLE
DEV: Fix system test assertion to avoid stale element reference error

### DIFF
--- a/spec/system/fast_edit_spec.rb
+++ b/spec/system/fast_edit_spec.rb
@@ -47,8 +47,9 @@ describe "Fast edit", type: :system, js: true do
       fast_editor.fill_content("day")
       fast_editor.save
 
-      expect(find("#{topic_page.post_by_number_selector(2)} .cooked p")).to have_content(
-        "It ‘twas a great’ “day”!",
+      expect(page).to have_selector(
+        "#{topic_page.post_by_number_selector(2)} .cooked p",
+        text: "It ‘twas a great’ “day”!",
       )
     end
   end


### PR DESCRIPTION
What is this change required?

We were seeing this error on CI

```
  1) Fast edit when editing text that has strange characters saves when paragraph contains apostrophe
     Failure/Error:
       expect(find("#{topic_page.post_by_number_selector(2)} .cooked p")).to have_content(
         "It ‘twas a great’ “day”!",
       )

     Selenium::WebDriver::Error::StaleElementReferenceError:
       stale element reference: stale element not found
         (Session info: chrome=114.0.5735.90)
```

I believe this is because the element that is "found" using `find` is
eventually re-rendered before the `have_content` matcher is called on
it.