### PR TITLE
PERF: Increase performance of large csv exports for User Histories

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -92,7 +92,6 @@ module Jobs
 
       # ensure directory exists
       FileUtils.mkdir_p(dirname) unless Dir.exist?(dirname)
-
       # Generate a compressed CSV file
       begin
         entities.each do |entity|
@@ -177,7 +176,7 @@ module Jobs
           UserHistory.where(admin_only: false).only_staff_actions.order("id DESC")
         end
 
-      staff_action_data.each { |staff_action| yield get_staff_action_fields(staff_action) }
+      staff_action_data.find_each { |staff_action| yield get_staff_action_fields(staff_action) }
     end
 
     def screened_email_export

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -184,7 +184,7 @@ module Jobs
 
       ScreenedEmail
         .order("last_match_at DESC")
-        .each { |screened_email| yield get_screened_email_fields(screened_email) }
+        .find_each { |screened_email| yield get_screened_email_fields(screened_email) }
     end
 
     def screened_ip_export


### PR DESCRIPTION
*Context*
We use CSV exports to save login actions in the `UserHistory` records

*Problem*
For very large exports the exports are failing silently after a certain amount of time with out alerting the user. 

*Solution*
Improve the performance of the CSV export proces for `UserHistory` records so that the process doesn't fail

