### PR TITLE
 UX: remove short topic timeline transition 

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -5,7 +5,6 @@
 .timeline-container {
   box-sizing: border-box;
   z-index: z("timeline");
-  transform: translateZ(0);
 
   &.timeline-docked-bottom {
     .timeline-footer-controls {

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -8,10 +8,6 @@
   transform: translateZ(0);
 
   &.timeline-docked-bottom {
-    margin-bottom: -4em;
-    @media screen and (prefers-reduced-motion: no-preference) {
-      transition: margin-bottom 0.5s ease-in;
-    }
     .timeline-footer-controls {
       opacity: 0;
       pointer-events: none;
@@ -184,6 +180,7 @@
   .topic-timeline {
     transition: opacity 0.2s ease-in;
     touch-action: none;
+    min-width: 6em;
 
     .timeline-controls {
       margin-bottom: 1em;
@@ -195,17 +192,17 @@
     }
 
     .timeline-footer-controls {
-      margin-top: 1.5em;
+      // this is absolutely positioned to avoid
+      // adding extra height below short topics
+      // above the topic-footer-controls
+      position: absolute;
+      margin-top: 1em;
       @media (prefers-reduced-motion: no-preference) {
         transition: opacity 0.2s ease-in;
       }
       display: flex;
+      gap: 0.5em;
       flex-wrap: wrap;
-      max-width: 9em;
-
-      .reply-to-post {
-        margin-right: 0.5em;
-      }
 
       button:last-child {
         margin-right: 0;


### PR DESCRIPTION
This removes a transition for the timeline on short topics. This was meant to ease-in the elimination of some extra whitespace, but in practice it causes some weird edge case bugs:


https://github.com/discourse/discourse/assets/1681963/66eb9d32-619e-409b-8137-931c70dca9de

So instead, I've absolutely positioned the timeline footer controls so they don't impact the height of the topic to begin with... so no extra whitespace or awkward transition:

[Kapture 2023-06-16 at 11.37.34.webm](https://github.com/discourse/discourse/assets/1681963/3ee0da90-55ef-49db-8ce5-4e51dd732b43)
