### PR TITLE
FIX: change dismiss new button label

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-dismiss-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-dismiss-buttons.js
@@ -1,16 +1,17 @@
 import { action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
-import User from "discourse/models/user";
 import discourseLater from "discourse-common/lib/later";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import Component from "@ember/component";
+import { inject as service } from "@ember/service";
 
 export default Component.extend({
   tagName: "",
   classNames: ["topic-dismiss-buttons"],
 
+  currentUser: service(),
   position: null,
   selectedTopics: null,
   model: null,
@@ -61,8 +62,7 @@ export default Component.extend({
 
   @discourseComputed("selectedTopics.length")
   dismissNewLabel(selectedTopicCount) {
-    const user = User.current();
-    if (user.new_new_view_enabled) {
+    if (this.currentUser.new_new_view_enabled) {
       return I18n.t("topics.bulk.dismiss_button");
     } else if (selectedTopicCount === 0) {
       return I18n.t("topics.bulk.dismiss_new");

--- a/app/assets/javascripts/discourse/app/components/topic-dismiss-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-dismiss-buttons.js
@@ -1,5 +1,6 @@
 import { action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
+import User from "discourse/models/user";
 import discourseLater from "discourse-common/lib/later";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
@@ -60,7 +61,10 @@ export default Component.extend({
 
   @discourseComputed("selectedTopics.length")
   dismissNewLabel(selectedTopicCount) {
-    if (selectedTopicCount === 0) {
+    const user = User.current();
+    if (user.new_new_view_enabled) {
+      return I18n.t("topics.bulk.dismiss_button");
+    } else if (selectedTopicCount === 0) {
       return I18n.t("topics.bulk.dismiss_new");
     }
     return I18n.t("topics.bulk.dismiss_new_with_selected", {

--- a/spec/system/dismiss_topics_spec.rb
+++ b/spec/system/dismiss_topics_spec.rb
@@ -15,7 +15,7 @@ describe "Filtering topics", type: :system, js: true do
     visit("/new")
 
     expect(topic_list).to have_topic(topic)
-    find(".dismiss-read").click
+    find(".dismiss-read", text: "Dismiss…").click
     expect(dismiss_new_modal).to have_dismiss_topics_checked
     expect(dismiss_new_modal).to have_dismiss_posts_checked
     expect(dismiss_new_modal).to have_untrack_unchecked


### PR DESCRIPTION
Button which is opening modal to dismiss topics should be "Dismiss…"

<img width="486" alt="Screenshot 2023-06-13 at 11 44 19 am" src="https://github.com/discourse/discourse/assets/72780/c9fb679d-7091-4543-b8b6-0df820c3460c">
