### PR TITLE
DEV: Temporarily hide form when editing topic with template

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -18,6 +18,7 @@
   @popupMenuOptions={{this.popupMenuOptions}}
   @formTemplateIds={{this.formTemplateIds}}
   @replyingToTopic={{this.composer.replyingToTopic}}
+  @editingPost={{this.composer.editingPost}}
   @disabled={{this.disableTextarea}}
   @outletArgs={{hash composer=this.composer editorType="composer"}}
 >

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -1,7 +1,3 @@
-{{!-- TODO(@keegan):
-Remove @editingPost={{this.composer.editingPost}}
-once we add edit/draft support to form templates
---}}
 <DEditor
   @value={{this.composer.reply}}
   @placeholder={{this.replyPlaceholder}}

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -1,3 +1,7 @@
+{{!-- TODO(@keegan):
+Remove @editingPost={{this.composer.editingPost}}
+once we add edit/draft support to form templates
+--}}
 <DEditor
   @value={{this.composer.reply}}
   @placeholder={{this.replyPlaceholder}}

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -247,9 +247,9 @@ export default Component.extend(TextareaTextManipulation, {
     this.selectedFormTemplateId = formTemplateId;
   },
 
-  @discourseComputed("formTemplateIds", "replyingToTopic")
-  showFormTemplateForm(formTemplateIds, replyingToTopic) {
-    if (formTemplateIds?.length > 0 && !replyingToTopic) {
+  @discourseComputed("formTemplateIds", "replyingToTopic", "editingPost")
+  showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
+    if (formTemplateIds?.length > 0 && !replyingToTopic && !editingPost) {
       return true;
     }
 

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -249,6 +249,7 @@ export default Component.extend(TextareaTextManipulation, {
 
   @discourseComputed("formTemplateIds", "replyingToTopic", "editingPost")
   showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
+    // TODO(@keegan): Remove !editingPost once we add edit/draft support for form templates
     if (formTemplateIds?.length > 0 && !replyingToTopic && !editingPost) {
       return true;
     }


### PR DESCRIPTION
Note: This PR is an addition to the `experimental_form_templates` feature.

This PR changes the behavior so that clicking **Edit** on a topic created by a form template shows a regular composer (with a `<textarea />`) so that the contents of the topic can easily be edited.

This is a **temporary** behavior which should be removed after adding edit/draft support to form templates