### PR TITLE
UX: Hide sidebar on invites page

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/disable-sidebar.js
+++ b/app/assets/javascripts/discourse/app/mixins/disable-sidebar.js
@@ -1,0 +1,15 @@
+import Mixin from "@ember/object/mixin";
+
+export default Mixin.create({
+  activate() {
+    this.controllerFor("application").setProperties({
+      sidebarDisabledRouteOverride: true,
+    });
+  },
+
+  deactivate() {
+    this.controllerFor("application").setProperties({
+      sidebarDisabledRouteOverride: false,
+    });
+  },
+});

--- a/app/assets/javascripts/discourse/app/routes/invites-show.js
+++ b/app/assets/javascripts/discourse/app/routes/invites-show.js
@@ -2,8 +2,9 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import PreloadStore from "discourse/lib/preload-store";
 import { deepMerge } from "discourse-common/lib/object";
+import DisableSidebar from "discourse/mixins/disable-sidebar";
 
-export default DiscourseRoute.extend({
+export default DiscourseRoute.extend(DisableSidebar, {
   titleToken() {
     return I18n.t("invites.accept_title");
   },

--- a/app/assets/javascripts/discourse/app/routes/second-factor-auth.js
+++ b/app/assets/javascripts/discourse/app/routes/second-factor-auth.js
@@ -2,8 +2,9 @@ import DiscourseRoute from "discourse/routes/discourse";
 import PreloadStore from "discourse/lib/preload-store";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
+import DisableSidebar from "discourse/mixins/disable-sidebar";
 
-export default DiscourseRoute.extend({
+export default DiscourseRoute.extend(DisableSidebar, {
   queryParams: {
     nonce: { refreshModel: true },
   },
@@ -24,18 +25,6 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
-
-  activate() {
-    this.controllerFor("application").setProperties({
-      sidebarDisabledRouteOverride: true,
-    });
-  },
-
-  deactivate() {
-    this.controllerFor("application").setProperties({
-      sidebarDisabledRouteOverride: false,
-    });
   },
 
   setupController(controller, model) {

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -97,6 +97,12 @@ acceptance("Invite accept", function (needs) {
     });
 
     await visit("/invites/my-valid-invite-token");
+
+    assert.notOk(
+      document.body.classList.contains("has-sidebar-page"),
+      "does not display the sidebar on the invites page"
+    );
+
     assert.ok(exists("#new-account-email"), "shows the email input");
     assert.ok(exists("#new-account-username"), "shows the username input");
     assert.strictEqual(

--- a/app/assets/javascripts/wizard/addon/routes/wizard.js
+++ b/app/assets/javascripts/wizard/addon/routes/wizard.js
@@ -1,28 +1,31 @@
 import Route from "@ember/routing/route";
 import { findWizard } from "wizard/models/wizard";
+import DisableSidebar from "discourse/mixins/disable-sidebar";
 
-export default Route.extend({
+export default Route.extend(DisableSidebar, {
   model() {
     return findWizard();
   },
 
   activate() {
+    this._super(...arguments);
+
     document.body.classList.add("wizard");
 
     this.controllerFor("application").setProperties({
       showTop: false,
       showFooter: false,
-      sidebarDisabledRouteOverride: true,
       showSiteHeader: false,
     });
   },
 
   deactivate() {
+    this._super(...arguments);
+
     document.body.classList.remove("wizard");
 
     this.controllerFor("application").setProperties({
       showTop: true,
-      sidebarDisabledRouteOverride: false,
       showSiteHeader: true,
     });
   },


### PR DESCRIPTION
This hides the sidebar to make the signup experience less confusing.

Co-authored-by: Ella E <ella.estigoy@gmail.com>