### PR TITLE
REFACTOR: move shadow vars to css custom props

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -135,4 +135,13 @@
   --gold: #{$gold};
   --silver: #{$silver};
   --bronze: #{$bronze};
+
+  --shadow-modal: 0 8px 60px rgba(0, 0, 0, #{$shadow-opacity-modal});
+  --shadow-composer: 0 -1px 40px rgba(0, 0, 0, #{$shadow-opacity-composer});
+  --shadow-menu-panel: 0 12px 12px rgba(0, 0, 0, #{$shadow-opacity-menu-panel});
+  --shadow-card: 0 4px 14px rgba(0, 0, 0, #{$shadow-opacity-card});
+  --shadow-dropdown: 0 2px 3px 0 rgba(0, 0, 0, #{$shadow-opacity-dropdown});
+  --shadow-header: 0 2px 4px -1px rgba(0, 0, 0, #{$shadow-opacity-header});
+  --shadow-footer-nav: 0 0 2px 0 rgba(0, 0, 0, #{$shadow-opacity-footer-nav});
+  --shadow-focus-danger: 0 0 6px 0 var(--danger);
 }

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -380,7 +380,7 @@ $mobile-breakpoint: 700px;
     width: 460px;
     right: 0;
     z-index: z("dropdown");
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     margin-top: -2px;
     background-color: var(--secondary);
     padding: 12px 12px 5px;

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -961,7 +961,7 @@ table.permalinks {
       height: calc(100vh - 450px);
       min-height: 200px;
       width: 100%;
-      box-shadow: shadow("footer-nav");
+      box-shadow: var(--shadow-footer-nav);
       border-radius: 4px;
     }
 

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -521,7 +521,7 @@
       }
     }
     &:hover {
-      box-shadow: shadow("card");
+      box-shadow: var(--shadow-card);
     }
   }
 }

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -36,7 +36,7 @@ html.composer-open {
   transition: height 250ms ease, background 250ms ease, transform 250ms ease,
     max-width 250ms ease, padding-bottom 250ms ease;
   background-color: var(--secondary);
-  box-shadow: shadow("composer");
+  box-shadow: var(--shadow-composer);
 
   .reply-area {
     display: flex;
@@ -426,7 +426,7 @@ html.composer-open {
   width: 300px;
   background-color: var(--secondary);
   border: 1px solid var(--primary-low);
-  box-shadow: shadow("dropdown-lite");
+  box-shadow: var(--shadow-dropdown);
   border-radius: 8px;
 
   ul {

--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -5,7 +5,7 @@ $d-popover-border: var(--primary-low);
   color: var(--primary);
   background: $d-popover-background;
   border: 1px solid var(--primary-low);
-  box-shadow: shadow("menu-panel");
+  box-shadow: var(--shadow-menu-panel);
 }
 
 .tippy-box[data-placement^="top"] .tippy-svg-arrow > svg {

--- a/app/assets/stylesheets/common/base/dialog.scss
+++ b/app/assets/stylesheets/common/base/dialog.scss
@@ -37,7 +37,7 @@
   position: relative;
   background-color: var(--secondary);
   animation: fade-in 250ms both;
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   min-width: 40vw;
 }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -198,7 +198,7 @@ textarea {
 
   &:focus:required:invalid:focus {
     border-color: var(--danger);
-    box-shadow: shadow("focus-danger");
+    box-shadow: var(--shadow-focus-danger);
   }
 }
 

--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -46,7 +46,7 @@
       transition: all 0.25s;
 
       &:hover {
-        box-shadow: shadow("card");
+        box-shadow: var(--shadow-card);
         border-color: var(--primary-low-mid-or-secondary-high);
       }
     }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -10,7 +10,7 @@
   width: 100%;
   z-index: z("header");
   background-color: var(--header_background);
-  box-shadow: shadow("header");
+  box-shadow: var(--shadow-header);
   backface-visibility: hidden; /** do magic for scrolling performance **/
 
   > .wrap {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -1,7 +1,7 @@
 .menu-panel.slide-in {
   position: fixed;
   right: 0;
-  box-shadow: shadow("header");
+  box-shadow: var(--shadow-header);
 
   .panel-body {
     width: 100%;
@@ -21,7 +21,7 @@
 
 .menu-panel {
   border: 1px solid var(--primary-low);
-  box-shadow: shadow("menu-panel");
+  box-shadow: var(--shadow-menu-panel);
   background-color: var(--secondary);
   z-index: z("header");
   padding: 0.5em;

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -18,7 +18,7 @@
   margin: 0 auto;
   max-width: var(--modal-max-width);
   background-color: var(--secondary);
-  box-shadow: shadow("modal");
+  box-shadow: var(--shadow-modal);
 
   .select-kit {
     width: 220px;
@@ -44,7 +44,7 @@
   overflow: auto;
   height: auto;
   background-color: var(--secondary);
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   background-clip: padding-box;
 }
 
@@ -208,7 +208,7 @@
           position: absolute;
           top: 70%;
           padding: 5px 10px;
-          box-shadow: shadow("card");
+          box-shadow: var(--shadow-card);
           z-index: 5;
           background-color: var(--secondary);
           max-height: 150px;

--- a/app/assets/stylesheets/common/base/popup-menu.scss
+++ b/app/assets/stylesheets/common/base/popup-menu.scss
@@ -3,7 +3,7 @@
   width: 14em;
   border: 1px solid var(--primary-low);
   z-index: z("dropdown");
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
 
   ul {
     margin: 0;

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -495,7 +495,7 @@
       background: var(--primary-very-low);
       color: var(--primary-high);
       font-size: var(--font-down-2);
-      box-shadow: shadow("dropdown-lite");
+      box-shadow: var(--shadow-dropdown);
       margin-left: 50%;
       transform: translateX(-50%);
       border-radius: 4px;

--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -26,7 +26,7 @@
 .sidebar-more-section-links-details-content {
   background-color: var(--d-sidebar-background);
   transition: background-color 0.25s;
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   border: 1px solid var(--primary-low);
   margin: 0 calc(var(--d-sidebar-row-horizontal-padding) * 2 / 3);
 

--- a/app/assets/stylesheets/common/base/static-login.scss
+++ b/app/assets/stylesheets/common/base/static-login.scss
@@ -34,7 +34,7 @@ body.static-login {
     border: 1px solid var(--primary-low);
     text-align: center;
     padding: 2em;
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     border-radius: 5px;
     display: grid;
     place-items: center;

--- a/app/assets/stylesheets/common/base/tooltip.scss
+++ b/app/assets/stylesheets/common/base/tooltip.scss
@@ -54,7 +54,7 @@ $discourse-tooltip-border: var(--primary-medium);
     max-width: 250px;
     font-size: var(--font-down-1);
     color: var(--primary);
-    box-shadow: shadow("dropdown");
+    box-shadow: var(--shadow-dropdown);
     line-height: 1.4em;
   }
 }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -556,7 +556,7 @@ aside.quote {
   z-index: z("dropdown");
   background-color: var(--secondary);
   border: 1px solid var(--primary-low);
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   flex-direction: column;
 
   &.animated {
@@ -1394,7 +1394,7 @@ span.mention {
         margin-left: 8px;
         background-color: var(--primary-low);
         color: var(--primary);
-        box-shadow: shadow("dropdown");
+        box-shadow: var(--shadow-dropdown);
       }
     }
   }

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -69,7 +69,7 @@ $topic-progress-height: 42px;
       overflow-y: auto;
       z-index: z("timeline");
       padding: 10px 10px 35px 10px;
-      box-shadow: shadow("dropdown");
+      box-shadow: var(--shadow-dropdown);
       background: var(--tertiary-low);
 
       .close {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -201,7 +201,7 @@
   border-radius: var(--d-border-radius);
   &:hover,
   &:focus {
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     outline: 1px solid #000;
   }
   &[href] {

--- a/app/assets/stylesheets/common/components/d-tooltip.scss
+++ b/app/assets/stylesheets/common/components/d-tooltip.scss
@@ -7,6 +7,6 @@
   color: var(--primary);
   background: var(--secondary);
   border: 1px solid var(--primary-low);
-  box-shadow: shadow("menu-panel");
+  box-shadow: var(--shadow-menu-panel);
   overflow-wrap: break-word;
 }

--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -30,7 +30,7 @@ body.footer-nav-visible {
 
 .footer-nav {
   background-color: rgba(var(--header_background-rgb), 0.9);
-  box-shadow: shadow("footer-nav");
+  box-shadow: var(--shadow-footer-nav);
   height: var(--footer-nav-height);
   position: fixed;
   bottom: calc(var(--footer-nav-height) * -1);

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -58,7 +58,7 @@ a.hashtag {
 .hashtag-autocomplete {
   max-height: 13.5em;
   overflow-y: auto;
-  box-shadow: shadow("dropdown-lite");
+  box-shadow: var(--shadow-dropdown);
   border-radius: 8px;
 
   &__fadeout {

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -37,7 +37,7 @@
 .user-card,
 .group-card {
   width: var(--card-width);
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   color: var(--primary);
   background: var(--secondary) center center;
   background-size: cover;

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -171,3 +171,12 @@ $hljs-attribute: dark-light-choose(
 $hljs-symbol: dark-light-choose(unquote("#990073"), unquote("#fbe")) !default;
 $hljs-bg: dark-light-choose(unquote("#f8f8f8"), unquote("#333")) !default;
 $hljs-builtin-name: dark-light-choose($tertiary-high, $tertiary-hover) !default;
+
+// shadow opacity variables
+$shadow-opacity-modal: dark-light-choose(0.6, 1) !default;
+$shadow-opacity-composer: dark-light-choose(0.12, 0.35) !default;
+$shadow-opacity-menu-panel: dark-light-choose(0.15, 0.35) !default;
+$shadow-opacity-card: dark-light-choose(0.15, 0.5) !default;
+$shadow-opacity-dropdown: dark-light-choose(0.2, 0.35) !default;
+$shadow-opacity-header: dark-light-choose(0.25, 0.45) !default;
+$shadow-opacity-footer-nav: dark-light-choose(0.2, 0.4) !default;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -132,49 +132,6 @@ $z-layers: (
   @return map-deep-get($z-layers, $layers...);
 }
 
-// Box-shadow
-// --------------------------------------------------
-
-$box-shadow-light: (
-  "modal": 0 8px 60px rgba(0, 0, 0, 0.6),
-  "composer": 0 -1px 40px rgba(0, 0, 0, 0.12),
-  "menu-panel": 0 12px 12px rgba(0, 0, 0, 0.15),
-  "card": 0 4px 14px rgba(0, 0, 0, 0.15),
-  "dropdown": 0 2px 3px 0 rgba(0, 0, 0, 0.2),
-  "dropdown-lite": 0px 2px 12px 0px rgba(0, 0, 0, 0.1),
-  "header": 0 2px 4px -1px rgba(0, 0, 0, 0.25),
-  "footer-nav": 0 0 2px 0 rgba(0, 0, 0, 0.25),
-  "kbd": (
-    0 2px 0 rgba(0, 0, 0, 0.2),
-    0 0 0 1px dark-light-choose(#fff, #000) inset,
-  ),
-  "focus": 0 0 3px 0 $tertiary,
-  "focus-danger": 0 0 6px 0 $danger,
-);
-
-// do not add a dark shadow without a light equivilant
-$box-shadow-dark: (
-  "modal": 0 8px 60px rgba(0, 0, 0, 1),
-  "composer": 0 -1px 40px rgba(0, 0, 0, 0.35),
-  "menu-panel": 0 8px 12px rgba(0, 0, 0, 0.35),
-  "card": 0 4px 14px rgba(0, 0, 0, 0.5),
-  "dropdown": 0 2px 3px 0 rgba(0, 0, 0, 0.35),
-  "dropdown-lite": 0px 2px 12px 0px rgba(0, 0, 0, 0.25),
-);
-
-@function shadow($key) {
-  @if is-light-color-scheme() {
-    @return map-get($box-shadow-light, $key);
-  } @else {
-    $shadow-dark: map-get($box-shadow-dark, $key);
-    @if $shadow-dark != null {
-      @return $shadow-dark;
-    } @else {
-      @return map-get($box-shadow-light, $key);
-    }
-  }
-}
-
 // Color utilities
 // --------------------------------------------------
 

--- a/app/assets/stylesheets/common/input_tip.scss
+++ b/app/assets/stylesheets/common/input_tip.scss
@@ -20,7 +20,7 @@
   &.bad {
     background: var(--danger-medium);
     color: white;
-    box-shadow: shadow("dropdown");
+    box-shadow: var(--shadow-dropdown);
   }
   &.hide,
   &.good {

--- a/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
+++ b/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
@@ -15,7 +15,7 @@
       .select-kit-body {
         border: 1px solid var(--primary-low);
         background-clip: padding-box;
-        box-shadow: shadow("dropdown");
+        box-shadow: var(--shadow-dropdown);
       }
 
       .select-kit-row {

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -40,7 +40,7 @@
       border-radius: 0;
       border: none;
       border: 1px solid var(--primary-low);
-      box-shadow: shadow("dropdown");
+      box-shadow: var(--shadow-dropdown);
       background: var(--secondary);
       max-width: 600px;
     }

--- a/app/assets/stylesheets/common/software-update-prompt.scss
+++ b/app/assets/stylesheets/common/software-update-prompt.scss
@@ -9,7 +9,7 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s;
-  box-shadow: shadow("header");
+  box-shadow: var(--shadow-header);
   z-index: z("header") - 10;
 
   .update-prompt-main-content {

--- a/app/assets/stylesheets/common/topic-entrance.scss
+++ b/app/assets/stylesheets/common/topic-entrance.scss
@@ -2,7 +2,7 @@
   border: 1px solid var(--primary-low);
   padding: 5px;
   background: var(--secondary);
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   z-index: z("dropdown");
 
   position: absolute;

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -55,7 +55,7 @@
     left: 0;
     right: 0;
     border-top: 1px solid var(--primary-low);
-    box-shadow: shadow("composer");
+    box-shadow: var(--shadow-composer);
     padding: 20px 0px;
     z-index: z("fullscreen");
     @media screen and (max-height: 425px) {

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -89,7 +89,7 @@
   overflow-y: auto;
   z-index: z("composer", "dropdown") + 1;
   padding: 1.5em;
-  box-shadow: shadow("dropdown");
+  box-shadow: var(--shadow-dropdown);
   background: var(--highlight-bg);
 
   &.urgent {

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -417,7 +417,7 @@
   }
   .invite-form,
   .invite-success {
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
   }
 }
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -547,7 +547,7 @@ blockquote {
   width: 200px;
   position: fixed;
   z-index: z("dropdown") + 1; // 1 higher than .select-posts
-  box-shadow: shadow("card");
+  box-shadow: var(--shadow-card);
   padding: 0.714em;
   margin-bottom: 5px;
   right: 10px;

--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -127,7 +127,7 @@
 
     .select-kit-body {
       padding: 0.5rem;
-      box-shadow: shadow("card");
+      box-shadow: var(--shadow-card);
       border: 1px solid var(--primary-300);
     }
 

--- a/plugins/chat/assets/stylesheets/common/direct-message-creator.scss
+++ b/plugins/chat/assets/stylesheets/common/direct-message-creator.scss
@@ -114,7 +114,7 @@
     margin: 0;
     flex-wrap: wrap;
     border-bottom: 1px solid var(--primary-low);
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     position: absolute;
     width: 100%;
     z-index: z("dropdown");
@@ -180,7 +180,7 @@
     text-align: center;
     padding: 1rem;
     width: 100%;
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     background: var(--secondary);
     margin: 0;
     box-sizing: border-box;

--- a/plugins/chat/assets/stylesheets/mobile/chat-emoji-picker.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-emoji-picker.scss
@@ -8,7 +8,7 @@
     right: 0;
     height: 50vh;
     width: 100%;
-    box-shadow: shadow("card");
+    box-shadow: var(--shadow-card);
     z-index: z("header") + 2;
     max-width: 100vw;
     box-sizing: border-box;


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/22051 I attempted to define dark opacity values for box-shadows, because they need to be darker to have proper contrast against dark backgrounds. This didn't end up working because it was being done in SCSS (using `is-light-color-scheme()`), so the values weren't being recompiled on color scheme change. 

My dev environment was leading me astray because my SCSS was recompiling on save, so I thought it was working. 🤦🏻‍♂️

So this replaces our sass maps and `shadow($key)` function with CSS custom properties. This allows us to set a different shadow opacity for light/dark color schemes, and these values will change along with the color scheme. 

So this will correctly produce these darker shadows in dark color schemes: 

![Kapture 2023-06-13 at 15 27 03](https://github.com/discourse/discourse/assets/1681963/859a08ff-afb3-4b85-8630-f2bbfdd790c4)



Before/After

![Screenshot 2023-06-09 at 6 00 11 PM](https://github.com/discourse/discourse/assets/1681963/a1b3ff60-ae5d-434b-8696-144b3dcb5d2f) ![Screenshot 2023-06-09 at 6 00 00 PM](https://github.com/discourse/discourse/assets/1681963/24f9c96c-2301-498a-8008-c73dabfa7610)

![Screenshot 2023-06-09 at 6 02 10 PM](https://github.com/discourse/discourse/assets/1681963/191a3b97-94ca-40cd-8e68-8028da1bd1dc) ![Screenshot 2023-06-09 at 6 02 40 PM](https://github.com/discourse/discourse/assets/1681963/6a33685c-0efa-45cd-9197-05377574e2dd)

![Screenshot 2023-06-09 at 6 03 28 PM](https://github.com/discourse/discourse/assets/1681963/303fa1b8-f2ae-412d-ba22-afa149d35599)
![Screenshot 2023-06-09 at 6 03 17 PM](https://github.com/discourse/discourse/assets/1681963/d526bb27-2923-439b-b6e6-a1fee5f25042)


![Screenshot 2023-06-09 at 6 05 03 PM](https://github.com/discourse/discourse/assets/1681963/39bc68b9-32e6-4ade-8657-98914d124b1b)
![Screenshot 2023-06-09 at 6 05 12 PM](https://github.com/discourse/discourse/assets/1681963/efe527da-e2dd-4e73-9cb2-641f3a6710d3)


Also tested on some other dark palettes 


Before/After

![Screenshot 2023-06-09 at 6 06 37 PM](https://github.com/discourse/discourse/assets/1681963/8034f30e-a305-4a33-98f4-76f4fc21cccc) ![Screenshot 2023-06-09 at 6 06 30 PM](https://github.com/discourse/discourse/assets/1681963/e0ac9e94-793f-47b2-b67c-75ef26b016d7)

![Screenshot 2023-06-09 at 6 06 40 PM](https://github.com/discourse/discourse/assets/1681963/d1e736d7-de71-404d-832b-bc544591b6cb) ![Screenshot 2023-06-09 at 6 06 22 PM](https://github.com/discourse/discourse/assets/1681963/1b4932b1-c5d2-43e8-acd4-659e3d6ad4ca)

Before/After

![Screenshot 2023-06-09 at 6 08 53 PM](https://github.com/discourse/discourse/assets/1681963/b9efbf4c-8dd3-414a-b40f-af3b28ad1ed1) ![Screenshot 2023-06-09 at 6 09 13 PM](https://github.com/discourse/discourse/assets/1681963/fed80578-fb68-4198-87d9-1038d43b648c)

![Screenshot 2023-06-09 at 6 08 58 PM](https://github.com/discourse/discourse/assets/1681963/976eea72-f108-4ccf-85a9-5af967df298b) ![Screenshot 2023-06-09 at 6 09 09 PM](https://github.com/discourse/discourse/assets/1681963/af457d56-84fa-4691-b2fd-5597fbcad4b9)



