### PR TITLE
FIX: Restore behavior of `window.Discourse`

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/inject-objects.js
@@ -10,13 +10,15 @@ export default {
     // This is required for Ember CLI tests to work
     setDefaultOwner(owner.__container__);
 
+    window.Discourse = owner;
+
     Object.defineProperty(owner, "SiteSettings", {
       get() {
         deprecated(
           `use injected siteSettings instead of Discourse.SiteSettings`,
           {
             since: "2.8",
-            dropFrom: "2.9",
+            dropFrom: "3.2",
             id: "discourse.global.site-settings",
           }
         );
@@ -29,7 +31,7 @@ export default {
           `import discourse/models/user instead of using Discourse.User`,
           {
             since: "2.8",
-            dropFrom: "2.9",
+            dropFrom: "3.2",
             id: "discourse.global.user",
           }
         );
@@ -42,12 +44,16 @@ export default {
           `import discourse/models/site instead of using Discourse.Site`,
           {
             since: "2.8",
-            dropFrom: "2.9",
+            dropFrom: "3.2",
             id: "discourse.global.site",
           }
         );
         return Site;
       },
     });
+  },
+
+  teardown() {
+    delete window.Discourse;
   },
 };

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -43,7 +43,6 @@
     "ember-cached-decorator-polyfill": "^1.0.1",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^8.0.0",
-    "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-modifier": "^4.1.0",
     "ember-on-resize-modifier": "^1.1.0",

--- a/app/assets/javascripts/discourse/tests/acceptance/globals-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/globals-test.js
@@ -1,0 +1,45 @@
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { getOwner } from "@ember/application";
+import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
+import User from "discourse/models/user";
+import Site from "discourse/models/site";
+
+acceptance("Acceptance | Globals", function () {
+  test("Globals function as expected", async function (assert) {
+    await visit("/");
+
+    assert.ok(window.Discourse, "window.Discourse is present");
+
+    assert.strictEqual(
+      window.Discourse,
+      getOwner(this),
+      "matches the expected application instance"
+    );
+
+    withSilencedDeprecations("discourse.global.user", () => {
+      assert.strictEqual(
+        window.Discourse.User,
+        User,
+        "Deprecated User alias is present"
+      );
+    });
+
+    withSilencedDeprecations("discourse.global.site", () => {
+      assert.strictEqual(
+        window.Discourse.Site,
+        Site,
+        "Deprecated Site alias is present"
+      );
+    });
+
+    withSilencedDeprecations("discourse.global.site-settings", () => {
+      assert.strictEqual(
+        window.Discourse.SiteSettings,
+        getOwner(this).lookup("service:site-settings"),
+        "Deprecated SiteSettings alias is present"
+      );
+    });
+  });
+});

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -4279,11 +4279,6 @@ ember-exam@^8.0.0:
     semver "^7.3.2"
     silent-error "^1.1.1"
 
-ember-export-application-global@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
-  integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
-
 ember-functions-as-helper-polyfill@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-functions-as-helper-polyfill/-/ember-functions-as-helper-polyfill-2.1.1.tgz#25240db29b4cd0366a2d2954d2ea26ce0872ff8f"


### PR DESCRIPTION
The work in fa509224f0bbf4ae69c44e01e7a570552d957408 updated our initializer patterns to match modern Ember. This caused the initializer from the (deprecated) ember-export-application-global addon to change its behavior from exporting the ApplicationInstance to exporting the Application. This affects customizations which were using some long-deprecated APIs.

This commit removes the deprecated addon, restores the previous ApplicationInstance behavior which we've come to depend on, and adds a test for the expected behavior. It also bumps the `dropFrom` version to make it clear that we do not intend to remove these APIs during this release cycle.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
