### PR TITLE
FIX: Send TL2 promotion message to correct user

### DIFF
--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -73,7 +73,12 @@ class SystemMessage
 
     post = I18n.with_locale(@recipient.effective_locale) { creator.create }
 
-    DiscourseEvent.trigger(:system_message_sent, post: post, message_type: type)
+    DiscourseEvent.trigger(
+      :system_message_sent,
+      post: post,
+      message_type: type,
+      recipient: @recipient,
+    )
 
     raise StandardError, creator.errors.full_messages.join(" ") if creator.errors.present?
 

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -292,8 +292,7 @@ after_initialize do
     next if !SiteSetting.discourse_narrative_bot_enabled
     next if args[:message_type] != "tl2_promotion_message"
 
-    recipient = args[:post].topic.topic_users.where.not(user_id: args[:post].user_id).last&.user
-    recipient ||= Discourse.site_contact_user if args[:post].user == Discourse.site_contact_user
+    recipient = args[:recipient]
     next if recipient.nil?
 
     I18n.with_locale(recipient.effective_locale) do

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -831,6 +831,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         :system_message_sent,
         post: Post.last,
         message_type: "tl2_promotion_message",
+        recipient: recipient,
       )
     }.to change { Topic.count }
     expect(Topic.last.title).to eq(
@@ -849,6 +850,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         :system_message_sent,
         post: Post.last,
         message_type: "tl2_promotion_message",
+        recipient: recipient,
       )
     }.to change { Topic.count }
     expect(Topic.last.title).to eq(
@@ -879,11 +881,25 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         :system_message_sent,
         post: Post.last,
         message_type: "tl2_promotion_message",
+        recipient: recipient,
       )
     }.to change { Topic.count }
 
     topic = Topic.last
     expect(topic.title).to eq("german title")
     expect(topic.first_post.raw).to eq("german body")
+  end
+
+  it "invites the correct user when users in site_contact_group_name are invited to the system message" do
+    recipient = Fabricate(:user)
+    group = Fabricate(:group)
+    group.add(Fabricate(:user))
+    SiteSetting.site_contact_group_name = "#{group.name}"
+
+    SystemMessage.new(recipient).create("tl2_promotion_message", {})
+
+    expect(Topic.last.topic_users.map(&:user_id).sort).to eq(
+      [DiscourseNarrativeBot::Base.new.discobot_user.id, recipient.id],
+    )
   end
 end

--- a/spec/lib/system_message_spec.rb
+++ b/spec/lib/system_message_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe SystemMessage do
       expect(event[:event_name]).to eq(:system_message_sent)
       expect(event[:params].first[:post]).to eq(Post.last)
       expect(event[:params].first[:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:params].first[:recipient]).to eq(user)
     end
 
     it "sends an event before the system message is sent" do


### PR DESCRIPTION
Usually, when a user is promoted to TL2 two messages are sent. The first one is a system message 'tl2_promotion_message' which triggers a 'system_message_sent' Discourse event.

When the event is fired and if Discourse Narrative Bot is enabled, then a second message is sent to the recipient of the first message. The recipients was determined by looking at the list of users that can access that topic and pick the last one. This method does not work if 'site_contact_group_name' site setting is set because it adds the group in the list of recipients.

A solution to this problem would have been to select the last user in the list of 'topic_allowed_users', but an even better solution is to pass the name of the recipients when the 'system_message_sent' Discourse event is fired.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
