### PR TITLE
UX: fix greyed out add button in chat composer when focussed

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer-button.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer-button.scss
@@ -24,7 +24,7 @@
       color: var(--primary-low-mid);
     }
 
-    .is-send-disabled.is-focused & {
+    .is-focused & {
       color: var(--primary-high);
     }
 


### PR DESCRIPTION
fixing
<img width="345" alt="image" src="https://github.com/discourse/discourse/assets/101828855/3fc28d33-9563-491c-9c61-085c32e835d2">

to
<img width="304" alt="image" src="https://github.com/discourse/discourse/assets/101828855/27f195f1-a4e9-4d77-8ca0-7c01d8668a87">


