### PR TITLE
DEV: Remove deprecated 'desc' parameter from group members endpoint

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -242,14 +242,6 @@ class GroupsController < ApplicationController
     raise Discourse::InvalidParameters.new(:offset) if offset < 0
 
     dir = (params[:asc] && params[:asc].present?) ? "ASC" : "DESC"
-    if params[:desc]
-      Discourse.deprecate(
-        ":desc is deprecated please use :asc instead",
-        output_in_test: true,
-        drop_from: "2.9.0",
-      )
-      dir = (params[:desc] && params[:desc].present?) ? "DESC" : "ASC"
-    end
     order = "NOT group_users.owner"
 
     if params[:requesters]


### PR DESCRIPTION
### What is this change?

This parameter was deprecated three years ago, and was due to be dropped in 2.9. I searched our logs, and there were 3 entries. They all had some nonsense value, e.g. a link, an HTML fragment, etc. so might be bots. Either way it should be safe to remove this now. The maximum impact is the ordering will fall back to ASC.
