### PR TITLE
FIX: Make the arrow and tooltip background the same color

### DIFF
--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -6,6 +6,10 @@ $d-popover-border: var(--primary-low);
   background: $d-popover-background;
   border: 1px solid var(--primary-low);
   box-shadow: var(--shadow-menu-panel);
+
+  > .tippy-svg-arrow {
+    color: $d-popover-background;
+  }
 }
 
 .tippy-box[data-placement^="top"] .tippy-svg-arrow > svg {
@@ -16,10 +20,6 @@ $d-popover-border: var(--primary-low);
 }
 
 #tippy-rounded-arrow {
-  .svg-content {
-    fill: $d-popover-background;
-  }
-
   .svg-arrow {
     fill: $d-popover-border;
   }

--- a/app/assets/stylesheets/common/base/user-tips.scss
+++ b/app/assets/stylesheets/common/base/user-tips.scss
@@ -20,7 +20,7 @@
     }
   }
 
-  > .tippy-svg-arrow > svg {
+  > .tippy-svg-arrow {
     color: var(--tertiary);
   }
 }

--- a/app/assets/stylesheets/common/base/user-tips.scss
+++ b/app/assets/stylesheets/common/base/user-tips.scss
@@ -52,19 +52,19 @@
 .tippy-box[data-theme~="user-tips"][data-placement^="left"]
   > .tippy-svg-arrow
   > svg {
-  left: 11px;
+  left: 12px;
 }
 
 .tippy-box[data-theme~="user-tips"][data-placement^="top"]
   > .tippy-svg-arrow
   > svg {
-  top: 11px;
+  top: 12px;
 }
 
 .tippy-box[data-theme~="user-tips"][data-placement^="bottom"]
   > .tippy-svg-arrow
   > svg {
-  top: -13px;
+  top: -14px;
   left: -1px;
 }
 


### PR DESCRIPTION
### Before
![image](https://github.com/discourse/discourse/assets/2790986/79bd78c0-3b83-4240-b4ac-681857fdd507)

### After
<img width="373" alt="image" src="https://github.com/discourse/discourse/assets/2790986/c69a8709-5246-4520-882f-c0f5287b538a">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
