### PR TITLE
DEV: fix flaky specs

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -594,6 +594,7 @@ export async function emulateAutocomplete(inputSelector, text) {
   await triggerKeyEvent(inputSelector, "keydown", "Backspace");
   await fillIn(inputSelector, text);
   await triggerKeyEvent(inputSelector, "keyup", "Backspace");
+  await settled();
 }
 
 // The order of attributes can vary in different browsers. When comparing

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -5,7 +5,7 @@ import {
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import { click, triggerEvent, visit, waitFor } from "@ember/test-helpers";
 import pretender, { OK } from "discourse/tests/helpers/create-pretender";
 
@@ -94,7 +94,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     setupAutocompleteResponses([mentionedUser2, mentionedUser3]);
   });
 
-  skip("just posted messages | it shows status on mentions ", async function (assert) {
+  test("just posted messages | it shows status on mentions ", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
     assertStatusIsRendered(
@@ -104,7 +104,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
-  skip("just posted messages | it updates status on mentions", async function (assert) {
+  test("just posted messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
 
@@ -117,7 +117,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assertStatusIsRendered(assert, selector, newStatus);
   });
 
-  skip("just posted messages | it deletes status on mentions", async function (assert) {
+  test("just posted messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await typeWithAutocompleteAndSend(`mentioning @${mentionedUser2.username}`);
@@ -131,7 +131,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assert.dom(selector).doesNotExist("status is deleted");
   });
 
-  skip("edited messages | it shows status on mentions", async function (assert) {
+  test("edited messages | it shows status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(
@@ -146,7 +146,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     );
   });
 
-  skip("edited messages | it updates status on mentions", async function (assert) {
+  test("edited messages | it updates status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
     await editMessage(
       ".chat-message-content",
@@ -162,7 +162,7 @@ acceptance("Chat | User status on mentions", function (needs) {
     assertStatusIsRendered(assert, selector, newStatus);
   });
 
-  skip("edited messages | it deletes status on mentions", async function (assert) {
+  test("edited messages | it deletes status on mentions", async function (assert) {
     await visit(`/chat/c/-/${channelId}`);
 
     await editMessage(


### PR DESCRIPTION
These spec are flaky only in CI, not locally and not in GitHub actions.

The previous attempt was in 44eabde1, but actually the failure happens a bit earlier. This is another attempt to fix these specs. Quite a lot of async logic is happening in `emulateAutocomplete()`, a call to `settled()` in the end should help make it more reliable.