### PR TITLE
UX: fix number cutoff in header chat indicator

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
@@ -1,12 +1,13 @@
 {{#if this.showUrgentIndicator}}
   <div class="chat-channel-unread-indicator urgent">
-    {{#if (gte this.chatTrackingStateManager.allChannelUrgentCount 1000)}}
-      <div class="chat-channel-unread-indicator__number -infinity">&#x221E;
-      </div>
-    {{else}}
-      <div class="chat-channel-unread-indicator__number">
-        {{this.chatTrackingStateManager.allChannelUrgentCount}}</div>
-    {{/if}}
+    <div
+      class={{concat-class
+        "chat-channel-unread-indicator__number"
+        this.numberIsTooHigh
+      }}
+    >
+      {{html-safe this.unreadCountLabel}}
+    </div>
   </div>
 {{else if this.showUnreadIndicator}}
   <div class="chat-channel-unread-indicator"></div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
@@ -1,12 +1,7 @@
 {{#if this.showUrgentIndicator}}
   <div class="chat-channel-unread-indicator urgent">
-    <div
-      class={{concat-class
-        "chat-channel-unread-indicator__number"
-        this.numberIsTooHigh
-      }}
-    >
-      {{html-safe this.unreadCountLabel}}
+    <div class="chat-channel-unread-indicator__number">
+      {{this.unreadCountLabel}}
     </div>
   </div>
 {{else if this.showUnreadIndicator}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.hbs
@@ -1,10 +1,12 @@
 {{#if this.showUrgentIndicator}}
   <div class="chat-channel-unread-indicator urgent">
-    <div class="number-wrap">
-      <div
-        class="number"
-      >{{this.chatTrackingStateManager.allChannelUrgentCount}}</div>
-    </div>
+    {{#if (gte this.chatTrackingStateManager.allChannelUrgentCount 1000)}}
+      <div class="chat-channel-unread-indicator__number -infinity">&#x221E;
+      </div>
+    {{else}}
+      <div class="chat-channel-unread-indicator__number">
+        {{this.chatTrackingStateManager.allChannelUrgentCount}}</div>
+    {{/if}}
   </div>
 {{else if this.showUnreadIndicator}}
   <div class="chat-channel-unread-indicator"></div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.js
@@ -41,4 +41,16 @@ export default class ChatHeaderIconUnreadIndicator extends Component {
 
     return preferences.includes(this.indicatorPreference);
   }
+
+  get unreadCountLabel() {
+    return this.chatTrackingStateManager.allChannelUrgentCount > 999
+      ? "&#x221E"
+      : this.chatTrackingStateManager.allChannelUrgentCount;
+  }
+
+  get numberIsTooHigh() {
+    return this.chatTrackingStateManager.allChannelUrgentCount > 999
+      ? "-too-high"
+      : "";
+  }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon-unread-indicator.js
@@ -43,14 +43,8 @@ export default class ChatHeaderIconUnreadIndicator extends Component {
   }
 
   get unreadCountLabel() {
-    return this.chatTrackingStateManager.allChannelUrgentCount > 999
-      ? "&#x221E"
+    return this.chatTrackingStateManager.allChannelUrgentCount > 99
+      ? "99+"
       : this.chatTrackingStateManager.allChannelUrgentCount;
-  }
-
-  get numberIsTooHigh() {
-    return this.chatTrackingStateManager.allChannelUrgentCount > 999
-      ? "-too-high"
-      : "";
   }
 }

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -129,6 +129,8 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
 
       &__number {
         font-size: 0.7rem;
+        line-height: 15px;
+        height: inherit;
 
         &.-too-high {
           font-size: 1.25rem;

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -114,11 +114,26 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
 .header-dropdown-toggle.chat-header-icon {
   .icon {
     .chat-channel-unread-indicator {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: auto;
+      min-width: 14px;
+      padding: 3px;
+      border-radius: 1em;
       border: 2px solid var(--header_background);
       position: absolute;
-      right: 2px;
+      right: 0;
       bottom: 2px;
       transition: border-color linear 0.15s;
+
+      &__number {
+        font-size: 0.7rem;
+
+        &.-infinity {
+          font-size: 1.25rem;
+        }
+      }
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -130,7 +130,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
       &__number {
         font-size: 0.7rem;
 
-        &.-infinity {
+        &.-too-high {
           font-size: 1.25rem;
         }
       }


### PR DESCRIPTION
### Problem when the number gets to 3 digits
<img width="168" alt="image" src="https://github.com/discourse/discourse/assets/101828855/4a01fd69-669d-4aab-8267-50f75c4b5161">

### Changes
#### 1. Let indicator stretch to pill
<img width="117" alt="image" src="https://github.com/discourse/discourse/assets/101828855/976c9254-4b25-4428-affb-20c133cf97a0">

#### 2. When more than 99 => 99+
<img width="189" alt="image" src="https://github.com/discourse/discourse/assets/101828855/ee9bc245-c57e-4d80-900b-cbc50b97cb6d">

#### 3. 1-2 digits still looks the same
Only moved a bit to the right to make sure there is room when it grows to a pill
<img width="135" alt="image" src="https://github.com/discourse/discourse/assets/101828855/b105d991-71bd-4513-bb39-bde0ebd80cc5">


