### PR TITLE
A11Y: Adjust contrast for the Dark and Solarized Dark tertiary color schemes

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -7,7 +7,7 @@ class ColorScheme < ActiveRecord::Base
     Dark: {
       "primary" => "dddddd",
       "secondary" => "222222",
-      "tertiary" => "0f82af",
+      "tertiary" => "099dd7",
       "quaternary" => "c14924",
       "header_background" => "111111",
       "header_primary" => "dddddd",
@@ -256,7 +256,7 @@ class ColorScheme < ActiveRecord::Base
       "secondary" => "002B36",
       "tertiary_low" => "003E54",
       "tertiary_medium" => "00557A",
-      "tertiary" => "0088cc",
+      "tertiary" => "1a97d5",
       "tertiary_high" => "006C9F",
       "quaternary_low" => "944835",
       "quaternary" => "e45735",


### PR DESCRIPTION
This updates the `var(--tertiary)` to improve contrast when viewing in dark mode

### Before
![image](https://github.com/discourse/discourse/assets/2790986/93e5aa36-06ba-421a-8847-73b410f6ab8e)
Dark

![image](https://github.com/discourse/discourse/assets/2790986/af328ca5-f4df-41c0-9b77-3444bf23512f)
Solarized Dark

### After
![image](https://github.com/discourse/discourse/assets/2790986/a1000212-da98-479e-b2a9-22e572de2f8c)
Dark

![image](https://github.com/discourse/discourse/assets/2790986/b7998b3f-70be-4596-b560-a27244f966ff)
Solarized Dark



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
