### PR TITLE
DEV: enable plain functions as helpers in Ember

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -100,6 +100,7 @@
     "ember-cli-progress-ci": "1.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-functions-as-helper-polyfill": "^2.1.1",
     "ember-qunit": "^6.2.0",
     "ember-exam": "^8.0.0",
     "eslint": "^8.42.0",

--- a/app/assets/javascripts/truth-helpers/addon/helpers/and.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/and.js
@@ -1,13 +1,13 @@
-import Helper from "@ember/component/helper";
 import truthConvert from "../utils/truth-convert";
 
-export function and(params) {
-  for (let i = 0, len = params.length; i < len; i++) {
-    if (truthConvert(params[i]) === false) {
-      return params[i];
+export default function and(...args) {
+  let arg = false;
+
+  for (arg of args) {
+    if (truthConvert(arg) === false) {
+      return arg;
     }
   }
-  return params[params.length - 1];
-}
 
-export default Helper.helper(and);
+  return arg;
+}

--- a/app/assets/javascripts/truth-helpers/addon/helpers/eq.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/eq.js
@@ -1,7 +1,3 @@
-import Helper from "@ember/component/helper";
-
-export function eq(params) {
-  return params[0] === params[1];
+export default function eq(left, right) {
+  return left === right;
 }
-
-export default Helper.helper(eq);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/gt.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/gt.js
@@ -1,7 +1,5 @@
-import Helper from "@ember/component/helper";
-
-export function gt([left, right], hash) {
-  if (hash.forceNumber) {
+export default function gt(left, right, { forceNumber = false } = {}) {
+  if (forceNumber) {
     if (typeof left !== "number") {
       left = Number(left);
     }
@@ -11,5 +9,3 @@ export function gt([left, right], hash) {
   }
   return left > right;
 }
-
-export default Helper.helper(gt);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/gte.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/gte.js
@@ -1,7 +1,5 @@
-import Helper from "@ember/component/helper";
-
-export function gte([left, right], hash) {
-  if (hash.forceNumber) {
+export default function gte(left, right, { forceNumber = false } = {}) {
+  if (forceNumber) {
     if (typeof left !== "number") {
       left = Number(left);
     }
@@ -11,5 +9,3 @@ export function gte([left, right], hash) {
   }
   return left >= right;
 }
-
-export default Helper.helper(gte);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/includes.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/includes.js
@@ -1,7 +1,3 @@
-import Helper from "@ember/component/helper";
-
-export function includes(params) {
-  return params[0].includes(params[1]);
+export default function includes(array, item) {
+  return array.includes(item);
 }
-
-export default Helper.helper(includes);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/lt.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/lt.js
@@ -1,7 +1,5 @@
-import Helper from "@ember/component/helper";
-
-export function lt([left, right], hash) {
-  if (hash.forceNumber) {
+export default function lt(left, right, { forceNumber = false } = {}) {
+  if (forceNumber) {
     if (typeof left !== "number") {
       left = Number(left);
     }
@@ -11,5 +9,3 @@ export function lt([left, right], hash) {
   }
   return left < right;
 }
-
-export default Helper.helper(lt);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/lte.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/lte.js
@@ -1,7 +1,5 @@
-import Helper from "@ember/component/helper";
-
-export function lte([left, right], hash) {
-  if (hash.forceNumber) {
+export default function lte(left, right, { forceNumber = false } = {}) {
+  if (forceNumber) {
     if (typeof left !== "number") {
       left = Number(left);
     }
@@ -11,5 +9,3 @@ export function lte([left, right], hash) {
   }
   return left <= right;
 }
-
-export default Helper.helper(lte);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/not-eq.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/not-eq.js
@@ -1,7 +1,3 @@
-import Helper from "@ember/component/helper";
-
-export function notEqualHelper(params) {
-  return params[0] !== params[1];
+export default function notEq(left, right) {
+  return left !== right;
 }
-
-export default Helper.helper(notEqualHelper);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/not.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/not.js
@@ -1,13 +1,11 @@
-import Helper from "@ember/component/helper";
 import truthConvert from "../utils/truth-convert";
 
-export function not(params) {
-  for (let i = 0, len = params.length; i < len; i++) {
-    if (truthConvert(params[i]) === true) {
+export default function not(...args) {
+  for (let arg of args) {
+    if (truthConvert(arg) === true) {
       return false;
     }
   }
+
   return true;
 }
-
-export default Helper.helper(not);

--- a/app/assets/javascripts/truth-helpers/addon/helpers/or.js
+++ b/app/assets/javascripts/truth-helpers/addon/helpers/or.js
@@ -1,13 +1,13 @@
-import Helper from "@ember/component/helper";
 import truthConvert from "../utils/truth-convert";
 
-export function or(params) {
-  for (let i = 0, len = params.length; i < len; i++) {
-    if (truthConvert(params[i]) === true) {
-      return params[i];
+export default function or(...args) {
+  let arg = false;
+
+  for (arg of args) {
+    if (truthConvert(arg) === true) {
+      return arg;
     }
   }
-  return params[params.length - 1];
-}
 
-export default Helper.helper(or);
+  return arg;
+}

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -4284,6 +4284,15 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
+ember-functions-as-helper-polyfill@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ember-functions-as-helper-polyfill/-/ember-functions-as-helper-polyfill-2.1.1.tgz#25240db29b4cd0366a2d2954d2ea26ce0872ff8f"
+  integrity sha512-vZ2w9G/foohwtPm99Jos1m6bhlXyyyiJ4vhLbxyjWB4wh7bcpRzXPgCewDRrwefZQ2BwtHg3c9zvVMlI0g+o2Q==
+  dependencies:
+    ember-cli-babel "^7.26.11"
+    ember-cli-typescript "^5.0.0"
+    ember-cli-version-checker "^5.1.2"
+
 ember-load-initializers@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz#8a47a656c1f64f9b10cecdb4e22a9d52ad9c7efa"


### PR DESCRIPTION
~~Rebased on top of #22095~~

Requested by @davidtaylorhq in https://github.com/discourse/discourse/pull/21899/files#r1221318682

This allows plain JavaScript functions to be used as template helpers. For now, it removes a bit of boilerplate from the helper files (see the truth-helpers refactor). Soon, with gjs/template imports (#21899), it will allow importing any JS functions into the template.

References

RFC: https://github.com/emberjs/rfcs/pull/756
Update: https://github.com/emberjs/rfcs/pull/788
Guides: https://github.com/ember-learn/guides-source/pull/1924