### PR TITLE
DEV: Use runtime info to split test files for parallel testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,10 +150,11 @@ jobs:
       - name: Fetch turbo_rspec_runtime.log cache
         uses: actions/cache@v3
         id: test-runtime-cache
-        if: matrix.build_type == 'backend' && matrix.target == 'core'
+        if: matrix.build_type == 'backend' || matrix.build_type == 'system'
         with:
           path: tmp/turbo_rspec_runtime.log
-          key: rspec-runtime-backend-core
+          key: rspec-runtime-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: rspec-runtime-${{ matrix.build_type }}-${{ matrix.target }}-
 
       - name: Run Zeitwerk check
         if: matrix.build_type == 'backend'
@@ -173,11 +174,11 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: bin/turbo_rspec --verbose
+        run: bin/turbo_rspec --use-runtime-info --verbose
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        run: bin/rake plugin:turbo_spec['*','--verbose --format documentation']
+        run: bin/rake plugin:turbo_spec['*','--verbose --format documentation --use-runtime-info']
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -194,11 +195,11 @@ jobs:
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
-        run: PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation spec/system
+        run: PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --profile=50 --verbose --format documentation plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=5 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -13,6 +13,7 @@ fail_fast = nil
 seed = rand(2**16)
 profile = false
 profile_print_slowest_examples_count = 10
+use_runtime_info = nil
 
 OptionParser
   .new do |opts|
@@ -49,6 +50,10 @@ OptionParser
     end
 
     opts.on("--seed SEED", "The seed for the random order") { |s| seed = s.to_i }
+
+    opts.on("--use-runtime-info", "Use runtime info for tests group splitting") do
+      use_runtime_info = true
+    end
   end
   .parse!(ARGV)
 
@@ -60,10 +65,10 @@ formatters.each { |formatter| formatter[:outputs] << "-" if formatter[:outputs].
 
 if ARGV.empty?
   files = TurboTests::Runner.default_spec_folders
-  use_runtime_info = true
+  use_runtime_info = true if use_runtime_info.nil?
 else
   files = ARGV
-  use_runtime_info = false
+  use_runtime_info = false if use_runtime_info.nil?
 end
 
 puts "::group::Run turbo_rspec" if ENV["GITHUB_ACTIONS"]


### PR DESCRIPTION
Using the runtime information, we will be able to more efficiently group
the test files across the test processes hence leading to better
utilization of resources.