### PR TITLE
Add discourse-newsletter-integration plugin

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -54,6 +54,7 @@ class Plugin::Metadata
         "discourse-math",
         "discourse-moderator-attention",
         "discourse-narrative-bot",
+        "discourse-newsletter-integration",
         "discourse-no-bump",
         "discourse-oauth2-basic",
         "discourse-openid-connect",


### PR DESCRIPTION
discourse-newsletter-integration is an official plugin: https://github.com/discourse/discourse-newsletter-integration.