### PR TITLE
FIX: add category colors back to categories pages

### DIFF
--- a/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.hbs
@@ -1,12 +1,7 @@
 {{#each this.categories as |c|}}
   <div
     data-notification-level={{c.notificationLevelString}}
-    style={{unless
-      this.noCategoryStyle
-      (html-safe
-        (concat (border-color c.color) (category-color-variable c.color))
-      )
-    }}
+    style={{unless this.noCategoryStyle (category-color-variable c.color)}}
     class="category category-box category-box-{{c.slug}}
       {{if c.isMuted 'muted'}}
       {{if this.noCategoryStyle 'no-category-boxes-style'}}"

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.hbs
@@ -5,12 +5,7 @@
   />
 
   <div
-    style={{unless
-      this.noCategoryStyle
-      (html-safe
-        (concat (border-color c.color) (category-color-variable c.color))
-      )
-    }}
+    style={{unless this.noCategoryStyle (category-color-variable c.color)}}
     data-category-id={{c.id}}
     data-notification-level={{c.notificationLevelString}}
     data-url={{c.url}}

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
@@ -20,12 +20,7 @@
         {{if this.noCategoryStyle 'no-category-style'}}"
       style={{unless
         this.noCategoryStyle
-        (html-safe
-          (concat
-            (border-color this.category.color)
-            (category-color-variable this.category.color)
-          )
-        )
+        (category-color-variable this.category.color)
       }}
     >
       <CategoryTitleLink @category={{this.category}} />

--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -58,7 +58,7 @@
     border-width: 0;
     border-left-width: 6px;
     border-style: solid;
-    border-color: var(--primary-low);
+    border-color: var(--category-color, var(--primary-low));
 
     .mobile-view & {
       width: 100%;

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -92,7 +92,7 @@
 
   tbody {
     .category {
-      border-left: 6px solid;
+      border-left: 6px solid var(--category-color, var(--primary-low));
       h3,
       h4 {
         line-height: var(--line-height-medium);


### PR DESCRIPTION
Seems colors regressed for some category page types, due to the new way these variables are set. More info here: https://meta.discourse.org/t/categories-boxes-border-color-broken-after-update/267521

Before/After

![Screenshot 2023-06-07 at 12 39 14 PM](https://github.com/discourse/discourse/assets/1681963/7e7fbe29-7f75-4bef-8205-e746ba308696)
![Screenshot 2023-06-07 at 12 39 05 PM](https://github.com/discourse/discourse/assets/1681963/36cef39f-636e-4a76-9d7a-8d1b5648f780)
