### PR TITLE
FIX: correctly sets and uses has-reply class

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -317,7 +317,7 @@ export default class ChatMessage extends Component {
   }
 
   get hasReply() {
-    return this.args.inReplyTo && !this.hideReplyToInfo;
+    return this.args.message.inReplyTo && !this.hideReplyToInfo;
   }
 
   get hideUserInfo() {

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -214,19 +214,21 @@
   }
 
   &.has-reply {
-    display: grid;
-    grid-template-columns: var(--message-left-width) 1fr;
-    grid-template-rows: 30px auto;
-    grid-template-areas:
-      "replyto replyto"
-      "avatar message";
+    .chat-message {
+      display: grid;
+      grid-template-columns: var(--message-left-width) 1fr;
+      grid-template-rows: 30px auto;
+      grid-template-areas:
+        "replyto replyto"
+        "avatar message";
 
-    .chat-user-avatar {
-      grid-area: avatar;
-    }
+      .chat-user-avatar {
+        grid-area: avatar;
+      }
 
-    .chat-message-content {
-      grid-area: message;
+      .chat-message-content {
+        grid-area: message;
+      }
     }
   }
 

--- a/plugins/chat/test/javascripts/components/chat-message-test.js
+++ b/plugins/chat/test/javascripts/components/chat-message-test.js
@@ -1,65 +1,23 @@
-import User from "discourse/models/user";
 import { render } from "@ember/test-helpers";
-import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import hbs from "htmlbars-inline-precompile";
-import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 import { module, test } from "qunit";
+import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
 module("Discourse Chat | Component | chat-message", function (hooks) {
   setupRenderingTest(hooks);
 
-  function generateMessageProps(messageData = {}) {
-    const channel = ChatChannel.create({
-      chatable_id: 1,
-      chatable_type: "Category",
-      id: 9,
-      title: "Site",
-      last_message_sent_at: "2021-11-08T21:26:05.710Z",
-      current_user_membership: {
-        unread_count: 0,
-        muted: false,
-      },
-      can_delete_self: true,
-      can_delete_others: true,
-      can_flag: true,
-      user_silenced: false,
-      can_moderate: true,
-    });
-    return {
-      message: ChatMessage.create(
-        channel,
-        Object.assign(
-          {
-            id: 178,
-            message: "from deleted user",
-            cooked: "<p>from deleted user</p>",
-            excerpt: "<p>from deleted user</p>",
-            created_at: "2021-07-22T08:14:16.950Z",
-            flag_count: 0,
-            user: User.create({ username: "someguy", id: 1424 }),
-            edited: false,
-          },
-          messageData
-        )
-      ),
-      channel,
-      messageDidEnterViewport: () => {},
-      messageDidLeaveViewport: () => {},
-    };
-  }
-
   const template = hbs`
     <ChatMessage
       @message={{this.message}}
-      @messageDidEnterViewport={{this.messageDidEnterViewport}}
-      @messageDidLeaveViewport={{this.messageDidLeaveViewport}}
+      @messageDidEnterViewport={{fn (noop)}}
+      @messageDidLeaveViewport={{fn (noop)}}
     />
   `;
 
   test("Message with edits", async function (assert) {
-    this.setProperties(generateMessageProps({ edited: true }));
+    this.message = fabricators.message({ edited: true });
     await render(template);
 
     assert.true(
@@ -69,7 +27,10 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
   });
 
   test("Deleted message", async function (assert) {
-    this.setProperties(generateMessageProps({ deleted_at: moment() }));
+    this.message = fabricators.message({
+      user: this.currentUser,
+      deleted_at: moment(),
+    });
     await render(template);
 
     assert.true(
@@ -79,11 +40,21 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
   });
 
   test("Hidden message", async function (assert) {
-    this.setProperties(generateMessageProps({ hidden: true }));
+    this.message = fabricators.message({ hidden: true });
     await render(template);
 
     assert.true(
       exists(".chat-message-hidden .chat-message-expand"),
+      "has the correct hidden css class and expand button within"
+    );
+  });
+
+  test("Message with reply", async function (assert) {
+    this.message = fabricators.message({ inReplyTo: fabricators.message() });
+    await render(template);
+
+    assert.true(
+      exists(".chat-message-container.has-reply"),
       "has the correct hidden css class and expand button within"
     );
   });

--- a/plugins/chat/test/javascripts/components/chat-message-test.js
+++ b/plugins/chat/test/javascripts/components/chat-message-test.js
@@ -20,10 +20,7 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
     this.message = fabricators.message({ edited: true });
     await render(template);
 
-    assert.true(
-      exists(".chat-message-edited"),
-      "has the correct edited css class"
-    );
+    assert.true(exists(".chat-message-edited"), "has the correct css class");
   });
 
   test("Deleted message", async function (assert) {
@@ -35,7 +32,7 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
 
     assert.true(
       exists(".chat-message-deleted .chat-message-expand"),
-      "has the correct deleted css class and expand button within"
+      "has the correct css class and expand button within"
     );
   });
 
@@ -45,7 +42,7 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
 
     assert.true(
       exists(".chat-message-hidden .chat-message-expand"),
-      "has the correct hidden css class and expand button within"
+      "has the correct css class and expand button within"
     );
   });
 
@@ -55,7 +52,7 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
 
     assert.true(
       exists(".chat-message-container.has-reply"),
-      "has the correct hidden css class and expand button within"
+      "has the correct css class"
     );
   });
 });


### PR DESCRIPTION
The layout was broken for messages replying to another message in non threaded channels.

This commit also refactors the chat-message-test to use fabricators.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
