### PR TITLE
DEV: Deselect all and reset to defaults btns to edit categories modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -34,15 +34,19 @@
             />
           {{/if}}
 
-          {{#if this.title}}
-            <div class="title">
-              <h3 id="discourse-modal-title">{{this.title}}</h3>
+          <div class="modal-title-wrapper">
+            {{#if this.title}}
+              <div class="title">
+                <h3 id="discourse-modal-title">{{this.title}}</h3>
 
-              {{#if this.subtitle}}
-                <p class="subtitle">{{this.subtitle}}</p>
-              {{/if}}
-            </div>
-          {{/if}}
+                {{#if this.subtitle}}
+                  <p class="subtitle">{{this.subtitle}}</p>
+                {{/if}}
+              </div>
+            {{/if}}
+
+            <span id="modal-header-after-title"></span>
+          </div>
 
           {{#if this.panels}}
             <ul class="modal-tabs">

--- a/app/assets/javascripts/discourse/app/components/sidebar/categories-form-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/categories-form-modal.hbs
@@ -1,75 +1,102 @@
-<DModalBody
-  @title="sidebar.categories_form.title"
-  @class="sidebar-categories-form-modal"
->
-  <form class="sidebar-categories-form">
-    <div class="sidebar-categories-form__filter">
-      {{d-icon "search" class="sidebar-categories-form__filter-input-icon"}}
+{{#in-element this.modalHeaderAfterTitleElement}}
+  <p class="sidebar-categories-form__deselect">
+    <DButton
+      @class="btn-flat sidebar-categories-form__deselect-all-btn"
+      @label="sidebar.categories_form_modal.subtitle.button_text"
+      @ariaLabel="sidebar.categories_form_modal.subtitle.button_text"
+      @action={{this.deselectAll}}
+    />
 
-      <Input
-        class="sidebar-categories-form__filter-input-field"
-        placeholder={{i18n "sidebar.categories_form.filter_placeholder"}}
-        @type="text"
-        @value={{this.filter}}
-        {{on "input" (action "onFilterInput" value="target.value")}}
-      />
-    </div>
+    {{i18n "sidebar.categories_form_modal.subtitle.text"}}
+  </p>
+{{/in-element}}
 
-    {{#if (gt this.filteredCategoriesGroupings.length 0)}}
-      {{#each this.filteredCategoriesGroupings as |categories|}}
-        <div
-          class="sidebar-categories-form__row"
-          style={{html-safe (border-color categories.0.color "left")}}
-        >
+<div class="sidebar-categories-form-modal">
+  <DModalBody
+    @title="sidebar.categories_form_modal.title"
+    @class="sidebar-categories-form__modal-body"
+  >
+    <form class="sidebar-categories-form">
+      <div class="sidebar-categories-form__filter">
+        {{d-icon "search" class="sidebar-categories-form__filter-input-icon"}}
 
-          {{#each categories as |category|}}
-            <div
-              class="sidebar-categories-form__category-row"
-              data-category-id={{category.id}}
-              data-category-level={{category.level}}
-            >
-              <label
-                class="sidebar-categories-form__category-label"
-                for={{concat "sidebar-categories-form__input--" category.id}}
-              >
-                <div class="sidebar-categories-form__category-badge">
-                  {{category-badge category}}
-                </div>
-
-                {{#unless category.parentCategory}}
-                  <div class="sidebar-categories-form__category-description">
-                    {{dir-span category.description_excerpt htmlSafe="true"}}
-                  </div>
-                {{/unless}}
-              </label>
-
-              <Input
-                id={{concat "sidebar-categories-form__input--" category.id}}
-                class="sidebar-categories-form__input"
-                @type="checkbox"
-                @checked={{includes
-                  this.selectedSidebarCategoryIds
-                  category.id
-                }}
-                {{on "click" (action "toggleCategory" category.id)}}
-              />
-            </div>
-          {{/each}}
-        </div>
-      {{/each}}
-    {{else}}
-      <div class="sidebar-categories-form__no-categories">
-        {{i18n "sidebar.categories_form.no_categories"}}
+        <Input
+          class="sidebar-categories-form__filter-input-field"
+          placeholder={{i18n
+            "sidebar.categories_form_modal.filter_placeholder"
+          }}
+          @type="text"
+          @value={{this.filter}}
+          {{on "input" (action "onFilterInput" value="target.value")}}
+        />
       </div>
-    {{/if}}
-  </form>
-</DModalBody>
 
-<div class="modal-footer">
-  <DButton
-    @class="btn-primary sidebar-categories-form__save-button"
-    @label="sidebar.categories_form.save"
-    @disabled={{this.saving}}
-    @action={{this.save}}
-  />
+      {{#if (gt this.filteredCategoriesGroupings.length 0)}}
+        {{#each this.filteredCategoriesGroupings as |categories|}}
+          <div
+            class="sidebar-categories-form__row"
+            style={{html-safe (border-color categories.0.color "left")}}
+          >
+
+            {{#each categories as |category|}}
+              <div
+                class="sidebar-categories-form__category-row"
+                data-category-id={{category.id}}
+                data-category-level={{category.level}}
+              >
+                <label
+                  class="sidebar-categories-form__category-label"
+                  for={{concat "sidebar-categories-form__input--" category.id}}
+                >
+                  <div class="sidebar-categories-form__category-badge">
+                    {{category-badge category}}
+                  </div>
+
+                  {{#unless category.parentCategory}}
+                    <div class="sidebar-categories-form__category-description">
+                      {{dir-span category.description_excerpt htmlSafe="true"}}
+                    </div>
+                  {{/unless}}
+                </label>
+
+                <Input
+                  id={{concat "sidebar-categories-form__input--" category.id}}
+                  class="sidebar-categories-form__input"
+                  @type="checkbox"
+                  @checked={{includes
+                    this.selectedSidebarCategoryIds
+                    category.id
+                  }}
+                  {{on "click" (action "toggleCategory" category.id)}}
+                />
+              </div>
+            {{/each}}
+          </div>
+        {{/each}}
+      {{else}}
+        <div class="sidebar-categories-form__no-categories">
+          {{i18n "sidebar.categories_form_modal.no_categories"}}
+        </div>
+      {{/if}}
+    </form>
+  </DModalBody>
+
+  <div class="modal-footer sidebar-categories-form__modal-footer">
+    <DButton
+      @class="btn-primary sidebar-categories-form__save-button"
+      @label="sidebar.categories_form_modal.save"
+      @disabled={{this.saving}}
+      @action={{this.save}}
+    />
+
+    {{#if (gt this.siteSettings.default_navigation_menu_categories.length 0)}}
+      <DButton
+        @icon="undo"
+        @class="btn-flat btn-text sidebar-categories-form__reset-to-defaults-btn"
+        @label="sidebar.categories_form_modal.reset_to_defaults"
+        @disabled={{this.saving}}
+        @action={{this.resetToDefaults}}
+      />
+    {{/if}}
+  </div>
 </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/categories-form-modal.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/categories-form-modal.js
@@ -8,8 +8,9 @@ import discourseDebounce from "discourse-common/lib/debounce";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default class extends Component {
-  @service site;
   @service currentUser;
+  @service site;
+  @service siteSettings;
 
   @tracked filter = "";
 
@@ -86,12 +87,29 @@ export default class extends Component {
   }
 
   @action
+  deselectAll() {
+    this.selectedSidebarCategoryIds.clear();
+  }
+
+  @action
   toggleCategory(categoryId) {
     if (this.selectedSidebarCategoryIds.includes(categoryId)) {
       this.selectedSidebarCategoryIds.removeObject(categoryId);
     } else {
       this.selectedSidebarCategoryIds.addObject(categoryId);
     }
+  }
+
+  get modalHeaderAfterTitleElement() {
+    return document.getElementById("modal-header-after-title");
+  }
+
+  @action
+  resetToDefaults() {
+    this.selectedSidebarCategoryIds =
+      this.siteSettings.default_navigation_menu_categories
+        .split("|")
+        .map((id) => parseInt(id, 10));
   }
 
   @action

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -134,7 +134,7 @@
   }
 
   &:not(.history-modal) {
-    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(.poll-breakdown):not(.sidebar-categories-form-modal) {
+    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(.poll-breakdown):not(.sidebar-categories-form__modal-body) {
       max-height: 80vh !important;
       @media screen and (max-height: 500px) {
         max-height: 65vh !important;

--- a/app/assets/stylesheets/common/components/sidebar-categories-form.scss
+++ b/app/assets/stylesheets/common/components/sidebar-categories-form.scss
@@ -4,13 +4,43 @@
   }
 }
 
+.sidebar-categories-form__modal-footer.modal-footer {
+  .sidebar-categories-form__reset-to-defaults-btn {
+    margin-left: auto;
+    margin-right: 0em;
+
+    .d-icon {
+      font-size: var(--font-down-1);
+      color: var(--tertiary);
+    }
+
+    &:focus,
+    &:active {
+      background: none;
+    }
+  }
+}
+
+.sidebar-categories-form__deselect {
+  margin: 0;
+
+  .btn-flat.sidebar-categories-form__deselect-all-btn {
+    margin-left: auto;
+    padding: 0;
+
+    &:focus,
+    &:active {
+      background: none;
+    }
+  }
+}
+
 .sidebar-categories-form {
   .sidebar-categories-form__filter {
     display: flex;
     flex-direction: row;
     margin-right: auto;
     width: 100%;
-    margin-bottom: 1em;
     position: relative;
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4389,11 +4389,15 @@ en:
       more: "More"
       all_categories: "All categories"
       all_tags: "All tags"
-      categories_form:
+      categories_form_modal:
         save: "Save"
         title: "Edit categories navigation"
+        subtitle:
+          button_text: "Deselect all"
+          text: "and we'll automatically show this site's most popular categories"
         filter_placeholder: "Filter categories"
         no_categories: "There are no categories matching the given term."
+        reset_to_defaults: "Reset to defaults"
 
       sections:
         custom:

--- a/spec/system/page_objects/modals/sidebar_edit_categories.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_categories.rb
@@ -29,7 +29,7 @@ module PageObjects
         has_no_css?(".sidebar-categories-form-modal .sidebar-categories-form__category-row") &&
           has_css?(
             ".sidebar-categories-form-modal .sidebar-categories-form__no-categories",
-            text: I18n.t("js.sidebar.categories_form.no_categories"),
+            text: I18n.t("js.sidebar.categories_form_modal.no_categories"),
           )
       end
 
@@ -64,6 +64,20 @@ module PageObjects
         )
 
         self
+      end
+
+      def deselect_all
+        click_button(I18n.t("js.sidebar.categories_form_modal.subtitle.button_text"))
+        self
+      end
+
+      def click_reset_to_defaults_button
+        click_button(I18n.t("js.sidebar.categories_form_modal.reset_to_defaults"))
+        self
+      end
+
+      def has_no_reset_to_defaults_button?
+        has_no_button?(I18n.t("js.sidebar.categories_form_modal.reset_to_defaults"))
       end
     end
   end


### PR DESCRIPTION
What does this change do?

This change adds the deselect all and reset to defaults buttons to the
edit navigation menu categories modal. The deselect all button when
click deselects all the selected categories in the modal. If the user
saves with no categories selected, the user's categories section in the
navigation menu will be set to the site's top categories.

The reset to defaults button is only shown when the
`default_navigation_menu_categories` site setting has been configured.
When clicked, the user's categories section in the navigation menu is
automatically set to the categories defined by the
`default_navigation_menu_categories` site setting.