### PR TITLE
DEV: Fix and unskip flaky specs

### DIFF
--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -5,7 +5,7 @@ import {
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import {
   click,
   triggerEvent,
@@ -100,7 +100,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     setupAutocompleteResponses([mentionedUser2, mentionedUser3]);
   });
 
-  skip("just posted messages | it shows status on mentions ", async function (assert) {
+  test("just posted messages | it shows status on mentions ", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
     assertStatusIsRendered(
@@ -110,7 +110,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
-  skip("just posted messages | it updates status on mentions", async function (assert) {
+  test("just posted messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
@@ -123,7 +123,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assertStatusIsRendered(assert, selector, newStatus);
   });
 
-  skip("just posted messages | it deletes status on mentions", async function (assert) {
+  test("just posted messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
@@ -137,7 +137,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assert.dom(selector).doesNotExist("status is deleted");
   });
 
-  skip("edited messages | it shows status on mentions", async function (assert) {
+  test("edited messages | it shows status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(
@@ -152,7 +152,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
-  skip("edited messages | it updates status on mentions", async function (assert) {
+  test("edited messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await editMessage(
       ".chat-message-content",
@@ -168,7 +168,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assertStatusIsRendered(assert, selector, newStatus);
   });
 
-  skip("edited messages | it deletes status on mentions", async function (assert) {
+  test("edited messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -6,13 +6,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import {
-  click,
-  triggerEvent,
-  triggerKeyEvent,
-  visit,
-  waitFor,
-} from "@ember/test-helpers";
+import { click, triggerEvent, visit, waitFor } from "@ember/test-helpers";
 import pretender, { OK } from "discourse/tests/helpers/create-pretender";
 
 acceptance("Chat | User status on mentions", function (needs) {
@@ -318,7 +312,7 @@ acceptance("Chat | User status on mentions", function (needs) {
   async function typeWithAutocompleteAndSend(text) {
     await emulateAutocomplete(".chat-composer__input", text);
     await click(".autocomplete.ac-user .selected");
-    await triggerKeyEvent(".chat-composer__input", "keydown", "Enter");
+    await click(".chat-composer-button.-send");
   }
 
   function setupAutocompleteResponses(results) {


### PR DESCRIPTION
These specs were skipped in d6d5eae1. They sometimes failed, and only on CI, not in GitHub Actions. 

I wasn't able to reproduce failures locally, but I expect clicking the send button in chat composer should be more reliable than emulating pressing <kbd>Enter</kbd>.
