### PR TITLE
UX: minor #mention style adjustments

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -23,8 +23,8 @@ a.hashtag {
   }
 
   .d-icon {
-    font-size: var(--font-down-1);
-    margin: 0 0.2em 0 0.1em;
+    font-size: var(--font-down-2);
+    margin: 0 0.33em 0 0.1em;
 
     &.hashtag-missing {
       color: var(--primary-medium);
@@ -43,9 +43,9 @@ a.hashtag {
 
   .hashtag-category-badge {
     flex: 0 0 auto;
-    width: 9px;
-    height: 9px;
-    margin-right: 5px;
+    width: 0.72em;
+    height: 0.72em;
+    margin-right: 0.33em;
     display: inline-block;
 
     &.hashtag-missing {

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -45,7 +45,8 @@ a.hashtag {
     flex: 0 0 auto;
     width: 0.72em;
     height: 0.72em;
-    margin-right: 0.33em;
+    margin-right: 0.25em;
+    margin-left: 0.1em;
     display: inline-block;
 
     &.hashtag-missing {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -251,7 +251,7 @@ $hpad: 0.65em;
   font-size: 0.93em;
   font-weight: normal;
   color: var(--primary);
-  padding: 0 0.3em 0.07em;
+  padding: 0 0.4em 0.07em;
   background: var(--primary-low);
   border-radius: 0.6em;
   text-decoration: none;


### PR DESCRIPTION
This slightly decreases icon size and increases category badge size so they're closer in size to each other. 

This also means that by default category badges in mentions are 10x10, so they can split evenly down the middle (at the moment they're 9x9)

Before:
![Screenshot 2023-06-09 at 2 37 26 PM](https://github.com/discourse/discourse/assets/1681963/314ae785-2e26-410d-8c3c-72ba630a406e)

After:
![Screenshot 2023-06-09 at 2 45 53 PM](https://github.com/discourse/discourse/assets/1681963/a222a9a1-e209-4c92-b585-9467d4aac645)
