### PR TITLE
FEATURE: Implement max_tags_per_email_subject

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -601,12 +601,19 @@ class UserNotifications < ActionMailer::Base
 
     # tag names
     if opts[:show_tags_in_subject] && post.topic_id
+      max_tags =
+        if SiteSetting.enable_max_tags_per_email_subject
+          [SiteSetting.max_tags_per_topic, SiteSetting.max_tags_per_email_subject].min
+        else
+          SiteSetting.max_tags_per_topic
+        end
+
       tags =
         DiscourseTagging
           .visible_tags(Guardian.new(user))
           .joins(:topic_tags)
           .where("topic_tags.topic_id = ?", post.topic_id)
-          .limit(SiteSetting.max_tags_per_topic)
+          .limit(max_tags)
           .pluck(:name)
 
       show_tags_in_subject = tags.any? ? tags.join(" ") : nil

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -603,7 +603,7 @@ class UserNotifications < ActionMailer::Base
     if opts[:show_tags_in_subject] && post.topic_id
       max_tags =
         if SiteSetting.enable_max_tags_per_email_subject
-          [SiteSetting.max_tags_per_topic, SiteSetting.max_tags_per_email_subject].min
+          SiteSetting.max_tags_per_email_subject
         else
           SiteSetting.max_tags_per_topic
         end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2360,7 +2360,7 @@ en:
     tagging_enabled: "Enable tags on topics?"
     min_trust_to_create_tag: "The minimum trust level required to create a tag."
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
-    enable_max_tags_per_email_subject: "Allows to control the maximum tags that can be in the subject of an email"
+    enable_max_tags_per_email_subject: "Use max_tags_per_email_subject when generating the subject of an email"
     max_tags_per_email_subject: "The maximum tags that can be in the subject of an email"
     max_tag_length: "The maximum amount of characters that can be used in a tag."
     max_tag_search_results: "When searching for tags, the maximum number of results to show."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2360,6 +2360,8 @@ en:
     tagging_enabled: "Enable tags on topics?"
     min_trust_to_create_tag: "The minimum trust level required to create a tag."
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
+    enable_max_tags_per_email_subject: "Allows to control the maximum tags that can be in the subject of an email"
+    max_tags_per_email_subject: "The maximum tags that can be in the subject of an email"
     max_tag_length: "The maximum amount of characters that can be used in a tag."
     max_tag_search_results: "When searching for tags, the maximum number of results to show."
     max_tags_in_filter_list: "Maximum number of tags to show in the filter dropdown. The most used tags will be shown."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2765,6 +2765,12 @@ tags:
   max_tags_per_topic:
     default: 5
     client: true
+  enable_max_tags_per_email_subject:
+    default: false
+    client: true
+  max_tags_per_email_subject:
+    default: 5
+    client: true
   max_tag_length:
     default: 20
     client: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2771,6 +2771,7 @@ tags:
   max_tags_per_email_subject:
     default: 5
     client: true
+    min: 0
   max_tag_length:
     default: 20
     client: true

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -445,6 +445,7 @@ RSpec.describe UserNotifications do
     let(:category) { Fabricate(:category, name: "India") }
     let(:tag1) { Fabricate(:tag, name: "Taggo") }
     let(:tag2) { Fabricate(:tag, name: "Taggie") }
+    let(:tag3) { Fabricate(:tag, name: "Teggo") }
 
     let(:hidden_tag) { Fabricate(:tag, name: "hidden") }
     let!(:hidden_tag_group) do
@@ -455,7 +456,7 @@ RSpec.describe UserNotifications do
       Fabricate(
         :topic,
         category: category,
-        tags: [tag1, tag2, hidden_tag],
+        tags: [tag1, tag2, tag3, hidden_tag],
         title: "Super cool topic",
       )
     end
@@ -558,19 +559,67 @@ RSpec.describe UserNotifications do
       expect(mail_html.scan(/>bobmarley/).count).to eq(1)
     end
 
-    it "the number of tags shown in subject should match max_tags_per_topic" do
-      SiteSetting.email_subject =
-        "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
-      SiteSetting.max_tags_per_topic = 1
-      mail =
-        UserNotifications.user_replied(
-          user,
-          post: response,
-          notification_type: notification.notification_type,
-          notification_data_hash: notification.data_hash,
-        )
-      expect(mail.subject).to match(/Taggo/)
-      expect(mail.subject).not_to match(/Taggie/)
+    describe "the number of tags shown in subject should match max_tags_per_topic or max_tags_per_email_subject" do
+      describe "max_tags_per_email_subject siteSetting enabled" do
+        before { SiteSetting.enable_max_tags_per_email_subject = true }
+
+        it "should match max_tags_per_topic" do
+          SiteSetting.email_subject =
+            "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
+          SiteSetting.max_tags_per_topic = 1
+          SiteSetting.max_tags_per_email_subject = 2
+
+          mail =
+            UserNotifications.user_replied(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+          expect(mail.subject).to match(/Taggo/)
+          expect(mail.subject).not_to match(/Taggie/)
+          expect(mail.subject).not_to match(/Teggo/)
+        end
+
+        it "should match max_tags_per_email_subject" do
+          SiteSetting.email_subject =
+            "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
+          SiteSetting.max_tags_per_topic = 3
+          SiteSetting.max_tags_per_email_subject = 2
+          mail =
+            UserNotifications.user_replied(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+          expect(mail.subject).to match(/Taggo/)
+          expect(mail.subject).to match(/Taggie/)
+          expect(mail.subject).not_to match(/Teggo/)
+        end
+      end
+
+      describe "max_tags_per_email_subject siteSetting disabled" do
+        before { SiteSetting.enable_max_tags_per_email_subject = false }
+
+        it "should match max_tags_per_topic" do
+          SiteSetting.email_subject =
+            "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
+          SiteSetting.max_tags_per_topic = 2
+          SiteSetting.max_tags_per_email_subject = 1
+
+          mail =
+            UserNotifications.user_replied(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+          expect(mail.subject).to match(/Taggo/)
+          expect(mail.subject).to match(/Taggie/)
+          expect(mail.subject).not_to match(/Teggo/)
+        end
+      end
     end
 
     it "doesn't include details when private_email is enabled" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -563,28 +563,10 @@ RSpec.describe UserNotifications do
       describe "max_tags_per_email_subject siteSetting enabled" do
         before { SiteSetting.enable_max_tags_per_email_subject = true }
 
-        it "should match max_tags_per_topic" do
-          SiteSetting.email_subject =
-            "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
-          SiteSetting.max_tags_per_topic = 1
-          SiteSetting.max_tags_per_email_subject = 2
-
-          mail =
-            UserNotifications.user_replied(
-              user,
-              post: response,
-              notification_type: notification.notification_type,
-              notification_data_hash: notification.data_hash,
-            )
-          expect(mail.subject).to match(/Taggo/)
-          expect(mail.subject).not_to match(/Taggie/)
-          expect(mail.subject).not_to match(/Teggo/)
-        end
-
         it "should match max_tags_per_email_subject" do
           SiteSetting.email_subject =
             "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
-          SiteSetting.max_tags_per_topic = 3
+          SiteSetting.max_tags_per_topic = 1
           SiteSetting.max_tags_per_email_subject = 2
           mail =
             UserNotifications.user_replied(

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe UserNotifications do
       expect(mail_html.scan(/>bobmarley/).count).to eq(1)
     end
 
-    describe "the number of tags shown in subject should match max_tags_per_topic or max_tags_per_email_subject" do
+    describe "number of tags shown in subject line" do
       describe "max_tags_per_email_subject siteSetting enabled" do
         before { SiteSetting.enable_max_tags_per_email_subject = true }
 


### PR DESCRIPTION
**Context**
Email subjects can contain tags. Currently, we have a `siteSetting` `max_tags_per_topic` that can be used to control how many tags are included

**Problem**
Even though we have `max_tags_per_topic` to control how many tags are included in the subject of an email, this also controls other aspects of tags. The customer requires to control the number of tags included in the subject of an email without affecting other parts of the app.

**Solution**
Implement `enable_max_tags_per_email_subject` to allow customers to enable and disable this behavior if desired. Implement `max_tags_per_email_subject` `siteSetting` that allows customers to choose how many tags they want in the subject of an email if the feature is enabled