### PR TITLE
DEV: Remove superfluous `js: true` metadata

### DIFF
--- a/plugins/chat/spec/system/anonymous_spec.rb
+++ b/plugins/chat/spec/system/anonymous_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Anonymous", type: :system, js: true do
+RSpec.describe "Anonymous", type: :system do
   fab!(:topic) { Fabricate(:topic) }
 
   before { chat_system_bootstrap }

--- a/plugins/chat/spec/system/archive_channel_spec.rb
+++ b/plugins/chat/spec/system/archive_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Archive channel", type: :system, js: true do
+RSpec.describe "Archive channel", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Bookmark message", type: :system, js: true do
+RSpec.describe "Bookmark message", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/browse_page_spec.rb
+++ b/plugins/chat/spec/system/browse_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Browse page", type: :system, js: true do
+RSpec.describe "Browse page", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/channel_about_page_spec.rb
+++ b/plugins/chat/spec/system/channel_about_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel - Info - About page", type: :system, js: true do
+RSpec.describe "Channel - Info - About page", type: :system do
   fab!(:channel_1) { Fabricate(:category_channel) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/channel_info_pages_spec.rb
+++ b/plugins/chat/spec/system/channel_info_pages_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Info pages", type: :system, js: true do
+RSpec.describe "Info pages", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel) { PageObjects::Pages::ChatChannel.new }
   fab!(:current_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel - Info - Members page", type: :system, js: true do
+RSpec.describe "Channel - Info - Members page", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
 
   fab!(:current_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/channel_message_selection_spec.rb
+++ b/plugins/chat/spec/system/channel_message_selection_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel message selection", type: :system, js: true do
+RSpec.describe "Channel message selection", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/channel_message_upload_spec.rb
+++ b/plugins/chat/spec/system/channel_message_upload_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel message selection", type: :system, js: true do
+RSpec.describe "Channel message selection", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/channel_selector_modal_spec.rb
+++ b/plugins/chat/spec/system/channel_selector_modal_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel selector modal", type: :system, js: true do
+RSpec.describe "Channel selector modal", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/channel_settings_page_spec.rb
+++ b/plugins/chat/spec/system/channel_settings_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Channel - Info - Settings page", type: :system, js: true do
+RSpec.describe "Channel - Info - Settings page", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }

--- a/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
+++ b/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Channel thread message echoing", type: :system, js: true do
+describe "Channel thread message echoing", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
 

--- a/plugins/chat/spec/system/chat/composer/shortcuts/channel_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat | composer | shortcuts | channel", type: :system, js: true do
+RSpec.describe "Chat | composer | shortcuts | channel", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:current_user) { Fabricate(:admin) }
 

--- a/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat | composer | shortcuts | thread", type: :system, js: true do
+RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat channel", type: :system, js: true do
+RSpec.describe "Chat channel", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/chat_composer_draft_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_draft_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat composer draft", type: :system, js: true do
+RSpec.describe "Chat composer draft", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat composer", type: :system, js: true do
+RSpec.describe "Chat composer", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, user: current_user, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/chat_message/channel_spec.rb
+++ b/plugins/chat/spec/system/chat_message/channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat message - channel", type: :system, js: true do
+RSpec.describe "Chat message - channel", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat message - thread", type: :system, js: true do
+RSpec.describe "Chat message - thread", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }

--- a/plugins/chat/spec/system/chat_message_onebox_spec.rb
+++ b/plugins/chat/spec/system/chat_message_onebox_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat message onebox", type: :system, js: true do
+RSpec.describe "Chat message onebox", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
 

--- a/plugins/chat/spec/system/closed_channel_spec.rb
+++ b/plugins/chat/spec/system/closed_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Closed channel", type: :system, js: true do
+RSpec.describe "Closed channel", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/create_channel_spec.rb
+++ b/plugins/chat/spec/system/create_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Create channel", type: :system, js: true do
+RSpec.describe "Create channel", type: :system do
   fab!(:category_1) { Fabricate(:category) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/dates_separators_spec.rb
+++ b/plugins/chat/spec/system/dates_separators_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Dates separators", type: :system, js: true do
+RSpec.describe "Dates separators", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
 

--- a/plugins/chat/spec/system/deleted_channel_spec.rb
+++ b/plugins/chat/spec/system/deleted_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Deleted channel", type: :system, js: true do
+RSpec.describe "Deleted channel", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Deleted message", type: :system, js: true do
+RSpec.describe "Deleted message", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:sidebar_component) { PageObjects::Components::Sidebar.new }

--- a/plugins/chat/spec/system/document_title_spec.rb
+++ b/plugins/chat/spec/system/document_title_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Document title", type: :system, js: true do
+RSpec.describe "Document title", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/draft_message_spec.rb
+++ b/plugins/chat/spec/system/draft_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Draft message", type: :system, js: true do
+RSpec.describe "Draft message", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Drawer", type: :system, js: true do
+RSpec.describe "Drawer", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }

--- a/plugins/chat/spec/system/edited_message_spec.rb
+++ b/plugins/chat/spec/system/edited_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Edited message", type: :system, js: true do
+RSpec.describe "Edited message", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
 

--- a/plugins/chat/spec/system/flag_message_spec.rb
+++ b/plugins/chat/spec/system/flag_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Flag message", type: :system, js: true do
+RSpec.describe "Flag message", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/hashtag_autocomplete_spec.rb
+++ b/plugins/chat/spec/system/hashtag_autocomplete_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-describe "Using #hashtag autocompletion to search for and lookup channels",
-         type: :system,
-         js: true do
+describe "Using #hashtag autocompletion to search for and lookup channels", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:channel1) { Fabricate(:chat_channel, name: "Music Lounge", slug: "music") }
   fab!(:channel2) { Fabricate(:chat_channel, name: "Random", slug: "random") }

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "JIT messages", type: :system, js: true do
+RSpec.describe "JIT messages", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/kick_user_from_channel_spec.rb
+++ b/plugins/chat/spec/system/kick_user_from_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Kick user from chat channel", type: :system, js: true do
+describe "Kick user from chat channel", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:channel_2) { Fabricate(:chat_channel) }

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "List channels | mobile", type: :system, js: true, mobile: true do
+RSpec.describe "List channels | mobile", type: :system, mobile: true do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/list_channels/no_sidebar_spec.rb
+++ b/plugins/chat/spec/system/list_channels/no_sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "List channels | no sidebar", type: :system, js: true do
+RSpec.describe "List channels | no sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/list_channels/sidebar_spec.rb
+++ b/plugins/chat/spec/system/list_channels/sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "List channels | sidebar", type: :system, js: true do
+RSpec.describe "List channels | sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/mention_warnings_spec.rb
+++ b/plugins/chat/spec/system/mention_warnings_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Mentions warnings", type: :system, js: true do
+RSpec.describe "Mentions warnings", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
 

--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Message errors", type: :system, js: true do
+RSpec.describe "Message errors", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }

--- a/plugins/chat/spec/system/message_notifications_mobile_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_mobile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Message notifications - mobile", type: :system, js: true, mobile: true do
+RSpec.describe "Message notifications - mobile", type: :system, mobile: true do
   fab!(:current_user) { Fabricate(:user) }
 
   let!(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Message notifications - with sidebar", type: :system, js: true do
+RSpec.describe "Message notifications - with sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let!(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Thread indicator for chat messages", type: :system, js: true do
+describe "Thread indicator for chat messages", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
 

--- a/plugins/chat/spec/system/message_user_info.rb
+++ b/plugins/chat/spec/system/message_user_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Message user info", type: :system, js: true do
+RSpec.describe "Message user info", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }
 

--- a/plugins/chat/spec/system/move_message_to_channel_spec.rb
+++ b/plugins/chat/spec/system/move_message_to_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Move message to channel", type: :system, js: true do
+RSpec.describe "Move message to channel", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
 

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Navigation", type: :system, js: true do
+RSpec.describe "Navigation", type: :system do
   fab!(:category) { Fabricate(:category) }
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "React to message", type: :system, js: true do
+RSpec.describe "React to message", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
   fab!(:category_channel_1) { Fabricate(:category_channel) }

--- a/plugins/chat/spec/system/read_only_spec.rb
+++ b/plugins/chat/spec/system/read_only_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Read only", type: :system, js: true do
+RSpec.describe "Read only", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Reply to message - channel - drawer", type: :system, js: true do
+RSpec.describe "Reply to message - channel - drawer", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Reply to message - channel - full page", type: :system, js: true do
+RSpec.describe "Reply to message - channel - full page", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }

--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Reply to message - channel - mobile", type: :system, js: true, mobile: true do
+RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: true do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }

--- a/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Reply to message - smoke", type: :system, js: true do
+RSpec.describe "Reply to message - smoke", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }

--- a/plugins/chat/spec/system/reviewables_spec.rb
+++ b/plugins/chat/spec/system/reviewables_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Reviewables", type: :system, js: true do
+describe "Reviewables", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/shortcuts/drawer_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/drawer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Shortcuts | drawer", type: :system, js: true do
+RSpec.describe "Shortcuts | drawer", type: :system do
   fab!(:user_1) { Fabricate(:admin) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:channel_2) { Fabricate(:chat_channel) }

--- a/plugins/chat/spec/system/shortcuts/full_page_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/full_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Shortcuts | full page", type: :system, js: true do
+RSpec.describe "Shortcuts | full page", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:current_user) { Fabricate(:user) }
 

--- a/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Shortcuts | mark all read", type: :system, js: true do
+RSpec.describe "Shortcuts | mark all read", type: :system do
   fab!(:user_1) { Fabricate(:admin) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:channel_2) { Fabricate(:chat_channel) }

--- a/plugins/chat/spec/system/shortcuts/sidebar_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Shortcuts | sidebar", type: :system, js: true do
+RSpec.describe "Shortcuts | sidebar", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
+++ b/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Sidebar navigation menu", type: :system, js: true do
+RSpec.describe "Sidebar navigation menu", type: :system do
   let(:sidebar_page) { PageObjects::Pages::Sidebar.new }
   let(:sidebar_component) { PageObjects::Components::Sidebar.new }
 

--- a/plugins/chat/spec/system/sidebars_spec.rb
+++ b/plugins/chat/spec/system/sidebars_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Navigation", type: :system, js: true do
+RSpec.describe "Navigation", type: :system do
   fab!(:category) { Fabricate(:category) }
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/plugins/chat/spec/system/silenced_user_spec.rb
+++ b/plugins/chat/spec/system/silenced_user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Silenced user", type: :system, js: true do
+RSpec.describe "Silenced user", type: :system do
   fab!(:channel_1) { Fabricate(:category_channel) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Single thread in side panel", type: :system, js: true do
+describe "Single thread in side panel", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/thread_list/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_list/drawer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Thread list in side panel | drawer", type: :system, js: true do
+describe "Thread list in side panel | drawer", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:channel) { Fabricate(:chat_channel) }
   fab!(:other_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/thread_list/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_list/full_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Thread list in side panel | full page", type: :system, js: true do
+describe "Thread list in side panel | full page", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:other_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Thread tracking state | drawer", type: :system, js: true do
+describe "Thread tracking state | drawer", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:other_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Thread tracking state | full page", type: :system, js: true do
+describe "Thread tracking state | full page", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:other_user) { Fabricate(:user) }

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
+RSpec.describe "Quoting chat message transcripts", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:chat_channel_1) { Fabricate(:chat_channel) }

--- a/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
+++ b/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Unfollow dm channel", type: :system, js: true do
+RSpec.describe "Unfollow dm channel", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:other_user) { Fabricate(:user) }
   fab!(:dm_channel_1) { Fabricate(:direct_message_channel, users: [current_user, other_user]) }

--- a/plugins/chat/spec/system/update_last_read.rb
+++ b/plugins/chat/spec/system/update_last_read.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Update last read", type: :system, js: true do
+RSpec.describe "Update last read", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:first_unread) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Uploading files in chat messages", type: :system, js: true do
+describe "Uploading files in chat messages", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }

--- a/plugins/chat/spec/system/user_card_spec.rb
+++ b/plugins/chat/spec/system/user_card_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "User card", type: :system, js: true do
+RSpec.describe "User card", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:topic_1) { Fabricate(:topic) }
 

--- a/plugins/chat/spec/system/user_chat_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_chat_preferences_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "User chat preferences", type: :system, js: true do
+RSpec.describe "User chat preferences", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
+RSpec.describe "User menu notifications | sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/user_presence.rb
+++ b/plugins/chat/spec/system/user_presence.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "User presence", type: :system, js: true do
+RSpec.describe "User presence", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:current_user) { Fabricate(:user) }
 

--- a/plugins/chat/spec/system/user_status/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_status/sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "User status | sidebar", type: :system, js: true do
+RSpec.describe "User status | sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:dm_channel_1) { Fabricate(:direct_message_channel, users: [current_user]) }
 

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Visit channel", type: :system, js: true do
+RSpec.describe "Visit channel", type: :system do
   fab!(:category) { Fabricate(:category) }
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Local dates", type: :system, js: true do
+describe "Local dates", type: :system do
   fab!(:topic) { Fabricate(:topic) }
   fab!(:user) { Fabricate(:user) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -393,13 +393,12 @@ RSpec.configure do |config|
 
   last_driven_by = nil
   config.before(:each, type: :system) do |example|
-    if example.metadata[:js]
-      driver = [:selenium]
-      driver << :mobile if example.metadata[:mobile]
-      driver << :chrome
-      driver << :headless unless ENV["SELENIUM_HEADLESS"] == "0"
-      driven_by driver.join("_").to_sym
-    end
+    driver = [:selenium]
+    driver << :mobile if example.metadata[:mobile]
+    driver << :chrome
+    driver << :headless unless ENV["SELENIUM_HEADLESS"] == "0"
+    driven_by driver.join("_").to_sym
+
     setup_system_test
   end
 

--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Admin Customize Form Templates", type: :system, js: true do
+describe "Admin Customize Form Templates", type: :system do
   let(:form_template_page) { PageObjects::Pages::FormTemplate.new }
   let(:ace_editor) { PageObjects::Components::AceEditor.new }
 

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Admin Customize Themes", type: :system, js: true do
+describe "Admin Customize Themes", type: :system do
   fab!(:color_scheme) { Fabricate(:color_scheme) }
   fab!(:theme) { Fabricate(:theme) }
   fab!(:admin) { Fabricate(:admin) }

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Bookmarking posts and topics", type: :system, js: true do
+describe "Bookmarking posts and topics", type: :system do
   fab!(:topic) { Fabricate(:topic) }
   fab!(:user) { Fabricate(:user) }
   fab!(:post) { Fabricate(:post, topic: topic, raw: "This is some post to bookmark") }

--- a/spec/system/category_edit_spec.rb
+++ b/spec/system/category_edit_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Edit Category", type: :system, js: true do
+describe "Edit Category", type: :system do
   fab!(:color_scheme) { Fabricate(:color_scheme) }
   fab!(:theme) { Fabricate(:theme) }
   fab!(:admin) { Fabricate(:admin) }

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Composer Form Templates", type: :system, js: true do
+describe "Composer Form Templates", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:form_template_1) do
     Fabricate(:form_template, name: "Bug Reports", template: "- type: checkbox")

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-describe "Default to Subcategory when parent Category doesn't allow posting",
-         type: :system,
-         js: true do
+describe "Default to Subcategory when parent Category doesn't allow posting", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:group) { Fabricate(:group) }
   fab!(:group_user) { Fabricate(:group_user, user: user, group: group) }

--- a/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
+++ b/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Composer don't feed the trolls popup", type: :system, js: true do
+describe "Composer don't feed the trolls popup", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:troll) { Fabricate(:user) }
   fab!(:topic) { Fabricate(:topic, user: user) }

--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Composer using review_media", type: :system, js: true do
+describe "Composer using review_media", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:topic) { Fabricate(:topic, category: Category.find(SiteSetting.uncategorized_category_id)) }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Custom sidebar sections", type: :system, js: true do
+describe "Custom sidebar sections", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   let(:section_modal) { PageObjects::Modals::SidebarSectionForm.new }

--- a/spec/system/discovery_breadcrumb_navigation_spec.rb
+++ b/spec/system/discovery_breadcrumb_navigation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Navigating with breadcrumbs", type: :system, js: true do
+describe "Navigating with breadcrumbs", type: :system do
   let(:discovery) { PageObjects::Pages::Discovery.new }
 
   fab!(:category1) { Fabricate(:category) }

--- a/spec/system/ember_deprecation_test.rb
+++ b/spec/system/ember_deprecation_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Production mode debug shims", type: :system, js: true do
+describe "Production mode debug shims", type: :system do
   it "can successfully print a deprecation message after applying prod shims" do
     visit("/latest")
     expect(find("#main-outlet-wrapper")).to be_visible

--- a/spec/system/emojis/emoji_deny_list_spec.rb
+++ b/spec/system/emojis/emoji_deny_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Emoji deny list", type: :system, js: true do
+describe "Emoji deny list", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:composer) { PageObjects::Components::Composer.new }
   let(:emoji_picker) { PageObjects::Components::EmojiPicker.new }

--- a/spec/system/fast_edit_spec.rb
+++ b/spec/system/fast_edit_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Fast edit", type: :system, js: true do
+describe "Fast edit", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:fast_editor) { PageObjects::Components::FastEditor.new }
   fab!(:topic) { Fabricate(:topic) }

--- a/spec/system/filtering_topics_spec.rb
+++ b/spec/system/filtering_topics_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Filtering topics", type: :system, js: true do
+describe "Filtering topics", type: :system do
   fab!(:user) { Fabricate(:user) }
   let(:topic_list) { PageObjects::Components::TopicList.new }
   let(:topic_query_filter) { PageObjects::Components::TopicQueryFilter.new }

--- a/spec/system/hashtag_autocomplete_spec.rb
+++ b/spec/system/hashtag_autocomplete_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 describe "Using #hashtag autocompletion to search for and lookup categories and tags",
-         type: :system,
-         js: true do
+         type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:category) do
     Fabricate(:category, name: "Cool Category", slug: "cool-cat", topic_count: 3234)

--- a/spec/system/network_disconnected_spec.rb
+++ b/spec/system/network_disconnected_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Network Disconnected", type: :system, js: true do
+RSpec.describe "Network Disconnected", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   before { skip(<<~TEXT) }

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Reviewables", type: :system, js: true do
+describe "Reviewables", type: :system do
   let(:review_page) { PageObjects::Pages::Review.new }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:theme) { Fabricate(:theme) }

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Search", type: :system, js: true do
+describe "Search", type: :system do
   let(:search_page) { PageObjects::Pages::Search.new }
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic, raw: "This is a test post in a test topic") }

--- a/spec/system/tag_notification_level_spec.rb
+++ b/spec/system/tag_notification_level_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Tag notification level", type: :system, js: true do
+describe "Tag notification level", type: :system do
   let(:tags_page) { PageObjects::Pages::Tag.new }
   let(:select_kit) { PageObjects::Components::SelectKit.new(".tag-notifications-button") }
 

--- a/spec/system/tag_synonyms_spec.rb
+++ b/spec/system/tag_synonyms_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Tag synonyms", type: :system, js: true do
+describe "Tag synonyms", type: :system do
   let(:tags_page) { PageObjects::Pages::Tag.new }
   fab!(:tag_1) { Fabricate(:tag, name: "design") }
   fab!(:tag_2) { Fabricate(:tag, name: "art") }

--- a/spec/system/user_page/staff_info_spec.rb
+++ b/spec/system/user_page/staff_info_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Viewing user staff info as an admin", type: :system, js: true do
+describe "Viewing user staff info as an admin", type: :system do
   fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   let(:user_page) { PageObjects::Pages::User.new }

--- a/spec/system/user_preferences_interface_spec.rb
+++ b/spec/system/user_preferences_interface_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "User preferences for Interface", type: :system, js: true do
+describe "User preferences for Interface", type: :system do
   fab!(:user) { Fabricate(:user) }
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
   let(:user_preferences_interface_page) { PageObjects::Pages::UserPreferencesInterface.new }

--- a/spec/system/user_preferences_navigation_spec.rb
+++ b/spec/system/user_preferences_navigation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "User page navigation menu", type: :system, js: true do
+describe "User page navigation menu", type: :system do
   fab!(:user) { Fabricate(:user) }
   let(:everyone_group) { Group[:everyone] }
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }

--- a/spec/system/user_selector_spec.rb
+++ b/spec/system/user_selector_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "User selector", type: :system, js: true do
+describe "User selector", type: :system do
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
   fab!(:current_user) { Fabricate(:admin) }

--- a/spec/system/viewing_category_spec.rb
+++ b/spec/system/viewing_category_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Viewing a category", type: :system, js: true do
+RSpec.describe "Viewing a category", type: :system do
   fab!(:category) { Fabricate(:category) }
   fab!(:user) { Fabricate(:user) }
   let(:category_page) { PageObjects::Pages::Category.new }

--- a/spec/system/viewing_sidebar_mobile_spec.rb
+++ b/spec/system/viewing_sidebar_mobile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Viewing sidebar mobile", type: :system, js: true, mobile: true do
+describe "Viewing sidebar mobile", type: :system, mobile: true do
   fab!(:user) { Fabricate(:user) }
   let(:sidebar_dropdown) { PageObjects::Components::SidebarHeaderDropdown.new }
   let(:composer) { PageObjects::Components::Composer.new }

--- a/spec/system/viewing_sidebar_preferences_spec.rb
+++ b/spec/system/viewing_sidebar_preferences_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Viewing sidebar preferences", type: :system, js: true do
+describe "Viewing sidebar preferences", type: :system do
   let(:user_preferences_sidebar_page) { PageObjects::Pages::UserPreferencesSidebar.new }
 
   before { SiteSetting.navigation_menu = "sidebar" }

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Viewing sidebar", type: :system, js: true do
+describe "Viewing sidebar", type: :system do
   fab!(:admin) { Fabricate(:admin) }
   fab!(:user) { Fabricate(:user) }
   fab!(:category_sidebar_section_link) { Fabricate(:category_sidebar_section_link, user: user) }


### PR DESCRIPTION
Why this change?

It is very unlikely that we need to ever disable JS for system tests considering
that we rely on a JS framework on the frontend.