### PR TITLE
DEV: Change `have_section_link` match to use exact text match.

### DIFF
--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -99,7 +99,7 @@ describe "Custom sidebar sections", type: :system do
     section_modal.save
 
     expect(sidebar).to have_section("Edited section")
-    expect(sidebar).to have_section_link("Edited Tag")
+    expect(sidebar).to have_section_link("Edited Tags")
 
     expect(sidebar).to have_no_section_link("Sidebar Categories")
   end

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -88,11 +88,11 @@ module PageObjects
       private
 
       def section_link_present?(name, href: nil, active: false, present:)
-        attributes = {}
+        attributes = { exact_text: name }
         attributes[:href] = href if href
         attributes[:class] = SIDEBAR_SECTION_LINK_SELECTOR
         attributes[:class] += "--active" if active
-        page.public_send(present ? :has_link? : :has_no_link?, name, **attributes)
+        page.public_send(present ? :has_link? : :has_no_link?, **attributes)
       end
 
       def add_section_button_text


### PR DESCRIPTION
Today I learnt that `has_link?("text of link")` by default does an
includes instead of looking for a link with the exact text. This is not
the behaviour I want so I'm changing
`PageObjects::Components::Sidebar.has_section_link?` to use the
`exact_text` option instead.