### PR TITLE
UX: Don't block render of user messages secondary nav for tracking state

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
@@ -11,7 +11,8 @@ export default class extends Controller {
 
   @computed(
     "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter"
+    "pmTopicTrackingState.statesModificationCounter",
+    "pmTopicTrackingState.isTracking"
   )
   get newLinkText() {
     return this.#linkText("new");
@@ -19,7 +20,8 @@ export default class extends Controller {
 
   @computed(
     "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter"
+    "pmTopicTrackingState.statesModificationCounter",
+    "pmTopicTrackingState.isTracking"
   )
   get unreadLinkText() {
     return this.#linkText("unread");

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages-user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages-user.js
@@ -22,7 +22,8 @@ export default class extends Controller {
 
   @computed(
     "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter"
+    "pmTopicTrackingState.statesModificationCounter",
+    "pmTopicTrackingState.isTracking"
   )
   get newLinkText() {
     return this.#linkText("new");
@@ -30,7 +31,8 @@ export default class extends Controller {
 
   @computed(
     "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter"
+    "pmTopicTrackingState.statesModificationCounter",
+    "pmTopicTrackingState.isTracking"
   )
   get unreadLinkText() {
     return this.#linkText("unread");

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages.js
@@ -8,12 +8,8 @@ export default DiscourseRoute.extend({
   templateName: "user/messages",
   composer: service(),
 
-  model() {
-    return this.modelFor("user");
-  },
-
   afterModel() {
-    return this.pmTopicTrackingState.startTracking();
+    this.pmTopicTrackingState.startTracking();
   },
 
   setupController() {


### PR DESCRIPTION
Why is this change required?

Right now, we're awaiting on the promise returned by
`this.pmTopicTrackingState.startTracking()` which blocks the rendering
of the template until the promise resolves. However, this blocking of
the rendering ends up introducing yet another intermediate loading state
in the UI which we find unsightly. Instead of blocking the rendering, we
allow the promise to resolve in the background and display the
new/unread counts when the promise resolves.

### Before 

![before](https://github.com/discourse/discourse/assets/4335742/e1735347-9e73-4b54-a250-f85ac2f0135a)

### After

![after](https://github.com/discourse/discourse/assets/4335742/50957a69-6dcc-480a-a4a1-c905310f5db1)
