### PR TITLE
DEV: Simplify search code

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -222,7 +222,10 @@ class Search
   attr_reader :clean_term, :guardian
 
   def initialize(term, opts = nil)
-    opts = opts || {}
+    # @opts is maintained for backwards compatability
+    # additionally some plugins like saved-search will tack on
+    # options
+    @opts = opts = opts || {}
 
     @guardian = opts[:guardian] || Guardian.new
     @search_context = opts[:search_context]

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe SearchLog, type: :model do
       freeze_time(time)
 
       search_log = Fabricate(:search_log, created_at: time - 1.hour)
-      search_log2 = Fabricate(:search_log, created_at: time + 1.hour)
+      _search_log2 = Fabricate(:search_log, created_at: time + 1.hour)
 
       details = SearchLog.term_details(search_log.term, :daily)
 


### PR DESCRIPTION
Previously we used to have an @opts var that had a back of options we
would reach for.

It makes reasoning about the code much more complicated.

Longer term we probably want to change to using named args, but this is
an important first move in the department

Also bolts on to a test to ensure SearchLog is properly called when IP is
supplied. This was not specified previously.
