### PR TITLE
FIX: prevents back history loop

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
@@ -16,10 +16,10 @@ export default class ChatIndexRoute extends DiscourseRoute {
     const id = this.chat.getIdealFirstChannelId();
     if (id) {
       return this.chatChannelsManager.find(id).then((c) => {
-        return this.router.transitionTo("chat.channel", ...c.routeModels);
+        return this.router.replaceWith("chat.channel", ...c.routeModels);
       });
     } else {
-      return this.router.transitionTo("chat.browse");
+      return this.router.replaceWith("chat.browse");
     }
   }
 


### PR DESCRIPTION
The following case would create the perception of a broken back button on desktop:

- open discourse on home page
- click chat button in header
- hit back button
- observes that we are still on the channel didn't navigate to homepage as we would have expected

The back button is actually working but it's in a loop. We were doing a `transitionTo` after finding the ideal channel to show, so the browser history would look something like this:

- home
- chat index
- channel page

When hitting back, we would go to chat index which would run the same logic and transition us to channel page.

This change will use `replaceWith` to replace the chat index step by the channel step, this way our history will now look like this:

- home
- channel page

Hitting back will now correctly bring us to home.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
