### PR TITLE
FIX: Incompatibility between default_composer_category and default_subcategory_on_read_only_category

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/open-composer.js
+++ b/app/assets/javascripts/discourse/app/mixins/open-composer.js
@@ -7,11 +7,11 @@ export default Mixin.create({
   openComposer(controller) {
     let categoryId = controller.get("category.id");
 
-    if (this.siteSettings.default_subcategory_on_read_only_category) {
-      if (
-        !controller.canCreateTopicOnCategory &&
-        controller.canCreateTopicOnSubCategory
-      ) {
+    if (
+      this.siteSettings.default_subcategory_on_read_only_category &&
+      !controller.canCreateTopicOnCategory
+    ) {
+      if (controller.canCreateTopicOnSubCategory) {
         categoryId = controller.get("defaultSubcategory.id");
       } else {
         categoryId = this.siteSettings.default_composer_category;
@@ -20,6 +20,7 @@ export default Mixin.create({
 
     if (
       categoryId &&
+      !this.siteSettings.default_subcategory_on_read_only_category &&
       controller.category.isUncategorizedCategory &&
       !this.siteSettings.allow_uncategorized_topics
     ) {


### PR DESCRIPTION
**Context** 
`default_subcategory_on_read_only_category` is a `SiteSetting` that allows the user to create a topic even when the category they are on doesn't allow them to.

**Problem**
There is an incompatibility between `default_subcategory_on_read_only_category` and `default_composer_category` `SiteSetting`  when on all categories page. There is also a problem when the `default_subcategory_on_read_only_category` `SiteSetting` was enabled and the user could create a topic in the current category.

**Solution**
`category_id` set in the `open-composer.js` is responsible for this. There was an issue in the logic for both cases and they have been fixed.  
