### PR TITLE
DEV: Escape html and emojis in search menu topic result type titles

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.hbs
@@ -1,1 +1,1 @@
-{{this.content}}
+<span>{{html-safe @string}}</span>

--- a/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.hbs
@@ -1,1 +1,1 @@
-<span>{{html-safe @string}}</span>
+{{html-safe @string}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.js
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import highlightSearch from "discourse/lib/highlight-search";
 import { inject as service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 
 export default class HighlightedSearch extends Component {
   @service search;
@@ -9,7 +10,6 @@ export default class HighlightedSearch extends Component {
     super(...arguments);
     const span = document.createElement("span");
     span.textContent = this.args.string;
-    this.content = span;
 
     highlightSearch(span, this.search.activeGlobalSearchTerm);
   }

--- a/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/highlighted-search.js
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import highlightSearch from "discourse/lib/highlight-search";
 import { inject as service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 
 export default class HighlightedSearch extends Component {
   @service search;

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
@@ -134,6 +134,34 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     );
   });
 
+  test("Topic type search result escapes html in topic title", async function (assert) {
+    await visit("/");
+    await click("#search-button");
+    await fillIn("#search-term", "dev");
+    await triggerKeyEvent("#search-term", "keyup", "Enter");
+
+    assert.ok(
+      exists(
+        ".search-menu .search-result-topic .item .topic-title span#topic-with-html"
+      ),
+      "html in the topic title is properly escaped"
+    );
+  });
+
+  test("Topic type search result escapes emojis in topic title", async function (assert) {
+    await visit("/");
+    await click("#search-button");
+    await fillIn("#search-term", "dev");
+    await triggerKeyEvent("#search-term", "keyup", "Enter");
+
+    assert.ok(
+      exists(
+        ".search-menu .search-result-topic .item .topic-title img[alt='+1']"
+      ),
+      ":+1: in the topic title is properly converted to an emoji"
+    );
+  });
+
   test("search button toggles search menu", async function (assert) {
     await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/fixtures/search-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/search-fixtures.js
@@ -643,9 +643,9 @@ export default {
       },
       {
         id: 2507,
-        title: "Getting dev instance to send email?",
-        fancy_title: "Getting dev instance to send email?",
-        slug: "getting-dev-instance-to-send-email",
+        title: "Topic with html in title",
+        fancy_title: "<span id='topic-with-html'>Topic with html in title :+1:</span>",
+        slug: "topic-with-html-in-title",
         posts_count: 19,
         reply_count: 13,
         highest_post_number: 21,


### PR DESCRIPTION
# Before
<img width="419" alt="Screenshot 2023-06-16 at 3 23 49 PM" src="https://github.com/discourse/discourse/assets/50783505/557e0657-afc8-4608-b025-d9896fd9a8c9">

# After
<img width="433" alt="Screenshot 2023-06-16 at 3 21 41 PM" src="https://github.com/discourse/discourse/assets/50783505/1df71b3b-479b-4163-8a7c-5bb434102a55">
