### PR TITLE
FIX: De-duplicate poll vote on user merge

### DIFF
--- a/plugins/poll/db/migrate/20230614041219_delete_duplicate_poll_votes.rb
+++ b/plugins/poll/db/migrate/20230614041219_delete_duplicate_poll_votes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DeleteDuplicatePollVotes < ActiveRecord::Migration[7.0]
+  def up
+    execute "
+    DELETE FROM poll_votes
+    WHERE (poll_id, user_id, updated_at) NOT IN (
+      SELECT poll_id, user_id, MAX(updated_at)
+      FROM poll_votes
+      GROUP BY poll_id, user_id
+    )"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/poll/db/migrate/20230614041219_delete_duplicate_poll_votes.rb
+++ b/plugins/poll/db/migrate/20230614041219_delete_duplicate_poll_votes.rb
@@ -2,13 +2,14 @@
 
 class DeleteDuplicatePollVotes < ActiveRecord::Migration[7.0]
   def up
-    execute "
-    DELETE FROM poll_votes
-    WHERE (poll_id, user_id, updated_at) NOT IN (
-      SELECT poll_id, user_id, MAX(updated_at)
-      FROM poll_votes
-      GROUP BY poll_id, user_id
-    )"
+    execute <<~SQL
+      DELETE FROM poll_votes
+      WHERE (poll_id, user_id, updated_at) NOT IN (
+        SELECT poll_id, user_id, MAX(updated_at)
+        FROM poll_votes
+        GROUP BY poll_id, user_id
+      )
+    SQL
   end
 
   def down

--- a/plugins/poll/spec/fabricators/poll_fabricator.rb
+++ b/plugins/poll/spec/fabricators/poll_fabricator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Fabricator(:poll, class_name: "Poll") do
+  post
+  name { sequence(:name) { |i| "Poll #{i}" } }
+end
+
+Fabricator(:poll_option, class_name: "PollOption") do
+  poll
+  html { sequence(:html) { |i| "Poll Option #{i}" } }
+  digest { sequence(:digest) { |i| "#{i}" } }
+end
+
+Fabricator(:poll_vote, class_name: "PollVote") do
+  poll
+  poll_option
+  user
+end

--- a/plugins/poll/spec/fabricators/poll_fabricator.rb
+++ b/plugins/poll/spec/fabricators/poll_fabricator.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-Fabricator(:poll, class_name: "Poll") do
+Fabricator(:poll) do
   post
   name { sequence(:name) { |i| "Poll #{i}" } }
 end
 
-Fabricator(:poll_option, class_name: "PollOption") do
+Fabricator(:poll_option) do
   poll
   html { sequence(:html) { |i| "Poll Option #{i}" } }
   digest { sequence(:digest) { |i| "#{i}" } }
 end
 
-Fabricator(:poll_vote, class_name: "PollVote") do
+Fabricator(:poll_vote) do
   poll
   poll_option
   user

--- a/plugins/poll/spec/integration/user_merger_spec.rb
+++ b/plugins/poll/spec/integration/user_merger_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe UserMerger do
+  fab!(:target_user) { Fabricate(:user, username: "galahad", email: "galahad@knights.com") }
+  fab!(:source_user) { Fabricate(:user, username: "lancelot", email: "lancelot@knights.com") }
+  fab!(:poll) { Fabricate(:poll) }
+
+  def merge_users!(source = nil, target = nil)
+    source ||= source_user
+    target ||= target_user
+    UserMerger.new(source, target).merge!
+  end
+
+  it "deletes source_user vote if target_user already voted" do
+    Fabricate(:poll_vote, poll: poll, user: target_user)
+    Fabricate(:poll_vote, poll: poll, user: source_user)
+
+    DiscourseEvent.trigger(:merging_users, source_user, target_user)
+
+    expect(PollVote.where(user: source_user).count).to eq(0)
+  end
+
+  it "keeps only target_user vote if duplicate" do
+    target_vote = Fabricate(:poll_vote, poll: poll, user: target_user)
+    Fabricate(:poll_vote, poll: poll, user: source_user)
+
+    DiscourseEvent.trigger(:merging_users, source_user, target_user)
+
+    expect(PollVote.where(user: target_user).to_json).to eq([target_vote].to_json)
+  end
+
+  it "reassigns source_user vote to target_user if not duplicate" do
+    Fabricate(:poll_vote, poll: poll, user: source_user)
+
+    expect { DiscourseEvent.trigger(:merging_users, source_user, target_user) }.to change(
+      PollVote.where(user: target_user),
+      :count,
+    ).from(0).to(1)
+  end
+
+  it "keeps any existing target_user votes" do
+    Fabricate(:poll_vote, poll: poll, user: target_user)
+
+    expect { DiscourseEvent.trigger(:merging_users, source_user, target_user) }.to not_change(
+      PollVote.where(user: target_user),
+      :count,
+    )
+  end
+end

--- a/plugins/poll/spec/integration/user_merger_spec.rb
+++ b/plugins/poll/spec/integration/user_merger_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe UserMerger do
   fab!(:source_user) { Fabricate(:user, username: "lancelot", email: "lancelot@knights.com") }
   fab!(:poll) { Fabricate(:poll) }
 
-  def merge_users!(source = nil, target = nil)
-    source ||= source_user
-    target ||= target_user
-    UserMerger.new(source, target).merge!
-  end
-
   it "deletes source_user vote if target_user already voted" do
     Fabricate(:poll_vote, poll: poll, user: target_user)
     Fabricate(:poll_vote, poll: poll, user: source_user)


### PR DESCRIPTION
Currently when merging users, polls may error out if the source and target users have both voted on the same poll before. 😢 

There is currently no constraint on the `poll_votes` table either to support this. Ideally a composite primary key can be used `(poll_id, user_id)`, but alas there is no support yet, which is probably why it wasn't created in the first place.

This fix ensures that merging is successful by only keeping the target poll votes if duplicates exist.

This fix also runs a migration on older poll votes where failed merges would have caused a single user to have voted twice on a single poll. e.g. this weird edge case

<img width="450" alt="Screenshot 2023-06-14 at 7 12 06 PM" src="https://github.com/discourse/discourse/assets/1555215/19d9ed06-2206-45f5-826f-e1c565f01bab">

Related: https://github.com/discourse/discourse/pull/22105