### PR TITLE
DEV: Fix warning when exporting Staff Actions

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -171,12 +171,14 @@ module Jobs
 
       staff_action_data =
         if @current_user.admin?
-          UserHistory.only_staff_actions.order("id DESC")
+          UserHistory.only_staff_actions
         else
-          UserHistory.where(admin_only: false).only_staff_actions.order("id DESC")
+          UserHistory.where(admin_only: false).only_staff_actions
         end
 
-      staff_action_data.find_each { |staff_action| yield get_staff_action_fields(staff_action) }
+      staff_action_data.find_each(order: :desc) do |staff_action|
+        yield get_staff_action_fields(staff_action)
+      end
     end
 
     def screened_email_export


### PR DESCRIPTION
**Context**
This PR improved performance for CSV exports https://github.com/discourse/discourse/pull/22008

**Problem** 
The following message started appearing with the changes 

`Message

Scoped order is ignored, it's forced to be batch order.`

**Solution**
`.order` doesn't work the same way when using `find_each` as with `each`. The correct syntax was implemented