### PR TITLE
DEV: Create posts from form templates

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-form-template-validation-options.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-form-template-validation-options.js
@@ -6,7 +6,7 @@ export default class AdminFormTemplateValidationOptions extends Controller.exten
   ModalFunctionality
 ) {
   TABLE_HEADER_KEYS = ["key", "type", "description"];
-  VALIDATION_KEYS = ["required", "minimum", "maximum", "pattern"];
+  VALIDATION_KEYS = ["required", "minimum", "maximum", "pattern", "type"];
 
   get tableHeaders() {
     const translatedHeaders = [];

--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -247,6 +247,15 @@
               @disableSubmit={{this.composer.disableSubmit}}
             />
 
+            {{#if this.composer.formTemplateIds}}
+              <DButton
+                @class="preview-template"
+                @icon="eye"
+                @label="composer.preview_template"
+                @action={{this.composer.previewTemplate}}
+              />
+            {{/if}}
+
             {{#if this.composer.site.mobileView}}
               <a
                 href

--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -247,15 +247,6 @@
               @disableSubmit={{this.composer.disableSubmit}}
             />
 
-            {{#if this.composer.formTemplateIds}}
-              <DButton
-                @class="preview-template"
-                @icon="eye"
-                @label="composer.preview_template"
-                @action={{this.composer.previewTemplate}}
-              />
-            {{/if}}
-
             {{#if this.composer.site.mobileView}}
               <a
                 href

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -17,6 +17,7 @@
   @onPopupMenuAction={{this.onPopupMenuAction}}
   @popupMenuOptions={{this.popupMenuOptions}}
   @formTemplateIds={{this.formTemplateIds}}
+  @replyingToTopic={{this.composer.replyingToTopic}}
   @disabled={{this.disableTextarea}}
   @outletArgs={{hash composer=this.composer editorType="composer"}}
 >

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -183,6 +183,11 @@ export default class ComposerMessages extends Component {
       return;
     }
 
+    // We don't care about similar topics when creating with a form template
+    if (this.composer?.category?.form_template_ids.length > 0) {
+      return;
+    }
+
     // TODO: pass the 200 in from somewhere
     const raw = (this.composer.reply || "").slice(0, 200);
     const title = this.composer.title || "";

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -1,4 +1,7 @@
-<div class="d-editor-container">
+<div
+  class="d-editor-container
+    {{if this.showFormTemplateForm 'has-form-template'}}"
+>
   <div class="d-editor-textarea-column">
     {{yield}}
     {{#if this.showFormTemplateForm}}

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -1,7 +1,7 @@
 <div class="d-editor-container">
   <div class="d-editor-textarea-column">
     {{yield}}
-    {{#if @formTemplateIds}}
+    {{#if this.showFormTemplateForm}}
       {{#if (gt @formTemplateIds.length 1)}}
         <FormTemplateChooser
           @class="composer-select-form-template"

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -11,7 +11,9 @@
           @options={{hash maximum=1}}
         />
       {{/if}}
-      <FormTemplateField::Wrapper @id={{this.selectedFormTemplateId}} />
+      <form id="form-template-form">
+        <FormTemplateField::Wrapper @id={{this.selectedFormTemplateId}} />
+      </form>
     {{else}}
       <div
         class="d-editor-textarea-wrapper

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -249,7 +249,7 @@ export default Component.extend(TextareaTextManipulation, {
 
   @discourseComputed("formTemplateIds", "replyingToTopic")
   showFormTemplateForm(formTemplateIds, replyingToTopic) {
-    if (formTemplateIds && !replyingToTopic) {
+    if (formTemplateIds?.length > 0 && !replyingToTopic) {
       return true;
     }
 

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -247,6 +247,15 @@ export default Component.extend(TextareaTextManipulation, {
     this.selectedFormTemplateId = formTemplateId;
   },
 
+  @discourseComputed("formTemplateIds", "replyingToTopic")
+  showFormTemplateForm(formTemplateIds, replyingToTopic) {
+    if (formTemplateIds && !replyingToTopic) {
+      return true;
+    }
+
+    return false;
+  },
+
   @discourseComputed("placeholder")
   placeholderTranslated(placeholder) {
     if (placeholder) {

--- a/app/assets/javascripts/discourse/app/components/form-template-field/checkbox.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/checkbox.hbs
@@ -1,6 +1,10 @@
 <div class="control-group form-template-field" data-field-type="checkbox">
   <label class="form-template-field__label">
-    <Input class="form-template-field__checkbox" @type="checkbox" />
+    <Input
+      name={{@attributes.label}}
+      class="form-template-field__checkbox"
+      @type="checkbox"
+    />
     {{@attributes.label}}
   </label>
 </div>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/checkbox.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/checkbox.hbs
@@ -4,6 +4,7 @@
       name={{@attributes.label}}
       class="form-template-field__checkbox"
       @type="checkbox"
+      required={{if @validations.required "required" ""}}
     />
     {{@attributes.label}}
   </label>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/dropdown.hbs
@@ -5,7 +5,11 @@
 
   {{! TODO(@keegan): Update implementation to use <ComboBox/> instead }}
   {{! Current using <select> as it integrates easily with FormData (will update in v2) }}
-  <select name={{@attributes.label}} class="form-template-field__dropdown">
+  <select
+    name={{@attributes.label}}
+    class="form-template-field__dropdown"
+    required={{if @validations.required "required" ""}}
+  >
     {{#if @attributes.none_label}}
       <option
         class="form-template-field__dropdown-placeholder"

--- a/app/assets/javascripts/discourse/app/components/form-template-field/dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/dropdown.hbs
@@ -2,14 +2,21 @@
   {{#if @attributes.label}}
     <label class="form-template-field__label">{{@attributes.label}}</label>
   {{/if}}
-  <ComboBox
-    @class="form-template-field__dropdown"
-    @content={{@choices}}
-    @nameProperty={{null}}
-    @valueProperty={{null}}
-    @options={{hash
-      translatedNone=@attributes.none_label
-      filterable=@attributes.filterable
-    }}
-  />
+
+  {{! TODO(@keegan): Update implementation to use <ComboBox/> instead }}
+  {{! Current using <select> as it integrates easily with FormData (will update in v2) }}
+  <select name={{@attributes.label}} class="form-template-field__dropdown">
+    {{#if @attributes.none_label}}
+      <option
+        class="form-template-field__dropdown-placeholder"
+        value=""
+        disabled
+        selected
+        hidden
+      >{{@attributes.none_label}}</option>
+    {{/if}}
+    {{#each @choices as |choice|}}
+      <option value={{choice}}>{{choice}}</option>
+    {{/each}}
+  </select>
 </div>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/input.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/input.hbs
@@ -3,6 +3,7 @@
     <label class="form-template-field__label">{{@attributes.label}}</label>
   {{/if}}
   <Input
+    name={{@attributes.label}}
     class="form-template-field__input"
     @type="text"
     placeholder={{@attributes.placeholder}}

--- a/app/assets/javascripts/discourse/app/components/form-template-field/input.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/input.hbs
@@ -1,11 +1,17 @@
 <div class="control-group form-template-field" data-field-type="input">
+  {{! TODO(@keegan): Make label required }}
   {{#if @attributes.label}}
     <label class="form-template-field__label">{{@attributes.label}}</label>
   {{/if}}
+
   <Input
     name={{@attributes.label}}
     class="form-template-field__input"
-    @type="text"
+    @type={{if @validations.type @validations.type "text"}}
     placeholder={{@attributes.placeholder}}
+    required={{if @validations.required "required" ""}}
+    pattern={{@validations.pattern}}
+    minLength={{@validations.min}}
+    maxLength={{@validations.max}}
   />
 </div>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/multi-select.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/multi-select.hbs
@@ -2,14 +2,25 @@
   {{#if @attributes.label}}
     <label class="form-template-field__label">{{@attributes.label}}</label>
   {{/if}}
-  <MultiSelect
-    @class="form-template-field__multi-select"
-    @content={{@choices}}
-    @nameProperty={{null}}
-    @valueProperty={{null}}
-    @options={{hash
-      translatedNone=@attributes.none_label
-      maximum=@validations.maximum
-    }}
-  />
+
+  {{! TODO(@keegan): Update implementation to use <MultiSelect/> instead }}
+  {{! Current using <select multiple> as it integrates easily with FormData (will update in v2) }}
+  <select
+    name={{@attributes.label}}
+    class="form-template-field__multi-select"
+    multiple
+  >
+    {{#if @attributes.none_label}}
+      <option
+        class="form-template-field__multi-select-placeholder"
+        value=""
+        disabled
+        selected
+        hidden
+      >{{@attributes.none_label}}</option>
+    {{/if}}
+    {{#each @choices as |choice|}}
+      <option value={{choice}}>{{choice}}</option>
+    {{/each}}
+  </select>
 </div>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/multi-select.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/multi-select.hbs
@@ -8,14 +8,14 @@
   <select
     name={{@attributes.label}}
     class="form-template-field__multi-select"
-    multiple
+    required={{if @validations.required "required" ""}}
+    multiple="multiple"
   >
     {{#if @attributes.none_label}}
       <option
         class="form-template-field__multi-select-placeholder"
         value=""
         disabled
-        selected
         hidden
       >{{@attributes.none_label}}</option>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/form-template-field/textarea.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/textarea.hbs
@@ -6,5 +6,9 @@
     name={{@attributes.label}}
     class="form-template-field__textarea"
     placeholder={{@attributes.placeholder}}
+    pattern={{@validations.pattern}}
+    minLength={{@validations.min}}
+    maxLength={{@validations.max}}
+    required={{if @validations.required "required" ""}}
   />
 </div>

--- a/app/assets/javascripts/discourse/app/components/form-template-field/textarea.hbs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/textarea.hbs
@@ -3,6 +3,7 @@
     <label class="form-template-field__label">{{@attributes.label}}</label>
   {{/if}}
   <Textarea
+    name={{@attributes.label}}
     class="form-template-field__textarea"
     placeholder={{@attributes.placeholder}}
   />

--- a/app/assets/javascripts/discourse/app/lib/form-template-validation.js
+++ b/app/assets/javascripts/discourse/app/lib/form-template-validation.js
@@ -1,13 +1,10 @@
-export default function prepareFormTemplateData(event) {
-  event?.preventDefault();
-
-  const form = document.querySelector("#form-template-form");
+export default function prepareFormTemplateData(form) {
   const formData = new FormData(form);
 
   // Validate the form template
   _validateFormTemplateData(form);
   if (!form.checkValidity()) {
-    return;
+    return false;
   }
 
   // Gather form template data
@@ -41,7 +38,7 @@ export default function prepareFormTemplateData(event) {
     }
   });
 
-  this.model.set("reply", formattedOutput.join("\n\n"));
+  return formattedOutput.join("\n\n");
 }
 
 function _validateFormTemplateData(form) {

--- a/app/assets/javascripts/discourse/app/lib/form-template-validation.js
+++ b/app/assets/javascripts/discourse/app/lib/form-template-validation.js
@@ -1,0 +1,85 @@
+export default function prepareFormTemplateData(event) {
+  event?.preventDefault();
+
+  const form = document.querySelector("#form-template-form");
+  const formData = new FormData(form);
+
+  // Validate the form template
+  _validateFormTemplateData(form);
+  if (!form.checkValidity()) {
+    return;
+  }
+
+  // Gather form template data
+  const formDetails = [];
+  for (let [key, value] of formData.entries()) {
+    formDetails.push({
+      [key]: value,
+    });
+  }
+
+  const mergedData = [];
+  const mergedKeys = new Set();
+
+  for (const item of formDetails) {
+    const key = Object.keys(item)[0]; // Get the key of the current item
+    if (mergedKeys.has(key)) {
+      // If the key has already been merged, append the value to the existing key
+      mergedData[mergedData.length - 1][key] += "\n" + item[key];
+    } else {
+      mergedData.push(item);
+      mergedKeys.add(key);
+    }
+  }
+
+  // Construct formatted post output
+  const formattedOutput = mergedData.map((item) => {
+    const key = Object.keys(item)[0];
+    const value = item[key];
+    if (value) {
+      return `### ${key}\n${value}`;
+    }
+  });
+
+  this.model.set("reply", formattedOutput.join("\n\n"));
+}
+
+function _validateFormTemplateData(form) {
+  const fields = Array.from(form.elements);
+
+  fields.forEach((field) => {
+    field.setAttribute("aria-invalid", false);
+
+    const errorBox = document.createElement("div");
+    errorBox.classList.add("form-template-field__error", "popup-tip");
+    const errorId = field.id + "-error";
+
+    field.addEventListener("invalid", () => {
+      field.setAttribute("aria-invalid", true);
+      errorBox.classList.add("bad");
+      errorBox.setAttribute("id", errorId);
+      field.setAttribute("aria-describedby", errorId);
+
+      if (!field.nextElementSibling) {
+        field.insertAdjacentElement("afterend", errorBox);
+      }
+
+      errorBox.textContent = field.validationMessage;
+    });
+
+    // Mark the field as valid as changed:
+    field.addEventListener("input", () => {
+      const valid = field.checkValidity();
+      if (valid) {
+        field.setAttribute("aria-invalid", false);
+        errorBox.classList.remove("bad");
+
+        errorBox.textContent = "";
+      }
+    });
+
+    field.addEventListener("blur", () => {
+      field.checkValidity();
+    });
+  });
+}

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -788,6 +788,10 @@ export default class ComposerController extends Controller {
 
   @action
   saveAction(ignore, event) {
+    if (this.formTemplateIds.length > 0) {
+      this.prepareFormTemplateData(event);
+    }
+
     this.save(false, {
       jump:
         !(event?.shiftKey && this.get("model.replyingToTopic")) &&
@@ -1662,5 +1666,22 @@ export default class ComposerController extends Controller {
 
   clearLastValidatedAt() {
     this.set("lastValidatedAt", null);
+  }
+
+  prepareFormTemplateData(event) {
+    event?.preventDefault();
+
+    const form = document.querySelector("#form-template-form");
+    const formData = new FormData(form);
+
+    const topic = [];
+    for (let [key, value] of formData.entries()) {
+      topic.push(`### ${key}\n${value}`);
+    }
+    this.model.set("reply", topic.join("\n\n"));
+
+    // TODO!(@keegan):
+    // - [ ] Fix multi-select appearing with multiple headings
+    // - [ ] Ensure validations are working
   }
 }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1672,6 +1672,10 @@ export default class ComposerController extends Controller {
   }
 
   prepareFormTemplateData(event, skipValidation = false) {
+    if (this.model.replyingToTopic) {
+      return;
+    }
+
     event?.preventDefault();
 
     const form = document.querySelector("#form-template-form");

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -795,8 +795,10 @@ export default class ComposerController extends Controller {
 
   @action
   saveAction(ignore, event) {
-    if (this.formTemplateIds.length > 0) {
-      this.prepareFormTemplateData(event);
+    if (this.siteSettings.experimental_form_templates) {
+      if (this.formTemplateIds?.length > 0) {
+        this.prepareFormTemplateData(event);
+      }
     }
 
     this.save(false, {

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1668,16 +1668,18 @@ export default class ComposerController extends Controller {
     this.set("lastValidatedAt", null);
   }
 
-  prepareFormTemplateData(event) {
+  prepareFormTemplateData(event, skipValidation = false) {
     event?.preventDefault();
 
     const form = document.querySelector("#form-template-form");
     const formData = new FormData(form);
 
     // Validate the form template
-    this._validateFormTemplateData(form);
-    if (!form.checkValidity()) {
-      return;
+    if (skipValidation === false) {
+      this._validateFormTemplateData(form);
+      if (!form.checkValidity()) {
+        return;
+      }
     }
 
     // Gather form template data
@@ -1752,5 +1754,10 @@ export default class ComposerController extends Controller {
         field.checkValidity();
       });
     });
+  }
+
+  @action
+  previewTemplate(event) {
+    this.prepareFormTemplateData(event, true);
   }
 }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -789,15 +789,6 @@ export default class ComposerController extends Controller {
 
   @action
   saveAction(ignore, event) {
-    if (this.siteSettings.experimental_form_templates) {
-      if (
-        this.formTemplateIds?.length > 0 &&
-        !this.get("model.replyingToTopic")
-      ) {
-        prepareFormTemplateData(event);
-      }
-    }
-
     this.save(false, {
       jump:
         !(event?.shiftKey && this.get("model.replyingToTopic")) &&
@@ -937,6 +928,22 @@ export default class ComposerController extends Controller {
 
     if (this.site.mobileView && this.showPreview) {
       this.set("showPreview", false);
+    }
+
+    if (this.siteSettings.experimental_form_templates) {
+      if (
+        this.formTemplateIds?.length > 0 &&
+        !this.get("model.replyingToTopic")
+      ) {
+        const formTemplateData = prepareFormTemplateData(
+          document.querySelector("#form-template-form")
+        );
+        if (formTemplateData) {
+          this.model.set("reply", formTemplateData);
+        } else {
+          return;
+        }
+      }
     }
 
     const composer = this.model;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -509,6 +509,13 @@ export default class ComposerController extends Controller {
   @action
   updateCategory(categoryId) {
     this.model.categoryId = categoryId;
+
+    // Hides preview when category has form template
+    if (this.siteSettings.experimental_form_templates) {
+      if (this.model?.category?.form_template_ids.length > 0) {
+        this.set("showPreview", false);
+      }
+    }
   }
 
   @action
@@ -1250,8 +1257,16 @@ export default class ComposerController extends Controller {
         "id",
         opts.prioritizedCategoryId
       );
+
       if (category) {
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
+
+        // Hide preview if prioritized category has a form template
+        if (this.siteSettings.experimental_form_templates) {
+          if (category.form_template_ids.length > 0) {
+            this.set("showPreview", false);
+          }
+        }
       }
     }
 
@@ -1754,10 +1769,5 @@ export default class ComposerController extends Controller {
         field.checkValidity();
       });
     });
-  }
-
-  @action
-  previewTemplate(event) {
-    this.prepareFormTemplateData(event, true);
   }
 }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1674,14 +1674,83 @@ export default class ComposerController extends Controller {
     const form = document.querySelector("#form-template-form");
     const formData = new FormData(form);
 
-    const topic = [];
-    for (let [key, value] of formData.entries()) {
-      topic.push(`### ${key}\n${value}`);
+    // Validate the form template
+    this._validateFormTemplateData(form);
+    if (!form.checkValidity()) {
+      return;
     }
-    this.model.set("reply", topic.join("\n\n"));
 
-    // TODO!(@keegan):
-    // - [ ] Fix multi-select appearing with multiple headings
-    // - [ ] Ensure validations are working
+    // Gather form template data
+    const formDetails = [];
+    for (let [key, value] of formData.entries()) {
+      formDetails.push({
+        [key]: value,
+      });
+    }
+
+    const mergedData = [];
+    const mergedKeys = new Set();
+
+    for (const item of formDetails) {
+      const key = Object.keys(item)[0]; // Get the key of the current item
+      if (mergedKeys.has(key)) {
+        // If the key has already been merged, append the value to the existing key
+        mergedData[mergedData.length - 1][key] += "\n" + item[key];
+      } else {
+        mergedData.push(item);
+        mergedKeys.add(key);
+      }
+    }
+
+    // Construct formatted post output
+    const formattedOutput = mergedData.map((item) => {
+      const key = Object.keys(item)[0];
+      const value = item[key];
+      if (value) {
+        return `### ${key}\n${value}`;
+      }
+    });
+
+    this.model.set("reply", formattedOutput.join("\n\n"));
+  }
+
+  _validateFormTemplateData(form) {
+    const fields = Array.from(form.elements);
+
+    fields.forEach((field) => {
+      field.setAttribute("aria-invalid", false);
+
+      const errorBox = document.createElement("div");
+      errorBox.classList.add("form-template-field__error", "popup-tip");
+      const errorId = field.id + "-error";
+
+      field.addEventListener("invalid", () => {
+        field.setAttribute("aria-invalid", true);
+        errorBox.classList.add("bad");
+        errorBox.setAttribute("id", errorId);
+        field.setAttribute("aria-describedby", errorId);
+
+        if (!field.nextElementSibling) {
+          field.insertAdjacentElement("afterend", errorBox);
+        }
+
+        errorBox.textContent = field.validationMessage;
+      });
+
+      // Mark the field as valid as changed:
+      field.addEventListener("input", () => {
+        const valid = field.checkValidity();
+        if (valid) {
+          field.setAttribute("aria-invalid", false);
+          errorBox.classList.remove("bad");
+
+          errorBox.textContent = "";
+        }
+      });
+
+      field.addEventListener("blur", () => {
+        field.checkValidity();
+      });
+    });
   }
 }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -509,13 +509,6 @@ export default class ComposerController extends Controller {
   @action
   updateCategory(categoryId) {
     this.model.categoryId = categoryId;
-
-    // Hides preview when category has form template
-    if (this.siteSettings.experimental_form_templates) {
-      if (this.model?.category?.form_template_ids.length > 0) {
-        this.set("showPreview", false);
-      }
-    }
   }
 
   @action
@@ -1262,13 +1255,6 @@ export default class ComposerController extends Controller {
 
       if (category) {
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
-
-        // Hide preview if prioritized category has a form template
-        if (this.siteSettings.experimental_form_templates) {
-          if (category.form_template_ids.length > 0) {
-            this.set("showPreview", false);
-          }
-        }
       }
     }
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1671,7 +1671,7 @@ export default class ComposerController extends Controller {
     this.set("lastValidatedAt", null);
   }
 
-  prepareFormTemplateData(event, skipValidation = false) {
+  prepareFormTemplateData(event) {
     if (this.model.replyingToTopic) {
       return;
     }
@@ -1682,11 +1682,9 @@ export default class ComposerController extends Controller {
     const formData = new FormData(form);
 
     // Validate the form template
-    if (skipValidation === false) {
-      this._validateFormTemplateData(form);
-      if (!form.checkValidity()) {
-        return;
-      }
+    this._validateFormTemplateData(form);
+    if (!form.checkValidity()) {
+      return;
     }
 
     // Gather form template data

--- a/app/assets/javascripts/discourse/tests/integration/components/form-template-field/dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-template-field/dropdown-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { exists } from "discourse/tests/helpers/qunit-helpers";
+import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 module(
   "Integration | Component | form-template-field | dropdown",
@@ -16,7 +16,6 @@ module(
 
     test("renders a dropdown with choices", async function (assert) {
       const choices = ["Choice 1", "Choice 2", "Choice 3"];
-
       this.set("choices", choices);
 
       await render(
@@ -27,22 +26,22 @@ module(
         "A dropdown component exists"
       );
 
-      await this.subject.expand();
-
-      const dropdown = this.subject.displayedContent();
+      const dropdown = queryAll(
+        ".form-template-field__dropdown option:not(.form-template-field__dropdown-placeholder)"
+      );
       assert.strictEqual(dropdown.length, 3, "it has 3 choices");
       assert.strictEqual(
-        dropdown[0].name,
+        dropdown[0].value,
         "Choice 1",
         "it has the correct name for choice 1"
       );
       assert.strictEqual(
-        dropdown[1].name,
+        dropdown[1].value,
         "Choice 2",
         "it has the correct name for choice 2"
       );
       assert.strictEqual(
-        dropdown[2].name,
+        dropdown[2].value,
         "Choice 3",
         "it has the correct name for choice 3"
       );
@@ -66,9 +65,8 @@ module(
         "A dropdown component exists"
       );
 
-      await this.subject.expand();
       assert.strictEqual(
-        this.subject.header().label(),
+        query(".form-template-field__dropdown-placeholder").innerText,
         attributes.none_label,
         "None label is correct"
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/form-template-field/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-template-field/multi-select-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { exists } from "discourse/tests/helpers/qunit-helpers";
+import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 module(
   "Integration | Component | form-template-field | multi-select",
@@ -27,22 +27,22 @@ module(
         "A multiselect component exists"
       );
 
-      await this.subject.expand();
-
-      const dropdown = this.subject.displayedContent();
+      const dropdown = queryAll(
+        ".form-template-field__multi-select option:not(.form-template-field__multi-select-placeholder)"
+      );
       assert.strictEqual(dropdown.length, 3, "it has 3 choices");
       assert.strictEqual(
-        dropdown[0].name,
+        dropdown[0].value,
         "Choice 1",
         "it has the correct name for choice 1"
       );
       assert.strictEqual(
-        dropdown[1].name,
+        dropdown[1].value,
         "Choice 2",
         "it has the correct name for choice 2"
       );
       assert.strictEqual(
-        dropdown[2].name,
+        dropdown[2].value,
         "Choice 3",
         "it has the correct name for choice 3"
       );
@@ -66,9 +66,8 @@ module(
         "A multiselect dropdown component exists"
       );
 
-      await this.subject.expand();
       assert.strictEqual(
-        this.subject.header().label(),
+        query(".form-template-field__multi-select-placeholder").innerText,
         attributes.none_label,
         "None label is correct"
       );

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -358,6 +358,10 @@ html.composer-open {
         color: var(--danger);
       }
     }
+
+    .preview-template {
+      margin-left: 0.5rem;
+    }
   }
 
   #draft-status,

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -16,9 +16,19 @@ html.composer-open {
   margin-right: auto;
   max-width: $reply-area-max-width;
   width: 100%;
+
   &.hide-preview {
     max-width: 740px;
   }
+
+  &:has(.has-form-template) {
+    max-width: 740px;
+
+    .toggle-preview {
+      display: none;
+    }
+  }
+
   @media screen and (max-width: 1200px) {
     min-width: 0;
   }

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -14,6 +14,7 @@
 @import "date-time-input-range";
 @import "date-time-input";
 @import "footer-nav";
+@import "form-template-field";
 @import "group-member-dropdown";
 @import "groups-form-membership-fields";
 @import "hashtag";

--- a/app/assets/stylesheets/common/components/form-template-field.scss
+++ b/app/assets/stylesheets/common/components/form-template-field.scss
@@ -1,0 +1,16 @@
+.form-template-field {
+  // TODO(@keegan): Remove after updating dropdown/multi-select to use select-kit
+  &__dropdown {
+    border: 1px solid var(--primary-medium);
+    border-radius: var(--d-input-border-radius);
+    padding: 0.5em 0.65em;
+    font-size: var(--font-0);
+  }
+
+  &__multi-select {
+    border: 1px solid var(--primary-medium);
+    border-radius: var(--d-input-border-radius);
+    padding: 0.5em 0.65em;
+    font-size: var(--font-0);
+  }
+}

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -345,7 +345,7 @@
   }
 }
 
-.d-editor .form-template-form__wrapper {
+.d-editor #form-template-form {
   overflow: auto;
   background: var(--primary-very-low);
   padding: 1rem;

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -2,6 +2,13 @@
   display: flex;
   flex-grow: 1;
   max-width: 100%;
+
+  &.has-form-template {
+    .d-editor-preview-wrapper {
+      display: none;
+      flex: 0;
+    }
+  }
 }
 
 .d-editor {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2419,6 +2419,7 @@ en:
       create_shared_draft: "Create Shared Draft"
       edit_shared_draft: "Edit Shared Draft"
       title: "Or press %{modifier}Enter"
+      preview_template: "Preview Post"
 
       users_placeholder: "Add users or groups"
       title_placeholder: "What is this discussion about in one brief sentence?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2419,7 +2419,6 @@ en:
       create_shared_draft: "Create Shared Draft"
       edit_shared_draft: "Edit Shared Draft"
       title: "Or press %{modifier}Enter"
-      preview_template: "Preview Post"
 
       users_placeholder: "Add users or groups"
       title_placeholder: "What is this discussion about in one brief sentence?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5654,15 +5654,19 @@ en:
             minimum:
               key: "minimum"
               type: "integer"
-              description: "In text fields, specifies the minimum number of characters allowed."
+              description: "For text fields, specifies the minimum number of characters allowed."
             maximum:
               key: "maximum"
               type: "integer"
-              description: "In text fields, specifies the maximum number of characters allowed. In multi select dropdowns, specifies the maximum number of options that can be selected."
+              description: "For text fields, specifies the maximum number of characters allowed."
             pattern:
               key: "pattern"
               type: "regex string"
-              description: "In text fields, a regular expression specifying the allowed input."
+              description: "For text fields, a regular expression specifying the allowed input."
+            type:
+              key: "type"
+              type: "string"
+              description: "For input fields, you can specify the type of input that should be expected (text|email|date|number|url|tel|color)"
         preview_modal:
           title: "Preview Template"
         field_placeholders:

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -82,6 +82,7 @@ module SvgSprite
         exclamation-circle
         exclamation-triangle
         external-link-alt
+        eye
         fab-android
         fab-apple
         fab-chrome

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -104,6 +104,20 @@ describe "Composer Form Templates", type: :system, js: true do
     expect(composer).to have_form_template_field("input")
   end
 
+  it "shows the preview when a category without a form template is selected" do
+    category_page.visit(category_no_template)
+    category_page.new_topic_button.click
+    expect(composer).to have_composer_preview
+    expect(composer).to have_composer_preview_toggle
+  end
+
+  it "hides the preivew when a category with a form template is selected" do
+    category_page.visit(category_with_template_1)
+    category_page.new_topic_button.click
+    expect(composer).to have_no_composer_preview
+    expect(composer).to have_no_composer_preview_toggle
+  end
+
   it "shows the correct template when switching categories" do
     category_page.visit(category_no_template)
     category_page.new_topic_button.click

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -16,7 +16,7 @@ describe "Composer Form Templates", type: :system, js: true do
     )
   end
   fab!(:form_template_2) do
-    Fabricate(:form_template, name: "Feature Request", template: "- type: input")
+    Fabricate(:form_template, name: "Feature Request", template: "- type: checkbox")
   end
   fab!(:form_template_3) do
     Fabricate(:form_template, name: "Awesome Possum", template: "- type: dropdown")
@@ -101,7 +101,7 @@ describe "Composer Form Templates", type: :system, js: true do
     category_page.new_topic_button.click
     expect(composer).not_to have_composer_input
     expect(composer).to have_form_template
-    expect(composer).to have_form_template_field("checkbox")
+    expect(composer).to have_form_template_field("input")
   end
 
   it "shows the correct template when switching categories" do
@@ -116,11 +116,11 @@ describe "Composer Form Templates", type: :system, js: true do
     # switch to category with form template
     composer.switch_category(category_with_template_1.name)
     expect(composer).to have_form_template
-    expect(composer).to have_form_template_field("checkbox")
+    expect(composer).to have_form_template_field("input")
     # switch to category with a different form template
     composer.switch_category(category_with_template_2.name)
     expect(composer).to have_form_template
-    expect(composer).to have_form_template_field("input")
+    expect(composer).to have_form_template_field("checkbox")
   end
 
   it "does not show form template chooser when a category only has form template" do
@@ -138,9 +138,9 @@ describe "Composer Form Templates", type: :system, js: true do
   it "updates the form template when a different template is selected" do
     category_page.visit(category_with_multiple_templates_1)
     category_page.new_topic_button.click
-    expect(composer).to have_form_template_field("checkbox")
-    form_template_chooser.select_row_by_name(form_template_2.name)
     expect(composer).to have_form_template_field("input")
+    form_template_chooser.select_row_by_name(form_template_2.name)
+    expect(composer).to have_form_template_field("checkbox")
   end
 
   it "shows the correct template options when switching categories" do

--- a/spec/system/composer/template_validation_spec.rb
+++ b/spec/system/composer/template_validation_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+describe "Composer Form Template Validations", type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:form_template) do
+    Fabricate(
+      :form_template,
+      name: "Bug Reports",
+      template:
+        "- type: input
+  attributes:
+    label: What is your full name?
+    placeholder: John Doe
+  validations:
+    required: true
+    type: email
+    min: 10",
+    )
+  end
+
+  fab!(:form_template_2) do
+    Fabricate(
+      :form_template,
+      name: "Websites",
+      template:
+        "- type: input
+  attributes:
+    label: What is your website name?
+    placeholder: https://www.example.com
+  validations:
+    pattern: https?://.+",
+    )
+  end
+  fab!(:category_with_template) do
+    Fabricate(
+      :category,
+      name: "Reports",
+      slug: "reports",
+      topic_count: 2,
+      form_template_ids: [form_template.id],
+    )
+  end
+  fab!(:category_with_template_2) do
+    Fabricate(
+      :category,
+      name: "Websites",
+      slug: "websites",
+      topic_count: 2,
+      form_template_ids: [form_template_2.id],
+    )
+  end
+  let(:category_page) { PageObjects::Pages::Category.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  let(:error_types) do
+    {
+      required_error: "Please fill out this field.",
+      type_error: "Please include an '@' in the email address. 'Bruce Wayne' is missing an '@'.",
+      min_error:
+        "Please lengthen this text to 10 characters or more (you are currently using 7 characters).",
+      pattern_error: "Please match the requested format.",
+    }
+  end
+  let(:topic_title) { "A topic about Batman" }
+
+  before do
+    SiteSetting.experimental_form_templates = true
+    sign_in user
+  end
+
+  it "shows an error when a required input is not filled in" do
+    category_page.visit(category_with_template)
+    category_page.new_topic_button.click
+    composer.fill_title(topic_title)
+    composer.create
+    expect(composer).to have_form_template_field_error(error_types[:required_error])
+  end
+
+  it "shows an error when an input filled doesn't satisfy the type expected" do
+    category_page.visit(category_with_template)
+    category_page.new_topic_button.click
+    composer.fill_title(topic_title)
+    composer.create
+    composer.fill_form_template_field("input", "Bruce Wayne")
+    expect(composer).to have_form_template_field_error(error_types[:type_error])
+  end
+
+  it "shows an error when an input doesn't satisfy the min length expected" do
+    category_page.visit(category_with_template)
+    category_page.new_topic_button.click
+    composer.fill_title(topic_title)
+    composer.create
+    composer.fill_form_template_field("input", "b@b.com")
+    expect(composer).to have_form_template_field_error(error_types[:min_error])
+  end
+
+  it "shows an error when an input doesn't satisfy the requested pattern" do
+    category_page.visit(category_with_template_2)
+    category_page.new_topic_button.click
+    composer.fill_title(topic_title)
+    composer.fill_form_template_field("input", "www.example.com")
+    composer.create
+    expect(composer).to have_form_template_field_error(error_types[:pattern_error])
+  end
+end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -30,6 +30,11 @@ module PageObjects
         self
       end
 
+      def fill_form_template_field(field, content)
+        form_template_field(field).fill_in(with: content)
+        self
+      end
+
       def type_content(content)
         composer_input.send_keys(content)
         self
@@ -125,6 +130,10 @@ module PageObjects
 
       def composer_popup
         find("#{COMPOSER_ID} .composer-popup")
+      end
+
+      def form_template_field(field)
+        find(".form-template-field[data-field-type='#{field}']")
       end
 
       private

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -124,6 +124,10 @@ module PageObjects
         page.has_css?(".composer-select-form-template")
       end
 
+      def has_form_template_field_error?(error)
+        page.has_css?(".form-template-field__error", text: error)
+      end
+
       def composer_input
         find("#{COMPOSER_ID} .d-editor .d-editor-input")
       end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -112,6 +112,22 @@ module PageObjects
         page.has_css?("#{COMPOSER_ID} .d-editor .d-editor-input")
       end
 
+      def has_composer_preview?
+        page.has_css?("#{COMPOSER_ID} .d-editor-preview-wrapper")
+      end
+
+      def has_no_composer_preview?
+        page.has_no_css?("#{COMPOSER_ID} .d-editor-preview-wrapper")
+      end
+
+      def has_composer_preview_toggle?
+        page.has_css?("#{COMPOSER_ID} .toggle-preview")
+      end
+
+      def has_no_composer_preview_toggle?
+        page.has_no_css?("#{COMPOSER_ID} .toggle-preview")
+      end
+
       def has_form_template?
         page.has_css?(".form-template-form__wrapper")
       end


### PR DESCRIPTION
Note: This PR is an addition to the `experimental_form_templates` feature.

In a previous PR (https://github.com/discourse/discourse/pull/21190), we added the ability to show a category's form template form in the composer. In **this PR** we add the logic for processing the form data and turning it into a topic. This PR also adds basic support for validations defined in the templates YAML markup.

https://github.com/discourse/discourse/assets/30090424/173d708d-9fa6-4953-a79e-e3f929e1c5c0

