### PR TITLE
FEATURE: Hide user tips for users with >10 posts

### DIFF
--- a/db/migrate/20230608180809_hide_user_tips_only_for_existing_users_with_more_than_ten_posts.rb
+++ b/db/migrate/20230608180809_hide_user_tips_only_for_existing_users_with_more_than_ten_posts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HideUserTipsOnlyForExistingUsersWithMoreThanTenPosts < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE user_options
+      SET seen_popups = '{}'
+      FROM user_stats
+      WHERE user_options.user_id = user_stats.user_id
+        AND user_stats.post_count < 10
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
In November 2022 we have added a migration to hide user tips for existing users irrespective of any stats. Now we want to hide the user tips only for those who have more than 10 posts. Users who dismissed the user tips, but still have less than 10 posts will be reminded of these user tips.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
