### PR TITLE
UX: Remove branded blobs background

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -352,7 +352,7 @@ body.invite-page {
   .invite-success {
     border-radius: 8px;
     margin-top: 25px;
-    border-color: 1px solid var(--primary-low);
+    border: 1px solid var(--primary-low);
     background-color: var(--secondary);
   }
 

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -1,6 +1,3 @@
-$invite-bg: absolute-image-url("/branded-background.svg");
-$invite-mobile-bg: absolute-image-url("/branded-background-mobile.svg");
-
 .caps-lock-warning {
   color: var(--danger);
   font-size: var(--font-down-1);
@@ -36,20 +33,10 @@ $invite-mobile-bg: absolute-image-url("/branded-background-mobile.svg");
 }
 
 body.invite-page {
-  background-image: $invite-bg;
-  background-size: 110vw 110vh; // crops better than cover at various viewport sizes
-  background-repeat: no-repeat;
-  background-position: bottom;
-  background-color: var(--secondary);
+  background-color: var(--primary-50);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
-  @include breakpoint("mobile-extra-large") {
-    background: $invite-mobile-bg;
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: bottom;
-  }
-  .d-header .panel.clearfix {
+  .d-header {
     display: none;
   }
 }
@@ -93,7 +80,6 @@ body.invite-page {
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-rows: auto 1fr;
-    background: var(--secondary);
     max-width: 33em;
     word-break: break-word;
     .login-title {
@@ -364,9 +350,9 @@ body.invite-page {
 
   .invite-form,
   .invite-success {
-    border-radius: 10px;
+    border-radius: 8px;
     margin-top: 25px;
-    border-top: 6px solid var(--tertiary);
+    border-color: 1px solid var(--primary-low);
     background-color: var(--secondary);
   }
 

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -1,6 +1,3 @@
-$wizard-bg: absolute-image-url("/branded-background.svg");
-$wizard-mobile-bg: absolute-image-url("/branded-background-mobile.svg");
-
 @keyframes bump {
   0% {
     transform: scale(1);
@@ -16,11 +13,7 @@ $wizard-mobile-bg: absolute-image-url("/branded-background-mobile.svg");
 }
 
 body.wizard {
-  background: $wizard-bg;
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: bottom;
-  background-color: var(--secondary);
+  background-color: var(--primary-50);
   color: var(--primary-very-high);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
@@ -50,13 +43,6 @@ body.wizard {
         display: none;
       }
     }
-  }
-
-  @include breakpoint("mobile-extra-large") {
-    background: $wizard-mobile-bg;
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: bottom;
   }
 }
 


### PR DESCRIPTION
This removes the branded blobs background on the accept invitation page and setup wizard. We want these pages to match with the theme and not our website.

### Before
<img width="1506" alt="image" src="https://github.com/discourse/discourse/assets/2790986/7afcee8a-d519-4afc-a28b-b2c6fd2be284">

<img width="1500" alt="image" src="https://github.com/discourse/discourse/assets/2790986/330ce70a-8750-4c72-9ce9-2e9b0236b5f7">


### After
<img width="1326" alt="image" src="https://github.com/discourse/discourse/assets/2790986/d391d262-954c-436b-819f-57540f61a9cf">

<img width="1459" alt="image" src="https://github.com/discourse/discourse/assets/2790986/43914c19-da90-4141-aef9-b5553622200b">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
