### PR TITLE
REVERT: makes touchstart passive

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -34,7 +34,7 @@ export default class ChatOnLongPress extends Modifier {
     this.onLongPressCancel = onLongPressCancel || (() => {});
 
     element.addEventListener("touchstart", this.handleTouchStart, {
-      passive: false,
+      passive: true,
       capture: true,
     });
   }

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -63,8 +63,6 @@ export default class ChatOnLongPress extends Modifier {
       return;
     }
 
-    cancelEvent(event);
-
     this.onLongPressStart(this.element, event);
 
     this.element.addEventListener("touchmove", this.onCancel, {


### PR DESCRIPTION
This is causing issues with scroll, I need to find a different issue for the event propagating as a click.