### PR TITLE
PERF: drop throttling from resize node

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/resizable-node.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/resizable-node.js
@@ -1,7 +1,6 @@
 import Modifier from "ember-modifier";
 import { registerDestructor } from "@ember/destroyable";
 import { bind } from "discourse-common/utils/decorators";
-import { throttle } from "@ember/runloop";
 
 const MINIMUM_SIZE = 20;
 
@@ -66,11 +65,6 @@ export default class ResizableNode extends Modifier {
     window.addEventListener("mouseup", this._stopResize);
   }
 
-  @bind
-  _resize(event) {
-    throttle(this, this._resizeThrottled, event, 50);
-  }
-
   /*
     The bulk of the logic is to calculate the new width and height of the element
     based on the current mouse position: width is calculated by subtracting
@@ -87,7 +81,7 @@ export default class ResizableNode extends Modifier {
     -------
   */
   @bind
-  _resizeThrottled(event) {
+  _resize(event) {
     let width = this._originalWidth;
     let diffWidth = event.pageX - this._originalMouseX;
     if (document.documentElement.classList.contains("rtl")) {


### PR DESCRIPTION
This is actually making things more sluggish than necessary. If any perf issue happen out of this they should be handled in the consequences of the resizing, not the resizing itself.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
