### PR TITLE
DEV: Do not attempt to overwrite UserOption enums during autoloading

### DIFF
--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -18,8 +18,13 @@ module Chat
         @chat_header_indicator_preferences ||= { all_new: 0, dm_and_mentions: 1, never: 2 }
       end
 
-      base.enum :chat_email_frequency, base.chat_email_frequencies, prefix: "send_chat_email"
-      base.enum :chat_header_indicator_preference, base.chat_header_indicator_preferences
+      if !base.method_defined?(:send_chat_email_never?) # Avoid attempting to override when autoloading
+        base.enum :chat_email_frequency, base.chat_email_frequencies, prefix: "send_chat_email"
+      end
+
+      if !base.method_defined?(:never?) # Avoid attempting to override when autoloading
+        base.enum :chat_header_indicator_preference, base.chat_header_indicator_preferences
+      end
     end
   end
 end


### PR DESCRIPTION
Unfortunately, Discourse's `UserOption` model is not currently autoloaded. That means that modifying it via a `reloadable_patch` will try to apply the changes repeatedly. Normally this doesn't matter since the changes are idempotent. However, introducing ActiveRecord enums is not idempotent - they raise an error if the same enum already exists on the model. This commit adds a check to avoid hitting this 'duplicate definition' error.

Reproduced via

```
rails runner 'Rails.application.reloader.reload!'
```