### PR TITLE
FIX: Theme translations resetting on save

### DIFF
--- a/app/assets/javascripts/admin/addon/components/theme-translation.js
+++ b/app/assets/javascripts/admin/addon/components/theme-translation.js
@@ -1,16 +1,23 @@
 import SiteSettingComponent from "./site-setting";
+import { ajax } from "discourse/lib/ajax";
+import { url } from "discourse/lib/computed";
 import { alias } from "@ember/object/computed";
 
-export default class ThemeTranslation extends SiteSettingComponent {
+export default class extends SiteSettingComponent {
   @alias("translation") setting;
   @alias("translation.key") settingName;
+  @url("model.id", "/admin/themes/%@") updateUrl;
 
   type = "string";
 
   _save() {
-    return this.model.saveTranslation(
-      this.get("translation.key"),
-      this.get("buffered.value")
-    );
+    const translations = {
+      [this.get("translation.key")]: this.get("buffered.value"),
+    };
+
+    return ajax(this.updateUrl, {
+      type: "PUT",
+      data: { theme: translations },
+    });
   }
 }

--- a/app/assets/javascripts/admin/addon/models/theme.js
+++ b/app/assets/javascripts/admin/addon/models/theme.js
@@ -309,16 +309,6 @@ class Theme extends RestModel {
       .finally(() => this.set("changed", false))
       .catch(popupAjaxError);
   }
-
-  saveSettings(name, value) {
-    const settings = {};
-    settings[name] = value;
-    return this.save({ settings });
-  }
-
-  saveTranslation(name, value) {
-    return this.save({ translations: { [name]: value } });
-  }
 }
 
 export default Theme;


### PR DESCRIPTION
Fixes an issue where saving a theme translation would reset unsaved changes made to other theme translations.

Also cleans up unused `saveSettings` and `saveTranslations` actions.
