### PR TITLE
UX: Improve defaults shown for categories and tags section in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.js
@@ -1,4 +1,3 @@
-import { canDisplayCategory } from "discourse/lib/sidebar/helpers";
 import SidebarCommonCategoriesSection from "discourse/components/sidebar/common/categories-section";
 import Category from "discourse/models/category";
 
@@ -19,14 +18,7 @@ export default class SidebarAnonymousCategoriesSection extends SidebarCommonCate
           .map((categoryId) => parseInt(categoryId, 10))
       );
     } else {
-      return this.site.categoriesList
-        .filter((category) => {
-          return (
-            !category.parent_category_id &&
-            canDisplayCategory(category.id, this.siteSettings)
-          );
-        })
-        .slice(0, 5);
+      return this.topSiteCategories;
     }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.js
@@ -1,9 +1,10 @@
 import { cached } from "@glimmer/tracking";
-import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+
+import SidebarCommonTagsSection from "discourse/components/sidebar/common/tags-section";
 import TagSectionLink from "discourse/lib/sidebar/user/tags-section/tag-section-link";
 
-export default class SidebarAnonymousTagsSection extends Component {
+export default class SidebarAnonymousTagsSection extends SidebarCommonTagsSection {
   @service router;
   @service topicTrackingState;
   @service site;
@@ -11,20 +12,15 @@ export default class SidebarAnonymousTagsSection extends Component {
   get displaySection() {
     return (
       this.site.anonymous_default_navigation_menu_tags?.length > 0 ||
-      this.site.top_tags?.length > 0
+      this.topSiteTags?.length > 0
     );
   }
 
   @cached
   get sectionLinks() {
-    let tags;
-
-    if (this.site.anonymous_default_navigation_menu_tags) {
-      tags = this.site.anonymous_default_navigation_menu_tags;
-    } else {
-      tags = this.site.top_tags.slice(0, 5);
-    }
-    return tags.map((tagName) => {
+    return (
+      this.site.anonymous_default_navigation_menu_tags || this.topSiteTags
+    ).map((tagName) => {
       return new TagSectionLink({
         tagName,
         topicTrackingState: this.topicTrackingState,

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/categories-section.js
@@ -6,6 +6,8 @@ import Category from "discourse/models/category";
 import CategorySectionLink from "discourse/lib/sidebar/user/categories-section/category-section-link";
 import { canDisplayCategory } from "discourse/lib/sidebar/helpers";
 
+export const TOP_SITE_CATEGORIES_TO_SHOW = 5;
+
 export default class SidebarCommonCategoriesSection extends Component {
   @service topicTrackingState;
   @service siteSettings;
@@ -19,6 +21,17 @@ export default class SidebarCommonCategoriesSection extends Component {
    * @returns {Object[]} An array of Category objects
    */
   get categories() {}
+
+  get topSiteCategories() {
+    return this.site.categoriesList
+      .filter((category) => {
+        return (
+          !category.parent_category_id &&
+          canDisplayCategory(category.id, this.siteSettings)
+        );
+      })
+      .slice(0, TOP_SITE_CATEGORIES_TO_SHOW);
+  }
 
   get sortedCategories() {
     if (!this.shouldSortCategoriesByDefault) {

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/tags-section.js
@@ -1,0 +1,20 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export const TOP_SITE_TAGS_TO_SHOW = 5;
+
+export default class SidebarCommonTagsSection extends Component {
+  @service site;
+
+  topSiteTags = [];
+
+  constructor() {
+    super(...arguments);
+
+    if (this.site.top_tags?.length > 0) {
+      this.site.top_tags.splice(0, TOP_SITE_TAGS_TO_SHOW).forEach((tagName) => {
+        this.topSiteTags.push(tagName);
+      });
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
@@ -1,81 +1,49 @@
-{{#if (or this.shouldDisplay this.shouldDisplayDefaultConfig)}}
-  <Sidebar::Section
-    @sectionName="categories"
-    @headerLinkText={{i18n "sidebar.sections.categories.header_link_text"}}
-    @headerActions={{array
-      (hash
-        action=this.editTracked
-        title=(i18n "sidebar.sections.categories.header_action_title")
-      )
-    }}
-    @headerActionsIcon="pencil-alt"
-    @collapsable={{@collapsable}}
-  >
+<Sidebar::Section
+  @sectionName="categories"
+  @headerLinkText={{i18n "sidebar.sections.categories.header_link_text"}}
+  @headerActions={{array
+    (hash
+      action=this.editTracked
+      title=(i18n "sidebar.sections.categories.header_action_title")
+    )
+  }}
+  @headerActionsIcon="pencil-alt"
+  @collapsable={{@collapsable}}
+>
 
-    {{#if this.shouldDisplay}}
-      {{#if (gt this.sectionLinks.length 0)}}
-        {{#each this.sectionLinks as |sectionLink|}}
-          <Sidebar::SectionLink
-            @route={{sectionLink.route}}
-            @query={{sectionLink.query}}
-            @title={{sectionLink.title}}
-            @content={{sectionLink.text}}
-            @currentWhen={{sectionLink.currentWhen}}
-            @model={{sectionLink.model}}
-            @badgeText={{sectionLink.badgeText}}
-            @prefixBadge={{sectionLink.prefixBadge}}
-            @prefixType={{sectionLink.prefixType}}
-            @prefixValue={{sectionLink.prefixValue}}
-            @prefixColor={{sectionLink.prefixColor}}
-            @suffixCSSClass={{sectionLink.suffixCSSClass}}
-            @suffixValue={{sectionLink.suffixValue}}
-            @suffixType={{sectionLink.suffixType}}
-            data-category-id={{sectionLink.category.id}}
-          />
-        {{/each}}
-      {{else if this.currentUser.new_edit_sidebar_categories_tags_interface_groups_enabled}}
-        <Sidebar::SectionLink
-          @linkName="configure-categories"
-          @prefixType="icon"
-          @prefixValue="pencil-alt"
-          @model={{this.currentUser}}
-          @content={{i18n
-            "sidebar.sections.categories.links.add_categories.content"
-          }}
-          @title={{i18n
-            "sidebar.sections.categories.links.add_categories.title"
-          }}
-          {{on "click" this.editTracked}}
-        />
-      {{else}}
-        <Sidebar::SectionLink
-          @linkName="configure-categories"
-          @route="preferences.navigation-menu"
-          @prefixType="icon"
-          @prefixValue="pencil-alt"
-          @model={{this.currentUser}}
-          @content={{i18n
-            "sidebar.sections.categories.links.add_categories.content"
-          }}
-          @title={{i18n
-            "sidebar.sections.categories.links.add_categories.title"
-          }}
-        />
-      {{/if}}
-
-      <Sidebar::Common::AllCategoriesSectionLink />
-    {{/if}}
-
-    {{#if this.shouldDisplayDefaultConfig}}
+  {{#if (gt this.sectionLinks.length 0)}}
+    {{#each this.sectionLinks as |sectionLink|}}
       <Sidebar::SectionLink
-        @linkName="configure-default-navigation-menu-categories"
-        @content={{i18n "sidebar.sections.categories.configure_defaults"}}
-        @prefixType="icon"
-        @prefixValue="wrench"
-        @route="adminSiteSettingsCategory"
-        @model="sidebar"
-        @query={{hash filter="default_navigation_menu_categories"}}
+        @route={{sectionLink.route}}
+        @query={{sectionLink.query}}
+        @title={{sectionLink.title}}
+        @content={{sectionLink.text}}
+        @currentWhen={{sectionLink.currentWhen}}
+        @model={{sectionLink.model}}
+        @badgeText={{sectionLink.badgeText}}
+        @prefixBadge={{sectionLink.prefixBadge}}
+        @prefixType={{sectionLink.prefixType}}
+        @prefixValue={{sectionLink.prefixValue}}
+        @prefixColor={{sectionLink.prefixColor}}
+        @suffixCSSClass={{sectionLink.suffixCSSClass}}
+        @suffixValue={{sectionLink.suffixValue}}
+        @suffixType={{sectionLink.suffixType}}
+        data-category-id={{sectionLink.category.id}}
       />
-    {{/if}}
-  </Sidebar::Section>
-{{/if}}
+    {{/each}}
+  {{/if}}
+
+  <Sidebar::Common::AllCategoriesSectionLink />
+
+  {{#if this.shouldDisplayDefaultConfig}}
+    <Sidebar::SectionLink
+      @linkName="configure-default-navigation-menu-categories"
+      @content={{i18n "sidebar.sections.categories.configure_defaults"}}
+      @prefixType="icon"
+      @prefixValue="wrench"
+      @route="adminSiteSettingsCategory"
+      @model="sidebar"
+      @query={{hash filter="default_navigation_menu_categories"}}
+    />
+  {{/if}}
+</Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
@@ -6,6 +6,7 @@ import { debounce } from "discourse-common/utils/decorators";
 import Category from "discourse/models/category";
 import SidebarCommonCategoriesSection from "discourse/components/sidebar/common/categories-section";
 import showModal from "discourse/lib/show-modal";
+import { hasDefaultSidebarCategories } from "discourse/lib/sidebar/helpers";
 
 export const REFRESH_COUNTS_APP_EVENT_NAME =
   "sidebar:refresh-categories-section-counts";
@@ -48,20 +49,10 @@ export default class SidebarUserCategoriesSection extends SidebarCommonCategorie
 
   @cached
   get categories() {
-    return Category.findByIds(this.currentUser.sidebarCategoryIds);
-  }
-
-  /**
-   * If a site has no default sidebar categories configured, show categories section if the user has categories configured.
-   * Otherwise, hide the categories section from the sidebar for the user.
-   *
-   * If a site has default sidebar categories configured, always show categories section for the user.
-   */
-  get shouldDisplay() {
-    if (this.hasDefaultSidebarCategories) {
-      return true;
+    if (this.currentUser.sidebarCategoryIds?.length > 0) {
+      return Category.findByIds(this.currentUser.sidebarCategoryIds);
     } else {
-      return this.categories.length > 0;
+      return this.topSiteCategories;
     }
   }
 
@@ -70,7 +61,7 @@ export default class SidebarUserCategoriesSection extends SidebarCommonCategorie
   }
 
   get hasDefaultSidebarCategories() {
-    return this.siteSettings.default_navigation_menu_categories.length > 0;
+    return hasDefaultSidebarCategories(this.siteSettings);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
@@ -1,61 +1,47 @@
-{{#if (or this.shouldDisplay this.shouldDisplayDefaultConfig)}}
-  <Sidebar::Section
-    @sectionName="tags"
-    @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
-    @headerActions={{array
-      (hash
-        action=this.editTracked
-        title=(i18n "sidebar.sections.tags.header_action_title")
-      )
-    }}
-    @headerActionsIcon="pencil-alt"
-    @collapsable={{@collapsable}}
-  >
+<Sidebar::Section
+  @sectionName="tags"
+  @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
+  @headerActions={{array
+    (hash
+      action=this.editTracked
+      title=(i18n "sidebar.sections.tags.header_action_title")
+    )
+  }}
+  @headerActionsIcon="pencil-alt"
+  @collapsable={{@collapsable}}
+>
 
-    {{#if this.shouldDisplay}}
-      {{#if (gt this.sectionLinks.length 0)}}
-        {{#each this.sectionLinks as |sectionLink|}}
-          <Sidebar::SectionLink
-            @route={{sectionLink.route}}
-            @title={{sectionLink.title}}
-            @content={{sectionLink.text}}
-            @currentWhen={{sectionLink.currentWhen}}
-            @prefixType={{sectionLink.prefixType}}
-            @prefixValue={{sectionLink.prefixValue}}
-            @prefixColor={{sectionLink.prefixColor}}
-            @badgeText={{sectionLink.badgeText}}
-            @models={{sectionLink.models}}
-            @suffixCSSClass={{sectionLink.suffixCSSClass}}
-            @suffixValue={{sectionLink.suffixValue}}
-            @suffixType={{sectionLink.suffixType}}
-            data-tag-name={{sectionLink.tagName}}
-          />
-        {{/each}}
-      {{else}}
-        <Sidebar::SectionLink
-          @linkName="configure-tags"
-          @route="preferences.navigation-menu"
-          @prefixType="icon"
-          @prefixValue="pencil-alt"
-          @model={{this.currentUser}}
-          @content={{i18n "sidebar.sections.tags.links.add_tags.content"}}
-          @title={{i18n "sidebar.sections.tags.links.add_tags.title"}}
-        />
-      {{/if}}
-
-      <Sidebar::Common::AllTagsSectionLink />
-    {{/if}}
-
-    {{#if this.shouldDisplayDefaultConfig}}
+  {{#if (gt this.sectionLinks.length 0)}}
+    {{#each this.sectionLinks as |sectionLink|}}
       <Sidebar::SectionLink
-        @linkName="configure-default-sidebar-tags"
-        @content={{i18n "sidebar.sections.tags.configure_defaults"}}
-        @prefixType="icon"
-        @prefixValue="wrench"
-        @route="adminSiteSettingsCategory"
-        @model="sidebar"
-        @query={{hash filter="default_navigation_menu_tags"}}
+        @route={{sectionLink.route}}
+        @title={{sectionLink.title}}
+        @content={{sectionLink.text}}
+        @currentWhen={{sectionLink.currentWhen}}
+        @prefixType={{sectionLink.prefixType}}
+        @prefixValue={{sectionLink.prefixValue}}
+        @prefixColor={{sectionLink.prefixColor}}
+        @badgeText={{sectionLink.badgeText}}
+        @models={{sectionLink.models}}
+        @suffixCSSClass={{sectionLink.suffixCSSClass}}
+        @suffixValue={{sectionLink.suffixValue}}
+        @suffixType={{sectionLink.suffixType}}
+        data-tag-name={{sectionLink.tagName}}
       />
-    {{/if}}
-  </Sidebar::Section>
-{{/if}}
+    {{/each}}
+  {{/if}}
+
+  <Sidebar::Common::AllTagsSectionLink />
+
+  {{#if this.shouldDisplayDefaultConfig}}
+    <Sidebar::SectionLink
+      @linkName="configure-default-navigation-menu-tags"
+      @content={{i18n "sidebar.sections.tags.configure_defaults"}}
+      @prefixType="icon"
+      @prefixValue="wrench"
+      @route="adminSiteSettingsCategory"
+      @model="sidebar"
+      @query={{hash filter="default_navigation_menu_tags"}}
+    />
+  {{/if}}
+</Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
@@ -1,12 +1,13 @@
 import { cached } from "@glimmer/tracking";
-import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 
+import SidebarCommonTagsSection from "discourse/components/sidebar/common/tags-section";
 import TagSectionLink from "discourse/lib/sidebar/user/tags-section/tag-section-link";
 import PMTagSectionLink from "discourse/lib/sidebar/user/tags-section/pm-tag-section-link";
+import { hasDefaultSidebarTags } from "discourse/lib/sidebar/helpers";
 
-export default class SidebarUserTagsSection extends Component {
+export default class SidebarUserTagsSection extends SidebarCommonTagsSection {
   @service router;
   @service topicTrackingState;
   @service pmTopicTrackingState;
@@ -33,7 +34,20 @@ export default class SidebarUserTagsSection extends Component {
   get sectionLinks() {
     const links = [];
 
-    for (const tag of this.currentUser.sidebarTags) {
+    let tags;
+
+    if (this.currentUser.sidebarTags.length > 0) {
+      tags = this.currentUser.sidebarTags;
+    } else {
+      tags = this.topSiteTags.map((tagName) => {
+        return {
+          name: tagName,
+          pm_only: false,
+        };
+      });
+    }
+
+    for (const tag of tags) {
       if (tag.pm_only) {
         links.push(
           new PMTagSectionLink({
@@ -55,26 +69,12 @@ export default class SidebarUserTagsSection extends Component {
     return links;
   }
 
-  /**
-   * If a site has no default sidebar tags configured, show tags section if the user has personal sidebar tags configured.
-   * Otherwise, hide the tags section from the sidebar for the user.
-   *
-   * If a site has default sidebar tags configured, always display the tags section.
-   */
-  get shouldDisplay() {
-    if (this.hasDefaultSidebarTags) {
-      return true;
-    } else {
-      return this.currentUser.sidebarTags.length > 0;
-    }
-  }
-
   get shouldDisplayDefaultConfig() {
     return this.currentUser.admin && !this.hasDefaultSidebarTags;
   }
 
   get hasDefaultSidebarTags() {
-    return this.siteSettings.default_navigation_menu_tags.length > 0;
+    return hasDefaultSidebarTags(this.siteSettings);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/lib/sidebar/helpers.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/helpers.js
@@ -7,3 +7,11 @@ export function canDisplayCategory(categoryId, siteSettings) {
 
   return !Category.isUncategorized(categoryId);
 }
+
+export function hasDefaultSidebarCategories(siteSettings) {
+  return siteSettings.default_navigation_menu_categories.length > 0;
+}
+
+export function hasDefaultSidebarTags(siteSettings) {
+  return siteSettings.default_navigation_menu_tags.length > 0;
+}

--- a/app/assets/javascripts/discourse/tests/acceptance/css-generator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/css-generator-test.js
@@ -4,11 +4,12 @@ import { test } from "qunit";
 
 acceptance("CSS Generator", function (needs) {
   needs.user();
+
   needs.site({
     categories: [
-      { id: 1, color: "ff0000" },
-      { id: 2, color: "333" },
-      { id: 4, color: "2B81AF", parentCategory: { id: 1 } },
+      { id: 1, color: "ff0000", name: "category1" },
+      { id: 2, color: "333", name: "category2" },
+      { id: 4, color: "2B81AF", parentCategory: { id: 1 }, name: "category3" },
     ],
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-tags-section-test.js
@@ -22,10 +22,10 @@ acceptance("Sidebar - Anonymous Tags Section", function (needs) {
     await visit("/");
 
     const categories = queryAll(
-      ".sidebar-section[data-section-name='tags'] .sidebar-section-link-wrapper"
+      ".sidebar-section[data-section-name='tags'] .sidebar-section-link-wrapper[data-tag-name]"
     );
 
-    assert.strictEqual(categories.length, 4);
+    assert.strictEqual(categories.length, 3);
     assert.strictEqual(categories[0].textContent.trim(), "design");
     assert.strictEqual(categories[1].textContent.trim(), "development");
     assert.strictEqual(categories[2].textContent.trim(), "fun");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -13,6 +13,8 @@ import {
 import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 import { NotificationLevels } from "discourse/lib/notification-levels";
+import Site from "discourse/models/site";
+import { TOP_SITE_TAGS_TO_SHOW } from "discourse/components/sidebar/common/tags-section";
 
 acceptance(
   "Sidebar - Logged on user - Tags section - tagging disabled",
@@ -115,49 +117,41 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     );
   });
 
-  test("tags section is hidden when user has not added any tags and there are no default tags configured", async function (assert) {
+  test("tags section is displayed with site's top tags when user has not added any tags and there are no default tags configured", async function (assert) {
     updateCurrentUser({
       sidebar_tags: [],
     });
 
-    await visit("/");
-
-    assert.notOk(
-      exists(".sidebar-section[data-section-name='tags']"),
-      "tags section is not displayed"
-    );
-  });
-
-  test("tags section is shown when user has not added any tags but default tags have been configured", async function (assert) {
-    updateCurrentUser({
-      sidebar_tags: [],
-    });
-
-    this.siteSettings.default_navigation_menu_tags = "tag1|tag2";
+    Site.current().top_tags = [
+      "test1",
+      "test2",
+      "test3",
+      "test4",
+      "test5",
+      "test6",
+    ];
 
     await visit("/");
 
     assert.ok(
       exists(".sidebar-section[data-section-name='tags']"),
-      "tags section is shown"
-    );
-
-    assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='tags'] .sidebar-section-link[data-link-name='configure-tags']"
-      ),
-      "section link to add tags to sidebar is displayed"
-    );
-
-    await click(
-      ".sidebar-section[data-section-name='tags'] .sidebar-section-link[data-link-name='configure-tags']"
+      "tags section is displayed"
     );
 
     assert.strictEqual(
-      currentURL(),
-      "/u/eviltrout/preferences/navigation-menu",
-      "it should transition to user preferences navigation menu page"
+      count(
+        ".sidebar-section[data-section-name='tags'] .sidebar-section-link-wrapper[data-tag-name]"
+      ),
+      TOP_SITE_TAGS_TO_SHOW,
+      "right number of tag section links are displayed"
     );
+
+    ["test1", "test2", "test3", "test4", "test5"].forEach((tagName) => {
+      assert.ok(
+        exists(`.sidebar-section-link-wrapper[data-tag-name=${tagName}]`),
+        `${tagName} tag section link is displayed`
+      );
+    });
   });
 
   test("tag section links are sorted alphabetically by tag's name", async function (assert) {
@@ -682,13 +676,13 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section-link[data-link-name='configure-default-sidebar-tags']"
+        ".sidebar-section-link[data-link-name='configure-default-navigation-menu-tags']"
       ),
       "section link to configure default sidebar tags is shown"
     );
 
     await click(
-      ".sidebar-section-link[data-link-name='configure-default-sidebar-tags']"
+      ".sidebar-section-link[data-link-name='configure-default-navigation-menu-tags']"
     );
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-navigation-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-navigation-menu-test.js
@@ -112,8 +112,6 @@ acceptance("User Preferences - Navigation Menu", function (needs) {
     updateCurrentUser({ admin: false, display_sidebar_tags: false });
     await visit("/u/eviltrout/preferences/navigation-menu");
 
-    assert.notOk(exists(".sidebar-section[data-section-name='categories']"));
-
     const categorySelector = selectKit(".category-selector");
     await categorySelector.expand();
     await categorySelector.selectKitSelectRowByName("support");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1207,9 +1207,9 @@ en:
         enable: "Enable sidebar"
         options: "Options"
         categories_section: "Categories Section"
-        categories_section_instruction: "Selected categories will be displayed under Navigation Menu's categories section."
+        categories_section_instruction: "Selected categories will be displayed under Navigation Menu's categories section. If no categories are selected, the site's top categories will be displayed."
         tags_section: "Tags Section"
-        tags_section_instruction: "Selected tags will be displayed under Navigation Menu's tags section."
+        tags_section_instruction: "Selected tags will be displayed under Navigation Menu's tags section. If no tags are selected, the site's top tags will be displayed."
         navigation_section: "Navigation"
         list_destination_instruction: "When there's new content in the navigation menu..."
         list_destination_default: "use the default link and show a badge for new items"
@@ -2058,7 +2058,7 @@ en:
       disable: "Show All Posts"
       short_label: "Summarize"
       short_title: "Show a summary of this topic: the most interesting posts as determined by the community"
-      strategy: 
+      strategy:
         button_title: "Summarize this topic"
         title: "Topic summary"
 
@@ -4444,20 +4444,12 @@ en:
             unread_with_count: "Unread (%{count})"
             archive: "Archive"
         tags:
-          links:
-            add_tags:
-              content: "Add tags"
-              title: "You have not added any tags. Click to get started."
           none: "You have not added any tags."
           click_to_get_started: "Click here to get started."
           header_link_text: "Tags"
           header_action_title: "Edit your sidebar tags"
           configure_defaults: "Configure defaults"
         categories:
-          links:
-            add_categories:
-              content: "Add categories"
-              title: "You have not added any categories. Click to get started."
           none: "You have not added any categories."
           click_to_get_started: "Click here to get started."
           header_link_text: "Categories"

--- a/plugins/chat/test/javascripts/acceptance/hashtag-css-generator-test.js
+++ b/plugins/chat/test/javascripts/acceptance/hashtag-css-generator-test.js
@@ -3,9 +3,14 @@ import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
 acceptance("Chat | Hashtag CSS Generator", function (needs) {
-  const category1 = { id: 1, color: "ff0000" };
-  const category2 = { id: 2, color: "333" };
-  const category3 = { id: 4, color: "2B81AF", parentCategory: { id: 1 } };
+  const category1 = { id: 1, color: "ff0000", name: "category1" };
+  const category2 = { id: 2, color: "333", name: "category2" };
+  const category3 = {
+    id: 4,
+    color: "2B81AF",
+    parentCategory: { id: 1 },
+    name: "category3",
+  };
 
   needs.settings({ chat_enabled: true });
   needs.user({


### PR DESCRIPTION
#### What is being changed?

In this commit, we're changing the logic such that the site's top
categories and tags are displayed if the user does not have any
categories/tags configured in each respective section. The only
regression introduced in this change is that the categories and tags
section can no longer be hidden as a result. However, we have plans to
address this in the future by allowing sidebar sections to be configured
to be hidden by each individual user.

#### Why is this change required?

When a site is newly setup and a user has just been created, the
categories and tags sections are hidden from the user. This happens
because the admin has not configured the `default_sidebar_categories` or
`default_sidebar_tags` site settings. When the categories and tags
sections are hidden from the user, the sidebar looks extremely bare and
does not create a good experience.

#### Screenshots

For a site that has not configured the `default_sidebar_categories` site setting:

### Before (normal user)

![Screenshot from 2023-06-12 14-26-24](https://github.com/discourse/discourse/assets/4335742/c88a9269-fbcf-4acc-afd6-b412d70ed8a6)

### After (normal user)


![Screenshot from 2023-06-12 14-21-08](https://github.com/discourse/discourse/assets/4335742/0f7aa8bd-50cc-4b68-a824-e547c002757d)

### Before (admin user)

![Screenshot from 2023-06-12 14-26-08](https://github.com/discourse/discourse/assets/4335742/243d72cf-d4a7-46c4-9265-62f488781986)
### After (admin user)
![Screenshot from 2023-06-13 08-33-24](https://github.com/discourse/discourse/assets/4335742/cab89907-1f5b-4451-8104-f09f2c55a9b9)



