### PR TITLE
FIX: css class was incorrect

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -167,7 +167,7 @@
 
 .no-touch .chat-message-container {
   &:hover,
-  &-active {
+  &.-active {
     background: var(--d-hover);
   }
 


### PR DESCRIPTION
This was preventing to have the correct active background on the chat message while hovering the action's menu.

Before:

![Screenshot 2023-06-16 at 12 13 34](https://github.com/discourse/discourse/assets/339945/07e2a91c-b017-4e3f-966a-0fff9494b021)

After:

![Screenshot 2023-06-16 at 12 13 28](https://github.com/discourse/discourse/assets/339945/da392248-c85b-48c9-891d-80130859c7ab)

