### PR TITLE
DRAFT: Count only approved flagged posts in user pages

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -734,7 +734,7 @@
           @query={{hash
             username=this.model.username
             type="ReviewableFlaggedPost"
-            status="all"
+            status="approved"
           }}
           class="btn"
         >

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -38,7 +38,7 @@
                   @route="review"
                   @query={{hash
                     username=this.model.username
-                    status="all"
+                    status="approved"
                     type="ReviewableFlaggedPost"
                   }}
                 >

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1214,6 +1214,7 @@ class User < ActiveRecord::Base
     posts
       .includes(:post_actions)
       .where("post_actions.post_action_type_id" => PostActionType.flag_types_without_custom.values)
+      .where("post_actions.agreed_at IS NOT NULL")
       .count
   end
 
@@ -1555,7 +1556,7 @@ class User < ActiveRecord::Base
   end
 
   def number_of_flagged_posts
-    ReviewableFlaggedPost.where(target_created_by: self.id).count
+    ReviewableFlaggedPost.where(target_created_by: self.id).approved.count
   end
 
   def number_of_rejected_posts

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2045,14 +2045,24 @@ RSpec.describe User do
     end
 
     describe "#number_of_flagged_posts" do
-      it "counts flagged posts from the user" do
-        Fabricate(:reviewable_flagged_post, target_created_by: user)
+      it "counts approved flagged posts from the user" do
+        ReviewableFlaggedPost
+          .statuses
+          .except(:approved)
+          .keys
+          .map do |status|
+            Fabricate(:reviewable_flagged_post, status: status, target_created_by: user)
+          end
+        Fabricate.times(2, :reviewable_flagged_post, status: :approved, target_created_by: user)
 
-        expect(user.number_of_flagged_posts).to eq(1)
+        expect(user.number_of_flagged_posts).to eq(2)
       end
 
       it "ignores flagged posts from another user" do
-        Fabricate(:reviewable_flagged_post, target_created_by: Fabricate(:user))
+        other_user = Fabricate(:user)
+        ReviewableFlaggedPost.statuses.keys.map do |status|
+          Fabricate(:reviewable_flagged_post, status: status, target_created_by: other_user)
+        end
 
         expect(user.number_of_flagged_posts).to eq(0)
       end

--- a/spec/system/page_objects/pages/user.rb
+++ b/spec/system/page_objects/pages/user.rb
@@ -24,10 +24,31 @@ module PageObjects
         page.has_current_path?("/u/#{user.username}/messages/warnings")
       end
 
+      def staff_info_section
+        begin
+          page.find(".staff-counters")
+        rescue Capybara::ElementNotFound
+          nil
+        end
+      end
+
       def click_staff_info_warnings_link(user, warnings_count: 0)
-        staff_counters = page.find(".staff-counters")
-        staff_counters.find("a[href='/u/#{user.username}/messages/warnings']").click
+        staff_info_section.find("a[href='/u/#{user.username}/messages/warnings']").click
         self
+      end
+
+      def has_reviewable_flagged_posts_path?(user)
+        params = {
+          status: "approved",
+          sort_order: "score",
+          type: "ReviewableFlaggedPost",
+          username: user.username,
+        }
+        page.has_current_path?("/review?#{params.to_query}")
+      end
+
+      def staff_info_flagged_posts_counter
+        staff_info_section&.find(".flagged-posts")
       end
     end
   end

--- a/spec/system/user_page/staff_info_spec.rb
+++ b/spec/system/user_page/staff_info_spec.rb
@@ -17,4 +17,40 @@ describe "Viewing user staff info as an admin", type: :system do
       expect(user_page).to have_warning_messages_path(user)
     end
   end
+
+  context "for flagged posts" do
+    before do
+      ReviewableFlaggedPost
+        .statuses
+        .except(:approved)
+        .keys
+        .map do |status|
+          Fabricate(:reviewable_flagged_post, status: status, target_created_by: user)
+        end
+    end
+
+    context "when there are no approved flagged posts" do
+      it "should not display a flagged-posts staff counter" do
+        expect(user_page.visit(user).try(:staff_info_flagged_posts_counter)).to be_nil
+      end
+    end
+
+    context "when there are approved flagged posts" do
+      before do
+        Fabricate.times(2, :reviewable_flagged_post, status: :approved, target_created_by: user)
+      end
+
+      it "should show the right count in the flagged-posts staff counter" do
+        user_page.visit(user)
+        expect(
+          user_page.staff_info_flagged_posts_counter.text.to_i,
+        ).to eq ReviewableFlaggedPost.approved.count
+      end
+
+      it "should have the right link to user's flagged posts in the flagged-posts staff counter" do
+        user_page.visit(user).staff_info_flagged_posts_counter.click
+        expect(user_page).to have_reviewable_flagged_posts_path(user)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### Context
Related topics: 
1. Public Request: https://meta.discourse.org/t/add-function-to-remove-flags-given-to-a-user/192750

This PR achieves the goal of reducing noise from flagged posts for admins/moderators by updating the counters in the user's profile page & admin view to only count posts with approved flags.
This more accurately reflects the signal from posts that were correctly flagged, and removes the noise from flags that were rejected, ignored or awaiting review.

#### Changes
* Modifying User#number_of_flagged_posts to only return the count of posts with approved flags, and associated model unit tests
* Updating the flagged post staff counter hyperlink to navigate to a filtered view of that user's approved flagged posts to maintain consistency with the counter
* Adding system tests for the profile page to cover the flagged posts staff counter
* Minor refactor of the user profile page object used for system testing
* Modifying User#flags_received_count to return posts with only approved standard flags
* Updating the `Show flags given` button in the user admin view to navigate to a filtered view of that user's approved flagged posts

#### Testing
How to test:
1. Populate a dev instance with topics & posts (with at least 5 from a specific user - this will be the flagged user)
4. All posts to be flagged should be from the same user.
5. Flag 3 posts with standard flags (i.e. `spam`, `inappropriate`, `off topic`).
6. As an admin/mod, review 2 of these posts with reject / ignore actions respectively, the last of these posts should be left as pending review.
7. Flag 1 post with a custom flag (i.e. `something else`)
8. Flag 1 post with 1 custom & 1 standard flag (you will need 2 different users here)
9.  As an admin/mod, approve the flags from both posts above.
10. Navigate to the user's profile page and test for expected behaviour.
11. Navigate to the user's admin view via the Admin index of users search page and test for expected behaviour.

Testing Artifact:

https://github.com/discourse/discourse/assets/133760061/dd322974-285a-425f-8247-25a365f0c9e3

- 00:00 - 00:15 - Scrolling through 5 flagged posts, showing 1 pending, 1 rejected, 1 ignored and 2 approved (of which, one has all custom flags, and the other a mix of standard/custom flags)
- 00:15 - 00:25 - Click through to user profile page to show flagged posts counter, and click on that counter to view approved flagged posts for that user
    - Expectation: Flagged Post counter should count all approved flagged posts
- 00:32 - 00:42 - View user page through admin users index, click through on Show Received Flags button to view approved flagged posts for that user
    - Expectation: Received Flags counter should count all approved flagged posts with only standard flags

#### Considerations / Questions

1. `User#flags_received_count` and `User#number_of_flagged_posts` differ in one key aspect - the latter includes custom flags. It is possible that including custom flags in the count adds noise (the extent of which depends on the proportion of custom flags used for non-negative flagging, and also whether the counters should be interpreted as wholly negative signals in the first place). I don't have enough data to opine either way (other than [anecdata](https://meta.discourse.org/t/please-distinguish-flags-for-bad-things-from-organizational-and-please-help-flags/266073/2)) so would like some input on the approach here if we want to maintain consistency between the counters in the user's profile page & the user's admin view.
2. The other tricky part if we opt to exclude custom flags from the count is that the filtered view upon clicking on the `flagged-posts` counter / `Show Flags Received` button currently has no way to filter out posts with only custom flags (if we want to differentiate the 2, perhaps this could be the subject of a future PR). 
