### PR TITLE
FIX: Don't add the no-text class if translatedLabel is present

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -10,7 +10,7 @@ export const ButtonClass = {
   buildClasses(attrs) {
     let className = this.attrs.className || "";
 
-    let hasText = attrs.label || attrs.contents;
+    let hasText = attrs.translatedLabel || attrs.label || attrs.contents;
 
     if (!hasText) {
       className += " no-text";

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/button-test.js
@@ -63,4 +63,12 @@ module("Integration | Component | Widget | button", function (hooks) {
 
     assert.strictEqual(query("button").title, "foo bar");
   });
+
+  test("translatedLabel skips no-text class in icon", async function (assert) {
+    this.set("args", { icon: "plus", translatedLabel: "foo bar" });
+
+    await render(hbs`<MountWidget @widget="button" @args={{this.args}} />`);
+
+    assert.ok(!exists("button.btn.btn-icon.no-text"), "skips no-text class");
+  });
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
