### PR TITLE
FIX: Correctly get the topic_id from the first post

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -271,7 +271,7 @@ export default MountWidget.extend({
 
   showSummary() {
     showModal("topic-summary").setProperties({
-      topicId: this.posts["posts"][0].topic_id,
+      topicId: this.posts.objectAt(0).topic_id,
     });
   },
 


### PR DESCRIPTION
The old way didn't work on mobile.