### PR TITLE
FIX: direct message channels can be flagged

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -122,7 +122,6 @@ export default class ChatMessageInteractor {
   get canFlagMessage() {
     return (
       this.currentUser?.id !== this.message?.user?.id &&
-      !this.message.channel?.isDirectMessageChannel &&
       this.message?.userFlagStatus === undefined &&
       this.message.channel?.canFlag &&
       !this.message?.chatWebhookEvent &&

--- a/plugins/chat/spec/system/flag_message_spec.rb
+++ b/plugins/chat/spec/system/flag_message_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "Flag message", type: :system do
     fab!(:dm_channel_1) { Fabricate(:direct_message_channel, users: [current_user]) }
     fab!(:message_1) { Fabricate(:chat_message, chat_channel: dm_channel_1) }
 
-    it "doesn’t allow to flag a message" do
+    it "allows to flag a message" do
       chat.visit_channel(dm_channel_1)
       channel.expand_message_actions(message_1)
 
-      expect(page).to have_no_css("[data-value='flag']")
+      expect(page).to have_css("[data-value='flag']")
     end
   end
 end


### PR DESCRIPTION
The events leading to this mistake are unclear but we decided few months ago to make direct messages NOT flaggable and even wrote a spec for this, when we actually support flagging of direct messages.

This commit ensures it will show for direct messages channels and inverses the existing spec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
