### PR TITLE
FIX: prevents lightbox to close chat on escape

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -92,6 +92,12 @@ export default {
     };
 
     const closeChat = (event) => {
+      // TODO (joffrey): removes this when we move from magnific popup
+      // there's no proper way to prevent propagation in mfp
+      if (event.srcElement?.classList?.value?.includes("mfp-wrap")) {
+        return;
+      }
+
       if (chatStateManager.isDrawerActive) {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
No test as this is very much a hack while lightbox is being revamped. We currently have no good/easy way AFAIK to stop event propagation on escape in magnificpopup.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
