### PR TITLE
FIX: don't add "Re:" prefix in email subject for first post of group PMs.

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -40,7 +40,7 @@ class GroupSmtpMailer < ActionMailer::Base
       template: "user_notifications.user_posted_pm",
       use_topic_title_subject: true,
       topic_title: op_incoming_email&.subject || post.topic.title,
-      add_re_to_subject: true,
+      add_re_to_subject: !post.is_first_post?,
       locale: SiteSetting.default_locale,
       delivery_method_options: delivery_options,
       from: from_group.smtp_from_address,

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe GroupSmtpMailer do
     SiteSetting.reply_by_email_enabled = true
   end
 
+  it "sends an email for first post when IMAP is disabled" do
+    staged = Fabricate(:staged)
+    group.update(imap_enabled: false)
+
+    PostCreator.create!(
+      user,
+      skip_validations: true,
+      title: "Hello from John",
+      archetype: Archetype.private_message,
+      target_usernames: staged.username,
+      target_group_names: group.name,
+      raw: raw,
+    )
+
+    expect(ActionMailer::Base.deliveries.size).to eq(1)
+
+    sent_mail = ActionMailer::Base.deliveries[0]
+    expect(sent_mail.to).to contain_exactly(staged.email)
+    expect(sent_mail.subject).to eq("Hello from John")
+    expect(sent_mail.to_s).to include(raw)
+  end
+
   it "sends an email as reply" do
     post = PostCreator.create(user, topic_id: receiver.incoming_email.topic.id, raw: raw)
 


### PR DESCRIPTION
Previously, it will add a "Re:" prefix to all the emails passing through the group SMTP mailer. It's creating confusion while receiving the mail for the first time on a PM.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
