### PR TITLE
FIX broken topic embedding because of incomplete security patch (#22088)

### DIFF
--- a/lib/topic_retriever.rb
+++ b/lib/topic_retriever.rb
@@ -50,6 +50,6 @@ class TopicRetriever
     user = User.where(username_lower: username.downcase).first
     return if user.blank?
 
-    TopicEmbed.import_remote(user, @embed_url)
+    TopicEmbed.import_remote(@embed_url, user: user)
   end
 end


### PR DESCRIPTION
Topic embedding is completely broken in v3.0.4 stable. This patch fixes that issue.

See https://meta.discourse.org/t/change-in-3-0-4-broke-embedding/268559/7

