### PR TITLE
FIX: prevents long press to hijack reaction event

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
@@ -1,8 +1,8 @@
 {{#if (and @reaction this.emojiUrl)}}
   <button
     type="button"
-    {{on "touchstart" this.handleTouchStart}}
-    {{on "click" this.handleClick}}
+    {{on "click" this.handleClick bubbles=false}}
+    {{on "touchstart" this.handleClick bubbles=false}}
     tabindex="0"
     class={{concat-class
       "chat-message-reaction"

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
@@ -46,14 +46,8 @@ export default class ChatMessageReaction extends Component {
   }
 
   @action
-  handleTouchStart(event) {
-    this.handleClick(event);
-  }
-
-  @action
   handleClick(event) {
     event.stopPropagation();
-    event.preventDefault();
 
     this.args.onReaction?.(
       this.args.reaction.emoji,

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -35,7 +35,6 @@ export default class ChatOnLongPress extends Modifier {
 
     element.addEventListener("touchstart", this.handleTouchStart, {
       passive: true,
-      capture: true,
     });
   }
 
@@ -43,15 +42,9 @@ export default class ChatOnLongPress extends Modifier {
   onCancel() {
     cancel(this.timeout);
 
-    this.element.removeEventListener("touchmove", this.onCancel, {
-      capture: true,
-    });
-    this.element.removeEventListener("touchend", this.onCancel, {
-      capture: true,
-    });
-    this.element.removeEventListener("touchcancel", this.onCancel, {
-      capture: true,
-    });
+    this.element.removeEventListener("touchmove", this.onCancel);
+    this.element.removeEventListener("touchend", this.onCancel);
+    this.element.removeEventListener("touchcancel", this.onCancel);
 
     this.onLongPressCancel(this.element);
   }
@@ -65,15 +58,9 @@ export default class ChatOnLongPress extends Modifier {
 
     this.onLongPressStart(this.element, event);
 
-    this.element.addEventListener("touchmove", this.onCancel, {
-      capture: true,
-    });
-    this.element.addEventListener("touchend", this.onCancel, {
-      capture: true,
-    });
-    this.element.addEventListener("touchcancel", this.onCancel, {
-      capture: true,
-    });
+    this.element.addEventListener("touchmove", this.onCancel);
+    this.element.addEventListener("touchend", this.onCancel);
+    this.element.addEventListener("touchcancel", this.onCancel);
 
     this.timeout = discourseLater(() => {
       if (this.isDestroying || this.isDestroyed) {
@@ -82,7 +69,6 @@ export default class ChatOnLongPress extends Modifier {
 
       this.element.addEventListener("touchend", cancelEvent, {
         once: true,
-        capture: true,
       });
 
       this.onLongPressEnd(this.element, event);


### PR DESCRIPTION
Removing a reaction could start a long press at the same time and put the screen in a stuck state.

This commit ensures we give an opportunity to the reaction to capture the event first and not propagate further.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
