### PR TITLE
DEV: Allow hiding chat secondary buttons for interactor

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
@@ -10,7 +10,14 @@
     }}
     data-id={{this.message.id}}
   >
-    <div class="chat-message-actions">
+    <div
+      class={{concat-class
+        "chat-message-actions"
+        (unless
+          this.messageInteractor.secondaryButtons.length "-no-more-buttons"
+        )
+      }}
+    >
       {{#if this.shouldRenderFavoriteReactions}}
         {{#each
           this.messageInteractor.emojiReactions

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -31,12 +31,10 @@ export default class ChatMessageActionsDesktop extends Component {
   }
 
   get messageInteractor() {
-    const activeMessage = this.chat.activeMessage;
-
     return new ChatMessageInteractor(
       getOwner(this),
-      activeMessage.model,
-      activeMessage.context
+      this.message,
+      this.context
     );
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
@@ -21,13 +21,15 @@ export default class ChatMessageActionsMobile extends Component {
     return this.chat.activeMessage.model;
   }
 
-  get messageInteractor() {
-    const activeMessage = this.chat.activeMessage;
+  get context() {
+    return this.chat.activeMessage.context;
+  }
 
+  get messageInteractor() {
     return new ChatMessageInteractor(
       getOwner(this),
-      activeMessage.model,
-      activeMessage.context
+      this.message,
+      this.context
     );
   }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -38,12 +38,13 @@ export default class ChatMessageInteractor {
 
   cachedFavoritesReactions = null;
 
-  constructor(owner, message, context) {
+  constructor(owner, message, context, options = {}) {
     setOwner(this, owner);
 
     this.message = message;
     this.context = context;
     this.cachedFavoritesReactions = this.chatEmojiReactionStore.favorites;
+    this.hiddenSecondaryButtons = options.hiddenSecondaryButtons || [];
   }
 
   get capabilities() {
@@ -204,7 +205,9 @@ export default class ChatMessageInteractor {
       });
     }
 
-    return buttons;
+    return buttons.reject((button) =>
+      this.hiddenSecondaryButtons.includes(button.id)
+    );
   }
 
   select(checked = true) {

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -76,6 +76,15 @@
     }
   }
 
+  &.-no-more-buttons {
+    .reply-btn {
+      border-right: 1px solid var(--primary-300);
+      border-top: 1px solid var(--primary-300);
+      border-bottom: 1px solid var(--primary-300);
+      border-radius: 0 0.25em 0.25em 0;
+    }
+  }
+
   .more-buttons.dropdown-select-box {
     .select-kit-header {
       background: none;


### PR DESCRIPTION
In some cases plugins may want to hide some of these buttons
at all times, overriding the rules for canX with hiding these
buttons. To achieve this, a plugin can override `messageInteractor`
on `ChatMessageActionsDesktop/Mobile` via `modifyClass` and pass
in the options to the constructor like so:

```
get messageInteractor() {
  return new ChatMessageInteractor(
    getOwner(this),
    this.message,
    this.context,
    {
      hiddenSecondaryButtons: [
        "copyLink",
        "select",
        "flag",
        "delete",
        "rebake",
      ],
    }
  );
}
```
