### PR TITLE
FIX: restore sidebar footer background

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -1,5 +1,6 @@
 .sidebar-footer-wrapper {
   box-sizing: border-box;
+  background: var(--d-sidebar-background);
   width: 100%;
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
follow-up to 10dce46, this background shouldn't have been removed... fixes this overlap issue:

![Screenshot 2023-06-06 at 2 44 18 PM](https://github.com/discourse/discourse/assets/1681963/f7c7b81b-49cc-4517-85ee-55519ee56677)
