### PR TITLE
UX: softer dropdown and menu panel shadows

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -138,9 +138,9 @@
 
   --shadow-modal: 0 8px 60px rgba(0, 0, 0, #{$shadow-opacity-modal});
   --shadow-composer: 0 -1px 40px rgba(0, 0, 0, #{$shadow-opacity-composer});
-  --shadow-menu-panel: 0 12px 12px rgba(0, 0, 0, #{$shadow-opacity-menu-panel});
+  --shadow-menu-panel: 0 8px 12px rgba(0, 0, 0, #{$shadow-opacity-menu-panel});
   --shadow-card: 0 4px 14px rgba(0, 0, 0, #{$shadow-opacity-card});
-  --shadow-dropdown: 0 2px 3px 0 rgba(0, 0, 0, #{$shadow-opacity-dropdown});
+  --shadow-dropdown: 0 2px 12px 0 rgba(0, 0, 0, #{$shadow-opacity-dropdown});
   --shadow-header: 0 2px 4px -1px rgba(0, 0, 0, #{$shadow-opacity-header});
   --shadow-footer-nav: 0 0 2px 0 rgba(0, 0, 0, #{$shadow-opacity-footer-nav});
   --shadow-focus-danger: 0 0 6px 0 var(--danger);

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -177,6 +177,6 @@ $shadow-opacity-modal: dark-light-choose(0.6, 1) !default;
 $shadow-opacity-composer: dark-light-choose(0.12, 0.35) !default;
 $shadow-opacity-menu-panel: dark-light-choose(0.15, 0.35) !default;
 $shadow-opacity-card: dark-light-choose(0.15, 0.5) !default;
-$shadow-opacity-dropdown: dark-light-choose(0.2, 0.35) !default;
+$shadow-opacity-dropdown: dark-light-choose(0.1, 0.25) !default;
 $shadow-opacity-header: dark-light-choose(0.25, 0.45) !default;
 $shadow-opacity-footer-nav: dark-light-choose(0.2, 0.4) !default;


### PR DESCRIPTION
@chapoi suggested the dropdown shadow was a little harsh, so this lightens it a bit! 


Before/After

![Screenshot 2023-06-14 at 2 03 17 PM](https://github.com/discourse/discourse/assets/1681963/686210e5-14d7-4075-9caf-9b6f484aa846)
![Screenshot 2023-06-14 at 2 08 30 PM](https://github.com/discourse/discourse/assets/1681963/551356bc-7f3d-41f6-b057-29b0073d3c42)


![Screenshot 2023-06-14 at 2 09 43 PM](https://github.com/discourse/discourse/assets/1681963/418da04f-a9db-4105-8356-5444c1f06d9a) ![Screenshot 2023-06-14 at 2 08 35 PM](https://github.com/discourse/discourse/assets/1681963/f9d9e6e3-8c7d-4f3a-a92a-48cc52a90bba)


I also made a slight adjustment to the menu-panel shadow

<img src="https://github.com/discourse/discourse/assets/1681963/4f4e3d2a-2a1a-44a4-8e88-97cdb06a516d" width="300">

<img src="https://github.com/discourse/discourse/assets/1681963/2be6bbd7-9d58-4d79-89e6-61bc0b846714" width="300">
