### PR TITLE
fix: when scheduling next update in the presence service `_presentChannels.length` is always undefined

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -606,7 +606,7 @@ export default class PresenceService extends Service {
       );
     } else if (
       !this._nextUpdateTimer &&
-      this._presentChannels.length > 0 &&
+      this._presentChannels.size > 0 &&
       !isTesting()
     ) {
       this._nextUpdateTimer = discourseLater(


### PR DESCRIPTION

The else if is then never triggered.

I would like to create a test but the `else if` is also testing `!isTesting()` so my test wouldn't be meaningful
