### PR TITLE
Revert "DEV: Use runtime info to split test files for parallel testin…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,11 +150,10 @@ jobs:
       - name: Fetch turbo_rspec_runtime.log cache
         uses: actions/cache@v3
         id: test-runtime-cache
-        if: matrix.build_type == 'backend' || matrix.build_type == 'system'
+        if: matrix.build_type == 'backend' && matrix.target == 'core'
         with:
           path: tmp/turbo_rspec_runtime.log
-          key: rspec-runtime-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.run_id }}
-          restore-keys: rspec-runtime-${{ matrix.build_type }}-${{ matrix.target }}-
+          key: rspec-runtime-backend-core
 
       - name: Run Zeitwerk check
         if: matrix.build_type == 'backend'
@@ -174,11 +173,11 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: bin/turbo_rspec --use-runtime-info --verbose
+        run: bin/turbo_rspec --verbose
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        run: bin/rake plugin:turbo_spec['*','--verbose --format documentation --use-runtime-info']
+        run: bin/rake plugin:turbo_spec['*','--verbose --format documentation']
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -195,11 +194,11 @@ jobs:
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
-        run: PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system
+        run: PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation spec/system
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -14,14 +14,6 @@ seed = rand(2**16)
 profile = false
 profile_print_slowest_examples_count = 10
 
-if ARGV.empty?
-  files = TurboTests::Runner.default_spec_folders
-  use_runtime_info = true
-else
-  files = ARGV
-  use_runtime_info = false
-end
-
 OptionParser
   .new do |opts|
     opts.on("-r", "--require PATH", "Require a file.") { |filename| requires << filename }
@@ -57,10 +49,6 @@ OptionParser
     end
 
     opts.on("--seed SEED", "The seed for the random order") { |s| seed = s.to_i }
-
-    opts.on("--use-runtime-info", "Use runtime info for tests group splitting") do
-      use_runtime_info = true
-    end
   end
   .parse!(ARGV)
 
@@ -69,6 +57,14 @@ requires.each { |f| require(f) }
 formatters << { name: "progress", outputs: [] } if formatters.empty?
 
 formatters.each { |formatter| formatter[:outputs] << "-" if formatter[:outputs].empty? }
+
+if ARGV.empty?
+  files = TurboTests::Runner.default_spec_folders
+  use_runtime_info = true
+else
+  files = ARGV
+  use_runtime_info = false
+end
 
 puts "::group::Run turbo_rspec" if ENV["GITHUB_ACTIONS"]
 puts "Running turbo_rspec (seed: #{seed}) using files in: #{files}"


### PR DESCRIPTION
…g (#21896)"

This reverts commit 14ed971db694ce632363cd17e4abc82c79428c7f.

This prevented the core backend tests from running in GitHub CI

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
