### PR TITLE
FIX: Add 'Ignored' flags to Moderator Activity report

### DIFF
--- a/app/models/concerns/reports/moderators_activity.rb
+++ b/app/models/concerns/reports/moderators_activity.rb
@@ -72,8 +72,9 @@ module Reports::ModeratorsActivity
       ),
       flag_count AS (
           WITH period_actions AS (
-          SELECT agreed_by_id,
-          disagreed_by_id
+          SELECT agreed_by_id, 
+          disagreed_by_id,
+          deferred_by_id
           FROM post_actions
           WHERE post_action_type_id IN (#{PostActionType.flag_types_without_custom.values.join(",")})
           AND created_at >= '#{report.start_date}'
@@ -94,13 +95,23 @@ module Reports::ModeratorsActivity
           JOIN period_actions pa
           ON pa.disagreed_by_id = m.user_id
           GROUP BY disagreed_by_id
+          ),
+          deferred_flags AS (
+          SELECT pa.deferred_by_id AS user_id,
+          COUNT(*) AS flag_count
+          FROM mods m
+          JOIN period_actions pa
+          ON pa.deferred_by_id = m.user_id
+          GROUP BY deferred_by_id
           )
       SELECT
-      COALESCE(af.user_id, df.user_id) AS user_id,
-      COALESCE(af.flag_count, 0) + COALESCE(df.flag_count, 0) AS flag_count
+      COALESCE(af.user_id, df.user_id, def.user_id) AS user_id,
+      COALESCE(af.flag_count, 0) + COALESCE(df.flag_count, 0) + COALESCE(def.flag_count, 0) AS flag_count 
       FROM agreed_flags af
       FULL OUTER JOIN disagreed_flags df
       ON df.user_id = af.user_id
+      FULL OUTER JOIN deferred_flags def
+      ON def.user_id = af.user_id
       ),
       revision_count AS (
       SELECT pr.user_id,

--- a/app/models/concerns/reports/moderators_activity.rb
+++ b/app/models/concerns/reports/moderators_activity.rb
@@ -72,7 +72,7 @@ module Reports::ModeratorsActivity
       ),
       flag_count AS (
           WITH period_actions AS (
-          SELECT agreed_by_id, 
+          SELECT agreed_by_id,
           disagreed_by_id,
           deferred_by_id
           FROM post_actions
@@ -106,7 +106,7 @@ module Reports::ModeratorsActivity
           )
       SELECT
       COALESCE(af.user_id, df.user_id, def.user_id) AS user_id,
-      COALESCE(af.flag_count, 0) + COALESCE(df.flag_count, 0) + COALESCE(def.flag_count, 0) AS flag_count 
+      COALESCE(af.flag_count, 0) + COALESCE(df.flag_count, 0) + COALESCE(def.flag_count, 0) AS flag_count
       FROM agreed_flags af
       FULL OUTER JOIN disagreed_flags df
       ON df.user_id = af.user_id


### PR DESCRIPTION
The Moderator Activity query didn’t include the number of deferred flags in the Flags Reviewed totals. As this number is designed to reflect how many flags a moderator has seen, reviewed, and made a judgement on, the Ignored ones should also be included.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
