### PR TITLE
FIX: small bug with topics and my posts translations

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
@@ -40,7 +40,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.everything.title");
+    return I18n.t("sidebar.sections.community.links.topics.title");
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -74,7 +74,7 @@ export default class MyPostsSectionLink extends BaseSectionLink {
       return I18n.t(
         `sidebar.sections.community.links.${this.overridenName
           .toLowerCase()
-          .replace(" ", "/")}.content`,
+          .replace(" ", "_")}.content`,
         { defaultValue: this.overridenName }
       );
     }


### PR DESCRIPTION
1. `everything` was changed to `topics`
2. Path for my posts translation is `sidebar.sections.community.links.my_posts.content` not `sidebar.sections.community.links.my/posts.content`
