### PR TITLE
UX: dark color palettes need darker shadows

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -135,7 +135,7 @@ $z-layers: (
 // Box-shadow
 // --------------------------------------------------
 
-$box-shadow: (
+$box-shadow-light: (
   "modal": 0 8px 60px rgba(0, 0, 0, 0.6),
   "composer": 0 -1px 40px rgba(0, 0, 0, 0.12),
   "menu-panel": 0 12px 12px rgba(0, 0, 0, 0.15),
@@ -152,6 +152,7 @@ $box-shadow: (
   "focus-danger": 0 0 6px 0 $danger,
 );
 
+// do not add a dark shadow without a light equivilant
 $box-shadow-dark: (
   "modal": 0 8px 60px rgba(0, 0, 0, 1),
   "composer": 0 -1px 40px rgba(0, 0, 0, 0.35),
@@ -163,13 +164,13 @@ $box-shadow-dark: (
 
 @function shadow($key) {
   @if is-light-color-scheme() {
-    @return map-get($box-shadow, $key);
+    @return map-get($box-shadow-light, $key);
   } @else {
     $shadow-dark: map-get($box-shadow-dark, $key);
     @if $shadow-dark != null {
       @return $shadow-dark;
     } @else {
-      @return map-get($box-shadow, $key);
+      @return map-get($box-shadow-light, $key);
     }
   }
 }

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -157,7 +157,7 @@ $box-shadow-dark: (
   "modal": 0 8px 60px rgba(0, 0, 0, 1),
   "composer": 0 -1px 40px rgba(0, 0, 0, 0.35),
   "menu-panel": 0 8px 12px rgba(0, 0, 0, 0.35),
-  "card": 0 4px 14px rgba(0, 0, 0, 0.55),
+  "card": 0 4px 14px rgba(0, 0, 0, 0.5),
   "dropdown": 0 2px 3px 0 rgba(0, 0, 0, 0.35),
   "dropdown-lite": 0px 2px 12px 0px rgba(0, 0, 0, 0.25),
 );

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -157,7 +157,7 @@ $box-shadow-dark: (
   "modal": 0 8px 60px rgba(0, 0, 0, 1),
   "composer": 0 -1px 40px rgba(0, 0, 0, 0.35),
   "menu-panel": 0 8px 12px rgba(0, 0, 0, 0.35),
-  "card": 0 4px 20px rgba(0, 0, 0, 0.5),
+  "card": 0 4px 14px rgba(0, 0, 0, 0.55),
   "dropdown": 0 2px 3px 0 rgba(0, 0, 0, 0.35),
   "dropdown-lite": 0px 2px 12px 0px rgba(0, 0, 0, 0.25),
 );

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -152,8 +152,26 @@ $box-shadow: (
   "focus-danger": 0 0 6px 0 $danger,
 );
 
+$box-shadow-dark: (
+  "modal": 0 8px 60px rgba(0, 0, 0, 1),
+  "composer": 0 -1px 40px rgba(0, 0, 0, 0.35),
+  "menu-panel": 0 8px 12px rgba(0, 0, 0, 0.35),
+  "card": 0 4px 20px rgba(0, 0, 0, 0.5),
+  "dropdown": 0 2px 3px 0 rgba(0, 0, 0, 0.35),
+  "dropdown-lite": 0px 2px 12px 0px rgba(0, 0, 0, 0.25),
+);
+
 @function shadow($key) {
-  @return map-get($box-shadow, $key);
+  @if is-light-color-scheme() {
+    @return map-get($box-shadow, $key);
+  } @else {
+    $shadow-dark: map-get($box-shadow-dark, $key);
+    @if $shadow-dark != null {
+      @return $shadow-dark;
+    } @else {
+      @return map-get($box-shadow, $key);
+    }
+  }
 }
 
 // Color utilities


### PR DESCRIPTION
This introduces a separate sass-map for dark shadows. A shadow with 0.15 opacity works fine on a white background, but is much harder to see on a dark grey background. 

I've updated the shadow function so if there's no dark shadow defined, it'll fall back to the original map (now called light). This means not all shadows necessarily need a dark counterpart. 

Before/After

![Screenshot 2023-06-09 at 6 00 11 PM](https://github.com/discourse/discourse/assets/1681963/a1b3ff60-ae5d-434b-8696-144b3dcb5d2f) ![Screenshot 2023-06-09 at 6 00 00 PM](https://github.com/discourse/discourse/assets/1681963/24f9c96c-2301-498a-8008-c73dabfa7610)

![Screenshot 2023-06-09 at 6 02 10 PM](https://github.com/discourse/discourse/assets/1681963/191a3b97-94ca-40cd-8e68-8028da1bd1dc) ![Screenshot 2023-06-09 at 6 02 40 PM](https://github.com/discourse/discourse/assets/1681963/6a33685c-0efa-45cd-9197-05377574e2dd)

![Screenshot 2023-06-09 at 6 03 28 PM](https://github.com/discourse/discourse/assets/1681963/303fa1b8-f2ae-412d-ba22-afa149d35599)
![Screenshot 2023-06-09 at 6 03 17 PM](https://github.com/discourse/discourse/assets/1681963/d526bb27-2923-439b-b6e6-a1fee5f25042)


![Screenshot 2023-06-09 at 6 05 03 PM](https://github.com/discourse/discourse/assets/1681963/39bc68b9-32e6-4ade-8657-98914d124b1b)
![Screenshot 2023-06-09 at 6 05 12 PM](https://github.com/discourse/discourse/assets/1681963/efe527da-e2dd-4e73-9cb2-641f3a6710d3)


Also tested on some other dark palettes 


Before/After

![Screenshot 2023-06-09 at 6 06 37 PM](https://github.com/discourse/discourse/assets/1681963/8034f30e-a305-4a33-98f4-76f4fc21cccc) ![Screenshot 2023-06-09 at 6 06 30 PM](https://github.com/discourse/discourse/assets/1681963/e0ac9e94-793f-47b2-b67c-75ef26b016d7)

![Screenshot 2023-06-09 at 6 06 40 PM](https://github.com/discourse/discourse/assets/1681963/d1e736d7-de71-404d-832b-bc544591b6cb) ![Screenshot 2023-06-09 at 6 06 22 PM](https://github.com/discourse/discourse/assets/1681963/1b4932b1-c5d2-43e8-acd4-659e3d6ad4ca)

Before/After

![Screenshot 2023-06-09 at 6 08 53 PM](https://github.com/discourse/discourse/assets/1681963/b9efbf4c-8dd3-414a-b40f-af3b28ad1ed1) ![Screenshot 2023-06-09 at 6 09 13 PM](https://github.com/discourse/discourse/assets/1681963/fed80578-fb68-4198-87d9-1038d43b648c)

![Screenshot 2023-06-09 at 6 08 58 PM](https://github.com/discourse/discourse/assets/1681963/976eea72-f108-4ccf-85a9-5af967df298b) ![Screenshot 2023-06-09 at 6 09 09 PM](https://github.com/discourse/discourse/assets/1681963/af457d56-84fa-4691-b2fd-5597fbcad4b9)
