### PR TITLE
FIX: update unread and new count for categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/category-list-item.js
@@ -26,4 +26,17 @@ export default Component.extend({
       (!isMutedCategory && listType === LIST_TYPE.MUTED)
     );
   },
+
+  @discourseComputed("topicTrackingState.messageCount")
+  unreadTopicsCount() {
+    return this.topicTrackingState.countUnread({
+      categoryId: this.category.id,
+    });
+  },
+  @discourseComputed("topicTrackingState.messageCount")
+  newTopicsCount() {
+    return this.topicTrackingState.countNew({
+      categoryId: this.category.id,
+    });
+  },
 });

--- a/app/assets/javascripts/discourse/app/components/category-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/category-list-item.js
@@ -33,6 +33,7 @@ export default Component.extend({
       categoryId: this.category.id,
     });
   },
+
   @discourseComputed("topicTrackingState.messageCount")
   newTopicsCount() {
     return this.topicTrackingState.countNew({

--- a/app/assets/javascripts/discourse/app/components/category-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/category-list-item.js
@@ -29,15 +29,11 @@ export default Component.extend({
 
   @discourseComputed("topicTrackingState.messageCount")
   unreadTopicsCount() {
-    return this.topicTrackingState.countUnread({
-      categoryId: this.category.id,
-    });
+    return this.category.unreadTopicsCount;
   },
 
   @discourseComputed("topicTrackingState.messageCount")
   newTopicsCount() {
-    return this.topicTrackingState.countNew({
-      categoryId: this.category.id,
-    });
+    return this.category.newTopicsCount;
   },
 });

--- a/app/assets/javascripts/discourse/app/components/category-unread.hbs
+++ b/app/assets/javascripts/discourse/app/components/category-unread.hbs
@@ -1,14 +1,17 @@
-{{#if this.countUnread}}
+{{#if this.unreadTopicsCount}}
   <a
     href={{this.category.unreadUrl}}
-    title={{i18n "topic.unread_topics" count=this.countUnread}}
+    title={{i18n "topic.unread_topics" count=this.unreadTopicsCount}}
     class="badge new-posts badge-notification"
-  >{{i18n "filters.unread.lower_title_with_count" count=this.countUnread}}</a>
+  >{{i18n
+      "filters.unread.lower_title_with_count"
+      count=this.unreadTopicsCount
+    }}</a>
 {{/if}}
-{{#if this.countNew}}
+{{#if this.newTopicsCount}}
   <a
     href={{this.category.newUrl}}
-    title={{i18n "topic.new_topics" count=this.countNew}}
+    title={{i18n "topic.new_topics" count=this.newTopicsCount}}
     class="badge new-posts badge-notification"
-  >{{i18n "filters.new.lower_title_with_count" count=this.countNew}}</a>
+  >{{i18n "filters.new.lower_title_with_count" count=this.newTopicsCount}}</a>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/category-unread.hbs
+++ b/app/assets/javascripts/discourse/app/components/category-unread.hbs
@@ -1,20 +1,14 @@
-{{#if this.category.unreadTopics}}
+{{#if this.countUnread}}
   <a
     href={{this.category.unreadUrl}}
-    title={{i18n "topic.unread_topics" count=this.category.unreadTopics}}
+    title={{i18n "topic.unread_topics" count=this.countUnread}}
     class="badge new-posts badge-notification"
-  >{{i18n
-      "filters.unread.lower_title_with_count"
-      count=this.category.unreadTopics
-    }}</a>
+  >{{i18n "filters.unread.lower_title_with_count" count=this.countUnread}}</a>
 {{/if}}
-{{#if this.category.newTopics}}
+{{#if this.countNew}}
   <a
     href={{this.category.newUrl}}
-    title={{i18n "topic.new_topics" count=this.category.newTopics}}
+    title={{i18n "topic.new_topics" count=this.countNew}}
     class="badge new-posts badge-notification"
-  >{{i18n
-      "filters.new.lower_title_with_count"
-      count=this.category.newTopics
-    }}</a>
+  >{{i18n "filters.new.lower_title_with_count" count=this.countNew}}</a>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
@@ -67,6 +67,8 @@
         @category={{this.category}}
         @tagName="div"
         @class="unread-new"
+        @countUnread={{this.unreadTopicsCount}}
+        @countNew={{this.newTopicsCount}}
       />
     </td>
 

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
@@ -67,8 +67,8 @@
         @category={{this.category}}
         @tagName="div"
         @class="unread-new"
-        @countUnread={{this.unreadTopicsCount}}
-        @countNew={{this.newTopicsCount}}
+        @unreadTopicsCount={{this.unreadTopicsCount}}
+        @newTopicsCount={{this.newTopicsCount}}
       />
     </td>
 

--- a/app/assets/javascripts/discourse/app/components/sub-category-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/sub-category-item.hbs
@@ -3,7 +3,11 @@
     <CategoryTitleBefore @category={{this.category}} />
     {{category-link this.category hideParent="true"}}
     {{#unless this.hideUnread}}
-      <CategoryUnread @category={{this.category}} />
+      <CategoryUnread
+        @category={{this.category}}
+        @countUnread={{this.unreadTopicsCount}}
+        @countNew={{this.newTopicsCount}}
+      />
     {{/unless}}
   </span>
 {{/unless}}

--- a/app/assets/javascripts/discourse/app/components/sub-category-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/sub-category-item.hbs
@@ -5,8 +5,8 @@
     {{#unless this.hideUnread}}
       <CategoryUnread
         @category={{this.category}}
-        @countUnread={{this.unreadTopicsCount}}
-        @countNew={{this.newTopicsCount}}
+        @unreadTopicsCount={{this.unreadTopicsCount}}
+        @newTopicsCount={{this.newTopicsCount}}
       />
     {{/unless}}
   </span>

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -198,11 +198,11 @@ const Category = RestModel.extend({
     return notificationLevel >= NotificationLevels.TRACKING;
   },
 
-  get unreadTopics() {
+  get unreadTopicsCount() {
     return this.topicTrackingState.countUnread({ categoryId: this.id });
   },
 
-  get newTopics() {
+  get newTopicsCount() {
     return this.topicTrackingState.countNew({ categoryId: this.id });
   },
 

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -198,6 +198,14 @@ const Category = RestModel.extend({
     return notificationLevel >= NotificationLevels.TRACKING;
   },
 
+  get unreadTopics() {
+    return this.topicTrackingState.countUnread({ categoryId: this.id });
+  },
+
+  get newTopics() {
+    return this.topicTrackingState.countNew({ categoryId: this.id });
+  },
+
   save() {
     const id = this.id;
     const url = id ? `/categories/${id}` : "/categories";

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -310,16 +310,6 @@ const Category = RestModel.extend({
     }
   },
 
-  @discourseComputed("id", "topicTrackingState.messageCount")
-  unreadTopics(id) {
-    return this.topicTrackingState.countUnread({ categoryId: id });
-  },
-
-  @discourseComputed("id", "topicTrackingState.messageCount")
-  newTopics(id) {
-    return this.topicTrackingState.countNew({ categoryId: id });
-  },
-
   setNotification(notification_level) {
     User.currentProp(
       "muted_category_ids",

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
@@ -20,7 +20,9 @@ createWidget("hamburger-category", {
     ];
 
     const unreadTotal =
-      parseInt(c.get("unreadTopics"), 10) + parseInt(c.get("newTopics"), 10);
+      this.site.topicTrackingState.countUnread({ categoryId: c.get("id") }) +
+      this.site.topicTrackingState.countNew({ categoryId: c.get("id") });
+
     if (unreadTotal) {
       results.push(
         h(

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
@@ -19,9 +19,7 @@ createWidget("hamburger-category", {
       this.attach("category-link", { category: c, allowUncategorized: true }),
     ];
 
-    const unreadTotal =
-      this.site.topicTrackingState.countUnread({ categoryId: c.get("id") }) +
-      this.site.topicTrackingState.countNew({ categoryId: c.get("id") });
+    const unreadTotal = c.unreadTopicsCount + c.newTopicsCount;
 
     if (unreadTotal) {
       results.push(

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -198,26 +198,12 @@ export default createWidget("hamburger-menu", {
         .filter((c) => c.notification_level !== NotificationLevels.MUTED);
 
       categories = allCategories
-        .filter(
-          (c) =>
-            this.site.topicTrackingState.countNew({ categoryId: c.get("id") }) >
-              0 ||
-            this.site.topicTrackingState.countUnread({
-              categoryId: c.get("id"),
-            }) > 0
-        )
+        .filter((c) => c.newTopicsCount > 0 || c.unreadTopicsCount > 0)
         .sort((a, b) => {
           return (
-            this.site.topicTrackingState.countNew({ categoryId: b.get("id") }) +
-            this.site.topicTrackingState.countUnread({
-              categoryId: b.get("id"),
-            }) -
-            (this.site.topicTrackingState.countUnread({
-              categoryId: a.get("id"),
-            }) +
-              this.site.topicTrackingState.countNew({
-                categoryId: a.get("id"),
-              }))
+            b.newTopicsCount +
+            b.unreadTopicsCount -
+            (a.unreadTopicsCount + a.newTopicsCount)
           );
         });
 

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -198,12 +198,26 @@ export default createWidget("hamburger-menu", {
         .filter((c) => c.notification_level !== NotificationLevels.MUTED);
 
       categories = allCategories
-        .filter((c) => c.get("newTopics") > 0 || c.get("unreadTopics") > 0)
+        .filter(
+          (c) =>
+            this.site.topicTrackingState.countNew({ categoryId: c.get("id") }) >
+              0 ||
+            this.site.topicTrackingState.countUnread({
+              categoryId: c.get("id"),
+            }) > 0
+        )
         .sort((a, b) => {
           return (
-            b.get("newTopics") +
-            b.get("unreadTopics") -
-            (a.get("newTopics") + a.get("unreadTopics"))
+            this.site.topicTrackingState.countNew({ categoryId: b.get("id") }) +
+            this.site.topicTrackingState.countUnread({
+              categoryId: b.get("id"),
+            }) -
+            (this.site.topicTrackingState.countUnread({
+              categoryId: a.get("id"),
+            }) +
+              this.site.topicTrackingState.countNew({
+                categoryId: a.get("id"),
+              }))
           );
         });
 

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "Catergory topics", type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  let(:category_list) { PageObjects::Components::CategoryList.new }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+
+  it "displays and updates new counter" do
+    sign_in(user)
+
+    visit("/categories")
+
+    category_list.click_new_posts_badge(count: 1)
+    category_list.click_topic(topic)
+    category_list.click_logo
+    category_list.click_category_navigation
+
+    expect(category_list).to have_category(category)
+    expect(category_list).to have_no_new_posts_badge
+  end
+end

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Catergory topics", type: :system, js: true do
+describe "Viewing top topics on categories page", type: :system, js: true do
   fab!(:user) { Fabricate(:user) }
   let(:category_list) { PageObjects::Components::CategoryList.new }
   fab!(:category) { Fabricate(:category) }

--- a/spec/system/page_objects/components/category_list.rb
+++ b/spec/system/page_objects/components/category_list.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class CategoryList < PageObjects::Components::Base
+      def has_category?(category)
+        page.has_css?("tr[data-category-id='#{category.id}']")
+      end
+
+      def has_topic?(topic)
+        page.has_css?(topic_list_item_class(topic))
+      end
+
+      def has_no_new_posts_badge?
+        page.has_no_css?(".new-posts")
+      end
+
+      def click_category_navigation
+        page.find(".nav-pills .categories").click
+      end
+
+      def click_logo
+        page.find(".title a").click
+      end
+
+      def click_new_posts_badge(count: 1)
+        page.find(".new-posts", text: "#{count} new").click
+      end
+
+      def click_topic(topic)
+        page.find("a", text: topic.title).click
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a problem that unread and new count is not updated to reflecting topicTrackingState.

It is because discourseComputed on Category is not working properly with topicTrackingState. Moving it to component level is making counter reliable.