### PR TITLE
DEV: Namespace chat_header_indicator UserOption enum

### DIFF
--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -22,8 +22,10 @@ module Chat
         base.enum :chat_email_frequency, base.chat_email_frequencies, prefix: "send_chat_email"
       end
 
-      if !base.method_defined?(:never?) # Avoid attempting to override when autoloading
-        base.enum :chat_header_indicator_preference, base.chat_header_indicator_preferences
+      if !base.method_defined?(:chat_header_indicator_never?) # Avoid attempting to override when autoloading
+        base.enum :chat_header_indicator_preference,
+                  base.chat_header_indicator_preferences,
+                  prefix: "chat_header_indicator"
       end
     end
   end


### PR DESCRIPTION
Previously this was defining methods like `UserOption#never?`, `UserOption#all_new?`, `UserOption#dm_and_mentions?`. Now they will be prefixed like `UserOption#chat_header_indicator_never?`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
