### PR TITLE
FIX: various mobile chat improvements

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/format-date.js
+++ b/app/assets/javascripts/discourse/app/helpers/format-date.js
@@ -28,6 +28,7 @@ registerUnbound("format-date", function (val, params) {
         format,
         title,
         leaveAgo,
+        prefix: params.prefix,
       })
     );
   }

--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -102,6 +102,11 @@ export function autoUpdatingRelativeAge(date, options) {
     append += "' title='" + longDate(date);
   }
 
+  let prefix = "";
+  if (options.prefix) {
+    prefix = options.prefix + " ";
+  }
+
   return (
     "<span class='relative-date" +
     append +
@@ -110,6 +115,7 @@ export function autoUpdatingRelativeAge(date, options) {
     "' data-format='" +
     format +
     "'>" +
+    prefix +
     relAge +
     "</span>"
   );

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -260,6 +260,9 @@ module("Unit | Utility | formatter", function (hooks) {
     assert.strictEqual(elem.dataset.time, d.getTime().toString());
     assert.strictEqual(elem.title, "");
     assert.strictEqual(elem.innerHTML, "1 day");
+
+    elem = domFromString(autoUpdatingRelativeAge(d, { prefix: "test" }))[0];
+    assert.strictEqual(elem.innerHTML, "test 1d");
   });
 
   test("updateRelativeAge", function (assert) {

--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -15,8 +15,14 @@ $d-popover-border: var(--primary-low);
   top: -10px;
 }
 
-.tippy-svg-arrow > svg {
-  color: $d-popover-background;
+#tippy-rounded-arrow {
+  .svg-content {
+    fill: $d-popover-background;
+  }
+
+  .svg-arrow {
+    fill: $d-popover-border;
+  }
 }
 
 [data-tooltip] > *,

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.hbs
@@ -9,7 +9,7 @@
     <div
       role="button"
       class="collapse-area"
-      {{on "touchstart" this.collapseMenu passive=true bubbles=false}}
+      {{on "touchstart" this.collapseMenu passive=false bubbles=false}}
     >
     </div>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
@@ -47,7 +47,8 @@ export default class ChatMessageActionsMobile extends Component {
   }
 
   @action
-  collapseMenu() {
+  collapseMenu(event) {
+    event.preventDefault();
     this.#onCloseMenu();
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.js
@@ -15,8 +15,6 @@ export default class ChatMessageActionsMobile extends Component {
   @tracked hasExpandedReply = false;
   @tracked showFadeIn = false;
 
-  messageActions = null;
-
   get message() {
     return this.chat.activeMessage.model;
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
@@ -1,18 +1,17 @@
 {{#if (and @reaction this.emojiUrl)}}
   <button
     type="button"
-    {{on "click" this.handleClick bubbles=false}}
-    {{on "touchstart" this.handleClick bubbles=false}}
     tabindex="0"
     class={{concat-class
       "chat-message-reaction"
       (if @reaction.reacted "reacted")
+      (if this.isActive "-active")
     }}
     data-emoji-name={{@reaction.emoji}}
     data-tippy-content={{this.popoverContent}}
     title={{this.emojiString}}
-    {{did-insert this.setupTooltip}}
-    {{will-destroy this.teardownTooltip}}
+    {{did-insert this.setup}}
+    {{will-destroy this.teardown}}
     {{did-update this.refreshTooltip this.popoverContent}}
   >
     <img

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
@@ -106,6 +106,11 @@ export default class ChatMessageReaction extends Component {
       interactive: false,
       allowHTML: true,
       offset: [0, 10],
+      onShow(instance) {
+        if (instance.props.content === "") {
+          return false;
+        }
+      },
     });
   }
 
@@ -116,7 +121,7 @@ export default class ChatMessageReaction extends Component {
 
   @action
   refreshTooltip() {
-    this._tippyInstance?.setContent(this.popoverContent);
+    this._tippyInstance?.setContent(this.popoverContent || "");
   }
 
   get emojiString() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
@@ -2,29 +2,111 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { emojiUnescape, emojiUrlFor } from "discourse/lib/text";
 import I18n from "I18n";
-import { schedule } from "@ember/runloop";
+import { cancel } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import setupPopover from "discourse/lib/d-popover";
+import discourseLater from "discourse-common/lib/later";
+import { tracked } from "@glimmer/tracking";
 
 export default class ChatMessageReaction extends Component {
+  @service capabilities;
   @service currentUser;
+
+  @tracked isActive = false;
 
   get showCount() {
     return this.args.showCount ?? true;
   }
 
   @action
-  setupTooltip(element) {
-    if (this.args.showTooltip) {
-      schedule("afterRender", () => {
-        this._tippyInstance?.destroy();
-        this._tippyInstance = setupPopover(element, {
-          interactive: false,
-          allowHTML: true,
-          delay: 250,
-        });
+  setup(element) {
+    this.setupListeners(element);
+    this.setupTooltip(element);
+  }
+
+  @action
+  teardown() {
+    cancel(this.longPressHandler);
+    this.teardownTooltip();
+  }
+
+  @action
+  setupListeners(element) {
+    this.element = element;
+
+    if (this.capabilities.touch) {
+      this.element.addEventListener("touchstart", this.onTouchStart, {
+        passive: true,
       });
+      this.element.addEventListener("touchmove", this.cancelTouch, {
+        passive: true,
+      });
+      this.element.addEventListener("touchend", this.onTouchEnd);
+      this.element.addEventListener("touchCancel", this.cancelTouch);
     }
+
+    this.element.addEventListener("click", this.handleClick, {
+      passive: true,
+    });
+  }
+
+  @action
+  teardownListeners() {
+    if (this.capabilities.touch) {
+      this.element.removeEventListener("touchstart", this.onTouchStart, {
+        passive: true,
+      });
+      this.element.removeEventListener("touchmove", this.cancelTouch, {
+        passive: true,
+      });
+      this.element.removeEventListener("touchend", this.onTouchEnd);
+      this.element.removeEventListener("touchCancel", this.cancelTouch);
+    }
+
+    this.element.removeEventListener("click", this.handleClick, {
+      passive: true,
+    });
+  }
+
+  @action
+  onTouchStart(event) {
+    event.stopPropagation();
+    this.isActive = true;
+
+    this.longPressHandler = discourseLater(() => {
+      this.touching = false;
+    }, 400);
+
+    this.touching = true;
+  }
+
+  @action
+  cancelTouch() {
+    cancel(this.longPressHandler);
+    this._tippyInstance?.hide();
+    this.touching = false;
+    this.isActive = false;
+  }
+
+  @action
+  onTouchEnd(event) {
+    if (this.touching) {
+      this.handleClick(event);
+    }
+
+    cancel(this.longPressHandler);
+    this._tippyInstance?.hide();
+    this.isActive = false;
+  }
+
+  @action
+  setupTooltip(element) {
+    this._tippyInstance = setupPopover(element, {
+      trigger: "mouseenter",
+      interactive: false,
+      allowHTML: true,
+      offset: [0, 10],
+    });
   }
 
   @action
@@ -53,6 +135,8 @@ export default class ChatMessageReaction extends Component {
       this.args.reaction.emoji,
       this.args.reaction.reacted ? "remove" : "add"
     );
+
+    this._tippyInstance?.clearDelayTimeouts();
   }
 
   get popoverContent() {
@@ -97,7 +181,7 @@ export default class ChatMessageReaction extends Component {
     if (unnamedUserCount > 0) {
       return I18n.t("chat.reactions.you_multiple_users_and_more", {
         emoji: this.args.reaction.emoji,
-        commaSeparatedUsernames: this._joinUsernames(usernames),
+        commaSeparatedUsernames: this.#joinUsernames(usernames),
         count: unnamedUserCount,
       });
     }
@@ -105,7 +189,7 @@ export default class ChatMessageReaction extends Component {
     return I18n.t("chat.reactions.you_and_multiple_users", {
       emoji: this.args.reaction.emoji,
       username: usernames.pop(),
-      commaSeparatedUsernames: this._joinUsernames(usernames),
+      commaSeparatedUsernames: this.#joinUsernames(usernames),
     });
   }
 
@@ -134,7 +218,7 @@ export default class ChatMessageReaction extends Component {
     if (unnamedUserCount > 0) {
       return I18n.t("chat.reactions.multiple_users_and_more", {
         emoji: this.args.reaction.emoji,
-        commaSeparatedUsernames: this._joinUsernames(usernames),
+        commaSeparatedUsernames: this.#joinUsernames(usernames),
         count: unnamedUserCount,
       });
     }
@@ -142,11 +226,11 @@ export default class ChatMessageReaction extends Component {
     return I18n.t("chat.reactions.multiple_users", {
       emoji: this.args.reaction.emoji,
       username: usernames.pop(),
-      commaSeparatedUsernames: this._joinUsernames(usernames),
+      commaSeparatedUsernames: this.#joinUsernames(usernames),
     });
   }
 
-  _joinUsernames(usernames) {
+  #joinUsernames(usernames) {
     return usernames.join(I18n.t("word_connector.comma"));
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -1,7 +1,12 @@
-<LinkTo
-  @route="chat.channel.thread"
-  @models={{@message.thread.routeModels}}
-  class="chat-message-thread-indicator"
+<div
+  class={{concat-class
+    "chat-message-thread-indicator"
+    (if this.isActive "-active")
+  }}
+  {{did-insert this.setup}}
+  {{will-destroy this.teardown}}
+  role="button"
+  title={{i18n "chat.threads.open"}}
 >
   {{#unless this.chatStateManager.isDrawerActive}}
     <div class="chat-message-thread-indicator__last-reply-avatar">
@@ -49,4 +54,4 @@
   <div class="chat-message-thread-indicator__participants">
     <Chat::Thread::Participants @thread={{@message.thread}} />
   </div>
-</LinkTo>
+</div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -33,14 +33,14 @@
           {{@message.thread.preview.lastReplyUser.username}}
         </span>
       </div>
-      <span><span class="chat-message-thread-indicator__last-reply-label">{{i18n
-            "chat.thread.last_reply"
-          }}</span>{{format-date
+      <span class="chat-message-thread-indicator__last-reply-container">
+        {{format-date
           @message.thread.preview.lastReplyCreatedAt
           leaveAgo="true"
-        }}</span>
-
-      |
+          prefix=(i18n "chat.thread.last_reply")
+        }}
+      </span>
+      <span class="separator">|</span>
       <span class="chat-message-thread-indicator__replies-count">
         {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
       </span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.js
@@ -1,10 +1,89 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { escapeExpression } from "discourse/lib/utilities";
+import { action } from "@ember/object";
+import { bind } from "discourse-common/utils/decorators";
+import { tracked } from "@glimmer/tracking";
 
 export default class ChatMessageThreadIndicator extends Component {
-  @service site;
+  @service capabilities;
+  @service chat;
   @service chatStateManager;
+  @service router;
+  @service site;
+
+  @tracked isActive = false;
+
+  @action
+  setup(element) {
+    this.element = element;
+
+    if (this.capabilities.touch) {
+      this.element.addEventListener("touchstart", this.onTouchStart, {
+        passive: true,
+      });
+      this.element.addEventListener("touchmove", this.cancelTouch, {
+        passive: true,
+      });
+      this.element.addEventListener("touchend", this.onTouchEnd);
+      this.element.addEventListener("touchCancel", this.cancelTouch);
+    }
+
+    this.element.addEventListener("click", this.openThread, {
+      passive: true,
+    });
+  }
+
+  @action
+  teardown() {
+    if (this.capabilities.touch) {
+      this.element.removeEventListener("touchstart", this.onTouchStart, {
+        passive: true,
+      });
+      this.element.removeEventListener("touchmove", this.cancelTouch, {
+        passive: true,
+      });
+      this.element.removeEventListener("touchend", this.onTouchEnd);
+      this.element.removeEventListener("touchCancel", this.cancelTouch);
+    }
+
+    this.element.removeEventListener("click", this.openThread, {
+      passive: true,
+    });
+  }
+
+  @bind
+  onTouchStart(event) {
+    this.isActive = true;
+    event.stopPropagation();
+
+    this.touching = true;
+  }
+
+  @bind
+  onTouchEnd() {
+    this.isActive = false;
+
+    if (this.touching) {
+      this.openThread();
+    }
+  }
+
+  @bind
+  cancelTouch() {
+    this.isActive = false;
+    this.touching = false;
+  }
+
+  @bind
+  openThread() {
+    this.chat.activeMessage = null;
+
+    this.router.transitionTo(
+      "chat.channel.thread",
+      ...this.args.message.thread.routeModels
+    );
+  }
 
   get threadTitle() {
     return escapeExpression(this.args.message.threadTitle);

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -13,24 +13,21 @@
       (if @message.highlighted "-highlighted")
       (if (eq @message.user.id this.currentUser.id) "is-by-current-user")
       (if @message.staged "-staged" "-persisted")
-      (if
-        (or (eq @message.id this.chat.activeMessage.model.id) this.isActive)
-        "-active"
-      )
+      (if this.isActive "-active")
       (if @message.bookmark "-bookmarked")
       (if @message.deletedAt "-deleted")
       (if @message.selected "-selected")
       (if @message.error "-errored")
-      (if (and @message.inReplyTo (not this.hideReplyToInfo)) "has-reply")
       (if this.showThreadIndicator "has-thread-indicator")
       (if this.hideUserInfo "-user-info-hidden")
+      (if this.hasReply "has-reply")
     }}
     data-id={{@message.id}}
     data-thread-id={{@message.thread.id}}
-    {{did-insert this.setup}}
-    {{did-update this.decorateCookedMessage @message.id}}
-    {{did-update this.decorateCookedMessage @message.version}}
-    {{will-destroy this.teardownChatMessage}}
+    {{did-insert this.didInsertMessage}}
+    {{did-update this.didUpdateMessageId @message.id}}
+    {{did-update this.didUpdateMessageVersion @message.version}}
+    {{will-destroy this.willDestroyMessage}}
     {{on "mouseenter" this.onMouseEnter passive=true}}
     {{on "mouseleave" this.onMouseLeave passive=true}}
     {{on "mousemove" this.onMouseMove passive=true}}
@@ -73,12 +70,7 @@
           />
         </div>
       {{else}}
-        <div
-          class="chat-message"
-          {{did-insert this.refreshStatusOnMentions}}
-          {{did-update this.refreshStatusOnMentions @message.version}}
-          {{did-update this.initMentionedUsers @message.version}}
-        >
+        <div class="chat-message">
           {{#unless this.hideReplyToInfo}}
             <ChatMessageInReplyToIndicator @message={{@message}} />
           {{/unless}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -7,10 +7,30 @@
   {{/if}}
 
   <div
-    {{will-destroy this.teardownChatMessage}}
+    class={{concat-class
+      "chat-message-container"
+      (if this.pane.selectingMessages "-selectable")
+      (if @message.highlighted "-highlighted")
+      (if (eq @message.user.id this.currentUser.id) "is-by-current-user")
+      (if @message.staged "-staged" "-persisted")
+      (if
+        (or (eq @message.id this.chat.activeMessage.model.id) this.isActive)
+        "-active"
+      )
+      (if @message.bookmark "-bookmarked")
+      (if @message.deletedAt "-deleted")
+      (if @message.selected "-selected")
+      (if @message.error "-errored")
+      (if (and @message.inReplyTo (not this.hideReplyToInfo)) "has-reply")
+      (if this.showThreadIndicator "has-thread-indicator")
+      (if this.hideUserInfo "-user-info-hidden")
+    }}
+    data-id={{@message.id}}
+    data-thread-id={{@message.thread.id}}
     {{did-insert this.decorateCookedMessage}}
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
+    {{will-destroy this.teardownChatMessage}}
     {{on "mouseenter" this.onMouseEnter passive=true}}
     {{on "mouseleave" this.onMouseLeave passive=true}}
     {{on "mousemove" this.onMouseMove passive=true}}
@@ -19,18 +39,6 @@
       this.handleLongPressEnd
       this.onLongPressCancel
     }}
-    class={{concat-class
-      "chat-message-container"
-      (if this.pane.selectingMessages "selecting-messages")
-      (if @message.highlighted "highlighted")
-      (if (eq @message.user.id this.currentUser.id) "is-by-current-user")
-      (if @message.staged "is-staged" "is-persisted")
-      (if @message.deletedAt "is-deleted")
-      (if (eq @message.id this.chat.activeMessage.model.id) "is-active")
-    }}
-    data-id={{@message.id}}
-    data-thread-id={{@message.thread.id}}
-    data-selected={{@message.selected}}
     {{chat/track-message
       (hash
         didEnterViewport=(fn @messageDidEnterViewport @message)
@@ -66,18 +74,10 @@
         </div>
       {{else}}
         <div
+          class="chat-message"
           {{did-insert this.refreshStatusOnMentions}}
           {{did-update this.refreshStatusOnMentions @message.version}}
           {{did-update this.initMentionedUsers @message.version}}
-          class={{concat-class
-            "chat-message"
-            (if @message.deletedAt "deleted")
-            (if (and @message.inReplyTo (not this.hideReplyToInfo)) "is-reply")
-            (if this.showThreadIndicator "is-threaded")
-            (if this.hideUserInfo "user-info-hidden")
-            (if @message.error "errored")
-            (if @message.bookmark "chat-message-bookmarked")
-          }}
         >
           {{#unless this.hideReplyToInfo}}
             <ChatMessageInReplyToIndicator @message={{@message}} />
@@ -195,9 +195,9 @@
                   {{/if}}
 
                   {{#if this.mentionWarning.groups_with_too_many_members}}
-                    <p
-                      class="warning-item"
-                    >{{this.groupsWithTooManyMembers}}</p>
+                    <p class="warning-item">
+                      {{this.groupsWithTooManyMembers}}
+                    </p>
                   {{/if}}
                 {{/if}}
               </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -27,7 +27,7 @@
     }}
     data-id={{@message.id}}
     data-thread-id={{@message.thread.id}}
-    {{did-insert this.decorateCookedMessage}}
+    {{did-insert this.setup}}
     {{did-update this.decorateCookedMessage @message.id}}
     {{did-update this.decorateCookedMessage @message.version}}
     {{will-destroy this.teardownChatMessage}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -13,7 +13,7 @@
       (if @message.highlighted "-highlighted")
       (if (eq @message.user.id this.currentUser.id) "is-by-current-user")
       (if @message.staged "-staged" "-persisted")
-      (if this.isActive "-active")
+      (if this.hasActiveState "-active")
       (if @message.bookmark "-bookmarked")
       (if @message.deletedAt "-deleted")
       (if @message.selected "-selected")

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -12,6 +12,7 @@ import ChatMessageInteractor from "discourse/plugins/chat/discourse/lib/chat-mes
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
 import { updateUserStatusOnMention } from "discourse/lib/update-user-status-on-mention";
+import { tracked } from "@glimmer/tracking";
 
 let _chatMessageDecorators = [];
 
@@ -40,6 +41,8 @@ export default class ChatMessage extends Component {
   @service chatThreadPane;
   @service chatChannelsManager;
   @service router;
+
+  @tracked isActive = false;
 
   @optionalService adminTools;
 
@@ -260,11 +263,13 @@ export default class ChatMessage extends Component {
   @action
   handleLongPressStart(element) {
     element.classList.add("is-long-pressed");
+    this.isActive = true;
   }
 
   @action
   onLongPressCancel(element) {
     element.classList.remove("is-long-pressed");
+    this.isActive = false;
 
     // this a tricky bit of code which is needed to prevent the long press
     // from triggering a click on the message actions panel when releasing finger press
@@ -281,6 +286,7 @@ export default class ChatMessage extends Component {
   @action
   handleLongPressEnd(element) {
     element.classList.remove("is-long-pressed");
+    this.isActive = false;
 
     if (isZoomed()) {
       // if zoomed don't handle long press

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -244,6 +244,7 @@ export default class ChatMessage extends Component {
     }
 
     this.chat.activeMessage = null;
+    this.isActive = false;
   }
 
   @bind

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -254,6 +254,10 @@ export default class ChatMessage extends Component {
       return;
     }
 
+    if (!this.args.message.expanded) {
+      return;
+    }
+
     this.chat.activeMessage = {
       model: this.args.message,
       context: this.args.context,

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -126,7 +126,7 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  teardownChatMessage() {
+  willDestroyMesage() {
     cancel(this._invitationSentTimer);
     cancel(this._disableMessageActionsHandler);
     this.#teardownMentionedUsers();
@@ -149,9 +149,22 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  setup(element) {
+  didInsertMessage(element) {
     this.messageContainer = element;
     this.decorateCookedMessage();
+    this.refreshStatusOnMentions();
+  }
+
+  @action
+  didUpdateMessageId() {
+    this.decorateCookedMessage();
+  }
+
+  @action
+  didUpdateMessageVersion() {
+    this.decorateCookedMessage();
+    this.refreshStatusOnMentions();
+    this.initMentionedUsers();
   }
 
   @action
@@ -190,7 +203,7 @@ export default class ChatMessage extends Component {
       return;
     }
 
-    if (this.chat.activeMessage?.model?.id === this.args.message.id) {
+    if (this.isActive) {
       return;
     }
 
@@ -207,7 +220,7 @@ export default class ChatMessage extends Component {
       return;
     }
 
-    if (this.chat.activeMessage?.model?.id === this.args.message.id) {
+    if (this.isActive) {
       return;
     }
 
@@ -253,6 +266,8 @@ export default class ChatMessage extends Component {
       model: this.args.message,
       context: this.args.context,
     };
+
+    this.isActive = true;
   }
 
   @action
@@ -290,6 +305,10 @@ export default class ChatMessage extends Component {
     document.querySelector(".chat-composer__input")?.blur();
 
     this._setActiveMessage();
+  }
+
+  get hasReply() {
+    return this.args.inReplyTo && !this.hideReplyToInfo;
   }
 
   get hideUserInfo() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -203,7 +203,7 @@ export default class ChatMessage extends Component {
       return;
     }
 
-    if (this.isActive) {
+    if (this.chat.activeMessage?.model?.id === this.args.message.id) {
       return;
     }
 
@@ -220,7 +220,7 @@ export default class ChatMessage extends Component {
       return;
     }
 
-    if (this.isActive) {
+    if (this.chat.activeMessage?.model?.id === this.args.message.id) {
       return;
     }
 
@@ -244,7 +244,6 @@ export default class ChatMessage extends Component {
     }
 
     this.chat.activeMessage = null;
-    this.isActive = false;
   }
 
   @bind
@@ -267,12 +266,14 @@ export default class ChatMessage extends Component {
       model: this.args.message,
       context: this.args.context,
     };
-
-    this.isActive = true;
   }
 
   @action
   handleLongPressStart() {
+    if (!this.args.message.expanded) {
+      return;
+    }
+
     this.isActive = true;
   }
 
@@ -306,6 +307,13 @@ export default class ChatMessage extends Component {
     document.querySelector(".chat-composer__input")?.blur();
 
     this._setActiveMessage();
+  }
+
+  get hasActiveState() {
+    return (
+      this.isActive ||
+      this.chat.activeMessage?.model?.id === this.args.message.id
+    );
   }
 
   get hasReply() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -126,7 +126,7 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  willDestroyMesage() {
+  willDestroyMessage() {
     cancel(this._invitationSentTimer);
     cancel(this._disableMessageActionsHandler);
     this.#teardownMentionedUsers();

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -135,10 +135,6 @@ export default class ChatMessage extends Component {
   @action
   refreshStatusOnMentions() {
     schedule("afterRender", () => {
-      if (!this.messageContainer) {
-        return;
-      }
-
       this.args.message.mentionedUsers.forEach((user) => {
         const href = `/u/${user.username.toLowerCase()}`;
         const mentions = this.messageContainer.querySelectorAll(
@@ -153,12 +149,14 @@ export default class ChatMessage extends Component {
   }
 
   @action
+  setup(element) {
+    this.messageContainer = element;
+    this.decorateCookedMessage();
+  }
+
+  @action
   decorateCookedMessage() {
     schedule("afterRender", () => {
-      if (!this.messageContainer) {
-        return;
-      }
-
       _chatMessageDecorators.forEach((decorator) => {
         decorator.call(this, this.messageContainer, this.args.message.channel);
       });
@@ -175,13 +173,6 @@ export default class ChatMessage extends Component {
       user.trackStatus();
       user.on("status-changed", this, "refreshStatusOnMentions");
     });
-  }
-
-  get messageContainer() {
-    const id = this.args.message?.id;
-    if (id) {
-      return document.querySelector(`.chat-message-container[data-id='${id}']`);
-    }
   }
 
   get show() {
@@ -265,14 +256,12 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  handleLongPressStart(element) {
-    element.classList.add("is-long-pressed");
+  handleLongPressStart() {
     this.isActive = true;
   }
 
   @action
-  onLongPressCancel(element) {
-    element.classList.remove("is-long-pressed");
+  onLongPressCancel() {
     this.isActive = false;
 
     // this a tricky bit of code which is needed to prevent the long press
@@ -288,8 +277,7 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  handleLongPressEnd(element) {
-    element.classList.remove("is-long-pressed");
+  handleLongPressEnd() {
     this.isActive = false;
 
     if (isZoomed()) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -327,31 +327,22 @@ export default class ChatThreadPanel extends Component {
   // we now use this hack to disable it
   @bind
   forceRendering(callback) {
-    schedule("afterRender", () => {
-      if (this._selfDeleted) {
-        return;
-      }
+    if (this.capabilities.isIOS) {
+      this.scrollable.style.overflow = "hidden";
+    }
 
-      if (!this.scrollable) {
-        return;
-      }
+    callback?.();
 
-      if (this.capabilities.isIOS) {
-        this.scrollable.style.overflow = "hidden";
-      }
-
-      callback?.();
-
-      if (this.capabilities.isIOS) {
-        discourseLater(() => {
-          if (!this.scrollable) {
+    if (this.capabilities.isIOS) {
+      next(() => {
+        schedule("afterRender", () => {
+          if (this._selfDeleted || !this.scrollable) {
             return;
           }
-
           this.scrollable.style.overflow = "auto";
-        }, 50);
-      }
-    });
+        });
+      });
+    }
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -36,7 +36,7 @@ export default class ChatMessage {
   @tracked reviewableId;
   @tracked user;
   @tracked inReplyTo;
-  @tracked expanded;
+  @tracked expanded = true;
   @tracked bookmark;
   @tracked userFlagStatus;
   @tracked hidden;
@@ -70,6 +70,7 @@ export default class ChatMessage {
     this.chatWebhookEvent = args.chatWebhookEvent || args.chat_webhook_event;
     this.createdAt = args.createdAt || args.created_at;
     this.deletedAt = args.deletedAt || args.deleted_at;
+    this.expanded = this.deletedAt ? false : args.expanded || true;
     this.excerpt = args.excerpt;
     this.reviewableId = args.reviewableId || args.reviewable_id;
     this.userFlagStatus = args.userFlagStatus || args.user_flag_status;

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -70,7 +70,8 @@ export default class ChatMessage {
     this.chatWebhookEvent = args.chatWebhookEvent || args.chat_webhook_event;
     this.createdAt = args.createdAt || args.created_at;
     this.deletedAt = args.deletedAt || args.deleted_at;
-    this.expanded = this.deletedAt ? false : args.expanded || true;
+    this.expanded =
+      this.hidden || this.deletedAt ? false : args.expanded || true;
     this.excerpt = args.excerpt;
     this.reviewableId = args.reviewableId || args.reviewable_id;
     this.userFlagStatus = args.userFlagStatus || args.user_flag_status;

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -29,7 +29,6 @@ export default class ChatMessage {
   @tracked draft;
   @tracked channelId;
   @tracked createdAt;
-  @tracked deletedAt;
   @tracked uploads;
   @tracked excerpt;
   @tracked reactions;
@@ -54,6 +53,7 @@ export default class ChatMessage {
   @tracked manager;
   @tracked threadTitle;
 
+  @tracked _deletedAt;
   @tracked _cooked;
 
   constructor(channel, args = {}) {
@@ -69,9 +69,9 @@ export default class ChatMessage {
     this.hidden = args.hidden || false;
     this.chatWebhookEvent = args.chatWebhookEvent || args.chat_webhook_event;
     this.createdAt = args.createdAt || args.created_at;
-    this.deletedAt = args.deletedAt || args.deleted_at;
+    this._deletedAt = args.deletedAt || args.deleted_at;
     this.expanded =
-      this.hidden || this.deletedAt ? false : args.expanded || true;
+      this.hidden || this._deletedAt ? false : args.expanded || true;
     this.excerpt = args.excerpt;
     this.reviewableId = args.reviewableId || args.reviewable_id;
     this.userFlagStatus = args.userFlagStatus || args.user_flag_status;
@@ -130,6 +130,16 @@ export default class ChatMessage {
 
   get editable() {
     return !this.staged && !this.error;
+  }
+
+  get deletedAt() {
+    return this._deletedAt;
+  }
+
+  set deletedAt(value) {
+    this._deletedAt = value;
+    this.incrementVersion();
+    return this._deletedAt;
   }
 
   get cooked() {

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -32,18 +32,7 @@ export default class ChatOnLongPress extends Modifier {
     this.onLongPressEnd = onLongPressEnd || (() => {});
     this.onLongPressCancel = onLongPressCancel || (() => {});
 
-    if (this.capabilities.touch) {
-      this.element.addEventListener("touchstart", this.onTouchStart, {
-        passive: true,
-      });
-      this.element.addEventListener("touchmove", this.cancelTouch, {
-        passive: true,
-      });
-      this.element.addEventListener("touchend", this.onTouchEnd);
-      this.element.addEventListener("touchCancel", this.cancelTouch);
-    }
-
-    this.element.addEventListener("click", this.handleClick, {
+    this.element.addEventListener("touchstart", this.handleTouchStart, {
       passive: true,
     });
   }
@@ -52,11 +41,13 @@ export default class ChatOnLongPress extends Modifier {
   onCancel() {
     cancel(this.timeout);
 
-    this.element.removeEventListener("touchmove", this.onCancel, {
-      passive: true,
-    });
-    this.element.removeEventListener("touchend", this.onCancel);
-    this.element.removeEventListener("touchcancel", this.onCancel);
+    if (this.capabilities.touch) {
+      this.element.removeEventListener("touchmove", this.onCancel, {
+        passive: true,
+      });
+      this.element.removeEventListener("touchend", this.onCancel);
+      this.element.removeEventListener("touchcancel", this.onCancel);
+    }
 
     this.onLongPressCancel(this.element);
   }

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/on-long-press.js
@@ -7,7 +7,6 @@ import discourseLater from "discourse-common/lib/later";
 
 function cancelEvent(event) {
   event.stopPropagation();
-  event.preventDefault();
 }
 
 export default class ChatOnLongPress extends Modifier {
@@ -33,7 +32,18 @@ export default class ChatOnLongPress extends Modifier {
     this.onLongPressEnd = onLongPressEnd || (() => {});
     this.onLongPressCancel = onLongPressCancel || (() => {});
 
-    element.addEventListener("touchstart", this.handleTouchStart, {
+    if (this.capabilities.touch) {
+      this.element.addEventListener("touchstart", this.onTouchStart, {
+        passive: true,
+      });
+      this.element.addEventListener("touchmove", this.cancelTouch, {
+        passive: true,
+      });
+      this.element.addEventListener("touchend", this.onTouchEnd);
+      this.element.addEventListener("touchCancel", this.cancelTouch);
+    }
+
+    this.element.addEventListener("click", this.handleClick, {
       passive: true,
     });
   }

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -137,7 +137,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   .chat-message-container {
     display: grid;
 
-    &.selecting-messages {
+    &.-selectable {
       grid-template-columns: 1.5em 1fr;
     }
 
@@ -191,7 +191,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   display: flex;
   align-items: center;
 
-  .chat-message:not(.is-reply) & {
+  .chat-message-container:not(.has-reply) & {
     width: var(--message-left-width);
     flex-shrink: 0;
   }

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -47,20 +47,34 @@
 
   &__last-reply-metadata {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     gap: 0.25rem;
     color: var(--primary-medium);
-    font-size: var(--font-down-1);
+
+    .separator {
+      font-size: var(--font-down-1);
+    }
   }
 
-  &__last-reply-label {
-    margin-right: 0.25rem;
+  &__last-reply-container {
+    display: inline-flex;
+    align-items: flex-end;
+    font-size: var(--font-down-1);
+    min-width: 0;
+
+    .relative-date {
+      @include ellipsis;
+    }
+  }
+
+  &__last-reply-user {
+    font-weight: bold;
+    color: var(--secondary-low);
   }
 
   &__last-reply-username {
     font-weight: bold;
     color: var(--secondary-low);
-    font-size: var(--font-up-1);
   }
 
   &__last-reply-excerpt {
@@ -81,6 +95,8 @@
   }
 
   &__replies-count {
+    @include ellipsis;
     color: var(--tertiary);
+    font-size: var(--font-down-1);
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -21,9 +21,16 @@
     color: var(--primary);
   }
 
-  &:hover,
-  &.-active {
-    box-shadow: var(--shadow-dropdown);
+  .touch & {
+    &.-active {
+      box-shadow: var(--shadow-dropdown);
+    }
+  }
+
+  .no-touch & {
+    &:hover {
+      box-shadow: var(--shadow-dropdown);
+    }
   }
 
   &__participants {

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -21,8 +21,9 @@
     color: var(--primary);
   }
 
-  &:hover {
-    box-shadow: var(--shadow-dropdown-lite);
+  &:hover,
+  &.-active {
+    box-shadow: var(--shadow-header);
   }
 
   &__participants {
@@ -64,6 +65,12 @@
     overflow: hidden;
     white-space: nowrap;
     flex-shrink: 1;
+  }
+
+  &:hover {
+    .chat-message-thread-indicator__replies-count {
+      text-decoration: underline;
+    }
   }
 
   &__replies-count {

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -12,6 +12,10 @@
   border-radius: 8px;
   color: var(--primary);
 
+  > * {
+    pointer-events: none;
+  }
+
   &:visited,
   &:hover {
     color: var(--primary);

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -23,7 +23,7 @@
 
   &:hover,
   &.-active {
-    box-shadow: var(--shadow-header);
+    box-shadow: var(--shadow-dropdown);
   }
 
   &__participants {

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -28,54 +28,8 @@
     @include chat-reaction;
   }
 
-  &.chat-action {
-    background-color: var(--highlight-bg);
-  }
-
-  &.errored {
-    color: var(--primary-medium);
-  }
-
-  &.deleted {
-    background-color: var(--danger-low);
-  }
-
   .not-mobile-device &.deleted:hover {
     background-color: var(--danger-hover);
-  }
-
-  &.is-reply {
-    display: grid;
-    grid-template-columns: var(--message-left-width) 1fr;
-    grid-template-rows: 30px auto;
-    grid-template-areas:
-      "replyto replyto"
-      "avatar message";
-
-    .chat-user-avatar {
-      grid-area: avatar;
-    }
-
-    .chat-message-content {
-      grid-area: message;
-    }
-  }
-
-  &.is-threaded {
-    display: grid;
-    grid-template-columns: var(--message-left-width) 1fr;
-    grid-template-rows: auto;
-    grid-template-areas:
-      "avatar message"
-      "threadindicator threadindicator";
-    padding: 0.65rem 1rem !important;
-    .chat-user-avatar {
-      grid-area: avatar;
-    }
-
-    .chat-message-content {
-      grid-area: message;
-    }
   }
 
   .chat-message-content {
@@ -200,77 +154,101 @@
   }
 }
 
-.chat-message-container.highlighted .chat-message {
-  background-color: var(--tertiary-low) !important;
+.touch .chat-message-container {
+  &.-active {
+    background: var(--d-hover);
+    border-radius: 5px;
+
+    &.-bookmarked {
+      background: var(--highlight-low);
+    }
+  }
 }
 
-.chat-messages-container {
-  .chat-message {
-    &.chat-message-bookmarked {
-      background: var(--highlight-bg);
-    }
+.no-touch .chat-message-container {
+  &:hover,
+  &-active {
+    background: var(--d-hover);
+  }
 
+  &:hover {
     .chat-message-reaction-list .chat-message-react-btn {
-      display: none;
+      display: inline-block;
     }
   }
 
-  .chat-message-container {
-    background-color: var(--secondary);
-
-    .touch & {
-      &:active,
-      &.is-active {
-        background: var(--d-hover);
-        border-radius: 5px;
-      }
-
-      &.chat-message-bookmarked {
-        &:active,
-        &.is-active {
-          background: var(--highlight-low);
-        }
-      }
+  &.-active,
+  &:hover {
+    &.-bookmarked {
+      background: var(--highlight-medium);
     }
 
-    .no-touch & {
-      &.is-active,
-      &:hover,
-      &:active {
-        background: var(--d-hover);
-      }
-
-      &:hover {
-        .chat-message-react-btn {
-          display: inline-block;
-        }
-      }
-
-      &.chat-message-bookmarked {
-        &.is-active,
-        &:hover {
-          background: var(--highlight-medium);
-        }
-      }
+    &.-deleted {
+      background-color: var(--danger-medium);
     }
   }
 }
 
-.chat-message-flagged {
-  display: inline-block;
-  color: var(--danger);
-  height: 100%;
-  padding: 0 0.3em;
-  cursor: pointer;
+.chat-message-container {
+  background-color: var(--secondary);
 
-  .flag-count,
-  .d-icon {
-    color: var(--danger);
+  &.-errored {
+    color: var(--primary-medium);
   }
-}
 
-.chat-action-text {
-  font-style: italic;
+  &.-deleted {
+    background-color: var(--danger-low);
+    padding: 0.5rem 0.65rem !important;
+  }
+
+  &.-bookmarked {
+    background: var(--highlight-bg);
+  }
+
+  &-.highlighted {
+    background-color: var(--tertiary-low);
+  }
+
+  &.has-reply {
+    display: grid;
+    grid-template-columns: var(--message-left-width) 1fr;
+    grid-template-rows: 30px auto;
+    grid-template-areas:
+      "replyto replyto"
+      "avatar message";
+
+    .chat-user-avatar {
+      grid-area: avatar;
+    }
+
+    .chat-message-content {
+      grid-area: message;
+    }
+  }
+
+  &.has-thread-indicator {
+    .chat-message {
+      display: grid;
+      grid-template-columns: var(--message-left-width) 1fr;
+      grid-template-rows: auto;
+      grid-template-areas:
+        "avatar message"
+        "threadindicator threadindicator";
+      padding: 0.65rem 1rem !important;
+
+      .chat-user-avatar {
+        grid-area: avatar;
+      }
+
+      .chat-message-content {
+        grid-area: message;
+      }
+    }
+  }
+
+  .chat-message-reaction-list .chat-message-react-btn {
+    display: none;
+  }
 }
 
 .has-full-page-chat .chat-message .onebox:not(img),
@@ -333,7 +311,7 @@
 
   &:hover,
   &:focus,
-  &:active {
+  .-active & {
     background: none !important;
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -234,7 +234,7 @@
       grid-template-areas:
         "avatar message"
         "threadindicator threadindicator";
-      padding: 0.65rem 1rem !important;
+      padding-bottom: 0.65rem !important;
 
       .chat-user-avatar {
         grid-area: avatar;

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -202,7 +202,7 @@
 
   &.-deleted {
     background-color: var(--danger-low);
-    padding: 0.5rem 0.65rem !important;
+    padding-block: 0.25rem;
   }
 
   &.-bookmarked {

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -186,6 +186,10 @@
     &.-deleted {
       background-color: var(--danger-medium);
     }
+
+    &.-highlighted {
+      background-color: var(--tertiary-medium);
+    }
   }
 }
 
@@ -205,7 +209,7 @@
     background: var(--highlight-bg);
   }
 
-  &-.highlighted {
+  &.-highlighted {
     background-color: var(--tertiary-low);
   }
 

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -21,20 +21,18 @@
 
   .chat-channel {
     .chat-messages-container {
-      .chat-message {
-        &.is-reply {
-          grid-template-columns: var(--message-left-width) 1fr;
-        }
+      &.has-reply {
+        grid-template-columns: var(--message-left-width) 1fr;
+      }
 
-        .chat-user {
-          width: var(--message-left-width);
-        }
+      .chat-user {
+        width: var(--message-left-width);
       }
     }
   }
 }
 
-.chat-message:not(.user-info-hidden) {
+.chat-message-container:not(.-user-info-hidden) {
   padding: 0.65rem 1rem 0.15rem;
 }
 
@@ -51,7 +49,7 @@
   }
 }
 
-.chat-message.user-info-hidden {
+.chat-message-container.-user-info-hidden {
   padding: 0.15rem 1rem;
 
   .chat-time {

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -32,10 +32,6 @@
   }
 }
 
-.chat-message-container:not(.-user-info-hidden) {
-  padding: 0.65rem 1rem 0.15rem;
-}
-
 .chat-message-text {
   img:not(.emoji):not(.avatar, .onebox-avatar-inline) {
     transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
@@ -49,8 +45,16 @@
   }
 }
 
+.chat-message-container:not(.-user-info-hidden) {
+  .chat-message {
+    padding: 0.65rem 1rem 0.15rem;
+  }
+}
+
 .chat-message-container.-user-info-hidden {
-  padding: 0.15rem 1rem;
+  .chat-message {
+    padding: 0.15rem 1rem;
+  }
 
   .chat-time {
     color: var(--secondary-medium);

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -1,6 +1,4 @@
 .chat-message-thread-indicator {
-  width: min-content;
-  min-width: 400px;
   max-width: 600px;
 
   .chat-drawer & {

--- a/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
+++ b/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
@@ -2,7 +2,7 @@
   --channel-list-avatar-size: 38px;
 }
 
-.chat-message:not(.user-info-hidden) {
+.chat-message-container:not(.-user-info-hidden) {
   padding-top: 0.75em;
 }
 

--- a/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
+++ b/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
@@ -3,7 +3,9 @@
 }
 
 .chat-message-container:not(.-user-info-hidden) {
-  padding-top: 0.75em;
+  .chat-message {
+    padding-top: 0.75em;
+  }
 }
 
 html.has-full-page-chat {

--- a/plugins/chat/assets/stylesheets/mobile/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message.scss
@@ -25,7 +25,7 @@
     transition: transform 400ms;
     transform: scale(1);
 
-    &.is-long-pressed {
+    &.-active {
       animation: scale-animation 400ms;
     }
   }

--- a/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
@@ -1,6 +1,9 @@
 .chat-thread {
   &__body {
     margin: 0 1px 0 0;
-    padding: 0 10px;
+  }
+
+  .chat-messages-scroll {
+    padding: 10px 10px 0 10px;
   }
 }

--- a/plugins/chat/spec/system/chat_message/channel_spec.rb
+++ b/plugins/chat/spec/system/chat_message/channel_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Chat message - channel", type: :system do
       channel.hover_message(message_1)
 
       expect(page).to have_css(
-        ".chat-channel[data-id='#{channel_1.id}'] .chat-message-container[data-id='#{message_1.id}'].is-active",
+        ".chat-channel[data-id='#{channel_1.id}'] .chat-message-container[data-id='#{message_1.id}'].-active",
       )
     end
   end

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Chat message - thread", type: :system do
       thread_page.hover_message(first_message)
 
       expect(page).to have_css(
-        ".chat-thread[data-id='#{thread_1.id}'] [data-id='#{first_message.id}'].chat-message-container.is-active",
+        ".chat-thread[data-id='#{thread_1.id}'] [data-id='#{first_message.id}'].chat-message-container.-active",
       )
     end
   end

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Deleted message", type: :system do
       chat_page.visit_channel(channel_1)
       channel_page.send_message("aaaaaaaaaaaaaaaaaaaa")
 
-      expect(page).to have_css(".is-persisted")
+      expect(page).to have_css(".-persisted")
 
       last_message = find(".chat-message-container:last-child")
       channel_page.delete_message(OpenStruct.new(id: last_message["data-id"]))

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -68,7 +68,7 @@ module PageObjects
       end
 
       def click_message_action_mobile(message, message_action)
-        expand_message_actions_mobile(message, delay: 0.6)
+        expand_message_actions_mobile(message, delay: 0.4)
         find(".chat-message-actions [data-id=\"#{message_action}\"]").click
       end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -143,7 +143,7 @@ module PageObjects
       end
 
       def has_bookmarked_message?(message)
-        within(message_by_id(message.id)) { find(".chat-message-bookmarked") }
+        find(message_by_id_selector(message.id) + ".-bookmarked")
       end
 
       def find_reaction(message, emoji)

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -22,7 +22,7 @@ module PageObjects
         end
 
         def select(shift: false)
-          if component[:class].include?("selecting-message")
+          if component[:class].include?("-selectable")
             message_selector = component.find(".chat-message-selector")
             if shift
               message_selector.click(:shift)

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -85,10 +85,10 @@ module PageObjects
         def build_selector(**args)
           selector = SELECTOR
           selector += "[data-id=\"#{args[:id]}\"]" if args[:id]
-          selector += "[data-selected]" if args[:selected]
-          selector += ".is-persisted" if args[:persisted]
-          selector += ".is-staged" if args[:staged]
-          selector += ".is-deleted" if args[:deleted]
+          selector += ".-selected" if args[:selected]
+          selector += ".-persisted" if args[:persisted]
+          selector += ".-staged" if args[:staged]
+          selector += ".-deleted" if args[:deleted]
           selector
         end
       end

--- a/plugins/chat/test/javascripts/components/chat-message-test.js
+++ b/plugins/chat/test/javascripts/components/chat-message-test.js
@@ -45,8 +45,6 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
         )
       ),
       channel,
-      afterExpand: () => {},
-      onHoverMessage: () => {},
       messageDidEnterViewport: () => {},
       messageDidLeaveViewport: () => {},
     };


### PR DESCRIPTION
- FIX: improves reactions and thread indicator touch event on mobile
These "buttons" are located inside a scroll list which makes them very specific. The general idea is to ensure these events are passive and are not bubbling to the parent.

- DEV: moves state on top level message node
- FIX: ensures popover arrow has the correct border
- FIX: makes a message expanded by default
- FIX applies the same ios scroll fix on thread and channel
- UI: better active/hover state for thread indicator
- UI: attempts to follow more closely our BEM naming scheme
- FIX: reduces bottom padding on message with thread indicator and user info hidden
- UI: add padding for first message in thread
- FIX: prevents actions backdrop to open thread
- UI: makes thread indicator resizable