### PR TITLE
 DEV: Remove old deprecation warnings where constants already removed

### DIFF
--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -10,8 +10,6 @@ class TopicLinkClick < ActiveRecord::Base
   validates_presence_of :topic_link_id
 
   ALLOWED_REDIRECT_HOSTNAMES = Set.new(%W[www.youtube.com youtu.be])
-  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
-  deprecate_constant "WHITELISTED_REDIRECT_HOSTNAMES", "TopicLinkClick::ALLOWED_REDIRECT_HOSTNAMES"
 
   # Create a click from a URL and post_id
   def self.create_from(args = {})

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -39,9 +39,6 @@ class TranslationOverride < ActiveRecord::Base
   }
 
   include HasSanitizableFields
-  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
-  deprecate_constant "CUSTOM_INTERPOLATION_KEYS_WHITELIST",
-                     "TranslationOverride::ALLOWED_CUSTOM_INTERPOLATION_KEYS"
 
   validates_uniqueness_of :translation_key, scope: :locale
   validates_presence_of :locale, :translation_key, :value

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -31,9 +31,6 @@ class UploadCreator
     use
   ].each(&:freeze)
 
-  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
-  deprecate_constant "WHITELISTED_SVG_ELEMENTS", "UploadCreator::ALLOWED_SVG_ELEMENTS"
-
   # Available options
   #  - type (string)
   #  - origin (string)


### PR DESCRIPTION
### What is this change?

We renamed these constants 3 years ago. This PR just removes the old deprecation notices.