### PR TITLE
FIX: scroll top after chat activation

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -62,6 +62,7 @@ export default class ChatRoute extends DiscourseRoute {
     schedule("afterRender", () => {
       document.body.classList.add("has-full-page-chat");
       document.documentElement.classList.add("has-full-page-chat");
+      scrollTop();
     });
   }
 
@@ -77,7 +78,6 @@ export default class ChatRoute extends DiscourseRoute {
     schedule("afterRender", () => {
       document.body.classList.remove("has-full-page-chat");
       document.documentElement.classList.remove("has-full-page-chat");
-      scrollTop();
     });
   }
 }

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "List channels | mobile", type: :system, js: true, mobile: true d
       sign_in(current_user)
       topic_page.visit_topic(topic)
       scroll_to(find("#post_19"))
+      page.evaluate_script("window.scrollBy(0,-100)") # ensures header buttons are displayed
       chat.open_from_header
 
       expect(page.evaluate_script("window.scrollY")).to be_within(1).of(0)

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "List channels | mobile", type: :system, js: true, mobile: true d
       sign_in(current_user)
       topic_page.visit_topic(topic)
       scroll_to(find("#post_19"))
-      page.evaluate_script("window.scrollBy(0,-100)") # ensures header buttons are displayed
+      page.evaluate_script("window.scrollBy(0,-150)") # ensures header buttons are displayed
       chat.open_from_header
 
       expect(page.evaluate_script("window.scrollY")).to be_within(1).of(0)

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -11,29 +11,6 @@ RSpec.describe "List channels | mobile", type: :system, js: true, mobile: true d
     sign_in(current_user)
   end
 
-  context "when navigating from a long topic" do
-    fab!(:topic) { Fabricate(:topic) }
-
-    before do
-      20.times do
-        channel = Fabricate(:chat_channel)
-        channel.add(current_user)
-      end
-
-      20.times { Fabricate(:post, topic: topic) }
-    end
-
-    it "doesn’t scroll to the bottom" do
-      sign_in(current_user)
-      topic_page.visit_topic(topic)
-      scroll_to(find("#post_19"))
-      page.evaluate_script("window.scrollBy(0,-150)") # ensures header buttons are displayed
-      chat.open_from_header
-
-      expect(page.evaluate_script("window.scrollY")).to be_within(1).of(0)
-    end
-  end
-
   context "when channels present" do
     context "when category channels" do
       fab!(:category_channel_1) { Fabricate(:category_channel) }

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -4,10 +4,33 @@ RSpec.describe "List channels | mobile", type: :system, js: true, mobile: true d
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
     chat_system_bootstrap
     sign_in(current_user)
+  end
+
+  context "when navigating from a long topic" do
+    fab!(:topic) { Fabricate(:topic) }
+
+    before do
+      20.times do
+        channel = Fabricate(:chat_channel)
+        channel.add(current_user)
+      end
+
+      20.times { Fabricate(:post, topic: topic) }
+    end
+
+    it "doesn’t scroll to the bottom" do
+      sign_in(current_user)
+      topic_page.visit_topic(topic)
+      scroll_to(find("#post_19"))
+      chat.open_from_header
+
+      expect(page.evaluate_script("window.scrollY")).to be_within(1).of(0)
+    end
   end
 
   context "when channels present" do

--- a/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
@@ -29,10 +29,9 @@ RSpec.describe "Reply to message - channel - drawer", type: :system, js: true do
 
       expect(drawer_page).to have_open_thread
 
-      thread_page.fill_composer("reply to message")
-      thread_page.click_send_message
+      thread_page.send_message("reply to message")
 
-      expect(thread_page).to have_message(text: "reply to message")
+      expect(thread_page.messages).to have_message(text: "reply to message")
 
       drawer_page.back
 
@@ -64,16 +63,15 @@ RSpec.describe "Reply to message - channel - drawer", type: :system, js: true do
 
       expect(drawer_page).to have_open_thread
 
-      thread_page.fill_composer("reply to message")
-      thread_page.click_send_message
+      thread_page.send_message("reply to message")
 
-      expect(thread_page).to have_message(text: message_1.message)
-      expect(thread_page).to have_message(text: "reply to message")
+      expect(thread_page.messages).to have_message(text: message_1.message)
+      expect(thread_page.messages).to have_message(text: "reply to message")
 
       drawer_page.back
 
       expect(channel_page).to have_thread_indicator(original_message, text: "2")
-      expect(channel_page).to have_no_message(text: "reply to message")
+      expect(channel_page.messages).to have_no_message(text: "reply to message")
     end
   end
 
@@ -91,10 +89,9 @@ RSpec.describe "Reply to message - channel - drawer", type: :system, js: true do
         text: original_message.excerpt,
       )
 
-      channel_page.fill_composer("reply to message")
-      channel_page.click_send_message
+      channel_page.send_message("reply to message")
 
-      expect(channel_page).to have_message(text: "reply to message")
+      expect(channel_page.messages).to have_message(text: "reply to message")
     end
   end
 end

--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -40,14 +40,13 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, js: true, m
       it "correctly loads the thread" do
         chat_page.visit_channel(channel_1)
         channel_page.reply_to(original_message)
-        thread_page.fill_composer("reply to message")
-        thread_page.click_send_message
+        thread_page.send_message("reply to message")
 
-        expect(thread_page).to have_message(text: "reply to message")
+        expect(thread_page.messages).to have_message(text: "reply to message")
 
         refresh
 
-        expect(thread_page).to have_message(text: "reply to message")
+        expect(thread_page.messages).to have_message(text: "reply to message")
       end
     end
   end
@@ -90,7 +89,7 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, js: true, m
       channel_page.fill_composer("reply to message")
       channel_page.click_send_message
 
-      expect(channel_page).to have_message(text: "reply to message")
+      expect(channel_page.messages).to have_message(text: "reply to message")
     end
   end
 end


### PR DESCRIPTION
Currently navigating a long topic and then opening chat would cause the view to be scrolled to the bottom. Using `scrollTop` here ensures we correctly scroll to top.

This had been incorrectly moved into `deactivate` during another change.