### PR TITLE
UX: Better alignment for experimental grids

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/columns.js
+++ b/app/assets/javascripts/discourse/app/lib/columns.js
@@ -69,15 +69,28 @@ export default class Columns {
     Array.from(this.container.children).forEach((child) => {
       if (child.nodeName === "P" && child.children.length > 0) {
         // sometimes children are wrapped in a paragraph
-        targets.push(...child.children);
+        Array.from(child.children).forEach((c) => {
+          targets.push(this._wrapDirectImage(c));
+        });
       } else {
-        targets.push(child);
+        targets.push(this._wrapDirectImage(child));
       }
     });
 
     return targets.filter((item) => {
       return !this.excluded.includes(item.nodeName);
     });
+  }
+
+  _wrapDirectImage(item) {
+    if (item.nodeName !== "IMG") {
+      return item;
+    }
+
+    const wrapper = document.createElement("span");
+    wrapper.classList.add("image-wrapper");
+    wrapper.append(item);
+    return wrapper;
   }
 
   _distributeEvenly() {

--- a/app/assets/stylesheets/common/base/d-image-grid.scss
+++ b/app/assets/stylesheets/common/base/d-image-grid.scss
@@ -18,6 +18,23 @@
 
   .d-image-grid-column {
     box-sizing: border-box;
+    // use flex layout, flex-grow and object-fit: cover
+    // to better have the images fill their containers
+    // and line up vertically (it's not perfect!)
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    > div,
+    > span {
+      flex-grow: 1;
+      overflow: hidden;
+
+      img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {
+        height: 100%;
+        object-fit: cover;
+      }
+    }
 
     &:last-child {
       margin-right: 0;
@@ -35,6 +52,10 @@
       width: 100%;
     }
 
+    > .lightbox-wrapper > .lightbox {
+      height: 100%;
+    }
+
     .lightbox-wrapper {
       .meta .informations {
         display: none;
@@ -47,21 +68,31 @@
     // when staging edits
     .image-wrapper {
       display: block;
-      padding-bottom: $grid-column-gap;
-      margin-bottom: 0em;
+      margin-bottom: $grid-column-gap;
+      padding-bottom: 0em;
     }
   }
 
-  .desktop-view .d-editor-preview & {
+  .d-editor-preview & {
     .image-wrapper {
-      padding-bottom: $grid-column-gap;
-      margin-bottom: 0em;
+      margin-bottom: $grid-column-gap;
+      padding-bottom: 0em;
       .button-wrapper {
         .scale-btn-container,
         &[editing] .wrap-image-grid-button {
           display: none;
         }
       }
+    }
+  }
+
+  .mobile-view .d-editor-preview & {
+    .image-wrapper .button-wrapper {
+      opacity: 0;
+    }
+
+    .image-wrapper:hover .button-wrapper {
+      opacity: 1;
     }
   }
 }

--- a/app/assets/stylesheets/common/base/d-image-grid.scss
+++ b/app/assets/stylesheets/common/base/d-image-grid.scss
@@ -30,6 +30,10 @@
       flex-grow: 1;
       overflow: hidden;
 
+      // hardcoded max-height here prevents extra tall images
+      // from having an outsized effect on the grid
+      max-height: 1200px;
+
       img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {
         height: 100%;
         object-fit: cover;

--- a/app/assets/stylesheets/common/base/d-image-grid.scss
+++ b/app/assets/stylesheets/common/base/d-image-grid.scss
@@ -29,7 +29,6 @@
     > span {
       flex-grow: 1;
       overflow: hidden;
-
       // hardcoded max-height here prevents extra tall images
       // from having an outsized effect on the grid
       max-height: 1200px;
@@ -49,15 +48,11 @@
       margin-bottom: $grid-column-gap;
     }
 
-    // Forces images in the grid to fill each column
+    // Forces images in the grid to fill each column width-wise
     img,
     > .lightbox-wrapper,
     > .lightbox-wrapper > .lightbox {
       width: 100%;
-    }
-
-    > .lightbox-wrapper > .lightbox {
-      height: 100%;
     }
 
     .lightbox-wrapper {
@@ -66,6 +61,10 @@
       }
       .meta .filename {
         flex-grow: 3;
+      }
+      // full-height lightbox element in container
+      > .lightbox {
+        height: 100%;
       }
     }
 
@@ -91,12 +90,13 @@
   }
 
   .mobile-view .d-editor-preview & {
-    .image-wrapper .button-wrapper {
-      opacity: 0;
-    }
-
-    .image-wrapper:hover .button-wrapper {
-      opacity: 1;
+    .image-wrapper {
+      .button-wrapper {
+        opacity: 0;
+      }
+      &:hover .button-wrapper {
+        opacity: 1;
+      }
     }
   }
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2422,6 +2422,7 @@ en:
     experimental_new_new_view_groups: 'EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
     enable_custom_sidebar_sections: "EXPERIMENTAL: Enable custom sidebar sections"
     experimental_topics_filter: "EXPERIMENTAL: Enables the experimental topics filter route at /filter"
+    experimental_post_image_grid: "EXPERIMENTAL: Enables a [grid] tag in posts to display images in a grid layout."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -988,9 +988,6 @@ posting:
   autohighlight_all_code:
     client: true
     default: false
-  experimental_post_image_grid:
-    client: true
-    default: false
   highlighted_languages:
     default: "bash|c|cpp|csharp|css|diff|go|graphql|ini|java|javascript|json|kotlin|lua|makefile|markdown|objectivec|perl|php|php-template|plaintext|python|python-repl|r|ruby|rust|scss|shell|sql|swift|typescript|xml|yaml|wasm"
     choices: "HighlightJs.languages"
@@ -2113,6 +2110,9 @@ developer:
     allow_any: false
     refresh: true
   experimental_topics_filter:
+    client: true
+    default: false
+  experimental_post_image_grid:
     client: true
     default: false
   new_edit_sidebar_categories_tags_interface_groups:


### PR DESCRIPTION
Improves the layout of most grids in posts, by using `object-fit: cover` for lightbox images. This allows images to better fill up the space, without changing their aspect ratio. 

In some cases (see last row, middle image, in screenshots below), the shown image will be cropped considerably in the grid, but that should be a rare use case. 

### Before

<img width="600" alt="image" src="https://github.com/discourse/discourse/assets/368961/3e00f248-803d-412e-8236-4eba23da675f">

### After 
<img width="600" alt="image" src="https://github.com/discourse/discourse/assets/368961/3b5b0ebf-9c45-4c44-b4a1-7b031b86a23b">
