### PR TITLE
DEV: Update TranslateAccelerator missing translation string

### DIFF
--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -148,7 +148,7 @@ module I18n
       elsif should_raise
         raise I18n::MissingTranslationData.new(locale, key)
       else
-        -"translation missing: #{locale}.#{key}"
+        -"Translation missing: #{locale}.#{key}"
       end
     end
 

--- a/spec/integrity/i18n_spec.rb
+++ b/spec/integrity/i18n_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "i18n integrity checks" do
   it "has an i18n key for each Site Setting" do
     SiteSetting.all_settings.each do |s|
       next if s[:plugin] == SiteSetting::SAMPLE_TEST_PLUGIN.name
-      expect(s[:description]).not_to match(/translation missing/)
+      expect(s[:description]).not_to match(/Translation missing/)
     end
   end
 

--- a/spec/lib/freedom_patches/translate_accelerator_spec.rb
+++ b/spec/lib/freedom_patches/translate_accelerator_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe "translate accelerator" do
     orig = I18n.t("i_am_an_unknown_key99")
 
     expect(I18n.t("i_am_an_unknown_key99").object_id).to eq(orig.object_id)
-    expect(I18n.t("i_am_an_unknown_key99")).to eq("translation missing: en.i_am_an_unknown_key99")
+    expect(I18n.t("i_am_an_unknown_key99")).to eq("Translation missing: en.i_am_an_unknown_key99")
+  end
+
+  it "has the same 'translation missing' message as upstream" do
+    expect(I18n.t("this_key_does_not_exist")).to eq(
+      I18n.translate_no_cache("this_key_does_not_exist"),
+    )
   end
 
   it "returns the correct language" do

--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -450,7 +450,7 @@ RSpec.describe Admin::EmailTemplatesController do
 
   it "uses only existing email templates" do
     Admin::EmailTemplatesController.email_keys.each do |key|
-      expect(I18n.t(key)).to_not include("translation missing")
+      expect(I18n.t(key)).to_not include("Translation missing")
     end
   end
 end


### PR DESCRIPTION
Upstream added a capital 'T' to the 'Translation missing' message in https://github.com/ruby-i18n/i18n/commit/c5c6e753f3. This caused our translate accelerator patch to diverge, and the change in case affected a number of our specs. This commit updates the translate accelerator to match the upstream casing, and introduces a spec to detect future divergence.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
