### PR TITLE
DEV: Added chat api to remove secondary buttons

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.hbs
@@ -10,7 +10,14 @@
     }}
     data-id={{this.message.id}}
   >
-    <div class="chat-message-actions">
+    <div
+      class={{concat-class
+        "chat-message-actions"
+        (unless
+          this.messageInteractor.secondaryButtons.length "-no-more-buttons"
+        )
+      }}
+    >
       {{#if this.shouldRenderFavoriteReactions}}
         {{#each
           this.messageInteractor.emojiReactions

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -31,12 +31,10 @@ export default class ChatMessageActionsDesktop extends Component {
   }
 
   get messageInteractor() {
-    const activeMessage = this.chat.activeMessage;
-
     return new ChatMessageInteractor(
       getOwner(this),
-      activeMessage.model,
-      activeMessage.context
+      this.message,
+      this.context
     );
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
@@ -21,13 +21,15 @@ export default class ChatMessageActionsMobile extends Component {
     return this.chat.activeMessage.model;
   }
 
-  get messageInteractor() {
-    const activeMessage = this.chat.activeMessage;
+  get context() {
+    return this.chat.activeMessage.context;
+  }
 
+  get messageInteractor() {
     return new ChatMessageInteractor(
       getOwner(this),
-      activeMessage.model,
-      activeMessage.context
+      this.message,
+      this.context
     );
   }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -38,12 +38,13 @@ export default class ChatMessageInteractor {
 
   cachedFavoritesReactions = null;
 
-  constructor(owner, message, context) {
+  constructor(owner, message, context, options = {}) {
     setOwner(this, owner);
 
     this.message = message;
     this.context = context;
     this.cachedFavoritesReactions = this.chatEmojiReactionStore.favorites;
+    this.hiddenSecondaryButtons = options.hiddenSecondaryButtons || [];
   }
 
   get capabilities() {
@@ -204,7 +205,9 @@ export default class ChatMessageInteractor {
       });
     }
 
-    return buttons;
+    return buttons.reject((button) =>
+      this.hiddenSecondaryButtons.includes(button.id)
+    );
   }
 
   select(checked = true) {

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -18,6 +18,12 @@ import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 import { MESSAGE_CONTEXT_THREAD } from "discourse/plugins/chat/discourse/components/chat-message";
 import I18n from "I18n";
 
+const removedSecondaryButtons = new Set();
+
+export function removeChatComposerSecondaryButtons(buttonIds) {
+  buttonIds.forEach((id) => removedSecondaryButtons.add(id));
+}
+
 export default class ChatMessageInteractor {
   @service appEvents;
   @service dialog;
@@ -38,13 +44,12 @@ export default class ChatMessageInteractor {
 
   cachedFavoritesReactions = null;
 
-  constructor(owner, message, context, options = {}) {
+  constructor(owner, message, context) {
     setOwner(this, owner);
 
     this.message = message;
     this.context = context;
     this.cachedFavoritesReactions = this.chatEmojiReactionStore.favorites;
-    this.hiddenSecondaryButtons = options.hiddenSecondaryButtons || [];
   }
 
   get capabilities() {
@@ -205,9 +210,7 @@ export default class ChatMessageInteractor {
       });
     }
 
-    return buttons.reject((button) =>
-      this.hiddenSecondaryButtons.includes(button.id)
-    );
+    return buttons.reject((button) => removedSecondaryButtons.has(button.id));
   }
 
   select(checked = true) {

--- a/plugins/chat/assets/javascripts/discourse/pre-initializers/chat-plugin-api.js
+++ b/plugins/chat/assets/javascripts/discourse/pre-initializers/chat-plugin-api.js
@@ -5,6 +5,7 @@ import {
 } from "discourse/plugins/chat/discourse/components/chat-message";
 import { registerChatComposerButton } from "discourse/plugins/chat/discourse/lib/chat-composer-buttons";
 import { addChatDrawerStateCallback } from "discourse/plugins/chat/discourse/services/chat-state-manager";
+import { removeChatComposerSecondaryButtons } from "discourse/plugins/chat/discourse/lib/chat-message-interactor";
 
 /**
  * Class exposing the javascript API available to plugins and themes.
@@ -111,6 +112,18 @@ import { addChatDrawerStateCallback } from "discourse/plugins/chat/discourse/ser
  * );
  */
 
+/**
+ * Removes secondary buttons from the chat composer
+ *
+ * @memberof PluginApi
+ * @instance
+ * @function removeChatComposerSecondaryButtons
+ * @param {...string} [1] - List of secondary button ids to remove, eg: `"foo", "bar"
+ * @example
+ *
+ * api.removeChatComposerSecondaryButtons("foo", "bar");
+ */
+
 export default {
   name: "chat-plugin-api",
   after: "inject-discourse-objects",
@@ -155,6 +168,18 @@ export default {
               });
           },
         });
+      }
+
+      if (!apiPrototype.hasOwnProperty("removeChatComposerSecondaryButtons")) {
+        Object.defineProperty(
+          apiPrototype,
+          "removeChatComposerSecondaryButtons",
+          {
+            value(...buttonIds) {
+              removeChatComposerSecondaryButtons(buttonIds);
+            },
+          }
+        );
       }
     });
   },

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -76,6 +76,15 @@
     }
   }
 
+  &.-no-more-buttons {
+    .reply-btn {
+      border-right: 1px solid var(--primary-300);
+      border-top: 1px solid var(--primary-300);
+      border-bottom: 1px solid var(--primary-300);
+      border-radius: 0 0.25em 0.25em 0;
+    }
+  }
+
   .more-buttons.dropdown-select-box {
     .select-kit-header {
       background: none;


### PR DESCRIPTION
In some cases plugins may want to hide some of these buttons
at all times, overriding the rules for canX with hiding these
buttons. To achieve this, a plugin can call the api
`removeChatComposerSecondaryButtons` and pass the list of button
ids that should be removed as argument, like the example below:

```
withPluginApi("1.2.0", (api) => {
  api.removeChatComposerSecondaryButtons("foo", "bar");
});
```