### PR TITLE
FIX: Make serialized watched word regex Javascript compatible

### DIFF
--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -18,7 +18,7 @@ class WatchedWordListSerializer < ApplicationSerializer
   def compiled_regular_expressions
     expressions = {}
     actions.each do |action|
-      expressions[action] = WordWatcher.serializable_word_matcher_regexp(action)
+      expressions[action] = WordWatcher.serializable_word_matcher_regexp(action, engine: :js)
     end
     expressions
   end

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -4,7 +4,7 @@ class WatchedWordSerializer < ApplicationSerializer
   attributes :id, :word, :regexp, :replacement, :action, :case_sensitive
 
   def regexp
-    WordWatcher.word_to_regexp(word)
+    WordWatcher.word_to_regexp(word, engine: :js)
   end
 
   def action


### PR DESCRIPTION
This change ensures Javascript compatible regex is serialized instead of the default ruby based one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
