### PR TITLE
DEV: Don't render header on invites page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/invites-show.js
+++ b/app/assets/javascripts/discourse/app/routes/invites-show.js
@@ -19,6 +19,22 @@ export default DiscourseRoute.extend(DisableSidebar, {
     }
   },
 
+  activate() {
+    this._super(...arguments);
+
+    this.controllerFor("application").setProperties({
+      showSiteHeader: false,
+    });
+  },
+
+  deactivate() {
+    this._super(...arguments);
+
+    this.controllerFor("application").setProperties({
+      showSiteHeader: true,
+    });
+  },
+
   setupController(controller, model) {
     this._super(...arguments);
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -103,6 +103,11 @@ acceptance("Invite accept", function (needs) {
       "does not display the sidebar on the invites page"
     );
 
+    assert.notOk(
+      exists(".d-header"),
+      "does not display the site header on the invites page"
+    );
+
     assert.ok(exists("#new-account-email"), "shows the email input");
     assert.ok(exists("#new-account-username"), "shows the username input");
     assert.strictEqual(

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -36,9 +36,6 @@ body.invite-page {
   background-color: var(--primary-50);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
-  .d-header {
-    display: none;
-  }
 }
 
 // Create Account + Login


### PR DESCRIPTION
What this change?

Previous solution relied on CSS to hide the header which is first
wasteful since we're still rendering the header and second makes it
untestable. If we don't want the header to show, we should avoid
rendering it in the first place.