### PR TITLE
FIX: Allow half-merged user to be accessed

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -74,7 +74,7 @@ module UserGuardian
   end
 
   def can_anonymize_user?(user)
-    is_staff? && !user.nil? && !user.staff? && !user.email.ends_with?(UserAnonymizer::EMAIL_SUFFIX)
+    is_staff? && !user.nil? && !user.staff? && !user.email&.ends_with?(UserAnonymizer::EMAIL_SUFFIX)
   end
 
   def can_merge_user?(user)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2777,8 +2777,14 @@ RSpec.describe Guardian do
       expect(Guardian.new(user).can_anonymize_user?(user)).to be_falsey
     end
 
-    it "it false for an anonymized user" do
+    it "is false for an anonymized user" do
       expect(Guardian.new(user).can_anonymize_user?(anonymous_user)).to be_falsey
+    end
+
+    it "is true for a user with no email" do
+      bad_state_user = Fabricate.build(:user, email: nil)
+      bad_state_user.skip_email_validation = true
+      expect(Guardian.new(moderator).can_anonymize_user?(bad_state_user)).to eq(true)
     end
 
     it "is true for admin anonymizing a regular user" do


### PR DESCRIPTION
This is somewhat of an uncommon case where if a plugin fails to merge a user, the merge would fail but the `user_email` of the `source_user` would have been transferred to the `target_user`. This leaves the `source_user` without an email, and this bug would occur when admins try to access `/admin/users/<id>/<username>`.

This allows the admin to continue dealing with the user.

https://meta.discourse.org/t/error-merging-users-with-duplicate-poll-votes/154711

A consideration here would be to use a transaction (probably very costly), or reorder the order of events in `UserMerger.merge!`