### PR TITLE
UI: correctly adds spacing for selection-management

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-selection-manager.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-selection-manager.scss
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    padding-bottom: env(safe-area-inset-bottom);
 
     .cancel-btn {
       margin-left: initial;
@@ -10,6 +11,10 @@
 
     .btn {
       margin-bottom: 0.25em;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
On iOS the safe area was not applied correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Look spacing at bottom of screenshots here.

Before:

![image](https://github.com/discourse/discourse/assets/339945/214b8221-e9fa-44b0-82a3-5670626efad2)

After:

![image](https://github.com/discourse/discourse/assets/339945/8866f5c5-0c8b-4663-b30a-c1345692c622)