### PR TITLE
DEV: Do not auto reload on plugin spec file changes

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -21,7 +21,9 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
       not_autoloaded =
         files.filter_map do |file|
           autoloaded = Rails.autoloaders.main.__autoloads.key? file
-          Pathname.new(file).relative_path_from(Rails.root) if !autoloaded
+          if !autoloaded && !file.end_with?("spec.rb")
+            Pathname.new(file).relative_path_from(Rails.root)
+          end
         end
 
       if not_autoloaded.length > 0


### PR DESCRIPTION
There is no need to reload the rails server if plugin spec
files change, since they are not autoloaded but they are also
not loaded into the app.
