### PR TITLE
FIX: Correctly intercept `<a href target="_self"`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -24,11 +24,13 @@ export default function interceptClick(e) {
 
   const currentTarget = e.currentTarget;
   const href = currentTarget.getAttribute("href");
+  const linkTarget = currentTarget.getAttribute("target");
+  const targettingOtherFrame = linkTarget && linkTarget !== "_self";
 
   if (
     !href ||
     href.startsWith("#") ||
-    currentTarget.getAttribute("target") ||
+    targettingOtherFrame ||
     currentTarget.dataset.emberAction ||
     currentTarget.dataset.autoRoute ||
     currentTarget.dataset.shareUrl ||


### PR DESCRIPTION
`_self` is the default, so we should treat it the same as having no value specified. This fixes navigation to links like `/my/...` in custom sidebar links.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
