### PR TITLE
FIX: Moderator(non-admin staff user) group visibility scope queries

### DIFF
--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -766,6 +766,11 @@ RSpec.describe Group do
       expect(can_view?(logged_on_user, group)).to eq(false)
       expect(can_view?(nil, group)).to eq(false)
 
+      group.add_owner(moderator)
+
+      expect(can_view?(moderator, group)).to eq(true)
+
+      GroupUser.delete_by(group: group, user: moderator)
       group.update_columns(visibility_level: Group.visibility_levels[:staff])
 
       expect(can_view?(admin, group)).to eq(true)
@@ -829,6 +834,11 @@ RSpec.describe Group do
       expect(can_view?(logged_on_user, group)).to eq(false)
       expect(can_view?(nil, group)).to eq(false)
 
+      group.add_owner(moderator)
+
+      expect(can_view?(moderator, group)).to eq(true)
+
+      GroupUser.delete_by(group: group, user: moderator)
       group.update_columns(members_visibility_level: Group.visibility_levels[:staff])
 
       expect(can_view?(admin, group)).to eq(true)


### PR DESCRIPTION
Currently, groups owned by moderators are not visible to them on the groups page. This happens because, the group visibility queries don't account for non-admin staff user group ownership.

This change updates the group visibility scope queries to account for a moderator(non-admin staff user) group ownership.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
