### PR TITLE
A11Y: more sidebar contrast in WCAG light palette

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -19,6 +19,7 @@
 
   --always-black-rgb: 0, 0, 0;
   --primary-rgb: #{hexToRGB($primary)};
+  --primary-high-rgb: #{hexToRGB($primary-high)};
   --primary-low-rgb: #{hexToRGB($primary-low)};
   --primary-very-low-rgb: #{hexToRGB($primary-very-low)};
   --secondary-rgb: #{hexToRGB($secondary)};

--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -308,9 +308,53 @@ html {
 
 // sidebar
 
-.sidebar-wrapper
-  .sidebar-sections
-  .sidebar-section-link-suffix.icon.unread
-  svg {
-  color: var(--tertiary);
+.sidebar-wrapper {
+  .sidebar-sections .sidebar-section-link-suffix.icon.unread svg {
+    color: var(--tertiary);
+  }
+
+  // applying an inverted color sidebar for the light theme only (for now)
+  // the lack of high-contrast sidebar color differentiation has been reported as an accessibility issue
+  // but a too-bright sidebar in dark mode may clash with some other accessibility needs
+  // this hopefully provides a reasonable amount of flexibility
+  @if #{schemeType()} == "light" {
+    --d-sidebar-background: var(--primary-high);
+    --d-sidebar-prefix-background: var(--primary-medium);
+
+    --d-sidebar-header-color: var(--secondary);
+    --d-sidebar-header-icon-color: var(--secondary-very-high);
+
+    --d-sidebar-link-color: var(--secondary);
+    --d-sidebar-link-icon-color: var(--secondary-very-high);
+    --d-sidebar-link-badge-color: var(--secondary-very-high);
+
+    --d-sidebar-highlight-background: var(--primary);
+    --d-sidebar-highlight-color: var(--secondary);
+    --d-sidebar-highlight-prefix-background: var(--primary-medium);
+    --d-sidebar-highlight-hover-background: var(--secondary);
+    --d-sidebar-highlight-hover-icon: var(--primary);
+
+    .btn-flat {
+      .d-icon {
+        color: var(--secondary-very-high);
+      }
+      &:focus,
+      .discourse-no-touch & {
+        &:hover {
+          color: var(--secondary);
+          .d-icon {
+            color: currentColor;
+          }
+        }
+      }
+    }
+
+    .sidebar-footer-wrapper .sidebar-footer-container:before {
+      background: linear-gradient(
+        to bottom,
+        rgba(var(--primary-high-rgb), 0),
+        rgba(var(--primary-high-rgb), 1)
+      );
+    }
+  }
 }


### PR DESCRIPTION
This adds a dark sidebar to the WCAG light color palette to provide a means to have strong contrast differentiation between the sidebar and main body content. We've received an accessibility report asking for this, and I've seen a similar option in other apps like Discord. 


![Screenshot 2023-06-06 at 1 05 48 PM](https://github.com/discourse/discourse/assets/1681963/ac7960d7-9b3b-47f2-9e46-1e28c6f9496d)


As I mentioned in the comment within the CSS, I'm only applying this to the light palette, as a light sidebar in a dark palette may interfere with other accessibility needs that call for dark colors.