### PR TITLE
FIX: Don't error when clicking on a custom link in community section

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -17,11 +17,15 @@
         @prefixValue={{link.prefixValue}}
         @href={{link.value}}
         @class={{link.linkDragCss}}
-        {{draggable
-          didStartDrag=link.didStartDrag
-          didEndDrag=link.didEndDrag
-          dragMove=link.dragMove
-        }}
+        {{(if
+          this.section.reorderable
+          (modifier
+            "draggable"
+            didStartDrag=link.didStartDrag
+            didEndDrag=link.didEndDrag
+            dragMove=link.dragMove
+          )
+        )}}
       />
     {{else}}
       <Sidebar::SectionLink
@@ -43,7 +47,7 @@
         @currentWhen={{link.currentWhen}}
         @class={{link.linkDragCss}}
         {{(if
-          link.didStartDrag
+          this.section.reorderable
           (modifier
             "draggable"
             didStartDrag=link.didStartDrag

--- a/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/community-section.js
@@ -44,6 +44,8 @@ export default class CommunitySection {
   @tracked links;
   @tracked moreLinks;
 
+  reorderable = false;
+
   constructor({ section, owner }) {
     setOwner(this, owner);
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section.js
@@ -14,6 +14,8 @@ export default class Section {
   @tracked dragCss;
   @tracked links;
 
+  reorderable = true;
+
   constructor({ section, owner }) {
     setOwner(this, owner);
 


### PR DESCRIPTION
The Community section in the sidebar used to be implemented as a hardcoded section in the sidebar with no ability to customize it. However, that has changed with https://github.com/discourse/discourse/commit/709fa24558ec7da797b334d0076613494e9bf408 when we made it possible for admins to customize the Community section. Under the hood, the Community section is now technically implemented as a custom section but some differences/special cases.

One of the differences between the Community section and custom sections is that links in the Community section cannot be reordered, but in custom sections, they can be. However, when custom links in the Community section are rendered, we incorrectly setup event listeners on DOM elements to allow reordering, but they don't work and generate errors when the link is clicked because the Community section doesn't support it.

This PR solves the problem by adding a boolean `reorderable` attribute to the Community section and custom section and checking the attribute before any events are attached to links within a section.

Internal topic: t/103509.