### PR TITLE
DEV: more reliable thread level spec

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
@@ -16,7 +16,12 @@
     {{replace-emoji this.label}}
   </span>
 
-  <div class="chat-thread-header__buttons">
+  <div
+    class={{concat-class
+      "chat-thread-header__buttons"
+      (if this.persistedNotificationLevel "-persisted")
+    }}
+  >
     <ThreadNotificationsButton
       @value={{this.threadNotificationLevel}}
       @onChange={{this.updateThreadNotificationLevel}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
@@ -5,11 +5,13 @@ import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 import UserChatThreadMembership from "discourse/plugins/chat/discourse/models/user-chat-thread-membership";
-
+import { tracked } from "@glimmer/tracking";
 export default class ChatThreadHeader extends Component {
   @service currentUser;
   @service chatApi;
   @service router;
+
+  @tracked persistedNotificationLevel = true;
 
   get label() {
     return this.args.thread.escapedTitle;
@@ -42,6 +44,8 @@ export default class ChatThreadHeader extends Component {
 
   @action
   updateThreadNotificationLevel(newNotificationLevel) {
+    this.persistedNotificationLevel = false;
+
     let currentNotificationLevel;
 
     if (this.membership) {
@@ -63,6 +67,8 @@ export default class ChatThreadHeader extends Component {
       .then((response) => {
         this.membership.last_read_message_id =
           response.membership.last_read_message_id;
+
+        this.persistedNotificationLevel = true;
       })
       .catch((err) => {
         this.membership.notificationLevel = currentNotificationLevel;

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -35,6 +35,16 @@ module PageObjects
         )
       end
 
+      def has_notification_level?(level)
+        select_kit =
+          PageObjects::Components::SelectKit.new(
+            ".chat-thread-header__buttons.-persisted .thread-notifications-button",
+          )
+        select_kit.has_selected_value?(
+          ::Chat::UserChatThreadMembership.notification_levels[level.to_sym],
+        )
+      end
+
       def selection_management
         @selection_management ||=
           PageObjects::Components::Chat::SelectionManagement.new(".chat-channel")

--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: tru
       channel_page.reply_to(original_message)
       thread_page.send_message("reply to message")
 
-      expect(thread_page).to have_message(text: message_1.message)
-      expect(thread_page).to have_message(text: "reply to message")
+      expect(thread_page.messages).to have_message(text: message_1.message)
+      expect(thread_page.messages).to have_message(text: "reply to message")
 
       thread_page.close
 

--- a/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
@@ -66,7 +66,7 @@ describe "Thread tracking state | full page", type: :system do
     it "allows the user to change their tracking level for an existing thread" do
       chat_page.visit_thread(thread)
       thread_page.notification_level = :normal
-      expect(thread.reload.membership_for(current_user).notification_level).to eq("normal")
+      expect(thread_page).to have_notification_level("normal")
     end
 
     it "allows the user to start tracking a thread they have not replied to" do
@@ -74,7 +74,7 @@ describe "Thread tracking state | full page", type: :system do
       Fabricate(:chat_message, chat_channel: channel, thread: new_thread)
       chat_page.visit_thread(new_thread)
       thread_page.notification_level = :tracking
-      expect(new_thread.reload.membership_for(current_user).notification_level).to eq("tracking")
+      expect(thread_page).to have_notification_level("tracking")
       chat_page.visit_channel(channel)
       channel_page.open_thread_list
       expect(thread_list_page).to have_thread(new_thread)


### PR DESCRIPTION
Rely on frontend state instead of checking backend state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
