### PR TITLE
FIX: Minor thread indicator issue

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -53,6 +53,7 @@
 
   &__last-reply-excerpt {
     @include ellipsis;
+    line-height: 1.8rem;
   }
 
   &__body {


### PR DESCRIPTION
Set a line height for the last reply excerpt so the height does not jump when including an emoji.
