### PR TITLE
UX: increase contrast of "more" sidebar dropdown

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -26,7 +26,8 @@
 .sidebar-more-section-links-details-content {
   background-color: var(--d-sidebar-background);
   transition: background-color 0.25s;
-  box-shadow: shadow("dropdown");
+  box-shadow: shadow("card");
+  border: 1px solid var(--primary-low);
   margin: 0 calc(var(--d-sidebar-row-horizontal-padding) * 2 / 3);
 
   .sidebar-row {


### PR DESCRIPTION
I've increased the box-shadow and added a light border to make this stand out a little more from the sidebar content. This is a similar style to the admin popup menu on posts.

Before:
![Screenshot 2023-06-09 at 12 31 20 PM](https://github.com/discourse/discourse/assets/1681963/48a26bda-88f5-4557-a958-f1a9f0f917d9)

After:
![Screenshot 2023-06-09 at 12 30 01 PM](https://github.com/discourse/discourse/assets/1681963/8bc88024-bf8d-4ce7-aca6-4c79dcac6d47)

It's a subtle change, but I'd like to avoid adding a background color here if possible, because that creates a new precedent we haven't implemented elsewhere and starts clashing with hover states and menu contrast. 
