### PR TITLE
DEV: Clean up old polls data from custom fields

### DIFF
--- a/plugins/poll/db/post_migrate/20230612134421_remove_old_polls_data_from_custom_fields.rb
+++ b/plugins/poll/db/post_migrate/20230612134421_remove_old_polls_data_from_custom_fields.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveOldPollsDataFromCustomFields < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+    DELETE FROM post_custom_fields
+    WHERE name LIKE 'polls%'
+    SQL
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
In early 2015, the poll plugin was writing its data to custom fields on the post containing the poll. It was later changed to have dedicated SQL tables and the polls were migrated but we forgot to clean the existing data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
