### PR TITLE
UX: fix avatar selector overflow

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -823,6 +823,7 @@
   max-height: 350px;
   margin-bottom: 1em;
   text-align: justify;
+  overflow-y: auto;
   .selectable-avatar {
     margin: 5px;
     display: inline-block;


### PR DESCRIPTION
Fixes avatar selector overflow when we have a lot of selectable avatars.

Before:
![image](https://github.com/discourse/discourse/assets/5654300/4e690a66-5834-40ba-9db4-ddc6990f6288)

After:
![image](https://github.com/discourse/discourse/assets/5654300/461153b3-fecc-4165-8b9e-8925c3661668)


