### PR TITLE
FIX: Use Twitter API v2 for oneboxes and restore OpenGraph fallback

### DIFF
--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -6,6 +6,7 @@ module Onebox
       include Engine
       include LayoutSupport
       include HTML
+      include ActionView::Helpers::NumberHelper
 
       matches_regexp(
         %r{^https?://(mobile\.|www\.)?twitter\.com/.+?/status(es)?/\d+(/(video|photo)/\d?+)?+(/?\?.*)?/?$},
@@ -162,7 +163,18 @@ module Onebox
     end
 
     def prettify_number(count)
-      count > 0 ? client.prettify_number(count) : nil
+      if count > 0
+        number_to_human(
+          count,
+          format: "%n%u",
+          precision: 2,
+          units: {
+            thousand: "K",
+            million: "M",
+            billion: "B",
+          },
+        )
+      end
     end
 
     def attr_at_css(css_property, attribute_name)

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -12,23 +12,50 @@ module Onebox
       )
       always_https
 
-      def self.===(other)
-        client = Onebox.options.twitter_client
-        client && !client.twitter_credentials_missing? && super
-      end
-
       def http_params
         { "User-Agent" => "DiscourseBot/1.0" }
       end
 
-      def to_html
-        raw.present? ? super : ""
-      end
-
       private
+
+      def get_twitter_data
+        response =
+          begin
+            Onebox::Helpers.fetch_response(url, headers: http_params)
+          rescue StandardError
+            nil
+          end
+        html = Nokogiri.HTML(response)
+        twitter_data = {}
+        html
+          .css("meta")
+          .each do |m|
+            if m.attribute("property") && m.attribute("property").to_s.match(/^og:/i)
+              m_content = m.attribute("content").to_s.strip
+              m_property = m.attribute("property").to_s.gsub("og:", "").gsub(":", "_")
+              twitter_data[m_property.to_sym] = m_content
+            end
+          end
+        twitter_data
+      end
 
       def match
         @match ||= @url.match(%r{twitter\.com/.+?/status(es)?/(?<id>\d+)})
+      end
+
+      def twitter_data
+        @twitter_data ||= get_twitter_data
+      end
+
+      def guess_tweet_index
+        usernames = meta_tags_data("additionalName").compact
+        usernames.each_with_index do |username, index|
+          return index if twitter_data[:url].to_s.include?(username)
+        end
+      end
+
+      def tweet_index
+        @tweet_index ||= guess_tweet_index
       end
 
       def client
@@ -51,72 +78,132 @@ module Onebox
       end
 
       def tweet
-        client.prettify_tweet(raw)&.strip
+        if twitter_api_credentials_present?
+          client.prettify_tweet(raw)&.strip
+        else
+          twitter_data[:description].gsub(/“(.+?)”/im) { $1 } if twitter_data[:description]
+        end
       end
 
       def timestamp
-        date = DateTime.strptime(access(:created_at), "%a %b %d %H:%M:%S %z %Y")
-        user_offset = access(:user, :utc_offset).to_i
-        offset = (user_offset >= 0 ? "+" : "-") + Time.at(user_offset.abs).gmtime.strftime("%H%M")
-        date.new_offset(offset).strftime("%-l:%M %p - %-d %b %Y")
+        if twitter_api_credentials_present?
+          date = DateTime.strptime(access(:created_at), "%a %b %d %H:%M:%S %z %Y")
+          user_offset = access(:user, :utc_offset).to_i
+          offset = (user_offset >= 0 ? "+" : "-") + Time.at(user_offset.abs).gmtime.strftime("%H%M")
+          date.new_offset(offset).strftime("%-l:%M %p - %-d %b %Y")
+        else
+          attr_at_css(".tweet-timestamp", "title")
+        end
       end
 
       def title
-        access(:user, :name)
+        if twitter_api_credentials_present?
+          access(:user, :name)
+        else
+          meta_tags_data("givenName")[tweet_index]
+        end
       end
 
       def screen_name
-        access(:user, :screen_name)
+        if twitter_api_credentials_present?
+          access(:user, :screen_name)
+        else
+          meta_tags_data("additionalName")[tweet_index]
+        end
       end
+    end
 
-      def avatar
+    def avatar
+      if twitter_api_credentials_present?
         access(:user, :profile_image_url_https).sub("normal", "400x400")
+      elsif twitter_data[:image]
+        twitter_data[:image] unless twitter_data[:image_user_generated]
       end
+    end
 
-      def likes
+    def likes
+      if twitter_api_credentials_present?
         prettify_number(access(:favorite_count).to_i)
+      else
+        attr_at_css(".request-favorited-popup", "data-compact-localized-count")
       end
+    end
 
-      def retweets
+    def retweets
+      if twitter_api_credentials_present?
         prettify_number(access(:retweet_count).to_i)
+      else
+        attr_at_css(".request-retweeted-popup", "data-compact-localized-count")
       end
+    end
 
-      def quoted_full_name
+    def quoted_full_name
+      if twitter_api_credentials_present?
         access(:quoted_status, :user, :name)
+      else
+        raw.css(".QuoteTweet-fullname")[0]&.text
       end
+    end
 
-      def quoted_screen_name
+    def quoted_screen_name
+      if twitter_api_credentials_present?
         access(:quoted_status, :user, :screen_name)
+      else
+        attr_at_css(".QuoteTweet-innerContainer", "data-screen-name")
       end
+    end
 
-      def quoted_tweet
+    def quoted_tweet
+      if twitter_api_credentials_present?
         access(:quoted_status, :full_text)
+      else
+        raw.css(".QuoteTweet-text")[0]&.text
       end
+    end
 
-      def quoted_link
+    def quoted_link
+      if twitter_api_credentials_present?
         "https://twitter.com/#{quoted_screen_name}/status/#{access(:quoted_status, :id)}"
+      else
+        "https://twitter.com#{attr_at_css(".QuoteTweet-innerContainer", "href")}"
       end
+    end
 
-      def prettify_number(count)
-        count > 0 ? client.prettify_number(count) : nil
-      end
+    def prettify_number(count)
+      count > 0 ? client.prettify_number(count) : nil
+    end
 
-      def data
-        @data ||= {
-          link: link,
-          tweet: tweet,
-          timestamp: timestamp,
-          title: title,
-          screen_name: screen_name,
-          avatar: avatar,
-          likes: likes,
-          retweets: retweets,
-          quoted_tweet: quoted_tweet,
-          quoted_full_name: quoted_full_name,
-          quoted_screen_name: quoted_screen_name,
-          quoted_link: quoted_link,
-        }
-      end
+    def attr_at_css(css_property, attribute_name)
+      raw.at_css(css_property)&.attr(attribute_name)
+    end
+
+    def meta_tags_data(attribute_name)
+      data = []
+      raw
+        .css("meta")
+        .each do |m|
+          if m.attribute("itemprop") && m.attribute("itemprop").to_s.strip == attribute_name
+            data.push(m.attribute("content").to_s.strip)
+          end
+        end
+      data
+    end
+
+    def data
+      @data ||= {
+        link: link,
+        tweet: tweet,
+        timestamp: timestamp,
+        title: title,
+        screen_name: screen_name,
+        avatar: avatar,
+        likes: likes,
+        retweets: retweets,
+        quoted_tweet: quoted_tweet,
+        quoted_full_name: quoted_full_name,
+        quoted_screen_name: quoted_screen_name,
+        quoted_link: quoted_link,
+      }
     end
   end
 end

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -101,15 +101,15 @@ module Onebox
       end
 
       def timestamp
-        if twitter_api_credentials_present? && raw[:data][:created_at]
-          date = DateTime.strptime(raw[:data][:created_at], "%Y-%m-%dT%H:%M:%S.%L%z")
+        if twitter_api_credentials_present? && (created_at = raw.dig(:data, :created_at))
+          date = DateTime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%L%z")
           date.strftime("%-l:%M %p - %-d %b %Y")
         end
       end
 
       def title
-        if twitter_api_credentials_present? && raw[:includes][:users][0][:name]
-          raw[:includes][:users][0][:name]
+        if twitter_api_credentials_present?
+          raw.dig(:includes, :users)&.first&.dig(:name)
         else
           meta_tags_data("givenName")[tweet_index]
         end
@@ -117,25 +117,27 @@ module Onebox
 
       def screen_name
         if twitter_api_credentials_present?
-          raw[:includes][:users][0][:username]
+          raw.dig(:includes, :users)&.first&.dig(:username)
         else
           meta_tags_data("additionalName")[tweet_index]
         end
       end
 
       def avatar
-        raw[:includes][:users][0][:profile_image_url] if twitter_api_credentials_present?
+        if twitter_api_credentials_present?
+          raw.dig(:includes, :users)&.first&.dig(:profile_image_url)
+        end
       end
 
       def likes
         if twitter_api_credentials_present?
-          prettify_number(raw[:data][:public_metrics][:like_count].to_i)
+          prettify_number(raw.dig(:data, :public_metrics, :like_count).to_i)
         end
       end
 
       def retweets
         if twitter_api_credentials_present?
-          prettify_number(raw[:data][:public_metrics][:retweet_count].to_i)
+          prettify_number(raw.dig(:data, :public_metrics, :retweet_count).to_i)
         end
       end
 

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -16,6 +16,10 @@ module Onebox
         { "User-Agent" => "DiscourseBot/1.0" }
       end
 
+      def to_html
+        raw.present? ? super : ""
+      end
+
       private
 
       def get_twitter_data
@@ -64,6 +68,7 @@ module Onebox
 
       def twitter_api_credentials_present?
         client && !client.twitter_credentials_missing?
+        false
       end
 
       def raw

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -67,7 +67,11 @@ module Onebox
       end
 
       def raw
-        @raw ||= client.status(match[:id]).to_hash if twitter_api_credentials_present?
+        if twitter_api_credentials_present?
+          @raw ||= OpenStruct.new(client.status(match[:id]).to_hash)
+        else
+          super
+        end
       end
 
       def access(*keys)

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -107,11 +107,7 @@ module Onebox
     end
 
     def avatar
-      if twitter_api_credentials_present?
-        raw["includes"]["users"][0]["profile_image_url"]
-      elsif twitter_data[:image]
-        twitter_data[:image] unless twitter_data[:image_user_generated]
-      end
+      raw["includes"]["users"][0]["profile_image_url"] if twitter_api_credentials_present?
     end
 
     def likes

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -28,7 +28,7 @@ module Onebox
           begin
             Onebox::Helpers.fetch_response(url, headers: http_params)
           rescue StandardError
-            nil
+            return nil
           end
         html = Nokogiri.HTML(response)
         twitter_data = {}

--- a/lib/onebox/templates/twitterstatus.mustache
+++ b/lib/onebox/templates/twitterstatus.mustache
@@ -4,15 +4,15 @@
 
 <div class="tweet">
   <span class="tweet-description">{{{tweet}}}</span>
-  {{#quoted_tweet}}
+  {{#quoted_text}}
     <div class="quoted">
       <a class="quoted-link" href="{{quoted_link}}">
         <p class="quoted-title">{{quoted_full_name}} <span>@{{quoted_screen_name}}</span></p>
       </a>
 
-      <div>{{quoted_tweet}}</div>
+      <div>{{quoted_text}}</div>
     </div>
-  {{/quoted_tweet}}
+  {{/quoted_text}}
 </div>
 
 <div class="date">

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -12,12 +12,12 @@ class TwitterApi
     ]
 
     def prettify_tweet(tweet)
-      text = tweet["data"]["text"].dup
-      if (entities = tweet["data"]["entities"]) && (urls = entities["urls"])
+      text = tweet[:data][:text].dup.to_s
+      if (entities = tweet[:data][:entities]) && (urls = entities[:urls])
         urls.each do |url|
           text.gsub!(
-            url["url"],
-            "<a target='_blank' href='#{url["expanded_url"]}'>#{url["display_url"]}</a>",
+            url[:url],
+            "<a target='_blank' href='#{url[:expanded_url]}'>#{url[:display_url]}</a>",
           )
         end
       end
@@ -26,23 +26,23 @@ class TwitterApi
 
       result = Rinku.auto_link(text, :all, 'target="_blank"').to_s
 
-      if tweet["includes"] && media = tweet["includes"]["media"]
+      if tweet[:includes] && media = tweet[:includes][:media]
         media.each do |m|
-          if m["type"] == "photo"
-            result << "<div class='tweet-images'><img class='tweet-image' src='#{m["url"]}' width='#{m["width"]}' height='#{m["height"]}'></div>"
-          elsif m["type"] == "video" || m["type"] == "animated_gif"
+          if m[:type] == "photo"
+            result << "<div class='tweet-images'><img class='tweet-image' src='#{m[:url]}' width='#{m[:width]}' height='#{m[:height]}'></div>"
+          elsif m[:type] == "video" || m[:type] == "animated_gif"
             video_to_display =
-              m["variants"]
-                .select { |v| v["content_type"] == "video/mp4" }
-                .sort { |v| v["bit_rate"] }
+              m[:variants]
+                .select { |v| v[:content_type] == "video/mp4" }
+                .sort { |v| v[:bit_rate] }
                 .last # choose highest bitrate
 
-            if video_to_display && url = video_to_display["url"]
-              width = m["width"]
-              height = m["height"]
+            if video_to_display && url = video_to_display[:url]
+              width = m[:width]
+              height = m[:height]
 
               attributes =
-                if m["type"] == "animated_gif"
+                if m[:type] == "animated_gif"
                   %w[playsinline loop muted autoplay disableRemotePlayback disablePictureInPicture]
                 else
                   %w[controls playsinline]
@@ -54,7 +54,7 @@ class TwitterApi
                     <video class='tweet-video' #{attributes}
                       width='#{width}'
                       height='#{height}'
-                      poster='#{m["preview_image_url"]}'>
+                      poster='#{m[:preview_image_url]}'>
                       <source src='#{url}' type="video/mp4">
                     </video>
                   </div>

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -3,8 +3,6 @@
 # lightweight Twitter api calls
 class TwitterApi
   class << self
-    include ActionView::Helpers::NumberHelper
-
     BASE_URL = "https://api.twitter.com"
     URL_PARAMS = %w[
       tweet.fields=id,author_id,text,created_at,entities,referenced_tweets,public_metrics
@@ -68,19 +66,6 @@ class TwitterApi
       end
 
       result
-    end
-
-    def prettify_number(count)
-      number_to_human(
-        count,
-        format: "%n%u",
-        precision: 2,
-        units: {
-          thousand: "K",
-          million: "M",
-          billion: "B",
-        },
-      )
     end
 
     def tweet_for(id)

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -111,7 +111,7 @@ class TwitterApi
     end
 
     def tweet_uri_for(id)
-      URI.parse "#{BASE_URL}/1.1/statuses/show.json?id=#{id}&tweet_mode=extended"
+      URI.parse "#{BASE_URL}/2/tweets?ids=#{id}"
     end
 
     def twitter_get(uri)

--- a/spec/fixtures/onebox/twitterstatus.response
+++ b/spec/fixtures/onebox/twitterstatus.response
@@ -1,2814 +1,1867 @@
 <!DOCTYPE html>
-<html lang="en" data-scribe-reduced-action-queue="true">
-  <head>
-
-
-
-
-
-
-
-    <meta charset="utf-8">
-
-    <noscript><meta http-equiv="refresh" content="0; URL=https://mobile.twitter.com/i/nojs_router?path=%2Fvyki_e%2Fstatus%2F363116819147538433"></noscript>
-
-
-
-  <script id="bouncer_terminate_iframe" nonce="KXwIjaJlN1QIxC47iHrsvQ==">
-    if (window.top != window) {
-  window.top.postMessage({'bouncer': true, 'event': 'complete'}, '*');
-}
-  </script>
-  <script id="swift_action_queue" nonce="KXwIjaJlN1QIxC47iHrsvQ==">
-    (function(){function m(a){a||(a=window.event);if(!a)return!1;a.timestamp=(new Date).getTime();!a.target&&a.srcElement&&(a.target=a.srcElement);if(document.documentElement.getAttribute("data-scribe-reduced-action-queue")){var b=a.target;while(b&&b!=document
-.body){if(b.tagName=="A")return;b=b.parentNode}}r("all",s(a));if(!q(a)){r("direct",a);return!0}document.addEventListener||(a=s(a));a.preventDefault=a.stopPropagation=a.stopImmediatePropagation=function(){};if(i){f.push(a);r("captured",a)}else r("ignored",a
-);return!1}function n($){p();for(var a=0,b;b=f[a];a++){var d=$(b.target),e=d.closest("a")[0];if(b.type=="click"&&e){var g=$.data(e,"events"),i=g&&g.click,j=!e.hostname.match(c)||!e.href.match(/#$/);if(!i&&j){window.location=e.href;continue}}d.trigger($.event
-.fix(b))}window.swiftActionQueue.wasFlushed=!0}function o(){for(var a in j){if(a=="all")continue;var b=j[a];for(var c=0;c<b.length;c++)console.log("actionQueue",u(b[c]))}}function p(){clearTimeout(g);for(var a=0,b;b=e[a];a++)document["on"+b]=null}function q
-(a){if(!a.target)return!1;var b=a.target,e=(b.tagName||"").toLowerCase();if(a.metaKey)return!1;if(a.shiftKey&&e=="a")return!1;if(b.hostname&&!b.hostname.match(c))return!1;if(a.type.match(d)&&w(b))return!1;if(e=="label"){var f=b.getAttribute("for");if(f){var g=
-document.getElementById(f);if(g&&v(g))return!1}else for(var i=0,j;j=b.childNodes[i];i++)if(v(j))return!1}return!0}function r(a,b){b.bucket=a;j[a].push(b)}function s(a){var b={};for(var c in a)b[c]=a[c];return b}function t(a){while(a&&a!=document.body){if(a
-.tagName=="A")return a;a=a.parentNode}}function u(b){var c=[];b.bucket&&c.push("["+b.bucket+"]");c.push(b.type);var d=b.target,e=t(d),f="",g,i,j=b.timestamp&&b.timestamp-a;if(b.type==="click"&&e){g=e.className.trim().replace(/\s+/g,".");i=e.id.trim();f=/[^#]$/
-.test(e.href)?" ("+e.href+")":"";d='"'+e.innerText.replace(/\n+/g," ").trim()+'"'}else{g=d.className.trim().replace(/\s+/g,".");i=d.id.trim();d=d.tagName.toLowerCase();b.keyCode&&(d=String.fromCharCode(b.keyCode)+" : "+d)}c.push(d+f+(i&&"#"+i)+(!i&&g?"."+g
-:""));j&&c.push(j);return c.join(" ")}function v(a){var b=(a.tagName||"").toLowerCase();return b=="input"&&a.getAttribute("type")=="checkbox"}function w(a){var b=(a.tagName||"").toLowerCase();return b=="textarea"||b=="input"&&a.getAttribute("type")=="text"||
-a.getAttribute("contenteditable")=="true"}var a=(new Date).getTime(),b=1e4,c=/^([^\.]+\.)*twitter\.com$/,d=/^key/,e=["click","keydown","keypress","keyup"],f=[],g=null,i=!0,j={captured:[],ignored:[],direct:[],all:[]};for(var k=0,l;l=e[k];k++)document["on"+l
-]=m;g=setTimeout(function(){i=!1},b);window.swiftActionQueue={buckets:j,flush:n,logActions:o,wasFlushed:!1}})();
-  </script>
-  <script id="composition_state" nonce="KXwIjaJlN1QIxC47iHrsvQ==">
-    (function(){function a(a){a.target.setAttribute("data-in-composition","true")}function b(a){a.target.removeAttribute("data-in-composition")}if(document.addEventListener){document.addEventListener("compositionstart",a,!1);document.addEventListener("compositionend"
-,b,!1)}})();
-  </script>
-  <script id="load_js" nonce="KXwIjaJlN1QIxC47iHrsvQ==">
-    /*! loadJS: load a JS file asynchronously. [c]2014 @scottjehl, Filament Group, Inc. (Based on http://goo.gl/REQGQ by Paul Irish). Licensed MIT */(function(a){var b=function(b,c){"use strict";var d=a.document.getElementsByTagName("script")[0],e=a.document.createElement
-("script");e.src=b;e.async=!0;d.parentNode.insertBefore(e,d);c&&typeof c=="function"&&(e.onload=c);return e};typeof module!="undefined"?module.exports=b:a.loadJS=b})(typeof global!="undefined"?global:this);
-  </script>
-
-    <link rel="stylesheet" href="https://abs.twimg.com/a/1467966468/css/t1/twitter_core.bundle.css">
-  <link rel="stylesheet" href="https://abs.twimg.com/a/1467966468/css/t1/twitter_more_1.bundle.css">
-  <link rel="stylesheet" href="https://abs.twimg.com/a/1467966468/css/t1/twitter_more_2.bundle.css">
-
-    <link rel="dns-prefetch" href="https://pbs.twimg.com">
-    <link rel="dns-prefetch" href="https://t.co">
-      <link rel="preload" href="https://abs.twimg.com/c/swift/en/init.314a9707f177773430c9b565030e9ea5b8638c96.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/timeline.20389bc2f54407a5eb508e248a2a7a64457c0609.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/c/swift/en/bundle/boot.c09735539d966801edba73cbc8a86a0042072a93.js" as="script">
-
-      <title>Vyki Englert on Twitter: &quot;I&#39;m a sucker for pledges.  @Peers Pledge #sharingeconomy http://t.co/T4Sc47KAzh&quot;</title>
-      <meta name="robots" content="NOODP">
-
-
-
-
-<meta name="msapplication-TileImage" content="//abs.twimg.com/favicons/win8-tile-144.png"/>
-<meta name="msapplication-TileColor" content="#00aced"/>
-
-
-<link rel="mask-icon" sizes="any" href="https://abs.twimg.com/a/1467966468/img/t1/favicon.svg" color="#55acee">
-
-<link href="//abs.twimg.com/favicons/favicon.ico" rel="shortcut icon" type="image/x-icon">
-
-<link rel="manifest" href="/manifest.json">
-
-
-  <meta name="swift-page-name" id="swift-page-name" content="permalink">
-
-    <link rel="canonical" href="https://twitter.com/vyki_e/status/363116819147538433">
-  <link rel="alternate" hreflang="x-default" href="https://twitter.com/vyki_e/status/363116819147538433">
-  <link rel="alternate" hreflang="fr" href="https://twitter.com/vyki_e/status/363116819147538433?lang=fr"><link rel="alternate" hreflang="en" href="https://twitter.com/vyki_e/status/363116819147538433?lang=en"><link rel="alternate" hreflang="ar" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ar"><link rel="alternate" hreflang="ja" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ja"><link rel="alternate" hreflang="es" href="https://twitter.com/vyki_e/status/363116819147538433?lang=es"><link rel="alternate" hreflang="de" href="https://twitter.com/vyki_e/status/363116819147538433?lang=de"><link rel="alternate" hreflang="it" href="https://twitter.com/vyki_e/status/363116819147538433?lang=it"><link rel="alternate" hreflang="id" href="https://twitter.com/vyki_e/status/363116819147538433?lang=id"><link rel="alternate" hreflang="pt" href="https://twitter.com/vyki_e/status/363116819147538433?lang=pt"><link rel="alternate" hreflang="ko" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ko"><link rel="alternate" hreflang="tr" href="https://twitter.com/vyki_e/status/363116819147538433?lang=tr"><link rel="alternate" hreflang="ru" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ru"><link rel="alternate" hreflang="nl" href="https://twitter.com/vyki_e/status/363116819147538433?lang=nl"><link rel="alternate" hreflang="fil" href="https://twitter.com/vyki_e/status/363116819147538433?lang=fil"><link rel="alternate" hreflang="ms" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ms"><link rel="alternate" hreflang="zh-tw" href="https://twitter.com/vyki_e/status/363116819147538433?lang=zh-tw"><link rel="alternate" hreflang="zh-cn" href="https://twitter.com/vyki_e/status/363116819147538433?lang=zh-cn"><link rel="alternate" hreflang="hi" href="https://twitter.com/vyki_e/status/363116819147538433?lang=hi"><link rel="alternate" hreflang="no" href="https://twitter.com/vyki_e/status/363116819147538433?lang=no"><link rel="alternate" hreflang="sv" href="https://twitter.com/vyki_e/status/363116819147538433?lang=sv"><link rel="alternate" hreflang="fi" href="https://twitter.com/vyki_e/status/363116819147538433?lang=fi"><link rel="alternate" hreflang="da" href="https://twitter.com/vyki_e/status/363116819147538433?lang=da"><link rel="alternate" hreflang="pl" href="https://twitter.com/vyki_e/status/363116819147538433?lang=pl"><link rel="alternate" hreflang="hu" href="https://twitter.com/vyki_e/status/363116819147538433?lang=hu"><link rel="alternate" hreflang="fa" href="https://twitter.com/vyki_e/status/363116819147538433?lang=fa"><link rel="alternate" hreflang="he" href="https://twitter.com/vyki_e/status/363116819147538433?lang=he"><link rel="alternate" hreflang="ur" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ur"><link rel="alternate" hreflang="th" href="https://twitter.com/vyki_e/status/363116819147538433?lang=th"><link rel="alternate" hreflang="uk" href="https://twitter.com/vyki_e/status/363116819147538433?lang=uk"><link rel="alternate" hreflang="ca" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ca"><link rel="alternate" hreflang="ga" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ga"><link rel="alternate" hreflang="el" href="https://twitter.com/vyki_e/status/363116819147538433?lang=el"><link rel="alternate" hreflang="eu" href="https://twitter.com/vyki_e/status/363116819147538433?lang=eu"><link rel="alternate" hreflang="cs" href="https://twitter.com/vyki_e/status/363116819147538433?lang=cs"><link rel="alternate" hreflang="gl" href="https://twitter.com/vyki_e/status/363116819147538433?lang=gl"><link rel="alternate" hreflang="ro" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ro"><link rel="alternate" hreflang="hr" href="https://twitter.com/vyki_e/status/363116819147538433?lang=hr"><link rel="alternate" hreflang="en-gb" href="https://twitter.com/vyki_e/status/363116819147538433?lang=en-gb"><link rel="alternate" hreflang="vi" href="https://twitter.com/vyki_e/status/363116819147538433?lang=vi"><link rel="alternate" hreflang="bn" href="https://twitter.com/vyki_e/status/363116819147538433?lang=bn"><link rel="alternate" hreflang="bg" href="https://twitter.com/vyki_e/status/363116819147538433?lang=bg"><link rel="alternate" hreflang="sr" href="https://twitter.com/vyki_e/status/363116819147538433?lang=sr"><link rel="alternate" hreflang="sk" href="https://twitter.com/vyki_e/status/363116819147538433?lang=sk"><link rel="alternate" hreflang="gu" href="https://twitter.com/vyki_e/status/363116819147538433?lang=gu"><link rel="alternate" hreflang="mr" href="https://twitter.com/vyki_e/status/363116819147538433?lang=mr"><link rel="alternate" hreflang="ta" href="https://twitter.com/vyki_e/status/363116819147538433?lang=ta"><link rel="alternate" hreflang="kn" href="https://twitter.com/vyki_e/status/363116819147538433?lang=kn">
-
-    <link rel="alternate" type="application/json+oembed" href="https://publish.twitter.com/oembed?url=https://twitter.com/vyki_e/status/363116819147538433" title="Vyki Englert on Twitter: &quot;I&#39;m a sucker for pledges.  @Peers Pledge #sharingeconomy http://t.co/T4Sc47KAzh&quot;">
-
-
-  <link rel="alternate" media="handheld, only screen and (max-width: 640px)" href="https://mobile.twitter.com/vyki_e/status/363116819147538433">
-
-      <link rel="alternate" href="android-app://com.twitter.android/twitter/tweet?status_id=363116819147538433&amp;ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Estatus%7Ctwterm%5E363116819147538433">
-
+<html dir="ltr" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover">
+<link rel="preconnect" href="//abs.twimg.com">
+<link rel="dns-prefetch" href="//abs.twimg.com">
+<link rel="preconnect" href="//api.twitter.com">
+<link rel="dns-prefetch" href="//api.twitter.com">
+<link rel="preconnect" href="//pbs.twimg.com">
+<link rel="dns-prefetch" href="//pbs.twimg.com">
+<link rel="preconnect" href="//t.co">
+<link rel="dns-prefetch" href="//t.co">
+<link rel="preconnect" href="//video.twimg.com">
+<link rel="dns-prefetch" href="//video.twimg.com">
+<meta property="fb:app_id" content="2231777543">
+<meta property="og:site_name" content="Twitter">
+<meta name="google-site-verification" content="acYOOcR5z6puMzLn6hLDZI1nNHXPxt57OIstz1vnCV0">
+<meta name="facebook-domain-verification" content="x6sdcc8b5ju3bh8nbm59eswogvg6t1">
+<meta http-equiv="onion-location" content="https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/">
+<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
 <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
-
-    <link id="async-css-placeholder">
-
-        <meta  property="og:type" content="article">
-        <meta  property="og:url" content="https://twitter.com/vyki_e/status/363116819147538433">
-        <meta  property="og:title" content="Vyki Englert on Twitter">
-        <meta  property="og:image" content="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_400x400.jpg">
-        <meta  property="og:description" content="“I&#39;m a sucker for pledges.  @Peers Pledge #sharingeconomy http://t.co/T4Sc47KAzh”">
-        <meta  property="og:site_name" content="Twitter">
-        <meta  property="fb:app_id" content="2231777543">
-      <input type="hidden" id="init-data" class="json-data" value="{&quot;keyboardShortcuts&quot;:[{&quot;name&quot;:&quot;Actions&quot;,&quot;description&quot;:&quot;Shortcuts for common actions.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;Enter&quot;],&quot;description&quot;:&quot;Open Tweet details&quot;},{&quot;keys&quot;:[&quot;o&quot;],&quot;description&quot;:&quot;Expand photo&quot;},{&quot;keys&quot;:[&quot;\/&quot;],&quot;description&quot;:&quot;Search&quot;}]},{&quot;name&quot;:&quot;Navigation&quot;,&quot;description&quot;:&quot;Shortcuts for navigating between items in timelines.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;?&quot;],&quot;description&quot;:&quot;This menu&quot;},{&quot;keys&quot;:[&quot;j&quot;],&quot;description&quot;:&quot;Next Tweet&quot;},{&quot;keys&quot;:[&quot;k&quot;],&quot;description&quot;:&quot;Previous Tweet&quot;},{&quot;keys&quot;:[&quot;Space&quot;],&quot;description&quot;:&quot;Page down&quot;},{&quot;keys&quot;:[&quot;.&quot;],&quot;description&quot;:&quot;Load new Tweets&quot;}]},{&quot;name&quot;:&quot;Timelines&quot;,&quot;description&quot;:&quot;Shortcuts for navigating to different timelines or pages.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;g&quot;,&quot;u&quot;],&quot;description&quot;:&quot;Go to user\u2026&quot;}]}],&quot;jsInitDelay&quot;:0,&quot;hasKenburnEffectOnSingleImage&quot;:false,&quot;composeIgnoreAttachmentText&quot;:false,&quot;baseFoucClass&quot;:&quot;swift-loading&quot;,&quot;bodyFoucClassNames&quot;:&quot;swift-loading&quot;,&quot;macawSwift&quot;:true,&quot;assetsBasePath&quot;:&quot;https:\/\/abs.twimg.com\/a\/1467966468\/&quot;,&quot;assetVersionKey&quot;:&quot;f28314&quot;,&quot;environment&quot;:&quot;production&quot;,&quot;formAuthenticityToken&quot;:&quot;0ca3d94aff5192efa7e34ae4eae60d07f5babd38&quot;,&quot;loggedIn&quot;:false,&quot;softUserLoggedIn&quot;:false,&quot;screenName&quot;:null,&quot;fullName&quot;:null,&quot;userId&quot;:null,&quot;guestId&quot;:&quot;142926596918437608&quot;,&quot;allowAdsPersonalization&quot;:true,&quot;scribeBufferSize&quot;:3,&quot;pageName&quot;:&quot;permalink&quot;,&quot;sectionName&quot;:&quot;permalink&quot;,&quot;scribeParameters&quot;:{},&quot;recaptchaApiUrl&quot;:&quot;https:\/\/www.google.com\/recaptcha\/api\/js\/recaptcha_ajax.js&quot;,&quot;internalReferer&quot;:null,&quot;geoEnabled&quot;:false,&quot;typeaheadData&quot;:{&quot;accounts&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;limit&quot;:6},&quot;trendLocations&quot;:{&quot;enabled&quot;:true},&quot;dmConversations&quot;:{&quot;enabled&quot;:false},&quot;savedSearches&quot;:{&quot;enabled&quot;:false,&quot;items&quot;:[]},&quot;dmAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyDMable&quot;:true},&quot;mediaTagAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:true,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyShowUsersWithCanMediaTag&quot;:false,&quot;currentUserId&quot;:-1},&quot;selectedUsers&quot;:{&quot;enabled&quot;:false},&quot;prefillUsers&quot;:{&quot;enabled&quot;:false},&quot;topics&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:4},&quot;concierge&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:6},&quot;recentSearches&quot;:{&quot;enabled&quot;:false},&quot;hashtags&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500},&quot;useIndexedDB&quot;:false,&quot;showSearchAccountSocialContext&quot;:false,&quot;showDebugInfo&quot;:false,&quot;useThrottle&quot;:true,&quot;accountsOnTop&quot;:false,&quot;remoteDebounceInterval&quot;:300,&quot;remoteThrottleInterval&quot;:300,&quot;tweetContextEnabled&quot;:false,&quot;fullNameMatchingInCompose&quot;:true,&quot;topicsWithFiltersEnabled&quot;:false},&quot;dm&quot;:{&quot;notifications&quot;:false,&quot;usePushForNotifications&quot;:false,&quot;participant_max&quot;:50,&quot;video_gif_render&quot;:true,&quot;video_gif_upload&quot;:true,&quot;twitter_video_player&quot;:true,&quot;typing_indicators_publish&quot;:false,&quot;poll_options&quot;:{&quot;foreground_poll_interval&quot;:3000,&quot;burst_poll_interval&quot;:3000,&quot;burst_poll_duration&quot;:300000,&quot;max_poll_interval&quot;:60000}},&quot;whitelistedVideoUser&quot;:false,&quot;autoplayDisabled&quot;:false,&quot;pushStatePageLimit&quot;:500000,&quot;routes&quot;:{&quot;profile&quot;:&quot;\/&quot;},&quot;pushState&quot;:true,&quot;viewContainer&quot;:&quot;#page-container&quot;,&quot;dragAndDropPhotoUpload&quot;:true,&quot;href&quot;:&quot;\/vyki_e\/status\/363116819147538433&quot;,&quot;searchPathWithQuery&quot;:&quot;\/search?q=query&amp;src=typd&quot;,&quot;timelineCardsGallery&quot;:true,&quot;composeAltText&quot;:false,&quot;deciders&quot;:{&quot;bulkUnfollowEnabled&quot;:true,&quot;custom_timeline_curation&quot;:false,&quot;moment_maker_enabled&quot;:false,&quot;disable_profile_popup&quot;:false,&quot;native_notifications&quot;:true,&quot;dm_polling_frequency_in_seconds&quot;:3000,&quot;enable_media_tag_prefetch&quot;:true,&quot;foundMediaTrendingEnabled&quot;:false,&quot;enableMacawNymizerConversionLanding&quot;:false,&quot;hqImageUploads&quot;:false,&quot;largeHeaderImageUpload&quot;:true,&quot;live_pipeline_consume&quot;:false,&quot;mqImageUploads&quot;:false,&quot;partnerIdSyncEnabled&quot;:true,&quot;sruMediaCategory&quot;:true,&quot;photoSruGifLimitMb&quot;:15,&quot;promoted_video_logging_enabled&quot;:true,&quot;pushState&quot;:true,&quot;scribeReducedActionQueue&quot;:true,&quot;smartInfiniteScroll&quot;:false,&quot;useHtml5Webcam&quot;:true,&quot;hideLeadingMentions&quot;:false,&quot;hideLeadingMentionsWithTooltip&quot;:true,&quot;web_perftown_stats&quot;:true,&quot;web_perftown_ttft&quot;:true,&quot;web_sru_stats&quot;:false,&quot;web_upload_direct&quot;:true,&quot;web_upload_video&quot;:true,&quot;web_upload_video_advanced&quot;:false,&quot;upload_video_size&quot;:500,&quot;defaultVideoDuration&quot;:45,&quot;maxVideoDuration&quot;:140,&quot;internationalShippingEnabled&quot;:true,&quot;useV2EndpointsEnabled&quot;:true,&quot;useVmapVariants&quot;:false,&quot;autoplayPreviewPreroll&quot;:true,&quot;moments_lohp_enabled&quot;:true,&quot;momentsExperienceEnabled&quot;:false,&quot;enableNativePush&quot;:false,&quot;installNativePush&quot;:false,&quot;autoSubscribeNativePush&quot;:false,&quot;stickersInteractivity&quot;:true,&quot;stickersInteractivityDuringLoading&quot;:true,&quot;stickersExperience&quot;:true,&quot;dynamic_video_ads_include_long_videos&quot;:true,&quot;push_state_size&quot;:1000,&quot;canBeSoftUser&quot;:false,&quot;isInSoftExperiment&quot;:false},&quot;experiments&quot;:{},&quot;toasts_dm&quot;:false,&quot;toasts_spoonbill&quot;:false,&quot;toasts_timeline&quot;:false,&quot;toasts_dm_poll_scale&quot;:60,&quot;defaultNotificationIcon&quot;:&quot;https:\/\/abs.twimg.com\/a\/1467966468\/img\/t1\/mobile\/wp7_app_icon.png&quot;,&quot;uploadDomain&quot;:&quot;upload.twitter.com&quot;,&quot;promptbirdData&quot;:{&quot;promptbirdEnabled&quot;:false,&quot;immediateTriggers&quot;:[&quot;PullToRefresh&quot;,&quot;Navigate&quot;],&quot;format&quot;:null},&quot;passwordResetAdvancedLoginForm&quot;:true,&quot;skipAutoSignupDialog&quot;:true,&quot;shouldReplaceSignupWithLogin&quot;:true,&quot;hashflagBaseUrl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/&quot;,&quot;activeHashflags&quot;:{&quot;المسافر&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;سفرة_الصيف&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;whitejersey&quot;:&quot;TDF2016\/WhiteJersey.png&quot;,&quot;bacphysique&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;togetherstronger&quot;:&quot;EurosFootball2016\/Wales.png&quot;,&quot;ger&quot;:&quot;EurosFootball2016\/Germany.png&quot;,&quot;meinestimme&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;bacst2s&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;اقترعت&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;immerwiederoesterreich&quot;:&quot;EurosFootball2016\/Austria.png&quot;,&quot;一站到底&quot;:&quot;JSBCI\/JSBCI_emoji.png&quot;,&quot;bacpro&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;سافر_الحين_وادفع_بعدين&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;tdf&quot;:&quot;TDF2016\/TDF.png&quot;,&quot;bacstmg&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;maillotjaunelcl&quot;:&quot;TDF2016\/YellowJersey.png&quot;,&quot;periscope&quot;:&quot;Periscope\/Periscope.png&quot;,&quot;bethefastest&quot;:&quot;EmojiVirgin\/EmojiVirgin.png&quot;,&quot;jederfuerjeden&quot;:&quot;EurosFootball2016\/Germany.png&quot;,&quot;abfabmovie&quot;:&quot;AbFabMovie\/AbFabMovie.png&quot;,&quot;yoenunvw&quot;:&quot;Volkswagen\/YoEnUnVW.png&quot;,&quot;lovetwitter&quot;:&quot;LoveTwitter\/LoveTwitter.png&quot;,&quot;ifoodnomengão&quot;:&quot;iFoodBrazil\/flamengo.png&quot;,&quot;badisbred&quot;:&quot;AnimalKingdom_Deliver\/BadisBred.png&quot;,&quot;arabianoud&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;عطور_عربية&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;admis&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;weareamerica&quot;:&quot;AdCouncilEmoji\/AdCouncilEmoji_Original.png&quot;,&quot;cervantes400&quot;:&quot;CervantesEmoji\/cervantes-emoji.png&quot;,&quot;maillotapoiscarrefour&quot;:&quot;TDF2016\/PolkaDotJersey.png&quot;,&quot;hovotato&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;seleçãoeuro&quot;:&quot;EuroNoSporTV\/EuroNoSporTV.png&quot;,&quot;япроголосовал(а)&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;bastilleday&quot;:&quot;BastilleDay2016\/BastilleDay.png&quot;,&quot;sienteelsabor&quot;:&quot;CocaCola\/SienteElSabor.png&quot;,&quot;bacfrançais&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;gawa&quot;:&quot;EurosFootball2016\/NorthernIreland.png&quot;,&quot;احساس&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;hun&quot;:&quot;EurosFootball2016\/Hungary.png&quot;,&quot;مضاوي&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;bacsti2d&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;wimbledon&quot;:&quot;Wimbledon2016\/Wimbledon.png&quot;,&quot;yellowjersey&quot;:&quot;TDF2016\/YellowJersey.png&quot;,&quot;vivelamannschaft&quot;:&quot;Mercedes\/Mercedes.png&quot;,&quot;maillotapois&quot;:&quot;TDF2016\/PolkaDotJersey.png&quot;,&quot;bacanglais&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;1of11million&quot;:&quot;EurosFootball2016\/Portugal.png&quot;,&quot;jaivoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;fetenationale&quot;:&quot;BastilleDay2016\/BastilleDay.png&quot;,&quot;golive&quot;:&quot;goLIVE2016\/goLIVE.png&quot;,&quot;zoella&quot;:&quot;ZoellaEmoji\/Zoella.png&quot;,&quot;everycharactermatters&quot;:&quot;EveryCharacterMatters\/EveryCharacterMatters.png&quot;,&quot;bachistoiregeographie&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;whosstillstanding&quot;:&quot;JSBCI\/JSBCI_emoji.png&quot;,&quot;我已投票&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;euro2016&quot;:&quot;EurosFootball2016\/trophy.png&quot;,&quot;bacsvt&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;twitterstaryarasky&quot;:&quot;TwitterstarYarasky\/TwitterstarYarasky.png&quot;,&quot;fazerdiferente&quot;:&quot;TIM\/emoji_tim_final_3.png&quot;,&quot;tousenfrance&quot;:&quot;EurosFootball2016\/Belgium.png&quot;,&quot;400cervantes&quot;:&quot;CervantesEmoji\/cervantes-emoji.png&quot;,&quot;directpr&quot;:&quot;BastilleDay2016\/BastilleDay.png&quot;,&quot;bacsthr&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;maillotblanc&quot;:&quot;TDF2016\/WhiteJersey.png&quot;,&quot;jaimonbac&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;isl&quot;:&quot;EurosFootball2016\/Iceland.png&quot;,&quot;bizbittidemedenbitmez&quot;:&quot;EurosFootball2016\/Turkey.png&quot;,&quot;ceskarepre&quot;:&quot;EurosFootball2016\/CzechRepublic.png&quot;,&quot;sui&quot;:&quot;EurosFootball2016\/Switzerland.png&quot;,&quot;svk&quot;:&quot;EurosFootball2016\/Slovakia.png&quot;,&quot;تطبيق_المسافر_للحجوزات&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;bactmd&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;투표했어요&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;euronosportv&quot;:&quot;EuroNoSporTV\/EuroNoSporTV.png&quot;,&quot;allezlasuisse&quot;:&quot;EurosFootball2016\/Switzerland.png&quot;,&quot;timchef&quot;:&quot;TIMChef\/emoji_masterchef.png&quot;,&quot;rumoaorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;однакоманда&quot;:&quot;EurosFootball2016\/Russia.png&quot;,&quot;nir&quot;:&quot;EurosFootball2016\/NorthernIreland.png&quot;,&quot;aut&quot;:&quot;EurosFootball2016\/Austria.png&quot;,&quot;bachistoire&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;وودي&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;csakegyutt&quot;:&quot;EurosFootball2016\/Hungary.png&quot;,&quot;goingsolo&quot;:&quot;ZoellaEmoji\/Zoella.png&quot;,&quot;تطبيق_المسافر&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;tdf2016&quot;:&quot;TDF2016\/TDF.png&quot;,&quot;bacphilo&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacphysiquechimie&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;твоязбірна&quot;:&quot;EurosFootball2016\/Ukraine.png&quot;,&quot;eng&quot;:&quot;EurosFootball2016\/England.png&quot;,&quot;14juillet2016&quot;:&quot;BastilleDay2016\/BastilleDay.png&quot;,&quot;chamaolimpica&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;presidentduterte&quot;:&quot;PresidentDuterte\/PHVoteDuterte.png&quot;,&quot;ivoted&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;rus&quot;:&quot;EurosFootball2016\/Russia.png&quot;,&quot;olympicflame&quot;:&quot;OlympicTorch_Emoji\/OlympicTorch.png&quot;,&quot;ifoodnomengao&quot;:&quot;iFoodBrazil\/flamengo.png&quot;,&quot;alb&quot;:&quot;EurosFootball2016\/Albania.png&quot;,&quot;thequeue&quot;:&quot;Wimbledon2016\/TheQueue.png&quot;,&quot;rou&quot;:&quot;EurosFootball2016\/Romania.png&quot;,&quot;badmoms&quot;:&quot;Universal_BadMoms_Emoji\/BadMoms.png&quot;,&quot;greenjersey&quot;:&quot;TDF2016\/GreenJersey.png&quot;,&quot;صقر&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;bacallemand&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;polkadotjersey&quot;:&quot;TDF2016\/PolkaDotJersey.png&quot;,&quot;الفارس&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;bumotoako&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;twittersparkle&quot;:&quot;TwitterSparkle\/TwitterSparkle.png&quot;,&quot;maillotvertskoda&quot;:&quot;TDF2016\/GreenJersey.png&quot;,&quot;ita&quot;:&quot;EurosFootball2016\/Italy.png&quot;,&quot;vivoazzurro&quot;:&quot;EurosFootball2016\/Italy.png&quot;,&quot;resultatsbac&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacitalien&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;لمسة&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;سناب_المسافر_دايما_مسافر&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;maillotblanckrys&quot;:&quot;TDF2016\/WhiteJersey.png&quot;,&quot;origin&quot;:&quot;StateOfOrigin\/Origin.png&quot;,&quot;bacfrancais&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bachotellerie&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;thehill&quot;:&quot;Wimbledon2016\/TheHill.png&quot;,&quot;hairomania&quot;:&quot;EurosFootball2016\/Romania.png&quot;,&quot;admise&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;yarasky&quot;:&quot;TwitterstarYarasky\/TwitterstarYarasky.png&quot;,&quot;maillotvert&quot;:&quot;TDF2016\/GreenJersey.png&quot;,&quot;yovote&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;qlder&quot;:&quot;StateOfOrigin\/QLDER.png&quot;,&quot;رسالة&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;energia&quot;:&quot;JBalvinNew\/JBalvinNew.png&quot;,&quot;انا_المسافر&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;rumboario&quot;:&quot;100Days\/100Days.png&quot;,&quot;girlonlinegoingsolo&quot;:&quot;ZoellaEmoji\/Zoella.png&quot;,&quot;blackhistorymonth&quot;:&quot;BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;overdadeirosabor&quot;:&quot;Hellmanns\/emoji_hellmans.png&quot;,&quot;baces&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacmaths&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;سافر_بالتقسيط&quot;:&quot;AlMosafer\/travel.png&quot;,&quot;とと姉ちゃん&quot;:&quot;NHKMorningDrama\/NHKMorningDrama.png&quot;,&quot;yovoté&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;14juillet&quot;:&quot;BastilleDay2016\/BastilleDay.png&quot;,&quot;togetherforengland&quot;:&quot;EurosFootball2016\/England.png&quot;,&quot;łączynaspolska&quot;:&quot;EurosFootball2016\/Poland.png&quot;,&quot;zoesugg&quot;:&quot;ZoellaEmoji\/Zoella.png&quot;,&quot;bachôtellerie&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacs&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacstav&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;nowyoucan&quot;:&quot;SkyNow\/SKYNowYouCan.png&quot;,&quot;tur&quot;:&quot;EurosFootball2016\/Turkey.png&quot;,&quot;bhm&quot;:&quot;BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;roadtorio&quot;:&quot;100Days\/100Days.png&quot;,&quot;bacses&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bacstl&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;wal&quot;:&quot;EurosFootball2016\/Wales.png&quot;,&quot;bacespagnol&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;bel&quot;:&quot;EurosFootball2016\/Belgium.png&quot;,&quot;bacstd2a&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;fiersdetrebleus&quot;:&quot;EurosFootball2016\/France.png&quot;,&quot;cze&quot;:&quot;EurosFootball2016\/CzechRepublic.png&quot;,&quot;blacklivesmatter&quot;:&quot;BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;pol&quot;:&quot;EurosFootball2016\/Poland.png&quot;,&quot;العربية_للعود&quot;:&quot;ArabianOud\/incense_burner.png&quot;,&quot;résultatsbac&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;budiponosan&quot;:&quot;EurosFootball2016\/Croatia.png&quot;,&quot;fandimespolu&quot;:&quot;EurosFootball2016\/Slovakia.png&quot;,&quot;thisbudsforyou&quot;:&quot;Bud_Emoji\/Bud.png&quot;,&quot;icaucused&quot;:&quot;USElections2016\/ivoted.png&quot;,&quot;ukr&quot;:&quot;EurosFootball2016\/Ukraine.png&quot;,&quot;esp&quot;:&quot;EurosFootball2016\/Spain.png&quot;,&quot;makethefuture&quot;:&quot;Shell_Emoji\/ShellLightbulb.png&quot;,&quot;cro&quot;:&quot;EurosFootball2016\/Croatia.png&quot;,&quot;irl&quot;:&quot;EurosFootball2016\/ROIreland.png&quot;,&quot;lovehasnolabels&quot;:&quot;AdCouncilEmoji\/AdCouncilEmoji_Original.png&quot;,&quot;vamosespaña&quot;:&quot;EurosFootball2016\/Spain.png&quot;,&quot;bacl&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;uptheblues&quot;:&quot;StateOfOrigin\/UpTheBlues.png&quot;,&quot;sharkweek&quot;:&quot;SharkWeekEmoji\/SharkWeek_Original.png&quot;,&quot;por&quot;:&quot;EurosFootball2016\/Portugal.png&quot;,&quot;swe&quot;:&quot;EurosFootball2016\/Sweden.png&quot;,&quot;bac2016&quot;:&quot;baccalaureat_emoji\/baccalaureat_emoji.png&quot;,&quot;maillotjaune&quot;:&quot;TDF2016\/YellowJersey.png&quot;,&quot;fra&quot;:&quot;EurosFootball2016\/France.png&quot;,&quot;ufc200&quot;:&quot;UFC200\/UFC200.png&quot;,&quot;coybig&quot;:&quot;EurosFootball2016\/ROIreland.png&quot;},&quot;tweetId&quot;:&quot;363116819147538433&quot;,&quot;profile_id&quot;:1087064150,&quot;endpoint&quot;:&quot;\/i\/vyki_e\/conversation\/363116819147538433&quot;,&quot;overlayCapable&quot;:false,&quot;finagleTraceId&quot;:&quot;00b1ca1d00abbeb2&quot;,&quot;isThreaded&quot;:true,&quot;inOverlay&quot;:true,&quot;trendsCacheKey&quot;:null,&quot;decider_personalized_trends&quot;:false,&quot;trendsEndpoint&quot;:&quot;\/i\/trends&quot;,&quot;initialState&quot;:{&quot;title&quot;:&quot;Vyki Englert on Twitter: \&quot;I&#39;m a sucker for pledges.  @Peers Pledge #sharingeconomy http:\/\/t.co\/T4Sc47KAzh\&quot;&quot;,&quot;section&quot;:null,&quot;module&quot;:&quot;app\/pages\/permalink&quot;,&quot;cache_ttl&quot;:300,&quot;body_class_names&quot;:&quot;three-col logged-out user-style-vyki_e PermalinkPage&quot;,&quot;doc_class_names&quot;:&quot;route-permalink&quot;,&quot;route_name&quot;:&quot;permalink&quot;,&quot;page_container_class_names&quot;:&quot;AppContent wrapper wrapper-permalink&quot;,&quot;ttft_navigation&quot;:false}}">
-
-
-
-    <input type="hidden" class="swift-boot-module" value="app/pages/permalink">
-  <input type="hidden" id="swift-module-path" value="https://abs.twimg.com/c/swift/en">
-
-
-    <script src="https://abs.twimg.com/c/swift/en/init.314a9707f177773430c9b565030e9ea5b8638c96.js" async></script>
-
-  </head>
-  <body class="three-col logged-out user-style-vyki_e PermalinkPage"
-data-fouc-class-names="swift-loading"
- dir="ltr">
-      <script id="swift_loading_indicator" nonce="KXwIjaJlN1QIxC47iHrsvQ==">
-        document.body.className=document.body.className+" "+document.body.getAttribute("data-fouc-class-names");
-      </script>
-
-
-
-
-
-
-
-
-
-
-    <div id="doc" data-at-shortcutkeys="{&quot;Enter&quot;:&quot;Open Tweet details&quot;,&quot;o&quot;:&quot;Expand photo&quot;,&quot;/&quot;:&quot;Search&quot;,&quot;?&quot;:&quot;This menu&quot;,&quot;j&quot;:&quot;Next Tweet&quot;,&quot;k&quot;:&quot;Previous Tweet&quot;,&quot;Space&quot;:&quot;Page down&quot;,&quot;.&quot;:&quot;Load new Tweets&quot;,&quot;gu&quot;:&quot;Go to user\u2026&quot;}" class="route-permalink">
-        <div class="topbar js-topbar">
-
-
-  <div class="global-nav global-nav--newLoggedOut" data-section-term="top_nav">
-    <div class="global-nav-inner">
-      <div class="container">
-
-
-<ul class="nav js-global-actions" role="navigation" id="global-actions">
-  <li id="global-nav-home" class="home" data-global-action="home">
-    <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/" data-component-context="home_nav" data-nav="home">
-      <span class="Icon Icon--bird Icon--large"></span>
-      <span class="text">Home</span>
-    </a>
-  </li>
-    <li id="global-nav-about" class="about" data-global-action="about">
-      <a class="js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/about" target="_blank" data-component-context="about_nav" data-nav="about">
-        <span class="text">About</span>
-      </a>
-    </li>
-</ul>
-<div class="pull-right">
-    <div role="search">
-  <form class="t1-form form-search js-search-form" action="/search" id="global-nav-search">
-    <label class="visuallyhidden" for="search-query">Search query</label>
-    <input class="search-input" type="text" id="search-query" placeholder="Search Twitter" name="q" autocomplete="off" spellcheck="false">
-    <span class="search-icon js-search-action">
-      <button type="submit" class="Icon Icon--search nav-search">
-        <span class="visuallyhidden">Search Twitter</span>
-      </button>
-    </span>
-
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-
-
-
-<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info">
-        <span class="fullname"></span>
-        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-        <span class="username"><s>@</s><b></b></span>
-      </span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-    <div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Suggested users
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-  </form>
-</div>
-
-
-  <ul class="nav secondary-nav language-dropdown">
-    <li class="dropdown js-language-dropdown">
-      <a href="#supported_languages" class="dropdown-toggle js-dropdown-toggle">
-        <small>Language:</small> <span class="js-current-language">English</span> <b class="caret"></b>
-      </a>
-      <div class="dropdown-menu">
-        <div class="dropdown-caret right">
-          <span class="caret-outer"> </span>
-          <span class="caret-inner"></span>
-        </div>
-        <ul id="supported_languages">
-            <li><a href="?lang=id" data-lang-code="id" title="Indonesian" class="js-language-link js-tooltip">Bahasa Indonesia</a></li>
-            <li><a href="?lang=msa" data-lang-code="msa" title="Malay" class="js-language-link js-tooltip">Bahasa Melayu</a></li>
-            <li><a href="?lang=ca" data-lang-code="ca" title="Catalan" class="js-language-link js-tooltip">Català</a></li>
-            <li><a href="?lang=cs" data-lang-code="cs" title="Czech" class="js-language-link js-tooltip">Čeština</a></li>
-            <li><a href="?lang=da" data-lang-code="da" title="Danish" class="js-language-link js-tooltip">Dansk</a></li>
-            <li><a href="?lang=de" data-lang-code="de" title="German" class="js-language-link js-tooltip">Deutsch</a></li>
-            <li><a href="?lang=en-gb" data-lang-code="en-gb" title="British English" class="js-language-link js-tooltip">English UK</a></li>
-            <li><a href="?lang=es" data-lang-code="es" title="Spanish" class="js-language-link js-tooltip">Español</a></li>
-            <li><a href="?lang=fil" data-lang-code="fil" title="Filipino" class="js-language-link js-tooltip">Filipino</a></li>
-            <li><a href="?lang=fr" data-lang-code="fr" title="French" class="js-language-link js-tooltip">Français</a></li>
-            <li><a href="?lang=hr" data-lang-code="hr" title="Croatian" class="js-language-link js-tooltip">Hrvatski</a></li>
-            <li><a href="?lang=it" data-lang-code="it" title="Italian" class="js-language-link js-tooltip">Italiano</a></li>
-            <li><a href="?lang=hu" data-lang-code="hu" title="Hungarian" class="js-language-link js-tooltip">Magyar</a></li>
-            <li><a href="?lang=nl" data-lang-code="nl" title="Dutch" class="js-language-link js-tooltip">Nederlands</a></li>
-            <li><a href="?lang=no" data-lang-code="no" title="Norwegian" class="js-language-link js-tooltip">Norsk</a></li>
-            <li><a href="?lang=pl" data-lang-code="pl" title="Polish" class="js-language-link js-tooltip">Polski</a></li>
-            <li><a href="?lang=pt" data-lang-code="pt" title="Portuguese" class="js-language-link js-tooltip">Português</a></li>
-            <li><a href="?lang=ro" data-lang-code="ro" title="Romanian" class="js-language-link js-tooltip">Română</a></li>
-            <li><a href="?lang=sk" data-lang-code="sk" title="Slovak" class="js-language-link js-tooltip">Slovenčina</a></li>
-            <li><a href="?lang=fi" data-lang-code="fi" title="Finnish" class="js-language-link js-tooltip">Suomi</a></li>
-            <li><a href="?lang=sv" data-lang-code="sv" title="Swedish" class="js-language-link js-tooltip">Svenska</a></li>
-            <li><a href="?lang=vi" data-lang-code="vi" title="Vietnamese" class="js-language-link js-tooltip">Tiếng Việt</a></li>
-            <li><a href="?lang=tr" data-lang-code="tr" title="Turkish" class="js-language-link js-tooltip">Türkçe</a></li>
-            <li><a href="?lang=el" data-lang-code="el" title="Greek" class="js-language-link js-tooltip">Ελληνικά</a></li>
-            <li><a href="?lang=bg" data-lang-code="bg" title="Bulgarian" class="js-language-link js-tooltip">Български език</a></li>
-            <li><a href="?lang=ru" data-lang-code="ru" title="Russian" class="js-language-link js-tooltip">Русский</a></li>
-            <li><a href="?lang=sr" data-lang-code="sr" title="Serbian" class="js-language-link js-tooltip">Српски</a></li>
-            <li><a href="?lang=uk" data-lang-code="uk" title="Ukrainian" class="js-language-link js-tooltip">Українська мова</a></li>
-            <li><a href="?lang=he" data-lang-code="he" title="Hebrew" class="js-language-link js-tooltip">עִבְרִית</a></li>
-            <li><a href="?lang=ar" data-lang-code="ar" title="Arabic" class="js-language-link js-tooltip">العربية</a></li>
-            <li><a href="?lang=fa" data-lang-code="fa" title="Persian" class="js-language-link js-tooltip">فارسی</a></li>
-            <li><a href="?lang=mr" data-lang-code="mr" title="Marathi" class="js-language-link js-tooltip">मराठी</a></li>
-            <li><a href="?lang=hi" data-lang-code="hi" title="Hindi" class="js-language-link js-tooltip">हिन्दी</a></li>
-            <li><a href="?lang=bn" data-lang-code="bn" title="Bengali" class="js-language-link js-tooltip">বাংলা</a></li>
-            <li><a href="?lang=gu" data-lang-code="gu" title="Gujarati" class="js-language-link js-tooltip">ગુજરાતી</a></li>
-            <li><a href="?lang=ta" data-lang-code="ta" title="Tamil" class="js-language-link js-tooltip">தமிழ்</a></li>
-            <li><a href="?lang=kn" data-lang-code="kn" title="Kannada" class="js-language-link js-tooltip">ಕನ್ನಡ</a></li>
-            <li><a href="?lang=th" data-lang-code="th" title="Thai" class="js-language-link js-tooltip">ภาษาไทย</a></li>
-            <li><a href="?lang=ko" data-lang-code="ko" title="Korean" class="js-language-link js-tooltip">한국어</a></li>
-            <li><a href="?lang=ja" data-lang-code="ja" title="Japanese" class="js-language-link js-tooltip">日本語</a></li>
-            <li><a href="?lang=zh-cn" data-lang-code="zh-cn" title="Simplified Chinese" class="js-language-link js-tooltip">简体中文</a></li>
-            <li><a href="?lang=zh-tw" data-lang-code="zh-tw" title="Traditional Chinese" class="js-language-link js-tooltip">繁體中文</a></li>
-        </ul>
-      </div>
-      <div class="js-front-language">
-        <form action="/sessions/change_locale" class="t1-form language" method="POST">
-          <input type="hidden" name="lang"> <input type="hidden" name="redirect">
-          <input type="hidden" name="authenticity_token" value="0ca3d94aff5192efa7e34ae4eae60d07f5babd38">
-        </form>
-      </div>
-    </li>
-  </ul>
-
-    <ul class="nav secondary-nav session-dropdown" id="session">
-      <li class="dropdown js-session">
-          <a href="/login" class="dropdown-toggle js-dropdown-toggle dropdown-signin" id="signin-link" data-nav="login">
-            <small>Have an account?</small> <span class="emphasize"> Log in</span><span class="caret"></span>
-          </a>
-          <div class="dropdown-menu dropdown-form" id="signin-dropdown">
-            <div class="dropdown-caret right"> <span class="caret-outer"></span> <span class="caret-inner"></span> </div>
-            <div class="signin-dialog-body">
-              <div>Have an account?</div>
-              <form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="login_callout"
-  data-element="form"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Phone, email or username"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
-  </div>
-
-  <div class="LoginForm-rememberForgot">
-    <label>
-      <input type="checkbox" value="1" name="remember_me" checked="checked">
-      <span>Remember me</span>
-    </label>
-    <span class="separator">&middot;</span>
-    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
-  </div>
-
-  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/vyki_e/status/363116819147538433">
-  <input type="hidden" value="0ca3d94aff5192efa7e34ae4eae60d07f5babd38" name="authenticity_token">
-</form>
-
-              <hr>
-              <div class="signup SignupForm">
-                <div class="SignupForm-header">New to Twitter?</div>
-                <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn"
-                  data-component="signup_callout"
-                  data-element="dropdown"
-                  >Sign up
-                </a>
-              </div>
-            </div>
-          </div>
-      </li>
-    </ul>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-
-        <div id="page-outer">
-          <div id="page-container" class="AppContent wrapper wrapper-permalink">
-
-
-<a class="PermalinkProfile-overlay js-nav" href="/vyki_e">
-  <span class="visuallyhidden">vyki_e's profile</span>
-</a>
-<div class="PermalinkProfile-background without-banner">
-  <div class="ProfileCanopy ProfileCanopy--withNav ProfileCanopy--large">
-  <div class="ProfileCanopy-inner">
-
-    <div class="ProfileCanopy-header u-bgUserColor">
-    <div class="ProfileCanopy-headerBg">
-      <img alt=""
-        src="https://pbs.twimg.com/profile_banners/1087064150/1424315468/1500x500"
-
-      >
-    </div>
-
-  <div class="AppContainer">
-
-    <div class="ProfileCanopy-avatar">
-      <div class="ProfileAvatar">
-    <a class="ProfileAvatar-container u-block js-tooltip profile-picture"
-        href="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-        title="Vyki Englert"
-        data-resolved-url-large="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-        data-url="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-        target="_blank">
-      <img class="ProfileAvatar-image " src="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_400x400.jpg" alt="Vyki Englert">
-    </a>
-</div>
-
-    </div>
-
-
-    <div class="ProfileCanopy-headerPromptAnchor"></div>
-  </div>
-
-</div>
-
-
-    <div class="ProfileCanopy-navBar">
-
-      <div class="AppContainer">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-size1of3 u-lg-size1of4">
-            <div class="ProfileCanopy-card" role="presentation">
-              <div class="ProfileCardMini">
-  <a class="ProfileCardMini-avatar profile-picture js-tooltip"
-     href="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-     title="Vyki Englert"
-     data-resolved-url-large="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-     data-url="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm.jpg"
-     target="_blank">
-    <img class="ProfileCardMini-avatarImage" alt="Vyki Englert" src="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_normal.jpg" >
-  </a>
-  <div class="ProfileCardMini-details">
-    <div class="ProfileNameTruncated">
-  <div class="u-textTruncate u-inlineBlock">
-    <a class="ProfileNameTruncated-link u-textInheritColor js-nav js-action-profile-name" href="/vyki_e"  data-aria-label-part>
-      Vyki Englert
-    </a>
-  </div>
-</div>
-    <div class="ProfileCardMini-screenname">
-      <a href="/vyki_e" class="ProfileCardMini-screennameLink u-linkComplex js-nav u-dir" dir="ltr">@<span class="u-linkComplex-target">vyki_e</span></a>
-    </div>
-  </div>
-</div>
-
-            </div>
-          </div>
-
-          <div class="Grid-cell u-size2of3 u-lg-size3of4">
-            <div class="ProfileCanopy-nav">
-
-
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-
-    <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-</div>
-
-
-  <div class="AppContainer">
-    <div class="Grid Grid--withGutter">
-      <div class="Grid-cell u-size1of3 u-lg-size1of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell">
-            <div class="ProfileSidebar ProfileSidebar--withLeftAlignment">
-  <div class="ProfileHeaderCard">
-  <h1 class="ProfileHeaderCard-name">
-    <a href="/vyki_e"
-       class="ProfileHeaderCard-nameLink u-textInheritColor js-nav
-">Vyki Englert</a>
-  </h1>
-
-  <h2 class="ProfileHeaderCard-screenname u-inlineBlock u-dir" dir="ltr">
-    <a class="ProfileHeaderCard-screennameLink u-linkComplex js-nav" href="/vyki_e">@<span class="u-linkComplex-target">vyki_e</span></a>
-  </h2>
-
-    <p class="ProfileHeaderCard-bio u-dir"
-
-      dir="ltr">Rides bikes, writes code, likes maps. <a href="/CompilerLA" class="tweet-url twitter-atreply pretty-link" dir="ltr" data-mentioned-user-id="0" rel="nofollow" ><s>@</s><b>CompilerLA</b></a> / <a href="/CityGrows" class="tweet-url twitter-atreply pretty-link" dir="ltr" data-mentioned-user-id="0" rel="nofollow" ><s>@</s><b>CityGrows</b></a> / Brigade Captain <a href="/HackforLA" class="tweet-url twitter-atreply pretty-link" dir="ltr" data-mentioned-user-id="0" rel="nofollow" ><s>@</s><b>HackforLA</b></a></p>
-
-
-
-
-    <div class="ProfileHeaderCard-joinDate">
-      <span class="Icon Icon--calendar Icon--small"></span>
-      <span class="ProfileHeaderCard-joinDateText js-tooltip u-dir" dir="ltr" title="11:53 AM - 13 Jan 2013">Joined January 2013</span>
-    </div>
-
-      <div class="ProfileHeaderCard-birthdate u-hidden">
-        <span class="Icon Icon--balloon Icon--medium"></span>
-        <span class="ProfileHeaderCard-birthdateText u-dir" dir="ltr">
-</span>
-      </div>
-
-
-</div>
-
-
-
-
-
-
-
-
-
-</div>
-
-          </div>
-        </div>
-      </div>
-      <div class="Grid-cell u-size2of3 u-lg-size3of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-lg-size2of3" data-test-selector="ProfileTimeline">
-              <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-          </div>
-          <div class="Grid-cell u-size1of3">
-            <div class="Grid Grid--withGutter">
-              <div class="Grid-cell">
-                <div class="ProfileSidebar ProfileSidebar--withRightAlignment">
-                  <div class="MoveableModule">
-
-<div class="SidebarCommonModules">
-
-
-
-
-
-
-  <div class="Footer module roaming-module
-            Footer--slim
-            ">
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2016 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about">About</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com">Help</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos">Terms</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy">Privacy</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170451">Ads info</a></li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-</div>
-
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-<style id="user-style-vyki_e">
-
-
-
-
-
-  a,
-  a:hover,
-  a:focus,
-  a:active {
-    color: #4E99D1;
-  }
-
-  .u-textUserColor,
-  .u-textUserColorHover:hover,
-  .u-textUserColorHover:focus {
-    color: #4E99D1 !important;
-  }
-
-  .u-borderUserColor,
-  .u-borderUserColorHover:hover,
-  .u-borderUserColorHover:focus {
-    border-color: #4E99D1 !important;
-  }
-
-  .u-bgUserColor,
-  .u-bgUserColorHover:hover,
-  .u-bgUserColorHover:focus {
-    background-color: #4E99D1 !important;
-  }
-
-
-  .u-dropdownUserColor > li:hover,
-  .u-dropdownUserColor > li:focus,
-  .u-dropdownUserColor > li > button:hover,
-  .u-dropdownUserColor > li > button:focus {
-    color: #fff !important;
-    background-color: #4E99D1 !important;
-  }
-
-  .u-boxShadowInsetUserColorHover:hover,
-  .u-boxShadowInsetUserColorHover:focus {
-    box-shadow: inset 0 0 0 5px #4E99D1 !important;
-  }
-
-
-
-  .u-textUserColorLight {
-    color: #B8D6EC !important;
-  }
-
-  .u-borderUserColorLight,
-  .u-borderUserColorLightFocus:focus,
-  .u-borderUserColorLightHover:hover,
-  .u-borderUserColorLightHover:focus {
-    border-color: #B8D6EC !important;
-  }
-
-  .u-bgUserColorLight {
-    background-color: #B8D6EC !important;
-  }
-
-
-  .u-boxShadowUserColorLighterFocus:focus {
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 2px rgba(78,153,209,0.25) !important;
-  }
-
-
-  .u-textUserColorLightest {
-    color: #EDF4FA !important;
-  }
-
-  .u-borderUserColorLightest {
-    border-color: #EDF4FA !important;
-  }
-
-  .u-bgUserColorLightest {
-    background-color: #EDF4FA !important;
-  }
-
-
-  .u-textUserColorLighter {
-    color: #D2E5F3 !important;
-  }
-
-  .u-borderUserColorLighter {
-    border-color: #D2E5F3 !important;
-  }
-
-  .u-bgUserColorLighter {
-    background-color: #D2E5F3 !important;
-  }
-
-
-  .u-bgUserColorDarkHover:hover {
-    background-color: #3E7AA7 !important;
-  }
-
-  .u-borderUserColorDark {
-    border-color: #3E7AA7 !important;
-  }
-
-
-  .u-bgUserColorDarkerActive:active {
-    background-color: #2E5B7D !important;
-  }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-a,
-.btn-link,
-.btn-link:focus,
-.icon-btn,
-
-
-
-.pretty-link b,
-.pretty-link:hover s,
-.pretty-link:hover b,
-.pretty-link:focus s,
-.pretty-link:focus b,
-/* Account Group */
-.metadata a:hover,
-.metadata a:focus,
-
-.account-group:hover .fullname,
-.account-group:focus .fullname,
-.account-summary:focus .fullname,
-
-.message .message-text a,
-.stats a strong,
-.plain-btn:hover,
-.plain-btn:focus,
-.dropdown.open .user-dropdown.plain-btn,
-.open > .plain-btn,
-#global-actions .new:before,
-.module .list-link:hover,
-.module .list-link:focus,
-
-.stats a:hover,
-.stats a:hover strong,
-.stats a:focus,
-.stats a:focus strong,
-
-.find-friends-sources li:hover .source,
-
-
-
-
-
-.stream-item a:hover .fullname,
-.stream-item a:focus .fullname,
-
-.stream-item .view-all-supplements:hover,
-.stream-item .view-all-supplements:focus,
-
-.tweet .time a:hover,
-.tweet .time a:focus,
-.tweet .details.with-icn b,
-.tweet .details.with-icn .Icon,
-.tweet .tweet-geo-text a:hover,
-
-.stream-item:hover .original-tweet .details b,
-.stream-item .original-tweet.focus .details b,
-.stream-item.open .original-tweet .details b,
-
-.client-and-actions a:hover,
-.client-and-actions a:focus,
-
-.dismiss-btn:hover b,
-
-.tweet .context .pretty-link:hover s,
-.tweet .context .pretty-link:hover b,
-.tweet .context .pretty-link:focus s,
-.tweet .context .pretty-link:focus b,
-
-.list .username a:hover,
-.list .username a:focus,
-.list-membership-container .create-a-list,
-.list-membership-container .create-a-list:hover,
-
-
-
-.card .list-details a:hover,
-.card .list-details a:focus,
-.card .card-body:hover .attribution,
-.card .card-body .attribution:focus,
-.new-tweets-bar,
-.onebox .soccer ul.ticker a:hover,
-.onebox .soccer ul.ticker a:focus,
-
-
-
-.remove-background-btn,
-
-
-
-.stream-item-activity-notification .latest-tweet .tweet-row a:hover,
-.stream-item-activity-notification .latest-tweet .tweet-row a:focus,
-.stream-item-activity-notification .latest-tweet .tweet-row a:hover b,
-.stream-item-activity-notification .latest-tweet .tweet-row a:focus b {
-    color: #4E99D1;
-}
-
-
-
-
-  /* hover state for found media items */
-  .FoundMediaSearch--keyboard .FoundMediaSearch-focusable.is-focused {
-    border-color: #4E99D1;
-  }
-
-  /* hover state for photo select button*/
-  .photo-selector:hover .btn,
-  .icon-btn:hover,
-  .icon-btn:active,
-  .icon-btn.active,
-  .icon-btn.enabled {
-    border-color: #4E99D1;
-    border-color: rgba(78,153,209,.5);
-    color: #4E99D1;
-  }
-
-  /* hover state for photo select button*/
-  .photo-selector:hover .btn,
-  .icon-btn:hover {
-    background-image: linear-gradient(rgba(255,255,255,0), rgba(78,153,209,.1));
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00FFFFFF', endColorstr='#194E99D1'); /* IE8-9 */
-  }
-
-  .icon-btn.disabled,
-  .icon-btn.disabled:hover,
-  .icon-btn[disabled],
-  .icon-btn[aria-disabled=true] {
-    color: #4E99D1;
-  }
-
-  /* tweet-btn can have primary-btn class as well so the following rules ensure that the correct background color is applied */
-  .tweet-btn,
-  .tweet-btn:focus {
-    background-color: #4E99D1;
-    background: rgba(78,153,209,.8);
-  }
-
-  .tweet-btn:hover,
-  .tweet-btn:active,
-  .tweet-btn.active {
-    background-color: #4E99D1;
-  }
-
-  .tweet-btn.btn.disabled,
-  .tweet-btn.btn.disabled:hover,
-  .tweet-btn.btn[disabled],
-  .tweet-btn.btn[aria-disabled=true] {
-    background: #4E99D1;
-  }
-
-  .btn:focus,
-  .btn.focus,
-  .Button:focus {
-    box-shadow:
-      0 0 0 1px #fff,
-      0 0 0 3px rgba(78, 153, 209, 0.5);
-  }
-
-  .selected-stream-item:focus {
-    box-shadow: 0 0 0 3px rgba(78, 153, 209, 0.5);
-  }
-
-  /* highlighting when navigate through timeline stream table view with j & k. */
-  .js-navigable-stream.stream-table-view .selected-stream-item[tabindex="-1"]:focus {
-    outline: 3px solid rgba(78, 153, 209, 0.5) !important;
-  }
-
-  /* box-shadow does not work with table tr element */
-  .js-navigable-stream.stream-table-view .selected-stream-item:focus {
-    box-shadow: none;
-  }
-
-  /**
-   * 1. Bring actionable tweet to top when active to ensure border
-   *    highlighting wraps entire tweet. Value must be at least at if not
-   *    higher than the z-index value of ProfileHeading to ensure first
-   *    tweet in timeline receives border on all four sides.
-   *    NOTE: z-index should be 2 to avoid conflicts with .ProfileCanopy and .ProfileCard-avatarLink
-   */
-
-  .js-stream-item.is-selected:focus .ProfileCard,
-  .QuoteTweet:hover,
-  .QuoteTweet:focus,
-  .QuoteTweet:active,
-  .activity-user-profile-content:hover,
-  .activity-user-profile-content:focus,
-  .activity-user-profile-content:active {
-    border-color: rgba(78, 153, 209, 0.5);
-    z-index: 2; /* 1 */
-  }
-
-  .global-dm-nav.new.with-count .dm-new {
-    background: #fff;
-  }
-
-  .global-dm-nav.new.with-count .dm-new .count-inner {
-    background: #4E99D1;
-  }
-
-  .global-nav .people .count .count-inner {
-    background: #4E99D1;
-  }
-
-  .dropdown-menu li > a:hover,
-  .dropdown-menu li > a:focus,
-  .dropdown-menu .dropdown-link:hover,
-  .dropdown-menu .dropdown-link:focus,
-  .dropdown-menu .dropdown-link.is-focused,
-  .dropdown-menu li:hover .dropdown-link,
-  .dropdown-menu li:focus .dropdown-link,
-  .dropdown-menu .typeahead-recent-search-item.selected,
-  .dropdown-menu .typeahead-saved-search-item.selected,
-  .dropdown-menu .selected a,
-  .dropdown-menu .dropdown-link.selected {
-    background-color: #4E99D1 !important;
-  }
-
-/* give tweet boxes 10% of the users link color as background */
-.home-tweet-box,
-.LiveVideo-tweetBox,
-.RetweetDialog-commentBox,
-.WebToast-box--altColor {
-  background-color: #EDF4FA;
-}
-
-.top-timeline-tweetbox .timeline-tweet-box .tweet-form.condensed .tweet-box {
-  color: #4E99D1;
-}
-/* give tweet box containers an outline using the users link color */
-.RichEditor {
-  border-color: #D2E5F3;
-}
-
-input:focus,
-textarea:focus,
-div[contenteditable="true"]:focus,
-div[contenteditable="true"].fake-focus {
-  border-color: #94C1E3;
-  box-shadow: inset 0 0 0 1px rgba(78, 153, 209, 0.7);
-}
-
-.tweet-box textarea:focus,
-.tweet-box input[type=text],
-.currently-dragging .tweet-form.is-droppable .tweet-drag-help,
-.tweet-box[contenteditable="true"]:focus,
-.RichEditor.is-fakeFocus {
-  border-color: #B8D6EC;
-  box-shadow: none;
-}
-
-
-
-
-s,
-.pretty-link:hover s,
-.pretty-link:focus s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:hover s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:focus s {
-    color: #4E99D1;
-}
-
-
-
-.vellip,
-.vellip:before,
-.vellip:after,
-.conversation-module > li:after,
-.conversation-module > li:before,
-.ThreadedConversation-tweet ~ .ThreadedConversation-tweet:before,
-.ThreadedConversation-tweet:after,
-.ThreadedConversation-viewOther:before,
-.ThreadedConversation-unavailableTweet:before,
-.ThreadedConversation-unavailableTweet:after {
-    background-color: #94C1E3;
-}
-
-
-
-
-.tweet .sm-reply,
-.tweet .sm-rt,
-.tweet .sm-fav,
-.tweet .sm-image,
-.tweet .sm-video,
-.tweet .sm-audio,
-.tweet .sm-geo,
-.tweet .sm-in,
-.tweet .sm-trash,
-.tweet .sm-more,
-.tweet .sm-page,
-.tweet .sm-embed,
-.tweet .sm-summary,
-.tweet .sm-chat,
-
-.timelines-navigation .active .profile-nav-icon,
-.timelines-navigation .profile-nav-icon:hover,
-.timelines-navigation .profile-nav-link:focus .profile-nav-icon,
-
-.sm-top-tweet,
-
-.metadata a.tweet-geo-text:hover .sm-geo {
-    background-color: #4E99D1;
-}
-
-.enhanced-mini-profile .mini-profile .profile-summary {
-  background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/mobile);
-}
-
-.wrapper-profile .profile-card.profile-header .profile-header-inner {
-  background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/web);
-}
-
-  #global-tweet-dialog .modal-header {
-    border-bottom: solid 1px rgba(78, 153, 209, .25);
-  }
-
-  #global-tweet-dialog .modal-tweet-form-container {
-    background-color: #4E99D1;
-    background: rgba(78, 153, 209, .1);
-  }
-
-  .inline-reply-tweetbox {
-    background-color: #EDF4FA;
-  }
-
-</style>
-
-
-<style id="user-style-vyki_e-header-img" class="js-user-style-header-img">
-
-    body.user-style-vyki_e .enhanced-mini-profile .mini-profile .profile-summary {
-      background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/web);
+<link rel="shortcut icon" href="//abs.twimg.com/favicons/twitter.2.ico">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Twitter">
+<meta name="apple-mobile-web-app-status-bar-style" content="white">
+<meta name="theme-color" content="#ffffff">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://twitter.com/","potentialAction":{"@type":"SearchAction","query-input":"required name=search_term_string","target":{"@type":"EntryPoint","urlTemplate":"https://twitter.com/search?q={search_term_string}&ref_src=twcamp%5Eseo_searchbox%7Ctwsrc%5Eseo"}}}</script><meta http-equiv="origin-trial" content="AlpCmb40F5ZjDi9ZYe+wnr/V8MF+XmY41K4qUhoq+2mbepJTNd3q4CRqlACfnythEPZqcjryfAS1+ExS0FFRcA8AAABmeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJMYXVuY2ggSGFuZGxlciIsImV4cGlyeSI6MTY1NTI1MTE5OSwiaXNTdWJkb21haW4iOnRydWV9">
+<style>html,body{height: 100%;}::cue{white-space:normal}</style>
+<style id="react-native-stylesheet">[stylesheet-group="0"]{}
+html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+body{margin:0;}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
+input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
+[stylesheet-group="0.1"]{}
+:focus:not([data-focusvisible-polyfill]){outline: none;}
+[stylesheet-group="0.5"]{}
+.css-4rbku5{background-color:rgba(0,0,0,0.00);color:inherit;font:inherit;list-style:none;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;text-align:inherit;text-decoration:none;}
+.css-18t94o4{cursor:pointer;}
+[stylesheet-group="1"]{}
+.css-1dbjc4n{-ms-flex-align:stretch;-ms-flex-direction:column;-ms-flex-negative:0;-ms-flex-preferred-size:auto;-webkit-align-items:stretch;-webkit-box-align:stretch;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-basis:auto;-webkit-flex-direction:column;-webkit-flex-shrink:0;align-items:stretch;border:0 solid black;box-sizing:border-box;display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;flex-basis:auto;flex-direction:column;flex-shrink:0;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;min-height:0px;min-width:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;position:relative;z-index:0;}
+.css-901oao{border:0 solid black;box-sizing:border-box;color:rgba(0,0,0,1.00);display:inline;font:14px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;white-space:pre-wrap;word-wrap:break-word;}
+.css-16my406{color:inherit;font:inherit;white-space:inherit;}
+.css-1hf3ou5{max-width:100%;overflow-x:hidden;overflow-y:hidden;text-overflow:ellipsis;white-space:nowrap;word-wrap:normal;}
+.css-9pa8cd{bottom:0px;height:100%;left:0px;opacity:0;position:absolute;right:0px;top:0px;width:100%;z-index:-1;}
+[stylesheet-group="2"]{}
+.r-13awgt0{-ms-flex:1 1 0%;-webkit-flex:1;flex:1;}
+.r-6koalj{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;}
+.r-sdzlij{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;border-top-left-radius:9999px;border-top-right-radius:9999px;}
+.r-1phboty{border-bottom-style:solid;border-left-style:solid;border-right-style:solid;border-top-style:solid;}
+.r-rs99b7{border-bottom-width:1px;border-left-width:1px;border-right-width:1px;border-top-width:1px;}
+.r-4qtqp9{display:inline-block;}
+.r-crgep1{margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;}
+.r-t60dpp{padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;}
+.r-1yadl64{border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;}
+.r-42olwf{border-bottom-color:rgba(0,0,0,0.00);border-left-color:rgba(0,0,0,0.00);border-right-color:rgba(0,0,0,0.00);border-top-color:rgba(0,0,0,0.00);}
+.r-17gur6a{border-bottom-left-radius:0px;border-bottom-right-radius:0px;border-top-left-radius:0px;border-top-right-radius:0px;}
+.r-xyw6el{padding-bottom:12px;padding-left:12px;padding-right:12px;padding-top:12px;}
+.r-jxzhtn{border-bottom-color:rgba(239,243,244,1.00);border-left-color:rgba(239,243,244,1.00);border-right-color:rgba(239,243,244,1.00);border-top-color:rgba(239,243,244,1.00);}
+.r-4iw3lz{border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;}
+.r-1udh08x{overflow-x:hidden;overflow-y:hidden;}
+.r-wwvuq4{padding-bottom:0;padding-left:0;padding-right:0;padding-top:0;}
+.r-1adg3ll{display:block;}
+.r-bztko3{overflow-x:visible;overflow-y:visible;}
+.r-xoduu5{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;}
+.r-1471scf{display:inline;}
+.r-xf4iuw{margin-bottom:-8px;margin-left:-8px;margin-right:-8px;margin-top:-8px;}
+.r-1ets6dv{border-bottom-color:rgba(207,217,222,1.00);border-left-color:rgba(207,217,222,1.00);border-right-color:rgba(207,217,222,1.00);border-top-color:rgba(207,217,222,1.00);}
+.r-1867qdf{border-bottom-left-radius:16px;border-bottom-right-radius:16px;border-top-left-radius:16px;border-top-right-radius:16px;}
+.r-z2wwpe{border-bottom-left-radius:4px;border-bottom-right-radius:4px;border-top-left-radius:4px;border-top-right-radius:4px;}
+.r-hvic4v{display:none;}
+.r-11mg6pl{border-bottom-color:rgba(255,255,255,1.00);border-left-color:rgba(255,255,255,1.00);border-right-color:rgba(255,255,255,1.00);border-top-color:rgba(255,255,255,1.00);}
+.r-14f9gny{border-bottom-width:4px;border-left-width:4px;border-right-width:4px;border-top-width:4px;}
+[stylesheet-group="2.1"]{}
+.r-1jgb5lz{margin-left:auto;margin-right:auto;}
+.r-ymttw5{padding-left:16px;padding-right:16px;}
+.r-oyd9sg{padding-bottom:4px;padding-top:4px;}
+.r-1fz3rvf{margin-left:12px;margin-right:12px;}
+.r-rjfia{padding-bottom:0px;padding-top:0px;}
+.r-1r5su4o{margin-bottom:16px;margin-top:16px;}
+.r-s1qlax{padding-left:4px;padding-right:4px;}
+.r-1yzf0co{padding-bottom:16px;padding-top:16px;}
+.r-1e081e0{padding-left:12px;padding-right:12px;}
+.r-1pn2ns4{padding-left:8px;padding-right:8px;}
+.r-t7s2l5{margin-bottom:auto;margin-top:auto;}
+.r-5njf8e{padding-bottom:8px;padding-top:8px;}
+[stylesheet-group="2.2"]{}
+.r-12vffkv>*{pointer-events:auto;}
+.r-12vffkv{pointer-events:none!important;}
+.r-2llsf{min-height:100%;}
+.r-13qz1uu{width:100%;}
+.r-417010{z-index:0;}
+.r-lrvibr{-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none;}
+.r-1g40b8q{z-index:3;}
+.r-orgf3d{opacity:0;}
+.r-633pao{pointer-events:none!important;}
+.r-1d2f490{left:0px;}
+.r-1xcajam{position:fixed;}
+.r-zchlnj{right:0px;}
+.r-1gn8etr{top:-0.5px;}
+.r-dkhcqf{-webkit-transition-duration:350ms;transition-duration:350ms;}
+.r-axxi2z{-moz-transition-property:transform;-webkit-transition-property:-webkit-transform,transform;transition-property:-webkit-transform,transform;}
+.r-18jm5s1{-webkit-transition-timing-function:cubic-bezier(0,0,0,1);transition-timing-function:cubic-bezier(0,0,0,1);}
+.r-16e0dcy{-webkit-transform:translate3d(0, 0, 0) translateY(0px);transform:translate3d(0, 0, 0) translateY(0px);}
+.r-1e5uvyk{-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);}
+.r-6026j{background-color:rgba(255,255,255,0.85);}
+.r-136ojw6{z-index:2;}
+.r-fxvszc{height:106px;}
+.r-1h3ijdo{height:53px;}
+.r-1awozwy{-ms-flex-align:center;-webkit-align-items:center;-webkit-box-align:center;align-items:center;}
+.r-18u37iz{-ms-flex-direction:row;-webkit-box-direction:normal;-webkit-box-orient:horizontal;-webkit-flex-direction:row;flex-direction:row;}
+.r-1777fci{-ms-flex-pack:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;}
+.r-1pz39u2{-ms-flex-item-align:stretch;-ms-grid-row-align:stretch;-webkit-align-self:stretch;align-self:stretch;}
+.r-15ysp7h{min-height:32px;}
+.r-4wgw6l{min-width:32px;}
+.r-1habvwh{-ms-flex-align:start;-webkit-align-items:flex-start;-webkit-box-align:start;align-items:flex-start;}
+.r-s8bhmr{min-width:56px;}
+.r-1mf7evn{margin-right:20px;}
+.r-1loqt21{cursor:pointer;}
+.r-16y2uox{-ms-flex-positive:1;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;}
+.r-2yi16{min-height:36px;}
+.r-1qi8awa{min-width:36px;}
+.r-o7ynqc{-webkit-transition-duration:0.2s;transition-duration:0.2s;}
+.r-6416eg{-moz-transition-property:background-color, box-shadow;-webkit-transition-property:background-color, box-shadow;transition-property:background-color, box-shadow;}
+.r-1ny4l3l{outline-style:none;}
+.r-bcqeeo{min-width:0px;}
+.r-qvutc0{word-wrap:break-word;}
+.r-rjixqe{line-height:20px;}
+.r-37j5jr{font-family:"TwitterChirp",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+.r-q4m81j{text-align:center;}
+.r-a023e6{font-size:15px;}
+.r-b88u0q{font-weight:700;}
+.r-yyyyoo{fill:currentcolor;}
+.r-1xvli5t{height:1.25em;}
+.r-dnmrzs{max-width:100%;}
+.r-bnwqim{position:relative;}
+.r-1plcrui{vertical-align:text-bottom;}
+.r-z80fyv{height:20px;}
+.r-19wmn03{width:20px;}
+.r-1cvl2hr{color:rgba(29,155,240,1.00);}
+.r-lwhw9o{height:1.75rem;}
+.r-poiln3{font-family:inherit;}
+.r-1wbh5a2{-ms-flex-negative:1;-webkit-flex-shrink:1;flex-shrink:1;}
+.r-1pi2tsx{height:100%;}
+.r-1iusvr4{-ms-flex-preferred-size:0px;-webkit-flex-basis:0px;flex-basis:0px;}
+.r-1oszu61{-ms-flex-align:stretch;-webkit-align-items:stretch;-webkit-box-align:stretch;align-items:stretch;}
+.r-eqz5dr{-ms-flex-direction:column;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-direction:column;flex-direction:column;}
+.r-8fdsdq{z-index:4;}
+.r-vqxq0j{border:0 solid black;}
+.r-deolkf{box-sizing:border-box;}
+.r-1mlwlqe{-ms-flex-preferred-size:auto;-webkit-flex-basis:auto;flex-basis:auto;}
+.r-ifefl9{min-height:0px;}
+.r-1sw30gj{background-color:rgba(239,243,244,1.00);}
+.r-1dqbpge{cursor:-webkit-text;cursor:text;}
+.r-7q8q6z{cursor:default;}
+.r-14j79pv{color:rgba(83,100,113,1.00);}
+.r-f727ji{padding-left:12px;}
+.r-16dba41{font-weight:400;}
+.r-30o5oe{-moz-appearance:none;-webkit-appearance:none;appearance:none;}
+.r-1dz5y72{resize:none;}
+.r-1niwhzg{background-color:rgba(0,0,0,0.00);}
+.r-homxoj{color:inherit;}
+.r-7cikom{font-size:inherit;}
+.r-1ttztb7{text-align:inherit;}
+.r-fdjqy7{text-align:left;}
+.r-y0fyvk::-webkit-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::-moz-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk:-ms-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-obd0qt{-ms-flex-align:end;-webkit-align-items:flex-end;-webkit-box-align:end;align-items:flex-end;}
+.r-1d4mawv{margin-right:4px;}
+.r-1w6e6rj{-ms-flex-wrap:wrap;-webkit-box-lines:multiple;-webkit-flex-wrap:wrap;flex-wrap:wrap;}
+.r-1wtj0ep{-ms-flex-pack:justify;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;}
+.r-1b43r93{font-size:14px;}
+.r-1cwl3u0{line-height:16px;}
+.r-u8s1d{position:absolute;}
+.r-150rngu{-webkit-overflow-scrolling:touch;}
+.r-17bb2tj{-webkit-animation-duration:0.75s;animation-duration:0.75s;}
+.r-1muvv40{-webkit-animation-iteration-count:infinite;animation-iteration-count:infinite;}
+.r-127358a{-webkit-animation-name:r-9p3sdl;animation-name:r-9p3sdl;}
+@-webkit-keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+@keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+.r-1ldzwu0{-webkit-animation-timing-function:linear;animation-timing-function:linear;}
+.r-aqfbo4{-webkit-backface-visibility:hidden;backface-visibility:hidden;}
+.r-14lw9ot{background-color:rgba(255,255,255,1.00);}
+.r-1ljd8xs{border-left-width:1px;}
+.r-13l2t4g{border-right-width:1px;}
+.r-33ulu8{width:600px;}
+.r-184en5c{z-index:1;}
+.r-1xk2f4g{clip:rect(1px, 1px, 1px, 1px);}
+.r-109y4c4{height:1px;}
+.r-92ng3h{width:1px;}
+.r-19u6a5r{margin-left:12px;}
+.r-1lul07w{-webkit-transform:translate3d(0, -3.5em, 0);transform:translate3d(0, -3.5em, 0);}
+.r-eafdt9{-webkit-transition-duration:0.15s;transition-duration:0.15s;}
+.r-1b8bd59{-moz-transition-property:transform, opacity;-webkit-transition-property:-webkit-transform,transform, opacity;transition-property:-webkit-transform,transform, opacity;}
+.r-nx0j10{-webkit-transition-timing-function:ease, ease, step-end;transition-timing-function:ease, ease, step-end;}
+.r-l5o3uw{background-color:rgba(29,155,240,1.00);}
+.r-y3da5r{box-shadow:0 0 8px rgba(101,119,134,0.2), 0 1px 3px 1px rgba(101,119,134,0.25);}
+.r-1kihuf0{-ms-flex-item-align:center;-ms-grid-row-align:center;-webkit-align-self:center;align-self:center;}
+.r-jwli3a{color:rgba(255,255,255,1.00);}
+.r-13hce6t{margin-left:4px;}
+.r-j5o65s{border-bottom-color:rgba(239,243,244,1.00);}
+.r-qklmqi{border-bottom-width:1px;}
+.r-1qhn6m8{padding-left:16px;}
+.r-i023vh{padding-right:16px;}
+.r-ttdzmv{padding-top:12px;}
+.r-15zivkp{margin-bottom:4px;}
+.r-18kxxzh{-ms-flex-positive:0;-webkit-box-flex:0;-webkit-flex-grow:0;flex-grow:0;}
+.r-1b7u577{margin-right:12px;}
+.r-1hwvwag{-ms-flex-preferred-size:48px;-webkit-flex-basis:48px;flex-basis:48px;}
+.r-1p0dtai{bottom:0px;}
+.r-ipm5af{top:0px;}
+.r-1wyvozj{left:50%;}
+.r-1v2oles{top:50%;}
+.r-desppf{-webkit-transform:translateX(-50%) translateY(-50%);transform:translateX(-50%) translateY(-50%);}
+.r-ggadg3{left:-2px;}
+.r-8jfcpp{top:-2px;}
+.r-vvn4in{background-position:center;}
+.r-u6sd8q{background-repeat:no-repeat;}
+.r-4gszlv{background-size:cover;}
+.r-1wyyakw{z-index:-1;}
+.r-12181gd{box-shadow:0 0 2px rgba(0,0,0,0.03) inset;}
+.r-zl2h9q{margin-bottom:2px;}
+.r-k4xj1c{-ms-flex-align:start;-webkit-align-items:start;-webkit-box-align:start;align-items:start;}
+.r-1d09ksm{-ms-flex-align:baseline;-webkit-align-items:baseline;-webkit-box-align:baseline;align-items:baseline;}
+.r-3s2u2q{white-space:nowrap;}
+.r-1q142lx{-ms-flex-negative:0;-webkit-flex-shrink:0;flex-shrink:0;}
+.r-f9ja8p{max-height:20px;}
+.r-og9te1{max-width:20px;}
+.r-9cviqr{margin-left:2px;}
+.r-1wvb978{-webkit-font-feature-settings:'ss01' on;font-feature-settings:'ss01' on;}
+.r-1s2bzr4{margin-top:12px;}
+.r-1inkyih{font-size:17px;}
+.r-9aw3ui{gap:4px;}
+.r-1dgieki{border-top-color:rgba(239,243,244,1.00);}
+.r-1efd50x{border-top-style:solid;}
+.r-5kkj8d{border-top-width:1px;}
+.r-1ta3fxp{-moz-column-gap:8px;-webkit-column-gap:8px;column-gap:8px;}
+.r-a2tzq0{-ms-flex-pack:distribute;-webkit-box-pack:justify;-webkit-justify-content:space-around;justify-content:space-around;}
+.r-3qxfft{min-height:1.875rem;}
+.r-h3s6tt{height:48px;}
+.r-rull8r{border-bottom-style:solid;}
+.r-1h0z5md{-ms-flex-pack:start;-webkit-box-pack:start;-webkit-justify-content:flex-start;justify-content:flex-start;}
+.r-bt1l66{min-height:20px;}
+.r-clp7b1{-moz-transition-property:color;-webkit-transition-property:color;transition-property:color;}
+.r-50lct3{height:1.5em;}
+.r-1srniue{width:1.5em;}
+.r-1ut4w64{margin-bottom:-1px;}
+.r-1bimlpy{background-color:rgba(207,217,222,1.00);}
+.r-m5arl1{width:2px;}
+.r-14gqq1x{margin-top:4px;}
+.r-kzbkwu{padding-bottom:12px;}
+.r-dflpy8{height:1.2em;}
+.r-sjv1od{margin-left:0.075em;}
+.r-zw8f10{margin-right:0.075em;}
+.r-10akycc{vertical-align:-20%;}
+.r-h9hxbl{width:1.2em;}
+.r-a5pmau{margin-right:2px;}
+.r-p3p4p0{max-height:17px;}
+.r-hm2b0w{max-width:17px;}
+.r-1mdbhws{max-width:425px;}
+.r-1hdv0qi{width:1.25em;}
+.r-n6v787{font-size:13px;}
+.r-1k6nrdp{min-width:calc(1em + 2 * 12px);}
+.r-vc7bo5{min-width:calc(1em + 2 * 8px);}
+.r-m2pi6t{padding-left:4px;}
+.r-1r8g8re{height:36px;}
+.r-10ptun7{height:16px;}
+.r-epq5cr{height:2px;}
+.r-1ssbvtb{gap:12px;}
+.r-pm9dpa{max-height:100%;}
+.r-rki7wi{bottom:12px;}
+.r-161ttwi{left:12px;}
+.r-k200y{-ms-flex-item-align:start;-webkit-align-self:flex-start;align-self:flex-start;}
+.r-loe9s5{background-color:rgba(0,0,0,0.77);}
+.r-pm2fo{border-bottom-left-radius:0px;}
+.r-zmljjp{border-bottom-right-radius:0px;}
+.r-ou6ah9{border-top-left-radius:0px;}
+.r-t12b5v{border-top-right-radius:0px;}
+.r-6t5ypu{border-bottom-left-radius:4px;}
+.r-kicko2{border-top-left-radius:4px;}
+.r-1dpl46z{border-bottom-right-radius:4px;}
+.r-notknq{border-top-right-radius:4px;}
+.r-105ug2t{pointer-events:auto!important;}
+.r-e6wyp1{height:67px;}
+.r-1p15a4t{width:67px;}
+.r-1sa8knb{height:calc(50% + 4px);}
+.r-gcko2u{width:calc(50% + 4px);}
+.r-1dsia8u{padding-left:3px;}
+.r-o52ifk{height:100px;}</style>
+<title data-rh="true">Marques Brownlee on Twitter: "I've never played Minecraft" / Twitter</title>
+<meta data-rh="true" content="article" property="og:type">
+<meta data-rh="true" content="https://twitter.com/MKBHD/status/1625192182859632661" property="og:url">
+<meta data-rh="true" content="Marques Brownlee on Twitter" property="og:title">
+<meta data-rh="true" content="“I've never played Minecraft”" property="og:description">
+<meta data-rh="true" content="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_200x200.jpg" property="og:image">
+<meta data-rh="true" description="" name="description"> <link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661" rel="canonical">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661" hreflang="x-default" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ar" hreflang="ar" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ar-x-fm" hreflang="ar-x-fm" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=bg" hreflang="bg" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=bn" hreflang="bn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ca" hreflang="ca" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=cs" hreflang="cs" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=da" hreflang="da" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=de" hreflang="de" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=el" hreflang="el" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=en" hreflang="en" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=en-GB" hreflang="en-GB" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=es" hreflang="es" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=eu" hreflang="eu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=fa" hreflang="fa" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=fi" hreflang="fi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=fil" hreflang="fil" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=fr" hreflang="fr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ga" hreflang="ga" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=gl" hreflang="gl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=gu" hreflang="gu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ha" hreflang="ha" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=he" hreflang="he" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=hi" hreflang="hi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=hr" hreflang="hr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=hu" hreflang="hu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=id" hreflang="id" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ig" hreflang="ig" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=it" hreflang="it" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ja" hreflang="ja" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=kn" hreflang="kn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ko" hreflang="ko" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=mr" hreflang="mr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ms" hreflang="ms" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=nb" hreflang="nb" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=nl" hreflang="nl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=no" hreflang="no" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=pl" hreflang="pl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=pt" hreflang="pt" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ro" hreflang="ro" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ru" hreflang="ru" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=sk" hreflang="sk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=sr" hreflang="sr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=sv" hreflang="sv" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ta" hreflang="ta" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=th" hreflang="th" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=tl" hreflang="tl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=tr" hreflang="tr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=uk" hreflang="uk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=ur" hreflang="ur" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=vi" hreflang="vi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=yo" hreflang="yo" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=zh" hreflang="zh" rel="alternate">
+<link data-rh="true" href="https://twitter.com/MKBHD/status/1625192182859632661?lang=zh-Hant" hreflang="zh-Hant" rel="alternate"> <meta data-rh="true" content="twitter://status?id=1625192182859632661" property="al:ios:url">
+<meta data-rh="true" content="333903271" property="al:ios:app_store_id">
+<meta data-rh="true" content="Twitter" property="al:ios:app_name">
+<meta data-rh="true" content="twitter://status?id=1625192182859632661" property="al:android:url">
+<meta data-rh="true" content="com.twitter.android" property="al:android:package">
+<meta data-rh="true" content="Twitter" property="al:android:app_name">
+</head>
+<body style="background-color: #FFFFFF;">
+  <noscript>
+    <style>
+    body {
+      -ms-overflow-style: scrollbar;
+      overflow-y: scroll;
+      overscroll-behavior-y: none;
     }
 
-    body.user-style-vyki_e .wrapper-profile .profile-card.profile-header .profile-header-inner {
-      background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/web);
+    .errorContainer {
+      background-color: #FFF;
+      color: #0F1419;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 10%;
+      font-family: Helvetica, sans-serif;
+      font-size: 16px;
     }
 
-    .DashboardProfileCard-bg {
-      background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/600x200);
+    .errorButton {
+      margin: 3em 0;
     }
 
-    body.user-style-vyki_e .profile-canopy .bg-img {
-      background-image: url(https://pbs.twimg.com/profile_banners/1087064150/1424315468/web_retina);
+    .errorButton a {
+      background: #1DA1F2;
+      border-radius: 2.5em;
+      color: white;
+      padding: 1em 2em;
+      text-decoration: none;
     }
 
-</style>
-
-
-
-
-          </div>
-        </div>
-
-    </div>
-    <div class="alert-messages hidden" id="message-drawer">
-    <div class="message ">
-  <div class="message-inside">
-    <span class="message-text"></span>
-      <a role="button" class="Icon Icon--close Icon--medium dismiss" href="#">
-        <span class="visuallyhidden">Dismiss</span>
-      </a>
-  </div>
-</div>
-</div>
-
-
-
-
-<div class="gallery-overlay"></div>
-<div class="Gallery">
-  <div class="Gallery-closeTarget"></div>
-  <div class="Gallery-content">
-    <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-    <div class="Gallery-media"></div>
-    <div class="GalleryNav GalleryNav--prev">
-      <span class="GalleryNav-handle GalleryNav-handle--prev">
-        <span class="Icon Icon--caretLeft Icon--large">
-          <span class="u-hiddenVisually">
-            Previous
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryNav GalleryNav--next">
-      <span class="GalleryNav-handle GalleryNav-handle--next">
-        <span class="Icon Icon--caretRight Icon--large">
-          <span class="u-hiddenVisually">
-            Next
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryTweet"></div>
-  </div>
-</div>
-
-
-
-<div class="modal-overlay"></div>
-
-<div id="profile-hover-container"></div>
-
-
-
-<div id="goto-user-dialog" class="modal-container">
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Go to a person's profile</h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="modal-inner">
-          <form class="t1-form goto-user-form">
-            <input class="input-block username-input" type="text" placeholder="Start typing a name to jump to a profile" aria-label="User">
-
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-
-
-
-<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info">
-        <span class="fullname"></span>
-        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-        <span class="username"><s>@</s><b></b></span>
-      </span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-    <div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Suggested users
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-          </form>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</div>
-
-
-  <div id="retweet-tweet-dialog" class="RetweetDialog modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="RetweetDialog-modal modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Retweet this to your followers?</h3>
-      </div>
-
-      <form class="t1-form tweet-form condensed RetweetDialog-tweetForm isWithoutComment" data-condensed-text="Add a comment...">
-        <div class="RetweetDialog-commentBox">
-          <span class="visuallyhidden" id="-label">Optional comment for Retweet</span>
-          <div class="tweet-content">
-            <div class="RichEditor">
-
-  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
-  <div class="RichEditor-scrollContainer">
-
-
-
-            <div aria-labelledby="-label" id="" class="tweet-box rich-editor"
-              contenteditable="true" spellcheck="true" role="textbox" aria-multiline="true"></div>
-
-    <div class="RichEditor-pictographs" aria-hidden="true"></div>
-  </div>
-  <div class="RichEditor-mozillaCursorWorkaround">&nbsp;</div>
-</div>
-
-          </div>
-
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-
-
-
-<ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info">
-        <span class="fullname"></span>
-        <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-        <span class="username"><s>@</s><b></b></span>
-      </span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-    <div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Suggested users
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span>
-          <span class="js-verified hidden"><span class="Icon Icon--verified Icon--small">
-  <span class="u-hiddenVisually">Verified account</span>
-</span></span>
-          <span class="username"><s>@</s><b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-        </div>
-
-        <div class="RetweetDialog-footer u-cf">
-          <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-          <div class="RetweetDialog-tweet modal-body modal-tweet tweet"></div>
-          <div class="tweet-button">
-            <span class="spinner"></span>
-            <span class="RetweetDialog-counter tweet-counter">140</span>
-            <button class="btn primary-btn retweet-action" type="button">
-              <span class="RetweetDialog-retweetActionLabel">
-                <span class="Icon Icon--retweet"></span>
-                Retweet
-              </span>
-              <span class="RetweetDialog-tweetActionLabel">
-                <span class="Icon Icon--tweet"></span>
-                Tweet
-              </span>
-            </button>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
-
-  <div id="delete-tweet-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Are you sure you want to delete this Tweet?</h3>
-      </div>
-
-      <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-      <div class="modal-body modal-tweet"></div>
-
-      <div class="modal-footer">
-        <button class="btn cancel-action js-close">Cancel</button>
-        <button class="btn primary-btn delete-action">Delete</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="quick-promote-dialog" class="QuickPromoteDialog modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Promote this Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="quick-promote-view-container">
-          <div class="media">
-            <iframe
-              class="quick-promote-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="block-user-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Block</h3>
-      </div>
-
-      <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-      <div class="modal-body modal-tweet"></div>
-
-      <div class="modal-footer">
-        <button class="btn cancel-action js-close">Cancel</button>
-        <button class="btn primary-btn block-action">Block</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-
-
-     <div id="geo-disabled-dropdown">
-      <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <ul>
-    <li class="geo-not-enabled-yet">
-      <h2>Add a location to your Tweets</h2>
-      <p>
-        When you tweet with a location, Twitter stores that location.&#32;
-        You can switch location on/off before each Tweet and always have the option to delete your location history.
-        <a href="http://support.twitter.com/forums/26810/entries/78525" target="_blank">Learn more</a>
-      </p>
-      <div>
-        <button type="button" class="geo-turn-on btn primary-btn">Turn location on</button>
-        <button type="button" class="geo-not-now btn-link">Not now</button>
-      </div>
-    </li>
-  </ul>
-</div>
-
-    </div>
-
-  <div id="geo-enabled-dropdown">
-    <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <div>
-    <div class="geo-query-location">
-      <input class="GeoSearch-queryInput" type="text" autocomplete="off" placeholder="Search for a neighborhood or city">
-      <span class="Icon Icon--search"></span>
-    </div>
-    <div class="geo-dropdown-status"></div>
-    <ul class="GeoSearch-dropdownMenu"></ul>
-  </div>
-</div>
-
-  </div>
-
-
-  <div id="profile_popup" class="modal-container ProfilePopupContainer--bellbird">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-small draggable">
-    <div class="modal-content clearfix">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Profile summary</h3>
-      </div>
-
-      <div class="modal-body profile-modal">
-
-      </div>
-
-      <div class="loading">
-        <span class="spinner-bigger"></span>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="list-membership-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Your lists</h3>
-      </div>
-      <div class="modal-body">
-        <div class="list-membership-content"></div>
-        <span class="spinner lists-spinner" title="Loading&hellip;"></span>
-      </div>
-    </div>
-  </div>
-</div>
-  <div id="list-operations-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Create a new list</h3>
-      </div>
-      <div class="modal-body">
-
-<div class="list-editor">
-  <div class="field">
-    <label class="t1-label" for="list-name">List name</label>
-    <input id="list-name" type="text" class="text" name="name" value="" />
-  </div>
-  <hr/>
-
-  <div class="field">
-    <label class="t1-label" for="list-description">Description</label>
-    <textarea id="list-description" name="description"></textarea>
-    <span class="help-text">Under 100 characters, optional</span>
-  </div>
-  <hr/>
-
-  <fieldset class="field">
-    <legend class="t1-legend">Privacy</legend>
-    <div class="options">
-      <label class="t1-label" for="list-public-radio">
-        <input class="radio" type="radio" name="mode" id="list-public-radio" value="public" checked="checked"  />
-        <b>Public</b> &middot; Anyone can follow this list
-      </label>
-      <label class="t1-label" for="list-private-radio">
-        <input class="radio" type="radio" name="mode" id="list-private-radio" value="private"  />
-        <b>Private</b> &middot; Only you can access this list
-      </label>
-    </div>
-  </fieldset>
-  <hr/>
-
-  <div class="list-editor-save">
-    <button type="button" class="btn btn-primary update-list-button" data-list-id="">Save list</button>
-  </div>
-
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="activity-popup-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content clearfix">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title"></h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="reply-users-header">
-  Your reply includes the people in this conversation up to this point. <a href="https://support.twitter.com/articles/14023">Learn more</a>
-</div>
-
-        <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-        <div class="activity-tweet modal-tweet clearfix"></div>
-        <div class="loading">
-          <span class="spinner-bigger"></span>
-        </div>
-        <div class="activity-content clearfix"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<div id="copy-link-to-tweet-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Copy link to Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="copy-link-to-tweet-container">
-          <label class="t1-label">
-            <p class="copy-link-to-tweet-instructions">The URL of this tweet is below. Copy it to easily share with friends.</p>
-            <textarea class="link-to-tweet-destination js-initial-focus u-dir" dir="ltr" readonly></textarea>
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="embed-tweet-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title embed-tweet-title">Embed this Tweet</h3>
-        <h3 class="modal-title embed-video-title">Embed this Video</h3>
-      </div>
-      <div class="modal-body">
-        <div class="embed-code-container">
-  <p class="embed-tweet-instructions">Add this Tweet to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
-  <p class="embed-video-instructions">Add this video to your website by copying the code below. <a href="//dev.twitter.com/docs/embedded-tweets">Learn more</a></p>
-  <form class="t1-form">
-
-    <div class="embed-destination-wrapper">
-      <div class="embed-overlay embed-overlay-spinner"><div class="embed-overlay-content"></div></div>
-      <div class="embed-overlay embed-overlay-error">
-        <p class="embed-overlay-content">Hmm, there was a problem reaching the server. <button type="button" class="btn-link retry-embed">Try again?</button></p>
-      </div>
-      <textarea class="embed-destination js-initial-focus"></textarea>
-      <div class="embed-options">
-        <div class="embed-include-parent-tweet">
-          <label class="t1-label" for="include-parent-tweet">
-            <input type="checkbox" id="include-parent-tweet" class="include-parent-tweet" checked>
-            Include parent Tweet
-          </label>
-        </div>
-        <div class="embed-include-card">
-          <label class="t1-label" for="include-card">
-            <input type="checkbox" id="include-card" class="include-card" checked>
-            Include media
-          </label>
-        </div>
-      </div>
-    </div>
-  </form>
-  <div class="embed-preview">
-    <h3>Preview</h3>
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-  <div id="login-dialog" class="LoginDialog modal-container u-textCenter">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-large draggable">
-    <div class="LoginDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Log in to Twitter</h3>
-      </div>
-      <div class="LoginDialog-body modal-body">
-        <div class="LoginDialog-bird">
-          <span class="Icon Icon--bird Icon--large"></span>
-        </div>
-        <div class="LoginDialog-form">
-<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="dialog"
-  data-element="login"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Phone, email or username"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
-  </div>
-
-  <div class="LoginForm-rememberForgot">
-    <label>
-      <input type="checkbox" value="1" name="remember_me" checked="checked">
-      <span>Remember me</span>
-    </label>
-    <span class="separator">&middot;</span>
-    <a class="forgot" href="/account/begin_password_reset">Forgot password?</a>
-  </div>
-
-  <input type="submit" class="submit btn primary-btn js-submit" value="Log in">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/vyki_e/status/363116819147538433">
-  <input type="hidden" value="0ca3d94aff5192efa7e34ae4eae60d07f5babd38" name="authenticity_token">
-</form>
-        </div>
-      </div>
-      <div class="LoginDialog-footer modal-footer u-textCenter">
-        Don't have an account? <a class="LoginDialog-signupLink" href="https://twitter.com/signup">Sign up &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="signup-dialog" class="SignupDialog modal-container u-textCenter">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-large draggable">
-    <div class="SignupDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Sign up for Twitter</h3>
-      </div>
-      <div class="SignupDialog-body modal-body">
-        <div class="SignupDialog-icon">
-          <span class="Icon Icon--bird Icon--extraLarge"></span>
-        </div>
-        <h2 class="SignupDialog-heading">Not on Twitter? Sign up, tune into the things you care about, and get updates as they happen.</h2>
-        <div class="SignupDialog-form">
-  <div class="signup SignupForm
-    ">
-    <a href="https://twitter.com/signup" role="button" class="SignupForm-submit u-block u-textCenter js-signup btn primary-btn"
-    data-component="dialog"
-    data-element="signup"
-    >Sign up</a>
-  </div>
-        </div>
-      </div>
-      <div class="SignupDialog-footer modal-footer u-textCenter">
-        Have an account? <a class="SignupDialog-signinLink" href="/login">Log in &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="sms-codes-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Two-way (sending and receiving) short codes:</h3>
-      </div>
-      <div class="modal-body">
-
-<table id="sms_codes" cellpadding="0" cellspacing="0">
-  <thead>
-    <tr>
-      <th>Country</th>
-      <th>Code</th>
-      <th>For customers of</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>United States</td>
-      <td>40404</td>
-      <td>(any)</td>
-    </tr>
-    <tr>
-      <td>Canada</td>
-      <td>21212</td>
-      <td>(any)</td>
-    </tr>
-    <tr>
-      <td>United Kingdom</td>
-      <td>86444</td>
-      <td>Vodafone, Orange, 3, O2</td>
-    </tr>
-    <tr>
-      <td>Brazil</td>
-      <td>40404</td>
-      <td>Nextel, TIM</td>
-    </tr>
-    <tr>
-      <td>Haiti</td>
-      <td>40404</td>
-      <td>Digicel, Voila</td>
-    </tr>
-    <tr>
-      <td>Ireland</td>
-      <td>51210</td>
-      <td>Vodafone, O2</td>
-    </tr>
-    <tr>
-      <td>India</td>
-      <td>53000</td>
-      <td>Bharti Airtel, Videocon, Reliance</td>
-    </tr>
-    <tr>
-      <td>Indonesia</td>
-      <td>89887</td>
-      <td>AXIS, 3, Telkomsel, Indosat, XL Axiata</td>
-    </tr>
-    <tr>
-      <td rowspan="2">Italy</td>
-      <td>4880804</td>
-      <td>Wind</td>
-    </tr>
-    <tr>
-      <td>3424486444</td>
-      <td>Vodafone</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="3">
-        &raquo; <a class="js-initial-focus" target="_blank" href="http://support.twitter.com/articles/14226-how-to-find-your-twitter-short-code-or-long-code">See SMS short codes for other countries</a>
-      </td>
-    </tr>
-  </tfoot>
-</table>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="leadgen-confirm-dialog" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Confirmation</h3>
-      </div>
-      <div class="modal-body">
-        <div class="leadgen-card-container">
-          <div class="media">
-            <iframe
-              class="cards2-promotion-iframe"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-        <div class="js-macaw-cards-iframe-container" data-card-name="promotion">
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="auth-webview-dialog" class="AuthWebViewDialog modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">&nbsp;</h3>
-      </div>
-      <div class="modal-body">
-        <div class="auth-webview-view-container">
-          <div class="media">
-            <iframe
-              class="auth-webview-card-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              width="590px"
-              height="500px"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-<div id="promptbird-modal-prompt" class="modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal">
-
-    <button type="button" class="modal-btn js-promptDismiss modal-close js-close">
-      <span class="Icon Icon--close Icon--medium">
-        <span class="visuallyhidden">Close</span>
-      </span>
-    </button>
-    <div class="modal-content"></div>
-  </div>
-</div>
-
-
-   <div id="payment-order-detail-dialog" class="PaymentOrderDialog modal-container">
-  <div class="close-modal-background-target"></div>
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Buy Now</h3>
-      </div>
-      <div class="modal-body">
-        <div class="alert">
-          <h4>Hmm... Something went wrong. Please try again.</h4>
-        </div>
-        <div class="spinner-bigger"></div>
-        <div class="PaymentOrderDialog-orderDetails"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-
-
-<div id="create-custom-timeline-dialog" class="modal-container"></div>
-<div id="edit-custom-timeline-dialog" class="modal-container"></div>
-<div id="curate-dialog" class="modal-container"></div>
-<div id="media-edit-dialog" class="modal-container"></div>
-
-
-      <div class="PermalinkOverlay PermalinkOverlay-with-background load-at-boot" id="permalink-overlay">
-  <button class="PermalinkOverlay-next PermalinkOverlay-button u-posFixed js-next" type="button">
-    <span class="Icon Icon--caretLeft Icon--large"></span>
-    <span class="u-hiddenVisually">Next Tweet from user</span>
-  </button>
-  <div class="PermalinkOverlay-modal">
-    <div class="PermalinkOverlay-spinnerContainer u-hidden">
-      <div class="PermalinkOverlay-spinner"></div>
-    </div>
-    <div class="PermalinkOverlay-content">
-      <div class="PermalinkOverlay-body"
-          data-background-path="/vyki_e"
->
-            <div class="permalink-container permalink-container--withArrows">
-  <div class="PermalinkProfile-dismiss">
-    <span class="Icon Icon--close Icon--large"></span>
-  </div>
-
-  <div role="main" class="permalink light-inline-actions  stream-uncapped original-permalink-page">
-
-<div class="TweetArrows">
-    <a href="/vyki_e/status/575780485156077568" class="TweetArrow-previous js-nav">
-      <span class="visuallyhidden">Previous Tweet</span>
-      <span class="Icon Icon--caretLeft"></span>
-    </a>
-</div>
-
-
-
-
-  <div class="permalink-inner permalink-tweet-container">
-
-
-    <div class="tweet permalink-tweet js-actionable-user js-actionable-tweet js-original-tweet
-
-
-
-
-          no-replies
-          js-initial-focus
-"
-        data-associated-tweet-id="363116819147538433"
-
-data-tweet-id="363116819147538433"
-data-item-id="363116819147538433"
-data-permalink-path="/vyki_e/status/363116819147538433"
-
-
-
-
-
-
-
-
-  data-screen-name="vyki_e" data-name="Vyki Englert" data-user-id="1087064150"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="peers"
-
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        tabindex="0"
-      >
-
-
-        <div class="content clearfix">
-          <div class="permalink-header">
-
-
-
-    <div class="follow-bar">
-      <div class="user-actions btn-group not-following  " data-user-id="1087064150"
-    data-screen-name="vyki_e" data-name="Vyki Englert" data-protected="false">
-
-
-
-
-
-
-  <button class="user-actions-follow-button js-follow-btn follow-button btn" type="button">
-  <span class="button-text follow-text">
-     <span class="Icon Icon--follow"></span> Follow
-
-  </span>
-  <span class="button-text following-text">
-     Following
-
-  </span>
-  <span class="button-text unfollow-text">
-     Unfollow
-
-  </span>
-  <span class="button-text blocked-text">Blocked</span>
-  <span class="button-text unblock-text">Unblock</span>
-  <span class="button-text pending-text">Pending</span>
-  <span class="button-text cancel-text">Cancel</span>
-</button>
-
-
-
-</div>
-
-    </div>
-
-
-              <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/vyki_e" data-user-id="1087064150">
-    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_bigger.jpg" alt="">
-    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>Vyki Englert</strong>
-    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>vyki_e</b></span>
-
-  </a>
-
-
-            <small class="time">
-  <a href="/vyki_e/status/363116819147538433" class="tweet-timestamp js-permalink js-nav js-tooltip" title="6:59 PM - 1 Aug 2013" ><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1375408770" data-time-ms="1375408770000" data-long-form="true">1 Aug 2013</span></a>
-</small>
-
-          </div>
-        </div>
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize TweetTextSize--26px js-tweet-text tweet-text" lang="en" data-aria-label-part="0">I&#39;m a sucker for pledges.  <a href="/peers" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="1428357889" ><s>@</s><b>Peers</b></a> Pledge <a href="/hashtag/sharingeconomy?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>sharingeconomy</b></a> <a href="http://t.co/T4Sc47KAzh" rel="nofollow" dir="ltr" data-expanded-url="http://www.peers.org/action/peers-pledgea/" class="twitter-timeline-link" target="_blank" title="http://www.peers.org/action/peers-pledgea/" ><span class="tco-ellipsis"></span><span class="invisible">http://www.</span><span class="js-display-url">peers.org/action/peers-p</span><span class="invisible">ledgea/</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
-</div>
-
-
-
-
-
-
-      <div class="js-tweet-details-fixer tweet-details-fixer">
-
-  <div class="js-machine-translated-tweet-container"></div>
-  <div class="js-tweet-stats-container tweet-stats-container">
-  </div>
-
-  <div class="client-and-actions">
-  <span class="metadata">
-    <span>6:59 PM - 1 Aug 2013</span>
-  </span>
-</div>
-
-
-</div>
-
-
-
-      <div class="stream-item-footer">
-
-
-
-
-
-              <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" >0 likes</span>
-      </span>
-    </span>
-  </div>
-
-    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-        <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply"
-    type="button">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-  </button>
-</div>
-        <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-        </span>
-      </div>
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-        </span>
-      </div>
-  </button>
-</div>
-
-      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Like">
-      <div class="HeartAnimationContainer">
-        <div class="HeartAnimation"></div>
-      </div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-        </span>
-      </div>
-  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <div class="HeartAnimationContainer">
-        <div class="HeartAnimation"></div>
-      </div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-        </span>
-      </div>
-  </button>
-</div>
-
-
-
-
-        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--dots"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-    </div>
-
-      </div>
-
-      <div class="permalink-footer">
-
-      </div>
-    </div>
-
-  </div>
-
-
-
-
-<div class="replies-to  hidden permalink-inner permalink-replies" data-component-context="replies">
-    <div class="tweets-wrapper">
-      <div id="descendants" class="ThreadedDescendants">
-          <div class="stream-container  "
-    data-max-position="" data-min-position=""
-    >
-
-    <div class="stream">
-        <ol class="stream-items js-navigable-stream" id="stream-items-id">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        </ol>
-        <div class="stream-footer ">
-  <div class='timeline-end  '>
-    <div class="stream-end">
-  <div class="stream-end-inner">
-      <span class="Icon Icon--large Icon--logo"></span>
-
-    <p class="empty-text">
-
-
+    .errorButton a:hover,
+    .errorButton a:focus {
+      background: rgb(26, 145, 218);
+    }
+
+    .errorFooter {
+      color: #657786;
+      font-size: 80%;
+      line-height: 1.5;
+      padding: 1em 0;
+    }
+
+    .errorFooter a,
+    .errorFooter a:visited {
+      color: #657786;
+      text-decoration: none;
+      padding-right: 1em;
+    }
+
+    .errorFooter a:hover,
+    .errorFooter a:active {
+      text-decoration: underline;
+    }
+
+      #placeholder,
+      #react-root {
+        display: none !important;
+      }
+      body {
+        background-color: #FFF !important;
+      }
+    </style>
+    <div class="errorContainer">
+      <img width="46" height="38" srcset="https://abs.twimg.com/errors/logo46x38.png 1x, https://abs.twimg.com/errors/logo46x38@2x.png 2x" src="https://abs.twimg.com/errors/logo46x38.png" alt="Twitter">
+      <h1>JavaScript is not available.</h1>
+      <p>We’ve detected that JavaScript is disabled in this browser. Please enable JavaScript or switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center.</p>
+      <p class="errorButton"><a href="https://help.twitter.com/using-twitter/twitter-supported-browsers">Help Center</a></p>
+    <p class="errorFooter">
+      <a href="https://twitter.com/tos">Terms of Service</a>
+      <a href="https://twitter.com/privacy">Privacy Policy</a>
+      <a href="https://support.twitter.com/articles/20170514">Cookie Policy</a>
+      <a href="https://legal.twitter.com/imprint.html">Imprint</a>
+      <a href="https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&amp;utm_source=twc&amp;utm_medium=web&amp;utm_campaign=ao&amp;utm_content=adsinfo">Ads info</a>
+      © 2023 X Corp.
     </p>
 
-          <p><button type='button' class='btn-link back-to-top hidden'>Back to top &uarr;</button></p>
-
-  </div>
-</div>
-
-    <div class="stream-loading">
-  <div class="stream-end-inner">
-    <span class="spinner" title="Loading..."></span>
-  </div>
-</div>
-
-  </div>
-</div>
-<div class="stream-fail-container">
-    <div class="js-stream-whale-end stream-whale-end stream-placeholder centered-placeholder">
-  <div class="stream-end-inner">
-    <h2 class="title">Loading seems to be taking a while.</h2>
-    <p>
-      Twitter may be over capacity or experiencing a momentary hiccup. <a role="button" href="#" class="try-again-after-whale">Try again</a> or visit <a target="_blank" href="http://status.twitter.com">Twitter Status</a> for more information.
-    </p>
-  </div>
-</div>
-</div>
-
-      <ol class="hidden-replies-container"></ol>
     </div>
-  </div>
-
-      </div>
-    </div>
+  </noscript>
+<div id="react-root" style="height:100%;display:flex;"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13qz1uu r-417010" style="min-height:736px">
+<div aria-label="Skip to home timeline" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<div aria-label="Skip to trending" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<header role="banner" class="css-1dbjc4n r-lrvibr r-1g40b8q"><div class="css-1dbjc4n r-1h3ijdo r-orgf3d r-633pao"></div>
+<div class="css-1dbjc4n" data-testid="SSRSafeLayer"><div class="css-1dbjc4n r-1d2f490 r-1xcajam r-zchlnj r-1gn8etr">
+<div class="css-1dbjc4n r-1e5uvyk r-6026j r-16e0dcy r-dkhcqf r-axxi2z r-18jm5s1" data-testid="TopNavBar"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-fxvszc r-136ojw6" data-testid="twitter-logged-out-nav">
+<div class="css-1dbjc4n r-1h3ijdo r-136ojw6"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1h3ijdo"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1h3ijdo r-1777fci r-1jgb5lz r-ymttw5 r-13qz1uu">
+<div class="css-1dbjc4n r-1habvwh r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div class="css-1dbjc4n r-1777fci r-1mf7evn"><h1 role="heading" class="css-4rbku5 css-1dbjc4n r-1awozwy r-1pz39u2 r-1loqt21 r-6koalj r-16y2uox r-1777fci r-4wgw6l"><a href="/" aria-label="Twitter" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-left:calc(0px + (-1 * ((36px + (1px * 2)) - 1.75rem) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-16y2uox r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M23.643 4.937c-.835.37-1.732.62-2.675.733.962-.576 1.7-1.49 2.048-2.578-.9.534-1.897.922-2.958 1.13-.85-.904-2.06-1.47-3.4-1.47-2.572 0-4.658 2.086-4.658 4.66 0 .364.042.718.12 1.06-3.873-.195-7.304-2.05-9.602-4.868-.4.69-.63 1.49-.63 2.342 0 1.616.823 3.043 2.072 3.878-.764-.025-1.482-.234-2.11-.583v.06c0 2.257 1.605 4.14 3.737 4.568-.392.106-.803.162-1.227.162-.3 0-.593-.028-.877-.082.593 1.85 2.313 3.198 4.352 3.234-1.595 1.25-3.604 1.995-5.786 1.995-.376 0-.747-.022-1.112-.065 2.062 1.323 4.51 2.093 7.14 2.093 8.57 0 13.255-7.098 13.255-13.254 0-.2-.005-.402-.014-.602.91-.658 1.7-1.477 2.323-2.41z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span>
+</div></a></h1></div></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1pi2tsx r-1777fci">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n r-1awozwy r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-13awgt0 r-eqz5dr r-bnwqim r-8fdsdq"><div class="r-1oszu61 r-vqxq0j r-deolkf r-6koalj r-1mlwlqe r-eqz5dr r-1wbh5a2 r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-13qz1uu r-417010"><form action="#" aria-label="Search Twitter" role="search" class="r-1oszu61 r-1phboty r-1yadl64 r-deolkf r-6koalj r-13awgt0 r-eqz5dr r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-417010">
+<div class="css-1dbjc4n r-1wbh5a2"><div class="css-1dbjc4n r-1sw30gj r-42olwf r-sdzlij r-1phboty r-rs99b7 r-eqz5dr r-16y2uox r-1wbh5a2 r-1777fci"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1awozwy r-18u37iz"><label class="css-1dbjc4n r-1dqbpge r-13awgt0 r-18u37iz" data-testid="SearchBox_Search_Input_label"><div class="css-1dbjc4n r-7q8q6z r-6koalj r-1777fci"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-14j79pv r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-4wgw6l r-f727ji r-bnwqim r-1plcrui r-lrvibr"><g><path d="M10.25 3.75c-3.59 0-6.5 2.91-6.5 6.5s2.91 6.5 6.5 6.5c1.795 0 3.419-.726 4.596-1.904 1.178-1.177 1.904-2.801 1.904-4.596 0-3.59-2.91-6.5-6.5-6.5zm-8.5 6.5c0-4.694 3.806-8.5 8.5-8.5s8.5 3.806 8.5 8.5c0 1.986-.682 3.815-1.824 5.262l4.781 4.781-1.414 1.414-4.781-4.781c-1.447 1.142-3.276 1.824-5.262 1.824-4.694 0-8.5-3.806-8.5-8.5z"></path></g></svg></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div dir="ltr" class="css-901oao r-6koalj r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><input type="text" aria-activedescendant="typeaheadFocus-0.006247190900518174" aria-autocomplete="list" aria-label="Search query" aria-owns="typeaheadDropdown-78518" autocapitalize="sentences" autocomplete="off" autocorrect="off" placeholder="Search Twitter" role="combobox" spellcheck="false" value="" enterkeyhint="search" dir="auto" class="r-30o5oe r-1niwhzg r-17gur6a r-1yadl64 r-deolkf r-homxoj r-poiln3 r-7cikom r-1ny4l3l r-xyw6el r-oyd9sg r-y0fyvk r-1dz5y72 r-fdjqy7 r-13qz1uu" data-testid="SearchBox_Search_Input"></div></div>
+<div class="css-1dbjc4n r-6koalj r-1777fci"></div></label></div></div></div></div>
+<div class="css-1dbjc4n r-13awgt0 r-bnwqim"></div>
+</form></div></div></div></div>
 </div>
-
-
-
-
-  </div>
-
-
-  <div class="stream-container suggested-tweet-stream-container dismissible-container ">
-    <div class="stream suggested-tweet-stream permalink-replies">
-      <h3 class="promoted-heading">Promoted Tweet</h3>
-      <ol class="stream-items suggested-tweet-stream-items js-navigable-stream" id="suggested-stream-items-id">
-
-
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable
-       original-tweet js-original-tweet
-
-       promoted-tweet pixel-promoted-tweet has-cards  has-content
-"
-
-data-tweet-id="708322579254267906"
-data-item-id="708322579254267906"
-data-permalink-path="/EnquetesOnline/status/708322579254267906"
-
-
-
-
-
-
-
-
-  data-screen-name="EnquetesOnline" data-name="EnqueteVergelijk" data-user-id="3832036337"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
-
-
-
-
-
-
-
-
-data-impression-id="2d21a58718bcb645"
-data-disclosure-type="promoted"
-  data-promoted="true"
-   data-advertiser-id="3832036337"
- data-impression-cookie="[&quot;708322579254267906&quot;,&quot;2d21a58718bcb645&quot;,&quot;promoted&quot;,&quot;&quot;,[],&quot;3832036337&quot;]"
-
-
-
- data-has-cards="true"
-
-
-
-
-
-
-
-
- data-component-context="conversation-suggestions"
-
-
-    >
-
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-      <div class="stream-item-header">
-          <a data-impression-cookie="[&quot;3832036337&quot;,&quot;2d21a58718bcb645&quot;,&quot;promoted&quot;,&quot;&quot;,[],&quot;3832036337&quot;]" class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/EnquetesOnline" data-user-id="3832036337">
-    <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/682161235798929409/WrtoYroK_bigger.png" alt="">
-    <strong class="fullname js-action-profile-name show-popup-with-id" data-aria-label-part>EnqueteVergelijk</strong>
-    <span>&rlm;</span><span class="username js-action-profile-name" data-aria-label-part><s>@</s><b>EnquetesOnline</b></span>
-
-  </a>
-
-        <small class="time">
-  <a href="/EnquetesOnline/status/708322579254267906" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:03 AM - 11 Mar 2016" data-send-impression-cookie><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1457712237" data-time-ms="1457712237000" data-long-form="true">Mar 11</span></a>
-</small>
-
-
-
-      </div>
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="nl" data-aria-label-part="0">Extra geld nodig voor komend weekeinde? Verdien tot €75 extra per week met betaalde enquêtes <a href="https://t.co/7URysZPCIG" rel="nofollow" dir="ltr" data-expanded-url="http://bit.ly/1T2Fhr3" class="twitter-timeline-link" target="_blank" title="http://bit.ly/1T2Fhr3" ><span class="tco-ellipsis"></span><span class="invisible">http://</span><span class="js-display-url">bit.ly/1T2Fhr3</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a><a href="https://t.co/fKtcerUzWC" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/fKtcerUzWC</a></p>
+<div class="css-1dbjc4n r-obd0qt r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div aria-expanded="false" aria-haspopup="menu" aria-label="More" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-right:calc(4px + (-1 * ((36px + (1px * 2)) - 20px) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-z80fyv r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03" style="color:rgba(15,20,25,1.00)"><g><path d="M3 12c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9 2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm7 0c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0" style="border-bottom:2px solid #0F1419"></span>
+</div></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-16y2uox r-1w6e6rj r-1h3ijdo r-1wtj0ep r-1fz3rvf r-rjfia"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox">
+<div class="css-1dbjc4n r-16y2uox"><a href="/login" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="login"><div dir="ltr" class="css-901oao r-1awozwy r-1cvl2hr r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Log in</span></span></div></a></div>
+<div class="css-1dbjc4n r-16y2uox r-19u6a5r"><a href="/i/flow/signup" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-l5o3uw r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="signup"><div dir="ltr" class="css-901oao r-1awozwy r-jwli3a r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Sign up</span></span></div></a></div>
+</div></div></div>
+</div></div></div>
+<div class="css-1dbjc4n r-633pao r-u8s1d r-dkhcqf r-axxi2z r-18jm5s1 r-13qz1uu r-1wyyakw" style="-webkit-transform:translate3d(0, 0, 0) translateY(53px);transform:translate3d(0, 0, 0) translateY(53px)"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-1awozwy r-1777fci r-1jgb5lz r-19u6a5r r-13qz1uu"><div role="status" class="css-1dbjc4n r-1r5su4o r-orgf3d r-1lul07w r-eafdt9 r-1b8bd59 r-nx0j10"><div aria-label="New Tweets are available. Push the period key to go to the them." role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-sdzlij r-y3da5r r-1777fci r-1ny4l3l r-ymttw5 r-oyd9sg r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1kihuf0 r-jwli3a r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M12 3.59l7.457 7.45-1.414 1.42L13 7.41V21h-2V7.41l-5.043 5.05-1.414-1.42L12 3.59z"></path></g></svg><div dir="ltr" class="css-901oao css-1hf3ou5 r-1kihuf0 r-jwli3a r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-13hce6t r-bcqeeo r-qvutc0" data-testid="pillLabel"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">See new Tweets</span></div>
+</div></div></div></div></div></div>
+</div></div></header><main role="main" class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-150rngu r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-aqfbo4 r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1niwhzg r-18u37iz r-16y2uox r-1jgb5lz r-2llsf r-13qz1uu"><div class="css-1dbjc4n r-14lw9ot r-42olwf r-1ljd8xs r-13l2t4g r-1phboty r-16y2uox r-1jgb5lz r-13qz1uu r-184en5c" data-testid="primaryColumn"><div aria-label="Home timeline" tabindex="0" class="css-1dbjc4n"><div itemscope="" itemtype="https://schema.org/Collection">
+<meta content="Tweet with replies" itemprop="name">
+<section aria-labelledby="accessible-list-35179" role="region" class="css-1dbjc4n"><h1 dir="auto" aria-level="1" role="heading" class="css-4rbku5 css-901oao r-4iw3lz r-1xk2f4g r-109y4c4 r-1udh08x r-wwvuq4 r-u8s1d r-92ng3h" id="accessible-list-35179">Conversation</h1>
+<div aria-label="Timeline: Conversation" class="css-1dbjc4n"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192182859632661" itemprop="identifier">
+<meta content="1" itemprop="position">
+<meta content="2734" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:56:25.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:56:25.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="url">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="mainEntityOfPage">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="29873662" itemprop="identifier">
+<meta content="MKBHD" itemprop="additionalName">
+<meta content="Marques Brownlee" itemprop="givenName">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/FollowAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="6099227" itemprop="userInteractionCount">
 </div>
-
-
-
-
-
-            <div class="AdaptiveMedia
-      allow-expansion
-
-
-      is-generic-video
-
-      has-autoplayable-media"
-    >
-    <div class="AdaptiveMedia-container
-        js-adaptive-media-container
-        "
-      >
-        <div class="AdaptiveMedia-video">
-  <div class="AdaptiveMedia-videoContainer">
-      <div class="PlayableMedia PlayableMedia--gif">
-
-  <div
-    class="PlayableMedia-player
-
-      "
-    data-playable-media-url=""
-      data-border-top-left-radius=""
-      data-border-top-right-radius=""
-      data-border-bottom-left-radius=""
-      data-border-bottom-right-radius=""
-    style="padding-bottom: 49.80237154150198%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/CdR3k4RWoAEPONJ.jpg')">
-  </div>
-
-
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/SubscribeAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="455" itemprop="userInteractionCount">
 </div>
-
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="54252" itemprop="userInteractionCount">
 </div>
-
-    </div>
-  </div>
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-        <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually"></span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="59">
-        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>59 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="334">
-        <span class="ProfileTweet-actionCountForAria" data-aria-label-part>334 likes</span>
-      </span>
-    </span>
-  </div>
-
-    <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-        <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton u-textUserColorHover js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply"
-    type="button">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-  </button>
 </div>
-        <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">59</span>
-        </span>
-      </div>
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">59</span>
-        </span>
-      </div>
-  </button>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661/likes" itemprop="url">
+<meta content="46756" itemprop="userInteractionCount">
 </div>
-
-      <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Like">
-      <div class="HeartAnimationContainer">
-        <div class="HeartAnimation"></div>
-      </div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">334</span>
-        </span>
-      </div>
-  </button><button class="ProfileTweet-actionButtonUndo u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <div class="HeartAnimationContainer">
-        <div class="HeartAnimation"></div>
-      </div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <div class="IconTextContainer">
-        <span class="ProfileTweet-actionCount">
-          <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">334</span>
-        </span>
-      </div>
-  </button>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661/retweets" itemprop="url">
+<meta content="1460" itemprop="userInteractionCount">
 </div>
-
-
-
-
-        <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--dots"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-        <li class="ads-info-link js-actionOpenAdsInfoPage">
-          <button type="button" class="dropdown-link">Ads info</button>
-        </li>
-  </ul>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661/retweets/with_comments" itemprop="url">
+<meta content="477" itemprop="userInteractionCount">
 </div>
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="url">
+<meta content="2734" itemprop="userInteractionCount">
 </div>
-
-  </div>
-
-    </div>
-
+<article aria-labelledby="id__w6erc4o3qb id__fyd1mhw8odq id__if1m3ijjejf id__f5amgd75ty id__bk3ru05nxq8 id__mdnukndkzq id__81ysxx9s95t id__i0vicyjkv2 id__4p0o3fcjr0b id__yl750m0dn8p id__jsfx3z75t4c id__rrm0096lkr id__gmw003czpn id__xtpjxxhecqf id__meugdhu0np id__f14cqbblq3c id__loq8wyezy9m id__ednkh7miqj8 id__iou8irloszm" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-15zivkp">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-MKBHD">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/MKBHD" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci"><div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__bk3ru05nxq8" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Marques Brownlee</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@MKBHD</span></div></a></div></div></div>
+</div></div></div></div></div></div>
 </div>
-
-      <div class="context">
-  <span class="metadata with-icn js-disclosure js-tooltip" title="">
-      <span class="Icon Icon--promoted"></span>
-<a href="/EnquetesOnline"
-   class="js-action-profile-promoted js-user-profile-link js-promoted-badge"
-   data-user-id="3832036337"
-   data-impression-cookie="[&quot;708322579254267906&quot;,&quot;2d21a58718bcb645&quot;,&quot;promoted&quot;,&quot;&quot;,[],&quot;3832036337&quot;]"
->Promoted</a>
-
-  </span>
-
-      <button type="button" class="btn-link dismiss-btn js-action-dismiss">
-        <span class="Icon Icon--close Icon--smallest"></span>
-        <span>Dismiss</span>
-      </button>
+<div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n"><div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n r-1s2bzr4"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-1inkyih r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__jsfx3z75t4c" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">I've never played Minecraft</span></div></div></div></div>
+<div class="css-1dbjc4n"></div>
+<div class="css-1dbjc4n"></div>
+<div class="css-1dbjc4n r-1r5su4o"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wtj0ep">
+<div class="css-1dbjc4n r-1b7u577"><div class="css-1dbjc4n r-1d09ksm r-1471scf r-18u37iz r-1wbh5a2">
+<div dir="ltr" class="css-901oao r-14j79pv r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><a href="/MKBHD/status/1625192182859632661" aria-describedby="id__aa01qsl1mhd" aria-label="5:56 PM · Feb 13, 2023" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-poiln3 r-9aw3ui r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:56:25.000Z">5:56 PM · Feb 13, 2023</time></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div dir="ltr" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">4M</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Views</span></span></span></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz"></div>
+</div></div>
+<div role="group" class="css-1dbjc4n r-18u37iz r-1w6e6rj">
+<div role="separator" class="css-1dbjc4n r-1dgieki r-1efd50x r-5kkj8d r-109y4c4 r-13qz1uu"></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/MKBHD/status/1625192182859632661/retweets" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,460</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Retweets</span></span></a></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/MKBHD/status/1625192182859632661/retweets/with_comments" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">477</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Quotes</span></span></a></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/MKBHD/status/1625192182859632661/likes" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">46.7K</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Likes</span></span></a></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><div dir="ltr" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">168</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Bookmarks</span></span>
+</div></div>
 </div>
-
-
-
-
-
-
-
-
-    </div>
-  </div>
-
-
-      </ol>
-    </div>
-   </div>
-
-    <div class="Trends module trends hidden
-            Trends--wide
-            ">
-  <div class="trends-inner">
-    <div class="flex-module trends-container ">
-  <div class="flex-module-header">
-
-    <h3><span class="trend-location js-trend-location">false</span></h3>
-  </div>
-  <div class="flex-module-inner">
-    <ul class="trend-items js-trends">
-    </ul>
-  </div>
+<div class="css-1dbjc4n"><div role="group" class="css-1dbjc4n r-1oszu61 r-j5o65s r-rull8r r-qklmqi r-1dgieki r-1efd50x r-5kkj8d r-1ta3fxp r-18u37iz r-h3s6tt r-a2tzq0 r-3qxfft r-s1qlax" id="id__iou8irloszm">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Bookmark" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="bookmark"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4 4.5C4 3.12 5.119 2 6.5 2h11C18.881 2 20 3.12 20 4.5v18.44l-8-5.71-8 5.71V4.5zM6.5 4c-.276 0-.5.22-.5.5v14.56l6-4.29 6 4.29V4.5c0-.28-.224-.5-.5-.5h-11z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
 </div>
-  </div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625209637837611008" itemprop="identifier">
+<meta content="2" itemprop="position">
+<meta content="64" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T19:05:47.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T19:05:47.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Quackity/status/1625209637837611008" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="2260704146" itemprop="identifier">
+<meta content="Quackity" itemprop="additionalName">
+<meta content="Quackity 🪷" itemprop="givenName">
+<meta content="QUACKITY MERCH" itemprop="disambiguatingDescription">
 </div>
-
-
-  <div class="permalink-footer">
-      <div class="Footer module roaming-module
-            Footer--slim
-            ">
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2016 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about">About</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com">Help</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos">Terms</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy">Privacy</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170451">Ads info</a></li>
-      </ul>
-    </div>
-  </div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Quackity/status/1625209637837611008/likes" itemprop="url">
+<meta content="24438" itemprop="userInteractionCount">
 </div>
-
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Quackity/status/1625209637837611008/retweets" itemprop="url">
+<meta content="405" itemprop="userInteractionCount">
 </div>
-
-
-      </div>
-    </div>
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Quackity/status/1625209637837611008/retweets/with_comments" itemprop="url">
+<meta content="12" itemprop="userInteractionCount">
 </div>
-
-    <div class="hidden" id="hidden-content">
-  <iframe aria-hidden="true" class="tweet-post-iframe" name="tweet-post-iframe"></iframe>
-  <iframe aria-hidden="true" class="dm-post-iframe" name="dm-post-iframe"></iframe>
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Quackity/status/1625209637837611008" itemprop="url">
+<meta content="64" itemprop="userInteractionCount">
 </div>
-
-
-    <div id="spoonbill-outer"></div>
-  </body>
+<article aria-labelledby="id__2mbzlvh4hd4 id__oxll8cknjy id__g16xu6t3ogq id__gy3scbv69va id__k9w29kn7wc id__f6nkt5684jd id__i274mimsvsr id__2hwitsnavfe id__bi5rmtaz5yp id__kv0w1cu7vb id__gwsfc2ctnz8 id__b5powkgtfa9 id__94f3506sh8o id__p1olhzydb1 id__24gujc7bnkw id__r8swkh4yf1f id__o3ttysy37zf id__sha9s5ijyuc id__xq8xoch4t2o" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Quackity">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Quackity" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1207501693799284738/x44HzZe5_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1207501693799284738/x44HzZe5_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q">
+<div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__k9w29kn7wc" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Quackity" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Quackity </span><img alt="🪷" draggable="false" src="https://abs-0.twimg.com/emoji/v2/svg/1fab7.svg" class="r-4qtqp9 r-dflpy8 r-sjv1od r-zw8f10 r-10akycc r-h9hxbl"></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg><div tabindex="0" class="css-1dbjc4n r-1loqt21 r-xoduu5 r-1777fci r-13hce6t r-a5pmau r-1ny4l3l"><div class="css-1dbjc4n r-4qtqp9 r-p3p4p0 r-hm2b0w r-bnwqim" style="height:calc(1.25em*0.85);width:calc(1.25em*0.85)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-6koalj r-1mlwlqe r-1pi2tsx r-1udh08x r-13qz1uu r-417010" style="border-top-left-radius:2px;border-top-right-radius:2px;border-bottom-right-radius:2px;border-bottom-left-radius:2px">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-xoduu5 r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1630800273018068992/kJwADgJJ_bigger.jpg")'></div>
+<img alt="" draggable="false" src="https://pbs.twimg.com/profile_images/1630800273018068992/kJwADgJJ_bigger.jpg" class="css-9pa8cd">
+</div></div>
+</div></div></div></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Quackity" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Quackity</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Quackity/status/1625209637837611008" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T19:05:47.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wtj0ep r-zl2h9q"></div>
+</div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__gwsfc2ctnz8" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Marques Brownlee i Can teach u How</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="64 replies, 417 Retweets, 24438 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__xq8xoch4t2o">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="64 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">64</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="417 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">417</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="24438 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">24.4K</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625300146790535170" itemprop="identifier">
+<meta content="3" itemprop="position">
+<meta content="21" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-14T01:05:26.000Z" itemprop="dateCreated">
+<meta content="2023-02-14T01:05:26.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/MKBHD/status/1625300146790535170" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="29873662" itemprop="identifier">
+<meta content="MKBHD" itemprop="additionalName">
+<meta content="Marques Brownlee" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Quackity/status/1625209637837611008" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625300146790535170/likes" itemprop="url">
+<meta content="2142" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625300146790535170/retweets" itemprop="url">
+<meta content="27" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625300146790535170/retweets/with_comments" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625300146790535170" itemprop="url">
+<meta content="21" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__buxyidni40m id__b5tqtplkqpb id__2dlu0zj2scf id__te2zcbhdp5 id__8v0egotwx4 id__rz8po5s4imo id__a0yx8dxz13e id__2vcdgn555eb id__1zk264oau1ri id__u2ai6exurbj id__s0in3nyc7td id__ac9x6109avr id__jkojo0qu9h id__b9ejkrre3jk id__haqc40842ni id__qz6jqenusn id__oinre35cqb id__6tw5g7qkcm3 id__i8qf3oz2igm" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1hwvwag r-18kxxzh r-15zivkp r-1b7u577"><div class="css-1dbjc4n r-1bimlpy r-1p0dtai r-1d2f490 r-1jgb5lz r-u8s1d r-zchlnj r-ipm5af r-m5arl1"></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-MKBHD">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/MKBHD" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__8v0egotwx4" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Marques Brownlee</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@MKBHD</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/MKBHD/status/1625300146790535170" dir="ltr" aria-label="Feb 14" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-14T01:05:26.000Z">Feb 14</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__s0in3nyc7td" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">What am I gonna need</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="21 replies, 29 Retweets, 2142 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__i8qf3oz2igm">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="21 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">21</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="29 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">29</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2142 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2,142</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div class="css-1dbjc4n r-1udh08x"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-16y2uox r-19u6a5r r-1ny4l3l r-m2pi6t r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-6koalj r-1hwvwag r-18kxxzh r-1r8g8re r-1b7u577 r-bnwqim"><div class="css-1dbjc4n r-1awozwy r-10ptun7 r-1wtj0ep r-t7s2l5">
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+</div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox"><div dir="ltr" class="css-901oao r-1cvl2hr r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-5njf8e r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Show replies</span></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625261225327181824" itemprop="identifier">
+<meta content="4" itemprop="position">
+<meta content="13" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T22:30:46.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T22:30:46.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1229072922641301508" itemprop="identifier">
+<meta content="AnnaCramling" itemprop="additionalName">
+<meta content="Anna Cramling" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824/likes" itemprop="url">
+<meta content="513" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824/retweets" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824/retweets/with_comments" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824" itemprop="url">
+<meta content="13" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__snybguy2p8 id__mr2c0m9sibm id__5y1s2ske6s7 id__x72277bdfck id__uncxi19l81o id__gsj01673wog id__f4xztc0uhtj id__zq6qieqo58 id__xh9k0vhf9zs id__zuxxiuwyvpe id__bw5g4h3lbs id__qxoe7furoz id__tk4krwe0ygk id__xy3i2kdfdz id__vkbu1t9nzlg id__r43pk6nwmx id__nhp0ei08kfo id__d98enbitmt id__y305zp4tz7" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-AnnaCramling">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/AnnaCramling" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1431215929564831749/su2lUm8t_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1431215929564831749/su2lUm8t_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__uncxi19l81o" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/AnnaCramling" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Anna Cramling</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/AnnaCramling" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@AnnaCramling</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/AnnaCramling/status/1625261225327181824" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T22:30:46.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__bw5g4h3lbs" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Have you played chess?</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="13 replies, 2 Retweets, 513 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__y305zp4tz7">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="13 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">13</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="2 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="513 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">513</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625299686067212288" itemprop="identifier">
+<meta content="5" itemprop="position">
+<meta content="6" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-14T01:03:36.000Z" itemprop="dateCreated">
+<meta content="2023-02-14T01:03:36.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/MKBHD/status/1625299686067212288" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="29873662" itemprop="identifier">
+<meta content="MKBHD" itemprop="additionalName">
+<meta content="Marques Brownlee" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/AnnaCramling/status/1625261225327181824" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299686067212288/likes" itemprop="url">
+<meta content="430" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299686067212288/retweets" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299686067212288/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299686067212288" itemprop="url">
+<meta content="6" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__5ghaodf7j2a id__vg6jvyup679 id__4njmecfnmi id__ydospg3u4w id__g5caa0gxzm id__81moxmw4gzr id__yivfmuar4b id__ljbf7obn8xl id__kw6nev2di id__4ibj8krmqmt id__vrvpj81bn5 id__9hhp7vupa9d id__drapiia4p0h id__ywyb9lf9zhp id__0y9svddk16h id__2tauv1esgo7 id__flzw7hvgjn8 id__0mutszf63it id__sujx2ku3y3" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1hwvwag r-18kxxzh r-15zivkp r-1b7u577"><div class="css-1dbjc4n r-1bimlpy r-1p0dtai r-1d2f490 r-1jgb5lz r-u8s1d r-zchlnj r-ipm5af r-m5arl1"></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-MKBHD">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/MKBHD" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__g5caa0gxzm" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Marques Brownlee</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@MKBHD</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/MKBHD/status/1625299686067212288" dir="ltr" aria-label="Feb 14" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-14T01:03:36.000Z">Feb 14</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__vrvpj81bn5" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Lil bit</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="6 replies, 2 Retweets, 430 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__sujx2ku3y3">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="6 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">6</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="2 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="430 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">430</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div class="css-1dbjc4n r-1udh08x"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-16y2uox r-19u6a5r r-1ny4l3l r-m2pi6t r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-6koalj r-1hwvwag r-18kxxzh r-1r8g8re r-1b7u577 r-bnwqim"><div class="css-1dbjc4n r-1awozwy r-10ptun7 r-1wtj0ep r-t7s2l5">
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+</div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox"><div dir="ltr" class="css-901oao r-1cvl2hr r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-5njf8e r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Show replies</span></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625296716013477888" itemprop="identifier">
+<meta content="6" itemprop="position">
+<meta content="2" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-14T00:51:48.000Z" itemprop="dateCreated">
+<meta content="2023-02-14T00:51:48.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1514735851565203461" itemprop="identifier">
+<meta content="ndgoHODL" itemprop="additionalName">
+<meta content="ndgo" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888/likes" itemprop="url">
+<meta content="576" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888/retweets" itemprop="url">
+<meta content="3" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__ognzg2rp0y id__76vk2uvu8pt id__q7eein2sq8b id__qu322x1w18 id__mvm1uha4c3f id__qam2o03xy68 id__0xdqjvp97oil id__zd314afc5qe id__tzro8823jjd id__9w4yjng7iuk id__bins29citqm id__rd8b42br07d id__cpmtz20cxia id__dw6y00qmjp6 id__p2mi9y7pg6b id__3r00dht2pyv id__m3w26m9onk9 id__odpgo1qrr9 id__6goidetaifs" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-ndgoHODL">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/ndgoHODL" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597917111669645315/XgoQoy94_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1597917111669645315/XgoQoy94_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__mvm1uha4c3f" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/ndgoHODL" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">ndgo</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/ndgoHODL" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@ndgoHODL</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/ndgoHODL/status/1625296716013477888" dir="ltr" aria-label="Feb 14" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-14T00:51:48.000Z">Feb 14</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__bins29citqm" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Step 1: punch a tree</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="2 replies, 3 Retweets, 576 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__6goidetaifs">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="3 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">3</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="576 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">576</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625299875926532107" itemprop="identifier">
+<meta content="7" itemprop="position">
+<meta content="13" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-14T01:04:21.000Z" itemprop="dateCreated">
+<meta content="2023-02-14T01:04:21.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/MKBHD/status/1625299875926532107" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="29873662" itemprop="identifier">
+<meta content="MKBHD" itemprop="additionalName">
+<meta content="Marques Brownlee" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/ndgoHODL/status/1625296716013477888" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299875926532107/likes" itemprop="url">
+<meta content="1433" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299875926532107/retweets" itemprop="url">
+<meta content="10" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299875926532107/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/MKBHD/status/1625299875926532107" itemprop="url">
+<meta content="13" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__n53lgeviwa8 id__fryb4qffc56 id__eh2uwhcdfhg id__hfbiis5nmj6 id__y3qzt4z3a4b id__uqfg4iu94sl id__y2sgqcdk1v id__puaeef7azd id__bki3sye7ldd id__aejttbj4ajw id__37v4vykp5u1 id__ea5hd7qy5ne id__y4rd2lxoad9 id__3rnagd2nsvt id__rhdryhu2jt id__uysq6db5eo id__m0htkq22rkb id__p3ifruo0u0r id__l7ijagtty5" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1hwvwag r-18kxxzh r-15zivkp r-1b7u577"><div class="css-1dbjc4n r-1bimlpy r-1p0dtai r-1d2f490 r-1jgb5lz r-u8s1d r-zchlnj r-ipm5af r-m5arl1"></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-MKBHD">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/MKBHD" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__y3qzt4z3a4b" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Marques Brownlee</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/MKBHD" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@MKBHD</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/MKBHD/status/1625299875926532107" dir="ltr" aria-label="Feb 14" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-14T01:04:21.000Z">Feb 14</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__37v4vykp5u1" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Instructions unclear, broken hand</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="13 replies, 10 Retweets, 1433 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__l7ijagtty5">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="13 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">13</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="10 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">10</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1433 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,433</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div class="css-1dbjc4n r-1udh08x"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-16y2uox r-19u6a5r r-1ny4l3l r-m2pi6t r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-6koalj r-1hwvwag r-18kxxzh r-1r8g8re r-1b7u577 r-bnwqim"><div class="css-1dbjc4n r-1awozwy r-10ptun7 r-1wtj0ep r-t7s2l5">
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+<div class="css-1dbjc4n r-1bimlpy r-1adg3ll r-epq5cr r-m5arl1"></div>
+</div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox"><div dir="ltr" class="css-901oao r-1cvl2hr r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-5njf8e r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Show replies</span></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192306658709507" itemprop="identifier">
+<meta content="8" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:56:55.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:56:55.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/tyler_warnecke/status/1625192306658709507" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="164958204" itemprop="identifier">
+<meta content="tyler_warnecke" itemprop="additionalName">
+<meta content="Tyler Jon Warnecke" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/tyler_warnecke/status/1625192306658709507/likes" itemprop="url">
+<meta content="13" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/tyler_warnecke/status/1625192306658709507/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/tyler_warnecke/status/1625192306658709507/retweets/with_comments" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/tyler_warnecke/status/1625192306658709507" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__ckemg9hk97s id__vu8voq9rn8d id__9q6d08tnzjo id__4j3zr78x2ef id__0eih57ny6s19 id__mqvhtqjelw id__lj10emf3wph id__zls745x8gzh id__0p8pkk5t51j id__77hg1n9emtu id__ngd52vr5z3 id__c6sxioy2bh id__qf5stfnx0ld id__c5otmt3ni5e id__3ff0t7i3z61 id__8lglwhd05yu id__bp2qptubtum id__s159ekmzx6i id__w8rydf83be" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-tyler_warnecke">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/tyler_warnecke" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1457091856131571725/K5gZT0b9_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1457091856131571725/K5gZT0b9_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__0eih57ny6s19" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/tyler_warnecke" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Tyler Jon Warnecke</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/tyler_warnecke" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@tyler_warnecke</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/tyler_warnecke/status/1625192306658709507" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:56:55.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__ngd52vr5z3" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Play it.</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 Retweet, 13 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__w8rydf83be">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="1 Retweet. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="13 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">13</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192315982696452" itemprop="identifier">
+<meta content="9" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:56:57.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:56:57.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="315296990" itemprop="identifier">
+<meta content="cottrell345" itemprop="additionalName">
+<meta content="TFM 🍊" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/15jc2Tzay7" itemprop="url">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452/photo/1" itemprop="url">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452/likes" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/cottrell345/status/1625192315982696452" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__jl51w70sf3t id__9xhimqbh2p id__4czwuov171z id__n2jm6kfrutj id__u69acygkjr id__mpnh5guuad id__ik1vwfyd54 id__17kesyaxih8 id__mec5z05we5f id__xx7nxg85fen id__7szlc25nie2 id__nl0eb95u21 id__kxzwrm993j id__rh15170zyk id__4xwm8zwmihd id__xqq9wd4x7rj id__f8dkuzvyhlh id__yob9b8gzxmc id__n3mb572a2b" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-cottrell345">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/cottrell345" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1629175304236285952/qMTK7azt_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1629175304236285952/qMTK7azt_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__u69acygkjr" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/cottrell345" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">TFM </span><img alt="🍊" draggable="false" src="https://abs-0.twimg.com/emoji/v2/svg/1f34a.svg" class="r-4qtqp9 r-dflpy8 r-sjv1od r-zw8f10 r-10akycc r-h9hxbl"></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/cottrell345" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@cottrell345</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/cottrell345/status/1625192315982696452" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:56:57.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"></div></div>
+<div aria-labelledby="id__eg8wuvx4p6 id__at3n6ht0daw" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__kxzwrm993j"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1pi2tsx" data-testid="tweetPhoto">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-1adg3ll r-pm9dpa r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:66.66666666666667%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Shocked Face GIF" class="css-1dbjc4n r-1awozwy r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af" data-testid="previewInterstitial">
+<div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Shocked Face GIF" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/tweet_video_thumb/Fo3Xy0iXgAAh-u8?format=jpg&amp;name=small")'></div>
+<img alt="Shocked Face GIF" draggable="true" src="https://pbs.twimg.com/tweet_video_thumb/Fo3Xy0iXgAAh-u8?format=jpg&amp;name=small" class="css-9pa8cd">
+</div></div>
+<div class="css-1dbjc4n r-rki7wi r-18u37iz r-161ttwi r-633pao r-u8s1d">
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-6t5ypu r-zmljjp r-z2wwpe r-kicko2 r-t12b5v r-z80fyv r-1777fci r-a5pmau r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-b88u0q r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">GIF</span></div></div>
+<div aria-expanded="false" aria-haspopup="menu" tabindex="-1" class="css-1dbjc4n r-pm2fo r-1dpl46z r-ou6ah9 r-notknq r-1ny4l3l r-o7ynqc r-6416eg">
+<div dir="auto" class="css-901oao r-hvic4v" id="id__5wyea6w7lug">read image description</div>
+<div aria-describedby="id__5wyea6w7lug" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1ny4l3l r-105ug2t r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-pm2fo r-1dpl46z r-z2wwpe r-ou6ah9 r-notknq r-z80fyv r-1777fci r-s1qlax r-105ug2t"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-b88u0q r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">ALT</span></div></div></div>
+</div>
+</div>
+<div aria-label="Play this GIF" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-11mg6pl r-sdzlij r-1phboty r-14f9gny r-e6wyp1 r-1ny4l3l r-o7ynqc r-6416eg r-1p15a4t" data-testid="playButton"><div class="css-1dbjc4n r-1awozwy r-1pi2tsx r-1777fci r-u8s1d r-13qz1uu"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-jwli3a r-4qtqp9 r-yyyyoo r-1sa8knb r-dnmrzs r-1dsia8u r-bnwqim r-1plcrui r-lrvibr r-gcko2u"><g><path d="M21 12L4 2v20l17-10z"></path></g></svg></div></div>
+</div></div>
+</div></div>
+<div itemprop="video" itemscope="" itemtype="https://schema.org/VideoObject">
+<meta content="@cottrell345's video Tweet" itemprop="name">
+<meta content="Shocked Face GIF" itemprop="description">
+<meta content="https://platform.twitter.com/embed/Tweet.html?dnt=false&amp;embedId=twitter-widget-1&amp;frame=false&amp;hideCard=false&amp;hideThread=false&amp;lang=en&amp;id=1625192315982696452" itemprop="embedUrl">
+<meta content="https://pbs.twimg.com/tweet_video_thumb/Fo3Xy0iXgAAh-u8.jpg" itemprop="thumbnailUrl">
+<meta content="Shocked Face GIF" itemprop="caption">
+<meta content="2023-02-13T17:56:57.000Z" itemprop="uploadDate">
+<meta content="PT0H0M0S" itemprop="duration">
+</div>
+</div></div></div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="2 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__n3mb572a2b">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192333443473408" itemprop="identifier">
+<meta content="10" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:57:01.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:57:01.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1666606794" itemprop="identifier">
+<meta content="papa_ice_water" itemprop="additionalName">
+<meta content="Jeff Bezos Without the Pesos" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/ve0ZTtO1MA" itemprop="url">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408/photo/1" itemprop="url">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408/likes" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/papa_ice_water/status/1625192333443473408" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__pu3wuh9w6jo id__lppuqfoj83r id__wqu7yzq8d0f id__hnc0iyab7t id__w00jonjpw58 id__3lto719j664 id__zuwzbjrowo id__wi37o1txq1 id__vmj7myy8jkg id__6xmqikmld1j id__1e6v6agayuz id__g2lycqyooot id__gytfex4gyxn id__pqa52xh8xm id__87xtv0z32ct id__v0cbk6dqt2b id__u141yxgchj id__mxpl02fu1a8" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-papa_ice_water">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/papa_ice_water" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1608352826610049025/cLyEbT5A_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1608352826610049025/cLyEbT5A_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__w00jonjpw58" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/papa_ice_water" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Jeff Bezos Without the Pesos</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/papa_ice_water" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@papa_ice_water</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/papa_ice_water/status/1625192333443473408" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:57:01.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"></div></div>
+<div aria-labelledby="id__nrkr2q0ic5p id__1px8q8ehv91" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__gytfex4gyxn"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1pi2tsx" data-testid="tweetPhoto">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-1adg3ll r-pm9dpa r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Gavin Free Love GIF by Rooster Teeth" class="css-1dbjc4n r-1awozwy r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af" data-testid="previewInterstitial">
+<div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Gavin Free Love GIF by Rooster Teeth" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/tweet_video_thumb/Fo3Xz59WYAEUNQD?format=jpg&amp;name=small")'></div>
+<img alt="Gavin Free Love GIF by Rooster Teeth" draggable="true" src="https://pbs.twimg.com/tweet_video_thumb/Fo3Xz59WYAEUNQD?format=jpg&amp;name=small" class="css-9pa8cd">
+</div></div>
+<div class="css-1dbjc4n r-rki7wi r-18u37iz r-161ttwi r-633pao r-u8s1d">
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-6t5ypu r-zmljjp r-z2wwpe r-kicko2 r-t12b5v r-z80fyv r-1777fci r-a5pmau r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-b88u0q r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">GIF</span></div></div>
+<div aria-expanded="false" aria-haspopup="menu" tabindex="-1" class="css-1dbjc4n r-pm2fo r-1dpl46z r-ou6ah9 r-notknq r-1ny4l3l r-o7ynqc r-6416eg">
+<div dir="auto" class="css-901oao r-hvic4v" id="id__ru8cv7cwr2s">read image description</div>
+<div aria-describedby="id__ru8cv7cwr2s" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1ny4l3l r-105ug2t r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-pm2fo r-1dpl46z r-z2wwpe r-ou6ah9 r-notknq r-z80fyv r-1777fci r-s1qlax r-105ug2t"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-b88u0q r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">ALT</span></div></div></div>
+</div>
+</div>
+<div aria-label="Play this GIF" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-11mg6pl r-sdzlij r-1phboty r-14f9gny r-e6wyp1 r-1ny4l3l r-o7ynqc r-6416eg r-1p15a4t" data-testid="playButton"><div class="css-1dbjc4n r-1awozwy r-1pi2tsx r-1777fci r-u8s1d r-13qz1uu"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-jwli3a r-4qtqp9 r-yyyyoo r-1sa8knb r-dnmrzs r-1dsia8u r-bnwqim r-1plcrui r-lrvibr r-gcko2u"><g><path d="M21 12L4 2v20l17-10z"></path></g></svg></div></div>
+</div></div>
+</div></div>
+<div itemprop="video" itemscope="" itemtype="https://schema.org/VideoObject">
+<meta content="@papa_ice_water's video Tweet" itemprop="name">
+<meta content="Gavin Free Love GIF by Rooster Teeth" itemprop="description">
+<meta content="https://platform.twitter.com/embed/Tweet.html?dnt=false&amp;embedId=twitter-widget-1&amp;frame=false&amp;hideCard=false&amp;hideThread=false&amp;lang=en&amp;id=1625192333443473408" itemprop="embedUrl">
+<meta content="https://pbs.twimg.com/tweet_video_thumb/Fo3Xz59WYAEUNQD.jpg" itemprop="thumbnailUrl">
+<meta content="Gavin Free Love GIF by Rooster Teeth" itemprop="caption">
+<meta content="2023-02-13T17:57:01.000Z" itemprop="uploadDate">
+<meta content="PT0H0M0S" itemprop="duration">
+</div>
+</div></div></div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__olmkp354pjp">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192452264198144" itemprop="identifier">
+<meta content="11" itemprop="position">
+<meta content="65" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:57:29.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:57:29.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/getpeid/status/1625192452264198144" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="41777199" itemprop="identifier">
+<meta content="getpeid" itemprop="additionalName">
+<meta content="Carl Pei" itemprop="givenName">
+<meta content="Nothing" itemprop="disambiguatingDescription">
+</div>
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/getpeid/status/1625192452264198144/likes" itemprop="url">
+<meta content="1037" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/getpeid/status/1625192452264198144/retweets" itemprop="url">
+<meta content="5" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/getpeid/status/1625192452264198144/retweets/with_comments" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/getpeid/status/1625192452264198144" itemprop="url">
+<meta content="65" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__615k64xeq59 id__ead91zmiyf4 id__ec9rn4rtnd6 id__ghinsu113ag id__tvvidrqvxs id__owp0vkj12l id__j7tcbrw6taq id__y78sz64djmc id__0pm1i9m9rj3 id__5mihwfr8pt id__ok4dae8tcat id__qu15hn5wa4h id__f7wcaz5589u id__i7e0ra137q id__ikmxfvl89oh id__wa1fsvo3idf id__69nzzqrgzso id__65gdccw3zuv id__7wxjgpnm5zv" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-getpeid">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/getpeid" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1640707890456711170/Q1IPes_W_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1640707890456711170/Q1IPes_W_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
+</div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q">
+<div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__tvvidrqvxs" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/getpeid" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Carl Pei</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg><div tabindex="0" class="css-1dbjc4n r-1loqt21 r-xoduu5 r-1777fci r-13hce6t r-a5pmau r-1ny4l3l"><div class="css-1dbjc4n r-4qtqp9 r-p3p4p0 r-hm2b0w r-bnwqim" style="height:calc(1.25em*0.85);width:calc(1.25em*0.85)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-6koalj r-1mlwlqe r-1pi2tsx r-1udh08x r-13qz1uu r-417010" style="border-top-left-radius:2px;border-top-right-radius:2px;border-bottom-right-radius:2px;border-bottom-left-radius:2px">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-xoduu5 r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1510020431696310279/fhgfNZ44_bigger.jpg")'></div>
+<img alt="" draggable="false" src="https://pbs.twimg.com/profile_images/1510020431696310279/fhgfNZ44_bigger.jpg" class="css-9pa8cd">
+</div></div>
+</div></div></div></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/getpeid" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@getpeid</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/getpeid/status/1625192452264198144" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:57:29.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wtj0ep r-zl2h9q"></div>
+</div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__ok4dae8tcat" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Same</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="65 replies, 6 Retweets, 1037 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__7wxjgpnm5zv">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="65 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">65</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="6 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">6</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1037 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,037</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1625192625971011586" itemprop="identifier">
+<meta content="12" itemprop="position">
+<meta content="1" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-02-13T17:58:11.000Z" itemprop="dateCreated">
+<meta content="2023-02-13T17:58:11.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/ianzelbo/status/1625192625971011586" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1328409419344990208" itemprop="identifier">
+<meta content="ianzelbo" itemprop="additionalName">
+<meta content="Ian Zelbo" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/getpeid/status/1625192452264198144" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/ianzelbo/status/1625192625971011586/likes" itemprop="url">
+<meta content="34" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/ianzelbo/status/1625192625971011586/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/ianzelbo/status/1625192625971011586/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/ianzelbo/status/1625192625971011586" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__rgl38ykh65 id__mkg4et4l15 id__74uwzd0qjhh id__wr67o29ncm id__q6yt09cgaqn id__dlleh8rsur id__wow90327yi id__be3ekicpo id__02p9n2vqt7qk id__5ci5fy1zbq id__56gilbzk7ji id__acxkrky7qy5 id__zzt1eude68q id__flvrfko1qk id__yliej5ncpwq id__epefonuyx1m id__svem2b3m9vf id__js4octv2y99 id__05qmwbv1j4yr" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1hwvwag r-18kxxzh r-15zivkp r-1b7u577"><div class="css-1dbjc4n r-1bimlpy r-1p0dtai r-1d2f490 r-1jgb5lz r-u8s1d r-zchlnj r-ipm5af r-m5arl1"></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-ianzelbo">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/ianzelbo" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1628559866808655877/40jJBV4T_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1628559866808655877/40jJBV4T_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__q6yt09cgaqn" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/ianzelbo" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Ian Zelbo</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><path d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"></path></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/ianzelbo" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@ianzelbo</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/ianzelbo/status/1625192625971011586" dir="ltr" aria-label="Feb 13" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-02-13T17:58:11.000Z">Feb 13</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__56gilbzk7ji" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">There’s nothing I want to do more in life than play hypixel with you</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 reply, 34 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__05qmwbv1j4yr">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Reply. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="34 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">34</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-o52ifk"><div class="css-1dbjc4n r-o52ifk"></div></div>
+</div></div></section>
+</div></div></div></div></div></div></main><div aria-valuemax="1" aria-valuemin="0" role="progressbar" class="css-1dbjc4n r-1awozwy r-1777fci" style="width:300px"><div class="css-1dbjc4n r-17bb2tj r-1muvv40 r-127358a r-1ldzwu0" style="height:26px;width:26px"><svg height="100%" viewbox="0 0 32 32" width="100%"><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;opacity:0.2"></circle><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;stroke-dasharray:80;stroke-dashoffset:60"></circle></svg></div></div>
+</div></div></div></div>
+</body>
 </html>
-

--- a/spec/fixtures/onebox/twitterstatus_featured_image.response
+++ b/spec/fixtures/onebox/twitterstatus_featured_image.response
@@ -1,4149 +1,1114 @@
 <!DOCTYPE html>
-<html lang="en" data-scribe-reduced-action-queue="true">
-  <head>
-    
-    
-    
-    
-    
-    
-    
-    <meta charset="utf-8">
-      <script  nonce="PumNFXfgvYvkQzJpN49/1g==">
-        !function(){window.initErrorstack||(window.initErrorstack=[]),window.onerror=function(r,i,n,o,t){r.indexOf("Script error.")>-1||window.initErrorstack.push({errorMsg:r,url:i,lineNumber:n,column:o,errorObj:t})}}();
-      </script>
-    
-    
-  
-  <script id="bouncer_terminate_iframe" nonce="PumNFXfgvYvkQzJpN49/1g==">
-    if (window.top != window) {
-  window.top.postMessage({'bouncer': true, 'event': 'complete'}, '*');
-}
-  </script>
-  <script id="swift_action_queue" nonce="PumNFXfgvYvkQzJpN49/1g==">
-    !function(){function e(e){if(e||(e=window.event),!e)return!1;if(e.timestamp=(new Date).getTime(),!e.target&&e.srcElement&&(e.target=e.srcElement),document.documentElement.getAttribute("data-scribe-reduced-action-queue"))for(var t=e.target;t&&t!=document.body;){if("A"==t.tagName)return;t=t.parentNode}return i("all",o(e)),a(e)?(document.addEventListener||(e=o(e)),e.preventDefault=e.stopPropagation=e.stopImmediatePropagation=function(){},y?(v.push(e),i("captured",e)):i("ignored",e),!1):(i("direct",e),!0)}function t(e){n();for(var t,r=0;t=v[r];r++){var a=e(t.target),i=a.closest("a")[0];if("click"==t.type&&i){var o=e.data(i,"events"),u=o&&o.click,c=!i.hostname.match(g)||!i.href.match(/#$/);if(!u&&c){window.location=i.href;continue}}a.trigger(e.event.fix(t))}window.swiftActionQueue.wasFlushed=!0}function r(){for(var e in b)if("all"!=e)for(var t=b[e],r=0;r<t.length;r++)console.log("actionQueue",c(t[r]))}function n(){clearTimeout(w);for(var e,t=0;e=h[t];t++)document["on"+e]=null}function a(e){if(!e.target)return!1;var t=e.target,r=(t.tagName||"").toLowerCase();if(e.metaKey)return!1;if(e.shiftKey&&"a"==r)return!1;if(t.hostname&&!t.hostname.match(g))return!1;if(e.type.match(p)&&s(t))return!1;if("label"==r){var n=t.getAttribute("for");if(n){var a=document.getElementById(n);if(a&&f(a))return!1}else for(var i,o=0;i=t.childNodes[o];o++)if(f(i))return!1}return!0}function i(e,t){t.bucket=e,b[e].push(t)}function o(e){var t={};for(var r in e)t[r]=e[r];return t}function u(e){for(;e&&e!=document.body;){if("A"==e.tagName)return e;e=e.parentNode}}function c(e){var t=[];e.bucket&&t.push("["+e.bucket+"]"),t.push(e.type);var r,n,a=e.target,i=u(a),o="",c=e.timestamp&&e.timestamp-d;return"click"===e.type&&i?(r=i.className.trim().replace(/\s+/g,"."),n=i.id.trim(),o=/[^#]$/.test(i.href)?" ("+i.href+")":"",a='"'+i.innerText.replace(/\n+/g," ").trim()+'"'):(r=a.className.trim().replace(/\s+/g,"."),n=a.id.trim(),a=a.tagName.toLowerCase(),e.keyCode&&(a=String.fromCharCode(e.keyCode)+" : "+a)),t.push(a+o+(n&&"#"+n)+(!n&&r?"."+r:"")),c&&t.push(c),t.join(" ")}function f(e){var t=(e.tagName||"").toLowerCase();return"input"==t&&"checkbox"==e.getAttribute("type")}function s(e){var t=(e.tagName||"").toLowerCase();return"textarea"==t||"input"==t&&"text"==e.getAttribute("type")||"true"==e.getAttribute("contenteditable")}for(var m,d=(new Date).getTime(),l=1e4,g=/^([^\.]+\.)*twitter\.com$/,p=/^key/,h=["click","keydown","keypress","keyup"],v=[],w=null,y=!0,b={captured:[],ignored:[],direct:[],all:[]},k=0;m=h[k];k++)document["on"+m]=e;w=setTimeout(function(){y=!1},l),window.swiftActionQueue={buckets:b,flush:t,logActions:r,wasFlushed:!1}}();
-  </script>
-  <script id="composition_state" nonce="PumNFXfgvYvkQzJpN49/1g==">
-    !function(){function t(t){t.target.setAttribute("data-in-composition","true")}function n(t){t.target.removeAttribute("data-in-composition")}document.addEventListener&&(document.addEventListener("compositionstart",t,!1),document.addEventListener("compositionend",n,!1))}();
-  </script>
-
-    <link rel="stylesheet" href="https://abs.twimg.com/a/1625696336/css/t1/twitter_core.bundle.css" class="coreCSSBundles">
-  <link rel="stylesheet" class="moreCSSBundles" href="https://abs.twimg.com/a/1625696336/css/t1/twitter_more_1.bundle.css">
-  <link rel="stylesheet" class="moreCSSBundles" href="https://abs.twimg.com/a/1625696336/css/t1/twitter_more_2.bundle.css">
-
-    <link rel="dns-prefetch" href="https://pbs.twimg.com">
-    <link rel="dns-prefetch" href="https://t.co">
-      <link rel="preload" href="https://abs.twimg.com/k/en/init.en.d28d8449d76b990b62bf.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/k/en/0.commons.en.2d6be4aa18878a5eb7fc.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/k/en/5.pages_permalink.en.d01701ba3cce1f0d3917.js" as="script">
-
-      <title>Jeff Atwood on Twitter: &quot;My first text message from my child! A moment that shall live on in infamy!… &quot;</title>
-      <meta name="robots" content="NOODP">
-  
-
-
-
-<meta name="msapplication-TileImage" content="//abs.twimg.com/favicons/win8-tile-144.png"/>
-<meta name="msapplication-TileColor" content="#00aced"/>
-
-
-
-<meta name="facebook-domain-verification" content="moho2ug7zs57jijiywrewd8wb5a08h" />
-
-
-
-<link rel="mask-icon" sizes="any" href="https://abs.twimg.com/a/1625696336/icons/favicon.svg" color="#1da1f2">
-
-<link rel="shortcut icon" href="//abs.twimg.com/favicons/favicon.ico" type="image/x-icon">
-<link rel="apple-touch-icon" href="https://abs.twimg.com/icons/apple-touch-icon-192x192.png" sizes="192x192">
-
-<link rel="manifest" href="/manifest.json">
-
-
-  <meta name="swift-page-name" id="swift-page-name" content="permalink">
-  <meta name="swift-page-section" id="swift-section-name" content="permalink">
-
-    <link rel="canonical" href="https://twitter.com/codinghorror/status/1409351083177046020">
-  <link rel="alternate" hreflang="x-default" href="https://twitter.com/codinghorror/status/1409351083177046020">
-  <link rel="alternate" hreflang="fr" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fr"><link rel="alternate" hreflang="en" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=en"><link rel="alternate" hreflang="ar" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ar"><link rel="alternate" hreflang="ja" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ja"><link rel="alternate" hreflang="es" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=es"><link rel="alternate" hreflang="de" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=de"><link rel="alternate" hreflang="it" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=it"><link rel="alternate" hreflang="id" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=id"><link rel="alternate" hreflang="pt" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=pt"><link rel="alternate" hreflang="ko" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ko"><link rel="alternate" hreflang="tr" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=tr"><link rel="alternate" hreflang="ru" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ru"><link rel="alternate" hreflang="nl" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=nl"><link rel="alternate" hreflang="fil" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fil"><link rel="alternate" hreflang="ms" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ms"><link rel="alternate" hreflang="zh-tw" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=zh-tw"><link rel="alternate" hreflang="zh-cn" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=zh-cn"><link rel="alternate" hreflang="hi" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hi"><link rel="alternate" hreflang="no" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=no"><link rel="alternate" hreflang="sv" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sv"><link rel="alternate" hreflang="fi" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fi"><link rel="alternate" hreflang="da" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=da"><link rel="alternate" hreflang="pl" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=pl"><link rel="alternate" hreflang="hu" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hu"><link rel="alternate" hreflang="fa" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fa"><link rel="alternate" hreflang="he" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=he"><link rel="alternate" hreflang="ur" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ur"><link rel="alternate" hreflang="th" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=th"><link rel="alternate" hreflang="uk" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=uk"><link rel="alternate" hreflang="ca" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ca"><link rel="alternate" hreflang="ga" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ga"><link rel="alternate" hreflang="el" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=el"><link rel="alternate" hreflang="eu" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=eu"><link rel="alternate" hreflang="cs" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=cs"><link rel="alternate" hreflang="gl" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=gl"><link rel="alternate" hreflang="ro" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ro"><link rel="alternate" hreflang="hr" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hr"><link rel="alternate" hreflang="en-gb" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=en-gb"><link rel="alternate" hreflang="vi" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=vi"><link rel="alternate" hreflang="bn" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=bn"><link rel="alternate" hreflang="bg" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=bg"><link rel="alternate" hreflang="sr" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sr"><link rel="alternate" hreflang="sk" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sk"><link rel="alternate" hreflang="gu" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=gu"><link rel="alternate" hreflang="mr" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=mr"><link rel="alternate" hreflang="ta" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ta"><link rel="alternate" hreflang="kn" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=kn">
-
-    <link rel="alternate" type="application/json+oembed" href="https://publish.twitter.com/oembed?url=https://twitter.com/codinghorror/status/1409351083177046020" title="Jeff Atwood on Twitter: &quot;My first text message from my child! A moment that shall live on in infamy!… &quot;">
-
-
-  <link rel="alternate" media="handheld, only screen and (max-width: 640px)" href="https://mobile.twitter.com/codinghorror/status/1409351083177046020">
-
-      <link rel="alternate" href="android-app://com.twitter.android/twitter/tweet?status_id=1409351083177046020&amp;ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Estatus%7Ctwterm%5E1409351083177046020">
-
+<html dir="ltr" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover">
+<link rel="preconnect" href="//abs.twimg.com">
+<link rel="dns-prefetch" href="//abs.twimg.com">
+<link rel="preconnect" href="//api.twitter.com">
+<link rel="dns-prefetch" href="//api.twitter.com">
+<link rel="preconnect" href="//pbs.twimg.com">
+<link rel="dns-prefetch" href="//pbs.twimg.com">
+<link rel="preconnect" href="//t.co">
+<link rel="dns-prefetch" href="//t.co">
+<link rel="preconnect" href="//video.twimg.com">
+<link rel="dns-prefetch" href="//video.twimg.com">
+<meta property="fb:app_id" content="2231777543">
+<meta property="og:site_name" content="Twitter">
+<meta name="google-site-verification" content="acYOOcR5z6puMzLn6hLDZI1nNHXPxt57OIstz1vnCV0">
+<meta name="facebook-domain-verification" content="x6sdcc8b5ju3bh8nbm59eswogvg6t1">
+<meta http-equiv="onion-location" content="https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/">
+<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
 <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
-
-    <link id="async-css-placeholder">
-
-        <meta  property="al:ios:url" content="twitter://status?id=1409351083177046020">
-    <meta  property="al:ios:app_store_id" content="333903271">
-    <meta  property="al:ios:app_name" content="Twitter">
-    <meta  property="al:android:url" content="twitter://status?status_id=1409351083177046020">
-    <meta  property="al:android:package" content="com.twitter.android">
-    <meta  property="al:android:app_name" content="Twitter">
-    <meta  property="og:type" content="article">
-    <meta  property="og:url" content="https://twitter.com/codinghorror/status/1409351083177046020">
-    <meta  property="og:title" content="Jeff Atwood on Twitter">
-    <meta  property="og:image" content="https://pbs.twimg.com/media/E48FVowUUAYyGLX.jpg:large">
-    <meta  property="og:image:user_generated" content="true">
-    <meta  property="og:description" content="“My first text message from my child! A moment that shall live on in infamy!”">
-    <meta  property="og:site_name" content="Twitter">
-    <meta  property="fb:app_id" content="2231777543">
-
-  </head>
-  <body class="three-col logged-out user-style-codinghorror PermalinkPage" 
-data-fouc-class-names="swift-loading no-nav-banners"
- dir="ltr">
-      <script id="swift_loading_indicator" nonce="PumNFXfgvYvkQzJpN49/1g==">
-        document.body.className=document.body.className+" "+document.body.getAttribute("data-fouc-class-names");
-      </script>
-
-    
-    <noscript>
-      <form action="https://mobile.twitter.com/i/nojs_router?path=%2Fcodinghorror%2Fstatus%2F1409351083177046020" method="POST" class="NoScriptForm">
-        <input type="hidden" value="46a6f55f84bf8fb45d8b56ce053c0606e73735e0" name="authenticity_token">
-
-        <div class="NoScriptForm-content">
-          <span class="NoScriptForm-logo Icon Icon--logo Icon--extraLarge"></span>
-          <p>We've detected that JavaScript is disabled in your browser. Would you like to proceed to legacy Twitter?</p>
-          <p class="NoScriptForm-buttonContainer"><button type="submit" class="EdgeButton EdgeButton--primary">Yes</button></p>
-        </div>
-      </form>
-    </noscript>
-
-    <a href="#timeline" class="u-hiddenVisually focusable">Skip to content</a>
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    <div id="doc" data-at-shortcutkeys="{&quot;Enter&quot;:&quot;Open Tweet details&quot;,&quot;o&quot;:&quot;Expand photo&quot;,&quot;/&quot;:&quot;Search&quot;,&quot;?&quot;:&quot;This menu&quot;,&quot;j&quot;:&quot;Next Tweet&quot;,&quot;k&quot;:&quot;Previous Tweet&quot;,&quot;Space&quot;:&quot;Page down&quot;,&quot;.&quot;:&quot;Load new Tweets&quot;,&quot;gu&quot;:&quot;Go to user\u2026&quot;}" class="route-permalink">
-        <div class="topbar js-topbar">
-    
-
-
-    <div class="global-nav global-nav--newLoggedOut" data-section-term="top_nav">
-      <div class="global-nav-inner">
-        <div class="container">
-
-          
-<ul class="nav js-global-actions" role="navigation" id="global-actions">
-  <li id="global-nav-home" class="home" data-global-action="home">
-    <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/" data-component-context="home_nav" data-nav="home">
-      <span class="Icon Icon--bird Icon--large"></span>
-      <span class="text" aria-hidden="true">Home</span>
-      <span class="u-hiddenVisually a11y-inactive-page-text">Home</span>
-      <span class="u-hiddenVisually a11y-active-page-text">Home, current page.</span>
-    </a>
-  </li>
-    <li id="global-nav-moments" class="moments" data-global-action="moments">
-      <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/i/moments" data-component-context="moments_nav" data-nav="moments">
-        <span class="Icon Icon--lightning Icon--large"></span>
-        <span class="Icon Icon--lightningFilled Icon--large"></span>
-        <span class="text" aria-hidden="true">Moments</span>
-        <span class="u-hiddenVisually a11y-inactive-page-text">Moments</span>
-        <span class="u-hiddenVisually a11y-active-page-text">Moments, current page.</span>
-      </a>
-    </li>
-</ul>
-<div class="pull-right nav-extras">
-    <div role="search">
-  <form class="t1-form form-search js-search-form" action="/search" id="global-nav-search">
-    <label class="visuallyhidden" for="search-query">Search query</label>
-    <input class="search-input" type="text" id="search-query" placeholder="Search Twitter" name="q" autocomplete="off" spellcheck="false">
-    <span class="search-icon js-search-action">
-      <button type="submit" class="Icon Icon--medium Icon--search nav-search">
-        <span class="visuallyhidden">Search Twitter</span>
-      </button>
-    </span>
-      
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-    
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-  
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-    <ul role="presentation" class="typeahead-items typeahead-accounts social-context js-typeahead-accounts">
-  
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-    
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <div class="js-selectable typeahead-in-conversation hidden">
-        <span class="Icon Icon--follower Icon--small"></span>
-        <span class="typeahead-in-conversation-text">In this conversation</span>
-      </div>
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info account-group">
-        <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-      </span>
-      <span class="typeahead-social-context"></span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-  
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-    
-<div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Suggested users
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-    
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-      
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-    
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-      
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-  </form>
-</div>
-
-
-  <ul class="nav secondary-nav language-dropdown">
-    <li class="dropdown js-language-dropdown">
-      <a href="#supported_languages" class="dropdown-toggle js-dropdown-toggle">
-        <small>Language:</small> <span class="js-current-language">English</span> <b class="caret"></b>
-      </a>
-      <div class="dropdown-menu dropdown-menu--rightAlign is-forceRight">
-        <div class="dropdown-caret right">
-          <span class="caret-outer"> </span>
-          <span class="caret-inner"></span>
-        </div>
-        <ul id="supported_languages">
-            <li><a href="?lang=id" data-lang-code="id" title="Indonesian" class="js-language-link js-tooltip" rel="noopener">Bahasa Indonesia</a></li>
-            <li><a href="?lang=msa" data-lang-code="msa" title="Malay" class="js-language-link js-tooltip" rel="noopener">Bahasa Melayu</a></li>
-            <li><a href="?lang=ca" data-lang-code="ca" title="Catalan" class="js-language-link js-tooltip" rel="noopener">Català</a></li>
-            <li><a href="?lang=cs" data-lang-code="cs" title="Czech" class="js-language-link js-tooltip" rel="noopener">Čeština</a></li>
-            <li><a href="?lang=da" data-lang-code="da" title="Danish" class="js-language-link js-tooltip" rel="noopener">Dansk</a></li>
-            <li><a href="?lang=de" data-lang-code="de" title="German" class="js-language-link js-tooltip" rel="noopener">Deutsch</a></li>
-            <li><a href="?lang=en-gb" data-lang-code="en-gb" title="British English" class="js-language-link js-tooltip" rel="noopener">English UK</a></li>
-            <li><a href="?lang=es" data-lang-code="es" title="Spanish" class="js-language-link js-tooltip" rel="noopener">Español</a></li>
-            <li><a href="?lang=fil" data-lang-code="fil" title="Filipino" class="js-language-link js-tooltip" rel="noopener">Filipino</a></li>
-            <li><a href="?lang=fr" data-lang-code="fr" title="French" class="js-language-link js-tooltip" rel="noopener">Français</a></li>
-            <li><a href="?lang=hr" data-lang-code="hr" title="Croatian" class="js-language-link js-tooltip" rel="noopener">Hrvatski</a></li>
-            <li><a href="?lang=it" data-lang-code="it" title="Italian" class="js-language-link js-tooltip" rel="noopener">Italiano</a></li>
-            <li><a href="?lang=hu" data-lang-code="hu" title="Hungarian" class="js-language-link js-tooltip" rel="noopener">Magyar</a></li>
-            <li><a href="?lang=nl" data-lang-code="nl" title="Dutch" class="js-language-link js-tooltip" rel="noopener">Nederlands</a></li>
-            <li><a href="?lang=no" data-lang-code="no" title="Norwegian" class="js-language-link js-tooltip" rel="noopener">Norsk</a></li>
-            <li><a href="?lang=pl" data-lang-code="pl" title="Polish" class="js-language-link js-tooltip" rel="noopener">Polski</a></li>
-            <li><a href="?lang=pt" data-lang-code="pt" title="Portuguese" class="js-language-link js-tooltip" rel="noopener">Português</a></li>
-            <li><a href="?lang=ro" data-lang-code="ro" title="Romanian" class="js-language-link js-tooltip" rel="noopener">Română</a></li>
-            <li><a href="?lang=sk" data-lang-code="sk" title="Slovak" class="js-language-link js-tooltip" rel="noopener">Slovenčina</a></li>
-            <li><a href="?lang=fi" data-lang-code="fi" title="Finnish" class="js-language-link js-tooltip" rel="noopener">Suomi</a></li>
-            <li><a href="?lang=sv" data-lang-code="sv" title="Swedish" class="js-language-link js-tooltip" rel="noopener">Svenska</a></li>
-            <li><a href="?lang=vi" data-lang-code="vi" title="Vietnamese" class="js-language-link js-tooltip" rel="noopener">Tiếng Việt</a></li>
-            <li><a href="?lang=tr" data-lang-code="tr" title="Turkish" class="js-language-link js-tooltip" rel="noopener">Türkçe</a></li>
-            <li><a href="?lang=el" data-lang-code="el" title="Greek" class="js-language-link js-tooltip" rel="noopener">Ελληνικά</a></li>
-            <li><a href="?lang=bg" data-lang-code="bg" title="Bulgarian" class="js-language-link js-tooltip" rel="noopener">Български език</a></li>
-            <li><a href="?lang=ru" data-lang-code="ru" title="Russian" class="js-language-link js-tooltip" rel="noopener">Русский</a></li>
-            <li><a href="?lang=sr" data-lang-code="sr" title="Serbian" class="js-language-link js-tooltip" rel="noopener">Српски</a></li>
-            <li><a href="?lang=uk" data-lang-code="uk" title="Ukrainian" class="js-language-link js-tooltip" rel="noopener">Українська мова</a></li>
-            <li><a href="?lang=he" data-lang-code="he" title="Hebrew" class="js-language-link js-tooltip" rel="noopener">עִבְרִית</a></li>
-            <li><a href="?lang=ar" data-lang-code="ar" title="Arabic" class="js-language-link js-tooltip" rel="noopener">العربية</a></li>
-            <li><a href="?lang=fa" data-lang-code="fa" title="Persian" class="js-language-link js-tooltip" rel="noopener">فارسی</a></li>
-            <li><a href="?lang=mr" data-lang-code="mr" title="Marathi" class="js-language-link js-tooltip" rel="noopener">मराठी</a></li>
-            <li><a href="?lang=hi" data-lang-code="hi" title="Hindi" class="js-language-link js-tooltip" rel="noopener">हिन्दी</a></li>
-            <li><a href="?lang=bn" data-lang-code="bn" title="Bangla" class="js-language-link js-tooltip" rel="noopener">বাংলা</a></li>
-            <li><a href="?lang=gu" data-lang-code="gu" title="Gujarati" class="js-language-link js-tooltip" rel="noopener">ગુજરાતી</a></li>
-            <li><a href="?lang=ta" data-lang-code="ta" title="Tamil" class="js-language-link js-tooltip" rel="noopener">தமிழ்</a></li>
-            <li><a href="?lang=kn" data-lang-code="kn" title="Kannada" class="js-language-link js-tooltip" rel="noopener">ಕನ್ನಡ</a></li>
-            <li><a href="?lang=th" data-lang-code="th" title="Thai" class="js-language-link js-tooltip" rel="noopener">ภาษาไทย</a></li>
-            <li><a href="?lang=ko" data-lang-code="ko" title="Korean" class="js-language-link js-tooltip" rel="noopener">한국어</a></li>
-            <li><a href="?lang=ja" data-lang-code="ja" title="Japanese" class="js-language-link js-tooltip" rel="noopener">日本語</a></li>
-            <li><a href="?lang=zh-cn" data-lang-code="zh-cn" title="Simplified Chinese" class="js-language-link js-tooltip" rel="noopener">简体中文</a></li>
-            <li><a href="?lang=zh-tw" data-lang-code="zh-tw" title="Traditional Chinese" class="js-language-link js-tooltip" rel="noopener">繁體中文</a></li>
-        </ul>
-      </div>
-      <div class="js-front-language">
-        <form action="/sessions/change_locale" class="t1-form language" method="POST">
-          <input type="hidden" name="lang"> <input type="hidden" name="redirect">
-          <input type="hidden" name="authenticity_token" value="46a6f55f84bf8fb45d8b56ce053c0606e73735e0">
-        </form>
-      </div>
-    </li>
-  </ul>
-
-    <ul class="nav secondary-nav session-dropdown" id="session">
-      <li class="dropdown js-session">
-          <a href="/login" class="dropdown-toggle js-dropdown-toggle dropdown-signin" role="button" id="signin-link" data-nav="login">
-            <small>Have an account?</small> <span class="emphasize"> Log in</span><span class="caret"></span>
-          </a>
-          <div class="dropdown-menu dropdown-form dropdown-menu--rightAlign is-forceRight" id="signin-dropdown">
-            <div class="dropdown-caret right"> <span class="caret-outer"></span> <span class="caret-inner"></span> </div>
-            <div class="signin-dialog-body">
-              <div>Have an account?</div>
-<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="login_callout"
-  data-element="form"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Phone, email, or username"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
-    
-  </div>
-
-    <div class="LoginForm-rememberForgot">
-      <label>
-        <input type="checkbox" value="1" name="remember_me" checked="checked">
-        <span>Remember me</span>
-      </label>
-      <span class="separator">&middot;</span>
-      <a class="forgot" href="/account/begin_password_reset" rel="noopener">Forgot password?</a>
-    </div>
-
-  <input type="submit" class="EdgeButton EdgeButton--primary EdgeButton--medium submit js-submit" value="Log in">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/codinghorror/status/1409351083177046020">
-  <input type="hidden" value="46a6f55f84bf8fb45d8b56ce053c0606e73735e0" name="authenticity_token">
-      <input type="hidden" name="ui_metrics" autocomplete="off">
-      <script src="/i/js_inst?c_name=ui_metrics" async></script>
-</form>
-              <hr>
-              <div class="signup SignupForm">
-                <div class="SignupForm-header">New to Twitter?</div>
-                <a href="https://twitter.com/signup" role="button" class="EdgeButton EdgeButton--secondary EdgeButton--medium u-block js-signup"
-                  data-component="signup_callout"
-                  data-element="dropdown"
-                  >Sign up
-                </a>
-              </div>
-            </div>
-          </div>
-      </li>
-    </ul>
-</div>
-
-        </div>
-      </div>
-    </div>
-</div>
-
-
-        <div id="page-outer">
-          <div id="page-container" class="AppContent wrapper wrapper-permalink">
-              
-              
-<a class="PermalinkProfile-overlay js-nav" href="/codinghorror">
-  <span class="visuallyhidden">codinghorror's profile</span>
-</a>
-<div class="PermalinkProfile-background without-banner">
-  <div class="ProfileCanopy ProfileCanopy--withNav ProfileCanopy--large js-variableHeightTopBar">
-  <div class="ProfileCanopy-inner">
-
-    <div class="ProfileCanopy-header u-bgUserColor">
-  <div class="ProfileCanopy-headerBg">
-    <img alt=""
-      src="https://pbs.twimg.com/profile_banners/5637652/1398207303/1500x500"
-      
-    >
-  </div>
-
-  <div class="AppContainer">
-
-    <div class="ProfileCanopy-avatar">
-      <div class="ProfileAvatar">
-    <a class="ProfileAvatar-container u-block js-tooltip profile-picture"
-        href="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_400x400.jpg"
-        title="Jeff Atwood"
-        data-resolved-url-large="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_400x400.jpg"
-        data-url="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_400x400.jpg"
-        target="_blank"
-        rel="noopener">
-        <img class="ProfileAvatar-image " src="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_400x400.jpg" alt="Jeff Atwood">
-    </a>
-</div>
-
-    </div>
-
-
-    <div class="ProfileCanopy-headerPromptAnchor"></div>
-  </div>
-
-</div>
-
-
-    <div class="ProfileCanopy-navBar u-boxShadow">
-      
-      <div class="AppContainer">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-size1of3 u-lg-size1of4">
-            <div class="ProfileCanopy-card" role="presentation">
-              <div class="ProfileCardMini">
-  <a class="ProfileCardMini-avatar profile-picture js-tooltip"
-     href="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl.jpg"
-     title="Jeff Atwood"
-     data-resolved-url-large="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl.jpg"
-     data-url="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl.jpg"
-     target="_blank"
-     rel="noopener">
-    <img class="ProfileCardMini-avatarImage" alt="Jeff Atwood" src="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_normal.jpg" >
-  </a>
-  <div class="ProfileCardMini-details">
-    <div class="ProfileNameTruncated account-group">
-  <div class="u-textTruncate u-inlineBlock ProfileNameTruncated-withBadges ProfileNameTruncated-withBadges--1">
-    <a class="fullname ProfileNameTruncated-link u-textInheritColor js-nav" href="/codinghorror"  data-aria-label-part>
-      Jeff Atwood</a></div><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></span>
-</div>
-    <div class="ProfileCardMini-screenname">
-      <a href="/codinghorror" class="ProfileCardMini-screennameLink u-linkComplex js-nav u-dir" dir="ltr">
-        <span class="username u-dir" dir="ltr">@<b class="u-linkComplex-target">codinghorror</b></span>
-      </a>
-    </div>
-  </div>
-</div>
-
-            </div>
-          </div>
-
-          <div class="Grid-cell u-size2of3 u-lg-size3of4">
-            <div class="ProfileCanopy-nav">
-              
-
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-
-    <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-    <h2 id="content-main-heading" class="u-hiddenVisually">Tweets</h2>
-</div>
-
-
-  <div class="AppContainer">
-    <div class="Grid Grid--withGutter">
-      <div class="Grid-cell u-size1of3 u-lg-size1of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell">
-            <div class="ProfileSidebar ProfileSidebar--withLeftAlignment">
-  <div class="ProfileHeaderCard">
-  <h1 class="ProfileHeaderCard-name">
-    <a href="/codinghorror"
-       class="ProfileHeaderCard-nameLink u-textInheritColor js-nav">Jeff Atwood</a><span class="ProfileHeaderCard-badges"><a href="" class="js-tooltip" target="_blank" title="Verified account" data-placement="right" rel="noopener"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a></span>
-  </h1>
-
-  <h2 class="ProfileHeaderCard-screenname u-inlineBlock u-dir" dir="ltr">
-    <a class="ProfileHeaderCard-screennameLink u-linkComplex js-nav" href="/codinghorror">
-      <span class="username u-dir" dir="ltr">@<b class="u-linkComplex-target">codinghorror</b></span>
-    </a>
-  </h2>
-
-  
-
-      <p class="ProfileHeaderCard-bio u-dir" dir="ltr">Indoor enthusiast. Co-founder of <a href="https://t.co/P7MEYP7MjF" rel="nofollow noopener" dir="ltr" data-expanded-url="http://stackoverflow.com" class="twitter-timeline-link" target="_blank" title="http://stackoverflow.com" ><span class="invisible">http://</span><span class="js-display-url">stackoverflow.com</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a> and <a href="https://t.co/rlk2RG61MA" rel="nofollow noopener" dir="ltr" data-expanded-url="http://discourse.org" class="twitter-timeline-link" target="_blank" title="http://discourse.org" ><span class="invisible">http://</span><span class="js-display-url">discourse.org</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a>. Let’s be kind to each other. Disclaimer: I have no idea what I&#39;m talking about.</p>
-
-      <div class="ProfileHeaderCard-location ">
-        <span class="Icon Icon--geo Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-locationText u-dir" dir="ltr">
-              Bay Area, CA
-
-        </span>
-      </div>
-
-      <div class="ProfileHeaderCard-url ">
-        <span class="Icon Icon--url Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-urlText u-dir">  <a class="u-textUserColor" target="_blank" rel="me nofollow noopener" href="http://t.co/rM9N1bQpLr" title="http://blog.codinghorror.com">
-    blog.codinghorror.com
-  </a>
-
-</span>
-      </div>
-
-
-      <div class="ProfileHeaderCard-joinDate">
-        <span class="Icon Icon--calendar Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-joinDateText js-tooltip u-dir" dir="ltr" title="1:50 PM - 29 Apr 2007">Joined April 2007</span>
-      </div>
-
-      <div class="ProfileHeaderCard-birthdate u-hidden">
-        <span class="Icon Icon--balloon Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-birthdateText u-dir" dir="ltr">
-</span>
-      </div>
-
-
-</div>
-
-
-
-
-
-
-
-</div>
-
-          </div>
-        </div>
-      </div>
-      <div class="Grid-cell u-size2of3 u-lg-size3of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-lg-size2of3" data-test-selector="ProfileTimeline">
-              <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-    <h2 id="content-main-heading" class="u-hiddenVisually">Tweets</h2>
-</div>
-
-            
-
-
-
-
-
-
-
-
-
-          </div>
-          <div class="Grid-cell u-size1of3">
-            <div class="Grid Grid--withGutter">
-              <div class="Grid-cell">
-                <div class="ProfileSidebar ProfileSidebar--withRightAlignment">
-                  <div class="MoveableModule">
-                    
-<div class="SidebarCommonModules">
-
-
-
-
-
-  <div class="Footer module roaming-module Footer--slim"
-  >
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2021 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about" rel="noopener">About</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com" rel="noopener">Help Center</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos" rel="noopener">Terms</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy" rel="noopener">Privacy policy</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514" rel="noopener">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html" rel="noopener">Ads info</a></li>
-      </ul>
-    </div>
-  </div>
-
-</div>
-
-</div>
-
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-    
-<style id="user-style-codinghorror">
-
-
-
-
-
-
-  a,
-  a:hover,
-  a:focus,
-  a:active {
-    color: #282D58;
-  }
-
-  .u-textUserColor,
-  .u-textUserColorHover:hover,
-  .u-textUserColorHover:hover .ProfileTweet-actionCount,
-  .u-textUserColorHover:focus {
-    color: #282D58 !important;
-  }
-
-  .u-borderUserColor,
-  .u-borderUserColorHover:hover,
-  .u-borderUserColorHover:focus {
-    border-color: #282D58 !important;
-  }
-
-  .u-bgUserColor,
-  .u-bgUserColorHover:hover,
-  .u-bgUserColorHover:focus {
-    background-color: #282D58 !important;
-  }
-
-  .u-dropdownUserColor > li:hover,
-  .u-dropdownUserColor > li:focus,
-  .u-dropdownUserColor > li > button:hover,
-  .u-dropdownUserColor > li > button:focus,
-  .u-dropdownUserColor > li > a:focus,
-  .u-dropdownUserColor > li > a:hover {
-    color: #fff !important;
-    background-color: #282D58 !important;
-  }
-
-  .u-boxShadowInsetUserColorHover:hover,
-  .u-boxShadowInsetUserColorHover:focus {
-    box-shadow: inset 0 0 0 5px #282D58 !important;
-  }
-
-  .u-dropdownOpenUserColor.dropdown.open .dropdown-toggle {
-    color: #282D58;
-  }
-
-
-  .u-textUserColorLight {
-    color: #A9ABBC !important;
-  }
-
-  .u-borderUserColorLight,
-  .u-borderUserColorLightFocus:focus,
-  .u-borderUserColorLightHover:hover,
-  .u-borderUserColorLightHover:focus {
-    border-color: #A9ABBC !important;
-  }
-
-  .u-bgUserColorLight {
-    background-color: #A9ABBC !important;
-  }
-
-
-  .u-boxShadowUserColorLighterFocus:focus {
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 2px rgba(40,45,88,0.25) !important;
-  }
-
-
-  .u-textUserColorLightest {
-    color: #E9EAEE !important;
-  }
-
-  .u-borderUserColorLightest {
-    border-color: #E9EAEE !important;
-  }
-
-  .u-bgUserColorLightest {
-    background-color: #E9EAEE !important;
-  }
-
-
-  .u-textUserColorLighter {
-    color: #C9CAD5 !important;
-  }
-
-  .u-borderUserColorLighter {
-    border-color: #C9CAD5 !important;
-  }
-
-  .u-bgUserColorLighter {
-    background-color: #C9CAD5 !important;
-  }
-
-
-  .u-bgUserColorDarkHover:hover {
-    background-color: #252C51 !important;
-  }
-
-  .u-borderUserColorDark {
-    border-color: #252C51 !important;
-  }
-
-
-  .u-bgUserColorDarkerActive:active {
-    background-color: #222B4A !important;
-  }
-
-
-
-
-
-
-
-
-
-
-
-
-
-a,
-.btn-link,
-.btn-link:focus,
-.icon-btn,
-
-
-
-.pretty-link b,
-.pretty-link:hover s,
-.pretty-link:hover b,
-.pretty-link:focus s,
-.pretty-link:focus b,
-
-.metadata a:hover,
-.metadata a:focus,
-
-a.account-group:hover .fullname,
-a.account-group:focus .fullname,
-.account-summary:focus .fullname,
-
-.message .message-text a,
-.message .message-text button,
-.stats a strong,
-.plain-btn:hover,
-.plain-btn:focus,
-.dropdown.open .user-dropdown.plain-btn,
-.open > .plain-btn,
-#global-actions .new:before,
-.module .list-link:hover,
-.module .list-link:focus,
-
-.stats a:hover,
-.stats a:hover strong,
-.stats a:focus,
-.stats a:focus strong,
-
-.find-friends-sources li:hover .source,
-
-
-
-
-
-.stream-item a:hover .fullname,
-.stream-item a:focus .fullname,
-
-.stream-item .view-all-supplements:hover,
-.stream-item .view-all-supplements:focus,
-
-.tweet .time a:hover,
-.tweet .time a:focus,
-.tweet .details.with-icn b,
-.tweet .details.with-icn .Icon,
-
-.stream-item:hover .original-tweet .details b,
-.stream-item .original-tweet.focus .details b,
-.stream-item.open .original-tweet .details b,
-
-.client-and-actions a:hover,
-.client-and-actions a:focus,
-
-.dismiss-btn:hover b,
-
-.tweet .context .pretty-link:hover s,
-.tweet .context .pretty-link:hover b,
-.tweet .context .pretty-link:focus s,
-.tweet .context .pretty-link:focus b,
-
-.list .username a:hover,
-.list .username a:focus,
-.list-membership-container .create-a-list,
-.list-membership-container .create-a-list:hover,
-.new-tweets-bar,
-
-
-
-.card .list-details a:hover,
-.card .list-details a:focus,
-.card .card-body:hover .attribution,
-.card .card-body .attribution:focus {
-  color: #282D58;
-}
-
-
-
-
-  
-  .FoundMediaSearch--keyboard .FoundMediaSearch-focusable.is-focused {
-    border-color: #282D58;
-  }
-
-  
-  .photo-selector:hover .btn,
-  .icon-btn:hover,
-  .icon-btn:active,
-  .icon-btn.active,
-  .icon-btn.enabled {
-    border-color: #282D58;
-    border-color: rgba(40,45,88,0.4);
-    color: #282D58;
-  }
-
-  
-  .photo-selector:hover .btn,
-  .icon-btn:hover {
-    background-image: linear-gradient(rgba(255,255,255,0), rgba(40,45,88,0.1));
-  }
-
-  .icon-btn.disabled,
-  .icon-btn.disabled:hover,
-  .icon-btn[disabled],
-  .icon-btn[aria-disabled=true] {
-    color: #282D58;
-  }
-
-  
-  
-
-  .EdgeButton--primary,
-  .EdgeButton--primary:focus {
-    background-color: #525679;
-    border-color: transparent;
-  }
-
-  .EdgeButton--primary:hover,
-  .EdgeButton--primary:active {
-    background-color: #282D58;
-    border-color: #282D58;
-  }
-
-  .EdgeButton--primary:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #A9ABBC;
-  }
-
-  .EdgeButton--primary:active {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #525679;
-  }
-
-  
-  
-
-  .EdgeButton--secondary,
-  .EdgeButton--secondary:hover,
-  .EdgeButton--secondary:focus,
-  .EdgeButton--secondary:active {
-    border-color: #282D58;
-    color: #282D58;
-  }
-
-  .EdgeButton--secondary:hover,
-  .EdgeButton--secondary:active {
-    background-color: #E9EAEE;
-  }
-
-  .EdgeButton--secondary:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px rgba(40,45,88,0.4);
-  }
-
-  .EdgeButton--secondary:active {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #282D58;
-  }
-
-  
-  
-
-  .EdgeButton--invertedPrimary {
-    color: #282D58 !important;
-  }
-
-  .EdgeButton--invertedPrimary:focus {
-    box-shadow:
-      0 0 0 2px #282D58,
-      0 0 0 4px #A9ABBC;
-  }
-
-  .EdgeButton--invertedPrimary:active {
-    box-shadow:
-      0 0 0 2px #282D58,
-      0 0 0 4px #FFFFFF;
-  }
-
-  
-  
-
-  .EdgeButton--invertedSecondary {
-    background-color: #282D58;
-  }
-
-  .EdgeButton--invertedSecondary:hover {
-    background-color: #525679;
-  }
-
-  .EdgeButton--invertedSecondary:focus {
-    box-shadow:
-      0 0 0 2px #282D58,
-      0 0 0 4px #A9ABBC;
-  }
-
-  .EdgeButton--invertedSecondary:active {
-    box-shadow:
-      0 0 0 2px #282D58,
-      0 0 0 4px #FFFFFF;
-  }
-
-  
-
-  .btn:focus,
-  .btn.focus,
-  .Button:focus,
-  .EmojiPicker-item.is-focused,
-  .EmojiPicker .EmojiCategoryIcon:focus,
-  .EmojiPicker-skinTone:focus + .EmojiPicker-skinToneSwatch,
-  a:focus > img:first-child:last-child,
-  button:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 2px 4px rgba(40,45,88,0.4);
-  }
-
-  .selected-stream-item:focus {
-    box-shadow: 0 0 0 3px rgba(40,45,88,0.4);
-  }
-
-  
-  .js-navigable-stream.stream-table-view .selected-stream-item[tabindex="-1"]:focus {
-    outline: 3px solid rgba(40,45,88,0.4) !important;
-  }
-
-  
-  .js-navigable-stream.stream-table-view .selected-stream-item:focus {
-    box-shadow: none;
-  }
-
-  
-
-  .global-dm-nav.new.with-count .dm-new .count-inner {
-    background: #282D58;
-  }
-
-  .global-nav .people .count .count-inner {
-    background: #282D58;
-  }
-
-  .dropdown-menu li > a:hover,
-  .dropdown-menu li > a:focus,
-  .dropdown-menu .dropdown-link:hover,
-  .dropdown-menu .dropdown-link:focus,
-  .dropdown-menu .dropdown-link.is-focused,
-  .dropdown-menu li:hover .dropdown-link,
-  .dropdown-menu li:focus .dropdown-link,
-  .dropdown-menu .selected a,
-  .dropdown-menu .dropdown-link.selected {
-    background-color: #282D58 !important;
-  }
-
-  /* for items in typeahead dropdown menu on logged in pages */
-  .dropdown-menu .typeahead-items li > a:focus,
-  .dropdown-menu .typeahead-items li > a:hover,
-  .dropdown-menu .typeahead-items .selected,
-  .dropdown-menu .typeahead-items .selected a {
-    background-color: #E9EAEE !important;
-    color: #282D58 !important;
-  }
-
-  .typeahead a:hover,
-  .typeahead a:hover strong,
-  .typeahead a:hover .fullname,
-  .typeahead .selected a,
-  .typeahead .selected strong,
-  .typeahead .selected .fullname,
-  .typeahead .selected .Icon--close {
-    color: #282D58 !important;
-  }
-
-
-.home-tweet-box,
-.LiveVideo-tweetBox,
-.RetweetDialog-commentBox {
-  background-color: #E9EAEE;
-}
-
-.top-timeline-tweetbox .timeline-tweet-box .tweet-form.condensed .tweet-box {
-  color: #282D58;
-}
-
-.RichEditor,
-.TweetBoxAttachments {
-  border-color: #C9CAD5;
-}
-
-input:focus,
-textarea:focus,
-div[contenteditable="true"]:focus,
-div[contenteditable="true"].fake-focus,
-div[contenteditable="plaintext-only"]:focus,
-div[contenteditable="plaintext-only"].fake-focus {
-  border-color: #A9ABBC;
-  box-shadow: inset 0 0 0 1px rgba(40,45,88,0.7);
-}
-
-.tweet-box textarea:focus,
-.tweet-box input[type=text],
-.currently-dragging .tweet-form.is-droppable .tweet-drag-help,
-.tweet-box[contenteditable="true"]:focus,
-.RichEditor.is-fakeFocus,
-.RichEditor.is-fakeFocus ~ .TweetBoxAttachments {
-  border-color: #A9ABBC;
-  box-shadow: 0 0 0 1px #A9ABBC;
-}
-
-.MomentCapsuleItem.selected-stream-item:focus {
-  box-shadow: 0 0 0 3px rgba(40,45,88,0.4);
-}
-
-
-
-
-s,
-.pretty-link:hover s,
-.pretty-link:focus s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:hover s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:focus s {
-    color: #282D58;
-}
-
-
-
-.vellip,
-.vellip:before,
-.vellip:after,
-.conversation-module > li:after,
-.conversation-module > li:before,
-.ThreadedConversation--loneTweet:after,
-.ThreadedConversation-tweet:not(.is-hiddenAncestor) ~ .ThreadedConversation-tweet:before,
-.ThreadedConversation-tweet:after,
-.ThreadedConversation-moreReplies:before,
-.ThreadedConversation-viewOther:before,
-.ThreadedConversation-unavailableTweet:before,
-.ThreadedConversation-unavailableTweet:after,
-.ThreadedConversation--permalinkTweetWithAncestors:before,
-.mini-avatar-with-thread:before,
-.permalink.self-thread-permalink-with-descendant .permalink-tweet-container:after,
-.permalink.self-thread-permalink-with-descendant .inline-reply-tweetbox-container:after {
-    border-color: #A9ABBC;
-}
-
-
-
-
-.tweet .sm-reply,
-.tweet .sm-rt,
-.tweet .sm-fav,
-.tweet .sm-image,
-.tweet .sm-video,
-.tweet .sm-audio,
-.tweet .sm-geo,
-.tweet .sm-in,
-.tweet .sm-trash,
-.tweet .sm-more,
-.tweet .sm-page,
-.tweet .sm-embed,
-.tweet .sm-summary,
-.tweet .sm-chat,
-
-.timelines-navigation .active .profile-nav-icon,
-.timelines-navigation .profile-nav-icon:hover,
-.timelines-navigation .profile-nav-link:focus .profile-nav-icon,
-
-.sm-top-tweet {
-    background-color: #282D58;
-}
-
-.enhanced-mini-profile .mini-profile .profile-summary {
-  background-image: url(https://pbs.twimg.com/profile_banners/5637652/1398207303/mobile);
-}
-
-  #global-tweet-dialog .modal-header,
-  #Tweetstorm-dialog .modal-header {
-    border-bottom: solid 1px rgba(40,45,88,0.25);
-  }
-
-  #global-tweet-dialog .modal-tweet-form-container,
-  #Tweetstorm-dialog .modal-body {
-    background-color: #282D58;
-    background: rgba(40,45,88,0.1);
-  }
-
-  .TweetstormDialog-reply-context .tweet-box-avatar:after,
-  .TweetstormDialog-reply-context .tweet-box-avatar:before,
-  .TweetstormDialog-tweet-box .tweet-box-avatar:after,
-  .TweetstormDialog-tweet-box .tweet-box-avatar:before {
-    border-color: #A9ABBC;
-  }
-
-  .global-nav .search-input:focus,
-  .global-nav .search-input.focus {
-    border: 2px solid #282D58;
-  }
-}
-
-  .inline-reply-tweetbox {
-    background-color: #E9EAEE;
-  }
-
-</style>
-
-
-<style id="user-style-codinghorror-header-img" class="js-user-style-header-img">
-
-    body.user-style-codinghorror .enhanced-mini-profile .mini-profile .profile-summary {
-      background-image: url(https://pbs.twimg.com/profile_banners/5637652/1398207303/web);
+<link rel="shortcut icon" href="//abs.twimg.com/favicons/twitter.2.ico">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Twitter">
+<meta name="apple-mobile-web-app-status-bar-style" content="white">
+<meta name="theme-color" content="#ffffff">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://twitter.com/","potentialAction":{"@type":"SearchAction","query-input":"required name=search_term_string","target":{"@type":"EntryPoint","urlTemplate":"https://twitter.com/search?q={search_term_string}&ref_src=twcamp%5Eseo_searchbox%7Ctwsrc%5Eseo"}}}</script><meta http-equiv="origin-trial" content="AlpCmb40F5ZjDi9ZYe+wnr/V8MF+XmY41K4qUhoq+2mbepJTNd3q4CRqlACfnythEPZqcjryfAS1+ExS0FFRcA8AAABmeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJMYXVuY2ggSGFuZGxlciIsImV4cGlyeSI6MTY1NTI1MTE5OSwiaXNTdWJkb21haW4iOnRydWV9">
+<style>html,body{height: 100%;}::cue{white-space:normal}</style>
+<style id="react-native-stylesheet">[stylesheet-group="0"]{}
+html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+body{margin:0;}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
+input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
+[stylesheet-group="0.1"]{}
+:focus:not([data-focusvisible-polyfill]){outline: none;}
+[stylesheet-group="0.5"]{}
+.css-18t94o4{cursor:pointer;}
+.css-4rbku5{background-color:rgba(0,0,0,0.00);color:inherit;font:inherit;list-style:none;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;text-align:inherit;text-decoration:none;}
+[stylesheet-group="1"]{}
+.css-1dbjc4n{-ms-flex-align:stretch;-ms-flex-direction:column;-ms-flex-negative:0;-ms-flex-preferred-size:auto;-webkit-align-items:stretch;-webkit-box-align:stretch;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-basis:auto;-webkit-flex-direction:column;-webkit-flex-shrink:0;align-items:stretch;border:0 solid black;box-sizing:border-box;display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;flex-basis:auto;flex-direction:column;flex-shrink:0;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;min-height:0px;min-width:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;position:relative;z-index:0;}
+.css-901oao{border:0 solid black;box-sizing:border-box;color:rgba(0,0,0,1.00);display:inline;font:14px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;white-space:pre-wrap;word-wrap:break-word;}
+.css-16my406{color:inherit;font:inherit;white-space:inherit;}
+.css-1hf3ou5{max-width:100%;overflow-x:hidden;overflow-y:hidden;text-overflow:ellipsis;white-space:nowrap;word-wrap:normal;}
+.css-9pa8cd{bottom:0px;height:100%;left:0px;opacity:0;position:absolute;right:0px;top:0px;width:100%;z-index:-1;}
+[stylesheet-group="2"]{}
+.r-13awgt0{-ms-flex:1 1 0%;-webkit-flex:1;flex:1;}
+.r-sdzlij{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;border-top-left-radius:9999px;border-top-right-radius:9999px;}
+.r-1phboty{border-bottom-style:solid;border-left-style:solid;border-right-style:solid;border-top-style:solid;}
+.r-rs99b7{border-bottom-width:1px;border-left-width:1px;border-right-width:1px;border-top-width:1px;}
+.r-4iw3lz{border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;}
+.r-1udh08x{overflow-x:hidden;overflow-y:hidden;}
+.r-wwvuq4{padding-bottom:0;padding-left:0;padding-right:0;padding-top:0;}
+.r-6koalj{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;}
+.r-4qtqp9{display:inline-block;}
+.r-crgep1{margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;}
+.r-t60dpp{padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;}
+.r-1yadl64{border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;}
+.r-42olwf{border-bottom-color:rgba(0,0,0,0.00);border-left-color:rgba(0,0,0,0.00);border-right-color:rgba(0,0,0,0.00);border-top-color:rgba(0,0,0,0.00);}
+.r-17gur6a{border-bottom-left-radius:0px;border-bottom-right-radius:0px;border-top-left-radius:0px;border-top-right-radius:0px;}
+.r-xyw6el{padding-bottom:12px;padding-left:12px;padding-right:12px;padding-top:12px;}
+.r-jxzhtn{border-bottom-color:rgba(239,243,244,1.00);border-left-color:rgba(239,243,244,1.00);border-right-color:rgba(239,243,244,1.00);border-top-color:rgba(239,243,244,1.00);}
+.r-1adg3ll{display:block;}
+.r-bztko3{overflow-x:visible;overflow-y:visible;}
+.r-xoduu5{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;}
+.r-xf4iuw{margin-bottom:-8px;margin-left:-8px;margin-right:-8px;margin-top:-8px;}
+.r-1ets6dv{border-bottom-color:rgba(207,217,222,1.00);border-left-color:rgba(207,217,222,1.00);border-right-color:rgba(207,217,222,1.00);border-top-color:rgba(207,217,222,1.00);}
+.r-1867qdf{border-bottom-left-radius:16px;border-bottom-right-radius:16px;border-top-left-radius:16px;border-top-right-radius:16px;}
+.r-1471scf{display:inline;}
+[stylesheet-group="2.1"]{}
+.r-1jgb5lz{margin-left:auto;margin-right:auto;}
+.r-ymttw5{padding-left:16px;padding-right:16px;}
+.r-oyd9sg{padding-bottom:4px;padding-top:4px;}
+.r-1fz3rvf{margin-left:12px;margin-right:12px;}
+.r-rjfia{padding-bottom:0px;padding-top:0px;}
+.r-1r5su4o{margin-bottom:16px;margin-top:16px;}
+.r-s1qlax{padding-left:4px;padding-right:4px;}
+.r-1e081e0{padding-left:12px;padding-right:12px;}
+.r-1pn2ns4{padding-left:8px;padding-right:8px;}
+.r-1yzf0co{padding-bottom:16px;padding-top:16px;}
+[stylesheet-group="2.2"]{}
+.r-12vffkv>*{pointer-events:auto;}
+.r-12vffkv{pointer-events:none!important;}
+.r-2llsf{min-height:100%;}
+.r-13qz1uu{width:100%;}
+.r-417010{z-index:0;}
+.r-lrvibr{-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none;}
+.r-1xk2f4g{clip:rect(1px, 1px, 1px, 1px);}
+.r-109y4c4{height:1px;}
+.r-u8s1d{position:absolute;}
+.r-92ng3h{width:1px;}
+.r-2yi16{min-height:36px;}
+.r-1qi8awa{min-width:36px;}
+.r-o7ynqc{-webkit-transition-duration:0.2s;transition-duration:0.2s;}
+.r-6416eg{-moz-transition-property:background-color, box-shadow;-webkit-transition-property:background-color, box-shadow;transition-property:background-color, box-shadow;}
+.r-1ny4l3l{outline-style:none;}
+.r-bcqeeo{min-width:0px;}
+.r-qvutc0{word-wrap:break-word;}
+.r-rjixqe{line-height:20px;}
+.r-37j5jr{font-family:"TwitterChirp",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+.r-q4m81j{text-align:center;}
+.r-a023e6{font-size:15px;}
+.r-b88u0q{font-weight:700;}
+.r-1awozwy{-ms-flex-align:center;-webkit-align-items:center;-webkit-box-align:center;align-items:center;}
+.r-18u37iz{-ms-flex-direction:row;-webkit-box-direction:normal;-webkit-box-orient:horizontal;-webkit-flex-direction:row;flex-direction:row;}
+.r-16y2uox{-ms-flex-positive:1;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;}
+.r-1777fci{-ms-flex-pack:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;}
+.r-poiln3{font-family:inherit;}
+.r-1g40b8q{z-index:3;}
+.r-orgf3d{opacity:0;}
+.r-633pao{pointer-events:none!important;}
+.r-1d2f490{left:0px;}
+.r-1xcajam{position:fixed;}
+.r-zchlnj{right:0px;}
+.r-1gn8etr{top:-0.5px;}
+.r-dkhcqf{-webkit-transition-duration:350ms;transition-duration:350ms;}
+.r-axxi2z{-moz-transition-property:transform;-webkit-transition-property:-webkit-transform,transform;transition-property:-webkit-transform,transform;}
+.r-18jm5s1{-webkit-transition-timing-function:cubic-bezier(0,0,0,1);transition-timing-function:cubic-bezier(0,0,0,1);}
+.r-16e0dcy{-webkit-transform:translate3d(0, 0, 0) translateY(0px);transform:translate3d(0, 0, 0) translateY(0px);}
+.r-1e5uvyk{-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);}
+.r-6026j{background-color:rgba(255,255,255,0.85);}
+.r-136ojw6{z-index:2;}
+.r-fxvszc{height:106px;}
+.r-1h3ijdo{height:53px;}
+.r-1pz39u2{-ms-flex-item-align:stretch;-ms-grid-row-align:stretch;-webkit-align-self:stretch;align-self:stretch;}
+.r-15ysp7h{min-height:32px;}
+.r-4wgw6l{min-width:32px;}
+.r-1habvwh{-ms-flex-align:start;-webkit-align-items:flex-start;-webkit-box-align:start;align-items:flex-start;}
+.r-s8bhmr{min-width:56px;}
+.r-1mf7evn{margin-right:20px;}
+.r-1loqt21{cursor:pointer;}
+.r-yyyyoo{fill:currentcolor;}
+.r-1xvli5t{height:1.25em;}
+.r-dnmrzs{max-width:100%;}
+.r-bnwqim{position:relative;}
+.r-1plcrui{vertical-align:text-bottom;}
+.r-z80fyv{height:20px;}
+.r-19wmn03{width:20px;}
+.r-1cvl2hr{color:rgba(29,155,240,1.00);}
+.r-lwhw9o{height:1.75rem;}
+.r-1wbh5a2{-ms-flex-negative:1;-webkit-flex-shrink:1;flex-shrink:1;}
+.r-1pi2tsx{height:100%;}
+.r-1iusvr4{-ms-flex-preferred-size:0px;-webkit-flex-basis:0px;flex-basis:0px;}
+.r-1oszu61{-ms-flex-align:stretch;-webkit-align-items:stretch;-webkit-box-align:stretch;align-items:stretch;}
+.r-eqz5dr{-ms-flex-direction:column;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-direction:column;flex-direction:column;}
+.r-8fdsdq{z-index:4;}
+.r-vqxq0j{border:0 solid black;}
+.r-deolkf{box-sizing:border-box;}
+.r-1mlwlqe{-ms-flex-preferred-size:auto;-webkit-flex-basis:auto;flex-basis:auto;}
+.r-ifefl9{min-height:0px;}
+.r-1sw30gj{background-color:rgba(239,243,244,1.00);}
+.r-1dqbpge{cursor:-webkit-text;cursor:text;}
+.r-7q8q6z{cursor:default;}
+.r-14j79pv{color:rgba(83,100,113,1.00);}
+.r-f727ji{padding-left:12px;}
+.r-16dba41{font-weight:400;}
+.r-30o5oe{-moz-appearance:none;-webkit-appearance:none;appearance:none;}
+.r-1dz5y72{resize:none;}
+.r-1niwhzg{background-color:rgba(0,0,0,0.00);}
+.r-homxoj{color:inherit;}
+.r-7cikom{font-size:inherit;}
+.r-1ttztb7{text-align:inherit;}
+.r-fdjqy7{text-align:left;}
+.r-y0fyvk::-webkit-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::-moz-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk:-ms-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-obd0qt{-ms-flex-align:end;-webkit-align-items:flex-end;-webkit-box-align:end;align-items:flex-end;}
+.r-1d4mawv{margin-right:4px;}
+.r-1w6e6rj{-ms-flex-wrap:wrap;-webkit-box-lines:multiple;-webkit-flex-wrap:wrap;flex-wrap:wrap;}
+.r-1wtj0ep{-ms-flex-pack:justify;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;}
+.r-1b43r93{font-size:14px;}
+.r-1cwl3u0{line-height:16px;}
+.r-19u6a5r{margin-left:12px;}
+.r-1lul07w{-webkit-transform:translate3d(0, -3.5em, 0);transform:translate3d(0, -3.5em, 0);}
+.r-eafdt9{-webkit-transition-duration:0.15s;transition-duration:0.15s;}
+.r-1b8bd59{-moz-transition-property:transform, opacity;-webkit-transition-property:-webkit-transform,transform, opacity;transition-property:-webkit-transform,transform, opacity;}
+.r-nx0j10{-webkit-transition-timing-function:ease, ease, step-end;transition-timing-function:ease, ease, step-end;}
+.r-l5o3uw{background-color:rgba(29,155,240,1.00);}
+.r-y3da5r{box-shadow:0 0 8px rgba(101,119,134,0.2), 0 1px 3px 1px rgba(101,119,134,0.25);}
+.r-1kihuf0{-ms-flex-item-align:center;-ms-grid-row-align:center;-webkit-align-self:center;align-self:center;}
+.r-jwli3a{color:rgba(255,255,255,1.00);}
+.r-13hce6t{margin-left:4px;}
+.r-150rngu{-webkit-overflow-scrolling:touch;}
+.r-aqfbo4{-webkit-backface-visibility:hidden;backface-visibility:hidden;}
+.r-14lw9ot{background-color:rgba(255,255,255,1.00);}
+.r-1ljd8xs{border-left-width:1px;}
+.r-13l2t4g{border-right-width:1px;}
+.r-33ulu8{width:600px;}
+.r-184en5c{z-index:1;}
+.r-1ut4w64{margin-bottom:-1px;}
+.r-1qhn6m8{padding-left:16px;}
+.r-i023vh{padding-right:16px;}
+.r-ttdzmv{padding-top:12px;}
+.r-18kxxzh{-ms-flex-positive:0;-webkit-box-flex:0;-webkit-flex-grow:0;flex-grow:0;}
+.r-1b7u577{margin-right:12px;}
+.r-1hwvwag{-ms-flex-preferred-size:48px;-webkit-flex-basis:48px;flex-basis:48px;}
+.r-1p0dtai{bottom:0px;}
+.r-ipm5af{top:0px;}
+.r-1wyvozj{left:50%;}
+.r-1v2oles{top:50%;}
+.r-desppf{-webkit-transform:translateX(-50%) translateY(-50%);transform:translateX(-50%) translateY(-50%);}
+.r-ggadg3{left:-2px;}
+.r-8jfcpp{top:-2px;}
+.r-vvn4in{background-position:center;}
+.r-u6sd8q{background-repeat:no-repeat;}
+.r-4gszlv{background-size:cover;}
+.r-1wyyakw{z-index:-1;}
+.r-12181gd{box-shadow:0 0 2px rgba(0,0,0,0.03) inset;}
+.r-1bimlpy{background-color:rgba(207,217,222,1.00);}
+.r-m5arl1{width:2px;}
+.r-14gqq1x{margin-top:4px;}
+.r-kzbkwu{padding-bottom:12px;}
+.r-zl2h9q{margin-bottom:2px;}
+.r-k4xj1c{-ms-flex-align:start;-webkit-align-items:start;-webkit-box-align:start;align-items:start;}
+.r-1d09ksm{-ms-flex-align:baseline;-webkit-align-items:baseline;-webkit-box-align:baseline;align-items:baseline;}
+.r-3s2u2q{white-space:nowrap;}
+.r-1q142lx{-ms-flex-negative:0;-webkit-flex-shrink:0;flex-shrink:0;}
+.r-1wvb978{-webkit-font-feature-settings:'ss01' on;font-feature-settings:'ss01' on;}
+.r-9aw3ui{gap:4px;}
+.r-1ta3fxp{-moz-column-gap:8px;-webkit-column-gap:8px;column-gap:8px;}
+.r-1mdbhws{max-width:425px;}
+.r-1s2bzr4{margin-top:12px;}
+.r-1h0z5md{-ms-flex-pack:start;-webkit-box-pack:start;-webkit-justify-content:flex-start;justify-content:flex-start;}
+.r-bt1l66{min-height:20px;}
+.r-clp7b1{-moz-transition-property:color;-webkit-transition-property:color;transition-property:color;}
+.r-1hdv0qi{width:1.25em;}
+.r-n6v787{font-size:13px;}
+.r-1k6nrdp{min-width:calc(1em + 2 * 12px);}
+.r-vc7bo5{min-width:calc(1em + 2 * 8px);}
+.r-j5o65s{border-bottom-color:rgba(239,243,244,1.00);}
+.r-qklmqi{border-bottom-width:1px;}
+.r-15zivkp{margin-bottom:4px;}
+.r-1inkyih{font-size:17px;}
+.r-1ssbvtb{gap:12px;}
+.r-1dgieki{border-top-color:rgba(239,243,244,1.00);}
+.r-1efd50x{border-top-style:solid;}
+.r-5kkj8d{border-top-width:1px;}
+.r-a2tzq0{-ms-flex-pack:distribute;-webkit-box-pack:justify;-webkit-justify-content:space-around;justify-content:space-around;}
+.r-3qxfft{min-height:1.875rem;}
+.r-h3s6tt{height:48px;}
+.r-50lct3{height:1.5em;}
+.r-1srniue{width:1.5em;}
+.r-rull8r{border-bottom-style:solid;}
+.r-o52ifk{height:100px;}
+.r-17bb2tj{-webkit-animation-duration:0.75s;animation-duration:0.75s;}
+.r-1muvv40{-webkit-animation-iteration-count:infinite;animation-iteration-count:infinite;}
+.r-127358a{-webkit-animation-name:r-9p3sdl;animation-name:r-9p3sdl;}
+@-webkit-keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+@keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+.r-1ldzwu0{-webkit-animation-timing-function:linear;animation-timing-function:linear;}</style>
+<title data-rh="true">Jeff Atwood on Twitter: "My first text message from my child! A moment that shall live on in infamy! https://t.co/TQMRJsFwnO" / Twitter</title>
+<meta data-rh="true" content="article" property="og:type">
+<meta data-rh="true" content="https://twitter.com/codinghorror/status/1409351083177046020" property="og:url">
+<meta data-rh="true" content="Jeff Atwood on Twitter" property="og:title">
+<meta data-rh="true" content="“My first text message from my child! A moment that shall live on in infamy!”" property="og:description">
+<meta data-rh="true" content="https://pbs.twimg.com/media/E48FVowUUAYyGLX.jpg:large" property="og:image">
+<meta data-rh="true" description="" name="description"> <link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020" rel="canonical">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020" hreflang="x-default" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ar" hreflang="ar" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ar-x-fm" hreflang="ar-x-fm" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=bg" hreflang="bg" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=bn" hreflang="bn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ca" hreflang="ca" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=cs" hreflang="cs" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=da" hreflang="da" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=de" hreflang="de" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=el" hreflang="el" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=en" hreflang="en" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=en-GB" hreflang="en-GB" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=es" hreflang="es" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=eu" hreflang="eu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fa" hreflang="fa" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fi" hreflang="fi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fil" hreflang="fil" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=fr" hreflang="fr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ga" hreflang="ga" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=gl" hreflang="gl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=gu" hreflang="gu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ha" hreflang="ha" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=he" hreflang="he" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hi" hreflang="hi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hr" hreflang="hr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=hu" hreflang="hu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=id" hreflang="id" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ig" hreflang="ig" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=it" hreflang="it" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ja" hreflang="ja" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=kn" hreflang="kn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ko" hreflang="ko" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=mr" hreflang="mr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ms" hreflang="ms" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=nb" hreflang="nb" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=nl" hreflang="nl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=no" hreflang="no" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=pl" hreflang="pl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=pt" hreflang="pt" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ro" hreflang="ro" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ru" hreflang="ru" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sk" hreflang="sk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sr" hreflang="sr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=sv" hreflang="sv" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ta" hreflang="ta" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=th" hreflang="th" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=tl" hreflang="tl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=tr" hreflang="tr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=uk" hreflang="uk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=ur" hreflang="ur" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=vi" hreflang="vi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=yo" hreflang="yo" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=zh" hreflang="zh" rel="alternate">
+<link data-rh="true" href="https://twitter.com/codinghorror/status/1409351083177046020?lang=zh-Hant" hreflang="zh-Hant" rel="alternate"> <meta data-rh="true" content="twitter://status?id=1409351083177046020" property="al:ios:url">
+<meta data-rh="true" content="333903271" property="al:ios:app_store_id">
+<meta data-rh="true" content="Twitter" property="al:ios:app_name">
+<meta data-rh="true" content="twitter://status?id=1409351083177046020" property="al:android:url">
+<meta data-rh="true" content="com.twitter.android" property="al:android:package">
+<meta data-rh="true" content="Twitter" property="al:android:app_name">
+</head>
+<body style="background-color: #FFFFFF;">
+  <noscript>
+    <style>
+    body {
+      -ms-overflow-style: scrollbar;
+      overflow-y: scroll;
+      overscroll-behavior-y: none;
     }
 
-    .DashboardProfileCard-bg {
-      background-image: url(https://pbs.twimg.com/profile_banners/5637652/1398207303/600x200);
+    .errorContainer {
+      background-color: #FFF;
+      color: #0F1419;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 10%;
+      font-family: Helvetica, sans-serif;
+      font-size: 16px;
     }
 
-</style>
-
-
-
-
-          </div>
-        </div>
-    </div>
-    <div class="alert-messages hidden" id="message-drawer">
-    <div class="message ">
-  <div class="message-inside">
-    <span class="message-text"></span>
-      <a role="button" class="Icon Icon--close Icon--medium dismiss" href="#">
-        <span class="visuallyhidden">Dismiss</span>
-      </a>
-  </div>
-</div>
-</div>
-
-    
-
-
-<div class="gallery-overlay"></div>
-<div class="Gallery with-tweet">
-  <style class="Gallery-styles"></style>
-  <div class="Gallery-closeTarget"></div>
-  <div class="Gallery-content">
-    <div class="GalleryTweet-newsCameraBadge"></div>
-    <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-    <div class="Gallery-media"></div>
-    <div class="GalleryNav GalleryNav--prev">
-      <span class="GalleryNav-handle GalleryNav-handle--prev">
-        <span class="Icon Icon--caretLeft Icon--large">
-          <span class="u-hiddenVisually">
-            Previous
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryNav GalleryNav--next">
-      <span class="GalleryNav-handle GalleryNav-handle--next">
-        <span class="Icon Icon--caretRight Icon--large">
-          <span class="u-hiddenVisually">
-            Next
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryTweet"></div>
-  </div>
-</div>
-
-
-<div class="modal-overlay"></div>
-
-<div id="profile-hover-container"></div>
-
-
-<div id="goto-user-dialog" class="modal-container">
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Go to a person's profile</h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="modal-inner">
-          <form class="t1-form goto-user-form">
-            <input class="input-block username-input" type="text" placeholder="Start typing a name to jump to a profile" aria-label="User">
-            
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Saved searches</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-    
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Remove</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-  
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-    <ul role="presentation" class="typeahead-items typeahead-accounts social-context js-typeahead-accounts">
-  
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-    
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <div class="js-selectable typeahead-in-conversation hidden">
-        <span class="Icon Icon--follower Icon--small"></span>
-        <span class="typeahead-in-conversation-text">In this conversation</span>
-      </div>
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info account-group">
-        <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-      </span>
-      <span class="typeahead-social-context"></span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-  
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-    
-<div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Suggested users
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-    
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-      
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-    
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-      
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Verified account</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Protected Tweets</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-          </form>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</div>
-
-<div id="quick-promote-dialog" class="QuickPromoteDialog modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Promote this Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="quick-promote-view-container">
-          <div class="media">
-            <iframe
-              class="quick-promote-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="block-user-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Block</h3>
-      </div>
-
-      <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-      <div class="modal-body modal-tweet"></div>
-
-      <div class="modal-footer">
-        <button class="EdgeButton EdgeButton--tertiary cancel-action js-close">Cancel</button>
-        <button class="EdgeButton EdgeButton--danger block-action">Block</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-
-
-   <div id="geo-disabled-dropdown">
-    <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <ul>
-    <li class="geo-not-enabled-yet">
-      <h2>Tweet with a location</h2>
-      <p>
-        You can add location information to your Tweets, such as your city or precise location, from the web and via third-party applications. You always have the option to delete your Tweet location history.
-        <a href="http://support.twitter.com/forums/26810/entries/78525" target="_blank" rel="noopener">Learn more</a>
-      </p>
-      <div>
-        <button type="button" class="geo-turn-on EdgeButton EdgeButton--primary">Turn on</button>
-        <button type="button" class="geo-not-now EdgeButton EdgeButton--secondary">Not now</button>
-      </div>
-    </li>
-  </ul>
-</div>
-
-  </div>
-
-<div id="geo-enabled-dropdown">
-  <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <div>
-    <div class="geo-query-location">
-      <input class="GeoSearch-queryInput" type="text" autocomplete="off" placeholder="Search for a neighborhood or city">
-      <span class="Icon Icon--search"></span>
-    </div>
-    <div class="geo-dropdown-status"></div>
-    <ul class="GeoSearch-dropdownMenu"></ul>
-  </div>
-</div>
-
-</div>
-
-
-
-  <div id="list-membership-dialog" class="modal-container">
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Your lists</h3>
-      </div>
-      <div class="modal-body">
-        <div class="list-membership-content"></div>
-        <span class="spinner lists-spinner" title="Loading&hellip;"></span>
-      </div>
-    </div>
-  </div>
-</div>
-  <div id="list-operations-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Create a new list</h3>
-      </div>
-      <div class="modal-body">
-        <div class="list-editor">
-  <div class="field">
-    <label class="t1-label" for="list-name">List name</label>
-    <input id="list-name" type="text" class="text" name="name" value="" />
-  </div>
-  <hr/>
-
-  <div class="field">
-    <label class="t1-label" for="list-description">Description</label>
-    <textarea id="list-description" name="description"></textarea>
-    <span class="help-text">Under 100 characters, optional</span>
-  </div>
-  <hr/>
-
-  <fieldset class="field">
-    <legend class="t1-legend">Privacy</legend>
-    <div class="options">
-      <label class="t1-label" for="list-public-radio">
-        <input class="radio" type="radio" name="mode" id="list-public-radio" value="public" checked="checked"  />
-        <b>Public</b> &middot; Anyone can follow this list
-      </label>
-      <label class="t1-label" for="list-private-radio">
-        <input class="radio" type="radio" name="mode" id="list-private-radio" value="private"  />
-        <b>Private</b> &middot; Only you can access this list
-      </label>
-    </div>
-  </fieldset>
-  <hr/>
-
-  <div class="list-editor-save">
-    <button type="button" class="EdgeButton EdgeButton--secondary update-list-button" data-list-id="">Save list</button>
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="activity-popup-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content clearfix">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title"></h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-        <div class="activity-popup-dialog-content modal-tweet clearfix"></div>
-        <div class="loading">
-          <span class="spinner-bigger"></span>
-        </div>
-        <div class="activity-popup-dialog-users clearfix"></div>
-        <div class="activity-popup-dialog-footer"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<div id="copy-link-to-tweet-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Copy link to Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="copy-link-to-tweet-container">
-          <label class="t1-label">
-            <p class="copy-link-to-tweet-instructions">Here's the URL for this Tweet. Copy it to easily share with friends.</p>
-            <textarea class="link-to-tweet-destination js-initial-focus u-dir" dir="ltr" readonly></textarea>
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="embed-tweet-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title embed-tweet-title">Embed this Tweet</h3>
-        <h3 class="modal-title embed-video-title">Embed this Video</h3>
-      </div>
-      <div class="modal-body">
-        <div class="embed-code-container">
-  <p class="embed-tweet-instructions">Add this Tweet to your website by copying the code below. <a href="https://dev.twitter.com/web/embedded-tweets" target="_blank" rel="noopener">Learn more</a></p>
-  <p class="embed-video-instructions">Add this video to your website by copying the code below. <a href="https://dev.twitter.com/web/embedded-tweets" target="_blank" rel="noopener">Learn more</a></p>
-  <form class="t1-form">
-
-    <div class="embed-destination-wrapper">
-      <div class="embed-overlay embed-overlay-spinner"><div class="embed-overlay-content"></div></div>
-      <div class="embed-overlay embed-overlay-error">
-        <p class="embed-overlay-content">Hmm, there was a problem reaching the server. <button type="button" class="btn-link retry-embed">Try again?</button></p>
-      </div>
-      <textarea class="embed-destination js-initial-focus"></textarea>
-      <div class="embed-options">
-        <div class="embed-include-parent-tweet">
-          <label class="t1-label" for="include-parent-tweet">
-            <input type="checkbox" id="include-parent-tweet" class="include-parent-tweet" checked>
-            Include parent Tweet
-          </label>
-        </div>
-        <div class="embed-include-card">
-          <label class="t1-label" for="include-card">
-            <input type="checkbox" id="include-card" class="include-card" checked>
-            Include media
-          </label>
-        </div>
-      </div>
-    </div>
-  </form>
-  <p class="embed-tweet-description">By embedding Twitter content in your website or app, you are agreeing to the Twitter <a href="https://dev.twitter.com/overview/terms/agreement" rel="noopener">Developer Agreement</a> and <a href="https://dev.twitter.com/overview/terms/policy" rel="noopener">Developer Policy</a>.</p>
-  <h3 class="embed-preview-header">Preview</h3>
-  <div class="embed-preview">
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="why-this-ad-dialog" class="modal-container why-this-ad-dialog">
-  <div class="modal modal-large draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title why-this-ad-title">Why you're seeing this ad</h3>
-      </div>
-      <div class="why-this-ad-content">
-        <div class="why-this-ad-spinner">
-          <div class="spinner-bigger"></div>
-        </div>
-        <iframe id="why-this-ad-frame" class="hidden" aria-hidden="true" scrolling="auto">
-        </iframe>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-  <div id="login-dialog" class="LoginDialog modal-container u-textCenter">
-  <div class="modal modal-large draggable">
-    <div class="LoginDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Log in to Twitter</h3>
-      </div>
-      <div class="LoginDialog-body modal-body">
-        <div class="LoginDialog-bird">
-          <span class="Icon Icon--bird Icon--large"></span>
-        </div>
-        <div class="LoginDialog-form">
-<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="dialog"
-  data-element="login"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Phone, email, or username"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Password" autocomplete="current-password">
-    
-  </div>
-
-    <div class="LoginForm-rememberForgot">
-      <label>
-        <input type="checkbox" value="1" name="remember_me" checked="checked">
-        <span>Remember me</span>
-      </label>
-      <span class="separator">&middot;</span>
-      <a class="forgot" href="/account/begin_password_reset" rel="noopener">Forgot password?</a>
-    </div>
-
-  <input type="submit" class="EdgeButton EdgeButton--primary EdgeButton--medium submit js-submit" value="Log in">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/codinghorror/status/1409351083177046020">
-  <input type="hidden" value="46a6f55f84bf8fb45d8b56ce053c0606e73735e0" name="authenticity_token">
-      <input type="hidden" name="ui_metrics" autocomplete="off">
-      <script src="/i/js_inst?c_name=ui_metrics" async></script>
-</form>
-        </div>
-      </div>
-      <div class="LoginDialog-footer modal-footer u-textCenter">
-        Don't have an account? <a class="LoginDialog-signupLink" href="https://twitter.com/signup" rel="noopener">Sign up &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="signup-dialog" class="SignupDialog modal-container u-textCenter">
-  <div class="modal modal-large draggable">
-    <div class="SignupDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Sign up for Twitter</h3>
-      </div>
-      <div class="SignupDialog-body modal-body">
-        <div class="SignupDialog-icon">
-          <span class="Icon Icon--bird Icon--extraLarge"></span>
-        </div>
-        <h2 class="SignupDialog-heading">Not on Twitter? Sign up, tune into the things you care about, and get updates as they happen.</h2>
-        <div class="SignupDialog-form">
-<div class="signup SignupForm
-  ">
-  <a href="https://twitter.com/signup" role="button" class="EdgeButton EdgeButton--large EdgeButton--primary SignupForm-submit u-block js-signup "
-  data-component="dialog"
-  data-element="signup"
-  >Sign up</a>
-</div>
-        </div>
-      </div>
-      <div class="SignupDialog-footer modal-footer u-textCenter">
-        Have an account? <a class="SignupDialog-signinLink" href="/login" rel="noopener">Log in &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="sms-codes-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Two-way (sending and receiving) short codes:</h3>
-      </div>
-      <div class="modal-body">
-        
-<table id="sms_codes" cellpadding="0" cellspacing="0">
-  <thead>
-    <tr>
-      <th>Country</th>
-      <th>Code</th>
-      <th>For customers of</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>United States</td>
-      <td>40404</td>
-      <td>(any)</td>
-    </tr>
-    <tr>
-      <td>Canada</td>
-      <td>21212</td>
-      <td>(any)</td>
-    </tr>
-    <tr>
-      <td>United Kingdom</td>
-      <td>86444</td>
-      <td>Vodafone, Orange, 3, O2</td>
-    </tr>
-    <tr>
-      <td>Brazil</td>
-      <td>40404</td>
-      <td>Nextel, TIM</td>
-    </tr>
-    <tr>
-      <td>Haiti</td>
-      <td>40404</td>
-      <td>Digicel, Voila</td>
-    </tr>
-    <tr>
-      <td>Ireland</td>
-      <td>51210</td>
-      <td>Vodafone, O2</td>
-    </tr>
-    <tr>
-      <td>India</td>
-      <td>53000</td>
-      <td>Bharti Airtel, Videocon, Reliance</td>
-    </tr>
-    <tr>
-      <td>Indonesia</td>
-      <td>89887</td>
-      <td>AXIS, 3, Telkomsel, Indosat, XL Axiata</td>
-    </tr>
-    <tr>
-      <td rowspan="2">Italy</td>
-      <td>4880804</td>
-      <td>Wind</td>
-    </tr>
-    <tr>
-      <td>3424486444</td>
-      <td>Vodafone</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="3">
-        &raquo; <a class="js-initial-focus" target="_blank" href="http://support.twitter.com/articles/14226-how-to-find-your-twitter-short-code-or-long-code" rel="noopener">See SMS short codes for other countries</a>
-      </td>
-    </tr>
-  </tfoot>
-</table>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="leadgen-confirm-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Confirmation</h3>
-      </div>
-      <div class="modal-body">
-        <div class="leadgen-card-container">
-          <div class="media">
-            <iframe
-              class="cards2-promotion-iframe"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-        <div class="js-macaw-cards-iframe-container" data-card-name="promotion">
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="auth-webview-dialog" class="AuthWebViewDialog modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Close</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">&nbsp;</h3>
-      </div>
-      <div class="modal-body">
-        <div class="auth-webview-view-container">
-          <div class="media">
-            <iframe
-              class="auth-webview-card-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              width="590px"
-              height="500px"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-<div id="promptbird-modal-prompt" class="modal-container">
-  <div class="modal">
-    
-    <button type="button" class="modal-btn js-promptDismiss modal-close js-close">
-      <span class="Icon Icon--close Icon--medium">
-        <span class="visuallyhidden">Close</span>
-      </span>
-    </button>
-    <div class="modal-content"></div>
-  </div>
-</div>
-
-
-<div id="ui-walkthrough-dialog" class="modal-container UIWalkthrough">
-  <div class="UIWalkthrough-clickBlocker"></div>
-  <div class="modal modal-small">
-    <div class="UIWalkthrough-caret"></div>
-    <div class="modal-content">
-      <div class="modal-body">
-        <div class="UIWalkthrough-header">
-          <span class="UIWalkthrough-stepProgress"></span>
-          <button class="UIWalkthrough-skip js-close">
-            Skip all
-          </button>
-        </div>
-        
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--welcome">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--home UIWalkthrough-icon"></span>
-    Welcome home!
-  </h3>
-  <p class="UIWalkthrough-message">This timeline is where you’ll spend most of your time, getting instant updates about what matters to you.</p>
-</div>
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--unfollow">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--smileRating1Fill UIWalkthrough-icon"></span>
-    Tweets not working for you?
-  </h3>
-  <p class="UIWalkthrough-message">
-    Hover over the profile pic and click the Following button to unfollow any account.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--like">
-
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--heart UIWalkthrough-icon"></span>
-    Say a lot with a little
-  </h3>
-  <p class="UIWalkthrough-message">
-    When you see a Tweet you love, tap the heart — it lets  the person who wrote it know you shared the love.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--retweet">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--retweet UIWalkthrough-icon"></span>
-    Spread the word
-  </h3>
-  <p class="UIWalkthrough-message">
-    The fastest way to share someone else’s Tweet with your followers is with a Retweet. Tap the icon to send it instantly.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--reply">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--reply UIWalkthrough-icon"></span>
-    Join the conversation
-  </h3>
-  <p class="UIWalkthrough-message">
-    Add your thoughts about any Tweet with a Reply. Find a topic you’re passionate about, and jump right in.
-  </p>
-</div>
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--trends">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--discover UIWalkthrough-icon"></span>
-    Learn the latest
-  </h3>
-  <p class="UIWalkthrough-message">
-    Get instant insight into what people are talking about now.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--wtf">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--follow UIWalkthrough-icon"></span>
-    Get more of what you love
-  </h3>
-  <p class="UIWalkthrough-message">
-    Follow more accounts to get instant updates about topics you care about.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--search">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--search UIWalkthrough-icon"></span>
-    Find what's happening
-  </h3>
-  <p class="UIWalkthrough-message">
-    See the latest conversations about any topic instantly.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--moments">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--lightning UIWalkthrough-icon"></span>
-    Never miss a Moment
-  </h3>
-  <p class="UIWalkthrough-message">
-    Catch up instantly on the best stories happening as they unfold.
-  </p>
-</div>
-      </div>
-
-      <div class="modal-footer">
-        <button class="EdgeButton EdgeButton--tertiary u-floatLeft plain-btn UIWalkthrough-button js-previous-step">Back</button>
-        <button class="EdgeButton EdgeButton--secondary UIWalkthrough-button js-next-step js-initial-focus">Next</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<div id="create-custom-timeline-dialog" class="modal-container"></div>
-<div id="edit-custom-timeline-dialog" class="modal-container"></div>
-<div id="curate-dialog" class="modal-container"></div>
-<div id="media-edit-dialog" class="modal-container"></div>
-
-
-      <div class="PermalinkOverlay PermalinkOverlay-with-background load-at-boot" id="permalink-overlay">
-  <div class="PermalinkProfile-dismiss modal-close-fixed">
-    <span class="Icon Icon--close"></span>
-  </div>
-  <button class="PermalinkOverlay-next PermalinkOverlay-button u-posFixed js-next" type="button">
-    <span class="Icon Icon--caretLeft Icon--large"></span>
-    <span class="u-hiddenVisually">Next Tweet from user</span>
-  </button>
-  <div class="PermalinkOverlay-modal">
-    <div class="PermalinkOverlay-spinnerContainer u-hidden">
-      <div class="PermalinkOverlay-spinner"></div>
-    </div>
-    <div class="PermalinkOverlay-content">
-      <div class="PermalinkOverlay-body"
-          data-background-path="/codinghorror"
->
-            <div class="permalink-container permalink-container--withArrows">
-  <div role="main" class="permalink light-inline-actions
-  stream-uncapped
-  has-replies
-  original-permalink-page
-  self-thread-permalink
-  ">
-
-        <div class="permalink-in-reply-tos" data-component-term="in_reply_to">
-          <div class="permalink-inner in-reply-to" data-replied-tweet-id="1409270864315486209" data-component-context="conversation">
-              <div class="tweets-wrapper">
-                <div id="ancestors" class="ThreadedConversation ThreadedConversation--ancestors">
-                    <div class="stream-container  "
-    data-max-position="" data-min-position=""
-    >
-    <div class="stream">
-        <ol class="stream-items js-navigable-stream" id="stream-items-id">
-          
-        <div class="ThreadedConversation-tweet">
-  <li class="js-stream-item stream-item stream-item
-" data-item-id="1409270864315486209"
-id="stream-item-tweet-1409270864315486209"
-data-item-type="tweet"
->
-    
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-      
-      
-      
-       ancestor permalink-ancestor-tweet
-"
-      
-data-tweet-id="1409270864315486209"
-data-item-id="1409270864315486209"
-data-permalink-path="/codinghorror/status/1409270864315486209"
-data-conversation-id="1409270864315486209"
-
-
-
-
-data-tweet-nonce="1409270864315486209-50f8bd6f-7f68-42bd-b161-0c76de903d13"
-data-tweet-stat-initialized="true"
-
-
-
-
-
-
-  data-screen-name="codinghorror" data-name="Jeff Atwood" data-user-id="5637652"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
-
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="conversation"
-
-
-    >
-
-    <div class="context">
-      
-      
-    </div>
-
-    <div class="content">
-      
-
-      
-
-      
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/codinghorror" data-user-id="5637652">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Jeff Atwood</strong><span>&rlm;</span><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>codinghorror</b></span></a>
-
-        
-        <small class="time">
-  <a href="/codinghorror/status/1409270864315486209" class="tweet-timestamp js-permalink js-nav js-tooltip" title="3:02 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624831331" data-time-ms="1624831331000" data-long-form="true">Jun 27</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-      
-
-      
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Anyone else doing cellular Apple Watches rather than full blown cell phones for their almost-teens? The more I research this the more I like it.</p>
-</div>
-
-
-      
-
-      
-        
-
-
-      
-      
-
-      
-      <div class="stream-item-footer">
-  
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="24">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409270864315486209" data-aria-label-part>24 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="5">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409270864315486209" data-aria-label-part>5 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="96">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409270864315486209" data-aria-label-part>96 likes</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409270864315486209">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">24</span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409270864315486209">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">5</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">5</span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409270864315486209">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">96</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-</div>
-  
-
-
-
-      
-      
-
-      
-        <div class="self-thread-context">
-  Show this thread
-</div>
-
-
-      
-
-    </div>
-
-  </div>
-
-
-
-</li>
-    </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-        </ol>
-      <ol class="hidden-replies-container"></ol>
-    </div>
-  </div>
-                </div>
-              </div>
-          </div>
-        </div>
-
-        
-  <div class="permalink-inner permalink-tweet-container ThreadedConversation ThreadedConversation--permalinkTweetWithAncestors">
-
-    <div class="tweet permalink-tweet js-actionable-user js-actionable-tweet js-original-tweet
-         has-cards with-social-proof  has-content
-
-        
-        
-          
-          js-initial-focus
-"
-        data-associated-tweet-id="1409351083177046020"
-        
-data-tweet-id="1409351083177046020"
-data-item-id="1409351083177046020"
-data-permalink-path="/codinghorror/status/1409351083177046020"
-data-conversation-id="1409270864315486209"
-
- data-is-reply-to="true" 
- data-has-parent-tweet="true" 
-
-data-tweet-nonce="1409351083177046020-1486a324-f369-4db8-9202-a350ed9b9535"
-data-tweet-stat-initialized="true"
-
-
-
-
-
-
-  data-screen-name="codinghorror" data-name="Jeff Atwood" data-user-id="5637652"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
-
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
- data-has-cards="true"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        tabindex="0"
-      >
-
-
-      
-      <div class="content clearfix">
-        <div class="permalink-header">
-            <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/codinghorror" data-user-id="5637652">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1246568020991864832/hh4FVqbl_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Jeff Atwood</strong><span>&rlm;</span><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>codinghorror</b></span></a>
-
-          
-          <small class="time">
-  <a href="/codinghorror/status/1409351083177046020" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:20 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624850457" data-time-ms="1624850457000" data-long-form="true">Jun 27</span></a>
-</small>
-
-            
-
-    
-    <div class="follow-bar">
-      <div class="user-actions btn-group not-following  "
-    data-user-id="5637652"
-    data-screen-name="codinghorror"
-    data-name="Jeff Atwood"
-    data-protected="false"
-  >
-  <span class="user-actions-follow-button js-follow-btn follow-button">
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-    
-    EdgeButton--medium 
-    button-text
-    follow-text">
-      <span aria-hidden="true">Follow</span>
-      <span class="u-hiddenVisually">Follow <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--primary
-    
-    EdgeButton--medium 
-    button-text
-    following-text">
-      <span aria-hidden="true">Following</span>
-      <span class="u-hiddenVisually">Following <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--danger
-    
-    EdgeButton--medium 
-    button-text
-    unfollow-text">
-      <span aria-hidden="true">Unfollow</span>
-      <span class="u-hiddenVisually">Unfollow <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--invertedDanger
-    
-    EdgeButton--medium 
-    button-text
-    blocked-text">
-    <span aria-hidden="true">Blocked</span>
-    <span class="u-hiddenVisually">Blocked <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--danger
-    
-    EdgeButton--medium 
-    button-text
-    unblock-text">
-    <span aria-hidden="true">Unblock</span>
-    <span class="u-hiddenVisually">Unblock <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-    
-    EdgeButton--medium 
-    button-text
-    pending-text">
-    <span aria-hidden="true">Pending</span>
-    <span class="u-hiddenVisually">Pending follow request from <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-    
-    EdgeButton--medium 
-    button-text
-    cancel-text">
-    <span aria-hidden="true">Cancel</span>
-    <span class="u-hiddenVisually">Cancel your follow request to <span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></span>
-  </button>
-</span>
-
-</div>
-
-    </div>
-
-            <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-        </div>
-        
-      </div>
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize TweetTextSize--jumbo js-tweet-text tweet-text" lang="en" data-aria-label-part="0">My first text message from my child! A moment that shall live on in infamy!<a href="https://t.co/TQMRJsFwnO" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/TQMRJsFwnO</a></p>
-</div>
-
-
-      
-
-      
-          <div class="AdaptiveMediaOuterContainer">
-    <div class="AdaptiveMedia
-        
-        is-square
-        
-        
-        
-        "
-      >
-      <div class="AdaptiveMedia-container">
-          <div class="AdaptiveMedia-singlePhoto"
-    style="padding-top: calc(1.2457684495599188 * 100% - 0.5px);"
->
-    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
-  data-image-url="https://pbs.twimg.com/media/E48FVowUUAYyGLX.jpg"
-  
-  
-  data-element-context="platform_photo_card"
-    style="background-color:rgba(38,10,6,1.0);"
-    data-dominant-color="[38,10,6]"
->
-  <img data-aria-label-part src="https://pbs.twimg.com/media/E48FVowUUAYyGLX.jpg" alt=""
-      style="width: 100%; top: -62px;"
->
-</div>
-
-
-</div>
-      </div>
-    </div>
-  </div>
-
-
-
-      <div class="js-tweet-details-fixer tweet-details-fixer">
-  <div class="client-and-actions">
-  <span class="metadata">
-    <span>8:20 PM - 27 Jun 2021</span>
-      
-  </span>
-  
-</div>
-
-
-  <div class="js-machine-translated-tweet-container"></div>
-  <div class="js-tweet-stats-container tweet-stats-container">      
-
-<ul class="stats" aria-label="Retweeted and favorited by">
-
-    <li class="js-stat-count js-stat-favorites stat-count" aria-hidden="true">
-      <a tabindex=0 role="button"
-         data-tweet-stat-count="90" 
-         data-compact-localized-count="90"
-         class="request-favorited-popup"
-         data-activity-popup-title="90 likes">
-          
-          <strong>90</strong> Likes
-      </a>
-    </li>
-
-  <li class="avatar-row js-face-pile-container">
-      <a class="js-profile-popup-actionable js-tooltip" href="/blairbryant" data-user-id="12336122" original-title="Blair &quot;The Architect&quot;" title="Blair &quot;The Architect&quot;" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/64678397/twiki01_normal.jpg" alt="Blair &quot;The Architect&quot;">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/f_fz" data-user-id="56679923" original-title="Ferdi (Ferdinand Fanötöna Zebua)" title="Ferdi (Ferdinand Fanötöna Zebua)" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1361289869025181696/xvnNIGUA_normal.jpg" alt="Ferdi (Ferdinand Fanötöna Zebua)">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/gregstoll" data-user-id="7155172" original-title="Greg Stoll 💉💉🎉" title="Greg Stoll 💉💉🎉" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/378800000124042138/6d6f7032a0efd358c83fc68083a1e8c7_normal.jpeg" alt="Greg Stoll 💉💉🎉">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/uncle_miles" data-user-id="731360639776493568" original-title="Miles McNerney" title="Miles McNerney" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/842604441089978369/DD3_BVQz_normal.jpg" alt="Miles McNerney">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/Castaa" data-user-id="14199776" original-title="Jon C" title="Jon C" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/831939185279791104/hUCGssdI_normal.jpg" alt="Jon C">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/threadripper_" data-user-id="336011917" original-title="Javad:~$" title="Javad:~$" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1008608583028822016/2Vyu7CLm_normal.jpg" alt="Javad:~$">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/pbrdmn" data-user-id="227124578" original-title="Philip is staying at home" title="Philip is staying at home" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1406905135825969159/ChusY6Di_normal.jpg" alt="Philip is staying at home">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/BrosukeH" data-user-id="259032808" original-title="Welcome to the NFT 📉 | BLM 🏳️‍🌈" title="Welcome to the NFT 📉 | BLM 🏳️‍🌈" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1228576203751092224/uoT5TCYW_normal.jpg" alt="Welcome to the NFT 📉 | BLM 🏳️‍🌈">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/liagason" data-user-id="65491901" original-title="liagason" title="liagason" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1405165059261669380/eoBV_sdh_normal.jpg" alt="liagason">
-</a>
-  </li>
-</ul>
-
-
-  </div>
-</div>
-
-
-      
-      <div class="stream-item-footer">
-          
-
-
-        
-            <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="4">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409351083177046020" data-aria-label-part>4 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409351083177046020" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="90">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409351083177046020" data-aria-label-part>90 likes</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409351083177046020">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">4</span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409351083177046020">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409351083177046020">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">90</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">90</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-      </div>
-
-      <div class="permalink-footer">
-        
-      </div>
-    </div>
-
-  </div>
-
-
-      
-<div class="replies-to  permalink-inner permalink-replies" data-component-context="replies">
-    <div class="tweets-wrapper">
-      <div id="descendants" class="ThreadedDescendants">
-          <div class="stream-container  "
-    data-max-position="" data-min-position=""
-    >
-    <div class="stream">
-        <ol class="stream-items js-navigable-stream" id="stream-items-id">
-          
-
-
-
-
-
-
-
-
-
-
-
-      <li class="ThreadedConversation--loneTweet
-  
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1409352104590729216"
-id="stream-item-tweet-1409352104590729216"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1409352104590729216&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-    
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-      
-      
-      
-       descendant permalink-descendant-tweet
-"
-      
-data-tweet-id="1409352104590729216"
-data-item-id="1409352104590729216"
-data-permalink-path="/f_fz/status/1409352104590729216"
-data-conversation-id="1409270864315486209"
-
-
- data-has-parent-tweet="true" 
-
-data-tweet-nonce="1409352104590729216-1de294b4-26f7-4472-a226-d318fdb734e4"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="f_fz" data-name="Ferdi (Ferdinand Fanötöna Zebua)" data-user-id="56679923"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="codinghorror"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;56679923&quot;,&quot;screen_name&quot;:&quot;f_fz&quot;,&quot;name&quot;:&quot;Ferdi (Ferdinand Fan\u00f6t\u00f6na Zebua)&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Ferdi (Ferdinand Fan\u00f6t\u00f6na Zebua)&quot;,&quot;emojified_text_as_html&quot;:&quot;Ferdi (Ferdinand Fan\u00f6t\u00f6na Zebua)&quot;}},{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-      
-      
-    </div>
-
-    <div class="content">
-      
-
-      
-
-      
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/f_fz" data-user-id="56679923">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1361289869025181696/xvnNIGUA_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Ferdi (Ferdinand Fanötöna Zebua)</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>f_fz</b></span></a>
-
-        
-        <small class="time">
-  <a href="/f_fz/status/1409352104590729216" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:25 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624850700" data-time-ms="1624850700000" data-long-form="true">Jun 27</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-      
-
-      
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-    Replying to <a class="pretty-link js-user-profile-link" href="/codinghorror" data-user-id="5637652" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></a>
-
-
-
-</div>
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Mind-blown!</p>
-</div>
-
-
-      
-
-      
-        
-
-
-      
-      
-
-      
-      <div class="stream-item-footer">
-  
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409352104590729216" >0 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409352104590729216" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409352104590729216" data-aria-label-part>1 like</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409352104590729216">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409352104590729216">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409352104590729216">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-</div>
-  
-
-
-
-      
-      
-
-      
-
-      
-
-    </div>
-
-  </div>
-
-
-
-    
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Thanks. Twitter will use this to make your timeline better.
-            <span class="undo-action">Undo</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Undo</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-  
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1409352727008714757"
-id="stream-item-tweet-1409352727008714757"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1409352727008714757&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-    
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-      
-      
-      
-       descendant permalink-descendant-tweet
-"
-      
-data-tweet-id="1409352727008714757"
-data-item-id="1409352727008714757"
-data-permalink-path="/chetfaliszek/status/1409352727008714757"
-data-conversation-id="1409270864315486209"
-
-
- data-has-parent-tweet="true" 
-
-data-tweet-nonce="1409352727008714757-f2f400be-6b3d-4292-b759-ea3b1953af8e"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="chetfaliszek" data-name="Chet Faliszek" data-user-id="982040378"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="codinghorror"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;982040378&quot;,&quot;screen_name&quot;:&quot;chetfaliszek&quot;,&quot;name&quot;:&quot;Chet Faliszek&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Chet Faliszek&quot;,&quot;emojified_text_as_html&quot;:&quot;Chet Faliszek&quot;}},{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-      
-      
-    </div>
-
-    <div class="content">
-      
-
-      
-
-      
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/chetfaliszek" data-user-id="982040378">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/2920094567/ecc0064d125a61407e9c0a735a5c5f76_bigger.jpeg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Chet Faliszek</strong><span>&rlm;</span><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>chetfaliszek</b></span></a>
-
-        
-        <small class="time">
-  <a href="/chetfaliszek/status/1409352727008714757" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:27 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624850849" data-time-ms="1624850849000" data-long-form="true">Jun 27</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-      
-
-      
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-    Replying to <a class="pretty-link js-user-profile-link" href="/codinghorror" data-user-id="5637652" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></a>
-
-
-
-</div>
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Make it their first NFT!</p>
-</div>
-
-
-      
-
-      
-        
-
-
-      
-      
-
-      
-      <div class="stream-item-footer">
-  
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409352727008714757" >0 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409352727008714757" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409352727008714757" data-aria-label-part>2 likes</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409352727008714757">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409352727008714757">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409352727008714757">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-</div>
-  
-
-
-
-      
-      
-
-      
-
-      
-
-    </div>
-
-  </div>
-
-
-
-    
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Thanks. Twitter will use this to make your timeline better.
-            <span class="undo-action">Undo</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Undo</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-  
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1409353075232362505"
-id="stream-item-tweet-1409353075232362505"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1409353075232362505&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-    
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-      
-      
-      
-       has-cards descendant permalink-descendant-tweet has-content
-"
-      
-data-tweet-id="1409353075232362505"
-data-item-id="1409353075232362505"
-data-permalink-path="/Hanzo55/status/1409353075232362505"
-data-conversation-id="1409270864315486209"
-
-
- data-has-parent-tweet="true" 
-
-data-tweet-nonce="1409353075232362505-800385d7-5a47-4d14-940c-106e408a2802"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="Hanzo55" data-name="Shawn Holmes" data-user-id="34945729"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="codinghorror"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;34945729&quot;,&quot;screen_name&quot;:&quot;Hanzo55&quot;,&quot;name&quot;:&quot;Shawn Holmes&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Shawn Holmes&quot;,&quot;emojified_text_as_html&quot;:&quot;Shawn Holmes&quot;}},{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
- data-has-cards="true"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-      
-      
-    </div>
-
-    <div class="content">
-      
-
-      
-
-      
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/Hanzo55" data-user-id="34945729">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1400457518669721604/v5zouGS9_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Shawn Holmes</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>Hanzo55</b></span></a>
-
-        
-        <small class="time">
-  <a href="/Hanzo55/status/1409353075232362505" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:28 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624850932" data-time-ms="1624850932000" data-long-form="true">Jun 27</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-      
-
-      
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-    Replying to <a class="pretty-link js-user-profile-link" href="/codinghorror" data-user-id="5637652" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></a>
-
-
-
-</div>
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">This will be the next milestone<a href="https://t.co/ARtq5AkZqG" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/ARtq5AkZqG</a></p>
-</div>
-
-
-      
-
-      
-            <div class="AdaptiveMediaOuterContainer">
-    <div class="AdaptiveMedia
-        
-        is-square
-        
-        
-        
-        "
-      >
-      <div class="AdaptiveMedia-container">
-          <div class="AdaptiveMedia-singlePhoto"
-    style="padding-top: calc(0.5807799442896936 * 100% - 0.5px);"
->
-    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
-  data-image-url="https://pbs.twimg.com/media/E48HJy6XIAAUbuy.jpg"
-  
-  
-  data-element-context="platform_photo_card"
-    style="background-color:rgba(25,40,38,1.0);"
-    data-dominant-color="[25,40,38]"
->
-  <img data-aria-label-part src="https://pbs.twimg.com/media/E48HJy6XIAAUbuy.jpg" alt=""
-      style="width: 100%; top: -0px;"
->
-</div>
-
-
-</div>
-      </div>
-    </div>
-  </div>
-
-
-
-
-      
-      
-
-      
-      <div class="stream-item-footer">
-  
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409353075232362505" >0 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409353075232362505" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409353075232362505" data-aria-label-part>2 likes</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409353075232362505">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409353075232362505">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409353075232362505">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-</div>
-  
-
-
-
-      
-      
-
-      
-
-      
-
-    </div>
-
-  </div>
-
-
-
-    
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Thanks. Twitter will use this to make your timeline better.
-            <span class="undo-action">Undo</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Undo</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-  
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1409354572838195201"
-id="stream-item-tweet-1409354572838195201"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1409354572838195201&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-    
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-      
-      
-      
-       descendant permalink-descendant-tweet
-"
-      
-data-tweet-id="1409354572838195201"
-data-item-id="1409354572838195201"
-data-permalink-path="/andrenaleen/status/1409354572838195201"
-data-conversation-id="1409270864315486209"
-
-
- data-has-parent-tweet="true" 
-
-data-tweet-nonce="1409354572838195201-c8f2982b-c875-4693-9374-ada017b355f4"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="andrenaleen" data-name="Andrei Taranchenko" data-user-id="901153681806176256"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="codinghorror"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;901153681806176256&quot;,&quot;screen_name&quot;:&quot;andrenaleen&quot;,&quot;name&quot;:&quot;Andrei Taranchenko&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Andrei Taranchenko&quot;,&quot;emojified_text_as_html&quot;:&quot;Andrei Taranchenko&quot;}},{&quot;id_str&quot;:&quot;5637652&quot;,&quot;screen_name&quot;:&quot;codinghorror&quot;,&quot;name&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Jeff Atwood&quot;,&quot;emojified_text_as_html&quot;:&quot;Jeff Atwood&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-      
-      
-    </div>
-
-    <div class="content">
-      
-
-      
-
-      
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/andrenaleen" data-user-id="901153681806176256">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1069583899683110912/Xe38w2ow_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Andrei Taranchenko</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>andrenaleen</b></span></a>
-
-        
-        <small class="time">
-  <a href="/andrenaleen/status/1409354572838195201" class="tweet-timestamp js-permalink js-nav js-tooltip" title="8:34 PM - 27 Jun 2021"  data-conversation-id="1409270864315486209"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1624851289" data-time-ms="1624851289000" data-long-form="true">Jun 27</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="More">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">More</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-    
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copy link to Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Embed Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-      
-
-      
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-    Replying to <a class="pretty-link js-user-profile-link" href="/codinghorror" data-user-id="5637652" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>codinghorror</b></span></a>
-
-
-
-</div>
-
-
-      
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">I mean, a text from your kid is less dramatic than Pearl Harbor, but I don&#39;t have all the info.</p>
-</div>
-
-
-      
-
-      
-        
-
-
-      
-      
-
-      
-      <div class="stream-item-footer">
-  
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-    
-    
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1409354572838195201" >0 replies</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1409354572838195201" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1409354572838195201" data-aria-label-part>1 like</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Tweet actions">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1409354572838195201">
-    <div class="IconContainer js-tooltip" title="Reply">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Reply</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-    
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1409354572838195201">
-    <div class="IconContainer js-tooltip" title="Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweet</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Undo retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retweeted</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1409354572838195201">
-    <div class="IconContainer js-tooltip" title="Like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Like</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Undo like">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Liked</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    
-
-    
-
-  </div>
-
-</div>
-  
-
-
-
-      
-      
-
-      
-
-      
-
-    </div>
-
-  </div>
-
-
-
-    
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Thanks. Twitter will use this to make your timeline better.
-            <span class="undo-action">Undo</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Undo</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-
-
-
- 
-
-        </ol>
-        <div class="stream-footer ">
-  <div class="timeline-end has-items ">
-      <div class="stream-end">
-    <div class="stream-end-inner">
-        <span class="Icon Icon--large Icon--logo"></span>
-
-      <p class="empty-text">
-
-          
-      </p>
-
-        <p><button type="button" class="btn-link back-to-top hidden">Back to top &uarr;</button></p>
-    </div>
-  </div>
-
-
-    <div class="stream-loading">
-  <div class="stream-end-inner">
-    <span class="spinner" title="Loading..."></span>
-  </div>
-</div>
-
-  </div>
-</div>
-<div class="stream-fail-container">
-    <div class="js-stream-whale-end stream-whale-end stream-placeholder centered-placeholder">
-  <div class="stream-end-inner">
-    <h2 class="title">Loading seems to be taking a while.</h2>
-    <p>
-      Twitter may be over capacity or experiencing a momentary hiccup. <a role="button" href="#" class="try-again-after-whale">Try again</a> or visit <a target="_blank" href="http://status.twitter.com" rel="noopener">Twitter Status</a> for more information.
+    .errorButton {
+      margin: 3em 0;
+    }
+
+    .errorButton a {
+      background: #1DA1F2;
+      border-radius: 2.5em;
+      color: white;
+      padding: 1em 2em;
+      text-decoration: none;
+    }
+
+    .errorButton a:hover,
+    .errorButton a:focus {
+      background: rgb(26, 145, 218);
+    }
+
+    .errorFooter {
+      color: #657786;
+      font-size: 80%;
+      line-height: 1.5;
+      padding: 1em 0;
+    }
+
+    .errorFooter a,
+    .errorFooter a:visited {
+      color: #657786;
+      text-decoration: none;
+      padding-right: 1em;
+    }
+
+    .errorFooter a:hover,
+    .errorFooter a:active {
+      text-decoration: underline;
+    }
+
+      #placeholder,
+      #react-root {
+        display: none !important;
+      }
+      body {
+        background-color: #FFF !important;
+      }
+    </style>
+    <div class="errorContainer">
+      <img width="46" height="38" srcset="https://abs.twimg.com/errors/logo46x38.png 1x, https://abs.twimg.com/errors/logo46x38@2x.png 2x" src="https://abs.twimg.com/errors/logo46x38.png" alt="Twitter">
+      <h1>JavaScript is not available.</h1>
+      <p>We’ve detected that JavaScript is disabled in this browser. Please enable JavaScript or switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center.</p>
+      <p class="errorButton"><a href="https://help.twitter.com/using-twitter/twitter-supported-browsers">Help Center</a></p>
+    <p class="errorFooter">
+      <a href="https://twitter.com/tos">Terms of Service</a>
+      <a href="https://twitter.com/privacy">Privacy Policy</a>
+      <a href="https://support.twitter.com/articles/20170514">Cookie Policy</a>
+      <a href="https://legal.twitter.com/imprint.html">Imprint</a>
+      <a href="https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&amp;utm_source=twc&amp;utm_medium=web&amp;utm_campaign=ao&amp;utm_content=adsinfo">Ads info</a>
+      © 2023 X Corp.
     </p>
-  </div>
-</div>
-</div>
 
-      <ol class="hidden-replies-container"></ol>
     </div>
-  </div>
-      </div>
-    </div>
+  </noscript>
+<div id="react-root" style="height:100%;display:flex;"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13qz1uu r-417010" style="min-height:736px">
+<div aria-label="Skip to home timeline" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<div aria-label="Skip to trending" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<header role="banner" class="css-1dbjc4n r-lrvibr r-1g40b8q"><div class="css-1dbjc4n r-1h3ijdo r-orgf3d r-633pao"></div>
+<div class="css-1dbjc4n" data-testid="SSRSafeLayer"><div class="css-1dbjc4n r-1d2f490 r-1xcajam r-zchlnj r-1gn8etr">
+<div class="css-1dbjc4n r-1e5uvyk r-6026j r-16e0dcy r-dkhcqf r-axxi2z r-18jm5s1" data-testid="TopNavBar"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-fxvszc r-136ojw6" data-testid="twitter-logged-out-nav">
+<div class="css-1dbjc4n r-1h3ijdo r-136ojw6"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1h3ijdo"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1h3ijdo r-1777fci r-1jgb5lz r-ymttw5 r-13qz1uu">
+<div class="css-1dbjc4n r-1habvwh r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div class="css-1dbjc4n r-1777fci r-1mf7evn"><h1 role="heading" class="css-4rbku5 css-1dbjc4n r-1awozwy r-1pz39u2 r-1loqt21 r-6koalj r-16y2uox r-1777fci r-4wgw6l"><a href="/" aria-label="Twitter" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-left:calc(0px + (-1 * ((36px + (1px * 2)) - 1.75rem) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-16y2uox r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M23.643 4.937c-.835.37-1.732.62-2.675.733.962-.576 1.7-1.49 2.048-2.578-.9.534-1.897.922-2.958 1.13-.85-.904-2.06-1.47-3.4-1.47-2.572 0-4.658 2.086-4.658 4.66 0 .364.042.718.12 1.06-3.873-.195-7.304-2.05-9.602-4.868-.4.69-.63 1.49-.63 2.342 0 1.616.823 3.043 2.072 3.878-.764-.025-1.482-.234-2.11-.583v.06c0 2.257 1.605 4.14 3.737 4.568-.392.106-.803.162-1.227.162-.3 0-.593-.028-.877-.082.593 1.85 2.313 3.198 4.352 3.234-1.595 1.25-3.604 1.995-5.786 1.995-.376 0-.747-.022-1.112-.065 2.062 1.323 4.51 2.093 7.14 2.093 8.57 0 13.255-7.098 13.255-13.254 0-.2-.005-.402-.014-.602.91-.658 1.7-1.477 2.323-2.41z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span>
+</div></a></h1></div></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1pi2tsx r-1777fci">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n r-1awozwy r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-13awgt0 r-eqz5dr r-bnwqim r-8fdsdq"><div class="r-1oszu61 r-vqxq0j r-deolkf r-6koalj r-1mlwlqe r-eqz5dr r-1wbh5a2 r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-13qz1uu r-417010"><form action="#" aria-label="Search Twitter" role="search" class="r-1oszu61 r-1phboty r-1yadl64 r-deolkf r-6koalj r-13awgt0 r-eqz5dr r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-417010">
+<div class="css-1dbjc4n r-1wbh5a2"><div class="css-1dbjc4n r-1sw30gj r-42olwf r-sdzlij r-1phboty r-rs99b7 r-eqz5dr r-16y2uox r-1wbh5a2 r-1777fci"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1awozwy r-18u37iz"><label class="css-1dbjc4n r-1dqbpge r-13awgt0 r-18u37iz" data-testid="SearchBox_Search_Input_label"><div class="css-1dbjc4n r-7q8q6z r-6koalj r-1777fci"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-14j79pv r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-4wgw6l r-f727ji r-bnwqim r-1plcrui r-lrvibr"><g><path d="M10.25 3.75c-3.59 0-6.5 2.91-6.5 6.5s2.91 6.5 6.5 6.5c1.795 0 3.419-.726 4.596-1.904 1.178-1.177 1.904-2.801 1.904-4.596 0-3.59-2.91-6.5-6.5-6.5zm-8.5 6.5c0-4.694 3.806-8.5 8.5-8.5s8.5 3.806 8.5 8.5c0 1.986-.682 3.815-1.824 5.262l4.781 4.781-1.414 1.414-4.781-4.781c-1.447 1.142-3.276 1.824-5.262 1.824-4.694 0-8.5-3.806-8.5-8.5z"></path></g></svg></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div dir="ltr" class="css-901oao r-6koalj r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><input type="text" aria-activedescendant="typeaheadFocus-0.5412497229651458" aria-autocomplete="list" aria-label="Search query" aria-owns="typeaheadDropdown-27962" autocapitalize="sentences" autocomplete="off" autocorrect="off" placeholder="Search Twitter" role="combobox" spellcheck="false" value="" enterkeyhint="search" dir="auto" class="r-30o5oe r-1niwhzg r-17gur6a r-1yadl64 r-deolkf r-homxoj r-poiln3 r-7cikom r-1ny4l3l r-xyw6el r-oyd9sg r-y0fyvk r-1dz5y72 r-fdjqy7 r-13qz1uu" data-testid="SearchBox_Search_Input"></div></div>
+<div class="css-1dbjc4n r-6koalj r-1777fci"></div></label></div></div></div></div>
+<div class="css-1dbjc4n r-13awgt0 r-bnwqim"></div>
+</form></div></div></div></div>
 </div>
-
-
-
-  </div>
-
-
-  <div class="stream-container suggested-tweet-stream-container dismissible-container u-hidden">
-    <div class="stream suggested-tweet-stream permalink-replies">
-      <h3 class="promoted-heading">Promoted Tweet</h3>
-      <ol class="stream-items suggested-tweet-stream-items js-navigable-stream" id="suggested-stream-items-id">
-        
-      </ol>
-    </div>
-   </div>
-
-    <div class="module Trends trends hidden Trends--wide">
-  <div class="trends-inner">
-    <div class="flex-module trends-container ">
-  <div class="flex-module-header">
-    
-    <h3><span class="trend-location js-trend-location">false</span></h3>
-  </div>
-  <div class="flex-module-inner">
-    <ul class="trend-items js-trends">
-    </ul>
-  </div>
+<div class="css-1dbjc4n r-obd0qt r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div aria-expanded="false" aria-haspopup="menu" aria-label="More" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-right:calc(4px + (-1 * ((36px + (1px * 2)) - 20px) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-z80fyv r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03" style="color:rgba(15,20,25,1.00)"><g><path d="M3 12c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9 2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm7 0c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0" style="border-bottom:2px solid #0F1419"></span>
+</div></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-16y2uox r-1w6e6rj r-1h3ijdo r-1wtj0ep r-1fz3rvf r-rjfia"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox">
+<div class="css-1dbjc4n r-16y2uox"><a href="/login" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="login"><div dir="ltr" class="css-901oao r-1awozwy r-1cvl2hr r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Log in</span></span></div></a></div>
+<div class="css-1dbjc4n r-16y2uox r-19u6a5r"><a href="/i/flow/signup" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-l5o3uw r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="signup"><div dir="ltr" class="css-901oao r-1awozwy r-jwli3a r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Sign up</span></span></div></a></div>
+</div></div></div>
+</div></div></div>
+<div class="css-1dbjc4n r-633pao r-u8s1d r-dkhcqf r-axxi2z r-18jm5s1 r-13qz1uu r-1wyyakw" style="-webkit-transform:translate3d(0, 0, 0) translateY(53px);transform:translate3d(0, 0, 0) translateY(53px)"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-1awozwy r-1777fci r-1jgb5lz r-19u6a5r r-13qz1uu"><div role="status" class="css-1dbjc4n r-1r5su4o r-orgf3d r-1lul07w r-eafdt9 r-1b8bd59 r-nx0j10"><div aria-label="New Tweets are available. Push the period key to go to the them." role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-sdzlij r-y3da5r r-1777fci r-1ny4l3l r-ymttw5 r-oyd9sg r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1kihuf0 r-jwli3a r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M12 3.59l7.457 7.45-1.414 1.42L13 7.41V21h-2V7.41l-5.043 5.05-1.414-1.42L12 3.59z"></path></g></svg><div dir="ltr" class="css-901oao css-1hf3ou5 r-1kihuf0 r-jwli3a r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-13hce6t r-bcqeeo r-qvutc0" data-testid="pillLabel"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">See new Tweets</span></div>
+</div></div></div></div></div></div>
+</div></div></header><main role="main" class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-150rngu r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-aqfbo4 r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1niwhzg r-18u37iz r-16y2uox r-1jgb5lz r-2llsf r-13qz1uu"><div class="css-1dbjc4n r-14lw9ot r-42olwf r-1ljd8xs r-13l2t4g r-1phboty r-16y2uox r-1jgb5lz r-13qz1uu r-184en5c" data-testid="primaryColumn"><div aria-label="Home timeline" tabindex="0" class="css-1dbjc4n"><div itemscope="" itemtype="https://schema.org/Collection">
+<meta content="Tweet with replies" itemprop="name">
+<section aria-labelledby="accessible-list-12471" role="region" class="css-1dbjc4n"><h1 dir="auto" aria-level="1" role="heading" class="css-4rbku5 css-901oao r-4iw3lz r-1xk2f4g r-109y4c4 r-1udh08x r-wwvuq4 r-u8s1d r-92ng3h" id="accessible-list-12471">Conversation</h1>
+<div aria-label="Timeline: Conversation" class="css-1dbjc4n"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409270864315486209" itemprop="identifier">
+<meta content="1" itemprop="position">
+<meta content="22" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-27T22:02:11.000Z" itemprop="dateCreated">
+<meta content="2021-06-27T22:02:11.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="5637652" itemprop="identifier">
+<meta content="codinghorror" itemprop="additionalName">
+<meta content="Jeff Atwood" itemprop="givenName">
 </div>
-
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209/likes" itemprop="url">
+<meta content="90" itemprop="userInteractionCount">
 </div>
-
-
-  <div class="permalink-footer">
-      <div class="Footer module roaming-module Footer--slim"
-  >
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2021 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about" rel="noopener">About</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com" rel="noopener">Help Center</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos" rel="noopener">Terms</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy" rel="noopener">Privacy policy</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514" rel="noopener">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html" rel="noopener">Ads info</a></li>
-      </ul>
-    </div>
-  </div>
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209/retweets" itemprop="url">
+<meta content="5" itemprop="userInteractionCount">
 </div>
-
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209/retweets/with_comments" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
 </div>
-
-
-      </div>
-    </div>
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209" itemprop="url">
+<meta content="22" itemprop="userInteractionCount">
 </div>
-
-    <div class="hidden" id="hidden-content">
-  <iframe aria-hidden="true" class="tweet-post-iframe" name="tweet-post-iframe"></iframe>
-  <iframe aria-hidden="true" class="dm-post-iframe" name="dm-post-iframe"></iframe>
-
+<article aria-labelledby="id__wk2npqyqe27 id__heytm06p3we id__1zlrqaji4zqj id__5lgpqiwbk3o id__zu7ppdkqypi id__fji39rts3g id__e9i5ssdstbm id__i961vzlkwe id__snsbalo4huf id__8y0tu67ubkg id__sd2ta53lv3 id__cq6e4s57d7d id__ch9rj9lapkr id__3yxqrgxmpz5 id__o450j16s83 id__bx2tmboihww id__6wsy9ir2gav id__yaid674jaw id__q2j8mv07ccl" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ut4w64 r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577">
+<div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-codinghorror">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/codinghorror" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1517287320235298816/Qx-O6UCY_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1517287320235298816/Qx-O6UCY_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-1bimlpy r-16y2uox r-1jgb5lz r-14gqq1x r-m5arl1"></div>
 </div>
-
-    
-    
-      <input type="hidden" id="init-data" class="json-data" value="{&quot;keyboardShortcuts&quot;:[{&quot;name&quot;:&quot;Actions&quot;,&quot;description&quot;:&quot;Shortcuts for common actions.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;Enter&quot;],&quot;description&quot;:&quot;Open Tweet details&quot;},{&quot;keys&quot;:[&quot;o&quot;],&quot;description&quot;:&quot;Expand photo&quot;},{&quot;keys&quot;:[&quot;\/&quot;],&quot;description&quot;:&quot;Search&quot;}]},{&quot;name&quot;:&quot;Navigation&quot;,&quot;description&quot;:&quot;Shortcuts for navigating between items in timelines.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;?&quot;],&quot;description&quot;:&quot;This menu&quot;},{&quot;keys&quot;:[&quot;j&quot;],&quot;description&quot;:&quot;Next Tweet&quot;},{&quot;keys&quot;:[&quot;k&quot;],&quot;description&quot;:&quot;Previous Tweet&quot;},{&quot;keys&quot;:[&quot;Space&quot;],&quot;description&quot;:&quot;Page down&quot;},{&quot;keys&quot;:[&quot;.&quot;],&quot;description&quot;:&quot;Load new Tweets&quot;}]},{&quot;name&quot;:&quot;Timelines&quot;,&quot;description&quot;:&quot;Shortcuts for navigating to different timelines or pages.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;g&quot;,&quot;u&quot;],&quot;description&quot;:&quot;Go to user\u2026&quot;}]}],&quot;baseFoucClass&quot;:&quot;swift-loading&quot;,&quot;bodyFoucClassNames&quot;:&quot;swift-loading no-nav-banners&quot;,&quot;assetsBasePath&quot;:&quot;https:\/\/abs.twimg.com\/a\/1625696336\/&quot;,&quot;assetVersionKey&quot;:&quot;2b0fec&quot;,&quot;emojiAssetsPath&quot;:&quot;https:\/\/abs.twimg.com\/emoji\/v2\/72x72\/&quot;,&quot;environment&quot;:&quot;production&quot;,&quot;formAuthenticityToken&quot;:&quot;46a6f55f84bf8fb45d8b56ce053c0606e73735e0&quot;,&quot;loggedIn&quot;:false,&quot;screenName&quot;:null,&quot;fullName&quot;:null,&quot;userId&quot;:null,&quot;guestId&quot;:&quot;162612517316402055&quot;,&quot;createdAt&quot;:null,&quot;needsPhoneVerification&quot;:false,&quot;allowAdsPersonalization&quot;:true,&quot;scribeBufferSize&quot;:3,&quot;pageName&quot;:&quot;permalink&quot;,&quot;sectionName&quot;:&quot;permalink&quot;,&quot;scribeParameters&quot;:{},&quot;recaptchaApiUrl&quot;:&quot;https:\/\/www.google.com\/recaptcha\/api\/js\/recaptcha_ajax.js&quot;,&quot;internalReferer&quot;:null,&quot;geoEnabled&quot;:false,&quot;typeaheadData&quot;:{&quot;accounts&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;limit&quot;:6},&quot;trendLocations&quot;:{&quot;enabled&quot;:true},&quot;dmConversations&quot;:{&quot;enabled&quot;:false},&quot;followedSearches&quot;:{&quot;enabled&quot;:false},&quot;savedSearches&quot;:{&quot;enabled&quot;:false,&quot;items&quot;:[]},&quot;dmAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyDMable&quot;:true},&quot;mediaTagAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyShowUsersWithCanMediaTag&quot;:false,&quot;currentUserId&quot;:-1},&quot;selectedUsers&quot;:{&quot;enabled&quot;:false},&quot;prefillUsers&quot;:{&quot;enabled&quot;:false},&quot;topics&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:4},&quot;concierge&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:6},&quot;recentSearches&quot;:{&quot;enabled&quot;:false},&quot;hashtags&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500},&quot;useIndexedDB&quot;:false,&quot;showSearchAccountSocialContext&quot;:false,&quot;showDebugInfo&quot;:false,&quot;useThrottle&quot;:true,&quot;accountsOnTop&quot;:false,&quot;remoteDebounceInterval&quot;:300,&quot;remoteThrottleInterval&quot;:300,&quot;tweetContextEnabled&quot;:false,&quot;fullNameMatchingInCompose&quot;:true,&quot;topicsWithFiltersEnabled&quot;:false},&quot;shellReferrer&quot;:null,&quot;rwebOptInCookieName&quot;:&quot;rweb_optin&quot;,&quot;rwebOptInCookieNewValue&quot;:&quot;on&quot;,&quot;dm&quot;:{&quot;notifications&quot;:false,&quot;usePushForNotifications&quot;:false,&quot;participant_max&quot;:50,&quot;welcome_message_add_to_conversation_enabled&quot;:true,&quot;poll_options&quot;:{&quot;foreground_poll_interval&quot;:3000,&quot;burst_poll_interval&quot;:3000,&quot;burst_poll_duration&quot;:300000,&quot;max_poll_interval&quot;:60000},&quot;card_prefetch&quot;:true,&quot;card_prefetch_interval_in_seconds&quot;:2000,&quot;dm_quick_reply_options_panel_dismiss_in_ms&quot;:2000,&quot;open_dm_enabled&quot;:false},&quot;autoplayDisabled&quot;:false,&quot;pushStatePageLimit&quot;:500000,&quot;routes&quot;:{&quot;profile&quot;:&quot;\/&quot;},&quot;pushState&quot;:false,&quot;viewContainer&quot;:&quot;#page-container&quot;,&quot;href&quot;:&quot;\/codinghorror\/status\/1409351083177046020&quot;,&quot;searchPathWithQuery&quot;:&quot;\/search?q=query&amp;src=typd&quot;,&quot;composeAltText&quot;:false,&quot;night_mode_activated&quot;:false,&quot;user_color&quot;:null,&quot;deciders&quot;:{&quot;gdprAgeGateDialog&quot;:true,&quot;gdprSoftBounceDialog&quot;:true,&quot;geo_picker_incident_reset&quot;:true,&quot;custom_timeline_curation&quot;:false,&quot;native_notifications&quot;:true,&quot;disable_ajax_datatype_default_to_text&quot;:false,&quot;dm_polling_frequency_in_seconds&quot;:3000,&quot;dm_granular_mute_controls&quot;:true,&quot;enable_media_tag_prefetch&quot;:true,&quot;enableMacawNymizerConversionLanding&quot;:false,&quot;hqImageUploads&quot;:false,&quot;live_pipeline_consume&quot;:true,&quot;mqImageUploads&quot;:false,&quot;partnerIdSyncEnabled&quot;:true,&quot;sruMediaCategory&quot;:true,&quot;photoSruGifLimitMb&quot;:15,&quot;promoted_logging_force_post&quot;:true,&quot;promoted_video_logging_enabled&quot;:true,&quot;pushState&quot;:false,&quot;emojiNewCategory&quot;:false,&quot;contentEditablePlainTextOnly&quot;:false,&quot;web_client_api_stats&quot;:false,&quot;web_perftown_stats&quot;:true,&quot;web_perftown_ttft&quot;:false,&quot;web_client_events_ttft&quot;:false,&quot;log_push_state_ttft_metrics&quot;:false,&quot;web_sru_stats&quot;:false,&quot;web_upload_video&quot;:true,&quot;web_upload_video_advanced&quot;:false,&quot;upload_video_size&quot;:500,&quot;useVmapVariants&quot;:false,&quot;autoplayPreviewPreroll&quot;:true,&quot;moments_home_module&quot;:false,&quot;moments_lohp_enabled&quot;:true,&quot;enableNativePush&quot;:false,&quot;autoSubscribeNativePush&quot;:false,&quot;allowWebPushVapidUpgrade&quot;:true,&quot;stickersInteractivity&quot;:true,&quot;stickersInteractivityDuringLoading&quot;:true,&quot;stickersExperience&quot;:true,&quot;dynamic_video_ads_include_long_videos&quot;:true,&quot;push_state_size&quot;:1000,&quot;live_video_media_control_enabled&quot;:false,&quot;cards2_enable_periscope_card_transition&quot;:true,&quot;use_api_for_retweet_and_unretweet&quot;:false,&quot;use_api_for_follow_and_unfollow&quot;:true,&quot;edge_probe_enabled&quot;:false,&quot;like_over_http_client&quot;:true,&quot;enable_inline_location&quot;:true,&quot;enable_tweetstorm_creation&quot;:true,&quot;enable_tweetstorm_drafts&quot;:false,&quot;enable_tweetstorm_tooltip&quot;:true,&quot;twitter_text_emoji_counting_enabled&quot;:true,&quot;text_length_for_tweetstorm_tooltip&quot;:50,&quot;dm_report_webview_macaw_swift_enabled&quot;:true,&quot;page_title_unread_notification_count&quot;:false,&quot;page_title_badge_after_unread_tweets&quot;:20},&quot;experiments&quot;:{},&quot;toasts_dm&quot;:false,&quot;toasts_timeline&quot;:false,&quot;toasts_dm_poll_scale&quot;:60,&quot;defaultNotificationIcon&quot;:&quot;https:\/\/abs.twimg.com\/a\/1625696336\/img\/t1\/mobile\/wp7_app_icon.png&quot;,&quot;promptbirdData&quot;:{&quot;promptbirdEnabled&quot;:false,&quot;immediateTriggers&quot;:[&quot;PullToRefresh&quot;,&quot;Navigate&quot;],&quot;format&quot;:null},&quot;passwordResetAdvancedLoginForm&quot;:true,&quot;skipAutoSignupDialog&quot;:true,&quot;shouldReplaceSignupWithLogin&quot;:false,&quot;activeHashflags&quot;:{&quot;thelword&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Showtime_Q2_21_v2\/Showtime_Q2_21_v2.png&quot;,&quot;matkoolkawanku&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MatKool_2021\/MatKool_2021.png&quot;,&quot;vamouz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_ReadyWillingAble\/EsportsAllAccess_Jan_2021_ReadyWillingAble.png&quot;,&quot;disabledandable&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Twitter_DisabledAndAble\/Twitter_DisabledAndAble.png&quot;,&quot;hbdfoodpanda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Foodpanda7thAnniversary_2021\/Foodpanda7thAnniversary_2021.png&quot;,&quot;euro2020&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021\/Euro_UK_2021.png&quot;,&quot;growtogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GrowTogether_v4\/GrowTogether_v4.png&quot;,&quot;kiakarakatiateao&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;oldthemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;petealonso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-Mets\/MLBHRDerby2021-Mets.png&quot;,&quot;parkboyoungonviu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DAYSOnViu_2021\/DAYSOnViu_2021.png&quot;,&quot;loveisland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_2021\/LoveIsland_2021.png&quot;,&quot;modok&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HuluMODOK2021\/HuluMODOK2021.png&quot;,&quot;listeningiseverything&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;verzuz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Verzuz_2020_Flight4\/Verzuz_2020_Flight4.png&quot;,&quot;zola&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZolaMovie_2021\/ZolaMovie_2021.png&quot;,&quot;gunakanmasker&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;akb単独コンサート&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/17_AKB_May_2021\/17_AKB_May_2021.png&quot;,&quot;eligeelpaisquequieres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChileElections_2021\/ChileElections_2021.png&quot;,&quot;levántateydale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_OAK\/MLB_Teams_2021_OAK.png&quot;,&quot;mladivode&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;sweettoothnetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021\/NetflixSweetTooth2021.png&quot;,&quot;mightywest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_MightyWest\/AFL_2021_MightyWest.png&quot;,&quot;mesraisons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VaccineCanada_2021\/VaccineCanada_2021.png&quot;,&quot;ausairforce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DFR_2021_AusAirForce_May\/DFR_2021_AusAirForce_May.png&quot;,&quot;somosmujeres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;posedinpurpose&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021\/FX_Pose_April_2021.png&quot;,&quot;asianpacificheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;백신맞았어요&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;onlyvegas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LVCVA_Vegas_June_2021\/LVCVA_Vegas_June_2021.png&quot;,&quot;tsm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_TSMWIN\/LCS_Jan_2021_TSMWIN.png&quot;,&quot;bts_butter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021_BTS_Butter\/KpopVIT_BTS_June2021_BTS_Butter.png&quot;,&quot;halomultiplayer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxOlympus_2021\/XboxOlympus_2021.png&quot;,&quot;maaf70ans&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MAAF_70thBirthday_2021_2\/MAAF_70thBirthday_2021_2.png&quot;,&quot;vidasnegrasimportam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackLivesMatter_VidasNegrasImportam\/BlackLivesMatter_VidasNegrasImportam.png&quot;,&quot;vaccinée&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;lfgthefilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LFGDocumentary_2021\/HBOMax_LFGDocumentary_2021.png&quot;,&quot;cubtogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CHC\/MLB_Teams_2021_CHC.png&quot;,&quot;restiamoacasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;manlyforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_ManlyForever\/NRL_2021_ManlyForever.png&quot;,&quot;t1win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_T1\/LCK_2021_Team_P1_T1.png&quot;,&quot;sheerios&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EdSheeran_June_UK_2021\/EdSheeran_June_UK_2021.png&quot;,&quot;mywhy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VaccineCanada_2021\/VaccineCanada_2021.png&quot;,&quot;legomastersonfoxtv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_LEGOGoldenBrick_2021\/FOX_LEGOGoldenBrick_2021.png&quot;,&quot;fortheh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_HOU\/MLB_Teams_2021_HOU.png&quot;,&quot;trx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRON_Coin_Feb_2021_ext\/TRON_Coin_Feb_2021_ext.png&quot;,&quot;nemumaamas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;zilliqa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zilliqa_April_2021\/Zilliqa_April_2021.png&quot;,&quot;youloveme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Turkey\/HBOMax_Friends_Turkey.png&quot;,&quot;hpe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HPEDiscover2021\/HPEDiscover2021.png&quot;,&quot;カルピス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkCalpis02TanabataJapan2021\/AsahiSoftDrinkCalpis02TanabataJapan2021.png&quot;,&quot;forza&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxWoodstock_2021\/XboxWoodstock_2021.png&quot;,&quot;ユージェネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouGeneration_JP_2021\/YouGeneration_JP_2021.png&quot;,&quot;geimpft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;thickandfluffyeggowaffles&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eggo_May_2021_2\/Eggo_May_2021_2.png&quot;,&quot;treseonnetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TreseOnNetflix_May_2021_ext\/TreseOnNetflix_May_2021_ext.png&quot;,&quot;lokibuaya&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;tänkförstdelasen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;katiethurston&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;जेनरेशनइक्वालिटी&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;jackinthebox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JackintheBoxTinyTacos_2021\/JackintheBoxTinyTacos_2021.png&quot;,&quot;ger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_GER\/Euro_UK_2021_GER.png&quot;,&quot;veioparaficar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avon_PowerStay_BR_2021\/Avon_PowerStay_BR_2021.png&quot;,&quot;フィギュアストーリー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bytedance_ako_figurestory_June_2021\/Bytedance_ako_figurestory_June_2021.png&quot;,&quot;spacejam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;cheetosllenosdediversión&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChesterCheetos_MX_2021\/ChesterCheetos_MX_2021.png&quot;,&quot;apagóndigital&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;davidoat10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Davido10YearAnniversary_2021_1\/Davido10YearAnniversary_2021_1.png&quot;,&quot;loveislandusa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIslandUSA_2021\/LoveIslandUSA_2021.png&quot;,&quot;diversifyyourbuy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SupplierInclusionDiversity_2021\/SupplierInclusionDiversity_2021.png&quot;,&quot;waltdisneyworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;bdo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackDesert2021Summer\/BlackDesert2021Summer.png&quot;,&quot;vaktsineeritud&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;ruadomedo1978&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy1978_2021\/Netflix_FearStreetTrilogy1978_2021.png&quot;,&quot;digwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_DIGWIN\/LCS_Jan_2021_DIGWIN.png&quot;,&quot;heretheycome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_HereTheyCome\/NBA_2021_Teams_HereTheyCome.png&quot;,&quot;silênciobruno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;blijfbinnen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;толькоты&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;dcaboveall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_DCAboveAll\/NBA_2021_Teams_DCAboveAll.png&quot;,&quot;ドラブラ世界頂戦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tencent_CDB_EVA_phase2_2021\/Tencent_CDB_EVA_phase2_2021.png&quot;,&quot;webexmclaren&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/webexmclaren_2021\/webexmclaren_2021.png&quot;,&quot;pixaralberto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;oneteam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OneTeam_Evergreen\/OneTeam_Evergreen.png&quot;,&quot;tineriilaconducere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;whohasmypig&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NeonRated_PigtheFilm_June2021\/NeonRated_PigtheFilm_June2021.png&quot;,&quot;международныйденькрасногокреста&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;ワクチン完了&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;housetargaryen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseoftheDragonHBO_2021\/HouseoftheDragonHBO_2021.png&quot;,&quot;wnbatwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBATwitter_2021\/WNBATwitter_2021.png&quot;,&quot;ởnhàlàyêunước&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;healthyathome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;theflightattendant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlightAttendant_LA_May_2021\/FlightAttendant_LA_May_2021.png&quot;,&quot;nextatacer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Acer_aspirevero_2021\/Acer_aspirevero_2021.png&quot;,&quot;somostimbers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_PT\/MLS_2021_PT.png&quot;,&quot;nursesweek2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CeraVe_ThankYouNurses_2021\/CeraVe_ThankYouNurses_2021.png&quot;,&quot;이달의소녀&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_LOONA_June_2021\/KpopVIT_LOONA_June_2021.png&quot;,&quot;prizm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaniniAmericaQ2_21\/PaniniAmericaQ2_21.png&quot;,&quot;ワンピースの日とナッツの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Meijinutschoco_2021\/Meijinutschoco_2021.png&quot;,&quot;ff7rの4人が幻影戦争に全員参戦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WOTV_JP_2021_April\/WOTV_JP_2021_April.png&quot;,&quot;qoo10最大のショッピング祭り&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Shopping_Q2_2021\/Qoo10_Shopping_Q2_2021.png&quot;,&quot;covid19indiahelp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;districtofchange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_WAS2\/WNBA_Teams_2021_WAS2.png&quot;,&quot;อยู่บ้านนะคนดี&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;fazerpartenãotempreço&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MasterButterfly_BR_2021\/MasterButterfly_BR_2021.png&quot;,&quot;실렌치오_브루노&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;dadstop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DadStopEmbarrassingMeNetflix_2021\/DadStopEmbarrassingMeNetflix_2021.png&quot;,&quot;bmm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackMusicMonth_2021\/BlackMusicMonth_2021.png&quot;,&quot;selenatheseries&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SelenaNetflix_2021\/SelenaNetflix_2021.png&quot;,&quot;메카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FinalgearKR2021KR\/FinalgearKR2021KR.png&quot;,&quot;thefastsaga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;wtfarcry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Farcry6_UK_2021\/Farcry6_UK_2021.png&quot;,&quot;ワタ棘&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Watatoge_June_2021\/Piccoma_Watatoge_June_2021.png&quot;,&quot;generationequality&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020_add\/OrangeTheWorld_2020_add.png&quot;,&quot;wearemisfits&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_MSFWIN\/LEC_EM_2021_MSFWIN.png&quot;,&quot;hondamvp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HondaMVP_July_2021\/HondaMVP_July_2021.png&quot;,&quot;16dagen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;defiantforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_TOR\/OWL_Season4_Team_Feb_2021_TOR.png&quot;,&quot;googleio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleIO2021\/GoogleIO2021.png&quot;,&quot;16gün&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;fiqueemcasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;レジェンズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyDBLegends_May_2021\/MyDBLegends_May_2021.png&quot;,&quot;俺だけレベルアップな件byピッコマ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Oreleve_June_2021\/Piccoma_Oreleve_June_2021.png&quot;,&quot;vaccinated&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021\/vaccinated_2021.png&quot;,&quot;ひとつぶで元気になる&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Meijinutschoco_2021\/Meijinutschoco_2021.png&quot;,&quot;bts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021\/KpopVIT_BTS_June2021.png&quot;,&quot;elmachips&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ElmaChipsMeFazUmPix_2021\/ElmaChipsMeFazUmPix_2021.png&quot;,&quot;lavaliant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_LAValiant\/OWL_Season4_Team_Feb_2021_LAValiant.png&quot;,&quot;리아&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_LIA\/KPOP_VIT_ITZY_April_2021_LIA.png&quot;,&quot;supersave&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AMFIQ2IPL_2021_v2\/AMFIQ2IPL_2021_v2.png&quot;,&quot;eqotoken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eqonex_July_2021\/Eqonex_July_2021.png&quot;,&quot;dbレジェンズキャラ診断&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyDBLegends_May_2021\/MyDBLegends_May_2021.png&quot;,&quot;muahecualuca&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;saudávelemcasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;verfdewereldoranje&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;dirtywater&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_BOS\/MLB_Teams_2021_BOS.png&quot;,&quot;smasheverymonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CamelotTokyo_2021\/CamelotTokyo_2021.png&quot;,&quot;spottedxoxo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Phone\/HBOMaxGossipGirl_July_2021_Phone.png&quot;,&quot;magicofthecup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FFACup_2021\/FFACup_2021.png&quot;,&quot;hotbirdsummer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TucaandBertie_2021\/TucaandBertie_2021.png&quot;,&quot;equiporepsolhonda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepsolMotogpMotorcycle_2021\/RepsolMotogpMotorcycle_2021.png&quot;,&quot;gherbo25&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Gherbo_25_Album_Emoji_2021\/Gherbo_25_Album_Emoji_2021.png&quot;,&quot;milkteaalliance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;فیلترنت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;あんスタ6周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/enstars_music6yearsanniversary_2021\/enstars_music6yearsanniversary_2021.png&quot;,&quot;boksvlions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LionsRugbyTour_2021_SeriesTrophy\/LionsRugbyTour_2021_SeriesTrophy.png&quot;,&quot;awssummit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AWSSummit_2021\/AWSSummit_2021.png&quot;,&quot;lavatelasmanos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;mntwins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MIN\/MLB_Teams_2021_MIN.png&quot;,&quot;gonnaneedmilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkPEP_May_2021\/MilkPEP_May_2021.png&quot;,&quot;veiopraficar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avon_PowerStay_BR_2021\/Avon_PowerStay_BR_2021.png&quot;,&quot;blackdesertsummer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackDesert2021Summer\/BlackDesert2021Summer.png&quot;,&quot;ライブ応援&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINChallengeCupJapan2021\/KIRINChallengeCupJapan2021.png&quot;,&quot;redbullgaming&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedBull_GIVESYOUWINGS_2021_V2\/RedBull_GIVESYOUWINGS_2021_V2.png&quot;,&quot;filmedindetroit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NoSuddenMove_July_2021\/NoSuddenMove_July_2021.png&quot;,&quot;daysonviu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DAYSOnViu_2021\/DAYSOnViu_2021.png&quot;,&quot;thatsgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_ThatsGame_2021\/NBA_ThatsGame_2021.png&quot;,&quot;deerboy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021\/NetflixSweetTooth2021.png&quot;,&quot;detidepende&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AdCouncilVaccine_2021_add\/AdCouncilVaccine_2021_add.png&quot;,&quot;ourwatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;xgppc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxGamePass_2021\/XboxGamePass_2021.png&quot;,&quot;blindspottingfinale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Blindspotting_May_2021\/STARZ_Blindspotting_May_2021.png&quot;,&quot;todosunidos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NSC\/MLS_2021_NSC.png&quot;,&quot;mostawaitedreno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OPPOReno6Series_2021\/OPPOReno6Series_2021.png&quot;,&quot;ユージェネってなに&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouGeneration_JP_2021\/YouGeneration_JP_2021.png&quot;,&quot;mulherespower&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PowerCouple_BR_May_2021\/PowerCouple_BR_May_2021.png&quot;,&quot;ace_comeback&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopACE_June_2021\/KpopACE_June_2021.png&quot;,&quot;백신접종&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;bitcoin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bitcoin_evergreen\/Bitcoin_evergreen.png&quot;,&quot;tfclive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_TFC\/MLS_2021_TFC.png&quot;,&quot;laatjevaccineren&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;tanaoreodebrincar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OreoPromocao_2021\/OreoPromocao_2021.png&quot;,&quot;gopies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_gopies\/AFL_2021_gopies.png&quot;,&quot;sparkit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Hangzhou\/OWL_Season4_Team_Feb_2021_Hangzhou.png&quot;,&quot;ognidonna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;strawberrydrinksforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StarbucksCanadaSummer2021\/StarbucksCanadaSummer2021.png&quot;,&quot;edgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_EDGWIN\/LPL_2021_EDGWIN.png&quot;,&quot;gunakanpelitupmuka&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;runtheworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_RuntheWorld_2021\/STARZ_RuntheWorld_2021.png&quot;,&quot;rapids96&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CR\/MLS_2021_CR.png&quot;,&quot;wearewpg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLWPGPlayoffs2021\/NHLWPGPlayoffs2021.png&quot;,&quot;gobolts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoBolts\/NHL_2021_Teams_GoBolts.png&quot;,&quot;équipecanada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CanadaOlympicParalympic_Tokyo\/CanadaOlympicParalympic_Tokyo.png&quot;,&quot;skywardswordhd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NintendoZeldaSkywardSword_2021\/NintendoZeldaSkywardSword_2021.png&quot;,&quot;عمانتل&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OmanTel5G_2021_v3\/OmanTel5G_2021_v3.png&quot;,&quot;coronanoparedão&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;killerthreesome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_All3_\/HitmansWifesBodyguard_2021_All3_.png&quot;,&quot;gaad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GAAD_May_2021_ext\/GAAD_May_2021_ext.png&quot;,&quot;repcosc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepcoSC_2021\/RepcoSC_2021.png&quot;,&quot;bólusettur&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;7月7日はカルピスの誕生日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkCalpis02TanabataJapan2021\/AsahiSoftDrinkCalpis02TanabataJapan2021.png&quot;,&quot;dieforaman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bebe_Rexha_2021\/Bebe_Rexha_2021.png&quot;,&quot;hlewin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_HLE\/LCK_2021_Team_P1_HLE.png&quot;,&quot;astralisfamily&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_ASTWIN\/LEC_EM_2021_ASTWIN.png&quot;,&quot;ステイホーム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;lpl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021\/LPL_2021.png&quot;,&quot;justiceisserved&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_WASH\/OWL_Season4_Team_2021_WASH.png&quot;,&quot;tether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRC20USDT_2021\/TRC20USDT_2021.png&quot;,&quot;valorantchampionstour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VALORANT_Champions_Tour_2021\/VALORANT_Champions_Tour_2021.png&quot;,&quot;wnba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_2021Season_25thAnniversary_2\/WNBA_2021Season_25thAnniversary_2.png&quot;,&quot;dblegends&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyDBLegends_May_2021\/MyDBLegends_May_2021.png&quot;,&quot;itvpeston&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Peston_UK_April_2021\/Peston_UK_April_2021.png&quot;,&quot;whitespikesspotted&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeVideoIndiaTomorrowWar_2021\/PrimeVideoIndiaTomorrowWar_2021.png&quot;,&quot;cazadorab15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_HunterB15_2021\/Disney_LokiLaunch_HunterB15_2021.png&quot;,&quot;khongraduong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;해야해&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_2PM\/Kpop_VIT_2PM.png&quot;,&quot;periscope&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Periscope\/Periscope.png&quot;,&quot;quedateencasaya&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;युवानेतृत्व&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;whiteclawhardseltzer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LetsWhiteClaw_2021_SP\/LetsWhiteClaw_2021_SP.png&quot;,&quot;tasaarvosukupolvi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;先想再点击&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;gokingsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoKingsGo\/NHL_2021_Teams_GoKingsGo.png&quot;,&quot;canucks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_canucks\/NHL_2021_Teams_canucks.png&quot;,&quot;ned&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_NED\/Euro_UK_2021_NED.png&quot;,&quot;babaeako&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;kamiwanita&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;俺だけレベルアップな件ーsmartoon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Oreleve_June_2021\/Piccoma_Oreleve_June_2021.png&quot;,&quot;v5win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_V5WIN\/LPL_2021_V5WIN.png&quot;,&quot;xboxbethesda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xbox_ProjectNeutron_2021_add2\/Xbox_ProjectNeutron_2021_add2.png&quot;,&quot;equalplayequalpay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LFGDocumentary_2021\/HBOMax_LFGDocumentary_2021.png&quot;,&quot;翻墙&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;私を突き刺す棘&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Watatoge_June_2021\/Piccoma_Watatoge_June_2021.png&quot;,&quot;erstdenkendannteilen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;wegotyousis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SistasOnBET_2021\/SistasOnBET_2021.png&quot;,&quot;cymrudragons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXWALES_2021\/JDXWALES_2021.png&quot;,&quot;کورونا_مدد_انڈیا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;6months6games&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxLoveStory_2021\/XboxLoveStory_2021.png&quot;,&quot;alligatorloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;thestory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZolaMovie_2021\/ZolaMovie_2021.png&quot;,&quot;noikhongvoibaohanh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;lckwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_League_2021\/LCK_League_2021.png&quot;,&quot;valorantchampions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VALORANT_Champions_Tour_April_2021\/VALORANT_Champions_Tour_April_2021.png&quot;,&quot;luca&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;lightingtheway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cadillac_LYRIQ_Phase1_April_2021\/Cadillac_LYRIQ_Phase1_April_2021.png&quot;,&quot;twittertips&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterTips_2020\/TwitterTips_2020.png&quot;,&quot;webelieve&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_LAA\/MLB_Teams_2021_LAA.png&quot;,&quot;අත්සෝදන්න&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;farcry6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Farcry6_UK_2021\/Farcry6_UK_2021.png&quot;,&quot;yosoyleón&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Guerreros_MX_June_2021_YoSoyLeon\/Guerreros_MX_June_2021_YoSoyLeon.png&quot;,&quot;tervekotona&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;haloinfinite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxOlympus_2021\/XboxOlympus_2021.png&quot;,&quot;あんスタ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/enstars_music6yearsanniversary_2021\/enstars_music6yearsanniversary_2021.png&quot;,&quot;اتحدث_بالمونث&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;tänkförstklickasen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;pixaralbertoid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;jdfactor50&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDLoveIsland_2021\/JDLoveIsland_2021.png&quot;,&quot;미투&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_Korea_2018_v2\/MeToo_Korea_2018_v2.png&quot;,&quot;ชานมข้นกว่าเลือด&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;animalkingdom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AnimalKingdom_S5_Surfboard\/AnimalKingdom_S5_Surfboard.png&quot;,&quot;halo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxOlympus_2021\/XboxOlympus_2021.png&quot;,&quot;rootedinla&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_LA\/WNBA_Teams_2021_LA.png&quot;,&quot;estamosready&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_NYY\/MLB_Teams_2021_NYY.png&quot;,&quot;spiral&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpiralSaw2021\/SpiralSaw2021.png&quot;,&quot;vakcinējos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;lostwins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MIN\/MLB_Teams_2021_MIN.png&quot;,&quot;红新月日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;thepowerofbetter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_XLWIN_fix\/LEC_EM_2021_XLWIN_fix.png&quot;,&quot;qoo10メガ割&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Shopping_Q2_2021\/Qoo10_Shopping_Q2_2021.png&quot;,&quot;أنا_اتطعمت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;toofaanonprime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToofaanOnPrime_July_2021\/ToofaanOnPrime_July_2021.png&quot;,&quot;mtgafr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MagicTheGathering_june_2021_\/MagicTheGathering_june_2021_.png&quot;,&quot;dadstopnetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DadStopEmbarrassingMeNetflix_2021\/DadStopEmbarrassingMeNetflix_2021.png&quot;,&quot;红十字日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;4thevalley&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_PHX_v2\/WNBA_Teams_2021_PHX_v2.png&quot;,&quot;rolltide&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlabamaCFP2021YEARLONG\/AlabamaCFP2021YEARLONG.png&quot;,&quot;lovetwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveTwitter\/LoveTwitter.png&quot;,&quot;poseball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021\/FX_Pose_April_2021.png&quot;,&quot;dalereal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_RSL\/MLS_2021_RSL.png&quot;,&quot;browin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_GOBRO\/LCK_2021_Team_P1_GOBRO.png&quot;,&quot;endalz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ALZ_2021\/ALZ_2021.png&quot;,&quot;lokilefanfaron&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;whatsthescoop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Phone\/HBOMaxGossipGirl_July_2021_Phone.png&quot;,&quot;sounders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_SeaS\/MLS_2021_SeaS.png&quot;,&quot;noussommeslesfemmes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;lattesandlovers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Latte\/HBOMaxGossipGirl_July_2021_Latte.png&quot;,&quot;ovw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;quakes74&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_SJE\/MLS_2021_SJE.png&quot;,&quot;xboxgobrrrrr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;裏切り王子&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;リィンラボ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReincarnationLaunch_May_2021\/NieRReincarnationLaunch_May_2021.png&quot;,&quot;ギアスト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bytedance_ako_figurestory_June_2021\/Bytedance_ako_figurestory_June_2021.png&quot;,&quot;dexter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Showtime_Q2_21_v2\/Showtime_Q2_21_v2.png&quot;,&quot;keinemehr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;blackmonday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Showtime_Q2_21_v2\/Showtime_Q2_21_v2.png&quot;,&quot;globalaccessibilityawarenessday2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GAAD_May_2021_ext\/GAAD_May_2021_ext.png&quot;,&quot;housebrokenonfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseBrokenFOX_May_2021\/HouseBrokenFOX_May_2021.png&quot;,&quot;rojoxsiempre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NYRB\/MLS_2021_NYRB.png&quot;,&quot;sotw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyNatGeo_SecretsoftheWhales_April_2021\/DisneyNatGeo_SecretsoftheWhales_April_2021.png&quot;,&quot;닥쳐_브루노&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;第五人格3周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IdentityVJP_Q3_2021\/IdentityVJP_Q3_2021.png&quot;,&quot;sherni&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SherniOnPrime_2021\/SherniOnPrime_2021.png&quot;,&quot;boastfulloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;gossipgirl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_XOXO\/HBOMaxGossipGirl_July_2021_XOXO.png&quot;,&quot;deerhybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021_add\/NetflixSweetTooth2021_add.png&quot;,&quot;sagars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Romasaga_25y_May_2021\/Romasaga_25y_May_2021.png&quot;,&quot;kynguyenmoi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;s04win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_S04WIN\/LEC_EM_2021_S04WIN.png&quot;,&quot;vamosangels&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_LAA\/MLB_Teams_2021_LAA.png&quot;,&quot;disneycruisewish&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_DisneyCruise_2021\/DisneyParks_DisneyCruise_2021.png&quot;,&quot;malusogsabahay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;cbj&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_CBJ\/NHL_2021_Teams_CBJ.png&quot;,&quot;poptart&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PopTarts_June_2021\/PopTarts_June_2021.png&quot;,&quot;aapi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;디즈니픽사_알베르토&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;zombietigercat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZombieTiger_UK_May_2021\/ZombieTiger_UK_May_2021.png&quot;,&quot;wimbledonthing&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Wimbledon_2021_hearts\/Wimbledon_2021_hearts.png&quot;,&quot;斷網&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;wowclassic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurningCrusadeClassic_2021\/BurningCrusadeClassic_2021.png&quot;,&quot;nierreplicant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReplicant_April_2021_V2\/NieRReplicant_April_2021_V2.png&quot;,&quot;imitchellcontrolemacchine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;หยุดอยู่บ้านเพื่อชาติ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;blueweekend&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WolfAlice_2021\/WolfAlice_2021.png&quot;,&quot;aspirevero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Acer_aspirevero_2021\/Acer_aspirevero_2021.png&quot;,&quot;vaskhendene&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;burgerkoreapedas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MD_BurgerKoreaPedas_2021\/MD_BurgerKoreaPedas_2021.png&quot;,&quot;badisbred&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AnimalKingdom_S5_Palmtree\/AnimalKingdom_S5_Palmtree.png&quot;,&quot;covid19brasilfome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;portatelamascherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;마스크착용&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;blackmusicmonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackMusicMonth_2021\/BlackMusicMonth_2021.png&quot;,&quot;portorosso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Portorosso_2021\/Disney_PixarLuca_Portorosso_2021.png&quot;,&quot;godrx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_DRX\/LcK_2021_Teams_DRX.png&quot;,&quot;lokilagarto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;guardiantecate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuardianTecate_July_2021\/GuardianTecate_July_2021.png&quot;,&quot;ワニロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;fusioncarry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Philly\/OWL_Season4_Team_Feb_2021_Philly.png&quot;,&quot;madden22&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaddenNFL22\/MaddenNFL22.png&quot;,&quot;بطاقاتنا_تربحك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RiyadBankCard_2021\/RiyadBankCard_2021.png&quot;,&quot;untilweallbelong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterTogether_2019_v3\/TwitterTogether_2019_v3.png&quot;,&quot;twitterparaobem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;gossipgirlhere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Phone\/HBOMaxGossipGirl_July_2021_Phone.png&quot;,&quot;wirbleibenzuhaus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;globalaccessibilityawarenessday21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GAAD_May_2021_ext\/GAAD_May_2021_ext.png&quot;,&quot;wijde15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;rakita&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JagameThandhiramOnNetflix_2021\/JagameThandhiramOnNetflix_2021.png&quot;,&quot;goldenguardians&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_GGWIN\/LCS_Jan_2021_GGWIN.png&quot;,&quot;pflmma&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PFLMMA_April_2021\/PFLMMA_April_2021.png&quot;,&quot;seakraken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_SeaKraken\/NHL_2021_Teams_SeaKraken.png&quot;,&quot;brickbybrick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_CHI\/CDL_Team_2021_CHI.png&quot;,&quot;stanleycup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StanleyCup_2021\/StanleyCup_2021.png&quot;,&quot;modokhulu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HuluMODOK2021\/HuluMODOK2021.png&quot;,&quot;nba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBALeague_2021\/NBALeague_2021.png&quot;,&quot;พลังคนรุ่นใหม่&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;vacúnate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;第五人格&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IdentityVJP_Q3_2021\/IdentityVJP_Q3_2021.png&quot;,&quot;friendsframe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Frame\/HBOMax_Friends_Frame.png&quot;,&quot;深淵覚醒チャレンジ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/blacksurgenightJapanHidden_2021\/blacksurgenightJapanHidden_2021.png&quot;,&quot;peston&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Peston_UK_April_2021\/Peston_UK_April_2021.png&quot;,&quot;sixofcrows&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_ShadowandBone_April_2021\/Netflix_ShadowandBone_April_2021.png&quot;,&quot;cookcleverwasteless&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HellmannsUKNomadMay2021\/HellmannsUKNomadMay2021.png&quot;,&quot;pasunedeplus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;rupaulsdragrace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountRuPaulsDragRaceAllStars_July_2021\/ParamountRuPaulsDragRaceAllStars_July_2021.png&quot;,&quot;rgewin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_RGEWIN\/LEC_EM_2021_RGEWIN.png&quot;,&quot;billions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Showtime_Q2_21_v2\/Showtime_Q2_21_v2.png&quot;,&quot;donttellmehowtodress&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;lokienfant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_KidlLoki_2021\/Disney_LokiLaunch_KidlLoki_2021.png&quot;,&quot;carritolleno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BodegaAurrera_PlanVerano_2021\/BodegaAurrera_PlanVerano_2021.png&quot;,&quot;usdtether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRC20USDT_2021\/TRC20USDT_2021.png&quot;,&quot;lokiclássico&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;bornforthis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_CON\/WNBA_Teams_2021_CON.png&quot;,&quot;eurocopa2020enas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiarioAs_2021\/DiarioAs_2021.png&quot;,&quot;realhousewivesofpotomac&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021\/Bravo_RHOP_Q3_2021.png&quot;,&quot;makeamazinghappen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CamelotTokyo_2021\/CamelotTokyo_2021.png&quot;,&quot;leverage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LeverageRedemption_2021\/Amazon_LeverageRedemption_2021.png&quot;,&quot;remesamala&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;ผู้หญิงทุกคน&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;marvelstudiosviúvanegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;thenevershbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/thenevershbo_2021_May_v2\/thenevershbo_2021_May_v2.png&quot;,&quot;obeymeanime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NTTSolmareObeyme_June_2021\/NTTSolmareObeyme_June_2021.png&quot;,&quot;水曜はロキの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;therealhousewivesofpotomac&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021\/Bravo_RHOP_Q3_2021.png&quot;,&quot;gloriaeterna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_July_2021\/Libertadores_July_2021.png&quot;,&quot;rokotettu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;intermiamicf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_IMCF\/MLS_2021_IMCF.png&quot;,&quot;blackladysketch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_ABLSS_May_2021\/HBO_ABLSS_May_2021.png&quot;,&quot;hernameis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;gosensgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoSensGo_v2\/NHL_2021_Teams_GoSensGo_v2.png&quot;,&quot;16dagar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;nosuddenmovehbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NoSuddenMove_July_2021\/NoSuddenMove_July_2021.png&quot;,&quot;contralasmáquinas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;портороссо&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Portorosso_2021\/Disney_PixarLuca_Portorosso_2021.png&quot;,&quot;stopvoldmodkvinder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020_add\/StopViolenceAgainstWomen_2020_add.png&quot;,&quot;ecfontnt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffsonTNT_2021\/NBAPlayoffsonTNT_2021.png&quot;,&quot;shieldsup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_LAG\/OWL_Season4_Team_2021_LAG.png&quot;,&quot;fordf150lightning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/F150Lightning_May_2021_2\/F150Lightning_May_2021_2.png&quot;,&quot;lokiprésident&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;mi11xpro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mi11XSeries_IN_April_2021_v2\/Mi11XSeries_IN_April_2021_v2.png&quot;,&quot;東京2020&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tokyo2020_Olympics_add\/Tokyo2020_Olympics_add.png&quot;,&quot;burningcrusadeclassic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurningCrusadeClassic_2021\/BurningCrusadeClassic_2021.png&quot;,&quot;valorantmasters&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VALORANT_Champions_Tour_April_2021\/VALORANT_Champions_Tour_April_2021.png&quot;,&quot;blackdesertonline&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackDesert2021Summer\/BlackDesert2021Summer.png&quot;,&quot;peakstreaming&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountPlus_2021_ext\/ParamountPlus_2021_ext.png&quot;,&quot;spacejam2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;legogoldenbrick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEGOGoldenBrick_2021\/LEGOGoldenBrick_2021.png&quot;,&quot;mlbtheshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBTheSho_2021\/MLBTheSho_2021.png&quot;,&quot;ruadomedo1666&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1666_2021\/Netflix_FearStreetTrilogy_1666_2021.png&quot;,&quot;boatcricketgiveaway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BOAT_IPL_2021_v2\/BOAT_IPL_2021_v2.png&quot;,&quot;алексейшостаков&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;楽天カードマン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenCard_May_2021_Flight3\/RakutenCard_May_2021_Flight3.png&quot;,&quot;goavsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoAvsGo\/NHL_2021_Teams_GoAvsGo.png&quot;,&quot;fiatlux&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Paris\/OWL_Season4_Team_Feb_2021_Paris.png&quot;,&quot;terlindungibersama&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KebaikanAqua_April_2021\/KebaikanAqua_April_2021.png&quot;,&quot;奶茶聯盟&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;heroesbehindthemasks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CeraVe_ThankYouNurses_2021\/CeraVe_ThankYouNurses_2021.png&quot;,&quot;babyboss2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BossBaby2_July_2021\/BossBaby2_July_2021.png&quot;,&quot;btcturkpro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/btcturk_May_2021\/btcturk_May_2021.png&quot;,&quot;7afl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_7AFL\/AFL_2021_7AFL.png&quot;,&quot;lovetoreadit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveToSeeIt_2021\/LoveToSeeIt_2021.png&quot;,&quot;pixarлука&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;wethe15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;verde&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_AFC\/MLS_2021_AFC.png&quot;,&quot;스쿨미투&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_Korea_2018_v2\/MeToo_Korea_2018_v2.png&quot;,&quot;engarde&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_PAR\/CDL_Team_2021_PAR.png&quot;,&quot;kpop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopTwitter_2021_Red\/KpopTwitter_2021_Red.png&quot;,&quot;lsbwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_SB_v2\/LCK_2021_Team_P1_SB_v2.png&quot;,&quot;おつかれパルム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MorinagaMilk_Parm_April_2021\/MorinagaMilk_Parm_April_2021.png&quot;,&quot;valentinethetiger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZombieTiger_UK_May_2021\/ZombieTiger_UK_May_2021.png&quot;,&quot;мойтеруки&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;bawatbabae&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;dragrace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountRuPaulsDragRaceAllStars_July_2021\/ParamountRuPaulsDragRaceAllStars_July_2021.png&quot;,&quot;deusdatrapaça&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;letthenetwork&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;wecandothis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HHS_WeCanDoThis_2021\/HHS_WeCanDoThis_2021.png&quot;,&quot;lávatelasmanos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;avt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;generasisetara&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;baradu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;منتخب_قطر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021\/QatarAtGoldCup_2021.png&quot;,&quot;இளைஞர்முதண்மையில்&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020_add\/YouthLead_2020_add.png&quot;,&quot;twitteruntukkebaikan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;pds2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeDayShow21_v2\/PrimeDayShow21_v2.png&quot;,&quot;lionssa2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LionsRugbyTour_2021_SeriesTrophy\/LionsRugbyTour_2021_SeriesTrophy.png&quot;,&quot;legomastersfoxtv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_LEGOGoldenBrick_2021\/FOX_LEGOGoldenBrick_2021.png&quot;,&quot;kadınızbiz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;alwaysgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_AlwaysGame\/NBA_2021_Teams_AlwaysGame.png&quot;,&quot;metooindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_India_2018\/MeToo_India_2018.png&quot;,&quot;juntosmiami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MIA\/MLB_Teams_2021_MIA.png&quot;,&quot;thankanurse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CeraVe_ThankYouNurses_2021\/CeraVe_ThankYouNurses_2021.png&quot;,&quot;मास्कपहनिये&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;blacktranswomenmatter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackTransLivesMatter_2020\/BlackTransLivesMatter_2020.png&quot;,&quot;방탄소년단&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021\/KpopVIT_BTS_June2021.png&quot;,&quot;soberish&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LizPhair_2021\/LizPhair_2021.png&quot;,&quot;قطر_في_الكأس_الذهبية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021_v2\/QatarAtGoldCup_2021_v2.png&quot;,&quot;usunited&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnyderCut_LA_May_2021\/SnyderCut_LA_May_2021.png&quot;,&quot;gointz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/INTZ_June_2021\/INTZ_June_2021.png&quot;,&quot;haendewaschen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;vaccinerad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;50周年・思い出のメニューが続々&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McDonalds50thanniversaryJP2021\/McDonalds50thanniversaryJP2021.png&quot;,&quot;១៦ថ្ងៃ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;fêtenationale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FranceBastilleDay2021\/FranceBastilleDay2021.png&quot;,&quot;capalothalloffame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Polo_G_Album_2021\/Polo_G_Album_2021.png&quot;,&quot;redbullsoloq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedBull_GIVESYOUWINGS_2021_V2\/RedBull_GIVESYOUWINGS_2021_V2.png&quot;,&quot;redtaylorsversion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TSRed2021\/TSRed2021.png&quot;,&quot;mitb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WWEMoneyintheBank_2021\/WWEMoneyintheBank_2021.png&quot;,&quot;ageofempiresiv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxCardinal_2021\/XboxCardinal_2021.png&quot;,&quot;nytspellingbee&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NYTimesGames_NYTSpellingBee_2021\/NYTimesGames_NYTSpellingBee_2021.png&quot;,&quot;gmtf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bastille_June_2021\/Bastille_June_2021.png&quot;,&quot;híbridowendy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Pig\/Netflix_SweetTooth_Pig.png&quot;,&quot;binancesmartchain&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BinanceTurns4_2021\/BinanceTurns4_2021.png&quot;,&quot;leggowitheggo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eggo_May_2021_2\/Eggo_May_2021_2.png&quot;,&quot;doitforthebay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Blindspotting_May_2021\/STARZ_Blindspotting_May_2021.png&quot;,&quot;netslevel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_BrooklynTogether_add\/NBA_2021_Teams_BrooklynTogether_add.png&quot;,&quot;optussport&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OptusSport_May_2021\/OptusSport_May_2021.png&quot;,&quot;キューテンサンプルマーケット&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Q22021\/Qoo10_Q22021.png&quot;,&quot;youknowyoumissedme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_CB\/HBOMaxGossipGirl_July_2021_CB.png&quot;,&quot;ewayselectropop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RenaulteWays_2_2021\/RenaulteWays_2_2021.png&quot;,&quot;milkaschokolade&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkaSummerCampaign_2021\/MilkaSummerCampaign_2021.png&quot;,&quot;renslayer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Renslayer_2021\/Disney_LokiLaunch_Renslayer_2021.png&quot;,&quot;allfly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_AllFly\/NBA_2021_Teams_AllFly.png&quot;,&quot;internetbloqueada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;ได้รับวัคซีนแล้ว&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;wearecol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_COLWIN\/EsportsAllAccess_Jan_2021_COLWIN.png&quot;,&quot;letsgobucs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_PIT\/MLB_Teams_2021_PIT.png&quot;,&quot;teamgb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TeamGB_2021\/TeamGB_2021.png&quot;,&quot;starbuckssummer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StarbucksCanadaSummer2021\/StarbucksCanadaSummer2021.png&quot;,&quot;ditohighspeed&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DITO_May_2021_ext\/DITO_May_2021_ext.png&quot;,&quot;තාරුණ්‍යයපෙරමගට&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020_add\/YouthLead_2020_add.png&quot;,&quot;zerokeganasan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;タルラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Yostar_ArknightsStaff_April_2021\/Yostar_ArknightsStaff_April_2021.png&quot;,&quot;俺だけレベルアップな件&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Oreleve_June_2021\/Piccoma_Oreleve_June_2021.png&quot;,&quot;genglol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_GenG\/LcK_2021_Teams_GenG.png&quot;,&quot;thecubetbs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BeatTheCube_2021\/BeatTheCube_2021.png&quot;,&quot;fncwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_FNCWIN\/LEC_EM_2021_FNCWIN.png&quot;,&quot;cofred&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_CofRed\/NHL_2021_Teams_CofRed.png&quot;,&quot;getvaccineanswers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AdCouncilVaccine_2021\/AdCouncilVaccine_2021.png&quot;,&quot;porlaa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_ATL\/MLB_Teams_2021_ATL.png&quot;,&quot;ทวิ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;lokialligator&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;이달의소녀_ptt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_LOONA_June_2021\/KpopVIT_LOONA_June_2021.png&quot;,&quot;myxawards2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MYXAwards2021\/MYXAwards2021.png&quot;,&quot;edgeofwonderful&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IntelMWC_2021\/IntelMWC_2021.png&quot;,&quot;madwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_MADWIN\/LEC_EM_2021_MADWIN.png&quot;,&quot;smackdown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WWE_Recurring_2020_SmackDown\/WWE_Recurring_2020_SmackDown.png&quot;,&quot;drumstick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DrumstickCone2021\/DrumstickCone2021.png&quot;,&quot;juntosreales&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_KC\/MLB_Teams_2021_KC.png&quot;,&quot;thebigscreenisback&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBigScreenIsBack_2021\/TheBigScreenIsBack_2021.png&quot;,&quot;אנחנו_נשים&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;climatepledge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_ClimatePledge_2021\/Amazon_ClimatePledge_2021.png&quot;,&quot;hellmanns&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HellmannsUKNomadMay2021\/HellmannsUKNomadMay2021.png&quot;,&quot;sucessonobanheiro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SucessoNoBanheiro_2021\/SucessoNoBanheiro_2021.png&quot;,&quot;soundofchampions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BOAT_IPL_2021_v2\/BOAT_IPL_2021_v2.png&quot;,&quot;sbmulti&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sportsbet_July_2021\/Sportsbet_July_2021.png&quot;,&quot;bastilleday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FranceBastilleDay2021\/FranceBastilleDay2021.png&quot;,&quot;jdgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_JDGWIN\/LPL_2021_JDGWIN.png&quot;,&quot;somosdetroit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_DET\/MLB_Teams_2021_DET.png&quot;,&quot;internetbloccato&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;rhop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021\/Bravo_RHOP_Q3_2021.png&quot;,&quot;blindspottingpremiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Blindspotting_May_2021\/STARZ_Blindspotting_May_2021.png&quot;,&quot;phongdich&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;jdgetgrafting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDLoveIsland_2021\/JDLoveIsland_2021.png&quot;,&quot;wewin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_WEWIN\/LPL_2021_WEWIN.png&quot;,&quot;ヴァルコネ5周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ateam_valkyrie_connect_0601_2021\/Ateam_valkyrie_connect_0601_2021.png&quot;,&quot;godfatherofharlem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GFOH_April_2021\/GFOH_April_2021.png&quot;,&quot;letsgocanes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LetsGoCanes\/NHL_2021_Teams_LetsGoCanes.png&quot;,&quot;daveburd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DaveFX_May_2021_v2\/DaveFX_May_2021_v2.png&quot;,&quot;grishaverse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_ShadowandBone_April_2021\/Netflix_ShadowandBone_April_2021.png&quot;,&quot;ageofempires&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxCardinal_2021\/XboxCardinal_2021.png&quot;,&quot;留在家裡&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;binanceturns4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BinanceTurns4_2021\/BinanceTurns4_2021.png&quot;,&quot;fos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOS_May_2021\/FOS_May_2021.png&quot;,&quot;missminutes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;imlookingforapig&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NeonRated_PigtheFilm_June2021\/NeonRated_PigtheFilm_June2021.png&quot;,&quot;shocktheworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_SF\/OWL_Season4_Team_Feb_2021_SF.png&quot;,&quot;barrioangelino&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_LAFC\/MLS_2021_LAFC.png&quot;,&quot;エミール探し&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReplicant_April_2021_V2\/NieRReplicant_April_2021_V2.png&quot;,&quot;gohabsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoHabsGo\/NHL_2021_Teams_GoHabsGo.png&quot;,&quot;periodweeksandbladderleaks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Poise_May_2021\/Poise_May_2021.png&quot;,&quot;مجلس_الصحة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GHC_SA_June_2021\/GHC_SA_June_2021.png&quot;,&quot;afreecafreecs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_AF_v2\/LCK_2021_Team_P1_AF_v2.png&quot;,&quot;상하이어니언&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McD_KR_July_2021\/McD_KR_July_2021.png&quot;,&quot;postforthepress&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WaPo_WorldPressFreedom_2021\/WaPo_WorldPressFreedom_2021.png&quot;,&quot;raysbeisbol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_TB\/MLB_Teams_2021_TB.png&quot;,&quot;lokiklasik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;usalamascarilla&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;yemeksepeti20yaşında&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YemekSepeti_2021\/YemekSepeti_2021.png&quot;,&quot;qoo10サンプルマーケット&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Q22021\/Qoo10_Q22021.png&quot;,&quot;88rising&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/88RISING_May_2021\/88RISING_May_2021.png&quot;,&quot;mtvmiaw2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PinkCarpetMTVMIAW_2021\/PinkCarpetMTVMIAW_2021.png&quot;,&quot;marcusrashfordbookclub&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MarcusRashfordBook_2021\/MarcusRashfordBook_2021.png&quot;,&quot;fearthedeer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_FearTheDeer\/NBA_2021_Teams_FearTheDeer.png&quot;,&quot;beliefbelongs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BeliefBelongs_2020\/BeliefBelongs_2020.png&quot;,&quot;အင်တာနက်ဆက်ဖွင့်ထားပါ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;hälsosamthem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;rtw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_RuntheWorld_2021\/STARZ_RuntheWorld_2021.png&quot;,&quot;indossalamascherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;lildicky&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DaveFX_May_2021_v2\/DaveFX_May_2021_v2.png&quot;,&quot;saludosme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectSoul_June_2021\/ProjectSoul_June_2021.png&quot;,&quot;wwptd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PopTarts_June_2021\/PopTarts_June_2021.png&quot;,&quot;thebadbatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;vamosorlando&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_OCSC\/MLS_2021_OCSC.png&quot;,&quot;荘園にも奇妙な物語&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IdentityVJP_Q3_2021\/IdentityVJP_Q3_2021.png&quot;,&quot;집콕생활&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;magicthegathering&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MagicTheGathering_june_2021_\/MagicTheGathering_june_2021_.png&quot;,&quot;geng&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_GenG\/LcK_2021_Teams_GenG.png&quot;,&quot;thetenthanniversary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;قطرفيالكأس_الذهبية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021\/QatarAtGoldCup_2021.png&quot;,&quot;preparadoslistospanic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_Panic_2021\/AmazonStudios_Panic_2021.png&quot;,&quot;awssummitindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AWSSummit_2021\/AWSSummit_2021.png&quot;,&quot;vacunada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;twittertogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterTogether_2019_v3\/TwitterTogether_2019_v3.png&quot;,&quot;rctid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_PT\/MLS_2021_PT.png&quot;,&quot;lvcapucines&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LVCapucines_April_2021\/LVCapucines_April_2021.png&quot;,&quot;robyndixon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_RobynDixon\/Bravo_RHOP_Q3_2021_RobynDixon.png&quot;,&quot;owlhybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Owl\/Netflix_SweetTooth_Owl.png&quot;,&quot;notonemore&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;世界紅十字日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;fin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_FIN\/Euro_UK_2021_FIN.png&quot;,&quot;wwdc21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/USEN_HRT_TLB_72x72_BAN_WWDC_DAYD_NA_NA_NA_NA_NA\/USEN_HRT_TLB_72x72_BAN_WWDC_DAYD_NA_NA_NA_NA_NA.png&quot;,&quot;feelthecharge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_Guangzhou\/OWL_Season4_Team_2021_Guangzhou.png&quot;,&quot;primedayshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeDayShow21_v2\/PrimeDayShow21_v2.png&quot;,&quot;bornthiswayanniversary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;recensementde2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StatCanCensus_2021\/StatCanCensus_2021.png&quot;,&quot;shoheiohtani&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-LAA\/MLBHRDerby2021-LAA.png&quot;,&quot;ablss&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_ABLSS_May_2021\/HBO_ABLSS_May_2021.png&quot;,&quot;coldplay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Coldplay_May_2021\/Coldplay_May_2021.png&quot;,&quot;guadiandelsabor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuardianTecate_July_2021\/GuardianTecate_July_2021.png&quot;,&quot;herkadın&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;youthlead&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;kduo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MD_BurgerKoreaPedas_2021\/MD_BurgerKoreaPedas_2021.png&quot;,&quot;edsheeran&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EdSheeran_June_UK_2021\/EdSheeran_June_UK_2021.png&quot;,&quot;hun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_HUN\/Euro_UK_2021_HUN.png&quot;,&quot;pixarluca&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;juégatelaconcheetos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChesterCheetos_MX_2021\/ChesterCheetos_MX_2021.png&quot;,&quot;tucaandbertie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TucaandBertie_2021\/TucaandBertie_2021.png&quot;,&quot;labretagneentête&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TourdeFrance_2021\/TourdeFrance_2021.png&quot;,&quot;igotmyshotsg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add3\/vaccinated_2021_add3.png&quot;,&quot;joeygallo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-Tex\/MLBHRDerby2021-Tex.png&quot;,&quot;futureinc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bastille_June_2021\/Bastille_June_2021.png&quot;,&quot;parm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MorinagaMilk_Parm_April_2021\/MorinagaMilk_Parm_April_2021.png&quot;,&quot;قطع_الإنترنت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;vaccinate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;សមធម៌ជំនាន់&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;ハリポタ新作ゲーム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HarryPotterNetease_Q2_2021\/HarryPotterNetease_Q2_2021.png&quot;,&quot;ハンターb15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_HunterB15_2021\/Disney_LokiLaunch_HunterB15_2021.png&quot;,&quot;yuna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_YUNA\/KPOP_VIT_ITZY_April_2021_YUNA.png&quot;,&quot;rawin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_RAWIN\/LPL_2021_RAWIN.png&quot;,&quot;gettheglow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OPPOReno6Series_2021\/OPPOReno6Series_2021.png&quot;,&quot;liveinvegas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LVCVA_Vegas_June_2021\/LVCVA_Vegas_June_2021.png&quot;,&quot;primadicliccarepensa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;twitterparaelbien&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;lsb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_SB_v2\/LCK_2021_Team_P1_SB_v2.png&quot;,&quot;ฉีดวัคซีน&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;mietiennenklikkia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;raisedbywolves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_RaisedByWolves\/NBA_2021_Teams_RaisedByWolves.png&quot;,&quot;atevencermosafome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;your_choice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_SEVENTEEN_June_2021\/KpopVIT_SEVENTEEN_June_2021.png&quot;,&quot;ニーアレプリカント&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReplicant_April_2021_V2\/NieRReplicant_April_2021_V2.png&quot;,&quot;temporaryhighsinthevioletskies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnohAalegra_2021\/SnohAalegra_2021.png&quot;,&quot;wimbledon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Wimbledon_2021\/Wimbledon_2021.png&quot;,&quot;wolfalice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WolfAlice_2021\/WolfAlice_2021.png&quot;,&quot;eligeelpaísquequieres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChileElections_2021\/ChileElections_2021.png&quot;,&quot;theforeverpurge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021\/TheForeverPurge_2021.png&quot;,&quot;vacunado&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;junefree&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hulu_THT_S4_2021\/Hulu_THT_S4_2021.png&quot;,&quot;ชัตดาวน์อินเทอร์เน็ต&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;yelenabelova&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Yelena_2021\/Disney_BlackWidow_Yelena_2021.png&quot;,&quot;2pm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_2PM\/Kpop_VIT_2PM.png&quot;,&quot;yaac&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MarcusRashfordBook_2021\/MarcusRashfordBook_2021.png&quot;,&quot;待在家里&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;doghybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Dog\/Netflix_SweetTooth_Dog.png&quot;,&quot;atinangmundo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectSoul_June_2021\/ProjectSoul_June_2021.png&quot;,&quot;grownish&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/grownishseason4_2021\/grownishseason4_2021.png&quot;,&quot;must&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_2PM\/Kpop_VIT_2PM.png&quot;,&quot;wendyosefo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_WendyOsefo\/Bravo_RHOP_Q3_2021_WendyOsefo.png&quot;,&quot;cymrucoch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXWALES_2021\/JDXWALES_2021.png&quot;,&quot;ミルクティー同盟&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021_add\/MilkTeaAlliance_2021_add.png&quot;,&quot;walk2endalz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ALZ_2021\/ALZ_2021.png&quot;,&quot;endalzheimers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ALZ_2021\/ALZ_2021.png&quot;,&quot;الجيل_الخامس_لعمان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OmanTel5G_2021_v3\/OmanTel5G_2021_v3.png&quot;,&quot;المراكز_الترفيهية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnjoySaudi_June2021\/EnjoySaudi_June2021.png&quot;,&quot;c9win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_C9WIN\/LCS_Jan_2021_C9WIN.png&quot;,&quot;우리는여성이다&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021_add\/TwitterWomenTentpole_2021_add.png&quot;,&quot;takeflight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_DAL\/WNBA_Teams_2021_DAL.png&quot;,&quot;מחוסן&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;disneyland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;somosatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_AU\/MLS_2021_AU.png&quot;,&quot;yourstorm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_YourStorm\/NRL_2021_YourStorm.png&quot;,&quot;winterinatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Njomza_Album_Emoji_2021\/Njomza_Album_Emoji_2021.png&quot;,&quot;밀크티동맹&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;makeanythingbetterwithheinz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KraftHeinz_CrowdSauce_SG_2021\/KraftHeinz_CrowdSauce_SG_2021.png&quot;,&quot;powerrankingdelaeuro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiarioAs_2021\/DiarioAs_2021.png&quot;,&quot;lokifanfarrón&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;thinkbeforeclicking&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;blackdesert&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackDesert2021Summer\/BlackDesert2021Summer.png&quot;,&quot;يومالهاللاألحمر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;omantel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OmanTel5G_2021_v3\/OmanTel5G_2021_v3.png&quot;,&quot;aquietplace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;presidentloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;armchairexpert&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArmchairExpert_2021\/ArmchairExpert_2021.png&quot;,&quot;reignathome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_ATL\/OWL_Season4_Team_2021_ATL.png&quot;,&quot;vivasualiberdade&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DoritosFreedom_2021\/DoritosFreedom_2021.png&quot;,&quot;ownthelifeyouwant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectSoul_June_2021\/ProjectSoul_June_2021.png&quot;,&quot;キューテンサンq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Q22021\/Qoo10_Q22021.png&quot;,&quot;유겸&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_Yugyeom_June_2021\/Kpop_Yugyeom_June_2021.png&quot;,&quot;alchemystars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TencentAlchemyStarsJPLaunch_2021\/TencentAlchemyStarsJPLaunch_2021.png&quot;,&quot;skatekitchen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BettyHBO_S2_2021\/BettyHBO_S2_2021.png&quot;,&quot;lavezvouslesmains&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;whitelotushbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_TheWhiteLotus_2021\/HBO_TheWhiteLotus_2021.png&quot;,&quot;nabakunahan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;เราคือผู้หญิง&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;rwwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_RWWIN\/LPL_2021_RWWIN.png&quot;,&quot;ロマサガrs祝2・5周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Romasaga_25y_May_2021\/Romasaga_25y_May_2021.png&quot;,&quot;ggwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_GGWIN\/LCS_Jan_2021_GGWIN.png&quot;,&quot;letsrakita&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JagameThandhiramOnNetflix_2021\/JagameThandhiramOnNetflix_2021.png&quot;,&quot;mattolson&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-OAK\/MLBHRDerby2021-OAK.png&quot;,&quot;mydblegends&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyDBLegends_May_2021\/MyDBLegends_May_2021.png&quot;,&quot;블랙위도우&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;nrlw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021\/NRL_2021.png&quot;,&quot;jdxsco&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXSCOTLAND_2021\/JDXSCOTLAND_2021.png&quot;,&quot;младежколидерство&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020_add\/YouthLead_2020_add.png&quot;,&quot;lunglives&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LungLives_May_2021_v2\/LungLives_May_2021_v2.png&quot;,&quot;poweredbyzil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zilliqa_April_2021\/Zilliqa_April_2021.png&quot;,&quot;thehandmaidstale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hulu_THT_S4_2021\/Hulu_THT_S4_2021.png&quot;,&quot;redguardian&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;samegamemulti&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sportsbet_July_2021\/Sportsbet_July_2021.png&quot;,&quot;alleenjij&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;thefinalpose&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021_add\/FX_Pose_April_2021_add.png&quot;,&quot;xoxogossipgirl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_XOXO\/HBOMaxGossipGirl_July_2021_XOXO.png&quot;,&quot;ageofempires4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxCardinal_2021\/XboxCardinal_2021.png&quot;,&quot;centenário2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_July_2021\/Libertadores_July_2021.png&quot;,&quot;cryptoclimate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CryptocomCimate_2021_v2\/CryptocomCimate_2021_v2.png&quot;,&quot;hybrids&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021\/NetflixSweetTooth2021.png&quot;,&quot;wearebluejays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_TOR\/MLB_Teams_2021_TOR.png&quot;,&quot;timeforasub&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimeForASub_2021\/TimeForASub_2021.png&quot;,&quot;先想再分享&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;決戦なのだ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Romasaga_25y_May_2021\/Romasaga_25y_May_2021.png&quot;,&quot;arawngredcross&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;magisipbagomagshare&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;lokiclassique&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;faze5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_Faze\/EsportsAllAccess_Jan_2021_Faze.png&quot;,&quot;lottoitcouldbeyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CamelotTokyo_2021\/CamelotTokyo_2021.png&quot;,&quot;fearstreet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_Franchise_2_2021\/Netflix_FearStreetTrilogy_Franchise_2_2021.png&quot;,&quot;nikkiglaser&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboyfbye\/FBOYIsland_2021_fboyfbye.png&quot;,&quot;nosuddenmove&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NoSuddenMove_July_2021\/NoSuddenMove_July_2021.png&quot;,&quot;quartasdoloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;anteup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_HOUSTON_v2\/OWL_Season4_Team_2021_HOUSTON_v2.png&quot;,&quot;맥도날드&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McD_KR_July_2021\/McD_KR_July_2021.png&quot;,&quot;hacksonhbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hacks_HBOMax_April_2021_v3\/Hacks_HBOMax_April_2021_v3.png&quot;,&quot;togetherwerise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_TogetherWeRise\/AFL_2021_TogetherWeRise.png&quot;,&quot;iagdzt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZombieTiger_UK_May_2021\/ZombieTiger_UK_May_2021.png&quot;,&quot;thepurge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021\/TheForeverPurge_2021.png&quot;,&quot;fetenationale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FranceBastilleDay2021\/FranceBastilleDay2021.png&quot;,&quot;cfmtl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CFMTL\/MLS_2021_CFMTL.png&quot;,&quot;منصة_عيشها&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnjoySaudi_June2021\/EnjoySaudi_June2021.png&quot;,&quot;verzuzbattle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Verzuz_2020_Flight4\/Verzuz_2020_Flight4.png&quot;,&quot;redv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_redv\/NRL_2021_redv.png&quot;,&quot;cesttoutmoi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;5aside&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ladbrokes5ASide_May_2021\/Ladbrokes5ASide_May_2021.png&quot;,&quot;madebymany&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_League_2021\/LCS_League_2021.png&quot;,&quot;kaotican&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Coldplay_May_2021\/Coldplay_May_2021.png&quot;,&quot;ace_higher&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopACE_June_2021\/KpopACE_June_2021.png&quot;,&quot;чернаявдова&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;နို့လက်ဖက်ရည်မဟာမိတ်&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;disneycruiseline&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_DisneyCruise_2021\/DisneyParks_DisneyCruise_2021.png&quot;,&quot;futbolziyafeti&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YemekSepeti_2021\/YemekSepeti_2021.png&quot;,&quot;الجوائز_الثقافية_الوطنية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NationalCulturalAwardsFinalEvent_2021\/NationalCulturalAwardsFinalEvent_2021.png&quot;,&quot;ausarmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DFR_2021_AusArmy_May\/DFR_2021_AusArmy_May.png&quot;,&quot;自然に健康new十六茶&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrink16tea02Japan_2021\/AsahiSoftDrink16tea02Japan_2021.png&quot;,&quot;cmoncymru&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXWALES_2021\/JDXWALES_2021.png&quot;,&quot;igwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_IGWIN\/LPL_2021_IGWIN.png&quot;,&quot;রেডক্রিসেন্টদিবস&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;gaga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;globalaccessibilityawarenessday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GAAD_May_2021_ext\/GAAD_May_2021_ext.png&quot;,&quot;realcoolmagic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Midea_RAC_May_2021\/Midea_RAC_May_2021.png&quot;,&quot;lfgdocumentary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LFGDocumentary_2021\/HBOMax_LFGDocumentary_2021.png&quot;,&quot;globalrickandmortyday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RickandMorty2021_globalrickandmortyday\/RickandMorty2021_globalrickandmortyday.png&quot;,&quot;bostonup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_BostonUp\/OWL_Season4_Team_Feb_2021_BostonUp.png&quot;,&quot;f150&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/F150Lightning_May_2021_2\/F150Lightning_May_2021_2.png&quot;,&quot;viudanegramarvel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;duo4realcool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Midea_RAC_May_2021\/Midea_RAC_May_2021.png&quot;,&quot;apahm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;intz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/INTZ_June_2021\/INTZ_June_2021.png&quot;,&quot;theturn2kl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheTurn2KL_2021\/TheTurn2KL_2021.png&quot;,&quot;lag&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_LAG_v2\/CDL_Team_2021_LAG_v2.png&quot;,&quot;someity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paralympic_Mascot_Emoji_EXT2\/Paralympic_Mascot_Emoji_EXT2.png&quot;,&quot;dewzonewithdruski&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewNBA_June_2021\/MountainDewNBA_June_2021.png&quot;,&quot;jodifyyourlife&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HuluMODOK2021\/HuluMODOK2021.png&quot;,&quot;bettys2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BettyHBO_S2_2021\/BettyHBO_S2_2021.png&quot;,&quot;aewontnt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/aewontnt_May_2021\/aewontnt_May_2021.png&quot;,&quot;断网&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;bittorrent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JustinSuntron_2021_ext\/JustinSuntron_2021_ext.png&quot;,&quot;heinzistheanswer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KraftHeinz_CrowdSauce_SG_2021\/KraftHeinz_CrowdSauce_SG_2021.png&quot;,&quot;สเปซแจม&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;lfgthemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LFGDocumentary_2021\/HBOMax_LFGDocumentary_2021.png&quot;,&quot;identityv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IdentityVJP_Q3_2021\/IdentityVJP_Q3_2021.png&quot;,&quot;hitungmundurloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;somosmibr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_MIBR\/EsportsAllAccess_Jan_2021_MIBR.png&quot;,&quot;supplierinclusion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SupplierInclusionDiversity_2021\/SupplierInclusionDiversity_2021.png&quot;,&quot;everupward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_NY\/OWL_Season4_Team_Feb_2021_NY.png&quot;,&quot;vaccinati&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;rockets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_Rockets\/NBA_2021_Teams_Rockets.png&quot;,&quot;sylvie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Sylvie_2021_V2\/Disney_LokiLaunch_Sylvie_2021_V2.png&quot;,&quot;อร่อยได้เมื่อมีไฮนซ์&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KraftHeinz_CrowdSauce_SG_2021\/KraftHeinz_CrowdSauce_SG_2021.png&quot;,&quot;zilnft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zilliqa_April_2021\/Zilliqa_April_2021.png&quot;,&quot;selenalaserie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SelenaNetflix_2021\/SelenaNetflix_2021.png&quot;,&quot;thankyounurses&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CeraVe_ThankYouNurses_2021\/CeraVe_ThankYouNurses_2021.png&quot;,&quot;lokiclassico&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;awsforindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AWSSummit_2021\/AWSSummit_2021.png&quot;,&quot;teswin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_TESWIN\/LPL_2021_TESWIN.png&quot;,&quot;farcry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Farcry6_UK_2021\/Farcry6_UK_2021.png&quot;,&quot;aflw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_AFLW\/AFL_2021_AFLW.png&quot;,&quot;サマナーズウォー7周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Com2us_summonerswar_April_2021\/Com2us_summonerswar_April_2021.png&quot;,&quot;doomatyourserviceonviu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DAYSOnViu_2021\/DAYSOnViu_2021.png&quot;,&quot;nrlgf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021\/NRL_2021.png&quot;,&quot;imaginequeépossível&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TIMOlimpiadas2021\/TIMOlimpiadas2021.png&quot;,&quot;fazeclan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_Faze\/EsportsAllAccess_Jan_2021_Faze.png&quot;,&quot;tomorrowwarmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021_add\/AmazonStudios_TomorrowWar_2021_add.png&quot;,&quot;ourcle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CLE\/MLB_Teams_2021_CLE.png&quot;,&quot;stopfeminicides&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;kakayaninnatinito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HHS_WeCanDoThis_2021_add\/HHS_WeCanDoThis_2021_add.png&quot;,&quot;thismeanseverything&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXSCOTLAND_2021\/JDXSCOTLAND_2021.png&quot;,&quot;알콜프리&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_TWICE_June_2021\/Kpop_VIT_TWICE_June_2021.png&quot;,&quot;colwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_COLWIN\/EsportsAllAccess_Jan_2021_COLWIN.png&quot;,&quot;jedefrau&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;sourpatchkidsmystery&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SourPatchMystery_May_2021\/SourPatchMystery_May_2021.png&quot;,&quot;단한명의여성도&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;vamosnyc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NYC_v2\/MLS_2021_NYC_v2.png&quot;,&quot;halomp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxOlympus_2021\/XboxOlympus_2021.png&quot;,&quot;saw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpiralSaw2021\/SpiralSaw2021.png&quot;,&quot;usemascara&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;followlocaljournalists&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FollowLocalJournalists_2021\/FollowLocalJournalists_2021.png&quot;,&quot;pūhouwhakahaere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;runskg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_SKWIN\/LEC_EM_2021_SKWIN.png&quot;,&quot;beliamemimpin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;btfs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JustinSuntron_2021_ext\/JustinSuntron_2021_ext.png&quot;,&quot;webull7&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeBull_May_2021_v2\/WeBull_May_2021_v2.png&quot;,&quot;skinsistareset&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SkinsistaRESET_2021\/SkinsistaRESET_2021.png&quot;,&quot;vierkvinner&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;cervezatecate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuardianTecate_July_2021\/GuardianTecate_July_2021.png&quot;,&quot;ひと夏の奇跡&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;ウォーサバ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ElexTWDSJP_2021\/ElexTWDSJP_2021.png&quot;,&quot;newworldamazon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewWorldLaunch_2021\/NewWorldLaunch_2021.png&quot;,&quot;legomastersonfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_LEGOGoldenBrick_2021\/FOX_LEGOGoldenBrick_2021.png&quot;,&quot;gopherhybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Gopher\/Netflix_SweetTooth_Gopher.png&quot;,&quot;リィンカネ生&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReincarnationLaunch_May_2021\/NieRReincarnationLaunch_May_2021.png&quot;,&quot;guinnesstime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuinnessTime_May_2021\/GuinnessTime_May_2021.png&quot;,&quot;spacejamanewlegacy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;khôngrađường&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;dodgers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_LAD\/MLB_Teams_2021_LAD.png&quot;,&quot;alexeishostakov&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;classicloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;alidanraturatuqueens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixARRQ_2021\/NetflixARRQ_2021.png&quot;,&quot;turkeyhead&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Turkey\/HBOMax_Friends_Turkey.png&quot;,&quot;saturdaysolstice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/inchscider_2021_add\/inchscider_2021_add.png&quot;,&quot;justiceiscoming&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;treymancini&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-BAL\/MLBHRDerby2021-BAL.png&quot;,&quot;msfwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_MSFWIN\/LEC_EM_2021_MSFWIN.png&quot;,&quot;askdionne&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dionne_Warwick_2021_V2\/Dionne_Warwick_2021_V2.png&quot;,&quot;dk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_DK\/LcK_2021_Teams_DK.png&quot;,&quot;qoo10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Shopping_Q2_2021\/Qoo10_Shopping_Q2_2021.png&quot;,&quot;haveago&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AU_Olympic_2021\/AU_Olympic_2021.png&quot;,&quot;キューテン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Shopping_Q2_2021\/Qoo10_Shopping_Q2_2021.png&quot;,&quot;squadup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_NYY\/MLB_Teams_2021_NYY.png&quot;,&quot;wweraw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WWE_Recurring_2020_WWERaw\/WWE_Recurring_2020_WWERaw.png&quot;,&quot;grownishsenioryear&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/grownishseason4_2021\/grownishseason4_2021.png&quot;,&quot;вечначистка&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;fikirsebelumklik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;16days&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020_add\/OrangeTheWorld_2020_add.png&quot;,&quot;mercredisdeloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;문샷&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_NFlying_June_2021\/KPOP_NFlying_June_2021.png&quot;,&quot;wethenorth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_WeTheNorth\/NBA_2021_Teams_WeTheNorth.png&quot;,&quot;permissiontodance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_BTS_single_July1_2021_W2\/Kpop_VIT_BTS_single_July1_2021_W2.png&quot;,&quot;pixarальберто&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;itsawimbledonthing&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Wimbledon_2021_hearts\/Wimbledon_2021_hearts.png&quot;,&quot;i̇yikidoyduk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YemekSepeti_2021\/YemekSepeti_2021.png&quot;,&quot;औरतकासम्मान&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;aflwgf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_AFLW\/AFL_2021_AFLW.png&quot;,&quot;brooklyntogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_BrooklynTogether\/NBA_2021_Teams_BrooklynTogether.png&quot;,&quot;spacejammovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;twitterparasakabutihan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;omgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_OMGWIN\/LPL_2021_OMGWIN.png&quot;,&quot;unitethepride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VodafoneLions_Tour_2021\/VodafoneLions_Tour_2021.png&quot;,&quot;dontspoilthetrip&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;opporeno6series&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OPPOReno6Series_2021\/OPPOReno6Series_2021.png&quot;,&quot;onlyyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;bettyhbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BettyHBO_S2_2021\/BettyHBO_S2_2021.png&quot;,&quot;coffeeconfidential&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Latte\/HBOMaxGossipGirl_July_2021_Latte.png&quot;,&quot;pensaprimadicondividere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;日本にはおいしいサイダーがある&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021.png&quot;,&quot;magsuotngmask&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;hacksonmax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hacks_HBOMax_April_2021_v3\/Hacks_HBOMax_April_2021_v3.png&quot;,&quot;parradise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_PARRAdise\/NRL_2021_PARRAdise.png&quot;,&quot;ナターシャロマノフ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_BWNatasha_again_2021\/Disney_BlackWidow_BWNatasha_again_2021.png&quot;,&quot;blindspotting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Blindspotting_May_2021\/STARZ_Blindspotting_May_2021.png&quot;,&quot;七夕の願い事&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2021StarFestivalTanabata\/2021StarFestivalTanabata.png&quot;,&quot;lizphair&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LizPhair_2021\/LizPhair_2021.png&quot;,&quot;libertadores&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_July_2021\/Libertadores_July_2021.png&quot;,&quot;ruletheschool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_CB\/HBOMaxGossipGirl_July_2021_CB.png&quot;,&quot;wirsinddie15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;7anosintz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/INTZ_June_2021\/INTZ_June_2021.png&quot;,&quot;foreverpurgesg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;distortedlightbeam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bastille_June_2021\/Bastille_June_2021.png&quot;,&quot;青年領導&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;gorabbitohs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_GoRabbitohs\/NRL_2021_GoRabbitohs.png&quot;,&quot;mysterysourpatchflavor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SourPatchMystery_May_2021\/SourPatchMystery_May_2021.png&quot;,&quot;maailmaoranssiksi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;gospursgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_GoSpursGo\/NBA_2021_Teams_GoSpursGo.png&quot;,&quot;infovacunacovid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AdCouncilVaccine_2021_add\/AdCouncilVaccine_2021_add.png&quot;,&quot;dragraceallstars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountRuPaulsDragRaceAllStars_July_2021\/ParamountRuPaulsDragRaceAllStars_July_2021.png&quot;,&quot;vaskdinehænder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;jagamethandhiramonnetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JagameThandhiramOnNetflix_2021\/JagameThandhiramOnNetflix_2021.png&quot;,&quot;pikirsebelumsebar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;touteslesfemmes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;hoochseries&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlus_TurnerandHooch_Dog_2021\/DisneyPlus_TurnerandHooch_Dog_2021.png&quot;,&quot;dubnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_DubNation\/NBA_2021_Teams_DubNation.png&quot;,&quot;spotifypodcasts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PodcastDiscoveryLATAM_2021\/PodcastDiscoveryLATAM_2021.png&quot;,&quot;gushybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021_add\/NetflixSweetTooth2021_add.png&quot;,&quot;đeokhẩutrang&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;releasethesnydercut&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnyderCut_LA_May_2021\/SnyderCut_LA_May_2021.png&quot;,&quot;픽사_알베르토&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;disneyplusturnerandhooch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlus_TurnerandHooch_Dog_2021\/DisneyPlus_TurnerandHooch_Dog_2021.png&quot;,&quot;يومالصليباألحمر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;dudukrumah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;ディーサイドトロイメライ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DCide_July_2021\/DCide_July_2021.png&quot;,&quot;takenote&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_TakeNote\/NBA_2021_Teams_TakeNote.png&quot;,&quot;انٹرنٹ_شٹ_ڈاؤنز&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;ispeakenserio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuardianTecate_July_2021\/GuardianTecate_July_2021.png&quot;,&quot;dionnewarwick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dionne_Warwick_2021_V2\/Dionne_Warwick_2021_V2.png&quot;,&quot;gizellebryant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_GizelleBryant\/Bravo_RHOP_Q3_2021_GizelleBryant.png&quot;,&quot;深淵覚醒&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/blacksurgenightJapanHidden_2021\/blacksurgenightJapanHidden_2021.png&quot;,&quot;beinfinite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Infinite_2021\/Paramount_Infinite_2021.png&quot;,&quot;färbdieweltorange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;nichtnocheine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;br6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RainbowSixProLeague_2021_BR6\/RainbowSixProLeague_2021_BR6.png&quot;,&quot;taste_of_love&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_TWICE_June_2021\/Kpop_VIT_TWICE_June_2021.png&quot;,&quot;포르토로소&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Portorosso_2021\/Disney_PixarLuca_Portorosso_2021.png&quot;,&quot;七夕&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2021StarFestivalTanabata\/2021StarFestivalTanabata.png&quot;,&quot;theflightattendantonhbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlightAttendant_LA_May_2021\/FlightAttendant_LA_May_2021.png&quot;,&quot;جيل_المساواة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;fboy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboy\/FBOYIsland_2021_fboy.png&quot;,&quot;cuidarteescuidarnos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;gokt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_KTWIN_v2\/LCK_2021_Team_P1_KTWIN_v2.png&quot;,&quot;outlawsnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_HOUSTON_v2\/OWL_Season4_Team_2021_HOUSTON_v2.png&quot;,&quot;legomastersfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_LEGOGoldenBrick_2021\/FOX_LEGOGoldenBrick_2021.png&quot;,&quot;dcu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_DCU\/MLS_2021_DCU.png&quot;,&quot;colorailmondodiarancione&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;goitz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/INTZ_June_2021\/INTZ_June_2021.png&quot;,&quot;shernitrailer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SherniOnPrime_2021\/SherniOnPrime_2021.png&quot;,&quot;thetomorrowwarmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021_add\/AmazonStudios_TomorrowWar_2021_add.png&quot;,&quot;١٦يوم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;twice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_TWICE_June_2021\/Kpop_VIT_TWICE_June_2021.png&quot;,&quot;女力覺醒&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;翻牆&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;internetkesilmesi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;loveandhiphop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VH1LHHAtlanta_2021\/VH1LHHAtlanta_2021.png&quot;,&quot;lapurgaporsiempre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LaPurgaPorSiempre_2021\/LaPurgaPorSiempre_2021.png&quot;,&quot;afl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021\/AFL_2021.png&quot;,&quot;hpediscover2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HPEDiscover2021\/HPEDiscover2021.png&quot;,&quot;lafamiliaimcf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_IMCF\/MLS_2021_IMCF.png&quot;,&quot;panelacheiasalva&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;feedthedream&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SobeysOlympic_2021\/SobeysOlympic_2021.png&quot;,&quot;lavatusmanos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;obeymebd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NTTSolmareObeyme_June_2021\/NTTSolmareObeyme_June_2021.png&quot;,&quot;поколениеравенства&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;msbuild&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MicrosoftBuild_2021\/MicrosoftBuild_2021.png&quot;,&quot;mifters&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneuPlus_MonstersatWork_Helmet_2021\/DisneuPlus_MonstersatWork_Helmet_2021.png&quot;,&quot;togetherroyal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_KC\/MLB_Teams_2021_KC.png&quot;,&quot;ditoph&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DITO_May_2021_ext\/DITO_May_2021_ext.png&quot;,&quot;トレクル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JP_ONEPIECE_trecru_2021\/JP_ONEPIECE_trecru_2021.png&quot;,&quot;generationgleichberechtigung&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;motherlandfortsalem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MotherlandFortSalem_2021\/MotherlandFortSalem_2021.png&quot;,&quot;evdesağlıklıkal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;boatxhardikpandya&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BOAT_IPL_2021_v2\/BOAT_IPL_2021_v2.png&quot;,&quot;thisisitzy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyxITZY_April_2021\/SpotifyxITZY_April_2021.png&quot;,&quot;buildtothemoon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BinanceTurns4_2021\/BinanceTurns4_2021.png&quot;,&quot;morenaluansantana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/morenaluansantana_June_2021\/morenaluansantana_June_2021.png&quot;,&quot;rngwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RNGWIN_May_2021\/RNGWIN_May_2021.png&quot;,&quot;mrinbetween&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MrInbetweenFX_May_2021\/MrInbetweenFX_May_2021.png&quot;,&quot;サマナーズウォー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Com2us_summonerswar_April_2021\/Com2us_summonerswar_April_2021.png&quot;,&quot;fortniteinvasion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FortniteSeason7_2021\/FortniteSeason7_2021.png&quot;,&quot;sf9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_SF9_June_2021\/Kpop_VIT_SF9_June_2021.png&quot;,&quot;คนรุ่นใหม่ที่เท่าเทียม&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;류진&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_RYUJIN\/KPOP_VIT_ITZY_April_2021_RYUJIN.png&quot;,&quot;vaksinasi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;ratedrookie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaniniAmericaQ2_21\/PaniniAmericaQ2_21.png&quot;,&quot;vidaspretasimportam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackLivesMatter_VidasNegrasImportam_add\/BlackLivesMatter_VidasNegrasImportam_add.png&quot;,&quot;nowruz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;siemprecercadeti&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KelloggsMasterBrandCercaDeTi_2021_V3\/KelloggsMasterBrandCercaDeTi_2021_V3.png&quot;,&quot;勤洗手&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;nonamenit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;lasparks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_LA\/WNBA_Teams_2021_LA.png&quot;,&quot;betheboss&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ladbrokes5ASide_May_2021\/Ladbrokes5ASide_May_2021.png&quot;,&quot;epcot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;timstwitterparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimsTwitterListeningParty_2021_2022\/TimsTwitterListeningParty_2021_2022.png&quot;,&quot;انٹرنیٹ_شٹ_ڈاؤنز&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;rickandmorty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RickandMorty2021\/RickandMorty2021.png&quot;,&quot;shopsmall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmexCanadaShopSmall_2021\/AmexCanadaShopSmall_2021.png&quot;,&quot;watchmework&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_2021Season_25thAnniversary_1\/WNBA_2021Season_25thAnniversary_1.png&quot;,&quot;lockdengobeefeater&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Beefeater_June_2021\/Beefeater_June_2021.png&quot;,&quot;snwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_SNWIN\/LPL_2021_SNWIN.png&quot;,&quot;lhhmia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VH1LHHAtlanta_2021\/VH1LHHAtlanta_2021.png&quot;,&quot;lck&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_League_2021\/LCK_League_2021.png&quot;,&quot;salvyperez&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-KC\/MLBHRDerby2021-KC.png&quot;,&quot;クラシックロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;dailyclimateshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DailyClimateShow_2021\/DailyClimateShow_2021.png&quot;,&quot;فكر_قبل_الضغط&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;thisismycrew&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MIL\/MLB_Teams_2021_MIL.png&quot;,&quot;larojaenas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiarioAs_2021_add\/DiarioAs_2021_add.png&quot;,&quot;mutualfundssahihai&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AMFIQ2IPL_2021_v2\/AMFIQ2IPL_2021_v2.png&quot;,&quot;ilnyaquevous&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;kvinnofrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;cricketsemftak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AMFIQ2IPL_2021_v2\/AMFIQ2IPL_2021_v2.png&quot;,&quot;観ようぜ日本代表戦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Akatsuki5_June_2021\/Akatsuki5_June_2021.png&quot;,&quot;heattwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_HEATTwitter\/NBA_2021_Teams_HEATTwitter.png&quot;,&quot;impracticaljokers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheImpracticalJokers_Julu_2021\/TheImpracticalJokers_Julu_2021.png&quot;,&quot;snakeeyeselorigen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnakeEyesMovie2021\/SnakeEyesMovie2021.png&quot;,&quot;adaaqua&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KebaikanAqua_April_2021\/KebaikanAqua_April_2021.png&quot;,&quot;sooultra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_TOR\/CDL_Team_2021_TOR.png&quot;,&quot;houseofthedragonhbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseoftheDragonHBO_2021\/HouseoftheDragonHBO_2021.png&quot;,&quot;youknowyouloveme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_XOXO\/HBOMaxGossipGirl_July_2021_XOXO.png&quot;,&quot;大切に使わせてもらう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YugiohYusei_May2021\/YugiohYusei_May2021.png&quot;,&quot;oguardiãovermelho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;godons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_godons\/AFL_2021_godons.png&quot;,&quot;トロメラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DCide_July_2021\/DCide_July_2021.png&quot;,&quot;generationjämställdhet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;civogliamovive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;wwenxt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WWE_Recurring_2020_WWENXT\/WWE_Recurring_2020_WWENXT.png&quot;,&quot;유나&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_YUNA\/KPOP_VIT_ITZY_April_2021_YUNA.png&quot;,&quot;flightattendant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlightAttendant_LA_May_2021\/FlightAttendant_LA_May_2021.png&quot;,&quot;sui&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_SUI\/Euro_UK_2021_SUI.png&quot;,&quot;sihatdirumah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;原神&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/miHoYo_genshin_0421\/miHoYo_genshin_0421.png&quot;,&quot;ルフィ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JP_ONEPIECE_trecru_2021\/JP_ONEPIECE_trecru_2021.png&quot;,&quot;thewhitelotushbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_TheWhiteLotus_2021\/HBO_TheWhiteLotus_2021.png&quot;,&quot;winnable&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_SF\/OWL_Season4_Team_Feb_2021_SF.png&quot;,&quot;natasharomanoff&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_BWNatasha_again_2021\/Disney_BlackWidow_BWNatasha_again_2021.png&quot;,&quot;elleriniyıka&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;橘起世界&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;lokiorgulhoso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;toduntaak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToofaanOnPrime_July_2021\/ToofaanOnPrime_July_2021.png&quot;,&quot;masketak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;acer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Acer_aspirevero_2021\/Acer_aspirevero_2021.png&quot;,&quot;geelongstrong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_GeelongStrong\/AFL_2021_GeelongStrong.png&quot;,&quot;بس_إنت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;lavesuasmãos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;gobro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_GOBRO\/LCK_2021_Team_P1_GOBRO.png&quot;,&quot;あの人と乾杯したい&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkCalpis02TanabataJapan2021\/AsahiSoftDrinkCalpis02TanabataJapan2021.png&quot;,&quot;svk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_SVK\/Euro_UK_2021_SVK.png&quot;,&quot;upwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_UPWIN\/LPL_2021_UPWIN.png&quot;,&quot;手を洗おう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;mytwitteranniversary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyTwitterAnniversary\/MyTwitterAnniversary.png&quot;,&quot;noponto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PontoFrio_Rebrand_2021\/PontoFrio_Rebrand_2021.png&quot;,&quot;man_on_the_moon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_NFlying_June_2021\/KPOP_NFlying_June_2021.png&quot;,&quot;itzy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021\/KPOP_VIT_ITZY_April_2021.png&quot;,&quot;guerreros2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Guerreros_MX_June_2021\/Guerreros_MX_June_2021.png&quot;,&quot;シーモンスター&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;karenhuger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_KarenHuger\/Bravo_RHOP_Q3_2021_KarenHuger.png&quot;,&quot;私を突き刺す棘ーsmartoon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Watatoge_June_2021\/Piccoma_Watatoge_June_2021.png&quot;,&quot;powercouple&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PowerCouple_BR_May_2021\/PowerCouple_BR_May_2021.png&quot;,&quot;رمضان_سليم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SaudiMOH_TaketheStep_2021\/SaudiMOH_TaketheStep_2021.png&quot;,&quot;semremorso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TomClancysWithoutRemorse_2021\/TomClancysWithoutRemorse_2021.png&quot;,&quot;إهداء_للتاريخ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/stcHistory2021\/stcHistory2021.png&quot;,&quot;renaulteways&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RenaulteWays_2_2021\/RenaulteWays_2_2021.png&quot;,&quot;ボスベイビー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BossBaby2_July_2021\/BossBaby2_July_2021.png&quot;,&quot;hunterb15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_HunterB15_2021\/Disney_LokiLaunch_HunterB15_2021.png&quot;,&quot;playasone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_MINN\/CDL_Team_2021_MINN.png&quot;,&quot;深淵&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/blacksurgenightJapanHidden_2021\/blacksurgenightJapanHidden_2021.png&quot;,&quot;영화_루카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;primedayshow2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeDayShow21_v2\/PrimeDayShow21_v2.png&quot;,&quot;iseeyouxoxo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Phone\/HBOMaxGossipGirl_July_2021_Phone.png&quot;,&quot;loki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;niunamenos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;diosdelengaño&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;tylortuskman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneuPlus_MonstersatWork_Helmet_2021\/DisneuPlus_MonstersatWork_Helmet_2021.png&quot;,&quot;presidenteloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;fortniteseason7&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FortniteSeason7_2021\/FortniteSeason7_2021.png&quot;,&quot;onhalayeunuoc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;animationdomination&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseBrokenFOX_May_2021\/HouseBrokenFOX_May_2021.png&quot;,&quot;greenwall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_GreenWall\/EsportsAllAccess_Jan_2021_GreenWall.png&quot;,&quot;ミライトワ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Olympic_Mascot_Emoji_EXT2\/Olympic_Mascot_Emoji_EXT2.png&quot;,&quot;ditotelecommunity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DITO_May_2021_ext\/DITO_May_2021_ext.png&quot;,&quot;daysviuoriginal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DAYSOnViu_2021\/DAYSOnViu_2021.png&quot;,&quot;nonunadipiù&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;generatievangelijkheid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;kerriwalshjennings&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Almonds_2021\/Almonds_2021.png&quot;,&quot;melina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Melina_2021\/Disney_BlackWidow_Melina_2021.png&quot;,&quot;2・5周年大決戦祭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Romasaga_25y_May_2021\/Romasaga_25y_May_2021.png&quot;,&quot;ezaf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_ATL\/CDL_Team_2021_ATL.png&quot;,&quot;br2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bebe_Rexha_2021\/Bebe_Rexha_2021.png&quot;,&quot;seaofred&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LionsRugbyTour_2021_Lion\/LionsRugbyTour_2021_Lion.png&quot;,&quot;femalearabic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;zombietiger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZombieTiger_UK_May_2021\/ZombieTiger_UK_May_2021.png&quot;,&quot;crypto4climate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CryptocomCimate_2021_v2\/CryptocomCimate_2021_v2.png&quot;,&quot;age4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxCardinal_2021\/XboxCardinal_2021.png&quot;,&quot;magicishere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;vivasnosqueremos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;neutralidaddelared&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Net_Emoji_Evergreen_SpanishAdd\/Net_Emoji_Evergreen_SpanishAdd.png&quot;,&quot;международныйденькрасногополумесяца&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;اغسل_يديك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;pds21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeDayShow21_v2\/PrimeDayShow21_v2.png&quot;,&quot;bettys2premiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BettyHBO_S2_2021\/BettyHBO_S2_2021.png&quot;,&quot;annepagbabalik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Foodpanda7thAnniversary_2021\/Foodpanda7thAnniversary_2021.png&quot;,&quot;sinremordimientos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TomClancysWithoutRemorse_2021\/TomClancysWithoutRemorse_2021.png&quot;,&quot;mlbtheshow21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBTheSho_2021\/MLBTheSho_2021.png&quot;,&quot;tomclancyswithoutremorse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TomClancysWithoutRemorse_2021\/TomClancysWithoutRemorse_2021.png&quot;,&quot;mnwild&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_mnwild\/NHL_2021_Teams_mnwild.png&quot;,&quot;glóriaeterna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_July_2021\/Libertadores_July_2021.png&quot;,&quot;세븐틴&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_SEVENTEEN_June_2021\/KpopVIT_SEVENTEEN_June_2021.png&quot;,&quot;cincoforgood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Corona_CincoForGood_2021\/Corona_CincoForGood_2021.png&quot;,&quot;gorickyourself&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RickandMorty2021_rick\/RickandMorty2021_rick.png&quot;,&quot;hbomaxhacks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hacks_HBOMax_April_2021_v3\/Hacks_HBOMax_April_2021_v3.png&quot;,&quot;letsgohunt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_CHENGDU\/OWL_Season4_Team_2021_CHENGDU.png&quot;,&quot;トロメラアニメ01&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DCide_July_2021\/DCide_July_2021.png&quot;,&quot;bigtricktrutv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BigTricktruTV_2021\/BigTricktruTV_2021.png&quot;,&quot;eurovisionagain&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EurovisionAgain_2021\/EurovisionAgain_2021.png&quot;,&quot;घरमेंरहेंस्वस्थरहें&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;venmoforbusiness&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Venmo_June_2021\/Venmo_June_2021.png&quot;,&quot;burningcrusade&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurningCrusadeClassic_2021\/BurningCrusadeClassic_2021.png&quot;,&quot;티어드롭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_SF9_June_2021\/Kpop_VIT_SF9_June_2021.png&quot;,&quot;goninjas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NiPGaming_Jan_2021\/NiPGaming_Jan_2021.png&quot;,&quot;jdxwales&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXWALES_2021\/JDXWALES_2021.png&quot;,&quot;insidethenba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffsonTNT_2021\/NBAPlayoffsonTNT_2021.png&quot;,&quot;wirsindfrauen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;우리는여자다&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;16วัน&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;olympictorchrelay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TokyoOlympic_2021_Part1\/TokyoOlympic_2021_Part1.png&quot;,&quot;cucitanganmu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;blgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_BLGWIN\/LPL_2021_BLGWIN.png&quot;,&quot;ウォーキング・デッドサバイバー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ElexTWDSJP_2021\/ElexTWDSJP_2021.png&quot;,&quot;summergamefest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/summergamefest_May_2021\/summergamefest_May_2021.png&quot;,&quot;welcometothewhitelotus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_TheWhiteLotus_2021\/HBO_TheWhiteLotus_2021.png&quot;,&quot;poweryourdrinks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;aut&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_AUT\/Euro_UK_2021_AUT.png&quot;,&quot;makeitmajor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MakeItMajor\/MLB_Teams_2021_MakeItMajor.png&quot;,&quot;respetonaman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;viúvanegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;savethehybrids&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021_add\/NetflixSweetTooth2021_add.png&quot;,&quot;اهداء_للتاريخ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/stcHistory2021\/stcHistory2021.png&quot;,&quot;maafassurances&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MAAF_70thBirthday_2021_2\/MAAF_70thBirthday_2021_2.png&quot;,&quot;fanzonespace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiarioAs_2021_add\/DiarioAs_2021_add.png&quot;,&quot;lokicoccodrillo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;liveevil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_EGWIN\/LCS_Jan_2021_EGWIN.png&quot;,&quot;sobrock&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/John_Mayer_2021_Album\/John_Mayer_2021_Album.png&quot;,&quot;newyorkforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_NewYorkForever\/NBA_2021_Teams_NewYorkForever.png&quot;,&quot;esteesmicrew&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_MIL\/MLB_Teams_2021_MIL.png&quot;,&quot;híbridocerdo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Pig\/Netflix_SweetTooth_Pig.png&quot;,&quot;hpediscover&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HPEDiscover2021\/HPEDiscover2021.png&quot;,&quot;btsarmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021_BTSARMY\/KpopVIT_BTS_June2021_BTSARMY.png&quot;,&quot;aflfinals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021\/AFL_2021.png&quot;,&quot;ミスミニッツ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;tsmwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_TSMWIN\/LCS_Jan_2021_TSMWIN.png&quot;,&quot;november19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TSRed2021\/TSRed2021.png&quot;,&quot;ディズニーピクサー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;kaotica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Coldplay_May_2021\/Coldplay_May_2021.png&quot;,&quot;sochkesharekaro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;lco&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCO_2021\/LCO_2021.png&quot;,&quot;mrinbetweenfx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MrInbetweenFX_May_2021\/MrInbetweenFX_May_2021.png&quot;,&quot;brasilcontraafome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;xoxopremiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Kiss\/HBOMaxGossipGirl_July_2021_Kiss.png&quot;,&quot;aquietplace2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;nyr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_NYR\/NHL_2021_Teams_NYR.png&quot;,&quot;njomza&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Njomza_Album_Emoji_2021\/Njomza_Album_Emoji_2021.png&quot;,&quot;mnightnewtrip&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;nonunadimeno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;echoke&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Davido10YearAnniversary_2021_2\/Davido10YearAnniversary_2021_2.png&quot;,&quot;yosoycobra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Guerreros_MX_June_2021_YoSoyCobra\/Guerreros_MX_June_2021_YoSoyCobra.png&quot;,&quot;sotinysomany&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JackintheBoxTinyTacos_2021\/JackintheBoxTinyTacos_2021.png&quot;,&quot;ontherise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_BostonUp\/OWL_Season4_Team_Feb_2021_BostonUp.png&quot;,&quot;dtid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_FCDal\/MLS_2021_FCDal.png&quot;,&quot;lavozargentina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LaVozArgentina_2021\/LaVozArgentina_2021.png&quot;,&quot;우리가바로15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;파이널기어&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FinalgearKR2021KR\/FinalgearKR2021KR.png&quot;,&quot;navination&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaVi_Esports_2021_v2\/NaVi_Esports_2021_v2.png&quot;,&quot;askkpoptwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopTwitter_2021_Red\/KpopTwitter_2021_Red.png&quot;,&quot;bornthisway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;askwolfalice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WolfAlice_2021\/WolfAlice_2021.png&quot;,&quot;jackstinytacos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JackintheBoxTinyTacos_2021\/JackintheBoxTinyTacos_2021.png&quot;,&quot;spacejamthemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;buildanempire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_DAL\/CDL_Team_2021_DAL.png&quot;,&quot;pantherpride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_pantherpride\/NRL_2021_pantherpride.png&quot;,&quot;losdodgers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_LosDodgers_2021\/MLB_LosDodgers_2021.png&quot;,&quot;टीकालगादेना&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;hinterdemmac&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FutureDays_Emoji_72px_72px\/FutureDays_Emoji_72px_72px.png&quot;,&quot;wanitabangkit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;キズナアイコラボ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bytedance_ako_figurestory_June_2021\/Bytedance_ako_figurestory_June_2021.png&quot;,&quot;weeklyclimateshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DailyClimateShow_2021_add\/DailyClimateShow_2021_add.png&quot;,&quot;အင်တာနက်ဆက်ဖွင့်ထား&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;lfghbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LFGDocumentary_2021\/HBOMax_LFGDocumentary_2021.png&quot;,&quot;orangezlemonde&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;phòngdịch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;theinsidestory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffsonTNT_2021\/NBAPlayoffsonTNT_2021.png&quot;,&quot;kamiber15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;ourwayunscripted&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_IND_add\/WNBA_Teams_2021_IND_add.png&quot;,&quot;lightsout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_LAG_v2\/CDL_Team_2021_LAG_v2.png&quot;,&quot;pratodascomunidades&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;eliminaçãopowercouple&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PowerCouple_BR_May_2021\/PowerCouple_BR_May_2021.png&quot;,&quot;weflyasone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_WeFlyAsOne\/AFL_2021_WeFlyAsOne.png&quot;,&quot;façaparte&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MasterButterfly_BR_2021\/MasterButterfly_BR_2021.png&quot;,&quot;dogsofwar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_DogsOfWar\/NRL_2021_DogsOfWar.png&quot;,&quot;onebypoise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Poise_May_2021\/Poise_May_2021.png&quot;,&quot;인터넷셧다운&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;díamundialmedialunaroja&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;corasjourney&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_UndergroundRailroad_2021\/Amazon_UndergroundRailroad_2021.png&quot;,&quot;supportjournalism&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WaPo_WorldPressFreedom_2021\/WaPo_WorldPressFreedom_2021.png&quot;,&quot;bachelorette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;doritosfreedom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DoritosFreedom_2021\/DoritosFreedom_2021.png&quot;,&quot;fpxwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_FPXWIN\/LPL_2021_FPXWIN.png&quot;,&quot;lionsden&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnglandEuros_May_2021\/EnglandEuros_May_2021.png&quot;,&quot;itsonlyamatteroftime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;solotú&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;sportingkc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_KC\/MLS_2021_KC.png&quot;,&quot;alwaysfnatic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_FNCWIN\/LEC_EM_2021_FNCWIN.png&quot;,&quot;cucitangananda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;görvärldenorange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;lildrums&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DrumstickCone2021\/DrumstickCone2021.png&quot;,&quot;foodpanda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Foodpanda7thAnniversary_2021\/Foodpanda7thAnniversary_2021.png&quot;,&quot;itsbetterwithheinz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KraftHeinz_CrowdSauce_SG_2021\/KraftHeinz_CrowdSauce_SG_2021.png&quot;,&quot;spacejamcandycrush&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021_add\/SpaceJam_2021_add.png&quot;,&quot;eggomothersnight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eggo_May_2021_2\/Eggo_May_2021_2.png&quot;,&quot;トロメラアニメ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DCide_July_2021\/DCide_July_2021.png&quot;,&quot;buildlikeamaster&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEGOGoldenBrick_2021\/LEGOGoldenBrick_2021.png&quot;,&quot;shinbonerspirit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_ShinbonerSpirit\/AFL_2021_ShinbonerSpirit.png&quot;,&quot;skywardsword&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NintendoZeldaSkywardSword_2021\/NintendoZeldaSkywardSword_2021.png&quot;,&quot;netflixdadstopembarrassingme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DadStopEmbarrassingMeNetflix_2021\/DadStopEmbarrassingMeNetflix_2021.png&quot;,&quot;サマナ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Com2us_summonerswar_April_2021\/Com2us_summonerswar_April_2021.png&quot;,&quot;siamodonne&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;happiestplace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;austinfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_AFC\/MLS_2021_AFC.png&quot;,&quot;defendthethrone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_DAL\/CDL_Team_2021_DAL.png&quot;,&quot;슈니언&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McD_KR_July_2021\/McD_KR_July_2021.png&quot;,&quot;snohaalegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnohAalegra_2021\/SnohAalegra_2021.png&quot;,&quot;elmachipsmefazumpix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ElmaChipsMeFazUmPix_2021\/ElmaChipsMeFazUmPix_2021.png&quot;,&quot;أفكار_الترفيه&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GEA_June_2021\/GEA_June_2021.png&quot;,&quot;мы15процентов&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;kickofflive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/summergamefest_May_2021\/summergamefest_May_2021.png&quot;,&quot;ใส่หน้ากากอนามัย&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;themitchellsvsthemachines&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;cleanitscrunchitcoopit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CooperativeEnvironment_July_2021\/CooperativeEnvironment_July_2021.png&quot;,&quot;njdevils&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_NJDevils\/NHL_2021_Teams_NJDevils.png&quot;,&quot;アレクセイ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;pinteomundodelaranja&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;siestakey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_April_2021\/MTV_April_2021.png&quot;,&quot;dadstopembarrassingme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DadStopEmbarrassingMeNetflix_2021\/DadStopEmbarrassingMeNetflix_2021.png&quot;,&quot;upthebaggers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_UpTheBaggers\/AFL_2021_UpTheBaggers.png&quot;,&quot;afwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_PL_AF\/LcK_2021_Teams_PL_AF.png&quot;,&quot;聖獣麒麟&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINChallengeCupJapan2021\/KIRINChallengeCupJapan2021.png&quot;,&quot;btt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JustinSuntron_2021_ext\/JustinSuntron_2021_ext.png&quot;,&quot;venmo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Venmo_June_2021\/Venmo_June_2021.png&quot;,&quot;niunpasoenfalso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NoSuddenMove_July_2021\/NoSuddenMove_July_2021.png&quot;,&quot;gunakanmask&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;americannightmare5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;foreverfreo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_foreverfreo\/AFL_2021_foreverfreo.png&quot;,&quot;adultswim&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RickandMorty2021_adultswim\/RickandMorty2021_adultswim.png&quot;,&quot;whitelotus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_TheWhiteLotus_2021\/HBO_TheWhiteLotus_2021.png&quot;,&quot;afterthefinalrose&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;レッドガーディアン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;itzy_guesswho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021\/KPOP_VIT_ITZY_April_2021.png&quot;,&quot;huomisensota&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;redcrescent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;netneutrality&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Net_Emoji_Evergreen\/Net_Emoji_Evergreen.png&quot;,&quot;primedayshow21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeDayShow21_v2\/PrimeDayShow21_v2.png&quot;,&quot;sansaucunremords&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TomClancysWithoutRemorse_2021\/TomClancysWithoutRemorse_2021.png&quot;,&quot;asianamericanpacificislanderheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;koollaweyh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MatKool_2021\/MatKool_2021.png&quot;,&quot;climatepledgesignatory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_ClimatePledge_2021\/Amazon_ClimatePledge_2021.png&quot;,&quot;leaveitallonthefloor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Legendary_S2_HBOMax_2021\/Legendary_S2_HBOMax_2021.png&quot;,&quot;ace&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopACE_June_2021\/KpopACE_June_2021.png&quot;,&quot;ຢູ່ເຮືອນເດີ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;gomad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_MADWIN\/LEC_EM_2021_MADWIN.png&quot;,&quot;เปลี่ยนโลกเป็นสีส้ม&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;utorrent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JustinSuntron_2021_ext\/JustinSuntron_2021_ext.png&quot;,&quot;点亮橙色&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;fastandfurious&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;twitterflightschool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterFlightSchool_2021_22\/TwitterFlightSchool_2021_22.png&quot;,&quot;lucalefilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;eways&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RenaulteWays_2_2021\/RenaulteWays_2_2021.png&quot;,&quot;secretdelacaramilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CaramilkSecret_May_2021\/CaramilkSecret_May_2021.png&quot;,&quot;kcgt2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YugiohYusei_May2021\/YugiohYusei_May2021.png&quot;,&quot;loona&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_LOONA_June_2021\/KpopVIT_LOONA_June_2021.png&quot;,&quot;dionneontour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dionne_Warwick_2021_V2\/Dionne_Warwick_2021_V2.png&quot;,&quot;teamcryptocom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CryptocomCimate_2021_v2\/CryptocomCimate_2021_v2.png&quot;,&quot;guardiánrojo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;withoutremorse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TomClancysWithoutRemorse_2021\/TomClancysWithoutRemorse_2021.png&quot;,&quot;seattlesurge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_SEA\/CDL_Team_2021_SEA.png&quot;,&quot;armcherry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArmchairExpert_2021\/ArmchairExpert_2021.png&quot;,&quot;nevershbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/thenevershbo_2021_May_v2\/thenevershbo_2021_May_v2.png&quot;,&quot;ಕೋವಿಡ್ಇಂಡಿಯಾಸಹಾಯ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;ヴァルコネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ateam_valkyrie_connect_0601_2021\/Ateam_valkyrie_connect_0601_2021.png&quot;,&quot;theboldtypetv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBoldTypeTV_May_2021\/TheBoldTypeTV_May_2021.png&quot;,&quot;deokhautrang&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;vivetaville&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BPIBigTour_2021\/BPIBigTour_2021.png&quot;,&quot;eng&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_ENG\/Euro_UK_2021_ENG.png&quot;,&quot;enjoytherivalry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Heineken_starofthematch_May_2021\/Heineken_starofthematch_May_2021.png&quot;,&quot;ownthecrown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_NY1\/WNBA_Teams_2021_NY1.png&quot;,&quot;agoraéponto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PontoFrio_Rebrand_2021\/PontoFrio_Rebrand_2021.png&quot;,&quot;porlah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_HOU\/MLB_Teams_2021_HOU.png&quot;,&quot;iem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IEM_2021\/IEM_2021.png&quot;,&quot;мелина&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Yelena_2021\/Disney_BlackWidow_Yelena_2021.png&quot;,&quot;قطاع_الترفيه&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GEA_June_2021\/GEA_June_2021.png&quot;,&quot;thecube&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BeatTheCube_2021\/BeatTheCube_2021.png&quot;,&quot;альберто&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;playnewworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewWorldLaunch_2021\/NewWorldLaunch_2021.png&quot;,&quot;청춘리드&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;dewxnba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewNBA_June_2021\/MountainDewNBA_June_2021.png&quot;,&quot;នៅផ្ទះ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;calldelterror1978&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy1978_2021\/Netflix_FearStreetTrilogy1978_2021.png&quot;,&quot;guardiãovermelho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;seattlestorm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_SEA\/WNBA_Teams_2021_SEA.png&quot;,&quot;reptar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rugrats_May_2021\/Paramount_Rugrats_May_2021.png&quot;,&quot;สวมหน้ากาก&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;starwarslaremesamala&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;คิดก่อนคลิก&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;capitalonesthematch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TurnerTheMatchQ22021\/TurnerTheMatchQ22021.png&quot;,&quot;canfessional&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Poise_May_2021\/Poise_May_2021.png&quot;,&quot;geekedweek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/geekedweeknetflix_2021\/geekedweeknetflix_2021.png&quot;,&quot;homeishere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HomeIsHere_2021\/HomeIsHere_2021.png&quot;,&quot;perempuanberbangga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;sacramentoproud&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_SacramentoProud\/NBA_2021_Teams_SacramentoProud.png&quot;,&quot;若者が主役&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;thunderup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_ThunderUp\/NBA_2021_Teams_ThunderUp.png&quot;,&quot;nysl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_NYS\/CDL_Team_2021_NYS.png&quot;,&quot;lokiniño&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_KidlLoki_2021\/Disney_LokiLaunch_KidlLoki_2021.png&quot;,&quot;最新作&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;spanishdoors&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LizPhair_2021\/LizPhair_2021.png&quot;,&quot;brighterdaysarehere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StarbucksCanadaSummer2021\/StarbucksCanadaSummer2021.png&quot;,&quot;nbatwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBATwitter_2018_RefreshEmoji\/NBATwitter_2018_RefreshEmoji.png&quot;,&quot;whywomenkill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountWhyWomenKill_2021\/ParamountWhyWomenKill_2021.png&quot;,&quot;sistasonbet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SistasOnBET_2021\/SistasOnBET_2021.png&quot;,&quot;sourpatchmystery&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SourPatchMystery_May_2021\/SourPatchMystery_May_2021.png&quot;,&quot;somosfcd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_FCDal\/MLS_2021_FCDal.png&quot;,&quot;stopkvindedrab&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020_add\/StopViolenceAgainstWomen_2020_add.png&quot;,&quot;temgentecomfome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/COVIDRelief_2021_Brazil\/COVIDRelief_2021_Brazil.png&quot;,&quot;мелинавостокофф&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Melina_2021\/Disney_BlackWidow_Melina_2021.png&quot;,&quot;withwebull&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeBull_May_2021_v2\/WeBull_May_2021_v2.png&quot;,&quot;aewdark&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/aewontnt_May_2021_add\/aewontnt_May_2021_add.png&quot;,&quot;thisisday6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyxITZY_April_2021\/SpotifyxITZY_April_2021.png&quot;,&quot;زكاتك_تصلهم_بزكاتي&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zakaty_May_2021\/Zakaty_May_2021.png&quot;,&quot;알렉세이쇼스타코프&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;roarwithsherni&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SherniOnPrime_2021\/SherniOnPrime_2021.png&quot;,&quot;wearamask&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;seventeen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_SEVENTEEN_June_2021\/KpopVIT_SEVENTEEN_June_2021.png&quot;,&quot;piensaantesdedarclick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;زكاتي&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zakaty_May_2021\/Zakaty_May_2021.png&quot;,&quot;matkool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MatKool_2021\/MatKool_2021.png&quot;,&quot;keepiton&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;애니_루카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;16दिन&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;youwantataste&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Kiss\/HBOMaxGossipGirl_July_2021_Kiss.png&quot;,&quot;bobbyhybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Gopher\/Netflix_SweetTooth_Gopher.png&quot;,&quot;poptarts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PopTarts_June_2021\/PopTarts_June_2021.png&quot;,&quot;fast92020&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;cheetosarraiá&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CheetosBrasil_June_2021\/CheetosBrasil_June_2021.png&quot;,&quot;알베르토&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;mettezunmasque&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;sundthjem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;مسرحيات_العيد&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldTheatreDay_2021_AE_2\/WorldTheatreDay_2021_AE_2.png&quot;,&quot;intothewaves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackDesert2021Summer\/BlackDesert2021Summer.png&quot;,&quot;楽天カード&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenCard_May_2021_Flight3\/RakutenCard_May_2021_Flight3.png&quot;,&quot;armchairexpertpod&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArmchairExpert_2021\/ArmchairExpert_2021.png&quot;,&quot;bancoagrícola&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BancolombiaNewHeart_April_2021\/BancolombiaNewHeart_April_2021.png&quot;,&quot;g2win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_G2WIN\/LEC_EM_2021_G2WIN.png&quot;,&quot;silenciobruno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;weareportadelaide&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_weareportadelaide\/AFL_2021_weareportadelaide.png&quot;,&quot;seafoamszn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_NY2\/WNBA_Teams_2021_NY2.png&quot;,&quot;posevirtualball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021\/FX_Pose_April_2021.png&quot;,&quot;tigernation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Seoul\/OWL_Season4_Team_Feb_2021_Seoul.png&quot;,&quot;seizart&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkaSummerCampaign_2021\/MilkaSummerCampaign_2021.png&quot;,&quot;tvättadinahänder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;juntossípodemos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HHS_WeCanDoThis_2021_add\/HHS_WeCanDoThis_2021_add.png&quot;,&quot;minidrums&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DrumstickCone2021\/DrumstickCone2021.png&quot;,&quot;백신접종완료&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;flightattendantonmax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlightAttendant_LA_May_2021\/FlightAttendant_LA_May_2021.png&quot;,&quot;snydercut&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnyderCut_LA_May_2021\/SnyderCut_LA_May_2021.png&quot;,&quot;newworldmmo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewWorldLaunch_2021\/NewWorldLaunch_2021.png&quot;,&quot;rus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_RUS\/Euro_UK_2021_RUS.png&quot;,&quot;itsmellsbadinhere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Turkey\/HBOMax_Friends_Turkey.png&quot;,&quot;mnight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;seouldynasty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Seoul\/OWL_Season4_Team_Feb_2021_Seoul.png&quot;,&quot;世界红十字日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;vijanawaongoza&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;론칭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FinalgearKR2021KR\/FinalgearKR2021KR.png&quot;,&quot;اتحدث_بالمؤنث&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;yosoyleon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Guerreros_MX_June_2021_YoSoyLeon\/Guerreros_MX_June_2021_YoSoyLeon.png&quot;,&quot;whodoyoucollect&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaniniAmericaQ2_21\/PaniniAmericaQ2_21.png&quot;,&quot;saveahybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021_add\/NetflixSweetTooth2021_add.png&quot;,&quot;ロマサガrs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Romasaga_25y_May_2021\/Romasaga_25y_May_2021.png&quot;,&quot;takewarning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLCarolinaPlayoffs2021\/NHLCarolinaPlayoffs2021.png&quot;,&quot;gopurple&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ALZ_2021\/ALZ_2021.png&quot;,&quot;nerevs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NER\/MLS_2021_NER.png&quot;,&quot;justiceforhan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;todasycadauna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;babaekami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;footballcan2041&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BSANTANDER_Footballcan2041_2021\/BSANTANDER_Footballcan2041_2021.png&quot;,&quot;puckerupnyc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Kiss\/HBOMaxGossipGirl_July_2021_Kiss.png&quot;,&quot;disneyparks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;चुप्पीतोड़ो&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;naistenoikeudet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;sistasseason3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SistasOnBET_2021\/SistasOnBET_2021.png&quot;,&quot;caramilksecret&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CaramilkSecret_May_2021\/CaramilkSecret_May_2021.png&quot;,&quot;ouractionsmatter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020_add\/OrangeTheWorld_2020_add.png&quot;,&quot;theletout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Legendary_S2_HBOMax_2021\/Legendary_S2_HBOMax_2021.png&quot;,&quot;onyendunkendindinaetoeto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;got_army_behind_us&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021_BTSARMY\/KpopVIT_BTS_June2021_BTSARMY.png&quot;,&quot;nosqueremosvivas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;闇を行け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/blacksurgenightJapanHidden_2021\/blacksurgenightJapanHidden_2021.png&quot;,&quot;philaunite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_PhilaUnite_add\/NBA_2021_Teams_PhilaUnite_add.png&quot;,&quot;summerforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StarbucksCanadaSummer2021\/StarbucksCanadaSummer2021.png&quot;,&quot;chốngbạohành&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;generazioneuguaglianza&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;standwithus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLNashvillePlayoffs2021_2\/NHLNashvillePlayoffs2021_2.png&quot;,&quot;hitcfest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/88RISING_May_2021\/88RISING_May_2021.png&quot;,&quot;disneyplusmalaysia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlusHotstarMalaysia_2021\/DisneyPlusHotstarMalaysia_2021.png&quot;,&quot;eyesontheprize&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_RuntheWorld_2021\/STARZ_RuntheWorld_2021.png&quot;,&quot;playdayone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxGamePass_2021\/XboxGamePass_2021.png&quot;,&quot;ミリしらニーアレプリカント&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReplicant_April_2021_V2\/NieRReplicant_April_2021_V2.png&quot;,&quot;erstdenkendannklicken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;ブラックウィドウ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;魔法覚醒&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HarryPotterNetease_Q2_2021\/HarryPotterNetease_Q2_2021.png&quot;,&quot;whoareyouridingwith&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BettyHBO_S2_2021\/BettyHBO_S2_2021.png&quot;,&quot;handleitall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Poise_May_2021\/Poise_May_2021.png&quot;,&quot;ikahelangmundo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;talktomenice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BeatTheCube_2021\/BeatTheCube_2021.png&quot;,&quot;先想再點擊&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;twitterforgood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;fearstreet1978&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy1978_2021\/Netflix_FearStreetTrilogy1978_2021.png&quot;,&quot;successanywhere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SFWT_successanywhere_2021\/SFWT_successanywhere_2021.png&quot;,&quot;bitcointurkiye&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/btcturk_May_2021\/btcturk_May_2021.png&quot;,&quot;lrr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_LON\/CDL_Team_2021_LON.png&quot;,&quot;dkwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_DK\/LcK_2021_Teams_DK.png&quot;,&quot;loswhitesox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CHW\/MLB_Teams_2021_CHW.png&quot;,&quot;इंटरनेटबंदी&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;watchuswingit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WatchUsWingIt_TwitterParents_2020\/WatchUsWingIt_TwitterParents_2020.png&quot;,&quot;lafc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_LAFC\/MLS_2021_LAFC.png&quot;,&quot;lovetohearit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveToSeeIt_2021\/LoveToSeeIt_2021.png&quot;,&quot;bloccointernet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;ラグオリ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RagnarokOrigin_June_2021\/RagnarokOrigin_June_2021.png&quot;,&quot;starofthematch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Heineken_starofthematch_May_2021\/Heineken_starofthematch_May_2021.png&quot;,&quot;lyriq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cadillac_LYRIQ_Phase1_April_2021\/Cadillac_LYRIQ_Phase1_April_2021.png&quot;,&quot;مستحقوها_أقرب_مما_تتصور&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zakaty_May_2021\/Zakaty_May_2021.png&quot;,&quot;레드가디언&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;夏はカルピスで乾杯&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkCalpis02TanabataJapan2021\/AsahiSoftDrinkCalpis02TanabataJapan2021.png&quot;,&quot;loona_and_orbit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_LOONA_June_2021\/KpopVIT_LOONA_June_2021.png&quot;,&quot;bigtimeinbigsky&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TurnerTheMatchQ22021\/TurnerTheMatchQ22021.png&quot;,&quot;disneywish&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_DisneyCruise_2021\/DisneyParks_DisneyCruise_2021.png&quot;,&quot;ヴァルキリーコネクト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ateam_valkyrie_connect_0601_2021\/Ateam_valkyrie_connect_0601_2021.png&quot;,&quot;ryujin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_RYUJIN\/KPOP_VIT_ITZY_April_2021_RYUJIN.png&quot;,&quot;blastpremier&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BLASTPremier_Jan_2021\/BLASTPremier_Jan_2021.png&quot;,&quot;rsl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_RSL\/MLS_2021_RSL.png&quot;,&quot;thenevers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/thenevershbo_2021_May_v2\/thenevershbo_2021_May_v2.png&quot;,&quot;netflixgeekedweek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/geekedweeknetflix_2021\/geekedweeknetflix_2021.png&quot;,&quot;黙れブルーノ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;oldlefilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;lovetobeit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveToSeeIt_2021\/LoveToSeeIt_2021.png&quot;,&quot;legendarymax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Legendary_S2_HBOMax_2021\/Legendary_S2_HBOMax_2021.png&quot;,&quot;mffl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_MFFL\/NBA_2021_Teams_MFFL.png&quot;,&quot;ヒロトラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/heroaca_ui_JP_2021\/heroaca_ui_JP_2021.png&quot;,&quot;opticchitown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_CHI\/CDL_Team_2021_CHI.png&quot;,&quot;無限殺戮日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;tipsyforcinco&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JoseCuervo_TipsyForCinco_2021\/JoseCuervo_TipsyForCinco_2021.png&quot;,&quot;ngs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PSO2NGS_JP_2021\/PSO2NGS_JP_2021.png&quot;,&quot;rokkr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_MINN\/CDL_Team_2021_MINN.png&quot;,&quot;detroitroots&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_DET\/MLB_Teams_2021_DET.png&quot;,&quot;メリーナ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Melina_2021\/Disney_BlackWidow_Melina_2021.png&quot;,&quot;maafpro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MAAF_70thBirthday_2021_2\/MAAF_70thBirthday_2021_2.png&quot;,&quot;funnelcakefrappuccino&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StarbucksCanadaSummer2021\/StarbucksCanadaSummer2021.png&quot;,&quot;dewchasethecrown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewNBA_June_2021\/MountainDewNBA_June_2021.png&quot;,&quot;youjuststartedabook&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouJustStartedABook_May_2021_v2\/YouJustStartedABook_May_2021_v2.png&quot;,&quot;isles&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_Isles\/NHL_2021_Teams_Isles.png&quot;,&quot;gamedayhappens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaddenNFL22\/MaddenNFL22.png&quot;,&quot;thotyssey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZolaMovie_2021\/ZolaMovie_2021.png&quot;,&quot;красныйстраж&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;nosgestescomptent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;نحن_نساء&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;bidibidibombom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SelenaNetflix_2021\/SelenaNetflix_2021.png&quot;,&quot;internetblockade&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;cuentaatrásloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;viejospelicula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;കോവിഡ്19ഇന്ത്യസഹായം&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;gengwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_GenG\/LcK_2021_Teams_GenG.png&quot;,&quot;アークナイツ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Yostar_ArknightsStaff_April_2021\/Yostar_ArknightsStaff_April_2021.png&quot;,&quot;shadowandbone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_ShadowandBone_April_2021\/Netflix_ShadowandBone_April_2021.png&quot;,&quot;hitmanswife&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_SamSalma_\/HitmansWifesBodyguard_2021_SamSalma_.png&quot;,&quot;usaeltapabocas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;noceiling&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_CHI\/WNBA_Teams_2021_CHI.png&quot;,&quot;ドラゴンボールレジェンズ3周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyDBLegends_May_2021\/MyDBLegends_May_2021.png&quot;,&quot;ponto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PontoFrio_Rebrand_2021\/PontoFrio_Rebrand_2021.png&quot;,&quot;covidindiasos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;xboxminifridge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;wasjehanden&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;hofpolog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Polo_G_Album_2021\/Polo_G_Album_2021.png&quot;,&quot;キリンチャレンジカップ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINChallengeCupJapan2021\/KIRINChallengeCupJapan2021.png&quot;,&quot;pixaralbertosg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;sgf2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/summergamefest_May_2021\/summergamefest_May_2021.png&quot;,&quot;opoderosochefinho2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BossBaby2_July_2021\/BossBaby2_July_2021.png&quot;,&quot;californiaalmonds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Almonds_2021\/Almonds_2021.png&quot;,&quot;lavalemani&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;myxawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MYXAwards2021\/MYXAwards2021.png&quot;,&quot;رحلة_ابداعية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GEA_June_2021\/GEA_June_2021.png&quot;,&quot;कोविड१९भारतसहाय&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;todaslasmujeres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;むむっ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenCard_May_2021_Flight3\/RakutenCard_May_2021_Flight3.png&quot;,&quot;fearlesstaylorsversion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TSFearless2021\/TSFearless2021.png&quot;,&quot;nnevvy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;masketragen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;mountaindewrise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewRise_April_2021\/MountainDewRise_April_2021.png&quot;,&quot;24時間短冊&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2021StarFestivalTanabata\/2021StarFestivalTanabata.png&quot;,&quot;一緒に宴をするなら&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JP_ONEPIECE_trecru_2021\/JP_ONEPIECE_trecru_2021.png&quot;,&quot;stopaapihate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StandForAsians_2021\/StandForAsians_2021.png&quot;,&quot;matkoolmatkoolkawanku&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MatKool_2021\/MatKool_2021.png&quot;,&quot;paralympics&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paralympics_2021\/Paralympics_2021.png&quot;,&quot;tronnetwork&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRON_Coin_Feb_2021_ext\/TRON_Coin_Feb_2021_ext.png&quot;,&quot;findnewroutes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/USPSSpring2021\/USPSSpring2021.png&quot;,&quot;trailheadx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SalesforceTrailhead2021\/SalesforceTrailhead2021.png&quot;,&quot;matkoolmatkool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MatKool_2021\/MatKool_2021.png&quot;,&quot;lhhatl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VH1LHHAtlanta_2021\/VH1LHHAtlanta_2021.png&quot;,&quot;디즈니픽사_루카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;io2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleIO2021\/GoogleIO2021.png&quot;,&quot;cruelsummer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Freeform_CruelSummer_2021\/Freeform_CruelSummer_2021.png&quot;,&quot;เราคือ15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;letsgoliquid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_TLWIN\/LCS_Jan_2021_TLWIN.png&quot;,&quot;siestakeymtv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_April_2021\/MTV_April_2021.png&quot;,&quot;pikirsebelumklik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;シェアする前に考えよう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;personajeskelloggs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KelloggsMasterBrandCercaDeTi_2021_V3\/KelloggsMasterBrandCercaDeTi_2021_V3.png&quot;,&quot;híbridobúho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Owl\/Netflix_SweetTooth_Owl.png&quot;,&quot;ditonakami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DITO_May_2021_ext\/DITO_May_2021_ext.png&quot;,&quot;armchairexpertpodcast&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArmchairExpert_2021\/ArmchairExpert_2021.png&quot;,&quot;마블스튜디오블랙위도우&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;apartment20&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Frame\/HBOMax_Friends_Frame.png&quot;,&quot;holdmymilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkPEP_May_2021\/MilkPEP_May_2021.png&quot;,&quot;fccincy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_FCCin\/MLS_2021_FCCin.png&quot;,&quot;olemmenaisia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;taylorswift&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TSRed2021\/TSRed2021.png&quot;,&quot;କୋଭିଡ୧୯ଭାରତସେବା&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;dracarys&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseoftheDragonHBO_2021\/HouseoftheDragonHBO_2021.png&quot;,&quot;burnblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Dallas\/OWL_Season4_Team_Feb_2021_Dallas.png&quot;,&quot;sansunbruit2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;트와이스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_TWICE_June_2021\/Kpop_VIT_TWICE_June_2021.png&quot;,&quot;whitespike&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeVideoIndiaTomorrowWar_2021\/PrimeVideoIndiaTomorrowWar_2021.png&quot;,&quot;findyourstar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/enstars_music6yearsanniversary_2021\/enstars_music6yearsanniversary_2021.png&quot;,&quot;protectblacktranswomen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackTransLivesMatter_2020\/BlackTransLivesMatter_2020.png&quot;,&quot;redbull3x&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedBull_GIVESYOUWINGS_2021_V2\/RedBull_GIVESYOUWINGS_2021_V2.png&quot;,&quot;kebaikanaqua&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KebaikanAqua_April_2021\/KebaikanAqua_April_2021.png&quot;,&quot;egready&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_EGWIN\/LCS_Jan_2021_EGWIN.png&quot;,&quot;thehobby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaniniAmericaQ2_21\/PaniniAmericaQ2_21.png&quot;,&quot;幻影戦争&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WOTV_JP_2021_April\/WOTV_JP_2021_April.png&quot;,&quot;henerasyongpantaypantay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;うちのカルピスつくろう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkCalpis02TanabataJapan2021\/AsahiSoftDrinkCalpis02TanabataJapan2021.png&quot;,&quot;viudanegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;aflgf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021\/AFL_2021.png&quot;,&quot;بوابة_الترفيه&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GEA_June_2021\/GEA_June_2021.png&quot;,&quot;कोविड१९भारतसेवा&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;btlm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackTransLivesMatter_2020\/BlackTransLivesMatter_2020.png&quot;,&quot;riseandgrind&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_OAK\/MLB_Teams_2021_OAK.png&quot;,&quot;r6latam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RainbowSixProLeague_2021_R6LATAM\/RainbowSixProLeague_2021_R6LATAM.png&quot;,&quot;vacinado&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;pintaelmundodenaranja&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;obois10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Davido10YearAnniversary_2021_1\/Davido10YearAnniversary_2021_1.png&quot;,&quot;aewdynamite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/aewontnt_May_2021\/aewontnt_May_2021.png&quot;,&quot;everyonen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NSC\/MLS_2021_NSC.png&quot;,&quot;alinastarkovwonder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_ShadowandBone_April_2021\/Netflix_ShadowandBone_April_2021.png&quot;,&quot;bethealpha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AnimalKingdom_S5_Wolf\/AnimalKingdom_S5_Wolf.png&quot;,&quot;phillypower&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Philly\/OWL_Season4_Team_Feb_2021_Philly.png&quot;,&quot;ruadomedo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1994_2021\/Netflix_FearStreetTrilogy_1994_2021.png&quot;,&quot;penseantesdeclicar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;theroadtof9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;razónycorazónes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BancolombiaNewHeart_April_2021\/BancolombiaNewHeart_April_2021.png&quot;,&quot;arrq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixARRQ_2021\/NetflixARRQ_2021.png&quot;,&quot;mi11xseries&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mi11XSeries_IN_April_2021_v2\/Mi11XSeries_IN_April_2021_v2.png&quot;,&quot;fuelfighting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Dallas\/OWL_Season4_Team_Feb_2021_Dallas.png&quot;,&quot;disneyplushotstarmalaysia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlusHotstarMalaysia_2021\/DisneyPlusHotstarMalaysia_2021.png&quot;,&quot;dlb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bastille_June_2021\/Bastille_June_2021.png&quot;,&quot;fearstreet1994&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1994_2021\/Netflix_FearStreetTrilogy_1994_2021.png&quot;,&quot;wewantusalive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;twitterignite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterIgnite_2021\/TwitterIgnite_2021.png&quot;,&quot;podcastsmexico&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PodcastDiscoveryLATAM_2021\/PodcastDiscoveryLATAM_2021.png&quot;,&quot;thechi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Showtime_Q2_21_v2\/Showtime_Q2_21_v2.png&quot;,&quot;countit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_2021Season_25thAnniversary_2\/WNBA_2021Season_25thAnniversary_2.png&quot;,&quot;shadowandbonenetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_ShadowandBone_April_2021\/Netflix_ShadowandBone_April_2021.png&quot;,&quot;mightyminidrums&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DrumstickCone2021\/DrumstickCone2021.png&quot;,&quot;hackshbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hacks_HBOMax_April_2021_v3\/Hacks_HBOMax_April_2021_v3.png&quot;,&quot;vacciné&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;grindcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_GrindCity\/NBA_2021_Teams_GrindCity.png&quot;,&quot;jdscotland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXSCOTLAND_2021\/JDXSCOTLAND_2021.png&quot;,&quot;हममहिलाएँहैं&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;三ツ矢夏まつり&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021.png&quot;,&quot;キリチャレの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINChallengeCupJapan2021\/KIRINChallengeCupJapan2021.png&quot;,&quot;いきなりですが&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenCard_May_2021_Flight3\/RakutenCard_May_2021_Flight3.png&quot;,&quot;tapmonayan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Foodpanda7thAnniversary_2021\/Foodpanda7thAnniversary_2021.png&quot;,&quot;lads5aside&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ladbrokes5ASide_May_2021\/Ladbrokes5ASide_May_2021.png&quot;,&quot;bettermistakes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bebe_Rexha_2021\/Bebe_Rexha_2021.png&quot;,&quot;mixballantines&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ballantinesbr_June_2021\/ballantinesbr_June_2021.png&quot;,&quot;thepurgemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021\/TheForeverPurge_2021.png&quot;,&quot;tothestars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_ASTWIN\/LEC_EM_2021_ASTWIN.png&quot;,&quot;boatxshikhardhawan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BOAT_IPL_2021_v2\/BOAT_IPL_2021_v2.png&quot;,&quot;에스에프나인&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_SF9_June_2021\/Kpop_VIT_SF9_June_2021.png&quot;,&quot;skwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_SKWIN\/LEC_EM_2021_SKWIN.png&quot;,&quot;ahm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;f9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;chúngtôilàphụnữ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;juansoto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-WAS\/MLBHRDerby2021-WAS.png&quot;,&quot;16tage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;世代平等&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;mobius&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Mobius_2021\/Disney_LokiLaunch_Mobius_2021.png&quot;,&quot;oneburningquestion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hulu_THT_S4_2021\/Hulu_THT_S4_2021.png&quot;,&quot;unjefeenpañales2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BossBaby2_July_2021\/BossBaby2_July_2021.png&quot;,&quot;ioniq5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hyundai_ZeroEmission_FR_2021\/Hyundai_ZeroEmission_FR_2021.png&quot;,&quot;ひとつぶの大秘宝&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Meijinutschoco_2021\/Meijinutschoco_2021.png&quot;,&quot;restateacasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;있지&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021\/KPOP_VIT_ITZY_April_2021.png&quot;,&quot;våldmotkvinnor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;zilliqafootballstars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zilliqa_April_2021\/Zilliqa_April_2021.png&quot;,&quot;blackwidow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;beberexha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bebe_Rexha_2021\/Bebe_Rexha_2021.png&quot;,&quot;electricvehicules&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RenaulteWays_2_2021\/RenaulteWays_2_2021.png&quot;,&quot;해리포터깨어난마법&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HarryPotterNetease_Q2_2021\/HarryPotterNetease_Q2_2021.png&quot;,&quot;weareimt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_IMTWIN\/LCS_Jan_2021_IMTWIN.png&quot;,&quot;mccartney&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaulMcCartney_April_2021\/PaulMcCartney_April_2021.png&quot;,&quot;fboyisland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboyisland\/FBOYIsland_2021_fboyisland.png&quot;,&quot;io21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleIO2021\/GoogleIO2021.png&quot;,&quot;lgrw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LGRW\/NHL_2021_Teams_LGRW.png&quot;,&quot;トレクル7周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JP_ONEPIECE_trecru_2021\/JP_ONEPIECE_trecru_2021.png&quot;,&quot;maskenan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;comeoutcharging&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_comeoutcharging\/NRL_2021_comeoutcharging.png&quot;,&quot;runtheworldstarz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_RuntheWorld_2021\/STARZ_RuntheWorld_2021.png&quot;,&quot;gotmilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkPEP_May_2021\/MilkPEP_May_2021.png&quot;,&quot;selenanetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SelenaNetflix_2021\/SelenaNetflix_2021.png&quot;,&quot;snakeeyes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnakeEyesMovie2021\/SnakeEyesMovie2021.png&quot;,&quot;tron&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRON_Coin_Feb_2021_ext\/TRON_Coin_Feb_2021_ext.png&quot;,&quot;dünyayıturuncuyaboya&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;f150lightning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/F150Lightning_May_2021_2\/F150Lightning_May_2021_2.png&quot;,&quot;結論パルム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MorinagaMilk_Parm_April_2021\/MorinagaMilk_Parm_April_2021.png&quot;,&quot;pledgesignatory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_ClimatePledge_2021\/Amazon_ClimatePledge_2021.png&quot;,&quot;racetohybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/webexmclaren_2021\/webexmclaren_2021.png&quot;,&quot;siemprehayconque&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tostitos_MX_May_2021\/Tostitos_MX_May_2021.png&quot;,&quot;stlblues&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_stlblues\/NHL_2021_Teams_stlblues.png&quot;,&quot;bnb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BinanceTurns4_2021\/BinanceTurns4_2021.png&quot;,&quot;hitmansbodyguard&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_SalmaRyan_\/HitmansWifesBodyguard_2021_SalmaRyan_.png&quot;,&quot;atobttr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CIN\/MLB_Teams_2021_CIN.png&quot;,&quot;mtvmiawtime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PinkCarpetMTVMIAW_2021\/PinkCarpetMTVMIAW_2021.png&quot;,&quot;hopegrows&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShebaHopeReef_2021\/ShebaHopeReef_2021.png&quot;,&quot;sicem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Baylor2021ChampFullyear\/Baylor2021ChampFullyear.png&quot;,&quot;welcometotheordeal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Blindspotting_May_2021\/STARZ_Blindspotting_May_2021.png&quot;,&quot;maskenitak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;lgdwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_LGDWIN\/LPL_2021_LGDWIN.png&quot;,&quot;100win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_100T\/LCS_Jan_2021_100T.png&quot;,&quot;hungryformore&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_SD\/MLB_Teams_2021_SD.png&quot;,&quot;oldmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;xbox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxLoveStory_2021\/XboxLoveStory_2021.png&quot;,&quot;imbackxoxo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Phone\/HBOMaxGossipGirl_July_2021_Phone.png&quot;,&quot;wontbowdown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_WontBowDown\/NBA_2021_Teams_WontBowDown.png&quot;,&quot;ita&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_ITA\/Euro_UK_2021_ITA.png&quot;,&quot;हाथकीसफाईमेंभलाई&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;badboysofmagic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BigTricktruTV_2021\/BigTricktruTV_2021.png&quot;,&quot;ready_to_love&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_SEVENTEEN_June_2021\/KpopVIT_SEVENTEEN_June_2021.png&quot;,&quot;indianafever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_IND\/WNBA_Teams_2021_IND.png&quot;,&quot;valoaeiväkivaltaa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;cooldownplaymore&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;마스크쓰세요&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;gotiges&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_gotiges\/AFL_2021_gotiges.png&quot;,&quot;vamossj&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_SJE\/MLS_2021_SJE.png&quot;,&quot;naisiinkohdistuvaväkivalta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;cloneforce99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;tupelotueleccion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dove_TuPeloTuEleccion_May_2021\/Dove_TuPeloTuEleccion_May_2021.png&quot;,&quot;konahybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hyundai_ZeroEmission_FR_2021\/Hyundai_ZeroEmission_FR_2021.png&quot;,&quot;jdsummer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDLoveIsland_2021\/JDLoveIsland_2021.png&quot;,&quot;vamosvancouver&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_VWFC\/MLS_2021_VWFC.png&quot;,&quot;私たちならでき&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HHS_WeCanDoThis_2021_add\/HHS_WeCanDoThis_2021_add.png&quot;,&quot;stc5g&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/stc_5G_Feb_2021_ext\/stc_5G_Feb_2021_ext.png&quot;,&quot;manatilisabahaymagligtasngbuhay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;apihm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;キミと走るアイドル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/enstars_music6yearsanniversary_2021\/enstars_music6yearsanniversary_2021.png&quot;,&quot;upthemilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_UpTheMilk\/NRL_2021_UpTheMilk.png&quot;,&quot;missedme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Latte\/HBOMaxGossipGirl_July_2021_Latte.png&quot;,&quot;jumbojuichcape&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JumboJuichcapeSummerOfSports2021\/JumboJuichcapeSummerOfSports2021.png&quot;,&quot;rockies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_COL\/MLB_Teams_2021_COL.png&quot;,&quot;집콕&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;thehillsnewbeginnings&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_April_2021\/MTV_April_2021.png&quot;,&quot;hybrides&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021\/NetflixSweetTooth2021.png&quot;,&quot;portarelamscherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;glassandahalf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CadburyGlassAndAHalf_2021\/CadburyGlassAndAHalf_2021.png&quot;,&quot;xboxgamepass&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxGamePass_2021\/XboxGamePass_2021.png&quot;,&quot;newweeknewmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_NewWeekNewMovie_2021\/Netflix_NewWeekNewMovie_2021.png&quot;,&quot;maghugasngkamay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;bodegazos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BodegaAurrera_PlanVerano_2021\/BodegaAurrera_PlanVerano_2021.png&quot;,&quot;ridemcowboys&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_ridemcowboys\/NRL_2021_ridemcowboys.png&quot;,&quot;bleedgreen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_BleedGreen\/NBA_2021_Teams_BleedGreen.png&quot;,&quot;starwarsbadbatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;maafpréférence&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MAAF_70thBirthday_2021_2\/MAAF_70thBirthday_2021_2.png&quot;,&quot;vacinada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;allstars6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountRuPaulsDragRaceAllStars_July_2021\/ParamountRuPaulsDragRaceAllStars_July_2021.png&quot;,&quot;anidommonday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseBrokenFOX_May_2021\/HouseBrokenFOX_May_2021.png&quot;,&quot;letsgonewarriors&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_LetsGoneWarriors\/NRL_2021_LetsGoneWarriors.png&quot;,&quot;filmeluca&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;moonshot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_NFlying_June_2021\/KPOP_NFlying_June_2021.png&quot;,&quot;filmluca&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;haloinfinitemp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxOlympus_2021\/XboxOlympus_2021.png&quot;,&quot;helpmeleggo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eggo_May_2021_2\/Eggo_May_2021_2.png&quot;,&quot;doubleornothing&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/aewontnt_May_2021\/aewontnt_May_2021.png&quot;,&quot;teamcanada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CanadaOlympicParalympic_Tokyo\/CanadaOlympicParalympic_Tokyo.png&quot;,&quot;세계적십자의날&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;equipecanada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CanadaOlympicParalympic_Tokyo\/CanadaOlympicParalympic_Tokyo.png&quot;,&quot;thetomorrowwaronprime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeVideoIndiaTomorrowWar_2021\/PrimeVideoIndiaTomorrowWar_2021.png&quot;,&quot;sahihai&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AMFIQ2IPL_2021_v2\/AMFIQ2IPL_2021_v2.png&quot;,&quot;pepsishow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PepsiOpeningCeremony2021\/PepsiOpeningCeremony2021.png&quot;,&quot;intzarmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/INTZ_June_2021\/INTZ_June_2021.png&quot;,&quot;فكر_قبل_المشاركة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;wirbleibendrin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;monicaturkeyhead&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Turkey\/HBOMax_Friends_Turkey.png&quot;,&quot;posefx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021\/FX_Pose_April_2021.png&quot;,&quot;12horasparasobrevivirescapealafrontera&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;คิดก่อนแชร์&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;fikirsebelumkongsi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;drxwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_DRX\/LcK_2021_Teams_DRX.png&quot;,&quot;truetoatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_TrueToAtlanta\/NBA_2021_Teams_TrueToAtlanta.png&quot;,&quot;ogsportsdrink&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkPEP_May_2021\/MilkPEP_May_2021.png&quot;,&quot;백야극광&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TencentAlchemyStarsJPLaunch_2021\/TencentAlchemyStarsJPLaunch_2021.png&quot;,&quot;टीकाकरण&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;makeit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_2PM\/Kpop_VIT_2PM.png&quot;,&quot;ได้วัคซีนแล้ว&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;westjet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WestJet_Summer_2021\/WestJet_Summer_2021.png&quot;,&quot;とびっきりのサイダーでございます&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021.png&quot;,&quot;tdf2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TourdeFrance_2021\/TourdeFrance_2021.png&quot;,&quot;theugrailroad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_UndergroundRailroad_2021\/Amazon_UndergroundRailroad_2021.png&quot;,&quot;écoutezmoiaussi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;dcl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_DisneyCruise_2021\/DisneyParks_DisneyCruise_2021.png&quot;,&quot;கோவிட்19இந்தியாஉதவி&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;oranyekandunia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;سلامتك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GHC_SA_June_2021\/GHC_SA_June_2021.png&quot;,&quot;quédateencasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;spotifyxday6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyxITZY_April_2021\/SpotifyxITZY_April_2021.png&quot;,&quot;timstwitterlisteningparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimsTwitterListeningParty_2021_2022\/TimsTwitterListeningParty_2021_2022.png&quot;,&quot;nfltwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NFLTwitter\/NFLTwitter.png&quot;,&quot;fordlightning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/F150Lightning_May_2021_2\/F150Lightning_May_2021_2.png&quot;,&quot;ポルトロッソ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Portorosso_2021\/Disney_PixarLuca_Portorosso_2021.png&quot;,&quot;自慢好きロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;aflwfinals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_AFLW\/AFL_2021_AFLW.png&quot;,&quot;piensaantesdecompartir&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;pakaimasker&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;ฉีดวัคซีนแล้ว&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;ヒロトラ100万dl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/heroaca_ui_JP_2021\/heroaca_ui_JP_2021.png&quot;,&quot;earthdayondisneyplus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyNatGeo_SecretsoftheWhales_April_2021\/DisneyNatGeo_SecretsoftheWhales_April_2021.png&quot;,&quot;f3arthedeep&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_FLO\/CDL_Team_2021_FLO.png&quot;,&quot;híbridoperro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Dog\/Netflix_SweetTooth_Dog.png&quot;,&quot;maafaçondêtre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MAAF_70thBirthday_2021_2\/MAAF_70thBirthday_2021_2.png&quot;,&quot;friendsreunion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Frame\/HBOMax_Friends_Frame.png&quot;,&quot;timslisteningparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimsTwitterListeningParty_2021_2022\/TimsTwitterListeningParty_2021_2022.png&quot;,&quot;今日のアイスどうする問題&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MorinagaMilk_Parm_April_2021\/MorinagaMilk_Parm_April_2021.png&quot;,&quot;warcraft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurningCrusadeClassic_2021\/BurningCrusadeClassic_2021.png&quot;,&quot;quedateencasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;bijakberplastik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KebaikanAqua_April_2021\/KebaikanAqua_April_2021.png&quot;,&quot;kaming15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;blackhawks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_Blackhawks\/NHL_2021_Teams_Blackhawks.png&quot;,&quot;tupelotuelección&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dove_TuPeloTuEleccion_May_2021\/Dove_TuPeloTuEleccion_May_2021.png&quot;,&quot;bossbaby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BossBaby2_July_2021\/BossBaby2_July_2021.png&quot;,&quot;손을씻으세요&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;starwarsremesamala&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;sjsharks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_SJSharks\/NHL_2021_Teams_SJSharks.png&quot;,&quot;watchhacks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hacks_HBOMax_April_2021_v3\/Hacks_HBOMax_April_2021_v3.png&quot;,&quot;toofan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToofaanOnPrime_July_2021\/ToofaanOnPrime_July_2021.png&quot;,&quot;tokyotogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AU_Olympic_2021\/AU_Olympic_2021.png&quot;,&quot;kidloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_KidlLoki_2021\/Disney_LokiLaunch_KidlLoki_2021.png&quot;,&quot;xbox20&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xbox20thAnniversary_2021\/Xbox20thAnniversary_2021.png&quot;,&quot;btcturk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/btcturk_May_2021\/btcturk_May_2021.png&quot;,&quot;señoritaminutos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;knowyouloveme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Kiss\/HBOMaxGossipGirl_July_2021_Kiss.png&quot;,&quot;contagemregressivaparaloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;슈니언버거&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McD_KR_July_2021\/McD_KR_July_2021.png&quot;,&quot;forzahorizon5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxWoodstock_2021\/XboxWoodstock_2021.png&quot;,&quot;superfan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JumboJuichcapeSummerOfSports2021\/JumboJuichcapeSummerOfSports2021.png&quot;,&quot;spotifyxitzy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyxITZY_April_2021\/SpotifyxITZY_April_2021.png&quot;,&quot;紅新月日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;lokijacaré&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_AlligatorLoki_2021_v2\/Disney_LokiLaunch_AlligatorLoki_2021_v2.png&quot;,&quot;whatwouldpoptartsdo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PopTarts_June_2021\/PopTarts_June_2021.png&quot;,&quot;mlbts21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBTheSho_2021\/MLBTheSho_2021.png&quot;,&quot;sourpatchmysteryflavor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SourPatchMystery_May_2021\/SourPatchMystery_May_2021.png&quot;,&quot;あの夏のルカ感想キャンペーン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;r6nal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RainbowSixProLeague_2021_R6NAL\/RainbowSixProLeague_2021_R6NAL.png&quot;,&quot;morethanaheadline&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WaPo_WorldPressFreedom_2021\/WaPo_WorldPressFreedom_2021.png&quot;,&quot;chargeforward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_Guangzhou\/OWL_Season4_Team_2021_Guangzhou.png&quot;,&quot;whitespikes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeVideoIndiaTomorrowWar_2021\/PrimeVideoIndiaTomorrowWar_2021.png&quot;,&quot;skytown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_CHI\/WNBA_Teams_2021_CHI.png&quot;,&quot;サンq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Q22021\/Qoo10_Q22021.png&quot;,&quot;thetomorrowwar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;fboyfbye&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboyfbye\/FBOYIsland_2021_fboyfbye.png&quot;,&quot;デュエルリンクス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YugiohYusei_May2021\/YugiohYusei_May2021.png&quot;,&quot;categoryislegendary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Legendary_S2_HBOMax_2021\/Legendary_S2_HBOMax_2021.png&quot;,&quot;ilovemilka&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkaSummerCampaign_2021\/MilkaSummerCampaign_2021.png&quot;,&quot;paramountplus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountPlus_2021_ext\/ParamountPlus_2021_ext.png&quot;,&quot;marvelstudiosblackwidow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;白夜極光リリース記念祭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TencentAlchemyStarsJPLaunch_2021\/TencentAlchemyStarsJPLaunch_2021.png&quot;,&quot;miraitowa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Olympic_Mascot_Emoji_EXT2\/Olympic_Mascot_Emoji_EXT2.png&quot;,&quot;ligadossaboreslays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LaysUEFAChampionsLeague_2021\/LaysUEFAChampionsLeague_2021.png&quot;,&quot;equiporepsol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepsolMotogpMotorcycle_2021\/RepsolMotogpMotorcycle_2021.png&quot;,&quot;letsgo2kl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LetsGo2KL_2021\/LetsGo2KL_2021.png&quot;,&quot;マイベストヒロトラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/heroaca_ui_JP_2021\/heroaca_ui_JP_2021.png&quot;,&quot;laguerrededemain&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;rugrats&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rugrats_May_2021\/Paramount_Rugrats_May_2021.png&quot;,&quot;cochcymru&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXWALES_2021\/JDXWALES_2021.png&quot;,&quot;chestercheetos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChesterCheetos_MX_2021\/ChesterCheetos_MX_2021.png&quot;,&quot;optic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_GreenWall\/EsportsAllAccess_Jan_2021_GreenWall.png&quot;,&quot;thebachelorette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;yugyeom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_Yugyeom_June_2021\/Kpop_Yugyeom_June_2021.png&quot;,&quot;risetogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_TOR\/OWL_Season4_Team_Feb_2021_TOR.png&quot;,&quot;candiacedillardbassett&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_CandiaceDillardBassett\/Bravo_RHOP_Q3_2021_CandiaceDillardBassett.png&quot;,&quot;letitreign&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_ATL\/OWL_Season4_Team_2021_ATL.png&quot;,&quot;showyourstripes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_ShowYourStripes\/NRL_2021_ShowYourStripes.png&quot;,&quot;restezalamaison&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;housebrokenfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseBrokenFOX_May_2021\/HouseBrokenFOX_May_2021.png&quot;,&quot;gostars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoStars\/NHL_2021_Teams_GoStars.png&quot;,&quot;마피아_inthemorning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021\/KPOP_VIT_ITZY_April_2021.png&quot;,&quot;mclarenxwebex&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/webexmclaren_2021\/webexmclaren_2021.png&quot;,&quot;thinkbeforesharing&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;verzuztalk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Verzuz_2020_Flight4\/Verzuz_2020_Flight4.png&quot;,&quot;operationspkmysteryflavor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SourPatchMystery_May_2021\/SourPatchMystery_May_2021.png&quot;,&quot;នៅផ្ទះសុខភាពល្អ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;sóvocê&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;maskeauf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;vero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Acer_aspirevero_2021\/Acer_aspirevero_2021.png&quot;,&quot;pigmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NeonRated_PigtheFilm_June2021\/NeonRated_PigtheFilm_June2021.png&quot;,&quot;jumpin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxLoveStory_2021\/XboxLoveStory_2021.png&quot;,&quot;16天&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;spotifyonlyyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;اسے_آن_رکھیں&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;webexftw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/webexmclaren_2021\/webexmclaren_2021.png&quot;,&quot;シルヴィ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Sylvie_2021_V2\/Disney_LokiLaunch_Sylvie_2021_V2.png&quot;,&quot;상하이어니언버거&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/McD_KR_July_2021\/McD_KR_July_2021.png&quot;,&quot;nemumpassoemfalso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NoSuddenMove_July_2021\/NoSuddenMove_July_2021.png&quot;,&quot;forceofnature&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Vancouver\/OWL_Season4_Team_Feb_2021_Vancouver.png&quot;,&quot;hollywoodstudios&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;eqonexexchange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eqonex_July_2021\/Eqonex_July_2021.png&quot;,&quot;badhabitsvideo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EdSheeran_June_UK_2021\/EdSheeran_June_UK_2021.png&quot;,&quot;kerriandalmonds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Almonds_2021\/Almonds_2021.png&quot;,&quot;レンスレイヤー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Renslayer_2021\/Disney_LokiLaunch_Renslayer_2021.png&quot;,&quot;hockeytwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HockeyTwitter_ON\/HockeyTwitter_ON.png&quot;,&quot;realcool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Midea_RAC_May_2021\/Midea_RAC_May_2021.png&quot;,&quot;turnerandhoochondisneyplus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlus_TurnerandHooch_Dog_2021\/DisneyPlus_TurnerandHooch_Dog_2021.png&quot;,&quot;アサルトリリィ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Assaultlily_LastBullet_Apr_2021\/Assaultlily_LastBullet_Apr_2021.png&quot;,&quot;vancouvertitans&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Vancouver\/OWL_Season4_Team_Feb_2021_Vancouver.png&quot;,&quot;theopen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheOpen_July2021\/TheOpen_July2021.png&quot;,&quot;t1fighting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_T1\/LCK_2021_Team_P1_T1.png&quot;,&quot;umlugarsilencioso2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;unleashthefury&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLWSHPlayoffs2021\/NHLWSHPlayoffs2021.png&quot;,&quot;cleartheskies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_London\/OWL_Season4_Team_Feb_2021_London.png&quot;,&quot;qlder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_QLDer\/NRL_2021_QLDer.png&quot;,&quot;binance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BinanceTurns4_2021\/BinanceTurns4_2021.png&quot;,&quot;ニーア&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReplicant_April_2021_V2\/NieRReplicant_April_2021_V2.png&quot;,&quot;spotify&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;flapanthers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_FLAPanthers\/NHL_2021_Teams_FLAPanthers.png&quot;,&quot;suenalacampana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_PHI\/MLB_Teams_2021_PHI.png&quot;,&quot;منتخبنا_في_أمريكا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021_v2\/QatarAtGoldCup_2021_v2.png&quot;,&quot;chking&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurgerKing_chking_2021\/BurgerKing_chking_2021.png&quot;,&quot;marcusrashfordbook&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MarcusRashfordBook_2021\/MarcusRashfordBook_2021.png&quot;,&quot;trc20usdt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRC20USDT_2021\/TRC20USDT_2021.png&quot;,&quot;lucamovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;asianheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;silenziobruno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;hopeunited&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HopeUnited_May_2021\/HopeUnited_May_2021.png&quot;,&quot;snakeeyesmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnakeEyesMovie2021\/SnakeEyesMovie2021.png&quot;,&quot;akb15周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/17_AKB_May_2021\/17_AKB_May_2021.png&quot;,&quot;salvemosaloshibridos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021_add\/NetflixSweetTooth2021_add.png&quot;,&quot;hazlogrande&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_HazloGrande\/MLB_Teams_2021_HazloGrande.png&quot;,&quot;tinytacos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JackintheBoxTinyTacos_2021\/JackintheBoxTinyTacos_2021.png&quot;,&quot;elguardiánrojo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;fboyorniceguy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboy\/FBOYIsland_2021_fboy.png&quot;,&quot;tesonline&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BethesdaElderScrollsBlackwood_2021\/BethesdaElderScrollsBlackwood_2021.png&quot;,&quot;edgetocloud&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HPEDiscover2021\/HPEDiscover2021.png&quot;,&quot;spotifylisteningiseverything&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;smartbts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SmartXBTS_2021\/SmartXBTS_2021.png&quot;,&quot;лука&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;lagradarepsol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepsolMotogpMotorcycle_2021\/RepsolMotogpMotorcycle_2021.png&quot;,&quot;venmoitforward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Venmo_June_2021\/Venmo_June_2021.png&quot;,&quot;अबऔरहिंसानहीं&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;sistascircle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SistasOnBET_2021\/SistasOnBET_2021.png&quot;,&quot;thebaddest10years&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Davido10YearAnniversary_2021_1\/Davido10YearAnniversary_2021_1.png&quot;,&quot;ruadomedo1994&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1994_2021\/Netflix_FearStreetTrilogy_1994_2021.png&quot;,&quot;teenqueens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_CB\/HBOMaxGossipGirl_July_2021_CB.png&quot;,&quot;ugrr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_UndergroundRailroad_2021\/Amazon_UndergroundRailroad_2021.png&quot;,&quot;matasanekejagoranci&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;femizid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;penseavantdepartager&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;heforshe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HeForShe_fixed\/HeForShe_fixed.png&quot;,&quot;lazeroemission&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hyundai_ZeroEmission_FR_2021\/Hyundai_ZeroEmission_FR_2021.png&quot;,&quot;obsessedwe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaVi_Esports_2021_v2\/NaVi_Esports_2021_v2.png&quot;,&quot;вакцинировано&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;rushtogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_HLE\/LCK_2021_Team_P1_HLE.png&quot;,&quot;နှာခေါင်းစည်းဝတ်ပါ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;לשטוףידיים&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;孤独な暗殺者&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;她力量&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;rupaulsdragraceallstars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ParamountRuPaulsDragRaceAllStars_July_2021\/ParamountRuPaulsDragRaceAllStars_July_2021.png&quot;,&quot;maketastenotwaste&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HellmannsUKNomadMay2021\/HellmannsUKNomadMay2021.png&quot;,&quot;သင့်လက်ကိုဆေးပါ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;اليومالعالميللصليب_الأحمر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;祝みぃちゃん卒業&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/17_AKB_May_2021\/17_AKB_May_2021.png&quot;,&quot;somosmulheres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;msbuild2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MicrosoftBuild_2021\/MicrosoftBuild_2021.png&quot;,&quot;centenario2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_July_2021\/Libertadores_July_2021.png&quot;,&quot;ニーアリィンカーネーション&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReincarnationLaunch_May_2021\/NieRReincarnationLaunch_May_2021.png&quot;,&quot;gghbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_XOXO\/HBOMaxGossipGirl_July_2021_XOXO.png&quot;,&quot;spotifypodcast&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PodcastDiscoveryLATAM_2021\/PodcastDiscoveryLATAM_2021.png&quot;,&quot;paulmccartney&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaulMcCartney_April_2021\/PaulMcCartney_April_2021.png&quot;,&quot;fastfurious&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;에이스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopACE_June_2021\/KpopACE_June_2021.png&quot;,&quot;callofdutyleague&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CallofDutyLeague2021\/CallofDutyLeague2021.png&quot;,&quot;yangmudamemimpin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;juventudlidera&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;worldofwarcraft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BurningCrusadeClassic_2021\/BurningCrusadeClassic_2021.png&quot;,&quot;أسهل_طريقة_لدفع_الزكاة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zakaty_May_2021\/Zakaty_May_2021.png&quot;,&quot;наташароманофф&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_BWNatasha_again_2021\/Disney_BlackWidow_BWNatasha_again_2021.png&quot;,&quot;峯岸みなみ卒コン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/17_AKB_May_2021\/17_AKB_May_2021.png&quot;,&quot;disneyplushotstarmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlusHotstarMalaysia_2021\/DisneyPlusHotstarMalaysia_2021.png&quot;,&quot;eqonex&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eqonex_July_2021\/Eqonex_July_2021.png&quot;,&quot;earthion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Acer_aspirevero_2021\/Acer_aspirevero_2021.png&quot;,&quot;laguerradidomani&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;先輩とあんさんぶるミッション&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/enstars_music6yearsanniversary_2021\/enstars_music6yearsanniversary_2021.png&quot;,&quot;dreamog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OGEsports_May_2021\/OGEsports_May_2021.png&quot;,&quot;orlandocity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_OCSC\/MLS_2021_OCSC.png&quot;,&quot;cuentaregresivaparaloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;vuelastl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_STL\/MLB_Teams_2021_STL.png&quot;,&quot;oldfilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;investwithwebull&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeBull_May_2021_v2\/WeBull_May_2021_v2.png&quot;,&quot;adoptazombietiger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZombieTiger_UK_May_2021\/ZombieTiger_UK_May_2021.png&quot;,&quot;monstersatwork&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneuPlus_MonstersatWork_Helmet_2021\/DisneuPlus_MonstersatWork_Helmet_2021.png&quot;,&quot;believeatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_TrueToAtlanta_add\/NBA_2021_Teams_TrueToAtlanta_add.png&quot;,&quot;mtndewrise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewRise_April_2021\/MountainDewRise_April_2021.png&quot;,&quot;lokiclásico&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_ClassiclLoki_2021\/Disney_LokiLaunch_ClassiclLoki_2021.png&quot;,&quot;davefxx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DaveFX_May_2021_v2\/DaveFX_May_2021_v2.png&quot;,&quot;conelsabornosejuega&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GuardianTecate_July_2021\/GuardianTecate_July_2021.png&quot;,&quot;determnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLMinnesotaPlayoffs2021\/NHLMinnesotaPlayoffs2021.png&quot;,&quot;rufflescheddarebacon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RufflesCheddarEBacon_2021\/RufflesCheddarEBacon_2021.png&quot;,&quot;takecover&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_SEA\/WNBA_Teams_2021_SEA.png&quot;,&quot;nbatopshotthis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBATopShotThis_2021\/NBATopShotThis_2021.png&quot;,&quot;usemáscara&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;三ツ矢サイダー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021.png&quot;,&quot;washyourhands&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;owntheshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBTheSho_2021\/MLBTheSho_2021.png&quot;,&quot;obeyme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NTTSolmareObeyme_June_2021\/NTTSolmareObeyme_June_2021.png&quot;,&quot;natitude&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_WAS\/MLB_Teams_2021_WAS.png&quot;,&quot;mediasrojas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_BOS\/MLB_Teams_2021_BOS.png&quot;,&quot;nrgontop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_V2_NRG\/EsportsAllAccess_Jan_2021_V2_NRG.png&quot;,&quot;breakmyheartmyself&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bebe_Rexha_2021\/Bebe_Rexha_2021.png&quot;,&quot;híbridobobby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Gopher\/Netflix_SweetTooth_Gopher.png&quot;,&quot;oneplusnordce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlusNord_2021\/OnePlusNord_2021.png&quot;,&quot;ficaemcasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;uncaged&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_Uncaged\/AFL_2021_Uncaged.png&quot;,&quot;силенциобруно&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Alberto_2021\/Disney_PixarLuca_Alberto_2021.png&quot;,&quot;vamosunited&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_DCU\/MLS_2021_DCU.png&quot;,&quot;spotifyxbts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyxITZY_April_2021\/SpotifyxITZY_April_2021.png&quot;,&quot;jdloveisland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDLoveIsland_2021\/JDLoveIsland_2021.png&quot;,&quot;itslaughterwereafter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneuPlus_MonstersatWork_Helmet_2021\/DisneuPlus_MonstersatWork_Helmet_2021.png&quot;,&quot;lgm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_NYM\/MLB_Teams_2021_NYM.png&quot;,&quot;lucalapelícula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;draageenmondmasker&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;투피엠&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_2PM\/Kpop_VIT_2PM.png&quot;,&quot;den&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_DEN\/Euro_UK_2021_DEN.png&quot;,&quot;16giorni&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;pighybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Pig\/Netflix_SweetTooth_Pig.png&quot;,&quot;ibelievejeanette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Freeform_CruelSummer_Jeanette_2021_\/Freeform_CruelSummer_Jeanette_2021_.png&quot;,&quot;xboxmoments&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xbox20thAnniversary_2021\/Xbox20thAnniversary_2021.png&quot;,&quot;bornthisway10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;ពណ៌ទឹកក្រូចពិភពលោក&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;nicholascage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NeonRated_PigtheFilm_June2021\/NeonRated_PigtheFilm_June2021.png&quot;,&quot;紅十字日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;stlfly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_STL\/MLB_Teams_2021_STL.png&quot;,&quot;housebroken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseBrokenFOX_May_2021\/HouseBrokenFOX_May_2021.png&quot;,&quot;doop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_PU\/MLS_2021_PU.png&quot;,&quot;ロキまでのカウントダウン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;青年领导&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;knightup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLVGKPlayoffs2021\/NHLVGKPlayoffs2021.png&quot;,&quot;4aklondikeshake&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KlondikeMasterband_2021\/KlondikeMasterband_2021.png&quot;,&quot;スネークアイズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnakeEyesMovie2021\/SnakeEyesMovie2021.png&quot;,&quot;letsgopens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LetsGoPens\/NHL_2021_Teams_LetsGoPens.png&quot;,&quot;indossatelamascherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;oneplusnord&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlusNord_2021\/OnePlusNord_2021.png&quot;,&quot;キッドロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_KidlLoki_2021\/Disney_LokiLaunch_KidlLoki_2021.png&quot;,&quot;minifridge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;इंटरनेटबंद&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;shanghaidragons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_Shanghai\/OWL_Season4_Team_2021_Shanghai.png&quot;,&quot;threelions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnglandEuros_May_2021\/EnglandEuros_May_2021.png&quot;,&quot;losrockies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_COL\/MLB_Teams_2021_COL.png&quot;,&quot;flytogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_FlyTogether\/NHL_2021_Teams_FlyTogether.png&quot;,&quot;goleafsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLTORPlayoffs2021_2\/NHLTORPlayoffs2021_2.png&quot;,&quot;fh5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxWoodstock_2021\/XboxWoodstock_2021.png&quot;,&quot;أتحدث_بالمؤنث&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;vamosninjas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NiPGaming_Jan_2021\/NiPGaming_Jan_2021.png&quot;,&quot;missedmexoxo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_CB\/HBOMaxGossipGirl_July_2021_CB.png&quot;,&quot;magicawakened&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HarryPotterNetease_Q2_2021\/HarryPotterNetease_Q2_2021.png&quot;,&quot;aguerradoamanhã&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;白夜極光&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TencentAlchemyStarsJPLaunch_2021\/TencentAlchemyStarsJPLaunch_2021.png&quot;,&quot;mantenhanoar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;thegoodfight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheGoodFight_July_2021\/TheGoodFight_July_2021.png&quot;,&quot;imtwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_IMTWIN\/LCS_Jan_2021_IMTWIN.png&quot;,&quot;eso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BethesdaElderScrollsBlackwood_2021\/BethesdaElderScrollsBlackwood_2021.png&quot;,&quot;givesyouwings&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedBull_GIVESYOUWINGS_2021_V2\/RedBull_GIVESYOUWINGS_2021_V2.png&quot;,&quot;stanleytweets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StanleyCup_2021_add\/StanleyCup_2021_add.png&quot;,&quot;nationalcultureawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NationalCulturalAwardsFinalEvent_2021\/NationalCulturalAwardsFinalEvent_2021.png&quot;,&quot;forçaclone99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;bacheloretteabc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;drownthemout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_SEA\/CDL_Team_2021_SEA.png&quot;,&quot;restecheztoi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;gorogue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_RGEWIN\/LEC_EM_2021_RGEWIN.png&quot;,&quot;thehills&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_April_2021\/MTV_April_2021.png&quot;,&quot;canttameus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_MIN\/WNBA_Teams_2021_MIN.png&quot;,&quot;vamoskc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_KC\/MLS_2021_KC.png&quot;,&quot;unlugarensilencio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;عروض_حية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnjoySaudi_June2021\/EnjoySaudi_June2021.png&quot;,&quot;readytopanic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_Panic_2021\/AmazonStudios_Panic_2021.png&quot;,&quot;vaccinato&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;نوروز&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;penseantesdecompartilhar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;lagalaxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_LAGalaxy\/MLS_2021_LAGalaxy.png&quot;,&quot;bringthemayhem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Florida\/OWL_Season4_Team_Feb_2021_Florida.png&quot;,&quot;nhlbruins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_NHLBruins\/NHL_2021_Teams_NHLBruins.png&quot;,&quot;flywin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_FLYWIN_v2\/LCS_Jan_2021_FLYWIN_v2.png&quot;,&quot;netflixgeeked&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/geekedweeknetflix_2021\/geekedweeknetflix_2021.png&quot;,&quot;blackhistorymonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;pixarlucasg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;thewhitelotus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_TheWhiteLotus_2021\/HBO_TheWhiteLotus_2021.png&quot;,&quot;aapihm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;pesekätesi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;jeunesseenavant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;theimpracticaljokers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheImpracticalJokers_Julu_2021\/TheImpracticalJokers_Julu_2021.png&quot;,&quot;askverzuz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Verzuz_2020_Flight4\/Verzuz_2020_Flight4.png&quot;,&quot;ioniq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hyundai_ZeroEmission_FR_2021\/Hyundai_ZeroEmission_FR_2021.png&quot;,&quot;wdw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;nycfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NYC_v2\/MLS_2021_NYC_v2.png&quot;,&quot;mccartneyiii&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaulMcCartney_April_2021\/PaulMcCartney_April_2021.png&quot;,&quot;jagamethandhiram&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JagameThandhiramOnNetflix_2021\/JagameThandhiramOnNetflix_2021.png&quot;,&quot;jdxscotland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDXSCOTLAND_2021\/JDXSCOTLAND_2021.png&quot;,&quot;svt_ready_to_love&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_SEVENTEEN_June_2021\/KpopVIT_SEVENTEEN_June_2021.png&quot;,&quot;chengduzone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_CHENGDU\/OWL_Season4_Team_2021_CHENGDU.png&quot;,&quot;dreamcometruemoney&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CamelotTokyo_2021\/CamelotTokyo_2021.png&quot;,&quot;bitcoinledegistir&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/btcturk_May_2021\/btcturk_May_2021.png&quot;,&quot;ffacup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FFACup_2021\/FFACup_2021.png&quot;,&quot;スペースプレイヤーズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;contralasmaquinas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;undergroundrailroad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_UndergroundRailroad_2021\/Amazon_UndergroundRailroad_2021.png&quot;,&quot;세상을_주황빛으로&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;xlwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_XLWIN_fix\/LEC_EM_2021_XLWIN_fix.png&quot;,&quot;vegasborn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_VegasBorn\/NHL_2021_Teams_VegasBorn.png&quot;,&quot;lalabanako&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;protectourelders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StandForAsians_2021\/StandForAsians_2021.png&quot;,&quot;dito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DITO_May_2021_ext\/DITO_May_2021_ext.png&quot;,&quot;foreverpurge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021\/TheForeverPurge_2021.png&quot;,&quot;justinsun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRON_Coin_Feb_2021_ext\/TRON_Coin_Feb_2021_ext.png&quot;,&quot;インターネット遮断&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;handmaidstale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hulu_THT_S4_2021\/Hulu_THT_S4_2021.png&quot;,&quot;monstersinc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneuPlus_MonstersatWork_Helmet_2021\/DisneuPlus_MonstersatWork_Helmet_2021.png&quot;,&quot;snoh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnohAalegra_2021\/SnohAalegra_2021.png&quot;,&quot;oatmilkandnicesilk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Latte\/HBOMaxGossipGirl_July_2021_Latte.png&quot;,&quot;thethotyssey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZolaMovie_2021\/ZolaMovie_2021.png&quot;,&quot;conquerthemorning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewRise_April_2021\/MountainDewRise_April_2021.png&quot;,&quot;winsathome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectSoul_June_2021\/ProjectSoul_June_2021.png&quot;,&quot;resetผิวใหม่ใน7วัน&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SkinsistaRESET_2021\/SkinsistaRESET_2021.png&quot;,&quot;大統領ロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;metoo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_v3\/MeToo_v3.png&quot;,&quot;blackwood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BethesdaElderScrollsBlackwood_2021\/BethesdaElderScrollsBlackwood_2021.png&quot;,&quot;qatarteam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021_v2\/QatarAtGoldCup_2021_v2.png&quot;,&quot;vacunate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;انٹرنیٹ_شٹ_ڈاؤن&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;guesswho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021\/KPOP_VIT_ITZY_April_2021.png&quot;,&quot;resetantiaging&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SkinsistaRESET_2021\/SkinsistaRESET_2021.png&quot;,&quot;aew&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/aewontnt_May_2021\/aewontnt_May_2021.png&quot;,&quot;btc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bitcoin_evergreen\/Bitcoin_evergreen.png&quot;,&quot;mitchellsvsmachines&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;hangzhouspark&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Hangzhou\/OWL_Season4_Team_Feb_2021_Hangzhou.png&quot;,&quot;あの夏のルカ夏待ちキャンペーン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Portorosso_2021\/Disney_PixarLuca_Portorosso_2021.png&quot;,&quot;heinzcrowdsauce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KraftHeinz_CrowdSauce_SG_2021\/KraftHeinz_CrowdSauce_SG_2021.png&quot;,&quot;nflying&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_NFlying_June_2021\/KPOP_NFlying_June_2021.png&quot;,&quot;cffc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CF\/MLS_2021_CF.png&quot;,&quot;higherpower&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Coldplay_May_2021\/Coldplay_May_2021.png&quot;,&quot;クリックする前に考えよう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;mnightshyamalan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;turnerandhooch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlus_TurnerandHooch_Dog_2021\/DisneyPlus_TurnerandHooch_Dog_2021.png&quot;,&quot;なななんと&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenCard_May_2021_Flight3\/RakutenCard_May_2021_Flight3.png&quot;,&quot;wemetontwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeMetOnt_Emoji\/WeMetOnt_Emoji.png&quot;,&quot;mfsahihai&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AMFIQ2IPL_2021_v2\/AMFIQ2IPL_2021_v2.png&quot;,&quot;2021census&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StatCanCensus_2021\/StatCanCensus_2021.png&quot;,&quot;dirumahaja&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;híbridogopher&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Gopher\/Netflix_SweetTooth_Gopher.png&quot;,&quot;కోవిడ్౧౯ఇండియాసహాయం&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;ヴァルコネ最大300連無料ガチャ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ateam_valkyrie_connect_0601_2021\/Ateam_valkyrie_connect_0601_2021.png&quot;,&quot;wingsout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_LAValiant\/OWL_Season4_Team_Feb_2021_LAValiant.png&quot;,&quot;netzeroby2040&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_ClimatePledge_2021\/Amazon_ClimatePledge_2021.png&quot;,&quot;xboxandchill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxMiniFridge_2021\/XboxMiniFridge_2021.png&quot;,&quot;alcoholfree&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_VIT_TWICE_June_2021\/Kpop_VIT_TWICE_June_2021.png&quot;,&quot;lokiwednesdays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;pridefx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrideFX_2021\/PrideFX_2021.png&quot;,&quot;nobodylistenslikeyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;btw10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;portalamascherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;nãoquerguerracomninguem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RufflesCheddarEBacon_2021\/RufflesCheddarEBacon_2021.png&quot;,&quot;ปิดอินเทอร์เน็ต&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;sco&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_SCO\/Euro_UK_2021_SCO.png&quot;,&quot;juegatelaconcheetos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChesterCheetos_MX_2021\/ChesterCheetos_MX_2021.png&quot;,&quot;almondmode&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Almonds_2021\/Almonds_2021.png&quot;,&quot;youareachampion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MarcusRashfordBook_2021\/MarcusRashfordBook_2021.png&quot;,&quot;آمن_بالبيت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;bigbigsound&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_BigBigSound\/AFL_2021_BigBigSound.png&quot;,&quot;だがオレはレアだぜ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YugiohYusei_May2021\/YugiohYusei_May2021.png&quot;,&quot;قطعی_اینترنت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;miércoleslokis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;届けてキリン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINChallengeCupJapan2021\/KIRINChallengeCupJapan2021.png&quot;,&quot;egwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_EGWIN\/LCS_Jan_2021_EGWIN.png&quot;,&quot;каждаяженщина&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;奶茶联盟&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;polog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Polo_G_Album_2021\/Polo_G_Album_2021.png&quot;,&quot;100thieves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_100T\/LCS_Jan_2021_100T.png&quot;,&quot;คุณเท่านั้น&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;pixarlucaid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;zolamovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZolaMovie_2021\/ZolaMovie_2021.png&quot;,&quot;함께이겨냅시다&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HHS_WeCanDoThis_2021_add\/HHS_WeCanDoThis_2021_add.png&quot;,&quot;明治ナッツチョコとワンピース&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Meijinutschoco_2021\/Meijinutschoco_2021.png&quot;,&quot;スターウォーズバッドバッチ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021_add\/Disney_TheBadBatch_Helmet_April_2021_add.png&quot;,&quot;chaeryeong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_CHAERYEONG\/KPOP_VIT_ITZY_April_2021_CHAERYEONG.png&quot;,&quot;gherboalbum25&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Gherbo_25_Album_Emoji_2021\/Gherbo_25_Album_Emoji_2021.png&quot;,&quot;cheetosdedosllenosdediversion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChesterCheetos_MX_2021\/ChesterCheetos_MX_2021.png&quot;,&quot;14juillet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FranceBastilleDay2021\/FranceBastilleDay2021.png&quot;,&quot;태스크마스터&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Taskmaster_2021\/Disney_BlackWidow_Taskmaster_2021.png&quot;,&quot;davefxonhulu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DaveFX_May_2021_v2\/DaveFX_May_2021_v2.png&quot;,&quot;メビウス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Mobius_2021\/Disney_LokiLaunch_Mobius_2021.png&quot;,&quot;suruli&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JagameThandhiramOnNetflix_2021\/JagameThandhiramOnNetflix_2021.png&quot;,&quot;tempofilme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;drpowercouple&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PowerCouple_BR_May_2021\/PowerCouple_BR_May_2021.png&quot;,&quot;kindfrozen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KINDFrozen_July_2021\/KINDFrozen_July_2021.png&quot;,&quot;zartebotschaft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkaSummerCampaign_2021\/MilkaSummerCampaign_2021.png&quot;,&quot;representasian&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHM_RepresentAsian_2021\/AHM_RepresentAsian_2021.png&quot;,&quot;fast9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;mnufc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_MNUFC\/MLS_2021_MNUFC.png&quot;,&quot;zacksnydersjusticeleague&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnyderCut_LA_May_2021\/SnyderCut_LA_May_2021.png&quot;,&quot;lokipresiden&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;중장전희&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FinalgearKR2021KR\/FinalgearKR2021KR.png&quot;,&quot;미소녀&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FinalgearKR2021KR\/FinalgearKR2021KR.png&quot;,&quot;mtndew3pt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewNBA_June_2021\/MountainDewNBA_June_2021.png&quot;,&quot;podcastmexico&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PodcastDiscoveryLATAM_2021\/PodcastDiscoveryLATAM_2021.png&quot;,&quot;fearnoone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLFloridaPlayoffs2021\/NHLFloridaPlayoffs2021.png&quot;,&quot;gatesofoblivion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BethesdaElderScrollsBlackwood_2021\/BethesdaElderScrollsBlackwood_2021.png&quot;,&quot;vwfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_VWFC\/MLS_2021_VWFC.png&quot;,&quot;vamosgalaxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_LAGalaxy\/MLS_2021_LAGalaxy.png&quot;,&quot;tylerperry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SistasOnBET_2021\/SistasOnBET_2021.png&quot;,&quot;20yıldıraynısofrada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YemekSepeti_2021\/YemekSepeti_2021.png&quot;,&quot;internetshutdown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;onlyamatteroftime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;bloqueodigital&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;ladbrokes5aside&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ladbrokes5ASide_May_2021\/Ladbrokes5ASide_May_2021.png&quot;,&quot;16hari&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;obeymehdd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NTTSolmareObeyme_June_2021\/NTTSolmareObeyme_June_2021.png&quot;,&quot;dadstopembarrassingmenetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DadStopEmbarrassingMeNetflix_2021\/DadStopEmbarrassingMeNetflix_2021.png&quot;,&quot;internetiaçıktut&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;letsgobuffalo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LetsGoBuffalo\/NHL_2021_Teams_LetsGoBuffalo.png&quot;,&quot;redbull&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedBull_GIVESYOUWINGS_2021_V2\/RedBull_GIVESYOUWINGS_2021_V2.png&quot;,&quot;losloons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_MNUFC\/MLS_2021_MNUFC.png&quot;,&quot;私たち15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;espnplus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ESPNPlus_2021_3_v3\/ESPNPlus_2021_3_v3.png&quot;,&quot;saudivision2030&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SaudiVision2030\/SaudiVision2030.png&quot;,&quot;standforasians&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StandForAsians_2021\/StandForAsians_2021.png&quot;,&quot;whitespikeshunt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PrimeVideoIndiaTomorrowWar_2021\/PrimeVideoIndiaTomorrowWar_2021.png&quot;,&quot;caçadorab15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_HunterB15_2021\/Disney_LokiLaunch_HunterB15_2021.png&quot;,&quot;yotes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_Yotes\/NHL_2021_Teams_Yotes.png&quot;,&quot;لوّن_العالم_برتقالياً&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;amaliatrue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/thenevershbo_2021_May_v2\/thenevershbo_2021_May_v2.png&quot;,&quot;lhha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VH1LHHAtlanta_2021\/VH1LHHAtlanta_2021.png&quot;,&quot;mtvwednesdays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_April_2021\/MTV_April_2021.png&quot;,&quot;donruss&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaniniAmericaQ2_21\/PaniniAmericaQ2_21.png&quot;,&quot;اليومالعالميللهلال_الأحمر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;パルム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MorinagaMilk_Parm_April_2021\/MorinagaMilk_Parm_April_2021.png&quot;,&quot;clgfighting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_CLGWIN\/LCS_Jan_2021_CLGWIN.png&quot;,&quot;vct&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VALORANT_Champions_Tour_2021\/VALORANT_Champions_Tour_2021.png&quot;,&quot;atfr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;ibelievekate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Freeform_CruelSummer_Kate_2021\/Freeform_CruelSummer_Kate_2021.png&quot;,&quot;midearealcool&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Midea_RAC_May_2021\/Midea_RAC_May_2021.png&quot;,&quot;diosdelasmentiras&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;itsalltruth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Kiss\/HBOMaxGossipGirl_July_2021_Kiss.png&quot;,&quot;envyus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_V2_Envy\/EsportsAllAccess_Jan_2021_V2_Envy.png&quot;,&quot;トゥモロー・ウォー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;prontosparapanic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_Panic_2021\/AmazonStudios_Panic_2021.png&quot;,&quot;usacubrebocas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;lgi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLNYIPlayoffs2021\/NHLNYIPlayoffs2021.png&quot;,&quot;siren&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopACE_June_2021\/KpopACE_June_2021.png&quot;,&quot;lapurgainfinita&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;build2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MicrosoftBuild_2021\/MicrosoftBuild_2021.png&quot;,&quot;ワタトゲー私を突き刺す棘&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Watatoge_June_2021\/Piccoma_Watatoge_June_2021.png&quot;,&quot;انٹرنٹ_شٹ_ڈاؤن&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;raturatuhidupku&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixARRQ_2021\/NetflixARRQ_2021.png&quot;,&quot;엔플라잉&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_NFlying_June_2021\/KPOP_NFlying_June_2021.png&quot;,&quot;blackladysketchshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_ABLSS_May_2021\/HBO_ABLSS_May_2021.png&quot;,&quot;mantodamassa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MantoDaMassa_June_2021\/MantoDaMassa_June_2021.png&quot;,&quot;พันธมิตรชานม&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkTeaAlliance_2021\/MilkTeaAlliance_2021.png&quot;,&quot;grownishseason4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/grownishseason4_2021\/grownishseason4_2021.png&quot;,&quot;theshow21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBTheSho_2021\/MLBTheSho_2021.png&quot;,&quot;jointhepride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LionsRugbyTour_2021_Lion\/LionsRugbyTour_2021_Lion.png&quot;,&quot;clgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_CLGWIN\/LCS_Jan_2021_CLGWIN.png&quot;,&quot;s04&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_S04WIN\/LEC_EM_2021_S04WIN.png&quot;,&quot;tur&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_TUR\/Euro_UK_2021_TUR.png&quot;,&quot;blijfgezond&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;टीकालगाना&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;5gforoman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OmanTel5G_2021_v3\/OmanTel5G_2021_v3.png&quot;,&quot;hbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_LatinAmerica_2021\/HBOMax_LatinAmerica_2021.png&quot;,&quot;nbaontnt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffsonTNT_2021\/NBAPlayoffsonTNT_2021.png&quot;,&quot;legomasters&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEGOGoldenBrick_2021\/LEGOGoldenBrick_2021.png&quot;,&quot;itswhatwedo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CooperativeEnvironment_July_2021\/CooperativeEnvironment_July_2021.png&quot;,&quot;bhm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;orangetheworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;အိမ်မှာကျန်းမာစွာနေပါ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;laremesamala&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;geekedweeknetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/geekedweeknetflix_2021\/geekedweeknetflix_2021.png&quot;,&quot;hotd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseoftheDragonHBO_2021\/HouseoftheDragonHBO_2021.png&quot;,&quot;fazeup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_Faze\/EsportsAllAccess_Jan_2021_Faze.png&quot;,&quot;leverageredemption&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LeverageRedemption_2021\/Amazon_LeverageRedemption_2021.png&quot;,&quot;pontofrio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PontoFrio_Rebrand_2021\/PontoFrio_Rebrand_2021.png&quot;,&quot;mcdkidolsearch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MD_BurgerKoreaPedas_2021\/MD_BurgerKoreaPedas_2021.png&quot;,&quot;nstogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_NS\/LcK_2021_Teams_NS.png&quot;,&quot;whiteclaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LetsWhiteClaw_2021_SP\/LetsWhiteClaw_2021_SP.png&quot;,&quot;lokipresidente&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_PresidentLoki_2021\/Disney_LokiLaunch_PresidentLoki_2021.png&quot;,&quot;លាងដៃ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;inourownwords&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CadburyGlassAndAHalf_2021\/CadburyGlassAndAHalf_2021.png&quot;,&quot;nbaplayoffsontnt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffsonTNT_2021\/NBAPlayoffsonTNT_2021.png&quot;,&quot;stopasianhatecrimes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StandForAsians_2021\/StandForAsians_2021.png&quot;,&quot;ysiencuentroconqué&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tostitos_MX_May_2021\/Tostitos_MX_May_2021.png&quot;,&quot;legendaryhbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Legendary_S2_HBOMax_2021\/Legendary_S2_HBOMax_2021.png&quot;,&quot;ຢູ່ເຮືອນຢຸດເຊື້ອເພື່ອຊາດ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;dionnebiopic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dionne_Warwick_2021_V2\/Dionne_Warwick_2021_V2.png&quot;,&quot;indossarelamascherina&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;gojetsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_GoJetsGo\/NHL_2021_Teams_GoJetsGo.png&quot;,&quot;કોવિડ૧૯ઈન્ડિયાહેલ્પ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;fordf150&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/F150Lightning_May_2021_2\/F150Lightning_May_2021_2.png&quot;,&quot;ล้างมือกัน&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WashYourHands_2020_2021_ext3\/WashYourHands_2020_2021_ext3.png&quot;,&quot;vaksinert&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;lokianakanak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_KidlLoki_2021\/Disney_LokiLaunch_KidlLoki_2021.png&quot;,&quot;あの夏のルカ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;bullsnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_BullsNation\/NBA_2021_Teams_BullsNation.png&quot;,&quot;googleio2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleIO2021\/GoogleIO2021.png&quot;,&quot;godofmischief&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;gegengewaltgegenfrauen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;internetbloqué&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;怪物奇兵全新世代&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;bakuna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;dropyourvenmo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Venmo_June_2021\/Venmo_June_2021.png&quot;,&quot;nrl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021\/NRL_2021.png&quot;,&quot;calledelterror1994&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1994_2021\/Netflix_FearStreetTrilogy_1994_2021.png&quot;,&quot;lia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_LIA\/KPOP_VIT_ITZY_April_2021_LIA.png&quot;,&quot;twdsurvivors&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TWDSurvivors_SG_2021\/TWDSurvivors_SG_2021.png&quot;,&quot;vamosfire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CF\/MLS_2021_CF.png&quot;,&quot;マーベルのブラックウィドウ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;,&quot;ruffles&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RufflesCheddarEBacon_2021\/RufflesCheddarEBacon_2021.png&quot;,&quot;highschoolheartthrobs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_CB\/HBOMaxGossipGirl_July_2021_CB.png&quot;,&quot;anytimeanywhere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_AnytimeAnywhere\/NHL_2021_Teams_AnytimeAnywhere.png&quot;,&quot;hereforthetea&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_Latte\/HBOMaxGossipGirl_July_2021_Latte.png&quot;,&quot;bigtour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BPIBigTour_2021\/BPIBigTour_2021.png&quot;,&quot;letsgoc9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_C9WIN\/LCS_Jan_2021_C9WIN.png&quot;,&quot;owl2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_2021\/OWL_2021.png&quot;,&quot;pročišćenjezauvek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;teamenvy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_V2_Envy\/EsportsAllAccess_Jan_2021_V2_Envy.png&quot;,&quot;wal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_WAL\/Euro_UK_2021_WAL.png&quot;,&quot;geeked&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/geekedweeknetflix_2021\/geekedweeknetflix_2021.png&quot;,&quot;タスクマスター&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Taskmaster_2021\/Disney_BlackWidow_Taskmaster_2021.png&quot;,&quot;valorantchallengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VALORANT_Champions_Tour_2021\/VALORANT_Champions_Tour_2021.png&quot;,&quot;おいデュエルしろよ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YugiohYusei_May2021\/YugiohYusei_May2021.png&quot;,&quot;bloqueodeinternet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;forthea&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_ATL\/MLB_Teams_2021_ATL.png&quot;,&quot;才能を追い越せ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Com2us_summonerswar_April_2021\/Com2us_summonerswar_April_2021.png&quot;,&quot;unlugartranquilo2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;mtgdnd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MagicTheGathering_june_2021_\/MagicTheGathering_june_2021_.png&quot;,&quot;트위터포굿&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;letswhiteclaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LetsWhiteClaw_2021_BCW\/LetsWhiteClaw_2021_BCW.png&quot;,&quot;disneyworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;bel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_BEL\/Euro_UK_2021_BEL.png&quot;,&quot;badhabits&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EdSheeran_June_UK_2021\/EdSheeran_June_UK_2021.png&quot;,&quot;ナッツチョコは明治&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Meijinutschoco_2021\/Meijinutschoco_2021.png&quot;,&quot;kpoptwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopTwitter_2021_Blue\/KpopTwitter_2021_Blue.png&quot;,&quot;teamupforexcellence&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RemyMartin_teamupforexcellence_2021\/RemyMartin_teamupforexcellence_2021.png&quot;,&quot;16araw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;لك_وللحياة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GHC_SA_June_2021\/GHC_SA_June_2021.png&quot;,&quot;うちで過ごそう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;therepsolstand&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepsolMotogpMotorcycle_2021\/RepsolMotogpMotorcycle_2021.png&quot;,&quot;giovanialcomando&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;classifieddrops&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnakeEyesMovie2021\/SnakeEyesMovie2021.png&quot;,&quot;cze&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_CZE\/Euro_UK_2021_CZE.png&quot;,&quot;멜리나&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Yelena_2021\/Disney_BlackWidow_Yelena_2021.png&quot;,&quot;blacklivesmatter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;ハリポタ覚醒&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HarryPotterNetease_Q2_2021\/HarryPotterNetease_Q2_2021.png&quot;,&quot;mtndewriseenergy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewRise_April_2021\/MountainDewRise_April_2021.png&quot;,&quot;pinkcarpetmtvmiaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PinkCarpetMTVMIAW_2021\/PinkCarpetMTVMIAW_2021.png&quot;,&quot;ladygaga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji\/Lady_Gaga_Born_This_Way_Anniversary_GOLD_Emoji.png&quot;,&quot;प्रत्येकमहिला&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;everywoman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;クワイエット・プレイス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AQuietPlace_P2_2021\/AQuietPlace_P2_2021.png&quot;,&quot;quédateencasaya&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;heineken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Heineken_starofthematch_May_2021\/Heineken_starofthematch_May_2021.png&quot;,&quot;رؤية_2030_واقع_يتحقق&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SaudiVision2030\/SaudiVision2030.png&quot;,&quot;루카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;aliandraturatuqueens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixARRQ_2021\/NetflixARRQ_2021.png&quot;,&quot;cdl2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CallofDutyLeague2021\/CallofDutyLeague2021.png&quot;,&quot;оставайтесьдома&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;akatsukifive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Akatsuki5_June_2021\/Akatsuki5_June_2021.png&quot;,&quot;怒号光明&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Yostar_ArknightsStaff_April_2021\/Yostar_ArknightsStaff_April_2021.png&quot;,&quot;الشباب_قادة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;somosel15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;ソメイティ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paralympic_Mascot_Emoji_EXT2\/Paralympic_Mascot_Emoji_EXT2.png&quot;,&quot;trevorstory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-COL\/MLBHRDerby2021-COL.png&quot;,&quot;foodpandabdayblowout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Foodpanda7thAnniversary_2021\/Foodpanda7thAnniversary_2021.png&quot;,&quot;theclimatepledge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_ClimatePledge_2021\/Amazon_ClimatePledge_2021.png&quot;,&quot;android12&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleIO2021\/GoogleIO2021.png&quot;,&quot;drivinghybridwork&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/webexmclaren_2021\/webexmclaren_2021.png&quot;,&quot;akorin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;ahstories&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AHStories_July_2021\/AHStories_July_2021.png&quot;,&quot;サンプルマーケット&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Q22021\/Qoo10_Q22021.png&quot;,&quot;スカイウォードソードhd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NintendoZeldaSkywardSword_2021\/NintendoZeldaSkywardSword_2021.png&quot;,&quot;ギア子&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bytedance_ako_figurestory_June_2021\/Bytedance_ako_figurestory_June_2021.png&quot;,&quot;mideaduo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Midea_RAC_May_2021\/Midea_RAC_May_2021.png&quot;,&quot;purotejas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_TEX\/MLB_Teams_2021_TEX.png&quot;,&quot;preds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_Preds\/NHL_2021_Teams_Preds.png&quot;,&quot;pol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_POL\/Euro_UK_2021_POL.png&quot;,&quot;16päivää&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;オレレベー俺だけレベルアップな件&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Oreleve_June_2021\/Piccoma_Oreleve_June_2021.png&quot;,&quot;noustoutes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;世界をオレンジ色に&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;noi15percento&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;disneycruise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_DisneyCruise_2021\/DisneyParks_DisneyCruise_2021.png&quot;,&quot;wearewomen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;allcaps&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_ALLCAPS\/NHL_2021_Teams_ALLCAPS.png&quot;,&quot;نحن_الـ15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021_add\/WeThe15_2021_add.png&quot;,&quot;eaststowin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_EastsToWin\/NRL_2021_EastsToWin.png&quot;,&quot;nrgfam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_V2_NRG\/EsportsAllAccess_Jan_2021_V2_NRG.png&quot;,&quot;showcasegreatness&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_FLYWIN_v2\/LCS_Jan_2021_FLYWIN_v2.png&quot;,&quot;seoingukonviu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DAYSOnViu_2021\/DAYSOnViu_2021.png&quot;,&quot;losmets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_NYM\/MLB_Teams_2021_NYM.png&quot;,&quot;منتخبنافيأمريكا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021\/QatarAtGoldCup_2021.png&quot;,&quot;togetherdc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_WAS1\/WNBA_Teams_2021_WAS1.png&quot;,&quot;sehatdirumah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;skinsista&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SkinsistaRESET_2021\/SkinsistaRESET_2021.png&quot;,&quot;overanddone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Njomza_Album_Emoji_2021\/Njomza_Album_Emoji_2021.png&quot;,&quot;laveniravélo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TourdeFrance_2021\/TourdeFrance_2021.png&quot;,&quot;thematch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TurnerTheMatchQ22021\/TurnerTheMatchQ22021.png&quot;,&quot;diretoaoponto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PontoFrio_Rebrand_2021\/PontoFrio_Rebrand_2021.png&quot;,&quot;vitwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_VITWIN\/LEC_EM_2021_VITWIN.png&quot;,&quot;digi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_DIGWIN\/LCS_Jan_2021_DIGWIN.png&quot;,&quot;16дней&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;bancolombia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BancolombiaNewHeart_April_2021\/BancolombiaNewHeart_April_2021.png&quot;,&quot;magictogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_MagicTogether\/NBA_2021_Teams_MagicTogether.png&quot;,&quot;letsgetkraken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_FLO\/CDL_Team_2021_FLO.png&quot;,&quot;バッドバッチ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;wendyhybrid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_SweetTooth_Pig\/Netflix_SweetTooth_Pig.png&quot;,&quot;milehighbasketball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_MileHighBasketball\/NBA_2021_Teams_MileHighBasketball.png&quot;,&quot;sadecesen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_Q2_21\/Spotify_Q2_21.png&quot;,&quot;أتحدث_بالمونث&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;onechampionship&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ONEonTNT_2021\/ONEonTNT_2021.png&quot;,&quot;3imagined&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaulMcCartney_April_2021\/PaulMcCartney_April_2021.png&quot;,&quot;alidinetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixARRQ_2021\/NetflixARRQ_2021.png&quot;,&quot;エレーナ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Yelena_2021\/Disney_BlackWidow_Yelena_2021.png&quot;,&quot;newbalance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewBalance574_2021\/NewBalance574_2021.png&quot;,&quot;tronics&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TRON_Coin_Feb_2021_ext\/TRON_Coin_Feb_2021_ext.png&quot;,&quot;lovetoseeit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveToSeeIt_2021\/LoveToSeeIt_2021.png&quot;,&quot;zilforthewin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zilliqa_April_2021\/Zilliqa_April_2021.png&quot;,&quot;holditdown&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_HOU\/MLS_2021_HOU.png&quot;,&quot;pariseternal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Paris\/OWL_Season4_Team_Feb_2021_Paris.png&quot;,&quot;r6apacl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RainbowSixProLeague_2021_R6APACL\/RainbowSixProLeague_2021_R6APACL.png&quot;,&quot;ngaraatekaumaono&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;thelongestday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ALZ_2021\/ALZ_2021.png&quot;,&quot;lego&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEGOGoldenBrick_2021\/LEGOGoldenBrick_2021.png&quot;,&quot;ysiencuentroconque&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tostitos_MX_May_2021\/Tostitos_MX_May_2021.png&quot;,&quot;bronxnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Origins21_Broxnation_\/Origins21_Broxnation_.png&quot;,&quot;badbatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;hivemind&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NYTimesGames_NYTSpellingBee_2021_add\/NYTimesGames_NYTSpellingBee_2021_add.png&quot;,&quot;inclusionishappening&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterTogether_InclusionIsHappening_v2\/TwitterTogether_InclusionIsHappening_v2.png&quot;,&quot;第五人格ivc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IdentityVJP_Q3_2021\/IdentityVJP_Q3_2021.png&quot;,&quot;morningmakesyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MountainDewRise_April_2021\/MountainDewRise_April_2021.png&quot;,&quot;hitmanswifesbodyguard&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_All3_\/HitmansWifesBodyguard_2021_All3_.png&quot;,&quot;ashleydarby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_AshleyDarby\/Bravo_RHOP_Q3_2021_AshleyDarby.png&quot;,&quot;doitforthedream&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_ATL\/WNBA_Teams_2021_ATL.png&quot;,&quot;تويتر_للخير&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;upup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2021_UpUp\/NRL_2021_UpUp.png&quot;,&quot;ऑरंजदीवर्ल्ड&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;obeymax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NTTSolmareObeyme_June_2021\/NTTSolmareObeyme_June_2021.png&quot;,&quot;mietiennenjakoa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2020_ThinkBeforeSharing.png&quot;,&quot;supportresponsibly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Heineken_starofthematch_May_2021\/Heineken_starofthematch_May_2021.png&quot;,&quot;教えてリィンカネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReincarnationLaunch_May_2021\/NieRReincarnationLaunch_May_2021.png&quot;,&quot;qataratgoldcup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAtGoldCup_2021_v2\/QatarAtGoldCup_2021_v2.png&quot;,&quot;lec&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_LEC\/LEC_EM_2021_LEC.png&quot;,&quot;bigtrickenergy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BigTricktruTV_2021\/BigTricktruTV_2021.png&quot;,&quot;niccage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NeonRated_PigtheFilm_June2021\/NeonRated_PigtheFilm_June2021.png&quot;,&quot;toduntak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToofaanOnPrime_July_2021\/ToofaanOnPrime_July_2021.png&quot;,&quot;flightattendanthbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlightAttendant_LA_May_2021\/FlightAttendant_LA_May_2021.png&quot;,&quot;lildrumsbigflavor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DrumstickCone2021\/DrumstickCone2021.png&quot;,&quot;fboyislandonmax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FBOYIsland_2021_fboyisland\/FBOYIsland_2021_fboyisland.png&quot;,&quot;lasttrainhome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/John_Mayer_2021_Album\/John_Mayer_2021_Album.png&quot;,&quot;lhhatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VH1LHHAtlanta_2021\/VH1LHHAtlanta_2021.png&quot;,&quot;vamosgigantes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_SF\/MLB_Teams_2021_SF.png&quot;,&quot;ukr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_UKR\/Euro_UK_2021_UKR.png&quot;,&quot;dejalotodo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_HOU\/MLS_2021_HOU.png&quot;,&quot;gevaccineerd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;tlwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_TLWIN\/LCS_Jan_2021_TLWIN.png&quot;,&quot;smoothlikebutter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_BTS_June2021_SmoothLikeButter\/KpopVIT_BTS_June2021_SmoothLikeButter.png&quot;,&quot;ロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;채령&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_CHAERYEONG\/KPOP_VIT_ITZY_April_2021_CHAERYEONG.png&quot;,&quot;justicefighting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_2021_WASH\/OWL_Season4_Team_2021_WASH.png&quot;,&quot;サイダートーク&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021\/AsahiSoftDrinkmitsuyasummercider2_Japan_2021.png&quot;,&quot;vaccinata&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;venmome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Venmo_June_2021\/Venmo_June_2021.png&quot;,&quot;eggo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eggo_May_2021_2\/Eggo_May_2021_2.png&quot;,&quot;konaelectric&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hyundai_ZeroEmission_FR_2021\/Hyundai_ZeroEmission_FR_2021.png&quot;,&quot;letsgooilers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LetsGoOilers\/NHL_2021_Teams_LetsGoOilers.png&quot;,&quot;boatxklrahul&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BOAT_IPL_2021_v2\/BOAT_IPL_2021_v2.png&quot;,&quot;blacktranslivesmatter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackTransLivesMatter_2020\/BlackTransLivesMatter_2020.png&quot;,&quot;lionsrugby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VodafoneLions_Tour_2021\/VodafoneLions_Tour_2021.png&quot;,&quot;wegotnow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewBalance574_2021\/NewBalance574_2021.png&quot;,&quot;amigoskelloggs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KelloggsMasterBrandCercaDeTi_2021_V3\/KelloggsMasterBrandCercaDeTi_2021_V3.png&quot;,&quot;poseonfx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FX_Pose_April_2021\/FX_Pose_April_2021.png&quot;,&quot;pointofviewu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kpop_Yugyeom_June_2021\/Kpop_Yugyeom_June_2021.png&quot;,&quot;アークナイツ戦友募集&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Yostar_ArknightsStaff_April_2021\/Yostar_ArknightsStaff_April_2021.png&quot;,&quot;magisipbagomagclick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2020_ThinkBeforeClicking.png&quot;,&quot;beatthecube&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BeatTheCube_2021\/BeatTheCube_2021.png&quot;,&quot;vamosnerevs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NER\/MLS_2021_NER.png&quot;,&quot;mkd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_MKD\/Euro_UK_2021_MKD.png&quot;,&quot;私たちは女性&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;hernesileşitlik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;bloods&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2021_Bloods\/AFL_2021_Bloods.png&quot;,&quot;fearstreet1666&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1666_2021\/Netflix_FearStreetTrilogy_1666_2021.png&quot;,&quot;snohalbum&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnohAalegra_2021\/SnohAalegra_2021.png&quot;,&quot;covidemergencyindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;tomorrowwar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021_add\/AmazonStudios_TomorrowWar_2021_add.png&quot;,&quot;inthere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LizPhair_2021\/LizPhair_2021.png&quot;,&quot;strengthinthenorth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_TOR\/CDL_Team_2021_TOR.png&quot;,&quot;leafsforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2021_Teams_LeafsForever\/NHL_2021_Teams_LeafsForever.png&quot;,&quot;ارتدي_الكمامة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;rattleon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_ARI\/MLB_Teams_2021_ARI.png&quot;,&quot;almonds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Almonds_2021\/Almonds_2021.png&quot;,&quot;сделаймироранжевым&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;crushitspacejam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021_add\/SpaceJam_2021_add.png&quot;,&quot;6in6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxLoveStory_2021\/XboxLoveStory_2021.png&quot;,&quot;milka&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MilkaSummerCampaign_2021\/MilkaSummerCampaign_2021.png&quot;,&quot;ripcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_RipCity\/NBA_2021_Teams_RipCity.png&quot;,&quot;ゼルダの伝説&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NintendoZeldaSkywardSword_2021\/NintendoZeldaSkywardSword_2021.png&quot;,&quot;spotifyxenjoyenjaami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyXEnjoyEnjaami_2021\/SpotifyXEnjoyEnjaami_2021.png&quot;,&quot;mvsm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_MitchellvsTheMachines_2021\/Netflix_MitchellvsTheMachines_2021.png&quot;,&quot;100t&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_Jan_2021_100T\/LCS_Jan_2021_100T.png&quot;,&quot;loona_ptt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KpopVIT_LOONA_June_2021\/KpopVIT_LOONA_June_2021.png&quot;,&quot;pso2ngs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PSO2NGS_JP_2021\/PSO2NGS_JP_2021.png&quot;,&quot;promoçãoelmachips&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ElmaChipsMeFazUmPix_2021\/ElmaChipsMeFazUmPix_2021.png&quot;,&quot;porcolumbus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CC\/MLS_2021_CC.png&quot;,&quot;ringthebell&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_PHI\/MLB_Teams_2021_PHI.png&quot;,&quot;disneyplusmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlusHotstarMalaysia_2021\/DisneyPlusHotstarMalaysia_2021.png&quot;,&quot;kami15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;weallbleedblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLSTLPlayoffs2021\/NHLSTLPlayoffs2021.png&quot;,&quot;stayhome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;lakeshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_LakeShow\/NBA_2021_Teams_LakeShow.png&quot;,&quot;白夜極光配信開始&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TencentAlchemyStarsJPLaunch_2021\/TencentAlchemyStarsJPLaunch_2021.png&quot;,&quot;픽사_루카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;ウルトラインパクト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/heroaca_ui_JP_2021\/heroaca_ui_JP_2021.png&quot;,&quot;ttwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_TTWIN\/LPL_2021_TTWIN.png&quot;,&quot;nyalakanlagi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;cheddarebacon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RufflesCheddarEBacon_2021\/RufflesCheddarEBacon_2021.png&quot;,&quot;miercolesdeloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;怪物奇兵&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;私を突き刺す棘byピッコマ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Watatoge_June_2021\/Piccoma_Watatoge_June_2021.png&quot;,&quot;新十六茶に新垣さんと中村さん&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrink16tea02Japan_2021\/AsahiSoftDrink16tea02Japan_2021.png&quot;,&quot;rbny&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_NYRB\/MLS_2021_NYRB.png&quot;,&quot;rallythevalley&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_RallyTheValley_add\/NBA_2021_Teams_RallyTheValley_add.png&quot;,&quot;fanzoneshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiarioAs_2021_add\/DiarioAs_2021_add.png&quot;,&quot;lngwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LPL_2021_LNGWIN\/LPL_2021_LNGWIN.png&quot;,&quot;dariuskincaid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_SamSalma_\/HitmansWifesBodyguard_2021_SamSalma_.png&quot;,&quot;esp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_ESP\/Euro_UK_2021_ESP.png&quot;,&quot;루카_애니&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;cro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_CRO\/Euro_UK_2021_CRO.png&quot;,&quot;ตเตอร์เพื่อสิ่งดีดี&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterForGood_Refresh_2021\/TwitterForGood_Refresh_2021.png&quot;,&quot;nousles15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;tva&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;sarahfier&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_Franchise_2_2021\/Netflix_FearStreetTrilogy_Franchise_2_2021.png&quot;,&quot;thitvs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnohAalegra_2021\/SnohAalegra_2021.png&quot;,&quot;astwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_ASTWIN\/LEC_EM_2021_ASTWIN.png&quot;,&quot;خليك_بالبيت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;cutabovethebest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mi11XSeries_IN_April_2021_v2\/Mi11XSeries_IN_April_2021_v2.png&quot;,&quot;princeherb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheImpracticalJokers_Julu_2021\/TheImpracticalJokers_Julu_2021.png&quot;,&quot;countdowntoloki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;リィンカネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NieRReincarnationLaunch_May_2021\/NieRReincarnationLaunch_May_2021.png&quot;,&quot;dunkindonutday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DunkinDonutDay_2021\/DunkinDonutDay_2021.png&quot;,&quot;ヒロトラフレンド募集&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/heroaca_ui_JP_2021\/heroaca_ui_JP_2021.png&quot;,&quot;livesmarterbts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SmartXBTS_2021\/SmartXBTS_2021.png&quot;,&quot;headintheclouds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/88RISING_May_2021\/88RISING_May_2021.png&quot;,&quot;turnerandhoochseries&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyPlus_TurnerandHooch_Dog_2021\/DisneyPlus_TurnerandHooch_Dog_2021.png&quot;,&quot;shyamalan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;nóikhôngvớibạohành&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;vaccineret&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;calledelterror1666&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1666_2021\/Netflix_FearStreetTrilogy_1666_2021.png&quot;,&quot;bam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BancolombiaNewHeart_April_2021\/BancolombiaNewHeart_April_2021.png&quot;,&quot;قطع_اینترنت&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;naotemjeitoerrado&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ballantinesbr_June_2021\/ballantinesbr_June_2021.png&quot;,&quot;tümkadınlar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;20yılıyedik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YemekSepeti_2021\/YemekSepeti_2021.png&quot;,&quot;bethefight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_BeTheFight\/NBA_2021_Teams_BeTheFight.png&quot;,&quot;هيئة_الترفيه&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GEA_June_2021\/GEA_June_2021.png&quot;,&quot;အိမ်မှာနေပါ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;survivalkitchallenge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TWDSurvivors_SG_2021\/TWDSurvivors_SG_2021.png&quot;,&quot;clippernation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_ClipperNation\/NBA_2021_Teams_ClipperNation.png&quot;,&quot;openingday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_OpeningDay\/MLB_Teams_2021_OpeningDay.png&quot;,&quot;таскмастер&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Taskmaster_2021\/Disney_BlackWidow_Taskmaster_2021.png&quot;,&quot;r6eul&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RainbowSixProLeague_2021_R6EUL\/RainbowSixProLeague_2021_R6EUL.png&quot;,&quot;starwarsthebadbatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;asiarisingtogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/88RISING_May_2021\/88RISING_May_2021.png&quot;,&quot;6thraven&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_LON\/CDL_Team_2021_LON.png&quot;,&quot;pemvaksinan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;purgaparasempre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021_v2\/TheForeverPurge_2021_v2.png&quot;,&quot;rickyourself&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RickandMorty2021_rick\/RickandMorty2021_rick.png&quot;,&quot;myx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MYXAwards2021\/MYXAwards2021.png&quot;,&quot;miathornton&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bravo_RHOP_Q3_2021_MiaThornton\/Bravo_RHOP_Q3_2021_MiaThornton.png&quot;,&quot;lucapelicula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;thebacheloretteabc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBachelorette_2021\/TheBachelorette_2021.png&quot;,&quot;magpabakuna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add\/vaccinated_2021_add.png&quot;,&quot;みんなの聖火リレー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TokyoOlympic_2021_Part1\/TokyoOlympic_2021_Part1.png&quot;,&quot;taskmaster&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Taskmaster_2021\/Disney_BlackWidow_Taskmaster_2021.png&quot;,&quot;raysup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_TB\/MLB_Teams_2021_TB.png&quot;,&quot;toofaan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToofaanOnPrime_July_2021\/ToofaanOnPrime_July_2021.png&quot;,&quot;mr10&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MarcusRashfordBook_2021\/MarcusRashfordBook_2021.png&quot;,&quot;루카_영화&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;vamossounders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_SeaS\/MLS_2021_SeaS.png&quot;,&quot;taylorsversion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TSRed2021\/TSRed2021.png&quot;,&quot;احجز_وعيشها&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnjoySaudi_June2021\/EnjoySaudi_June2021.png&quot;,&quot;留在家里&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;yeji&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_YEJI\/KPOP_VIT_ITZY_April_2021_YEJI.png&quot;,&quot;나타샤로마노프&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_BWNatasha_again_2021\/Disney_BlackWidow_BWNatasha_again_2021.png&quot;,&quot;ausnavy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DFR_2021_AusNavy_May\/DFR_2021_AusNavy_May.png&quot;,&quot;deoorlogvanmorgen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;bigtour2021&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BPIBigTour_2021\/BPIBigTour_2021.png&quot;,&quot;snollebollekesjuichcape&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JumboJuichcapeSummerOfSports2021\/JumboJuichcapeSummerOfSports2021.png&quot;,&quot;молодежьлидирует&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YouthLead_2020\/YouthLead_2020.png&quot;,&quot;detroitup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_DetroitUp\/NBA_2021_Teams_DetroitUp.png&quot;,&quot;pologhalloffame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Polo_G_Album_2021\/Polo_G_Album_2021.png&quot;,&quot;passionpurposebts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SmartXBTS_2021\/SmartXBTS_2021.png&quot;,&quot;zelda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NintendoZeldaSkywardSword_2021\/NintendoZeldaSkywardSword_2021.png&quot;,&quot;johnmayer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/John_Mayer_2021_Album\/John_Mayer_2021_Album.png&quot;,&quot;fastandfurious9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FastFurious9_April_2021\/FastFurious9_April_2021.png&quot;,&quot;xlweekend&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_NY\/OWL_Season4_Team_Feb_2021_NY.png&quot;,&quot;elderscrollsonline&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BethesdaElderScrollsBlackwood_2021\/BethesdaElderScrollsBlackwood_2021.png&quot;,&quot;dödsorsakkvinna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;verzuztv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Verzuz_2020_Flight4\/Verzuz_2020_Flight4.png&quot;,&quot;repsolhondateam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RepsolMotogpMotorcycle_2021\/RepsolMotogpMotorcycle_2021.png&quot;,&quot;changethegame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CHW\/MLB_Teams_2021_CHW.png&quot;,&quot;星よりレアより育成だ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Com2us_summonerswar_April_2021\/Com2us_summonerswar_April_2021.png&quot;,&quot;हम15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeThe15_2021\/WeThe15_2021.png&quot;,&quot;eqos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eqonex_July_2021\/Eqonex_July_2021.png&quot;,&quot;1series1xperience&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mi11XSeries_IN_April_2021_v2\/Mi11XSeries_IN_April_2021_v2.png&quot;,&quot;eltigretoño&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KelloggsMasterBrandCercaDeTi_2021_V3\/KelloggsMasterBrandCercaDeTi_2021_V3.png&quot;,&quot;limboep&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Njomza_Album_Emoji_2021\/Njomza_Album_Emoji_2021.png&quot;,&quot;tokyo2020&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Tokyo2020_Olympics\/Tokyo2020_Olympics.png&quot;,&quot;inchscider&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/inchscider_2021\/inchscider_2021.png&quot;,&quot;mtgmeetsdnd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MagicTheGathering_june_2021_\/MagicTheGathering_june_2021_.png&quot;,&quot;20yearsofxbox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xbox20thAnniversary_2021\/Xbox20thAnniversary_2021.png&quot;,&quot;armcherries&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArmchairExpert_2021\/ArmchairExpert_2021.png&quot;,&quot;stopgeweldtegenvrouwen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;mtgxdnd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MagicTheGathering_june_2021_\/MagicTheGathering_june_2021_.png&quot;,&quot;aceshigh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_London\/OWL_Season4_Team_Feb_2021_London.png&quot;,&quot;aoe4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxCardinal_2021\/XboxCardinal_2021.png&quot;,&quot;getgrafting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JDLoveIsland_2021\/JDLoveIsland_2021.png&quot;,&quot;gofreecs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_PL_AF\/LcK_2021_Teams_PL_AF.png&quot;,&quot;michaelbryce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HitmansWifesBodyguard_2021_SalmaRyan_\/HitmansWifesBodyguard_2021_SalmaRyan_.png&quot;,&quot;bigdealtinytacos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JackintheBoxTinyTacos_2021\/JackintheBoxTinyTacos_2021.png&quot;,&quot;persiannewyear&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;threeimagined&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PaulMcCartney_April_2021\/PaulMcCartney_April_2021.png&quot;,&quot;guardianorosso&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_RedGuardian_2021\/Disney_BlackWidow_RedGuardian_2021.png&quot;,&quot;adaptoid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HuluMODOK2021\/HuluMODOK2021.png&quot;,&quot;teoritetangaongawhakatipuranga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;스페이스잼&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpaceJam_2021\/SpaceJam_2021.png&quot;,&quot;secretsofthewhales&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyNatGeo_SecretsoftheWhales_April_2021\/DisneyNatGeo_SecretsoftheWhales_April_2021.png&quot;,&quot;hrderby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLBHRDerby2021-HRDerby\/MLBHRDerby2021-HRDerby.png&quot;,&quot;xbox6in6&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxLoveStory_2021\/XboxLoveStory_2021.png&quot;,&quot;howcanimakeitok&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WolfAlice_2021\/WolfAlice_2021.png&quot;,&quot;lathieves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_LAT\/CDL_Team_2021_LAT.png&quot;,&quot;nieteenmeer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;banistmo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BancolombiaNewHeart_April_2021\/BancolombiaNewHeart_April_2021.png&quot;,&quot;por&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_POR\/Euro_UK_2021_POR.png&quot;,&quot;lagrandeboucleelectrique&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Enedis_TDF_2021\/Enedis_TDF_2021.png&quot;,&quot;stopasianhate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StandForAsians_2021\/StandForAsians_2021.png&quot;,&quot;pandaigdigangarawngredcross&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;2inonebypoise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Poise_May_2021\/Poise_May_2021.png&quot;,&quot;diamundialmedialunaroja&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldRedCrossDay_May_2021_add2\/WorldRedCrossDay_May_2021_add2.png&quot;,&quot;uniteandconquer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_AU\/MLS_2021_AU.png&quot;,&quot;monicaturkeydance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Turkey\/HBOMax_Friends_Turkey.png&quot;,&quot;俺レベ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Piccoma_Oreleve_June_2021\/Piccoma_Oreleve_June_2021.png&quot;,&quot;ktwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCK_2021_Team_P1_KTWIN_v2\/LCK_2021_Team_P1_KTWIN_v2.png&quot;,&quot;كل_امرأة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;チーム8ツアーファイナル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/17_AKB_May_2021\/17_AKB_May_2021.png&quot;,&quot;xgp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XboxGamePass_2021\/XboxGamePass_2021.png&quot;,&quot;g2army&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_G2WIN\/LEC_EM_2021_G2WIN.png&quot;,&quot;おしえてトレクル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JP_ONEPIECE_trecru_2021\/JP_ONEPIECE_trecru_2021.png&quot;,&quot;mibr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_MIBR\/EsportsAllAccess_Jan_2021_MIBR.png&quot;,&quot;sweettooth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NetflixSweetTooth2021\/NetflixSweetTooth2021.png&quot;,&quot;eqo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Eqonex_July_2021\/Eqonex_July_2021.png&quot;,&quot;nbatwitterlive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBATwitterLive_2021\/NBATwitterLive_2021.png&quot;,&quot;マスクをしよう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WearAMask_2020_2021_ext3\/WearAMask_2020_2021_ext3.png&quot;,&quot;ਕੋਵਿਡ19ਭਾਰਤਸੇਵਾ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;femininearabic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FemaleArabic_21\/FemaleArabic_21.png&quot;,&quot;nonunadipiu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;vamosdbacks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_VamosDbacks_2021\/MLB_VamosDbacks_2021.png&quot;,&quot;igottheshot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AdCouncilVaccine_2021\/AdCouncilVaccine_2021.png&quot;,&quot;gherbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Gherbo_25_Album_Emoji_2021\/Gherbo_25_Album_Emoji_2021.png&quot;,&quot;resilientsf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_SF\/MLB_Teams_2021_SF.png&quot;,&quot;electricoffensive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RenaulteWays_2_2021\/RenaulteWays_2_2021.png&quot;,&quot;seausrise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_SEA\/MLB_Teams_2021_SEA.png&quot;,&quot;lvaces&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_Teams_2021_LV\/WNBA_Teams_2021_LV.png&quot;,&quot;birdland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_BAL\/MLB_Teams_2021_BAL.png&quot;,&quot;internetshutdowns&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KeepItOn_InternetShutdown_2021\/KeepItOn_InternetShutdown_2021.png&quot;,&quot;nursehero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CeraVe_ThankYouNurses_2021\/CeraVe_ThankYouNurses_2021.png&quot;,&quot;лукафильм&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_PixarLuca_Luca_2021\/Disney_PixarLuca_Luca_2021.png&quot;,&quot;待在家裡&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StayHome_2020_2021_ext3\/StayHome_2020_2021_ext3.png&quot;,&quot;buildyour5asideteam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ladbrokes5ASide_May_2021\/Ladbrokes5ASide_May_2021.png&quot;,&quot;dlive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JustinSuntron_2021_ext\/JustinSuntron_2021_ext.png&quot;,&quot;swe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_SWE\/Euro_UK_2021_SWE.png&quot;,&quot;تطبيق_عيشها&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EnjoySaudi_June2021\/EnjoySaudi_June2021.png&quot;,&quot;gostanford&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StanfordWomensFULLYearChamp\/StanfordWomensFULLYearChamp.png&quot;,&quot;maddennfl22&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaddenNFL22\/MaddenNFL22.png&quot;,&quot;sonukupaolsun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/btcturk_May_2021\/btcturk_May_2021.png&quot;,&quot;readysetpanic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_Panic_2021\/AmazonStudios_Panic_2021.png&quot;,&quot;tabitabipo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TreseOnNetflix_May_2021_ext\/TreseOnNetflix_May_2021_ext.png&quot;,&quot;houseofthedragon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseoftheDragonHBO_2021\/HouseoftheDragonHBO_2021.png&quot;,&quot;crew96&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_2021_CC\/MLS_2021_CC.png&quot;,&quot;رؤية_السعودية_2030&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SaudiVision2030\/SaudiVision2030.png&quot;,&quot;농심레드포스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LcK_2021_Teams_NS\/LcK_2021_Teams_NS.png&quot;,&quot;studentsstandup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Parkland_Extension\/Parkland_Extension.png&quot;,&quot;marshmello&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PepsiOpeningCeremony2021\/PepsiOpeningCeremony2021.png&quot;,&quot;vforvictory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_VITWIN\/LEC_EM_2021_VITWIN.png&quot;,&quot;eumasters&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LEC_EM_2021_EUMasters\/LEC_EM_2021_EUMasters.png&quot;,&quot;hktwittergetsvaxxed&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/vaccinated_2021_add2\/vaccinated_2021_add2.png&quot;,&quot;niunamás&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;shernionprime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SherniOnPrime_2021\/SherniOnPrime_2021.png&quot;,&quot;marvelsmodok&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HuluMODOK2021\/HuluMODOK2021.png&quot;,&quot;laguerradelmañana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TomorrowWar_2021\/AmazonStudios_TomorrowWar_2021.png&quot;,&quot;anewtrip&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBC_OldMovie_May_2021_v2\/NBC_OldMovie_May_2021_v2.png&quot;,&quot;tdx21&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SalesforceTrailhead2021\/SalesforceTrailhead2021.png&quot;,&quot;penanceadair&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/thenevershbo_2021_May_v2\/thenevershbo_2021_May_v2.png&quot;,&quot;infinite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Infinite_2021\/Paramount_Infinite_2021.png&quot;,&quot;niunamas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StopViolenceAgainstWomen_2020\/StopViolenceAgainstWomen_2020.png&quot;,&quot;ablackladysketchshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_ABLSS_May_2021\/HBO_ABLSS_May_2021.png&quot;,&quot;elecciones2021cl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChileElections_2021\/ChileElections_2021.png&quot;,&quot;oneplusnord2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlusNord_2021\/OnePlusNord_2021.png&quot;,&quot;senhoritaminutos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_Miss_Minutes_2021\/Disney_LokiLaunch_Miss_Minutes_2021.png&quot;,&quot;lightitup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_Season4_Team_Feb_2021_Florida\/OWL_Season4_Team_Feb_2021_Florida.png&quot;,&quot;gossipgirlhbomax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMaxGossipGirl_July_2021_XOXO\/HBOMaxGossipGirl_July_2021_XOXO.png&quot;,&quot;lcs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_League_2021\/LCS_League_2021.png&quot;,&quot;lovetomakeit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveToSeeIt_2021\/LoveToSeeIt_2021.png&quot;,&quot;কোভিড১৯ইন্ডিয়াসাহায্য&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Covid19India_2021\/Covid19India_2021.png&quot;,&quot;minumaqua&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KebaikanAqua_April_2021\/KebaikanAqua_April_2021.png&quot;,&quot;raidiant&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Raidiant_June_2021\/Raidiant_June_2021.png&quot;,&quot;メガ割&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qoo10_Shopping_Q2_2021\/Qoo10_Shopping_Q2_2021.png&quot;,&quot;fra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euro_UK_2021_FRA\/Euro_UK_2021_FRA.png&quot;,&quot;calledelterror&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_FearStreetTrilogy_1994_2021\/Netflix_FearStreetTrilogy_1994_2021.png&quot;,&quot;todasasmulheres&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EveryWoman_2020\/EveryWoman_2020.png&quot;,&quot;juichcape&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JumboJuichcapeSummerOfSports2021\/JumboJuichcapeSummerOfSports2021.png&quot;,&quot;dieudelamalice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2\/Disney_LokiLaunch_TVA_Jacket_Loki_2021_V2.png&quot;,&quot;purgemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheForeverPurge_2021\/TheForeverPurge_2021.png&quot;,&quot;backtheblues&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Origins21_BackTheBlues\/Origins21_BackTheBlues.png&quot;,&quot;atlup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CDL_Team_2021_ATL\/CDL_Team_2021_ATL.png&quot;,&quot;missuniverse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MissUniverse_2021\/MissUniverse_2021.png&quot;,&quot;maddennfl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaddenNFL22\/MaddenNFL22.png&quot;,&quot;wearethevalley&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_2021_Teams_WeAreTheValley\/NBA_2021_Teams_WeAreTheValley.png&quot;,&quot;theundergroundrailroad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_UndergroundRailroad_2021\/Amazon_UndergroundRailroad_2021.png&quot;,&quot;selenaday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SelenaNetflix_2021\/SelenaNetflix_2021.png&quot;,&quot;misschanandlerbong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBOMax_Friends_Frame\/HBOMax_Friends_Frame.png&quot;,&quot;十六茶&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiSoftDrink16tea02Japan_2021\/AsahiSoftDrink16tea02Japan_2021.png&quot;,&quot;theboldtype&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheBoldTypeTV_May_2021\/TheBoldTypeTV_May_2021.png&quot;,&quot;webull&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeBull_May_2021_v2\/WeBull_May_2021_v2.png&quot;,&quot;playme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpiralSaw2021\/SpiralSaw2021.png&quot;,&quot;homenspower&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PowerCouple_BR_May_2021\/PowerCouple_BR_May_2021.png&quot;,&quot;點亮橙色&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrangeTheWorld_2020\/OrangeTheWorld_2020.png&quot;,&quot;straightuptx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_TEX\/MLB_Teams_2021_TEX.png&quot;,&quot;мыженщины&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterWomenTentpole_2021\/TwitterWomenTentpole_2021.png&quot;,&quot;adobesummit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AdobeSummit_2021\/AdobeSummit_2021.png&quot;,&quot;physical&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PHYS_HASHFLAG_STRONGARM_2021\/PHYS_HASHFLAG_STRONGARM_2021.png&quot;,&quot;nuestrocle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_Teams_2021_CLE\/MLB_Teams_2021_CLE.png&quot;,&quot;pologhof&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Polo_G_Album_2021\/Polo_G_Album_2021.png&quot;,&quot;lokicongkak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_LokiLaunch_BoastfulLoki_2021\/Disney_LokiLaunch_BoastfulLoki_2021.png&quot;,&quot;hitc3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/88RISING_May_2021\/88RISING_May_2021.png&quot;,&quot;예지&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_VIT_ITZY_April_2021_YEJI\/KPOP_VIT_ITZY_April_2021_YEJI.png&quot;,&quot;readywillingable&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EsportsAllAccess_Jan_2021_ReadyWillingAble\/EsportsAllAccess_Jan_2021_ReadyWillingAble.png&quot;,&quot;timstwitterlisteningparties&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimsTwitterListeningParty_2021_2022\/TimsTwitterListeningParty_2021_2022.png&quot;,&quot;fuerzaclon99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_TheBadBatch_Helmet_April_2021\/Disney_TheBadBatch_Helmet_April_2021.png&quot;,&quot;magickingdom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_2020_Flight5_V2\/DisneyParks_MickeyEars_2020_Flight5_V2.png&quot;,&quot;marvelчернаявдова&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_BlackWidow_Symbol_2021_V2\/Disney_BlackWidow_Symbol_2021_V2.png&quot;},&quot;tweetId&quot;:&quot;1409351083177046020&quot;,&quot;profile_id&quot;:5637652,&quot;endpoint&quot;:&quot;\/i\/codinghorror\/conversation\/1409351083177046020&quot;,&quot;overlayCapable&quot;:false,&quot;finagleTraceId&quot;:&quot;001a05230064e857&quot;,&quot;isThreaded&quot;:true,&quot;inOverlay&quot;:true,&quot;trendsCacheKey&quot;:null,&quot;decider_personalized_trends&quot;:false,&quot;trendsEndpoint&quot;:&quot;\/i\/trends&quot;,&quot;initialState&quot;:{&quot;title&quot;:&quot;Jeff Atwood on Twitter: \&quot;My first text message from my child! A moment that shall live on in infamy!\u2026 \&quot;&quot;,&quot;section&quot;:null,&quot;module&quot;:&quot;app\/pages\/permalink&quot;,&quot;cache_ttl&quot;:300,&quot;body_class_names&quot;:&quot;three-col logged-out user-style-codinghorror PermalinkPage&quot;,&quot;doc_class_names&quot;:&quot;route-permalink&quot;,&quot;route_name&quot;:&quot;permalink&quot;,&quot;page_container_class_names&quot;:&quot;AppContent wrapper wrapper-permalink&quot;,&quot;ttft_navigation&quot;:false}}">
-
-  
-
-    <input type="hidden" class="swift-boot-module" value="app/pages/permalink">
-  <input type="hidden" id="swift-module-path" value="https://abs.twimg.com/k/swift/en">
-
-  
-    <script src="https://abs.twimg.com/k/en/init.en.d28d8449d76b990b62bf.js" async></script>
-
-  </body>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__zu7ppdkqypi" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/codinghorror" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Jeff Atwood</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/codinghorror" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@codinghorror</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/codinghorror/status/1409270864315486209" dir="ltr" aria-label="Jun 27, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-27T22:02:11.000Z">Jun 27, 2021</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__sd2ta53lv3" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Anyone else doing cellular Apple Watches rather than full blown cell phones for their almost-teens? The more I research this the more I like it.</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="22 replies, 6 Retweets, 90 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__q2j8mv07ccl">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="22 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">22</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="6 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">6</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="90 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">90</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409351083177046020" itemprop="identifier">
+<meta content="2" itemprop="position">
+<meta content="4" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-28T03:20:57.000Z" itemprop="dateCreated">
+<meta content="2021-06-28T03:20:57.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="url">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="mainEntityOfPage">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="5637652" itemprop="identifier">
+<meta content="codinghorror" itemprop="additionalName">
+<meta content="Jeff Atwood" itemprop="givenName">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/FollowAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="284044" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/SubscribeAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="277" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="82117" itemprop="userInteractionCount">
+</div>
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/TQMRJsFwnO" itemprop="url">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020/photo/1" itemprop="url">
+</div>
+<meta content="https://twitter.com/codinghorror/status/1409270864315486209" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020/likes" itemprop="url">
+<meta content="85" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="url">
+<meta content="4" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__suctvga0xlr id__kj6f74rrf5r id__b0efe6oquqf id__f3z2uddesr id__xmkqo9g1w1q id__bwl366m317s id__rnobdd1dfy id__4ne6vtsu02n id__k3kkoosn7lm id__iw09csvxbqa id__pie16bp4qbj id__rxqpdtu6rwq id__f7iutpffwuj id__1ipvwa4pbuz id__z59ufmodgg id__lf27xcfcf6s id__sl06dryrnk id__fmj9712b4x id__u8kmfj3tezh" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1hwvwag r-18kxxzh r-15zivkp r-1b7u577"><div class="css-1dbjc4n r-1bimlpy r-1p0dtai r-1d2f490 r-1jgb5lz r-u8s1d r-zchlnj r-ipm5af r-m5arl1"></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div>
+</div></div>
+<div class="css-1dbjc4n r-18u37iz r-15zivkp">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-codinghorror">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/codinghorror" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1517287320235298816/Qx-O6UCY_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1517287320235298816/Qx-O6UCY_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci"><div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__xmkqo9g1w1q" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/codinghorror" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Jeff Atwood</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/codinghorror" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@codinghorror</span></div></a></div></div></div>
+</div></div></div></div></div></div>
+</div>
+<div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n"><div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n r-1s2bzr4"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-1inkyih r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__pie16bp4qbj" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">My first text message from my child! A moment that shall live on in infamy!</span></div></div></div></div>
+<div class="css-1dbjc4n"><div aria-labelledby="id__7ylkdjmyscc id__x9cyyyj309m" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__f7iutpffwuj"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:124.57684495599187%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/E48FVowUUAYyGLX?format=jpg&amp;name=large")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/E48FVowUUAYyGLX?format=jpg&amp;name=large" class="css-9pa8cd">
+</div></div>
+</div></div></div></div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/E48FVowUUAYyGLX.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/E48FVowUUAYyGLX?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="1477" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n"></div>
+<div class="css-1dbjc4n r-1r5su4o"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wtj0ep">
+<div class="css-1dbjc4n r-1b7u577"><div class="css-1dbjc4n r-1d09ksm r-1471scf r-18u37iz r-1wbh5a2"><div dir="ltr" class="css-901oao r-14j79pv r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><a href="/codinghorror/status/1409351083177046020" aria-describedby="id__lcuy47jaujk" aria-label="3:20 AM · Jun 28, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-poiln3 r-9aw3ui r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-28T03:20:57.000Z">3:20 AM · Jun 28, 2021</time></a></div></div></div>
+<div class="css-1dbjc4n r-18u37iz"></div>
+</div></div>
+<div role="group" class="css-1dbjc4n r-18u37iz r-1w6e6rj">
+<div role="separator" class="css-1dbjc4n r-1dgieki r-1efd50x r-5kkj8d r-109y4c4 r-13qz1uu"></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/codinghorror/status/1409351083177046020/likes" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">85</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Likes</span></span></a></div>
+</div>
+<div class="css-1dbjc4n"><div role="group" class="css-1dbjc4n r-1oszu61 r-1dgieki r-1efd50x r-5kkj8d r-1ta3fxp r-18u37iz r-h3s6tt r-a2tzq0 r-3qxfft r-s1qlax" id="id__u8kmfj3tezh">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Bookmark" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="bookmark"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4 4.5C4 3.12 5.119 2 6.5 2h11C18.881 2 20 3.12 20 4.5v18.44l-8-5.71-8 5.71V4.5zM6.5 4c-.276 0-.5.22-.5.5v14.56l6-4.29 6 4.29V4.5c0-.28-.224-.5-.5-.5h-11z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-rull8r r-qklmqi"></div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409352104590729216" itemprop="identifier">
+<meta content="3" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-28T03:25:00.000Z" itemprop="dateCreated">
+<meta content="2021-06-28T03:25:00.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/f_fz/status/1409352104590729216" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="56679923" itemprop="identifier">
+<meta content="f_fz" itemprop="additionalName">
+<meta content="Ferdi F.Z." itemprop="givenName">
+</div>
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/f_fz/status/1409352104590729216/likes" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/f_fz/status/1409352104590729216/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/f_fz/status/1409352104590729216/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/f_fz/status/1409352104590729216" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__bejfoqizk5 id__d4nrpwgwmwk id__fj9wmixnu7n id__vyvu1f5clp id__bj2jrgmi7u5 id__s50mes4osei id__zozaeyvv4lp id__b8pwfq6rp4e id__z7jk16pt6t id__pous16hv06l id__kcl6ciq674a id__3xnlzwvx60v id__ao9xmr9n23w id__99uy1bs53xd id__20ffhwkuid8 id__lnl96mogrza id__6sfa5g6xjf id__pz7aekvp1f id__mm5atbl979f" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-f_fz">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/f_fz" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1361289869025181696/xvnNIGUA_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1361289869025181696/xvnNIGUA_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__bj2jrgmi7u5" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/f_fz" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Ferdi F.Z.</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/f_fz" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@f_fz</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/f_fz/status/1409352104590729216" dir="ltr" aria-label="Jun 28, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-28T03:25:00.000Z">Jun 28, 2021</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__kcl6ciq674a" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Mind-blown!</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 like" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__mm5atbl979f">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Like. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409352727008714757" itemprop="identifier">
+<meta content="4" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-28T03:27:29.000Z" itemprop="dateCreated">
+<meta content="2021-06-28T03:27:29.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/chetfaliszek/status/1409352727008714757" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="982040378" itemprop="identifier">
+<meta content="chetfaliszek" itemprop="additionalName">
+<meta content="Chet Faliszek" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/chetfaliszek/status/1409352727008714757/likes" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/chetfaliszek/status/1409352727008714757/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/chetfaliszek/status/1409352727008714757/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/chetfaliszek/status/1409352727008714757" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__6s3oxgufz6r id__atl1s0nqiwe id__dm1b7tg5a46 id__jlzv7mqmzus id__r6naboxypj9 id__qq9yprs0szb id__j8yzpnggksk id__h8ef30teyk id__60viiklzgl6 id__hjvr8n6lpb id__tr5imvyt5bg id__y4hm0wgr8r id__uefmcgxzbec id__2sa5ffr9i7d id__6k87dgzslqq id__9edyg17z9fe id__ak7eo0ltcxw id__c16rhgl89uh id__h22detcuhtf" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-chetfaliszek">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/chetfaliszek" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/2920094567/ecc0064d125a61407e9c0a735a5c5f76_400x400.jpeg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/2920094567/ecc0064d125a61407e9c0a735a5c5f76_400x400.jpeg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__r6naboxypj9" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/chetfaliszek" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Chet Faliszek</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/chetfaliszek" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@chetfaliszek</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/chetfaliszek/status/1409352727008714757" dir="ltr" aria-label="Jun 28, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-28T03:27:29.000Z">Jun 28, 2021</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__tr5imvyt5bg" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Make it their first NFT!</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="2 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__h22detcuhtf">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409353075232362505" itemprop="identifier">
+<meta content="5" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-28T03:28:52.000Z" itemprop="dateCreated">
+<meta content="2021-06-28T03:28:52.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="34945729" itemprop="identifier">
+<meta content="Hanzo55" itemprop="additionalName">
+<meta content="Shawn Holmes" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/ARtq5AkZqG" itemprop="url">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505/photo/1" itemprop="url">
+</div>
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505/likes" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Hanzo55/status/1409353075232362505" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__86a4p49htdb id__xh9f4uz2plb id__zoyrlnm72c id__ddin2pguay id__ljree44kcpc id__2bmhbv5czdm id__1uwenpesxk7 id__pik36rqcqt id__zoq5r106ejb id__4faym9u57th id__fcxz47a7ikl id__1vur6c8r629 id__dws3bivncbd id__4859bu5qwus id__hzik0htuiwb id__nih33plwasd id__agtlessmu7 id__j2x7h2airba id__nafsejmaop" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Hanzo55">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Hanzo55" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1400457518669721604/v5zouGS9_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1400457518669721604/v5zouGS9_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__ljree44kcpc" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Hanzo55" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Shawn Holmes</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Hanzo55" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Hanzo55</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Hanzo55/status/1409353075232362505" dir="ltr" aria-label="Jun 28, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-28T03:28:52.000Z">Jun 28, 2021</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__fcxz47a7ikl" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">This will be the next milestone</span></div></div></div>
+<div aria-labelledby="id__iqqc4vxsqc id__bnes0pdnfdh" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__dws3bivncbd"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:58.07799442896936%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/E48HJy6XIAAUbuy?format=jpg&amp;name=900x900")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/E48HJy6XIAAUbuy?format=jpg&amp;name=900x900" class="css-9pa8cd">
+</div></div>
+</div></div></div></div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/E48HJy6XIAAUbuy.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/E48HJy6XIAAUbuy?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="718" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+</div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="2 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__nafsejmaop">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1409354572838195201" itemprop="identifier">
+<meta content="6" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2021-06-28T03:34:49.000Z" itemprop="dateCreated">
+<meta content="2021-06-28T03:34:49.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/andrenaleen/status/1409354572838195201" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="901153681806176256" itemprop="identifier">
+<meta content="andrenaleen" itemprop="additionalName">
+<meta content="Andrei Taranchenko" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/codinghorror/status/1409351083177046020" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/andrenaleen/status/1409354572838195201/likes" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/andrenaleen/status/1409354572838195201/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/andrenaleen/status/1409354572838195201/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/andrenaleen/status/1409354572838195201" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__h7bvcsebky9 id__hc8ixps6x5t id__nu952nfyqk id__peis6vyrys id__8dcsijrt8sb id__fayyx23n6i id__pnx8m01a1l id__tn2xwku5nr id__9v81q0zmtu4 id__gcwkb5ylrii id__zllf8uan3kc id__cs37rzzpt9o id__smsdaa7bkhc id__suaoitn4fj id__rxd6aqy76rq id__mcxhli3g73g id__guc3dmwzabr id__dc5tj6adrit id__hoo5q3ndf1h" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-andrenaleen">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/andrenaleen" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1069583899683110912/Xe38w2ow_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1069583899683110912/Xe38w2ow_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__8dcsijrt8sb" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/andrenaleen" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Andrei Taranchenko</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/andrenaleen" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@andrenaleen</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/andrenaleen/status/1409354572838195201" dir="ltr" aria-label="Jun 28, 2021" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2021-06-28T03:34:49.000Z">Jun 28, 2021</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__zllf8uan3kc" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">I mean, a text from your kid is less dramatic than Pearl Harbor, but I don't have all the info.</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 like" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__hoo5q3ndf1h">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Like. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-o52ifk"><div class="css-1dbjc4n r-o52ifk"></div></div>
+</div></div></section>
+</div></div></div></div></div></div></main><div aria-valuemax="1" aria-valuemin="0" role="progressbar" class="css-1dbjc4n r-1awozwy r-1777fci" style="width:300px"><div class="css-1dbjc4n r-17bb2tj r-1muvv40 r-127358a r-1ldzwu0" style="height:26px;width:26px"><svg height="100%" viewbox="0 0 32 32" width="100%"><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;opacity:0.2"></circle><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;stroke-dasharray:80;stroke-dashoffset:60"></circle></svg></div></div>
+</div></div></div></div>
+</body>
 </html>

--- a/spec/fixtures/onebox/twitterstatus_quoted.response
+++ b/spec/fixtures/onebox/twitterstatus_quoted.response
@@ -1,7199 +1,1940 @@
 <!DOCTYPE html>
-<html lang="es" data-scribe-reduced-action-queue="true">
-  <head>
-
-
-
-
-
-
-
-    <meta charset="utf-8">
-      <script  nonce="EhqI0o5dnBq1BU4s2e1q/w==">
-        !function(){window.initErrorstack||(window.initErrorstack=[]),window.onerror=function(r,i,n,o,t){r.indexOf("Script error.")>-1||window.initErrorstack.push({errorMsg:r,url:i,lineNumber:n,column:o,errorObj:t})}}();
-      </script>
-
-
-
-  <script id="bouncer_terminate_iframe" nonce="EhqI0o5dnBq1BU4s2e1q/w==">
-    if (window.top != window) {
-  window.top.postMessage({'bouncer': true, 'event': 'complete'}, '*');
-}
-  </script>
-  <script id="swift_action_queue" nonce="EhqI0o5dnBq1BU4s2e1q/w==">
-    !function(){function e(e){if(e||(e=window.event),!e)return!1;if(e.timestamp=(new Date).getTime(),!e.target&&e.srcElement&&(e.target=e.srcElement),document.documentElement.getAttribute("data-scribe-reduced-action-queue"))for(var t=e.target;t&&t!=document.body;){if("A"==t.tagName)return;t=t.parentNode}return i("all",o(e)),a(e)?(document.addEventListener||(e=o(e)),e.preventDefault=e.stopPropagation=e.stopImmediatePropagation=function(){},y?(v.push(e),i("captured",e)):i("ignored",e),!1):(i("direct",e),!0)}function t(e){n();for(var t,r=0;t=v[r];r++){var a=e(t.target),i=a.closest("a")[0];if("click"==t.type&&i){var o=e.data(i,"events"),u=o&&o.click,c=!i.hostname.match(g)||!i.href.match(/#$/);if(!u&&c){window.location=i.href;continue}}a.trigger(e.event.fix(t))}window.swiftActionQueue.wasFlushed=!0}function r(){for(var e in b)if("all"!=e)for(var t=b[e],r=0;r<t.length;r++)console.log("actionQueue",c(t[r]))}function n(){clearTimeout(w);for(var e,t=0;e=h[t];t++)document["on"+e]=null}function a(e){if(!e.target)return!1;var t=e.target,r=(t.tagName||"").toLowerCase();if(e.metaKey)return!1;if(e.shiftKey&&"a"==r)return!1;if(t.hostname&&!t.hostname.match(g))return!1;if(e.type.match(p)&&s(t))return!1;if("label"==r){var n=t.getAttribute("for");if(n){var a=document.getElementById(n);if(a&&f(a))return!1}else for(var i,o=0;i=t.childNodes[o];o++)if(f(i))return!1}return!0}function i(e,t){t.bucket=e,b[e].push(t)}function o(e){var t={};for(var r in e)t[r]=e[r];return t}function u(e){for(;e&&e!=document.body;){if("A"==e.tagName)return e;e=e.parentNode}}function c(e){var t=[];e.bucket&&t.push("["+e.bucket+"]"),t.push(e.type);var r,n,a=e.target,i=u(a),o="",c=e.timestamp&&e.timestamp-d;return"click"===e.type&&i?(r=i.className.trim().replace(/\s+/g,"."),n=i.id.trim(),o=/[^#]$/.test(i.href)?" ("+i.href+")":"",a='"'+i.innerText.replace(/\n+/g," ").trim()+'"'):(r=a.className.trim().replace(/\s+/g,"."),n=a.id.trim(),a=a.tagName.toLowerCase(),e.keyCode&&(a=String.fromCharCode(e.keyCode)+" : "+a)),t.push(a+o+(n&&"#"+n)+(!n&&r?"."+r:"")),c&&t.push(c),t.join(" ")}function f(e){var t=(e.tagName||"").toLowerCase();return"input"==t&&"checkbox"==e.getAttribute("type")}function s(e){var t=(e.tagName||"").toLowerCase();return"textarea"==t||"input"==t&&"text"==e.getAttribute("type")||"true"==e.getAttribute("contenteditable")}for(var m,d=(new Date).getTime(),l=1e4,g=/^([^\.]+\.)*twitter\.com$/,p=/^key/,h=["click","keydown","keypress","keyup"],v=[],w=null,y=!0,b={captured:[],ignored:[],direct:[],all:[]},k=0;m=h[k];k++)document["on"+m]=e;w=setTimeout(function(){y=!1},l),window.swiftActionQueue={buckets:b,flush:t,logActions:r,wasFlushed:!1}}();
-  </script>
-  <script id="composition_state" nonce="EhqI0o5dnBq1BU4s2e1q/w==">
-    !function(){function t(t){t.target.setAttribute("data-in-composition","true")}function n(t){t.target.removeAttribute("data-in-composition")}document.addEventListener&&(document.addEventListener("compositionstart",t,!1),document.addEventListener("compositionend",n,!1))}();
-  </script>
-
-    <link rel="stylesheet" href="https://abs.twimg.com/a/1558678534/css/t1/twitter_core.bundle.css" class="coreCSSBundles">
-  <link rel="stylesheet" class="moreCSSBundles" href="https://abs.twimg.com/a/1558678534/css/t1/twitter_more_1.bundle.css">
-  <link rel="stylesheet" class="moreCSSBundles" href="https://abs.twimg.com/a/1558678534/css/t1/twitter_more_2.bundle.css">
-
-    <link rel="dns-prefetch" href="https://pbs.twimg.com">
-    <link rel="dns-prefetch" href="https://t.co">
-      <link rel="preload" href="https://abs.twimg.com/k/es/init.es.385f8696ec56dc29cfc0.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/k/es/0.commons.es.db1356329b6e4ff88e45.js" as="script">
-      <link rel="preload" href="https://abs.twimg.com/k/es/5.pages_permalink.es.284053c57214b5dfa9de.js" as="script">
-
-      <title>Metallica en Twitter: &quot;Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp; @PompiersParis. #AWMH #MetalicaGivesBack… https://t.co/00ZbffUluP&quot;</title>
-      <meta name="robots" content="NOODP">
-
-
-
-
-<meta name="msapplication-TileImage" content="//abs.twimg.com/favicons/win8-tile-144.png"/>
-<meta name="msapplication-TileColor" content="#00aced"/>
-
-
-
-<link rel="mask-icon" sizes="any" href="https://abs.twimg.com/a/1558678534/icons/favicon.svg" color="#1da1f2">
-
-<link rel="shortcut icon" href="//abs.twimg.com/favicons/favicon.ico" type="image/x-icon">
-<link rel="apple-touch-icon" href="https://abs.twimg.com/icons/apple-touch-icon-192x192.png" sizes="192x192">
-
-<link rel="manifest" href="/manifest.json">
-
-
-  <meta name="swift-page-name" id="swift-page-name" content="permalink">
-  <meta name="swift-page-section" id="swift-section-name" content="permalink">
-
-    <link rel="canonical" href="https://twitter.com/metallica/status/1128068672289890305">
-  <link rel="alternate" hreflang="x-default" href="https://twitter.com/metallica/status/1128068672289890305">
-  <link rel="alternate" hreflang="fr" href="https://twitter.com/metallica/status/1128068672289890305?lang=fr"><link rel="alternate" hreflang="en" href="https://twitter.com/metallica/status/1128068672289890305?lang=en"><link rel="alternate" hreflang="ar" href="https://twitter.com/metallica/status/1128068672289890305?lang=ar"><link rel="alternate" hreflang="ja" href="https://twitter.com/metallica/status/1128068672289890305?lang=ja"><link rel="alternate" hreflang="es" href="https://twitter.com/metallica/status/1128068672289890305?lang=es"><link rel="alternate" hreflang="de" href="https://twitter.com/metallica/status/1128068672289890305?lang=de"><link rel="alternate" hreflang="it" href="https://twitter.com/metallica/status/1128068672289890305?lang=it"><link rel="alternate" hreflang="id" href="https://twitter.com/metallica/status/1128068672289890305?lang=id"><link rel="alternate" hreflang="pt" href="https://twitter.com/metallica/status/1128068672289890305?lang=pt"><link rel="alternate" hreflang="ko" href="https://twitter.com/metallica/status/1128068672289890305?lang=ko"><link rel="alternate" hreflang="tr" href="https://twitter.com/metallica/status/1128068672289890305?lang=tr"><link rel="alternate" hreflang="ru" href="https://twitter.com/metallica/status/1128068672289890305?lang=ru"><link rel="alternate" hreflang="nl" href="https://twitter.com/metallica/status/1128068672289890305?lang=nl"><link rel="alternate" hreflang="fil" href="https://twitter.com/metallica/status/1128068672289890305?lang=fil"><link rel="alternate" hreflang="ms" href="https://twitter.com/metallica/status/1128068672289890305?lang=ms"><link rel="alternate" hreflang="zh-tw" href="https://twitter.com/metallica/status/1128068672289890305?lang=zh-tw"><link rel="alternate" hreflang="zh-cn" href="https://twitter.com/metallica/status/1128068672289890305?lang=zh-cn"><link rel="alternate" hreflang="hi" href="https://twitter.com/metallica/status/1128068672289890305?lang=hi"><link rel="alternate" hreflang="no" href="https://twitter.com/metallica/status/1128068672289890305?lang=no"><link rel="alternate" hreflang="sv" href="https://twitter.com/metallica/status/1128068672289890305?lang=sv"><link rel="alternate" hreflang="fi" href="https://twitter.com/metallica/status/1128068672289890305?lang=fi"><link rel="alternate" hreflang="da" href="https://twitter.com/metallica/status/1128068672289890305?lang=da"><link rel="alternate" hreflang="pl" href="https://twitter.com/metallica/status/1128068672289890305?lang=pl"><link rel="alternate" hreflang="hu" href="https://twitter.com/metallica/status/1128068672289890305?lang=hu"><link rel="alternate" hreflang="fa" href="https://twitter.com/metallica/status/1128068672289890305?lang=fa"><link rel="alternate" hreflang="he" href="https://twitter.com/metallica/status/1128068672289890305?lang=he"><link rel="alternate" hreflang="ur" href="https://twitter.com/metallica/status/1128068672289890305?lang=ur"><link rel="alternate" hreflang="th" href="https://twitter.com/metallica/status/1128068672289890305?lang=th"><link rel="alternate" hreflang="uk" href="https://twitter.com/metallica/status/1128068672289890305?lang=uk"><link rel="alternate" hreflang="ca" href="https://twitter.com/metallica/status/1128068672289890305?lang=ca"><link rel="alternate" hreflang="ga" href="https://twitter.com/metallica/status/1128068672289890305?lang=ga"><link rel="alternate" hreflang="el" href="https://twitter.com/metallica/status/1128068672289890305?lang=el"><link rel="alternate" hreflang="eu" href="https://twitter.com/metallica/status/1128068672289890305?lang=eu"><link rel="alternate" hreflang="cs" href="https://twitter.com/metallica/status/1128068672289890305?lang=cs"><link rel="alternate" hreflang="gl" href="https://twitter.com/metallica/status/1128068672289890305?lang=gl"><link rel="alternate" hreflang="ro" href="https://twitter.com/metallica/status/1128068672289890305?lang=ro"><link rel="alternate" hreflang="hr" href="https://twitter.com/metallica/status/1128068672289890305?lang=hr"><link rel="alternate" hreflang="en-gb" href="https://twitter.com/metallica/status/1128068672289890305?lang=en-gb"><link rel="alternate" hreflang="vi" href="https://twitter.com/metallica/status/1128068672289890305?lang=vi"><link rel="alternate" hreflang="bn" href="https://twitter.com/metallica/status/1128068672289890305?lang=bn"><link rel="alternate" hreflang="bg" href="https://twitter.com/metallica/status/1128068672289890305?lang=bg"><link rel="alternate" hreflang="sr" href="https://twitter.com/metallica/status/1128068672289890305?lang=sr"><link rel="alternate" hreflang="sk" href="https://twitter.com/metallica/status/1128068672289890305?lang=sk"><link rel="alternate" hreflang="gu" href="https://twitter.com/metallica/status/1128068672289890305?lang=gu"><link rel="alternate" hreflang="mr" href="https://twitter.com/metallica/status/1128068672289890305?lang=mr"><link rel="alternate" hreflang="ta" href="https://twitter.com/metallica/status/1128068672289890305?lang=ta"><link rel="alternate" hreflang="kn" href="https://twitter.com/metallica/status/1128068672289890305?lang=kn">
-
-    <link rel="alternate" type="application/json+oembed" href="https://publish.twitter.com/oembed?url=https://twitter.com/Metallica/status/1128068672289890305" title="Metallica en Twitter: &quot;Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp; @PompiersParis. #AWMH #MetalicaGivesBack… https://t.co/00ZbffUluP&quot;">
-
-
-  <link rel="alternate" media="handheld, only screen and (max-width: 640px)" href="https://mobile.twitter.com/metallica/status/1128068672289890305">
-
-      <link rel="alternate" href="android-app://com.twitter.android/twitter/tweet?status_id=1128068672289890305&amp;ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Estatus%7Ctwterm%5E1128068672289890305">
-
+<html dir="ltr" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover">
+<link rel="preconnect" href="//abs.twimg.com">
+<link rel="dns-prefetch" href="//abs.twimg.com">
+<link rel="preconnect" href="//api.twitter.com">
+<link rel="dns-prefetch" href="//api.twitter.com">
+<link rel="preconnect" href="//pbs.twimg.com">
+<link rel="dns-prefetch" href="//pbs.twimg.com">
+<link rel="preconnect" href="//t.co">
+<link rel="dns-prefetch" href="//t.co">
+<link rel="preconnect" href="//video.twimg.com">
+<link rel="dns-prefetch" href="//video.twimg.com">
+<meta property="fb:app_id" content="2231777543">
+<meta property="og:site_name" content="Twitter">
+<meta name="google-site-verification" content="acYOOcR5z6puMzLn6hLDZI1nNHXPxt57OIstz1vnCV0">
+<meta name="facebook-domain-verification" content="x6sdcc8b5ju3bh8nbm59eswogvg6t1">
+<meta http-equiv="onion-location" content="https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/">
+<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
 <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
-
-    <link id="async-css-placeholder">
-
-        <meta  property="al:ios:url" content="twitter://status?id=1128068672289890305">
-    <meta  property="al:ios:app_store_id" content="333903271">
-    <meta  property="al:ios:app_name" content="Twitter">
-    <meta  property="al:android:url" content="twitter://status?status_id=1128068672289890305">
-    <meta  property="al:android:package" content="com.twitter.android">
-    <meta  property="al:android:app_name" content="Twitter">
-    <meta  property="og:type" content="article">
-    <meta  property="og:url" content="https://twitter.com/Metallica/status/1128068672289890305">
-    <meta  property="og:title" content="Metallica on Twitter">
-    <meta  property="og:image" content="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_400x400.jpg">
-    <meta  property="og:description" content="“Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp;amp; @PompiersParis. #AWMH #MetalicaGivesBack https://t.co/gLtZSdDFmN”">
-    <meta  property="og:site_name" content="Twitter">
-    <meta  property="fb:app_id" content="2231777543">
-
-  </head>
-  <body class="three-col logged-out user-style-Metallica western es PermalinkPage"
-data-fouc-class-names="swift-loading no-nav-banners"
- dir="ltr">
-      <script id="swift_loading_indicator" nonce="EhqI0o5dnBq1BU4s2e1q/w==">
-        document.body.className=document.body.className+" "+document.body.getAttribute("data-fouc-class-names");
-      </script>
-
-
-    <noscript>
-      <form action="https://mobile.twitter.com/i/nojs_router?path=%2FMetallica%2Fstatus%2F1128068672289890305" method="POST" class="NoScriptForm">
-        <input type="hidden" value="b236e0558eecae44fa52b464d55738d5236980e7" name="authenticity_token">
-
-        <div class="NoScriptForm-content">
-          <span class="NoScriptForm-logo Icon Icon--logo Icon--extraLarge"></span>
-          <p>Detectamos que JavaScript está desactivado en tu navegador. ¿Quieres continuar con la versión antigua de Twitter?</p>
-          <p class="NoScriptForm-buttonContainer"><button type="submit" class="EdgeButton EdgeButton--primary">Sí</button></p>
-        </div>
-      </form>
-    </noscript>
-
-    <a href="#timeline" class="u-hiddenVisually focusable">Saltar al contenido</a>
-
-
-
-
-
-
-
-
-
-
-    <div id="doc" data-at-shortcutkeys="{&quot;Enter&quot;:&quot;Abrir detalles del Tweet&quot;,&quot;o&quot;:&quot;Expandir foto&quot;,&quot;/&quot;:&quot;Buscar&quot;,&quot;?&quot;:&quot;Este men\u00fa&quot;,&quot;j&quot;:&quot;Siguiente Tweet&quot;,&quot;k&quot;:&quot;Tweet anterior&quot;,&quot;Space&quot;:&quot;Desplazar hacia abajo&quot;,&quot;.&quot;:&quot;Cargar Tweets nuevos&quot;,&quot;gu&quot;:&quot;Ir al usuario\u2026&quot;}" class="route-permalink">
-        <div class="topbar js-topbar">
-
-
-
-    <div class="global-nav global-nav--newLoggedOut" data-section-term="top_nav">
-      <div class="global-nav-inner">
-        <div class="container">
-
-
-<ul class="nav js-global-actions" role="navigation" id="global-actions">
-  <li id="global-nav-home" class="home" data-global-action="home">
-    <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/" data-component-context="home_nav" data-nav="home">
-      <span class="Icon Icon--bird Icon--large"></span>
-      <span class="text" aria-hidden="true">Inicio</span>
-      <span class="u-hiddenVisually a11y-inactive-page-text">Inicio</span>
-      <span class="u-hiddenVisually a11y-active-page-text">Inicio, página actual.</span>
-    </a>
-  </li>
-    <li id="global-nav-moments" class="moments" data-global-action="moments">
-      <a class="js-nav js-tooltip js-dynamic-tooltip" data-placement="bottom" href="/i/moments" data-component-context="moments_nav" data-nav="moments">
-        <span class="Icon Icon--lightning Icon--large"></span>
-        <span class="Icon Icon--lightningFilled Icon--large"></span>
-        <span class="text" aria-hidden="true">Momentos</span>
-        <span class="u-hiddenVisually a11y-inactive-page-text">Momentos</span>
-        <span class="u-hiddenVisually a11y-active-page-text">Momentos, página actual.</span>
-      </a>
-    </li>
-</ul>
-<div class="pull-right nav-extras">
-    <div role="search">
-  <form class="t1-form form-search js-search-form" action="/search" id="global-nav-search">
-    <label class="visuallyhidden" for="search-query">Consulta de búsqueda</label>
-    <input class="search-input" type="text" id="search-query" placeholder="Buscar en Twitter" name="q" autocomplete="off" spellcheck="false">
-    <span class="search-icon js-search-action">
-      <button type="submit" class="Icon Icon--medium Icon--search nav-search">
-        <span class="visuallyhidden">Buscar en Twitter</span>
-      </button>
-    </span>
-
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Búsquedas guardadas</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Eliminar</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-    <ul role="presentation" class="typeahead-items typeahead-accounts social-context js-typeahead-accounts">
-
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <div class="js-selectable typeahead-in-conversation hidden">
-        <span class="Icon Icon--follower Icon--small"></span>
-        <span class="typeahead-in-conversation-text">En esta conversación</span>
-      </div>
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info account-group">
-        <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-      </span>
-      <span class="typeahead-social-context"></span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-
-<div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Usuarios recomendados
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-  </form>
-</div>
-
-
-  <ul class="nav secondary-nav language-dropdown">
-    <li class="dropdown js-language-dropdown">
-      <a href="#supported_languages" class="dropdown-toggle js-dropdown-toggle">
-        <small>Idioma:</small> <span class="js-current-language">Español</span> <b class="caret"></b>
-      </a>
-      <div class="dropdown-menu dropdown-menu--rightAlign is-forceRight">
-        <div class="dropdown-caret right">
-          <span class="caret-outer"> </span>
-          <span class="caret-inner"></span>
-        </div>
-        <ul id="supported_languages">
-            <li><a href="?lang=id" data-lang-code="id" title="indonesio" class="js-language-link js-tooltip" rel="noopener">Bahasa Indonesia</a></li>
-            <li><a href="?lang=msa" data-lang-code="msa" title="malayo" class="js-language-link js-tooltip" rel="noopener">Bahasa Melayu</a></li>
-            <li><a href="?lang=ca" data-lang-code="ca" title="catalán" class="js-language-link js-tooltip" rel="noopener">Català</a></li>
-            <li><a href="?lang=cs" data-lang-code="cs" title="checo" class="js-language-link js-tooltip" rel="noopener">Čeština</a></li>
-            <li><a href="?lang=da" data-lang-code="da" title="danés" class="js-language-link js-tooltip" rel="noopener">Dansk</a></li>
-            <li><a href="?lang=de" data-lang-code="de" title="alemán" class="js-language-link js-tooltip" rel="noopener">Deutsch</a></li>
-            <li><a href="?lang=en" data-lang-code="en" title="inglés" class="js-language-link js-tooltip" rel="noopener">English</a></li>
-            <li><a href="?lang=en-gb" data-lang-code="en-gb" title="inglés británico" class="js-language-link js-tooltip" rel="noopener">English UK</a></li>
-            <li><a href="?lang=fil" data-lang-code="fil" title="filipino" class="js-language-link js-tooltip" rel="noopener">Filipino</a></li>
-            <li><a href="?lang=fr" data-lang-code="fr" title="francés" class="js-language-link js-tooltip" rel="noopener">Français</a></li>
-            <li><a href="?lang=hr" data-lang-code="hr" title="croata" class="js-language-link js-tooltip" rel="noopener">Hrvatski</a></li>
-            <li><a href="?lang=it" data-lang-code="it" title="italiano" class="js-language-link js-tooltip" rel="noopener">Italiano</a></li>
-            <li><a href="?lang=hu" data-lang-code="hu" title="húngaro" class="js-language-link js-tooltip" rel="noopener">Magyar</a></li>
-            <li><a href="?lang=nl" data-lang-code="nl" title="neerlandés" class="js-language-link js-tooltip" rel="noopener">Nederlands</a></li>
-            <li><a href="?lang=no" data-lang-code="no" title="noruego" class="js-language-link js-tooltip" rel="noopener">Norsk</a></li>
-            <li><a href="?lang=pl" data-lang-code="pl" title="polaco" class="js-language-link js-tooltip" rel="noopener">Polski</a></li>
-            <li><a href="?lang=pt" data-lang-code="pt" title="portugués" class="js-language-link js-tooltip" rel="noopener">Português</a></li>
-            <li><a href="?lang=ro" data-lang-code="ro" title="rumano" class="js-language-link js-tooltip" rel="noopener">Română</a></li>
-            <li><a href="?lang=sk" data-lang-code="sk" title="eslovaco" class="js-language-link js-tooltip" rel="noopener">Slovenčina</a></li>
-            <li><a href="?lang=fi" data-lang-code="fi" title="finés" class="js-language-link js-tooltip" rel="noopener">Suomi</a></li>
-            <li><a href="?lang=sv" data-lang-code="sv" title="sueco" class="js-language-link js-tooltip" rel="noopener">Svenska</a></li>
-            <li><a href="?lang=vi" data-lang-code="vi" title="vietnamita" class="js-language-link js-tooltip" rel="noopener">Tiếng Việt</a></li>
-            <li><a href="?lang=tr" data-lang-code="tr" title="turco" class="js-language-link js-tooltip" rel="noopener">Türkçe</a></li>
-            <li><a href="?lang=el" data-lang-code="el" title="griego" class="js-language-link js-tooltip" rel="noopener">Ελληνικά</a></li>
-            <li><a href="?lang=bg" data-lang-code="bg" title="búlgaro" class="js-language-link js-tooltip" rel="noopener">Български език</a></li>
-            <li><a href="?lang=ru" data-lang-code="ru" title="ruso" class="js-language-link js-tooltip" rel="noopener">Русский</a></li>
-            <li><a href="?lang=sr" data-lang-code="sr" title="serbio" class="js-language-link js-tooltip" rel="noopener">Српски</a></li>
-            <li><a href="?lang=uk" data-lang-code="uk" title="ucraniano" class="js-language-link js-tooltip" rel="noopener">Українська мова</a></li>
-            <li><a href="?lang=he" data-lang-code="he" title="hebreo" class="js-language-link js-tooltip" rel="noopener">עִבְרִית</a></li>
-            <li><a href="?lang=ar" data-lang-code="ar" title="árabe" class="js-language-link js-tooltip" rel="noopener">العربية</a></li>
-            <li><a href="?lang=fa" data-lang-code="fa" title="persa" class="js-language-link js-tooltip" rel="noopener">فارسی</a></li>
-            <li><a href="?lang=mr" data-lang-code="mr" title="maratí" class="js-language-link js-tooltip" rel="noopener">मराठी</a></li>
-            <li><a href="?lang=hi" data-lang-code="hi" title="hindi" class="js-language-link js-tooltip" rel="noopener">हिन्दी</a></li>
-            <li><a href="?lang=bn" data-lang-code="bn" title="bengalí" class="js-language-link js-tooltip" rel="noopener">বাংলা</a></li>
-            <li><a href="?lang=gu" data-lang-code="gu" title="guyaratí" class="js-language-link js-tooltip" rel="noopener">ગુજરાતી</a></li>
-            <li><a href="?lang=ta" data-lang-code="ta" title="tamil" class="js-language-link js-tooltip" rel="noopener">தமிழ்</a></li>
-            <li><a href="?lang=kn" data-lang-code="kn" title="canarés" class="js-language-link js-tooltip" rel="noopener">ಕನ್ನಡ</a></li>
-            <li><a href="?lang=th" data-lang-code="th" title="tailandés" class="js-language-link js-tooltip" rel="noopener">ภาษาไทย</a></li>
-            <li><a href="?lang=ko" data-lang-code="ko" title="coreano" class="js-language-link js-tooltip" rel="noopener">한국어</a></li>
-            <li><a href="?lang=ja" data-lang-code="ja" title="japonés" class="js-language-link js-tooltip" rel="noopener">日本語</a></li>
-            <li><a href="?lang=zh-cn" data-lang-code="zh-cn" title="chino simplificado" class="js-language-link js-tooltip" rel="noopener">简体中文</a></li>
-            <li><a href="?lang=zh-tw" data-lang-code="zh-tw" title="chino tradicional" class="js-language-link js-tooltip" rel="noopener">繁體中文</a></li>
-        </ul>
-      </div>
-      <div class="js-front-language">
-        <form action="/sessions/change_locale" class="t1-form language" method="POST">
-          <input type="hidden" name="lang"> <input type="hidden" name="redirect">
-          <input type="hidden" name="authenticity_token" value="b236e0558eecae44fa52b464d55738d5236980e7">
-        </form>
-      </div>
-    </li>
-  </ul>
-
-    <ul class="nav secondary-nav session-dropdown" id="session">
-      <li class="dropdown js-session">
-          <a href="/login" class="dropdown-toggle js-dropdown-toggle dropdown-signin" role="button" id="signin-link" data-nav="login">
-            <small>¿Tienes cuenta?</small> <span class="emphasize"> Iniciar sesión</span><span class="caret"></span>
-          </a>
-          <div class="dropdown-menu dropdown-form dropdown-menu--rightAlign is-forceRight" id="signin-dropdown">
-            <div class="dropdown-caret right"> <span class="caret-outer"></span> <span class="caret-inner"></span> </div>
-            <div class="signin-dialog-body">
-              <div>¿Tienes cuenta?</div>
-<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="login_callout"
-  data-element="form"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Teléfono, correo electrónico o nombre de usuario"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Contraseña" autocomplete="current-password">
-
-  </div>
-
-    <div class="LoginForm-rememberForgot">
-      <label>
-        <input type="checkbox" value="1" name="remember_me" checked="checked">
-        <span>Recordar mis datos</span>
-      </label>
-      <span class="separator">&middot;</span>
-      <a class="forgot" href="/account/begin_password_reset" rel="noopener">¿Olvidaste tu contraseña?</a>
-    </div>
-
-  <input type="submit" class="EdgeButton EdgeButton--primary EdgeButton--medium submit js-submit" value="Iniciar sesión">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/Metallica/status/1128068672289890305">
-  <input type="hidden" value="b236e0558eecae44fa52b464d55738d5236980e7" name="authenticity_token">
-      <input type="hidden" name="ui_metrics" autocomplete="off">
-      <script src="/i/js_inst?c_name=ui_metrics" async></script>
-</form>
-              <hr>
-              <div class="signup SignupForm">
-                <div class="SignupForm-header">¿Nuevo en Twitter?</div>
-                <a href="https://twitter.com/signup" role="button" class="EdgeButton EdgeButton--secondary EdgeButton--medium u-block js-signup"
-                  data-component="signup_callout"
-                  data-element="dropdown"
-                  >Regístrate
-                </a>
-              </div>
-            </div>
-          </div>
-      </li>
-    </ul>
-</div>
-
-        </div>
-      </div>
-    </div>
-</div>
-
-
-        <div id="page-outer">
-          <div id="page-container" class="AppContent wrapper wrapper-permalink">
-
-
-<a class="PermalinkProfile-overlay js-nav" href="/Metallica">
-  <span class="visuallyhidden">Perfil de Metallica</span>
-</a>
-<div class="PermalinkProfile-background without-banner">
-  <div class="ProfileCanopy ProfileCanopy--withNav ProfileCanopy--large js-variableHeightTopBar">
-  <div class="ProfileCanopy-inner">
-
-    <div class="ProfileCanopy-header u-bgUserColor">
-  <div class="ProfileCanopy-headerBg">
-    <img alt=""
-      src="https://pbs.twimg.com/profile_banners/238475531/1479538295/1500x500"
-
-    >
-  </div>
-
-  <div class="AppContainer">
-
-    <div class="ProfileCanopy-avatar">
-      <div class="ProfileAvatar">
-    <a class="ProfileAvatar-container u-block js-tooltip profile-picture"
-        href="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_400x400.jpg"
-        title="Metallica"
-        data-resolved-url-large="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_400x400.jpg"
-        data-url="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_400x400.jpg"
-        target="_blank"
-        rel="noopener">
-        <img class="ProfileAvatar-image " src="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_400x400.jpg" alt="Metallica">
-    </a>
-</div>
-
-    </div>
-
-
-    <div class="ProfileCanopy-headerPromptAnchor"></div>
-  </div>
-
-</div>
-
-
-    <div class="ProfileCanopy-navBar u-boxShadow">
-
-      <div class="AppContainer">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-size1of3 u-lg-size1of4">
-            <div class="ProfileCanopy-card" role="presentation">
-              <div class="ProfileCardMini">
-  <a class="ProfileCardMini-avatar profile-picture js-tooltip"
-     href="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv.jpg"
-     title="Metallica"
-     data-resolved-url-large="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv.jpg"
-     data-url="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv.jpg"
-     target="_blank"
-     rel="noopener">
-    <img class="ProfileCardMini-avatarImage" alt="Metallica" src="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_normal.jpg" >
-  </a>
-  <div class="ProfileCardMini-details">
-    <div class="ProfileNameTruncated account-group">
-  <div class="u-textTruncate u-inlineBlock ProfileNameTruncated-withBadges ProfileNameTruncated-withBadges--1">
-    <a class="fullname ProfileNameTruncated-link u-textInheritColor js-nav" href="/Metallica"  data-aria-label-part>
-      Metallica</a></div><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Cuenta verificada</span></span></span>
-</div>
-    <div class="ProfileCardMini-screenname">
-      <a href="/Metallica" class="ProfileCardMini-screennameLink u-linkComplex js-nav u-dir" dir="ltr">
-        <span class="username u-dir" dir="ltr">@<b class="u-linkComplex-target">Metallica</b></span>
-      </a>
-    </div>
-  </div>
-</div>
-
-            </div>
-          </div>
-
-          <div class="Grid-cell u-size2of3 u-lg-size3of4">
-            <div class="ProfileCanopy-nav">
-
-
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-
-
-    <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-    <h2 id="content-main-heading" class="u-hiddenVisually">Tweets</h2>
-</div>
-
-
-  <div class="AppContainer">
-    <div class="Grid Grid--withGutter">
-      <div class="Grid-cell u-size1of3 u-lg-size1of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell">
-            <div class="ProfileSidebar ProfileSidebar--withLeftAlignment">
-  <div class="ProfileHeaderCard">
-  <h1 class="ProfileHeaderCard-name">
-    <a href="/Metallica"
-       class="ProfileHeaderCard-nameLink u-textInheritColor js-nav">Metallica</a><span class="ProfileHeaderCard-badges"><a href="" class="js-tooltip" target="_blank" title="Cuenta verificada" data-placement="right" rel="noopener"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Cuenta verificada</span></span></a></span>
-  </h1>
-
-  <h2 class="ProfileHeaderCard-screenname u-inlineBlock u-dir" dir="ltr">
-    <a class="ProfileHeaderCard-screennameLink u-linkComplex js-nav" href="/Metallica">
-      <span class="username u-dir" dir="ltr">@<b class="u-linkComplex-target">Metallica</b></span>
-    </a>
-  </h2>
-
-
-
-      <p class="ProfileHeaderCard-bio u-dir" dir="ltr"><a href="http://t.co/EAkqroM0OA" rel="nofollow noopener" dir="ltr" data-expanded-url="http://metallica.com" class="twitter-timeline-link" target="_blank" title="http://metallica.com" ><span class="invisible">http://</span><span class="js-display-url">metallica.com</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a> | <a href="http://t.co/BEu6OVRhKG" rel="nofollow noopener" dir="ltr" data-expanded-url="http://livemetallica.com" class="twitter-timeline-link" target="_blank" title="http://livemetallica.com" ><span class="invisible">http://</span><span class="js-display-url">livemetallica.com</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
-
-      <div class="ProfileHeaderCard-location ">
-        <span class="Icon Icon--geo Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-locationText u-dir" dir="ltr">
-              San Francisco, CA
-
-        </span>
-      </div>
-
-      <div class="ProfileHeaderCard-url ">
-        <span class="Icon Icon--url Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-urlText u-dir">  <a class="u-textUserColor" target="_blank" rel="me nofollow noopener" href="http://t.co/kVxaQpmqSI" title="http://www.metallica.com">
-    metallica.com
-  </a>
-
-</span>
-      </div>
-
-
-      <div class="ProfileHeaderCard-joinDate">
-        <span class="Icon Icon--calendar Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-joinDateText js-tooltip u-dir" dir="ltr" title="23:34 - 14 ene. 2011">Se unió en enero de 2011</span>
-      </div>
-
-      <div class="ProfileHeaderCard-birthdate u-hidden">
-        <span class="Icon Icon--balloon Icon--medium" aria-hidden="true" role="presentation"></span>
-        <span class="ProfileHeaderCard-birthdateText u-dir" dir="ltr">
-</span>
-      </div>
-
-
-</div>
-
-
-
-
-
-
-
-</div>
-
-          </div>
-        </div>
-      </div>
-      <div class="Grid-cell u-size2of3 u-lg-size3of4">
-        <div class="Grid Grid--withGutter">
-          <div class="Grid-cell u-lg-size2of3" data-test-selector="ProfileTimeline">
-              <div class="ProfileHeading">
-  <div class="ProfileHeading-spacer"></div>
-    <h2 id="content-main-heading" class="u-hiddenVisually">Tweets</h2>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-          </div>
-          <div class="Grid-cell u-size1of3">
-            <div class="Grid Grid--withGutter">
-              <div class="Grid-cell">
-                <div class="ProfileSidebar ProfileSidebar--withRightAlignment">
-                  <div class="MoveableModule">
-
-<div class="SidebarCommonModules">
-
-
-
-
-
-  <div class="Footer module roaming-module Footer--slim"
-  >
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2019 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about" rel="noopener">Sobre nosotros</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com" rel="noopener">Centro de Ayuda</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos" rel="noopener">Condiciones</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy" rel="noopener">Política de privacidad</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514" rel="noopener">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html" rel="noopener">Información sobre anuncios</a></li>
-      </ul>
-    </div>
-  </div>
-
-</div>
-
-</div>
-
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-<style id="user-style-Metallica">
-
-
-
-
-
-
-  a,
-  a:hover,
-  a:focus,
-  a:active {
-    color: #2FC2EF;
-  }
-
-  .u-textUserColor,
-  .u-textUserColorHover:hover,
-  .u-textUserColorHover:hover .ProfileTweet-actionCount,
-  .u-textUserColorHover:focus {
-    color: #2FC2EF !important;
-  }
-
-  .u-borderUserColor,
-  .u-borderUserColorHover:hover,
-  .u-borderUserColorHover:focus {
-    border-color: #2FC2EF !important;
-  }
-
-  .u-bgUserColor,
-  .u-bgUserColorHover:hover,
-  .u-bgUserColorHover:focus {
-    background-color: #2FC2EF !important;
-  }
-
-  .u-dropdownUserColor > li:hover,
-  .u-dropdownUserColor > li:focus,
-  .u-dropdownUserColor > li > button:hover,
-  .u-dropdownUserColor > li > button:focus,
-  .u-dropdownUserColor > li > a:focus,
-  .u-dropdownUserColor > li > a:hover {
-    color: #fff !important;
-    background-color: #2FC2EF !important;
-  }
-
-  .u-boxShadowInsetUserColorHover:hover,
-  .u-boxShadowInsetUserColorHover:focus {
-    box-shadow: inset 0 0 0 5px #2FC2EF !important;
-  }
-
-  .u-dropdownOpenUserColor.dropdown.open .dropdown-toggle {
-    color: #2FC2EF;
-  }
-
-
-  .u-textUserColorLight {
-    color: #ABE6F8 !important;
-  }
-
-  .u-borderUserColorLight,
-  .u-borderUserColorLightFocus:focus,
-  .u-borderUserColorLightHover:hover,
-  .u-borderUserColorLightHover:focus {
-    border-color: #ABE6F8 !important;
-  }
-
-  .u-bgUserColorLight {
-    background-color: #ABE6F8 !important;
-  }
-
-
-  .u-boxShadowUserColorLighterFocus:focus {
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 2px rgba(47,194,239,0.25) !important;
-  }
-
-
-  .u-textUserColorLightest {
-    color: #EAF8FD !important;
-  }
-
-  .u-borderUserColorLightest {
-    border-color: #EAF8FD !important;
-  }
-
-  .u-bgUserColorLightest {
-    background-color: #EAF8FD !important;
-  }
-
-
-  .u-textUserColorLighter {
-    color: #CBEFFB !important;
-  }
-
-  .u-borderUserColorLighter {
-    border-color: #CBEFFB !important;
-  }
-
-  .u-bgUserColorLighter {
-    background-color: #CBEFFB !important;
-  }
-
-
-  .u-bgUserColorDarkHover:hover {
-    background-color: #2BA3CA !important;
-  }
-
-  .u-borderUserColorDark {
-    border-color: #2BA3CA !important;
-  }
-
-
-  .u-bgUserColorDarkerActive:active {
-    background-color: #2784A5 !important;
-  }
-
-
-
-
-
-
-
-
-
-
-
-
-
-a,
-.btn-link,
-.btn-link:focus,
-.icon-btn,
-
-
-
-.pretty-link b,
-.pretty-link:hover s,
-.pretty-link:hover b,
-.pretty-link:focus s,
-.pretty-link:focus b,
-
-.metadata a:hover,
-.metadata a:focus,
-
-a.account-group:hover .fullname,
-a.account-group:focus .fullname,
-.account-summary:focus .fullname,
-
-.message .message-text a,
-.message .message-text button,
-.stats a strong,
-.plain-btn:hover,
-.plain-btn:focus,
-.dropdown.open .user-dropdown.plain-btn,
-.open > .plain-btn,
-#global-actions .new:before,
-.module .list-link:hover,
-.module .list-link:focus,
-
-.stats a:hover,
-.stats a:hover strong,
-.stats a:focus,
-.stats a:focus strong,
-
-.find-friends-sources li:hover .source,
-
-
-
-
-
-.stream-item a:hover .fullname,
-.stream-item a:focus .fullname,
-
-.stream-item .view-all-supplements:hover,
-.stream-item .view-all-supplements:focus,
-
-.tweet .time a:hover,
-.tweet .time a:focus,
-.tweet .details.with-icn b,
-.tweet .details.with-icn .Icon,
-
-.stream-item:hover .original-tweet .details b,
-.stream-item .original-tweet.focus .details b,
-.stream-item.open .original-tweet .details b,
-
-.client-and-actions a:hover,
-.client-and-actions a:focus,
-
-.dismiss-btn:hover b,
-
-.tweet .context .pretty-link:hover s,
-.tweet .context .pretty-link:hover b,
-.tweet .context .pretty-link:focus s,
-.tweet .context .pretty-link:focus b,
-
-.list .username a:hover,
-.list .username a:focus,
-.list-membership-container .create-a-list,
-.list-membership-container .create-a-list:hover,
-.new-tweets-bar,
-
-
-
-.card .list-details a:hover,
-.card .list-details a:focus,
-.card .card-body:hover .attribution,
-.card .card-body .attribution:focus {
-  color: #2FC2EF;
-}
-
-
-
-
-
-  .FoundMediaSearch--keyboard .FoundMediaSearch-focusable.is-focused {
-    border-color: #2FC2EF;
-  }
-
-
-  .photo-selector:hover .btn,
-  .icon-btn:hover,
-  .icon-btn:active,
-  .icon-btn.active,
-  .icon-btn.enabled {
-    border-color: #2FC2EF;
-    border-color: rgba(47,194,239,0.4);
-    color: #2FC2EF;
-  }
-
-
-  .photo-selector:hover .btn,
-  .icon-btn:hover {
-    background-image: linear-gradient(rgba(255,255,255,0), rgba(47,194,239,0.1));
-  }
-
-  .icon-btn.disabled,
-  .icon-btn.disabled:hover,
-  .icon-btn[disabled],
-  .icon-btn[aria-disabled=true] {
-    color: #2FC2EF;
-  }
-
-
-
-
-  .EdgeButton--primary,
-  .EdgeButton--primary:focus {
-    background-color: #58CEF2;
-    border-color: transparent;
-  }
-
-  .EdgeButton--primary:hover,
-  .EdgeButton--primary:active {
-    background-color: #2FC2EF;
-    border-color: #2FC2EF;
-  }
-
-  .EdgeButton--primary:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #ABE6F8;
-  }
-
-  .EdgeButton--primary:active {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #58CEF2;
-  }
-
-
-
-
-  .EdgeButton--secondary,
-  .EdgeButton--secondary:hover,
-  .EdgeButton--secondary:focus,
-  .EdgeButton--secondary:active {
-    border-color: #2FC2EF;
-    color: #2FC2EF;
-  }
-
-  .EdgeButton--secondary:hover,
-  .EdgeButton--secondary:active {
-    background-color: #EAF8FD;
-  }
-
-  .EdgeButton--secondary:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px rgba(47,194,239,0.4);
-  }
-
-  .EdgeButton--secondary:active {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 0 4px #2FC2EF;
-  }
-
-
-
-
-  .EdgeButton--invertedPrimary {
-    color: #2FC2EF !important;
-  }
-
-  .EdgeButton--invertedPrimary:focus {
-    box-shadow:
-      0 0 0 2px #2FC2EF,
-      0 0 0 4px #ABE6F8;
-  }
-
-  .EdgeButton--invertedPrimary:active {
-    box-shadow:
-      0 0 0 2px #2FC2EF,
-      0 0 0 4px #FFFFFF;
-  }
-
-
-
-
-  .EdgeButton--invertedSecondary {
-    background-color: #2FC2EF;
-  }
-
-  .EdgeButton--invertedSecondary:hover {
-    background-color: #58CEF2;
-  }
-
-  .EdgeButton--invertedSecondary:focus {
-    box-shadow:
-      0 0 0 2px #2FC2EF,
-      0 0 0 4px #ABE6F8;
-  }
-
-  .EdgeButton--invertedSecondary:active {
-    box-shadow:
-      0 0 0 2px #2FC2EF,
-      0 0 0 4px #FFFFFF;
-  }
-
-
-
-  .btn:focus,
-  .btn.focus,
-  .Button:focus,
-  .EmojiPicker-item.is-focused,
-  .EmojiPicker .EmojiCategoryIcon:focus,
-  .EmojiPicker-skinTone:focus + .EmojiPicker-skinToneSwatch,
-  a:focus > img:first-child:last-child,
-  button:focus {
-    box-shadow:
-      0 0 0 2px #FFFFFF,
-      0 0 2px 4px rgba(47,194,239,0.4);
-  }
-
-  .selected-stream-item:focus {
-    box-shadow: 0 0 0 3px rgba(47,194,239,0.4);
-  }
-
-
-  .js-navigable-stream.stream-table-view .selected-stream-item[tabindex="-1"]:focus {
-    outline: 3px solid rgba(47,194,239,0.4) !important;
-  }
-
-
-  .js-navigable-stream.stream-table-view .selected-stream-item:focus {
-    box-shadow: none;
-  }
-
-
-
-  .global-dm-nav.new.with-count .dm-new .count-inner {
-    background: #2FC2EF;
-  }
-
-  .global-nav .people .count .count-inner {
-    background: #2FC2EF;
-  }
-
-  .dropdown-menu li > a:hover,
-  .dropdown-menu li > a:focus,
-  .dropdown-menu .dropdown-link:hover,
-  .dropdown-menu .dropdown-link:focus,
-  .dropdown-menu .dropdown-link.is-focused,
-  .dropdown-menu li:hover .dropdown-link,
-  .dropdown-menu li:focus .dropdown-link,
-  .dropdown-menu .selected a,
-  .dropdown-menu .dropdown-link.selected {
-    background-color: #2FC2EF !important;
-  }
-
-  /* for items in typeahead dropdown menu on logged in pages */
-  .dropdown-menu .typeahead-items li > a:focus,
-  .dropdown-menu .typeahead-items li > a:hover,
-  .dropdown-menu .typeahead-items .selected,
-  .dropdown-menu .typeahead-items .selected a {
-    background-color: #EAF8FD !important;
-    color: #2FC2EF !important;
-  }
-
-  .typeahead a:hover,
-  .typeahead a:hover strong,
-  .typeahead a:hover .fullname,
-  .typeahead .selected a,
-  .typeahead .selected strong,
-  .typeahead .selected .fullname,
-  .typeahead .selected .Icon--close {
-    color: #2FC2EF !important;
-  }
-
-
-.home-tweet-box,
-.LiveVideo-tweetBox,
-.RetweetDialog-commentBox {
-  background-color: #EAF8FD;
-}
-
-.top-timeline-tweetbox .timeline-tweet-box .tweet-form.condensed .tweet-box {
-  color: #2FC2EF;
-}
-
-.RichEditor,
-.TweetBoxAttachments {
-  border-color: #CBEFFB;
-}
-
-input:focus,
-textarea:focus,
-div[contenteditable="true"]:focus,
-div[contenteditable="true"].fake-focus,
-div[contenteditable="plaintext-only"]:focus,
-div[contenteditable="plaintext-only"].fake-focus {
-  border-color: #ABE6F8;
-  box-shadow: inset 0 0 0 1px rgba(47,194,239,0.7);
-}
-
-.tweet-box textarea:focus,
-.tweet-box input[type=text],
-.currently-dragging .tweet-form.is-droppable .tweet-drag-help,
-.tweet-box[contenteditable="true"]:focus,
-.RichEditor.is-fakeFocus,
-.RichEditor.is-fakeFocus ~ .TweetBoxAttachments {
-  border-color: #ABE6F8;
-  box-shadow: 0 0 0 1px #ABE6F8;
-}
-
-.MomentCapsuleItem.selected-stream-item:focus {
-  box-shadow: 0 0 0 3px rgba(47,194,239,0.4);
-}
-
-
-
-
-s,
-.pretty-link:hover s,
-.pretty-link:focus s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:hover s,
-.stream-item-activity-notification .latest-tweet .tweet-row a:focus s {
-    color: #2FC2EF;
-}
-
-
-
-.vellip,
-.vellip:before,
-.vellip:after,
-.conversation-module > li:after,
-.conversation-module > li:before,
-.ThreadedConversation--loneTweet:after,
-.ThreadedConversation-tweet:not(.is-hiddenAncestor) ~ .ThreadedConversation-tweet:before,
-.ThreadedConversation-tweet:after,
-.ThreadedConversation-moreReplies:before,
-.ThreadedConversation-viewOther:before,
-.ThreadedConversation-unavailableTweet:before,
-.ThreadedConversation-unavailableTweet:after,
-.ThreadedConversation--permalinkTweetWithAncestors:before,
-.mini-avatar-with-thread:before,
-.permalink.self-thread-permalink-with-descendant .permalink-tweet-container:after,
-.permalink.self-thread-permalink-with-descendant .inline-reply-tweetbox-container:after {
-    border-color: #ABE6F8;
-}
-
-
-
-
-.tweet .sm-reply,
-.tweet .sm-rt,
-.tweet .sm-fav,
-.tweet .sm-image,
-.tweet .sm-video,
-.tweet .sm-audio,
-.tweet .sm-geo,
-.tweet .sm-in,
-.tweet .sm-trash,
-.tweet .sm-more,
-.tweet .sm-page,
-.tweet .sm-embed,
-.tweet .sm-summary,
-.tweet .sm-chat,
-
-.timelines-navigation .active .profile-nav-icon,
-.timelines-navigation .profile-nav-icon:hover,
-.timelines-navigation .profile-nav-link:focus .profile-nav-icon,
-
-.sm-top-tweet {
-    background-color: #2FC2EF;
-}
-
-.enhanced-mini-profile .mini-profile .profile-summary {
-  background-image: url(https://pbs.twimg.com/profile_banners/238475531/1479538295/mobile);
-}
-
-  #global-tweet-dialog .modal-header,
-  #Tweetstorm-dialog .modal-header {
-    border-bottom: solid 1px rgba(47,194,239,0.25);
-  }
-
-  #global-tweet-dialog .modal-tweet-form-container,
-  #Tweetstorm-dialog .modal-body {
-    background-color: #2FC2EF;
-    background: rgba(47,194,239,0.1);
-  }
-
-  .TweetstormDialog-reply-context .tweet-box-avatar:after,
-  .TweetstormDialog-reply-context .tweet-box-avatar:before,
-  .TweetstormDialog-tweet-box .tweet-box-avatar:after,
-  .TweetstormDialog-tweet-box .tweet-box-avatar:before {
-    border-color: #ABE6F8;
-  }
-
-  .global-nav .search-input:focus,
-  .global-nav .search-input.focus {
-    border: 2px solid #2FC2EF;
-  }
-}
-
-  .inline-reply-tweetbox {
-    background-color: #EAF8FD;
-  }
-
-</style>
-
-
-<style id="user-style-Metallica-header-img" class="js-user-style-header-img">
-
-    body.user-style-Metallica .enhanced-mini-profile .mini-profile .profile-summary {
-      background-image: url(https://pbs.twimg.com/profile_banners/238475531/1479538295/web);
+<link rel="shortcut icon" href="//abs.twimg.com/favicons/twitter.2.ico">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Twitter">
+<meta name="apple-mobile-web-app-status-bar-style" content="white">
+<meta name="theme-color" content="#ffffff">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://twitter.com/","potentialAction":{"@type":"SearchAction","query-input":"required name=search_term_string","target":{"@type":"EntryPoint","urlTemplate":"https://twitter.com/search?q={search_term_string}&ref_src=twcamp%5Eseo_searchbox%7Ctwsrc%5Eseo"}}}</script><meta http-equiv="origin-trial" content="AlpCmb40F5ZjDi9ZYe+wnr/V8MF+XmY41K4qUhoq+2mbepJTNd3q4CRqlACfnythEPZqcjryfAS1+ExS0FFRcA8AAABmeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJMYXVuY2ggSGFuZGxlciIsImV4cGlyeSI6MTY1NTI1MTE5OSwiaXNTdWJkb21haW4iOnRydWV9">
+<style>html,body{height: 100%;}::cue{white-space:normal}</style>
+<style id="react-native-stylesheet">[stylesheet-group="0"]{}
+html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+body{margin:0;}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
+input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
+[stylesheet-group="0.1"]{}
+:focus:not([data-focusvisible-polyfill]){outline: none;}
+[stylesheet-group="0.5"]{}
+.css-4rbku5{background-color:rgba(0,0,0,0.00);color:inherit;font:inherit;list-style:none;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;text-align:inherit;text-decoration:none;}
+.css-18t94o4{cursor:pointer;}
+[stylesheet-group="1"]{}
+.css-1dbjc4n{-ms-flex-align:stretch;-ms-flex-direction:column;-ms-flex-negative:0;-ms-flex-preferred-size:auto;-webkit-align-items:stretch;-webkit-box-align:stretch;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-basis:auto;-webkit-flex-direction:column;-webkit-flex-shrink:0;align-items:stretch;border:0 solid black;box-sizing:border-box;display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;flex-basis:auto;flex-direction:column;flex-shrink:0;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;min-height:0px;min-width:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;position:relative;z-index:0;}
+.css-901oao{border:0 solid black;box-sizing:border-box;color:rgba(0,0,0,1.00);display:inline;font:14px -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;white-space:pre-wrap;word-wrap:break-word;}
+.css-16my406{color:inherit;font:inherit;white-space:inherit;}
+.css-1hf3ou5{max-width:100%;overflow-x:hidden;overflow-y:hidden;text-overflow:ellipsis;white-space:nowrap;word-wrap:normal;}
+.css-9pa8cd{bottom:0px;height:100%;left:0px;opacity:0;position:absolute;right:0px;top:0px;width:100%;z-index:-1;}
+.css-cens5h{-webkit-box-orient:vertical;display:-webkit-box;max-width:100%;overflow-x:hidden;overflow-y:hidden;text-overflow:ellipsis;}
+[stylesheet-group="2"]{}
+.r-13awgt0{-ms-flex:1 1 0%;-webkit-flex:1;flex:1;}
+.r-6koalj{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;}
+.r-sdzlij{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;border-top-left-radius:9999px;border-top-right-radius:9999px;}
+.r-1phboty{border-bottom-style:solid;border-left-style:solid;border-right-style:solid;border-top-style:solid;}
+.r-rs99b7{border-bottom-width:1px;border-left-width:1px;border-right-width:1px;border-top-width:1px;}
+.r-4qtqp9{display:inline-block;}
+.r-crgep1{margin-bottom:0px;margin-left:0px;margin-right:0px;margin-top:0px;}
+.r-t60dpp{padding-bottom:0px;padding-left:0px;padding-right:0px;padding-top:0px;}
+.r-1yadl64{border-bottom-width:0px;border-left-width:0px;border-right-width:0px;border-top-width:0px;}
+.r-42olwf{border-bottom-color:rgba(0,0,0,0.00);border-left-color:rgba(0,0,0,0.00);border-right-color:rgba(0,0,0,0.00);border-top-color:rgba(0,0,0,0.00);}
+.r-17gur6a{border-bottom-left-radius:0px;border-bottom-right-radius:0px;border-top-left-radius:0px;border-top-right-radius:0px;}
+.r-xyw6el{padding-bottom:12px;padding-left:12px;padding-right:12px;padding-top:12px;}
+.r-jxzhtn{border-bottom-color:rgba(239,243,244,1.00);border-left-color:rgba(239,243,244,1.00);border-right-color:rgba(239,243,244,1.00);border-top-color:rgba(239,243,244,1.00);}
+.r-4iw3lz{border-bottom-width:0;border-left-width:0;border-right-width:0;border-top-width:0;}
+.r-1udh08x{overflow-x:hidden;overflow-y:hidden;}
+.r-wwvuq4{padding-bottom:0;padding-left:0;padding-right:0;padding-top:0;}
+.r-1adg3ll{display:block;}
+.r-bztko3{overflow-x:visible;overflow-y:visible;}
+.r-xoduu5{display:-webkit-inline-box;display:-moz-inline-box;display:-ms-inline-flexbox;display:-webkit-inline-flex;display:inline-flex;}
+.r-1ets6dv{border-bottom-color:rgba(207,217,222,1.00);border-left-color:rgba(207,217,222,1.00);border-right-color:rgba(207,217,222,1.00);border-top-color:rgba(207,217,222,1.00);}
+.r-1867qdf{border-bottom-left-radius:16px;border-bottom-right-radius:16px;border-top-left-radius:16px;border-top-right-radius:16px;}
+.r-1471scf{display:inline;}
+.r-xf4iuw{margin-bottom:-8px;margin-left:-8px;margin-right:-8px;margin-top:-8px;}
+.r-z2wwpe{border-bottom-left-radius:4px;border-bottom-right-radius:4px;border-top-left-radius:4px;border-top-right-radius:4px;}
+.r-11mg6pl{border-bottom-color:rgba(255,255,255,1.00);border-left-color:rgba(255,255,255,1.00);border-right-color:rgba(255,255,255,1.00);border-top-color:rgba(255,255,255,1.00);}
+.r-14f9gny{border-bottom-width:4px;border-left-width:4px;border-right-width:4px;border-top-width:4px;}
+[stylesheet-group="2.1"]{}
+.r-1jgb5lz{margin-left:auto;margin-right:auto;}
+.r-ymttw5{padding-left:16px;padding-right:16px;}
+.r-oyd9sg{padding-bottom:4px;padding-top:4px;}
+.r-1fz3rvf{margin-left:12px;margin-right:12px;}
+.r-rjfia{padding-bottom:0px;padding-top:0px;}
+.r-1r5su4o{margin-bottom:16px;margin-top:16px;}
+.r-s1qlax{padding-left:4px;padding-right:4px;}
+.r-1yzf0co{padding-bottom:16px;padding-top:16px;}
+.r-1e081e0{padding-left:12px;padding-right:12px;}
+.r-1pn2ns4{padding-left:8px;padding-right:8px;}
+.r-1f1sjgu{padding-bottom:12px;padding-top:12px;}
+[stylesheet-group="2.2"]{}
+.r-12vffkv>*{pointer-events:auto;}
+.r-12vffkv{pointer-events:none!important;}
+.r-2llsf{min-height:100%;}
+.r-13qz1uu{width:100%;}
+.r-417010{z-index:0;}
+.r-lrvibr{-moz-user-select:none;-ms-user-select:none;-webkit-user-select:none;user-select:none;}
+.r-1g40b8q{z-index:3;}
+.r-orgf3d{opacity:0;}
+.r-633pao{pointer-events:none!important;}
+.r-1d2f490{left:0px;}
+.r-1xcajam{position:fixed;}
+.r-zchlnj{right:0px;}
+.r-1gn8etr{top:-0.5px;}
+.r-dkhcqf{-webkit-transition-duration:350ms;transition-duration:350ms;}
+.r-axxi2z{-moz-transition-property:transform;-webkit-transition-property:-webkit-transform,transform;transition-property:-webkit-transform,transform;}
+.r-18jm5s1{-webkit-transition-timing-function:cubic-bezier(0,0,0,1);transition-timing-function:cubic-bezier(0,0,0,1);}
+.r-16e0dcy{-webkit-transform:translate3d(0, 0, 0) translateY(0px);transform:translate3d(0, 0, 0) translateY(0px);}
+.r-1e5uvyk{-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);}
+.r-6026j{background-color:rgba(255,255,255,0.85);}
+.r-136ojw6{z-index:2;}
+.r-fxvszc{height:106px;}
+.r-1h3ijdo{height:53px;}
+.r-1awozwy{-ms-flex-align:center;-webkit-align-items:center;-webkit-box-align:center;align-items:center;}
+.r-18u37iz{-ms-flex-direction:row;-webkit-box-direction:normal;-webkit-box-orient:horizontal;-webkit-flex-direction:row;flex-direction:row;}
+.r-1777fci{-ms-flex-pack:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;}
+.r-1pz39u2{-ms-flex-item-align:stretch;-ms-grid-row-align:stretch;-webkit-align-self:stretch;align-self:stretch;}
+.r-15ysp7h{min-height:32px;}
+.r-4wgw6l{min-width:32px;}
+.r-1habvwh{-ms-flex-align:start;-webkit-align-items:flex-start;-webkit-box-align:start;align-items:flex-start;}
+.r-s8bhmr{min-width:56px;}
+.r-1mf7evn{margin-right:20px;}
+.r-1loqt21{cursor:pointer;}
+.r-16y2uox{-ms-flex-positive:1;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;}
+.r-2yi16{min-height:36px;}
+.r-1qi8awa{min-width:36px;}
+.r-o7ynqc{-webkit-transition-duration:0.2s;transition-duration:0.2s;}
+.r-6416eg{-moz-transition-property:background-color, box-shadow;-webkit-transition-property:background-color, box-shadow;transition-property:background-color, box-shadow;}
+.r-1ny4l3l{outline-style:none;}
+.r-bcqeeo{min-width:0px;}
+.r-qvutc0{word-wrap:break-word;}
+.r-rjixqe{line-height:20px;}
+.r-37j5jr{font-family:"TwitterChirp",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+.r-q4m81j{text-align:center;}
+.r-a023e6{font-size:15px;}
+.r-b88u0q{font-weight:700;}
+.r-yyyyoo{fill:currentcolor;}
+.r-1xvli5t{height:1.25em;}
+.r-dnmrzs{max-width:100%;}
+.r-bnwqim{position:relative;}
+.r-1plcrui{vertical-align:text-bottom;}
+.r-z80fyv{height:20px;}
+.r-19wmn03{width:20px;}
+.r-1cvl2hr{color:rgba(29,155,240,1.00);}
+.r-lwhw9o{height:1.75rem;}
+.r-poiln3{font-family:inherit;}
+.r-1wbh5a2{-ms-flex-negative:1;-webkit-flex-shrink:1;flex-shrink:1;}
+.r-1pi2tsx{height:100%;}
+.r-1iusvr4{-ms-flex-preferred-size:0px;-webkit-flex-basis:0px;flex-basis:0px;}
+.r-1oszu61{-ms-flex-align:stretch;-webkit-align-items:stretch;-webkit-box-align:stretch;align-items:stretch;}
+.r-eqz5dr{-ms-flex-direction:column;-webkit-box-direction:normal;-webkit-box-orient:vertical;-webkit-flex-direction:column;flex-direction:column;}
+.r-8fdsdq{z-index:4;}
+.r-vqxq0j{border:0 solid black;}
+.r-deolkf{box-sizing:border-box;}
+.r-1mlwlqe{-ms-flex-preferred-size:auto;-webkit-flex-basis:auto;flex-basis:auto;}
+.r-ifefl9{min-height:0px;}
+.r-1sw30gj{background-color:rgba(239,243,244,1.00);}
+.r-1dqbpge{cursor:-webkit-text;cursor:text;}
+.r-7q8q6z{cursor:default;}
+.r-14j79pv{color:rgba(83,100,113,1.00);}
+.r-f727ji{padding-left:12px;}
+.r-16dba41{font-weight:400;}
+.r-30o5oe{-moz-appearance:none;-webkit-appearance:none;appearance:none;}
+.r-1dz5y72{resize:none;}
+.r-1niwhzg{background-color:rgba(0,0,0,0.00);}
+.r-homxoj{color:inherit;}
+.r-7cikom{font-size:inherit;}
+.r-1ttztb7{text-align:inherit;}
+.r-fdjqy7{text-align:left;}
+.r-y0fyvk::-webkit-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::-moz-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk:-ms-input-placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-y0fyvk::placeholder{color:rgba(83,100,113,1.00);opacity:1;}
+.r-obd0qt{-ms-flex-align:end;-webkit-align-items:flex-end;-webkit-box-align:end;align-items:flex-end;}
+.r-1d4mawv{margin-right:4px;}
+.r-1w6e6rj{-ms-flex-wrap:wrap;-webkit-box-lines:multiple;-webkit-flex-wrap:wrap;flex-wrap:wrap;}
+.r-1wtj0ep{-ms-flex-pack:justify;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;}
+.r-1b43r93{font-size:14px;}
+.r-1cwl3u0{line-height:16px;}
+.r-u8s1d{position:absolute;}
+.r-150rngu{-webkit-overflow-scrolling:touch;}
+.r-17bb2tj{-webkit-animation-duration:0.75s;animation-duration:0.75s;}
+.r-1muvv40{-webkit-animation-iteration-count:infinite;animation-iteration-count:infinite;}
+.r-127358a{-webkit-animation-name:r-9p3sdl;animation-name:r-9p3sdl;}
+@-webkit-keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+@keyframes r-9p3sdl{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg);}100%{-webkit-transform:rotate(360deg);transform:rotate(360deg);}}
+.r-1ldzwu0{-webkit-animation-timing-function:linear;animation-timing-function:linear;}
+.r-aqfbo4{-webkit-backface-visibility:hidden;backface-visibility:hidden;}
+.r-14lw9ot{background-color:rgba(255,255,255,1.00);}
+.r-1ljd8xs{border-left-width:1px;}
+.r-13l2t4g{border-right-width:1px;}
+.r-33ulu8{width:600px;}
+.r-184en5c{z-index:1;}
+.r-1xk2f4g{clip:rect(1px, 1px, 1px, 1px);}
+.r-109y4c4{height:1px;}
+.r-92ng3h{width:1px;}
+.r-19u6a5r{margin-left:12px;}
+.r-1lul07w{-webkit-transform:translate3d(0, -3.5em, 0);transform:translate3d(0, -3.5em, 0);}
+.r-eafdt9{-webkit-transition-duration:0.15s;transition-duration:0.15s;}
+.r-1b8bd59{-moz-transition-property:transform, opacity;-webkit-transition-property:-webkit-transform,transform, opacity;transition-property:-webkit-transform,transform, opacity;}
+.r-nx0j10{-webkit-transition-timing-function:ease, ease, step-end;transition-timing-function:ease, ease, step-end;}
+.r-l5o3uw{background-color:rgba(29,155,240,1.00);}
+.r-y3da5r{box-shadow:0 0 8px rgba(101,119,134,0.2), 0 1px 3px 1px rgba(101,119,134,0.25);}
+.r-1kihuf0{-ms-flex-item-align:center;-ms-grid-row-align:center;-webkit-align-self:center;align-self:center;}
+.r-jwli3a{color:rgba(255,255,255,1.00);}
+.r-13hce6t{margin-left:4px;}
+.r-j5o65s{border-bottom-color:rgba(239,243,244,1.00);}
+.r-qklmqi{border-bottom-width:1px;}
+.r-1qhn6m8{padding-left:16px;}
+.r-i023vh{padding-right:16px;}
+.r-ttdzmv{padding-top:12px;}
+.r-15zivkp{margin-bottom:4px;}
+.r-18kxxzh{-ms-flex-positive:0;-webkit-box-flex:0;-webkit-flex-grow:0;flex-grow:0;}
+.r-1b7u577{margin-right:12px;}
+.r-1hwvwag{-ms-flex-preferred-size:48px;-webkit-flex-basis:48px;flex-basis:48px;}
+.r-1p0dtai{bottom:0px;}
+.r-ipm5af{top:0px;}
+.r-1wyvozj{left:50%;}
+.r-1v2oles{top:50%;}
+.r-desppf{-webkit-transform:translateX(-50%) translateY(-50%);transform:translateX(-50%) translateY(-50%);}
+.r-ggadg3{left:-2px;}
+.r-8jfcpp{top:-2px;}
+.r-vvn4in{background-position:center;}
+.r-u6sd8q{background-repeat:no-repeat;}
+.r-4gszlv{background-size:cover;}
+.r-1wyyakw{z-index:-1;}
+.r-12181gd{box-shadow:0 0 2px rgba(0,0,0,0.03) inset;}
+.r-zl2h9q{margin-bottom:2px;}
+.r-k4xj1c{-ms-flex-align:start;-webkit-align-items:start;-webkit-box-align:start;align-items:start;}
+.r-1d09ksm{-ms-flex-align:baseline;-webkit-align-items:baseline;-webkit-box-align:baseline;align-items:baseline;}
+.r-3s2u2q{white-space:nowrap;}
+.r-1q142lx{-ms-flex-negative:0;-webkit-flex-shrink:0;flex-shrink:0;}
+.r-f9ja8p{max-height:20px;}
+.r-og9te1{max-width:20px;}
+.r-9cviqr{margin-left:2px;}
+.r-1wvb978{-webkit-font-feature-settings:'ss01' on;font-feature-settings:'ss01' on;}
+.r-1s2bzr4{margin-top:12px;}
+.r-1inkyih{font-size:17px;}
+.r-1ssbvtb{gap:12px;}
+.r-adacv{min-height:64px;}
+.r-9aw3ui{gap:4px;}
+.r-6gpygo{margin-bottom:12px;}
+.r-14gqq1x{margin-top:4px;}
+.r-a5pmau{margin-right:2px;}
+.r-1dgieki{border-top-color:rgba(239,243,244,1.00);}
+.r-1efd50x{border-top-style:solid;}
+.r-5kkj8d{border-top-width:1px;}
+.r-1ta3fxp{-moz-column-gap:8px;-webkit-column-gap:8px;column-gap:8px;}
+.r-a2tzq0{-ms-flex-pack:distribute;-webkit-box-pack:justify;-webkit-justify-content:space-around;justify-content:space-around;}
+.r-3qxfft{min-height:1.875rem;}
+.r-h3s6tt{height:48px;}
+.r-rull8r{border-bottom-style:solid;}
+.r-1h0z5md{-ms-flex-pack:start;-webkit-box-pack:start;-webkit-justify-content:flex-start;justify-content:flex-start;}
+.r-bt1l66{min-height:20px;}
+.r-clp7b1{-moz-transition-property:color;-webkit-transition-property:color;transition-property:color;}
+.r-50lct3{height:1.5em;}
+.r-1srniue{width:1.5em;}
+.r-kzbkwu{padding-bottom:12px;}
+.r-dflpy8{height:1.2em;}
+.r-sjv1od{margin-left:0.075em;}
+.r-zw8f10{margin-right:0.075em;}
+.r-10akycc{vertical-align:-20%;}
+.r-h9hxbl{width:1.2em;}
+.r-1mdbhws{max-width:425px;}
+.r-1hdv0qi{width:1.25em;}
+.r-n6v787{font-size:13px;}
+.r-1k6nrdp{min-width:calc(1em + 2 * 12px);}
+.r-vc7bo5{min-width:calc(1em + 2 * 8px);}
+.r-k200y{-ms-flex-item-align:start;-webkit-align-self:flex-start;align-self:flex-start;}
+.r-adyw6z{font-size:20px;}
+.r-135wba7{line-height:24px;}
+.r-1vr29t4{font-weight:800;}
+.r-17s6mgv{-ms-flex-pack:end;-webkit-box-pack:end;-webkit-justify-content:flex-end;justify-content:flex-end;}
+.r-hiw28u{font-size:0px;}
+.r-qvk6io{line-height:0px;}
+.r-pm9dpa{max-height:100%;}
+.r-rki7wi{bottom:12px;}
+.r-161ttwi{left:12px;}
+.r-loe9s5{background-color:rgba(0,0,0,0.77);}
+.r-pm2fo{border-bottom-left-radius:0px;}
+.r-zmljjp{border-bottom-right-radius:0px;}
+.r-ou6ah9{border-top-left-radius:0px;}
+.r-t12b5v{border-top-right-radius:0px;}
+.r-6t5ypu{border-bottom-left-radius:4px;}
+.r-kicko2{border-top-left-radius:4px;}
+.r-1dpl46z{border-bottom-right-radius:4px;}
+.r-notknq{border-top-right-radius:4px;}
+.r-e6wyp1{height:67px;}
+.r-1p15a4t{width:67px;}
+.r-1sa8knb{height:calc(50% + 4px);}
+.r-gcko2u{width:calc(50% + 4px);}
+.r-1dsia8u{padding-left:3px;}
+.r-o52ifk{height:100px;}</style>
+<title data-rh="true">Metallica on Twitter: "Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp;amp; @PompiersParis. #AWMH #MetalicaGivesBack" / Twitter</title>
+<meta data-rh="true" content="article" property="og:type">
+<meta data-rh="true" content="https://twitter.com/Metallica/status/1128068672289890305" property="og:url">
+<meta data-rh="true" content="Metallica on Twitter" property="og:title">
+<meta data-rh="true" content="“Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp;amp; @PompiersParis. #AWMH #MetalicaGivesBack”" property="og:description">
+<meta data-rh="true" content="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_200x200.jpg" property="og:image">
+<meta data-rh="true" description="" name="description"> <link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305" rel="canonical">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305" hreflang="x-default" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ar" hreflang="ar" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ar-x-fm" hreflang="ar-x-fm" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=bg" hreflang="bg" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=bn" hreflang="bn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ca" hreflang="ca" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=cs" hreflang="cs" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=da" hreflang="da" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=de" hreflang="de" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=el" hreflang="el" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=en" hreflang="en" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=en-GB" hreflang="en-GB" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=es" hreflang="es" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=eu" hreflang="eu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=fa" hreflang="fa" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=fi" hreflang="fi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=fil" hreflang="fil" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=fr" hreflang="fr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ga" hreflang="ga" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=gl" hreflang="gl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=gu" hreflang="gu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ha" hreflang="ha" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=he" hreflang="he" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=hi" hreflang="hi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=hr" hreflang="hr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=hu" hreflang="hu" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=id" hreflang="id" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ig" hreflang="ig" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=it" hreflang="it" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ja" hreflang="ja" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=kn" hreflang="kn" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ko" hreflang="ko" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=mr" hreflang="mr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ms" hreflang="ms" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=nb" hreflang="nb" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=nl" hreflang="nl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=no" hreflang="no" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=pl" hreflang="pl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=pt" hreflang="pt" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ro" hreflang="ro" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ru" hreflang="ru" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=sk" hreflang="sk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=sr" hreflang="sr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=sv" hreflang="sv" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ta" hreflang="ta" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=th" hreflang="th" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=tl" hreflang="tl" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=tr" hreflang="tr" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=uk" hreflang="uk" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=ur" hreflang="ur" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=vi" hreflang="vi" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=yo" hreflang="yo" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=zh" hreflang="zh" rel="alternate">
+<link data-rh="true" href="https://twitter.com/Metallica/status/1128068672289890305?lang=zh-Hant" hreflang="zh-Hant" rel="alternate"> <meta data-rh="true" content="twitter://status?id=1128068672289890305" property="al:ios:url">
+<meta data-rh="true" content="333903271" property="al:ios:app_store_id">
+<meta data-rh="true" content="Twitter" property="al:ios:app_name">
+<meta data-rh="true" content="twitter://status?id=1128068672289890305" property="al:android:url">
+<meta data-rh="true" content="com.twitter.android" property="al:android:package">
+<meta data-rh="true" content="Twitter" property="al:android:app_name">
+</head>
+<body style="background-color: #FFFFFF;">
+  <noscript>
+    <style>
+    body {
+      -ms-overflow-style: scrollbar;
+      overflow-y: scroll;
+      overscroll-behavior-y: none;
     }
 
-    .DashboardProfileCard-bg {
-      background-image: url(https://pbs.twimg.com/profile_banners/238475531/1479538295/600x200);
+    .errorContainer {
+      background-color: #FFF;
+      color: #0F1419;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 10%;
+      font-family: Helvetica, sans-serif;
+      font-size: 16px;
     }
 
-</style>
-
-
-
-
-          </div>
-        </div>
-    </div>
-    <div class="alert-messages hidden" id="message-drawer">
-    <div class="message ">
-  <div class="message-inside">
-    <span class="message-text"></span>
-      <a role="button" class="Icon Icon--close Icon--medium dismiss" href="#">
-        <span class="visuallyhidden">Descartar</span>
-      </a>
-  </div>
-</div>
-</div>
-
-
-
-
-<div class="gallery-overlay"></div>
-<div class="Gallery with-tweet">
-  <style class="Gallery-styles"></style>
-  <div class="Gallery-closeTarget"></div>
-  <div class="Gallery-content">
-    <div class="GalleryTweet-newsCameraBadge"></div>
-    <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-    <div class="Gallery-media"></div>
-    <div class="GalleryNav GalleryNav--prev">
-      <span class="GalleryNav-handle GalleryNav-handle--prev">
-        <span class="Icon Icon--caretLeft Icon--large">
-          <span class="u-hiddenVisually">
-            Anterior
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryNav GalleryNav--next">
-      <span class="GalleryNav-handle GalleryNav-handle--next">
-        <span class="Icon Icon--caretRight Icon--large">
-          <span class="u-hiddenVisually">
-            Siguiente
-          </span>
-        </span>
-      </span>
-    </div>
-    <div class="GalleryTweet"></div>
-  </div>
-</div>
-
-
-<div class="modal-overlay"></div>
-
-<div id="profile-hover-container"></div>
-
-
-<div id="goto-user-dialog" class="modal-container">
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Ir al perfil de un usuario</h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="modal-inner">
-          <form class="t1-form goto-user-form">
-            <input class="input-block username-input" type="text" placeholder="Empieza escribiendo un nombre para saltar a un perfil" aria-label="Usuario">
-
-
-
-<div role="listbox" class="dropdown-menu typeahead">
-  <div aria-hidden="true" class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <div role="presentation" class="dropdown-inner js-typeahead-results">
-    <div role="presentation" class="typeahead-saved-searches">
-  <h3 id="saved-searches-heading" class="typeahead-category-title saved-searches-title">Búsquedas guardadas</h3>
-  <ul role="presentation" class="typeahead-items saved-searches-list">
-
-    <li role="presentation" class="typeahead-item typeahead-saved-search-item">
-      <span class="Icon Icon--close" aria-hidden="true"><span class="visuallyhidden">Eliminar</span></span>
-      <a role="option" aria-describedby="saved-searches-heading" class="js-nav" href="" data-search-query="" data-query-source="" data-ds="saved_search" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-
-    <ul role="presentation" class="typeahead-items typeahead-topics">
-
-  <li role="presentation" class="typeahead-item typeahead-topic-item">
-    <a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-ds="topics" tabindex="-1"></a>
-  </li>
-</ul>
-    <ul role="presentation" class="typeahead-items typeahead-accounts social-context js-typeahead-accounts">
-
-  <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-    <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-      <div class="js-selectable typeahead-in-conversation hidden">
-        <span class="Icon Icon--follower Icon--small"></span>
-        <span class="typeahead-in-conversation-text">En esta conversación</span>
-      </div>
-      <img class="avatar size32" alt="">
-      <span class="typeahead-user-item-info account-group">
-        <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-      </span>
-      <span class="typeahead-social-context"></span>
-    </a>
-  </li>
-  <li role="presentation" class="js-selectable typeahead-accounts-shortcut js-shortcut"><a role="option" class="js-nav" href="" data-search-query="" data-query-source="typeahead_click" data-shortcut="true" data-ds="account_search"></a></li>
-</ul>
-
-    <ul role="presentation" class="typeahead-items typeahead-trend-locations-list">
-
-  <li role="presentation" class="typeahead-item typeahead-trend-locations-item"><a role="option" class="js-nav" href="" data-ds="trend_location" data-search-query="" tabindex="-1"></a></li>
-</ul>
-
-<div role="presentation" class="typeahead-user-select">
-  <div role="presentation" class="typeahead-empty-suggestions">
-    Usuarios recomendados
-  </div>
-  <ul role="presentation" class="typeahead-items typeahead-selected js-typeahead-selected">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-selected-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-selected-end"></li>
-  </ul>
-
-  <ul role="presentation" class="typeahead-items typeahead-accounts js-typeahead-accounts">
-
-    <li role="presentation" data-user-id="" data-user-screenname="" data-remote="true" data-score="" class="typeahead-item typeahead-account-item js-selectable">
-
-      <a role="option" class="js-nav" data-query-source="typeahead_click" data-search-query="" data-ds="account">
-        <img class="avatar size32" alt="">
-        <span class="typeahead-user-item-info account-group">
-          <span class="select-status deselect-user js-deselect-user Icon Icon--check"></span>
-          <span class="select-status select-disabled Icon Icon--unfollow"></span>
-          <span class="fullname"></span><span class="UserBadges"><span class="Icon Icon--verified js-verified hidden"><span class="u-hiddenVisually">Cuenta verificada</span></span><span class="Icon Icon--protected js-protected hidden"><span class="u-hiddenVisually">Tweets Protegidos</span></span></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir" dir="ltr">@<b></b></span>
-        </span>
-      </a>
-    </li>
-    <li role="presentation" class="typeahead-accounts-end"></li>
-  </ul>
-</div>
-
-    <div role="presentation" class="typeahead-dm-conversations">
-  <ul role="presentation" class="typeahead-items typeahead-dm-conversation-items">
-    <li role="presentation" class="typeahead-item typeahead-dm-conversation-item">
-      <a role="option" tabindex="-1"></a>
-    </li>
-  </ul>
-</div>
-  </div>
-</div>
-
-          </form>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</div>
-
-<div id="quick-promote-dialog" class="QuickPromoteDialog modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Promocionar este Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="quick-promote-view-container">
-          <div class="media">
-            <iframe
-              class="quick-promote-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="block-user-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title">Bloquear</h3>
-      </div>
-
-      <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-      <div class="modal-body modal-tweet"></div>
-
-      <div class="modal-footer">
-        <button class="EdgeButton EdgeButton--tertiary cancel-action js-close">Cancelar</button>
-        <button class="EdgeButton EdgeButton--danger block-action">Bloquear</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-
-
-   <div id="geo-disabled-dropdown">
-    <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <ul>
-    <li class="geo-not-enabled-yet">
-      <h2>Twittear con la ubicación</h2>
-      <p>
-        Puedes agregar la información de ubicación a tus Tweets, como tu ciudad o tu ubicación exacta, desde la web y a través de aplicaciones de terceros. Siempre tendrás la opción de eliminar el historial de ubicaciones de tus Tweets.
-        <a href="http://support.twitter.com/forums/26810/entries/78525" target="_blank" rel="noopener">Más información</a>
-      </p>
-      <div>
-        <button type="button" class="geo-turn-on EdgeButton EdgeButton--primary">Activar</button>
-        <button type="button" class="geo-not-now EdgeButton EdgeButton--secondary">Por ahora no</button>
-      </div>
-    </li>
-  </ul>
-</div>
-
-  </div>
-
-<div id="geo-enabled-dropdown">
-  <div tabindex="-1">
-  <div class="dropdown-caret">
-    <span class="caret-outer"></span>
-    <span class="caret-inner"></span>
-  </div>
-  <div>
-    <div class="geo-query-location">
-      <input class="GeoSearch-queryInput" type="text" autocomplete="off" placeholder="Buscar un vecindario o ciudad">
-      <span class="Icon Icon--search"></span>
-    </div>
-    <div class="geo-dropdown-status"></div>
-    <ul class="GeoSearch-dropdownMenu"></ul>
-  </div>
-</div>
-
-</div>
-
-
-
-  <div id="list-membership-dialog" class="modal-container">
-  <div class="modal modal-small draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Tus listas</h3>
-      </div>
-      <div class="modal-body">
-        <div class="list-membership-content"></div>
-        <span class="spinner lists-spinner" title="Cargando&hellip;"></span>
-      </div>
-    </div>
-  </div>
-</div>
-  <div id="list-operations-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Crear una nueva lista</h3>
-      </div>
-      <div class="modal-body">
-        <div class="list-editor">
-  <div class="field">
-    <label class="t1-label" for="list-name">Nombre de la lista</label>
-    <input id="list-name" type="text" class="text" name="name" value="" />
-  </div>
-  <hr/>
-
-  <div class="field">
-    <label class="t1-label" for="list-description">Descripción</label>
-    <textarea id="list-description" name="description"></textarea>
-    <span class="help-text">Menos de 100 caracteres, opcional</span>
-  </div>
-  <hr/>
-
-  <fieldset class="field">
-    <legend class="t1-legend">Privacidad</legend>
-    <div class="options">
-      <label class="t1-label" for="list-public-radio">
-        <input class="radio" type="radio" name="mode" id="list-public-radio" value="public" checked="checked"  />
-        <b>Pública</b> &middot; Cualquiera puede seguir esta lista
-      </label>
-      <label class="t1-label" for="list-private-radio">
-        <input class="radio" type="radio" name="mode" id="list-private-radio" value="private"  />
-        <b>Privada</b> &middot; Solo tú puedes acceder a esta lista
-      </label>
-    </div>
-  </fieldset>
-  <hr/>
-
-  <div class="list-editor-save">
-    <button type="button" class="EdgeButton EdgeButton--secondary update-list-button" data-list-id="">Guardar lista</button>
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="activity-popup-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content clearfix">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-
-      <div class="modal-header">
-        <h3 class="modal-title"></h3>
-      </div>
-
-      <div class="modal-body">
-        <div class="tweet-loading">
-  <div class="spinner-bigger"></div>
-</div>
-
-        <div class="activity-popup-dialog-content modal-tweet clearfix"></div>
-        <div class="loading">
-          <span class="spinner-bigger"></span>
-        </div>
-        <div class="activity-popup-dialog-users clearfix"></div>
-        <div class="activity-popup-dialog-footer"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<div id="copy-link-to-tweet-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Copiar enlace del Tweet</h3>
-      </div>
-      <div class="modal-body">
-        <div class="copy-link-to-tweet-container">
-          <label class="t1-label">
-            <p class="copy-link-to-tweet-instructions">Aquí está la URL para este Tweet. Cópiala para compartirlo fácilmente con tus amigos.</p>
-            <textarea class="link-to-tweet-destination js-initial-focus u-dir" dir="ltr" readonly></textarea>
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="embed-tweet-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title embed-tweet-title">Insertar este Tweet</h3>
-        <h3 class="modal-title embed-video-title">Embed this Video</h3>
-      </div>
-      <div class="modal-body">
-        <div class="embed-code-container">
-  <p class="embed-tweet-instructions">Añade este Tweet a tu sitio web copiando el siguiente código. <a href="https://dev.twitter.com/web/embedded-tweets" target="_blank" rel="noopener">Más información</a></p>
-  <p class="embed-video-instructions">Añade este video a tu sitio web copiando el siguiente código. <a href="https://dev.twitter.com/web/embedded-tweets" target="_blank" rel="noopener">Más información</a></p>
-  <form class="t1-form">
-
-    <div class="embed-destination-wrapper">
-      <div class="embed-overlay embed-overlay-spinner"><div class="embed-overlay-content"></div></div>
-      <div class="embed-overlay embed-overlay-error">
-        <p class="embed-overlay-content">Mmm, hubo un problema al contactar con el servidor. <button type="button" class="btn-link retry-embed">¿Intentar de nuevo?</button></p>
-      </div>
-      <textarea class="embed-destination js-initial-focus"></textarea>
-      <div class="embed-options">
-        <div class="embed-include-parent-tweet">
-          <label class="t1-label" for="include-parent-tweet">
-            <input type="checkbox" id="include-parent-tweet" class="include-parent-tweet" checked>
-            Incluir Tweet principal
-          </label>
-        </div>
-        <div class="embed-include-card">
-          <label class="t1-label" for="include-card">
-            <input type="checkbox" id="include-card" class="include-card" checked>
-            Incluir contenido multimedia
-          </label>
-        </div>
-      </div>
-    </div>
-  </form>
-  <p class="embed-tweet-description">Al insertar contenido de Twitter en tu sitio web o aplicación, aceptas el <a href="https://dev.twitter.com/overview/terms/agreement" rel="noopener">Acuerdo para desarrolladores</a> y la <a href="https://dev.twitter.com/overview/terms/policy" rel="noopener">Política para desarrolladores</a> de Twitter.</p>
-  <h3 class="embed-preview-header">Vista previa</h3>
-  <div class="embed-preview">
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="why-this-ad-dialog" class="modal-container why-this-ad-dialog">
-  <div class="modal modal-large draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title why-this-ad-title">Por qué se te muestra este anuncio</h3>
-      </div>
-      <div class="why-this-ad-content">
-        <div class="why-this-ad-spinner">
-          <div class="spinner-bigger"></div>
-        </div>
-        <iframe id="why-this-ad-frame" class="hidden" aria-hidden="true" scrolling="auto">
-        </iframe>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-  <div id="login-dialog" class="LoginDialog modal-container u-textCenter">
-  <div class="modal modal-large draggable">
-    <div class="LoginDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Inicia sesión en Twitter</h3>
-      </div>
-      <div class="LoginDialog-body modal-body">
-        <div class="LoginDialog-bird">
-          <span class="Icon Icon--bird Icon--large"></span>
-        </div>
-        <div class="LoginDialog-form">
-<form action="https://twitter.com/sessions" class="LoginForm js-front-signin" method="post"
-  data-component="dialog"
-  data-element="login"
->
-  <div class="LoginForm-input LoginForm-username">
-    <input
-      type="text"
-      class="text-input email-input js-signin-email"
-      name="session[username_or_email]"
-      autocomplete="username"
-      placeholder="Teléfono, correo electrónico o nombre de usuario"
-    />
-  </div>
-
-  <div class="LoginForm-input LoginForm-password">
-    <input type="password" class="text-input" name="session[password]" placeholder="Contraseña" autocomplete="current-password">
-
-  </div>
-
-    <div class="LoginForm-rememberForgot">
-      <label>
-        <input type="checkbox" value="1" name="remember_me" checked="checked">
-        <span>Recordar mis datos</span>
-      </label>
-      <span class="separator">&middot;</span>
-      <a class="forgot" href="/account/begin_password_reset" rel="noopener">¿Olvidaste tu contraseña?</a>
-    </div>
-
-  <input type="submit" class="EdgeButton EdgeButton--primary EdgeButton--medium submit js-submit" value="Iniciar sesión">
-
-    <input type="hidden" name="return_to_ssl" value="true">
-
-  <input type="hidden" name="scribe_log">
-  <input type="hidden" name="redirect_after_login" value="/Metallica/status/1128068672289890305">
-  <input type="hidden" value="b236e0558eecae44fa52b464d55738d5236980e7" name="authenticity_token">
-      <input type="hidden" name="ui_metrics" autocomplete="off">
-      <script src="/i/js_inst?c_name=ui_metrics" async></script>
-</form>
-        </div>
-      </div>
-      <div class="LoginDialog-footer modal-footer u-textCenter">
-        ¿No tienes una cuenta? <a class="LoginDialog-signupLink" href="https://twitter.com/signup" rel="noopener">Regístrate &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="signup-dialog" class="SignupDialog modal-container u-textCenter">
-  <div class="modal modal-large draggable">
-    <div class="SignupDialog-content modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Regístrate en Twitter</h3>
-      </div>
-      <div class="SignupDialog-body modal-body">
-        <div class="SignupDialog-icon">
-          <span class="Icon Icon--bird Icon--extraLarge"></span>
-        </div>
-        <h2 class="SignupDialog-heading">¿No estás en Twitter? Regístrate, ponte al día con las cosas que te importan y recibe actualizaciones inmediatas.</h2>
-        <div class="SignupDialog-form">
-<div class="signup SignupForm
-  ">
-  <a href="https://twitter.com/signup" role="button" class="EdgeButton EdgeButton--large EdgeButton--primary SignupForm-submit u-block js-signup "
-  data-component="dialog"
-  data-element="signup"
-  >Regístrate</a>
-</div>
-        </div>
-      </div>
-      <div class="SignupDialog-footer modal-footer u-textCenter">
-        ¿Tienes cuenta? <a class="SignupDialog-signinLink" href="/login" rel="noopener">Iniciar sesión &raquo;</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-  <div id="sms-codes-dialog" class="modal-container">
-  <div class="modal modal-medium draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Códigos cortos</h3>
-      </div>
-      <div class="modal-body">
-
-<table id="sms_codes" cellpadding="0" cellspacing="0">
-  <thead>
-    <tr>
-      <th>País</th>
-      <th>Código</th>
-      <th>Para clientes de</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Estados Unidos</td>
-      <td>40404</td>
-      <td>(cualquiera)</td>
-    </tr>
-    <tr>
-      <td>Canadá</td>
-      <td>21212</td>
-      <td>(cualquiera)</td>
-    </tr>
-    <tr>
-      <td>Reino Unido</td>
-      <td>86444</td>
-      <td>Vodafone, Orange, 3, O2</td>
-    </tr>
-    <tr>
-      <td>Brasil</td>
-      <td>40404</td>
-      <td>Nextel, TIM</td>
-    </tr>
-    <tr>
-      <td>Haití</td>
-      <td>40404</td>
-      <td>Digicel, Voila</td>
-    </tr>
-    <tr>
-      <td>Irlanda</td>
-      <td>51210</td>
-      <td>Vodafone, O2</td>
-    </tr>
-    <tr>
-      <td>India</td>
-      <td>53000</td>
-      <td>Bharti Airtel, Videocon, Reliance</td>
-    </tr>
-    <tr>
-      <td>Indonesia</td>
-      <td>89887</td>
-      <td>AXIS, 3, Telkomsel, Indosat, XL Axiata</td>
-    </tr>
-    <tr>
-      <td rowspan="2">Italia</td>
-      <td>4880804</td>
-      <td>Wind</td>
-    </tr>
-    <tr>
-      <td>3424486444</td>
-      <td>Vodafone</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="3">
-        &raquo; <a class="js-initial-focus" target="_blank" href="http://support.twitter.com/articles/14226-how-to-find-your-twitter-short-code-or-long-code" rel="noopener">Ver códigos cortos de SMS para otros países</a>
-      </td>
-    </tr>
-  </tfoot>
-</table>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="leadgen-confirm-dialog" class="modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close js-close">
-  <span class="Icon Icon--close Icon--medium">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">Confirmación</h3>
-      </div>
-      <div class="modal-body">
-        <div class="leadgen-card-container">
-          <div class="media">
-            <iframe
-              class="cards2-promotion-iframe"
-              scrolling="no"
-              frameborder="0"
-              src="">
-            </iframe>
-          </div>
-        </div>
-        <div class="js-macaw-cards-iframe-container" data-card-name="promotion">
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div id="auth-webview-dialog" class="AuthWebViewDialog modal-container">
-  <div class="modal draggable">
-    <div class="modal-content">
-      <button type="button" class="modal-btn modal-close modal-close-fixed js-close">
-  <span class="Icon Icon--close Icon--large">
-    <span class="visuallyhidden">Cerrar</span>
-  </span>
-</button>
-
-      <div class="modal-header">
-        <h3 class="modal-title">&nbsp;</h3>
-      </div>
-      <div class="modal-body">
-        <div class="auth-webview-view-container">
-          <div class="media">
-            <iframe
-              class="auth-webview-card-iframe js-initial-focus"
-              scrolling="no"
-              frameborder="0"
-              width="590px"
-              height="500px"
-              src="">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-<div id="promptbird-modal-prompt" class="modal-container">
-  <div class="modal">
-
-    <button type="button" class="modal-btn js-promptDismiss modal-close js-close">
-      <span class="Icon Icon--close Icon--medium">
-        <span class="visuallyhidden">Cerrar</span>
-      </span>
-    </button>
-    <div class="modal-content"></div>
-  </div>
-</div>
-
-
-<div id="ui-walkthrough-dialog" class="modal-container UIWalkthrough">
-  <div class="UIWalkthrough-clickBlocker"></div>
-  <div class="modal modal-small">
-    <div class="UIWalkthrough-caret"></div>
-    <div class="modal-content">
-      <div class="modal-body">
-        <div class="UIWalkthrough-header">
-          <span class="UIWalkthrough-stepProgress"></span>
-          <button class="UIWalkthrough-skip js-close">
-            Omitir todo
-          </button>
-        </div>
-
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--welcome">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--home UIWalkthrough-icon"></span>
-    ¡Bienvenido a casa!
-  </h3>
-  <p class="UIWalkthrough-message">En esta cronología pasarás la mayoría de tu tiempo recibiendo actualizaciones sobre lo que más te interesa.</p>
-</div>
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--unfollow">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--smileRating1Fill UIWalkthrough-icon"></span>
-    ¿Ninguno de los Tweets te interesa?
-  </h3>
-  <p class="UIWalkthrough-message">
-    Posiciona tu puntero sobre la imagen de perfil y haz clic en el botón Siguiendo para dejar de seguir a cualquier cuenta.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--like">
-
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--heart UIWalkthrough-icon"></span>
-    Di mucho con poco
-  </h3>
-  <p class="UIWalkthrough-message">
-    Cuando te guste un Tweet, pulsa el corazón: le hará saber a la persona que lo escribió que compartiste el amor.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--retweet">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--retweet UIWalkthrough-icon"></span>
-    Difunde el mensaje
-  </h3>
-  <p class="UIWalkthrough-message">
-    La manera más rápida de compartir el Tweet de alguien con tus seguidores es con un Retweet. Pulsa el icono para enviarlo instantáneamente.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--reply">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--reply UIWalkthrough-icon"></span>
-    Únete a la conversación
-  </h3>
-  <p class="UIWalkthrough-message">
-    Di lo que opinas sobre cualquier Tweet con una respuesta. Encuentra un tema que te apasione, y únete a la conversación.
-  </p>
-</div>
-
-
-
-<div class="UIWalkthrough-step UIWalkthrough-step--trends">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--discover UIWalkthrough-icon"></span>
-    Infórmate de lo más reciente
-  </h3>
-  <p class="UIWalkthrough-message">
-    Consigue información instantánea sobre lo que las personas están hablando en este momento.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--wtf">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--follow UIWalkthrough-icon"></span>
-    Consigue más de lo que te encanta
-  </h3>
-  <p class="UIWalkthrough-message">
-    Sigue a más cuentas para recibir actualizaciones instantáneas sobre los temas que te interesan.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--search">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--search UIWalkthrough-icon"></span>
-    Encuentra lo que está sucediendo
-  </h3>
-  <p class="UIWalkthrough-message">
-    Ve las conversaciones más recientes sobre cualquier tema instantáneamente.
-  </p>
-</div>
-
-<div class="UIWalkthrough-step UIWalkthrough-step--moments">
-  <h3 class="UIWalkthrough-title">
-    <span class="Icon Icon--lightning UIWalkthrough-icon"></span>
-    Nunca te pierdas un Momento
-  </h3>
-  <p class="UIWalkthrough-message">
-    Infórmate de las mejores historias instantáneamente mientras están sucediendo.
-  </p>
-</div>
-      </div>
-
-      <div class="modal-footer">
-        <button class="EdgeButton EdgeButton--tertiary u-floatLeft plain-btn UIWalkthrough-button js-previous-step">Regresar</button>
-        <button class="EdgeButton EdgeButton--secondary UIWalkthrough-button js-next-step js-initial-focus">Siguiente</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-<div id="create-custom-timeline-dialog" class="modal-container"></div>
-<div id="edit-custom-timeline-dialog" class="modal-container"></div>
-<div id="curate-dialog" class="modal-container"></div>
-<div id="media-edit-dialog" class="modal-container"></div>
-
-
-      <div class="PermalinkOverlay PermalinkOverlay-with-background load-at-boot" id="permalink-overlay">
-  <div class="PermalinkProfile-dismiss modal-close-fixed">
-    <span class="Icon Icon--close"></span>
-  </div>
-  <button class="PermalinkOverlay-next PermalinkOverlay-button u-posFixed js-next" type="button">
-    <span class="Icon Icon--caretLeft Icon--large"></span>
-    <span class="u-hiddenVisually">Siguiente Tweet del usuario</span>
-  </button>
-  <div class="PermalinkOverlay-modal">
-    <div class="PermalinkOverlay-spinnerContainer u-hidden">
-      <div class="PermalinkOverlay-spinner"></div>
-    </div>
-    <div class="PermalinkOverlay-content">
-      <div class="PermalinkOverlay-body"
-          data-background-path="/Metallica"
->
-            <div class="permalink-container permalink-container--withArrows">
-  <div role="main" class="permalink light-inline-actions
-  stream-uncapped
-  has-replies
-  original-permalink-page
-
-  ">
-
-
-
-  <div class="permalink-inner permalink-tweet-container">
-
-    <div class="tweet permalink-tweet js-actionable-user js-actionable-tweet js-original-tweet
-         with-social-proof
-
-
-
-
-          js-initial-focus
-"
-        data-associated-tweet-id="1128068672289890305"
-
-data-tweet-id="1128068672289890305"
-data-item-id="1128068672289890305"
-data-permalink-path="/Metallica/status/1128068672289890305"
-data-conversation-id="1128068672289890305"
-
-
-
-
-data-tweet-nonce="1128068672289890305-09d498bc-7a50-4dc3-8f18-1cf6222200e7"
-
-
-
-
-
-
-
-  data-screen-name="Metallica" data-name="Metallica" data-user-id="238475531"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        tabindex="0"
-      >
-
-
-
-      <div class="content clearfix">
-        <div class="permalink-header">
-            <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/Metallica" data-user-id="238475531">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " >Metallica</strong><span>&rlm;</span><span class="UserBadges"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Cuenta verificada</span></span></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a>
-
-
-          <small class="time">
-  <a href="/Metallica/status/1128068672289890305" class="tweet-timestamp js-permalink js-nav js-tooltip" title="10:45 PM - 13 May 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557787504" data-time-ms="1557787504000" data-long-form="true">13 may.</span></a>
-</small>
-
-
-
-
-    <div class="follow-bar">
-      <div class="user-actions btn-group not-following  "
-    data-user-id="238475531"
-    data-screen-name="Metallica"
-    data-name="Metallica"
-    data-protected="false"
-  >
-  <span class="user-actions-follow-button js-follow-btn follow-button">
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-
-    EdgeButton--medium
-    button-text
-    follow-text">
-      <span aria-hidden="true">Seguir</span>
-      <span class="u-hiddenVisually">Seguir a <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--primary
-
-    EdgeButton--medium
-    button-text
-    following-text">
-      <span aria-hidden="true">Siguiendo</span>
-      <span class="u-hiddenVisually">Siguiendo a <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--danger
-
-    EdgeButton--medium
-    button-text
-    unfollow-text">
-      <span aria-hidden="true">Dejar de seguir</span>
-      <span class="u-hiddenVisually">Dejar de seguir a <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--invertedDanger
-
-    EdgeButton--medium
-    button-text
-    blocked-text">
-    <span aria-hidden="true">Bloqueado</span>
-    <span class="u-hiddenVisually"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span> está bloqueado</span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--danger
-
-    EdgeButton--medium
-    button-text
-    unblock-text">
-    <span aria-hidden="true">Desbloquear</span>
-    <span class="u-hiddenVisually">Desbloquear a <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-
-    EdgeButton--medium
-    button-text
-    pending-text">
-    <span aria-hidden="true">Pendiente</span>
-    <span class="u-hiddenVisually">Solicitud de seguimiento de <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span> pendiente</span>
-  </button>
-  <button type="button" class="
-    EdgeButton
-    EdgeButton--secondary
-
-    EdgeButton--medium
-    button-text
-    cancel-text">
-    <span aria-hidden="true">Cancelar</span>
-    <span class="u-hiddenVisually">Cancelar tu solicitud de seguimiento a <span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></span>
-  </button>
-</span>
-
-</div>
-
-    </div>
-
-            <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-        </div>
-
-      </div>
-
-
-
-          <p class="u-hiddenVisually" aria-hidden="true" data-aria-label-part="1">Metallica Retwitteó All Within My Hands Foundation</p>
-
-
-<div class="js-tweet-text-container">
-  <p class="TweetTextSize TweetTextSize--jumbo js-tweet-text tweet-text" lang="en" data-aria-label-part="4">Thank you to everyone who came out for <a href="/hashtag/MetInParis?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>MetInParis</b></a> last night for helping us support <a href="/EMMAUSolidarite" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2912493406" ><s>@</s><b>EMMAUSolidarite</b></a> &amp; <a href="/PompiersParis" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="1342191438" ><s>@</s><b>PompiersParis</b></a>. <a href="/hashtag/AWMH?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>AWMH</b></a> <a href="/hashtag/MetalicaGivesBack?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>MetalicaGivesBack</b></a><a href="https://t.co/gLtZSdDFmN" rel="nofollow noopener" dir="ltr" data-expanded-url="https://twitter.com/AWMHFoundation/status/1127646016931487744" class="twitter-timeline-link u-hidden" target="_blank" title="https://twitter.com/AWMHFoundation/status/1127646016931487744" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">twitter.com/AWMHFoundation</span><span class="invisible">/status/1127646016931487744</span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span>…</span></a></p>
-</div>
-
-
-<p class="u-hiddenVisually" aria-hidden="true" data-aria-label-part="3">Metallica agregado,</p>
-
-      <div class="QuoteTweet
-
-
-    u-block js-tweet-details-fixer">
-  <div class="QuoteTweet-container">
-    <a class="QuoteTweet-link js-nav" href="/AWMHFoundation/status/1127646016931487744" data-conversation-id="1127646016931487744" aria-hidden="true"
-       >
-    </a>
-    <div class="QuoteTweet-innerContainer u-cf js-permalink js-media-container"
-      data-item-id="1127646016931487744"
-      data-item-type="tweet"
-      data-screen-name="AWMHFoundation"
-      data-user-id="886959980254871552"
-      href="/AWMHFoundation/status/1127646016931487744"
-      data-conversation-id="1127646016931487744"
-      tabindex="0">
-      <div class="tweet-content">
-            <div class="QuoteMedia">
-      <div class="QuoteMedia-container js-quote-media-container">
-          <div class="QuoteMedia-doublePhoto">
-    <div class="QuoteMedia-halfPhoto">
-      <div class="QuoteMedia-photoContainer js-quote-photo"
-  data-image-url="https://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg"
-
-  data-element-context="platform_photo_card"
-    style="background-color:rgba(48,55,64,1.0);"
-    data-dominant-color="[48,55,64]"
->
-  <img data-aria-label-part src="https://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg" alt=""
-      style="height: 100%; left: -18px;"
->
-</div>
-
-    </div>
-    <div class="QuoteMedia-halfPhoto">
-      <div class="QuoteMedia-photoContainer js-quote-photo"
-  data-image-url="https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ.jpg"
-
-  data-element-context="platform_photo_card"
-    style="background-color:rgba(39,33,35,1.0);"
-    data-dominant-color="[39,33,35]"
->
-  <img data-aria-label-part src="https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ.jpg" alt=""
-      style="height: 100%; left: -6px;"
->
-</div>
-
-    </div>
-</div>
-      </div>
-  </div>
-
-        <div class="QuoteTweet-authorAndText u-alignTop">
-
-  <div class="QuoteTweet-originalAuthor u-cf u-textTruncate stream-item-header account-group js-user-profile-link">
-    <b class="QuoteTweet-fullname u-linkComplex-target">All Within My Hands Foundation</b><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span><span class="username u-dir u-textTruncate" dir="ltr" >@<b>AWMHFoundation</b></span>
-  </div>
-
-
-
-          <div class="QuoteTweet-text tweet-text u-dir js-ellipsis"
-            lang="en"
-            data-aria-label-part="2"
-
-            dir="ltr">If you bought a ticket for tonight’s <span class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="238475531" ><s>@</s><b>Metallica</b></span> show at Stade de France, you have helped contribute to <span class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="2912493406" ><s>@</s><b>EMMAUSolidarite</b></span> &amp; <span class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="1342191438" ><s>@</s><b>PompiersParis</b></span>. <span data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>MetallicaGivesBack</b></span> <span data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>AWMH</b></span> <span data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>MetInParis</b></span> <span class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/wlUtDQbQEK</span></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-
-
-
-
-
-
-      <div class="js-tweet-details-fixer tweet-details-fixer">
-  <div class="client-and-actions">
-  <span class="metadata">
-    <span>15:45 - 13 may. 2019</span>
-
-  </span>
-
-</div>
-
-
-  <div class="js-machine-translated-tweet-container"></div>
-  <div class="js-tweet-stats-container tweet-stats-container">
-
-<ul class="stats" aria-label="Retwitteado y marcado como favorito por">
-    <li class="js-stat-count js-stat-retweets stat-count" aria-hidden="true">
-      <a tabindex=0 role="button"
-        data-tweet-stat-count="201"
-        data-compact-localized-count="201"
-        class="request-retweeted-popup"
-        data-activity-popup-title="201 retweets">
-
-          <strong>201</strong> Retweets      </a>
-    </li>
-
-    <li class="js-stat-count js-stat-favorites stat-count" aria-hidden="true">
-      <a tabindex=0 role="button"
-         data-tweet-stat-count="1664"
-         data-compact-localized-count="1.7K"
-         class="request-favorited-popup"
-         data-activity-popup-title="1.664 Me gusta">
-
-          <strong>1.664</strong> Me gusta      </a>
-    </li>
-
-  <li class="avatar-row js-face-pile-container">
-      <a class="js-profile-popup-actionable js-tooltip" href="/Vivana88703255" data-user-id="1132748366415368192" original-title="ViiviiCasco" title="ViiviiCasco" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1132994451524202496/7LlpbEKj_normal.jpg" alt="ViiviiCasco">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/estrelaffu2" data-user-id="1032598497202192384" original-title="Raphaela Estrela" title="Raphaela Estrela" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1032599434968883205/5lgWkVgu_normal.jpg" alt="Raphaela Estrela">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/Abby6668" data-user-id="1050416779481231360" original-title="Abby_666" title="Abby_666" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1075798931433492486/qWUkHSxF_normal.jpg" alt="Abby_666">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/orangemama22" data-user-id="609709195" original-title="Gena Gonzales" title="Gena Gonzales" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/965319987672924160/P2-5m21G_normal.jpg" alt="Gena Gonzales">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/Gahbueno99Bueno" data-user-id="723158862786879490" original-title="Gabriel Bueno" title="Gabriel Bueno" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1087665289393815553/6dY77Wxt_normal.jpg" alt="Gabriel Bueno">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/MakanaMclain" data-user-id="1130321701181374464" original-title="makana mclain" title="makana mclain" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1131796514177556480/KoIb9exq_normal.jpg" alt="makana mclain">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/HippyDrewTHR" data-user-id="972559413704830977" original-title="Drew" title="Drew" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1125086235574321152/kDS4jgBT_normal.jpg" alt="Drew">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/Alexandralsnc" data-user-id="4289465071" original-title="Александра" title="Александра" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/1128627557740556288/dTq-jPnx_normal.jpg" alt="Александра">
-</a>
-      <a class="js-profile-popup-actionable js-tooltip" href="/LordiCavalera" data-user-id="4610880202" original-title="Lordi Walmir Cavalera" title="Lordi Walmir Cavalera" rel="noopener">
-  <img class="avatar size24 js-user-profile-link" src="https://pbs.twimg.com/profile_images/943333887807295488/xjLBnbQ0_normal.jpg" alt="Lordi Walmir Cavalera">
-</a>
-  </li>
-</ul>
-
-
-  </div>
-</div>
-
-
-
-      <div class="stream-item-footer">
-
-
-
-
-            <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="23">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128068672289890305" data-aria-label-part>23 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="201">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128068672289890305" data-aria-label-part>201 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1664">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128068672289890305" data-aria-label-part>1.664 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128068672289890305">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128068672289890305">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128068672289890305">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-      </div>
-
-      <div class="permalink-footer">
-
-      </div>
-    </div>
-
-  </div>
-
-
-
-<div class="replies-to  permalink-inner permalink-replies" data-component-context="replies">
-    <div class="tweets-wrapper">
-      <div id="descendants" class="ThreadedDescendants">
-          <div class="stream-container  "
-    data-max-position="" data-min-position="DAACDwABCgAAABMPp9UNahfgAA-ntQcs1uABD6e2XSUWkAEPp7X2zFeQAA-n2_DWFVAAD6l3n0uWwAEPp7S3ZFTQAA-p7d0wlCAHD6l2-v_WwAAPp7TbdxRQAA-nxlb6FrAAD6yjmiiW4AUPqAfHjVbAAA-ohleelNABD6e07-FUwAEPqjYWdVRgAA-n5kZfF7ACD6gI875X4AAPp7ZvGpegAwgAAwAAAAECAAQAAAA"
-    >
-    <div class="stream">
-        <ol class="stream-items js-navigable-stream" id="stream-items-id">
-
-
-
-
-
-
-
-
-
-
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128104485270839296"
-id="stream-item-tweet-1128104485270839296"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128104485270839296&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128104485270839296"
-data-item-id="1128104485270839296"
-data-permalink-path="/totopopi56/status/1128104485270839296"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128104485270839296-9cc18e95-a3d9-49a0-94b3-21d717710a64"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="totopopi56" data-name="norali" data-user-id="741037312151330816"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;741037312151330816&quot;,&quot;screen_name&quot;:&quot;totopopi56&quot;,&quot;name&quot;:&quot;norali&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;norali&quot;,&quot;emojified_text_as_html&quot;:&quot;norali&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/totopopi56" data-user-id="741037312151330816">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1081516152013185024/cHbT4Wof_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>norali</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>totopopi56</b></span></a>
-
-
-        <small class="time">
-  <a href="/totopopi56/status/1128104485270839296" class="tweet-timestamp js-permalink js-nav js-tooltip" title="18:07 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557796043" data-time-ms="1557796043000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">GOOD MEN GOOD ACTIONS  <img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/2764.png" draggable="false" alt="❤" title="Corazón rojo" aria-label="Emoji: Corazón rojo"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128104485270839296" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128104485270839296" data-aria-label-part>1 retweet</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="3">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128104485270839296" data-aria-label-part>3 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128104485270839296">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128104485270839296">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128104485270839296">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">3</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">3</span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128069274101276673"
-id="stream-item-tweet-1128069274101276673"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128069274101276673&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128069274101276673"
-data-item-id="1128069274101276673"
-data-permalink-path="/LizzyHock1963/status/1128069274101276673"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128069274101276673-60bc7d8d-bf5b-48d8-b37a-e4b6cd3c1b86"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="LizzyHock1963" data-name="♬♪♬ 🇺🇸 Elizabeth Hock 🇮🇱 ♬♪♬" data-user-id="863480651881734144"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;863480651881734144&quot;,&quot;screen_name&quot;:&quot;LizzyHock1963&quot;,&quot;name&quot;:&quot;\u266c\u266a\u266c \ud83c\uddfa\ud83c\uddf8 Elizabeth Hock \ud83c\uddee\ud83c\uddf1 \u266c\u266a\u266c&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;\u266c\u266a\u266c \ud83c\uddfa\ud83c\uddf8 Elizabeth Hock \ud83c\uddee\ud83c\uddf1 \u266c\u266a\u266c&quot;,&quot;emojified_text_as_html&quot;:&quot;\u266c\u266a\u266c \u003cspan class=\&quot;Emoji Emoji--forLinks\&quot; style=\&quot;background-image:url(&#39;https:\/\/abs.twimg.com\/emoji\/v2\/72x72\/1f1fa-1f1f8.png&#39;)\&quot; title=\&quot;Bandera de Estados Unidos\&quot; aria-label=\&quot;Emoji: Bandera de Estados Unidos\&quot;\u003e&amp;nbsp;\u003c\/span\u003e\u003cspan class=\&quot;visuallyhidden\&quot; aria-hidden=\&quot;true\&quot;\u003e\ud83c\uddfa\ud83c\uddf8\u003c\/span\u003e Elizabeth Hock \u003cspan class=\&quot;Emoji Emoji--forLinks\&quot; style=\&quot;background-image:url(&#39;https:\/\/abs.twimg.com\/emoji\/v2\/72x72\/1f1ee-1f1f1.png&#39;)\&quot; title=\&quot;Bandera de Israel\&quot; aria-label=\&quot;Emoji: Bandera de Israel\&quot;\u003e&amp;nbsp;\u003c\/span\u003e\u003cspan class=\&quot;visuallyhidden\&quot; aria-hidden=\&quot;true\&quot;\u003e\ud83c\uddee\ud83c\uddf1\u003c\/span\u003e \u266c\u266a\u266c&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/LizzyHock1963" data-user-id="863480651881734144">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1062506213588516864/bDltXSyt_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>♬♪♬ <span class="Emoji Emoji--forLinks" style="background-image:url('https://abs.twimg.com/emoji/v2/72x72/1f1fa-1f1f8.png')" title="Bandera de Estados Unidos" aria-label="Emoji: Bandera de Estados Unidos">&nbsp;</span><span class="visuallyhidden" aria-hidden="true">🇺🇸</span> Elizabeth Hock <span class="Emoji Emoji--forLinks" style="background-image:url('https://abs.twimg.com/emoji/v2/72x72/1f1ee-1f1f1.png')" title="Bandera de Israel" aria-label="Emoji: Bandera de Israel">&nbsp;</span><span class="visuallyhidden" aria-hidden="true">🇮🇱</span> ♬♪♬</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>LizzyHock1963</b></span></a>
-
-
-        <small class="time">
-  <a href="/LizzyHock1963/status/1128069274101276673" class="tweet-timestamp js-permalink js-nav js-tooltip" title="15:47 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557787648" data-time-ms="1557787648000" data-long-form="true">13 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Thank you MetallicA, for being so generous!<img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f495.png" draggable="false" alt="💕" title="Dos corazones" aria-label="Emoji: Dos corazones"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f49e.png" draggable="false" alt="💞" title="Corazones girando" aria-label="Emoji: Corazones girando"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f49f.png" draggable="false" alt="💟" title="Decoración de corazón" aria-label="Emoji: Decoración de corazón"> <img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128069274101276673" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128069274101276673" data-aria-label-part>1 retweet</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="2">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128069274101276673" data-aria-label-part>2 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128069274101276673">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128069274101276673">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128069274101276673">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">2</span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128070742850048001"
-id="stream-item-tweet-1128070742850048001"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128070742850048001&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128070742850048001"
-data-item-id="1128070742850048001"
-data-permalink-path="/Glen010982/status/1128070742850048001"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128070742850048001-28dbc73d-7c59-4d2d-bf53-fa8c1b97b087"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="Glen010982" data-name="Glen" data-user-id="959118933558222848"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;959118933558222848&quot;,&quot;screen_name&quot;:&quot;Glen010982&quot;,&quot;name&quot;:&quot;Glen&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Glen&quot;,&quot;emojified_text_as_html&quot;:&quot;Glen&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/Glen010982" data-user-id="959118933558222848">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1073306696573952001/00J19A8-_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Glen</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>Glen010982</b></span></a>
-
-
-        <small class="time">
-  <a href="/Glen010982/status/1128070742850048001" class="tweet-timestamp js-permalink js-nav js-tooltip" title="15:53 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557787998" data-time-ms="1557787998000" data-long-form="true">13 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">These guys are always awesome on good causes and good times.<img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/2764.png" draggable="false" alt="❤️" title="Corazón rojo" aria-label="Emoji: Corazón rojo"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128070742850048001" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128070742850048001" data-aria-label-part>1 retweet</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128070742850048001" data-aria-label-part>1 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128070742850048001">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128070742850048001">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128070742850048001">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-    <li class="ThreadedConversation">
-  <ol class="stream-items">
-          <div class="ThreadedConversation-tweet"
-  >
-      <span class="u-hiddenVisually">Conversación nueva</span>
-    <li class="js-stream-item stream-item stream-item
-" data-item-id="1128070303274471424"
-id="stream-item-tweet-1128070303274471424"
-data-item-type="tweet"
->
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128070303274471424"
-data-item-id="1128070303274471424"
-data-permalink-path="/TomOlson8/status/1128070303274471424"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128070303274471424-80a4c24d-d768-4ba3-b589-a7227b7510de"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="TomOlson8" data-name="Brutus" data-user-id="623979006"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;623979006&quot;,&quot;screen_name&quot;:&quot;TomOlson8&quot;,&quot;name&quot;:&quot;Brutus&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Brutus&quot;,&quot;emojified_text_as_html&quot;:&quot;Brutus&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/TomOlson8" data-user-id="623979006">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/543212042631794688/lMegt8oL_bigger.jpeg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Brutus</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>TomOlson8</b></span></a>
-
-
-        <small class="time">
-  <a href="/TomOlson8/status/1128070303274471424" class="tweet-timestamp js-permalink js-nav js-tooltip" title="15:51 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557787893" data-time-ms="1557787893000" data-long-form="true">13 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Orion <img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128070303274471424" data-aria-label-part>1 respuesta</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128070303274471424" data-aria-label-part>1 retweet</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128070303274471424" data-aria-label-part>1 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128070303274471424">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128070303274471424">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128070303274471424">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-</li>
-  </div>
-
-      <li class="ThreadedConversation-moreReplies" data-element-context="show_more_button" data-expansion-url="/i/threaded_conversation/1128070303274471424/DAADCgABD6e19sxXkAALAAIAAAAmY29udmVyc2F0aW9uVGhyZWFkLTExMjgwNzAzMDMyNzQ0NzE0MjQIAAMAAAABAAA">
-        <a href="" class="ThreadedConversation-moreRepliesLink">1 respuesta más</a>
-        <span class="vellip"></span>
-        <span class="ThreadedConversation-moreRepliesSpinner u-hidden"></span>
-      </li>
-  </ol>
-</li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128112059109953536"
-id="stream-item-tweet-1128112059109953536"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128112059109953536&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128112059109953536"
-data-item-id="1128112059109953536"
-data-permalink-path="/sandymitt6/status/1128112059109953536"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128112059109953536-58e50e50-9d20-4225-b991-fd1c48e48f96"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="sandymitt6" data-name="Stephen Marsh" data-user-id="3021820380"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis VANS_66"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;3021820380&quot;,&quot;screen_name&quot;:&quot;sandymitt6&quot;,&quot;name&quot;:&quot;Stephen Marsh&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Stephen Marsh&quot;,&quot;emojified_text_as_html&quot;:&quot;Stephen Marsh&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}},{&quot;id_str&quot;:&quot;15383636&quot;,&quot;screen_name&quot;:&quot;VANS_66&quot;,&quot;name&quot;:&quot;Vans&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Vans&quot;,&quot;emojified_text_as_html&quot;:&quot;Vans&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/sandymitt6" data-user-id="3021820380">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/567159111880437760/pnQNr4qa_bigger.jpeg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Stephen Marsh</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>sandymitt6</b></span></a>
-
-
-        <small class="time">
-  <a href="/sandymitt6/status/1128112059109953536" class="tweet-timestamp js-permalink js-nav js-tooltip" title="18:37 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557797848" data-time-ms="1557797848000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="da" data-aria-label-part="0">Sweet <a href="/VANS_66" class="twitter-atreply pretty-link js-nav" dir="ltr" data-mentioned-user-id="15383636" ><s>@</s><b>VANS_66</b></a> Kirk.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128112059109953536" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128112059109953536" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount"  data-tweet-stat-count="1">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128112059109953536" data-aria-label-part>1 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128112059109953536">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128112059109953536">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128112059109953536">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true">1</span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128564707684696065"
-id="stream-item-tweet-1128564707684696065"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128564707684696065&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       has-cards descendant permalink-descendant-tweet cards-forward
-"
-
-data-tweet-id="1128564707684696065"
-data-item-id="1128564707684696065"
-data-permalink-path="/124OUNxV9IlLMFN/status/1128564707684696065"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128564707684696065-fe34948b-cd4c-4792-99be-7f0ad62fc814"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="124OUNxV9IlLMFN" data-name="עמרי שחר" data-user-id="1124395358359040000"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;1124395358359040000&quot;,&quot;screen_name&quot;:&quot;124OUNxV9IlLMFN&quot;,&quot;name&quot;:&quot;\u05e2\u05de\u05e8\u05d9 \u05e9\u05d7\u05e8&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;\u05e2\u05de\u05e8\u05d9 \u05e9\u05d7\u05e8&quot;,&quot;emojified_text_as_html&quot;:&quot;\u05e2\u05de\u05e8\u05d9 \u05e9\u05d7\u05e8&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
- data-possibly-sensitive="true"
-
-
-
-data-disclosure-type=""
-
-
-
- data-card2-type="player"
- data-has-cards="true"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/124OUNxV9IlLMFN" data-user-id="1124395358359040000">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1124508998491938817/0WXst_2N_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate fullname-rtl" data-aria-label-part>עמרי שחר</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>124OUNxV9IlLMFN</b></span></a>
-
-
-        <small class="time">
-  <a href="/124OUNxV9IlLMFN/status/1128564707684696065" class="tweet-timestamp js-permalink js-nav js-tooltip" title="0:36 - 15 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557905768" data-time-ms="1557905768000" data-long-form="true">15 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="und" data-aria-label-part="0"><a href="https://t.co/y8gyw6vwZl" rel="nofollow noopener" dir="ltr" data-expanded-url="https://youtu.be/yCNees5_doE" class="twitter-timeline-link u-hidden" target="_blank" title="https://youtu.be/yCNees5_doE" ><span class="tco-ellipsis"></span><span class="invisible">https://</span><span class="js-display-url">youtu.be/yCNees5_doE</span><span class="invisible"></span><span class="tco-ellipsis"><span class="invisible">&nbsp;</span></span></a></p>
-</div>
-
-
-
-
-
-
-
-
-
-          <div class="card2 js-media-container
-    "
-    data-card2-name="player"
-  >
-
-<div class="js-macaw-cards-iframe-container initial-card-height card-type-player"
-  data-src="/i/cards/tfw/v1/1128564707684696065?cardname=player&amp;autoplay_disabled=true&amp;forward=true&amp;possibly_sensitive=true&amp;earned=true&amp;edge=true&amp;lang=es"
-  data-card-name="player"
-  data-card-url="https://t.co/y8gyw6vwZl"
-  data-publisher-id="10228272"
-  data-creator-id=""
-  data-amplify-content-id=""
-  data-amplify-playlist-url=""
-  data-full-card-iframe-url="/i/cards/tfw/v1/1128564707684696065?cardname=player&amp;autoplay_disabled=true&amp;possibly_sensitive=true&amp;earned=true&amp;edge=true&amp;lang=es"
-  data-has-autoplayable-media="false">
-</div>
-
-</div>
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128564707684696065" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128564707684696065" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128564707684696065" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128564707684696065">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128564707684696065">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128564707684696065">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-    <div class="ThreadedConversation--loneTweet">
-    <div class="stream-tombstone-container ThreadedConversation-tweet last">
-  <li class="stream-tombstone-item stream-item js-stream-item">
-<div class="Tombstone">
-  <span class="Tombstone-label">        <span class="Tombstone-label">Este Tweet no está disponible</span>
-</span>
-
-</div>  </li>
-</div>
-
-  </div>
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128694715891589127"
-id="stream-item-tweet-1128694715891589127"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128694715891589127&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       has-cards descendant permalink-descendant-tweet has-content
-"
-
-data-tweet-id="1128694715891589127"
-data-item-id="1128694715891589127"
-data-permalink-path="/nvmbvrz/status/1128694715891589127"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128694715891589127-0f69a7ae-a7fa-45a5-bfb2-8c60ded220b2"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="nvmbvrz" data-name="NVMBVRZ" data-user-id="1113181115039092736"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;1113181115039092736&quot;,&quot;screen_name&quot;:&quot;nvmbvrz&quot;,&quot;name&quot;:&quot;NVMBVRZ&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;NVMBVRZ&quot;,&quot;emojified_text_as_html&quot;:&quot;NVMBVRZ&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
- data-has-cards="true"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/nvmbvrz" data-user-id="1113181115039092736">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1113181211721994240/65l1Lb9E_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>NVMBVRZ</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>nvmbvrz</b></span></a>
-
-
-        <small class="time">
-  <a href="/nvmbvrz/status/1128694715891589127" class="tweet-timestamp js-permalink js-nav js-tooltip" title="9:12 - 15 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557936765" data-time-ms="1557936765000" data-long-form="true">15 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Metallica is awesome!!!<a href="https://t.co/qhaStTXtOy" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/qhaStTXtOy</a></p>
-</div>
-
-
-
-
-
-            <div class="AdaptiveMediaOuterContainer">
-    <div class="AdaptiveMedia
-
-
-        is-video
-
-        has-autoplayable-media
-        "
-      >
-      <div class="AdaptiveMedia-container">
-          <div class="AdaptiveMedia-video">
-  <div class="AdaptiveMedia-videoContainer">
-      <div class="PlayableMedia PlayableMedia--gif">
-
-
-  <div class="PlayableMedia-container">
-    <div
-      class="PlayableMedia-player
-
-        "
-      data-playable-media-url=""
-        data-use-react-player
-        data-use-b-version-of-react-player
-        data-use-player-precache
-
-        data-border-top-left-radius=""
-        data-border-top-right-radius=""
-        data-border-bottom-left-radius=""
-        data-border-bottom-right-radius=""
-      style="padding-bottom: 55.99999999999999%; background-image:url('https://pbs.twimg.com/tweet_video_thumb/D6ntppdVUAAZqRV.jpg')">
-    </div>
-
-  </div>
-</div>
-
-  </div>
-</div>
-
-      </div>
-    </div>
-  </div>
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128694715891589127" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128694715891589127" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128694715891589127" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128694715891589127">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128694715891589127">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128694715891589127">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-    <div class="ThreadedConversation--loneTweet">
-    <div class="stream-tombstone-container ThreadedConversation-tweet last">
-  <li class="stream-tombstone-item stream-item js-stream-item">
-<div class="Tombstone">
-  <span class="Tombstone-label">        <span class="Tombstone-label">Este Tweet no está disponible</span>
-</span>
-
-</div>  </li>
-</div>
-
-  </div>
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128088308544876544"
-id="stream-item-tweet-1128088308544876544"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128088308544876544&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128088308544876544"
-data-item-id="1128088308544876544"
-data-permalink-path="/BeeWall74/status/1128088308544876544"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128088308544876544-b8ac1bb3-b1ae-48a5-8577-ca80e235cbee"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="BeeWall74" data-name="Unleash the Beast" data-user-id="1265540816"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;1265540816&quot;,&quot;screen_name&quot;:&quot;BeeWall74&quot;,&quot;name&quot;:&quot;Unleash the Beast&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Unleash the Beast&quot;,&quot;emojified_text_as_html&quot;:&quot;Unleash the Beast&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/BeeWall74" data-user-id="1265540816">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1018183975158808577/hdyYsK-G_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Unleash the Beast</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>BeeWall74</b></span></a>
-
-
-        <small class="time">
-  <a href="/BeeWall74/status/1128088308544876544" class="tweet-timestamp js-permalink js-nav js-tooltip" title="17:03 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557792186" data-time-ms="1557792186000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Love Papa Het but,,,,,he always looks like he&#39;s got a stomach problem in pics,,</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128088308544876544" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128088308544876544" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128088308544876544" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128088308544876544">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128088308544876544">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128088308544876544">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1129457489064419333"
-id="stream-item-tweet-1129457489064419333"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1129457489064419333&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1129457489064419333"
-data-item-id="1129457489064419333"
-data-permalink-path="/Jasmeeneem/status/1129457489064419333"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1129457489064419333-c2950797-adc4-47a2-9793-455535a9a33e"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="Jasmeeneem" data-name="Moumoucha" data-user-id="913084942732677123"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;913084942732677123&quot;,&quot;screen_name&quot;:&quot;Jasmeeneem&quot;,&quot;name&quot;:&quot;Moumoucha&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Moumoucha&quot;,&quot;emojified_text_as_html&quot;:&quot;Moumoucha&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/Jasmeeneem" data-user-id="913084942732677123">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1134169061296877570/026s0-U0_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Moumoucha</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>Jasmeeneem</b></span></a>
-
-
-        <small class="time">
-  <a href="/Jasmeeneem/status/1129457489064419333" class="tweet-timestamp js-permalink js-nav js-tooltip" title="11:43 - 17 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1558118624" data-time-ms="1558118624000" data-long-form="true">17 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/2764.png" draggable="false" alt="❤️" title="Corazón rojo" aria-label="Emoji: Corazón rojo">be blessed...</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1129457489064419333" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1129457489064419333" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1129457489064419333" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1129457489064419333">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1129457489064419333">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1129457489064419333">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128160260307468288"
-id="stream-item-tweet-1128160260307468288"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128160260307468288&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128160260307468288"
-data-item-id="1128160260307468288"
-data-permalink-path="/kaelgoth/status/1128160260307468288"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128160260307468288-d0dd2f6e-d609-479d-b05e-9d24885ab90b"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="kaelgoth" data-name="Mika Chu" data-user-id="702699632"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;702699632&quot;,&quot;screen_name&quot;:&quot;kaelgoth&quot;,&quot;name&quot;:&quot;Mika Chu&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Mika Chu&quot;,&quot;emojified_text_as_html&quot;:&quot;Mika Chu&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/kaelgoth" data-user-id="702699632">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/780634865641349120/G3fP0jhI_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Mika Chu</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>kaelgoth</b></span></a>
-
-
-        <small class="time">
-  <a href="/kaelgoth/status/1128160260307468288" class="tweet-timestamp js-permalink js-nav js-tooltip" title="21:49 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557809340" data-time-ms="1557809340000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Great move for 2 great causes.</p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128160260307468288" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128160260307468288" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128160260307468288" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128160260307468288">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128160260307468288">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128160260307468288">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128299417537138689"
-id="stream-item-tweet-1128299417537138689"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128299417537138689&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128299417537138689"
-data-item-id="1128299417537138689"
-data-permalink-path="/lchristinep/status/1128299417537138689"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128299417537138689-2454137d-ca6e-4912-9554-b349e731526c"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="lchristinep" data-name="Servant" data-user-id="777529956"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;777529956&quot;,&quot;screen_name&quot;:&quot;lchristinep&quot;,&quot;name&quot;:&quot;Servant&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Servant&quot;,&quot;emojified_text_as_html&quot;:&quot;Servant&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/lchristinep" data-user-id="777529956">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1117402765292998663/cNsxPk3j_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Servant</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>lchristinep</b></span></a>
-
-
-        <small class="time">
-  <a href="/lchristinep/status/1128299417537138689" class="tweet-timestamp js-permalink js-nav js-tooltip" title="7:01 - 14 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557842518" data-time-ms="1557842518000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="und" data-aria-label-part="0"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f49c.png" draggable="false" alt="💜" title="Corazón morado" aria-label="Emoji: Corazón morado"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128299417537138689" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128299417537138689" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128299417537138689" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128299417537138689">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128299417537138689">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128299417537138689">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-    <div class="ThreadedConversation--loneTweet">
-    <div class="stream-tombstone-container ThreadedConversation-tweet last">
-  <li class="stream-tombstone-item stream-item js-stream-item">
-<div class="Tombstone">
-  <span class="Tombstone-label">        <span class="Tombstone-label">Este Tweet no está disponible</span>
-</span>
-
-</div>  </li>
-</div>
-
-  </div>
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128774126695374848"
-id="stream-item-tweet-1128774126695374848"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128774126695374848&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       has-cards descendant permalink-descendant-tweet has-content
-"
-
-data-tweet-id="1128774126695374848"
-data-item-id="1128774126695374848"
-data-permalink-path="/bralalalala/status/1128774126695374848"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128774126695374848-49d0aa19-3e90-4246-af40-644b4b5b6504"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="bralalalala" data-name="Bralalalala (An Artist &amp; Band,Not “Banned”)" data-user-id="1005982702850281473"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;1005982702850281473&quot;,&quot;screen_name&quot;:&quot;bralalalala&quot;,&quot;name&quot;:&quot;Bralalalala (An Artist &amp; Band,Not \u201cBanned\u201d)&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Bralalalala (An Artist &amp; Band,Not \u201cBanned\u201d)&quot;,&quot;emojified_text_as_html&quot;:&quot;Bralalalala (An Artist &amp;amp; Band,Not \u201cBanned\u201d)&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
- data-has-cards="true"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/bralalalala" data-user-id="1005982702850281473">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1129973210370285568/WfpAc8Jh_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Bralalalala (An Artist &amp; Band,Not “Banned”)</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>bralalalala</b></span></a>
-
-
-        <small class="time">
-  <a href="/bralalalala/status/1128774126695374848" class="tweet-timestamp js-permalink js-nav js-tooltip" title="14:28 - 15 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557955698" data-time-ms="1557955698000" data-long-form="true">15 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">It looks like Bralalalala albums are too good for the public which is still mired in ancient sexist and transphobic lore .Well, tough luck...best albums in metal history not being performed for you then...feature the drummer of Megadeth and blow Metallica out of the game<a href="https://t.co/lhr7f687Mo" class="twitter-timeline-link u-hidden" data-pre-embedded="true" dir="ltr" >pic.twitter.com/lhr7f687Mo</a></p>
-</div>
-
-
-
-
-
-            <div class="AdaptiveMediaOuterContainer">
-    <div class="AdaptiveMedia
-
-        is-square
-
-
-
-        "
-      >
-      <div class="AdaptiveMedia-container">
-          <div class="AdaptiveMedia-singlePhoto"
-    style="padding-top: calc(0.986328125 * 100% - 0.5px);"
->
-    <div class="AdaptiveMedia-photoContainer js-adaptive-photo "
-  data-image-url="https://pbs.twimg.com/media/D6o2FSMU8AEYN4a.jpg"
-
-
-  data-element-context="platform_photo_card"
-    style="background-color:rgba(38,27,30,1.0);"
-    data-dominant-color="[38,27,30]"
->
-  <img data-aria-label-part src="https://pbs.twimg.com/media/D6o2FSMU8AEYN4a.jpg" alt=""
-      style="width: 100%; top: -0px;"
->
-</div>
-
-
-</div>
-      </div>
-    </div>
-  </div>
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128774126695374848" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128774126695374848" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128774126695374848" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128774126695374848">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128774126695374848">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128774126695374848">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128123421597085698"
-id="stream-item-tweet-1128123421597085698"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128123421597085698&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128123421597085698"
-data-item-id="1128123421597085698"
-data-permalink-path="/MaryMagdallena/status/1128123421597085698"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128123421597085698-c4ba0f99-fcd1-4050-bdca-4534e941d5c7"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="MaryMagdallena" data-name="aga" data-user-id="631026979"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;631026979&quot;,&quot;screen_name&quot;:&quot;MaryMagdallena&quot;,&quot;name&quot;:&quot;aga&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;aga&quot;,&quot;emojified_text_as_html&quot;:&quot;aga&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/MaryMagdallena" data-user-id="631026979">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/1049575595628216320/n8iq2u66_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>aga</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>MaryMagdallena</b></span></a>
-
-
-        <small class="time">
-  <a href="/MaryMagdallena/status/1128123421597085698" class="tweet-timestamp js-permalink js-nav js-tooltip" title="19:22 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557800557" data-time-ms="1557800557000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="und" data-aria-label-part="0"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/2764.png" draggable="false" alt="❤" title="Corazón rojo" aria-label="Emoji: Corazón rojo"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128123421597085698" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128123421597085698" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128123421597085698" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128123421597085698">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128123421597085698">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128123421597085698">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128161549619814400"
-id="stream-item-tweet-1128161549619814400"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128161549619814400&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128161549619814400"
-data-item-id="1128161549619814400"
-data-permalink-path="/JR_Seas/status/1128161549619814400"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128161549619814400-1637358d-f989-4b32-b105-f9948485513e"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="JR_Seas" data-name="Josh Doesn&#39;t Abide" data-user-id="1279066278"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;1279066278&quot;,&quot;screen_name&quot;:&quot;JR_Seas&quot;,&quot;name&quot;:&quot;Josh Doesn&#39;t Abide&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Josh Doesn&#39;t Abide&quot;,&quot;emojified_text_as_html&quot;:&quot;Josh Doesn&amp;#39;t Abide&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/JR_Seas" data-user-id="1279066278">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/941427634306732034/n-UdIQ8t_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Josh Doesn&#39;t Abide</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>JR_Seas</b></span></a>
-
-
-        <small class="time">
-  <a href="/JR_Seas/status/1128161549619814400" class="tweet-timestamp js-permalink js-nav js-tooltip" title="21:54 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557809648" data-time-ms="1557809648000" data-long-form="true">14 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Papa Het is looking very well fed with large amounts of hunted game meat. As a big man myself, it&#39;s nice to see him embrace not living in a pretentious place full of hypocritical, smug, self-righteous douchebags. True hunters never let anything go to waste. <a href="/hashtag/RealOrganticLife?src=hash" data-query-source="hashtag_click" class="twitter-hashtag pretty-link js-nav" dir="ltr" ><s>#</s><b>RealOrganticLife</b></a></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128161549619814400" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128161549619814400" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128161549619814400" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128161549619814400">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128161549619814400">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128161549619814400">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-      <li class="ThreadedConversation--loneTweet
-
-  ">
-    <ol class="stream-items">
-      <li class="js-stream-item stream-item stream-item
-" data-item-id="1128070819983368195"
-id="stream-item-tweet-1128070819983368195"
-data-item-type="tweet"
- data-suggestion-json="{&quot;suggestion_details&quot;:{},&quot;tweet_ids&quot;:&quot;1128070819983368195&quot;,&quot;scribe_component&quot;:&quot;tweet&quot;}">
-
-
-
-  <div class="tweet js-stream-tweet js-actionable-tweet js-profile-popup-actionable dismissible-content
-
-
-
-       descendant permalink-descendant-tweet
-"
-
-data-tweet-id="1128070819983368195"
-data-item-id="1128070819983368195"
-data-permalink-path="/Hammoud33308783/status/1128070819983368195"
-data-conversation-id="1128068672289890305"
-
-
- data-has-parent-tweet="true"
-
-data-tweet-nonce="1128070819983368195-6c456bad-83ed-4e2e-8fc4-4671908e8a37"
-data-tweet-stat-initialized="true"
-data-conversation-section-quality="HighQuality"
-
-
-
-
-
-  data-screen-name="Hammoud33308783" data-name="Hammoudi" data-user-id="3346991835"
-  data-you-follow="false"
-  data-follows-you="false"
-  data-you-block="false"
- data-mentions="Metallica EMMAUSolidarite PompiersParis"
-
-data-reply-to-users-json="[{&quot;id_str&quot;:&quot;3346991835&quot;,&quot;screen_name&quot;:&quot;Hammoud33308783&quot;,&quot;name&quot;:&quot;Hammoudi&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Hammoudi&quot;,&quot;emojified_text_as_html&quot;:&quot;Hammoudi&quot;}},{&quot;id_str&quot;:&quot;238475531&quot;,&quot;screen_name&quot;:&quot;Metallica&quot;,&quot;name&quot;:&quot;Metallica&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Metallica&quot;,&quot;emojified_text_as_html&quot;:&quot;Metallica&quot;}},{&quot;id_str&quot;:&quot;2912493406&quot;,&quot;screen_name&quot;:&quot;EMMAUSolidarite&quot;,&quot;name&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;,&quot;emojified_text_as_html&quot;:&quot;EMMA\u00dcS Solidarit\u00e9&quot;}},{&quot;id_str&quot;:&quot;1342191438&quot;,&quot;screen_name&quot;:&quot;PompiersParis&quot;,&quot;name&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_name&quot;:{&quot;text&quot;:&quot;Pompiers de Paris&quot;,&quot;emojified_text_as_html&quot;:&quot;Pompiers de Paris&quot;}}]"
-
-
-
-
-
-
-
-data-disclosure-type=""
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- data-component-context="replies"
-
-
-    >
-
-    <div class="context">
-
-
-    </div>
-
-    <div class="content">
-
-
-
-
-
-      <div class="stream-item-header">
-          <a  class="account-group js-account-group js-action-profile js-user-profile-link js-nav" href="/Hammoud33308783" data-user-id="3346991835">
-      <img class="avatar js-action-profile-avatar" src="https://pbs.twimg.com/profile_images/614575659944411136/zY_lTG1A_bigger.jpg" alt="">
-    <span class="FullNameGroup">
-      <strong class="fullname show-popup-with-id u-textTruncate " data-aria-label-part>Hammoudi</strong><span>&rlm;</span><span class="UserBadges"></span><span class="UserNameBreak">&nbsp;</span></span><span class="username u-dir u-textTruncate" dir="ltr" data-aria-label-part>@<b>Hammoud33308783</b></span></a>
-
-
-        <small class="time">
-  <a href="/Hammoud33308783/status/1128070819983368195" class="tweet-timestamp js-permalink js-nav js-tooltip" title="15:53 - 13 may. 2019"  data-conversation-id="1128068672289890305"><span class="_timestamp js-short-timestamp " data-aria-label-part="last" data-time="1557788016" data-time-ms="1557788016000" data-long-form="true">13 may.</span></a>
-</small>
-
-          <div class="ProfileTweet-action ProfileTweet-action--more js-more-ProfileTweet-actions">
-    <div class="dropdown">
-  <button class="ProfileTweet-actionButton u-textUserColorHover dropdown-toggle js-dropdown-toggle" type="button">
-      <div class="IconContainer js-tooltip" title="Más">
-        <span class="Icon Icon--caretDownLight Icon--small"></span>
-        <span class="u-hiddenVisually">Más</span>
-      </div>
-  </button>
-  <div class="dropdown-menu is-autoCentered">
-  <div class="dropdown-caret">
-    <div class="caret-outer"></div>
-    <div class="caret-inner"></div>
-  </div>
-  <ul>
-
-      <li class="copy-link-to-tweet js-actionCopyLinkToTweet">
-        <button type="button" class="dropdown-link">Copiar enlace del Tweet</button>
-      </li>
-      <li class="embed-link js-actionEmbedTweet" data-nav="embed_tweet">
-        <button type="button" class="dropdown-link">Insertar Tweet</button>
-      </li>
-  </ul>
-</div>
-
-</div>
-
-  </div>
-
-      </div>
-
-
-
-
-
-        <div class="ReplyingToContextBelowAuthor" data-aria-label-part>
-
-
-    En respuesta a <a class="pretty-link js-user-profile-link" href="/Metallica" data-user-id="238475531" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>Metallica</b></span></a> <a class="pretty-link js-user-profile-link" href="/EMMAUSolidarite" data-user-id="2912493406" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>EMMAUSolidarite</b></span></a> <a class="pretty-link js-user-profile-link" href="/PompiersParis" data-user-id="1342191438" rel="noopener" dir="ltr"><span class="username u-dir u-textTruncate" dir="ltr" >@<b>PompiersParis</b></span></a>
-
-</div>
-
-
-
-        <div class="js-tweet-text-container">
-  <p class="TweetTextSize  js-tweet-text tweet-text" lang="en" data-aria-label-part="0">Thank you very much !!! Im fan of Metallica since 1982 guys !! You are my family !!<img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44d.png" draggable="false" alt="👍" title="Signo de pulgar hacia arriba" aria-label="Emoji: Signo de pulgar hacia arriba"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44b.png" draggable="false" alt="👋" title="Signo de mano saludando" aria-label="Emoji: Signo de mano saludando"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44b.png" draggable="false" alt="👋" title="Signo de mano saludando" aria-label="Emoji: Signo de mano saludando"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44b.png" draggable="false" alt="👋" title="Signo de mano saludando" aria-label="Emoji: Signo de mano saludando"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f44b.png" draggable="false" alt="👋" title="Signo de mano saludando" aria-label="Emoji: Signo de mano saludando"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f918.png" draggable="false" alt="🤘" title="Señal de los cuernos" aria-label="Emoji: Señal de los cuernos"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f1eb-1f1f7.png" draggable="false" alt="🇫🇷" title="Bandera de Francia" aria-label="Emoji: Bandera de Francia"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f1eb-1f1f7.png" draggable="false" alt="🇫🇷" title="Bandera de Francia" aria-label="Emoji: Bandera de Francia"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f1eb-1f1f7.png" draggable="false" alt="🇫🇷" title="Bandera de Francia" aria-label="Emoji: Bandera de Francia"><img class="Emoji Emoji--forText" src="https://abs.twimg.com/emoji/v2/72x72/1f1eb-1f1f7.png" draggable="false" alt="🇫🇷" title="Bandera de Francia" aria-label="Emoji: Bandera de Francia"></p>
-</div>
-
-
-
-
-
-
-
-
-
-
-
-
-      <div class="stream-item-footer">
-
-      <div class="ProfileTweet-actionCountList u-hiddenVisually">
-
-
-    <span class="ProfileTweet-action--reply u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-reply-count-aria-1128070819983368195" >0 respuestas</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--retweet u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-retweet-count-aria-1128070819983368195" >0 retweets</span>
-      </span>
-    </span>
-    <span class="ProfileTweet-action--favorite u-hiddenVisually">
-      <span class="ProfileTweet-actionCount" aria-hidden="true" data-tweet-stat-count="0">
-        <span class="ProfileTweet-actionCountForAria" id="profile-tweet-action-favorite-count-aria-1128070819983368195" >0 Me gusta</span>
-      </span>
-    </span>
-  </div>
-
-  <div class="ProfileTweet-actionList js-actions" role="group" aria-label="Acciones del Tweet">
-    <div class="ProfileTweet-action ProfileTweet-action--reply">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionReply"
-    data-modal="ProfileTweet-reply" type="button"
-    aria-describedby="profile-tweet-action-reply-count-aria-1128070819983368195">
-    <div class="IconContainer js-tooltip" title="Responder">
-      <span class="Icon Icon--medium Icon--reply"></span>
-      <span class="u-hiddenVisually">Responder</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero ">
-        <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-      </span>
-  </button>
-</div>
-
-    <div class="ProfileTweet-action ProfileTweet-action--retweet js-toggleState js-toggleRt">
-  <button class="ProfileTweet-actionButton  js-actionButton js-actionRetweet"
-
-    data-modal="ProfileTweet-retweet"
-    type="button"
-    aria-describedby="profile-tweet-action-retweet-count-aria-1128070819983368195">
-    <div class="IconContainer js-tooltip" title="Retwittear">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwittear</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo js-actionButton js-actionRetweet" data-modal="ProfileTweet-retweet" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer Retweet">
-      <span class="Icon Icon--medium Icon--retweet"></span>
-      <span class="u-hiddenVisually">Retwitteado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-    <div class="ProfileTweet-action ProfileTweet-action--favorite js-toggleState">
-  <button class="ProfileTweet-actionButton js-actionButton js-actionFavorite" type="button"
-    aria-describedby="profile-tweet-action-favorite-count-aria-1128070819983368195">
-    <div class="IconContainer js-tooltip" title="Me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Me gusta</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button><button class="ProfileTweet-actionButtonUndo ProfileTweet-action--unfavorite u-linkClean js-actionButton js-actionFavorite" type="button">
-    <div class="IconContainer js-tooltip" title="Deshacer me gusta">
-      <span role="presentation" class="Icon Icon--heart Icon--medium"></span>
-      <div class="HeartAnimation"></div>
-      <span class="u-hiddenVisually">Gustado</span>
-    </div>
-      <span class="ProfileTweet-actionCount ProfileTweet-actionCount--isZero">
-    <span class="ProfileTweet-actionCountForPresentation" aria-hidden="true"></span>
-  </span>
-
-  </button>
-</div>
-
-
-
-
-
-
-  </div>
-
-</div>
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-
-  </div>
-
-
-
-
-<div class="dismiss-module">
-  <div class="dismissed-module">
-    <div class="feedback-actions">
-        <div class="feedback-action" data-feedback-type="DontLike" data-feedback-url="">
-          <div class="action-confirmation dismiss-module-item">Gracias. Twitter usará esto para mejorar tu cronología.
-            <span class="undo-action">Deshacer</span>
-          </div>
-        </div>
-    </div>
-    <div class="child-feedback-confirmation">
-      <div class="child-confirmation-item">
-        <span class="child-confirmation-text"></span>
-        <span class="undo-child-feedback-action">Deshacer</span>
-      </div>
-    </div>
-  </div>
-</div>
-
-</li>
-    </ol>
-  </li>
-
-
-
-
-
-
-
-        </ol>
-        <div class="stream-footer ">
-  <div class="timeline-end has-items has-more-items">
-      <div class="stream-end">
-    <div class="stream-end-inner">
-        <span class="Icon Icon--large Icon--logo"></span>
-
-      <p class="empty-text">
-
-
-      </p>
-
-        <p><button type="button" class="btn-link back-to-top hidden">Volver arriba &uarr;</button></p>
-    </div>
-  </div>
-
-
-    <div class="stream-loading">
-  <div class="stream-end-inner">
-    <span class="spinner" title="Cargando..."></span>
-  </div>
-</div>
-
-  </div>
-</div>
-<div class="stream-fail-container">
-    <div class="js-stream-whale-end stream-whale-end stream-placeholder centered-placeholder">
-  <div class="stream-end-inner">
-    <h2 class="title">Parece que el contenido está tardando un poco en cargarse.</h2>
-    <p>
-      Puede que Twitter esté saturado o experimentando un problema momentáneo.
- <a role="button" href="#" class="try-again-after-whale">Inténtalo
- de nuevo</a> o visita el <a target="_blank" href="http://status.twitter.com" rel="noopener">Estado de Twitter</a> para más
-información.
+    .errorButton {
+      margin: 3em 0;
+    }
+
+    .errorButton a {
+      background: #1DA1F2;
+      border-radius: 2.5em;
+      color: white;
+      padding: 1em 2em;
+      text-decoration: none;
+    }
+
+    .errorButton a:hover,
+    .errorButton a:focus {
+      background: rgb(26, 145, 218);
+    }
+
+    .errorFooter {
+      color: #657786;
+      font-size: 80%;
+      line-height: 1.5;
+      padding: 1em 0;
+    }
+
+    .errorFooter a,
+    .errorFooter a:visited {
+      color: #657786;
+      text-decoration: none;
+      padding-right: 1em;
+    }
+
+    .errorFooter a:hover,
+    .errorFooter a:active {
+      text-decoration: underline;
+    }
+
+      #placeholder,
+      #react-root {
+        display: none !important;
+      }
+      body {
+        background-color: #FFF !important;
+      }
+    </style>
+    <div class="errorContainer">
+      <img width="46" height="38" srcset="https://abs.twimg.com/errors/logo46x38.png 1x, https://abs.twimg.com/errors/logo46x38@2x.png 2x" src="https://abs.twimg.com/errors/logo46x38.png" alt="Twitter">
+      <h1>JavaScript is not available.</h1>
+      <p>We’ve detected that JavaScript is disabled in this browser. Please enable JavaScript or switch to a supported browser to continue using twitter.com. You can see a list of supported browsers in our Help Center.</p>
+      <p class="errorButton"><a href="https://help.twitter.com/using-twitter/twitter-supported-browsers">Help Center</a></p>
+    <p class="errorFooter">
+      <a href="https://twitter.com/tos">Terms of Service</a>
+      <a href="https://twitter.com/privacy">Privacy Policy</a>
+      <a href="https://support.twitter.com/articles/20170514">Cookie Policy</a>
+      <a href="https://legal.twitter.com/imprint.html">Imprint</a>
+      <a href="https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&amp;utm_source=twc&amp;utm_medium=web&amp;utm_campaign=ao&amp;utm_content=adsinfo">Ads info</a>
+      © 2023 X Corp.
     </p>
-  </div>
-</div>
-</div>
 
-      <ol class="hidden-replies-container"></ol>
     </div>
-  </div>
-      </div>
-    </div>
+  </noscript>
+<div id="react-root" style="height:100%;display:flex;"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13awgt0 r-12vffkv"><div class="css-1dbjc4n r-13qz1uu r-417010" style="min-height:736px">
+<div aria-label="Skip to home timeline" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<div aria-label="Skip to trending" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-4iw3lz r-1xk2f4g r-109y4c4 r-2yi16 r-1qi8awa r-1ny4l3l r-1udh08x r-wwvuq4 r-u8s1d r-o7ynqc r-6416eg r-lrvibr r-92ng3h"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span></div></div>
+<header role="banner" class="css-1dbjc4n r-lrvibr r-1g40b8q"><div class="css-1dbjc4n r-1h3ijdo r-orgf3d r-633pao"></div>
+<div class="css-1dbjc4n" data-testid="SSRSafeLayer"><div class="css-1dbjc4n r-1d2f490 r-1xcajam r-zchlnj r-1gn8etr">
+<div class="css-1dbjc4n r-1e5uvyk r-6026j r-16e0dcy r-dkhcqf r-axxi2z r-18jm5s1" data-testid="TopNavBar"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-fxvszc r-136ojw6" data-testid="twitter-logged-out-nav">
+<div class="css-1dbjc4n r-1h3ijdo r-136ojw6"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1h3ijdo"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1h3ijdo r-1777fci r-1jgb5lz r-ymttw5 r-13qz1uu">
+<div class="css-1dbjc4n r-1habvwh r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div class="css-1dbjc4n r-1777fci r-1mf7evn"><h1 role="heading" class="css-4rbku5 css-1dbjc4n r-1awozwy r-1pz39u2 r-1loqt21 r-6koalj r-16y2uox r-1777fci r-4wgw6l"><a href="/" aria-label="Twitter" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-left:calc(0px + (-1 * ((36px + (1px * 2)) - 1.75rem) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1cvl2hr r-4qtqp9 r-yyyyoo r-16y2uox r-lwhw9o r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M23.643 4.937c-.835.37-1.732.62-2.675.733.962-.576 1.7-1.49 2.048-2.578-.9.534-1.897.922-2.958 1.13-.85-.904-2.06-1.47-3.4-1.47-2.572 0-4.658 2.086-4.658 4.66 0 .364.042.718.12 1.06-3.873-.195-7.304-2.05-9.602-4.868-.4.69-.63 1.49-.63 2.342 0 1.616.823 3.043 2.072 3.878-.764-.025-1.482-.234-2.11-.583v.06c0 2.257 1.605 4.14 3.737 4.568-.392.106-.803.162-1.227.162-.3 0-.593-.028-.877-.082.593 1.85 2.313 3.198 4.352 3.234-1.595 1.25-3.604 1.995-5.786 1.995-.376 0-.747-.022-1.112-.065 2.062 1.323 4.51 2.093 7.14 2.093 8.57 0 13.255-7.098 13.255-13.254 0-.2-.005-.402-.014-.602.91-.658 1.7-1.477 2.323-2.41z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0"></span>
+</div></a></h1></div></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1pi2tsx r-1777fci">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n r-1awozwy r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1iusvr4 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-13awgt0 r-eqz5dr r-bnwqim r-8fdsdq"><div class="r-1oszu61 r-vqxq0j r-deolkf r-6koalj r-1mlwlqe r-eqz5dr r-1wbh5a2 r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-13qz1uu r-417010"><form action="#" aria-label="Search Twitter" role="search" class="r-1oszu61 r-1phboty r-1yadl64 r-deolkf r-6koalj r-13awgt0 r-eqz5dr r-crgep1 r-ifefl9 r-bcqeeo r-t60dpp r-bnwqim r-417010">
+<div class="css-1dbjc4n r-1wbh5a2"><div class="css-1dbjc4n r-1sw30gj r-42olwf r-sdzlij r-1phboty r-rs99b7 r-eqz5dr r-16y2uox r-1wbh5a2 r-1777fci"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1awozwy r-18u37iz"><label class="css-1dbjc4n r-1dqbpge r-13awgt0 r-18u37iz" data-testid="SearchBox_Search_Input_label"><div class="css-1dbjc4n r-7q8q6z r-6koalj r-1777fci"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-14j79pv r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-4wgw6l r-f727ji r-bnwqim r-1plcrui r-lrvibr"><g><path d="M10.25 3.75c-3.59 0-6.5 2.91-6.5 6.5s2.91 6.5 6.5 6.5c1.795 0 3.419-.726 4.596-1.904 1.178-1.177 1.904-2.801 1.904-4.596 0-3.59-2.91-6.5-6.5-6.5zm-8.5 6.5c0-4.694 3.806-8.5 8.5-8.5s8.5 3.806 8.5 8.5c0 1.986-.682 3.815-1.824 5.262l4.781 4.781-1.414 1.414-4.781-4.781c-1.447 1.142-3.276 1.824-5.262 1.824-4.694 0-8.5-3.806-8.5-8.5z"></path></g></svg></div>
+<div class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div dir="ltr" class="css-901oao r-6koalj r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><input type="text" aria-activedescendant="typeaheadFocus-0.6013879544345411" aria-autocomplete="list" aria-label="Search query" aria-owns="typeaheadDropdown-139588" autocapitalize="sentences" autocomplete="off" autocorrect="off" placeholder="Search Twitter" role="combobox" spellcheck="false" value="" enterkeyhint="search" dir="auto" class="r-30o5oe r-1niwhzg r-17gur6a r-1yadl64 r-deolkf r-homxoj r-poiln3 r-7cikom r-1ny4l3l r-xyw6el r-oyd9sg r-y0fyvk r-1dz5y72 r-fdjqy7 r-13qz1uu" data-testid="SearchBox_Search_Input"></div></div>
+<div class="css-1dbjc4n r-6koalj r-1777fci"></div></label></div></div></div></div>
+<div class="css-1dbjc4n r-13awgt0 r-bnwqim"></div>
+</form></div></div></div></div>
 </div>
-
-
-
-  </div>
-
-
-  <div class="stream-container suggested-tweet-stream-container dismissible-container u-hidden">
-    <div class="stream suggested-tweet-stream permalink-replies">
-      <h3 class="promoted-heading">Tweet promocionado</h3>
-      <ol class="stream-items suggested-tweet-stream-items js-navigable-stream" id="suggested-stream-items-id">
-
-      </ol>
-    </div>
-   </div>
-
-    <div class="module Trends trends hidden Trends--wide">
-  <div class="trends-inner">
-    <div class="flex-module trends-container ">
-  <div class="flex-module-header">
-
-    <h3><span class="trend-location js-trend-location">false</span></h3>
-  </div>
-  <div class="flex-module-inner">
-    <ul class="trend-items js-trends">
-    </ul>
-  </div>
+<div class="css-1dbjc4n r-obd0qt r-1pz39u2 r-1777fci r-15ysp7h r-s8bhmr"><div aria-expanded="false" aria-haspopup="menu" aria-label="More" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1niwhzg r-42olwf r-sdzlij r-1phboty r-rs99b7 r-2yi16 r-1qi8awa r-1ny4l3l r-o7ynqc r-6416eg r-lrvibr" style="margin-right:calc(4px + (-1 * ((36px + (1px * 2)) - 20px) / 2))"><div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-z80fyv r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03" style="color:rgba(15,20,25,1.00)"><g><path d="M3 12c0-1.1.9-2 2-2s2 .9 2 2-.9 2-2 2-2-.9-2-2zm9 2c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm7 0c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></g></svg><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-a023e6 r-rjixqe r-bcqeeo r-qvutc0" style="border-bottom:2px solid #0F1419"></span>
+</div></div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-16y2uox r-1w6e6rj r-1h3ijdo r-1wtj0ep r-1fz3rvf r-rjfia"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox"><div class="css-1dbjc4n r-1awozwy r-1pz39u2 r-18u37iz r-16y2uox">
+<div class="css-1dbjc4n r-16y2uox"><a href="/login" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1ets6dv r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="login"><div dir="ltr" class="css-901oao r-1awozwy r-1cvl2hr r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Log in</span></span></div></a></div>
+<div class="css-1dbjc4n r-16y2uox r-19u6a5r"><a href="/i/flow/signup" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-l5o3uw r-42olwf r-sdzlij r-1phboty r-rs99b7 r-1loqt21 r-15ysp7h r-4wgw6l r-1ny4l3l r-ymttw5 r-o7ynqc r-6416eg r-lrvibr" data-testid="signup"><div dir="ltr" class="css-901oao r-1awozwy r-jwli3a r-6koalj r-18u37iz r-16y2uox r-37j5jr r-a023e6 r-b88u0q r-1777fci r-rjixqe r-bcqeeo r-q4m81j r-qvutc0"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Sign up</span></span></div></a></div>
+</div></div></div>
+</div></div></div>
+<div class="css-1dbjc4n r-633pao r-u8s1d r-dkhcqf r-axxi2z r-18jm5s1 r-13qz1uu r-1wyyakw" style="-webkit-transform:translate3d(0, 0, 0) translateY(53px);transform:translate3d(0, 0, 0) translateY(53px)"><div class="css-1dbjc4n r-1jgb5lz r-13qz1uu"><div class="css-1dbjc4n r-1awozwy r-1777fci r-1jgb5lz r-19u6a5r r-13qz1uu"><div role="status" class="css-1dbjc4n r-1r5su4o r-orgf3d r-1lul07w r-eafdt9 r-1b8bd59 r-nx0j10"><div aria-label="New Tweets are available. Push the period key to go to the them." role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-sdzlij r-y3da5r r-1777fci r-1ny4l3l r-ymttw5 r-oyd9sg r-o7ynqc r-6416eg"><div class="css-1dbjc4n r-18u37iz">
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-1kihuf0 r-jwli3a r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-19wmn03"><g><path d="M12 3.59l7.457 7.45-1.414 1.42L13 7.41V21h-2V7.41l-5.043 5.05-1.414-1.42L12 3.59z"></path></g></svg><div dir="ltr" class="css-901oao css-1hf3ou5 r-1kihuf0 r-jwli3a r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-13hce6t r-bcqeeo r-qvutc0" data-testid="pillLabel"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">See new Tweets</span></div>
+</div></div></div></div></div></div>
+</div></div></header><main role="main" class="css-1dbjc4n r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-150rngu r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-aqfbo4 r-16y2uox"><div class="css-1dbjc4n r-1oszu61 r-1niwhzg r-18u37iz r-16y2uox r-1jgb5lz r-2llsf r-13qz1uu"><div class="css-1dbjc4n r-14lw9ot r-42olwf r-1ljd8xs r-13l2t4g r-1phboty r-16y2uox r-1jgb5lz r-13qz1uu r-184en5c" data-testid="primaryColumn"><div aria-label="Home timeline" tabindex="0" class="css-1dbjc4n"><div itemscope="" itemtype="https://schema.org/Collection">
+<meta content="Tweet with replies" itemprop="name">
+<section aria-labelledby="accessible-list-62189" role="region" class="css-1dbjc4n"><h1 dir="auto" aria-level="1" role="heading" class="css-4rbku5 css-901oao r-4iw3lz r-1xk2f4g r-109y4c4 r-1udh08x r-wwvuq4 r-u8s1d r-92ng3h" id="accessible-list-62189">Conversation</h1>
+<div aria-label="Timeline: Conversation" class="css-1dbjc4n"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128068672289890305" itemprop="identifier">
+<meta content="1" itemprop="position">
+<meta content="21" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-13T22:45:04.000Z" itemprop="dateCreated">
+<meta content="2019-05-13T22:45:04.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="url">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="mainEntityOfPage">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="238475531" itemprop="identifier">
+<meta content="Metallica" itemprop="additionalName">
+<meta content="Metallica" itemprop="givenName">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/FollowAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="6201953" itemprop="userInteractionCount">
 </div>
-
-  </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/SubscribeAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="36" itemprop="userInteractionCount">
 </div>
-
-
-  <div class="permalink-footer">
-      <div class="Footer module roaming-module Footer--slim"
-  >
-  <div class="flex-module">
-    <div class="flex-module-inner js-items-container">
-      <ul class="u-cf">
-        <li class="Footer-item Footer-copyright copyright">&copy; 2019 Twitter</li>
-        <li class="Footer-item"><a class="Footer-link" href="/about" rel="noopener">Sobre nosotros</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com" rel="noopener">Centro de Ayuda</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/tos" rel="noopener">Condiciones</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="/privacy" rel="noopener">Política de privacidad</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//support.twitter.com/articles/20170514" rel="noopener">Cookies</a></li>
-        <li class="Footer-item"><a class="Footer-link" href="//business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html" rel="noopener">Información sobre anuncios</a></li>
-      </ul>
-    </div>
-  </div>
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="5640" itemprop="userInteractionCount">
 </div>
-
-  </div>
 </div>
-
-
-      </div>
-    </div>
-  </div>
+<meta content="https://twitter.com/AWMHFoundation/status/1127646016931487744" itemprop="isBasedOn">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305/likes" itemprop="url">
+<meta content="1424" itemprop="userInteractionCount">
 </div>
-
-    <div class="hidden" id="hidden-content">
-  <iframe aria-hidden="true" class="tweet-post-iframe" name="tweet-post-iframe"></iframe>
-  <iframe aria-hidden="true" class="dm-post-iframe" name="dm-post-iframe"></iframe>
-
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305/retweets" itemprop="url">
+<meta content="171" itemprop="userInteractionCount">
 </div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="url">
+<meta content="21" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__7niw2xrn83p id__wiaodv8wbng id__l1qvmbpbn5 id__mptyoylc8ya id__k6dqn3tgyyp id__gp902kqdw7d id__rvp2ny97qj id__f6nt4i3i067 id__hg2hl2vkp0k id__joscq79mhk id__k6mh68isd1 id__gg1kalgjw4t id__2w5b4v3q2m8 id__nnd3mx6ihvn id__ydnjvea5f1 id__2fdcpu82ok5 id__vxje9y78up id__xu65rqh5er id__9qyczaa555" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-15zivkp">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Metallica">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-ggadg3 r-u8s1d r-8jfcpp" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Square profile picture" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg")'></div>
+<img alt="Square profile picture" draggable="true" src="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-1wyvozj r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci"><div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__k6dqn3tgyyp" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Metallica</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><lineargradient gradientunits="userSpaceOnUse" id="18690-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></lineargradient><lineargradient gradientunits="userSpaceOnUse" id="18690-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></lineargradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18690-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18690-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></div></a></div></div></div>
+</div></div></div></div></div></div>
+</div>
+<div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-1habvwh"></div>
+<div class="css-1dbjc4n"><div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n r-1s2bzr4"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-1inkyih r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__k6mh68isd1" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Thank you to everyone who came out for </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/MetInParis?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#MetInParis</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> last night for helping us support </span><div class="css-1dbjc4n r-xoduu5"><span class="r-18u37iz"><a dir="ltr" href="/EMMAUSolidarite" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">@EMMAUSolidarite</a></span></div>
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> &amp; </span><div class="css-1dbjc4n r-xoduu5"><span class="r-18u37iz"><a dir="ltr" href="/PompiersParis" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">@PompiersParis</a></span></div>
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">. </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/AWMH?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#AWMH</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/MetalicaGivesBack?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#MetalicaGivesBack</a></span>
+</div></div></div></div>
+<div class="css-1dbjc4n"><div aria-labelledby="id__da3mlwmkmnc id__3agb7x3hqvt" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__2w5b4v3q2m8"><div class="css-1dbjc4n" id="id__da3mlwmkmnc">
+<div dir="ltr" class="css-901oao r-4iw3lz r-1xk2f4g r-37j5jr r-a023e6 r-16dba41 r-109y4c4 r-rjixqe r-bcqeeo r-1udh08x r-wwvuq4 r-u8s1d r-92ng3h r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Quote Tweet</span></div>
+<div tabindex="0" class="css-1dbjc4n r-1ets6dv r-1867qdf r-rs99b7 r-1loqt21 r-adacv r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n r-eqz5dr r-1fz3rvf r-1s2bzr4"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-1udh08x"><div class="css-1dbjc4n r-1habvwh r-18u37iz r-dnmrzs">
+<div class="css-1dbjc4n r-1d4mawv" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-z80fyv r-bztko3 r-19wmn03" data-testid="UserAvatar-Container-AWMHFoundation">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/AWMHFoundation" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/935181032185241600/D8FoOIRJ_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/935181032185241600/D8FoOIRJ_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div>
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/AWMHFoundation" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">All Within My Hands Foundation</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/AWMHFoundation" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@AWMHFoundation</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><a href="/AWMHFoundation/status/1127646016931487744" dir="ltr" aria-label="May 12, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-12T18:45:35.000Z">May 12, 2019</time></a></div></div>
+</div></div>
+</div></div>
+</div></div></div></div>
+<div class="css-1dbjc4n r-6gpygo r-1fz3rvf"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-14gqq1x r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">If you bought a ticket for tonight’s </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> show at Stade de France, you have helped contribute to </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@EMMAUSolidarite</span></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> &amp; </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@PompiersParis</span></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">. </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">#MetallicaGivesBack</span></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">#AWMH</span></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><span dir="ltr" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">#MetInParis</span></span>
+</div></div>
+<div class="css-1dbjc4n r-14gqq1x"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ny4l3l r-o7ynqc r-6416eg">
+<div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:56.25%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-18u37iz r-1pi2tsx r-13qz1uu">
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-a5pmau r-bnwqim"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div class="css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/D6YzUC8V4AApDdF?format=jpg&amp;name=4096x4096")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/D6YzUC8V4AApDdF?format=jpg&amp;name=4096x4096" class="css-9pa8cd">
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-bnwqim"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div class="css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ?format=jpg&amp;name=4096x4096")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ?format=jpg&amp;name=4096x4096" class="css-9pa8cd">
+</div></div></div></div></div>
+</div></div>
+</div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/D6YzUC8V4AApDdF?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="4096" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="4096" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+</div></div></div>
+</div></div>
+</div></div></div>
+<div class="css-1dbjc4n"></div>
+<div class="css-1dbjc4n r-1r5su4o"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wtj0ep">
+<div class="css-1dbjc4n r-1b7u577"><div class="css-1dbjc4n r-1d09ksm r-1471scf r-18u37iz r-1wbh5a2"><div dir="ltr" class="css-901oao r-14j79pv r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><a href="/Metallica/status/1128068672289890305" aria-describedby="id__uvi818zhjqi" aria-label="10:45 PM · May 13, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-poiln3 r-9aw3ui r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-13T22:45:04.000Z">10:45 PM · May 13, 2019</time></a></div></div></div>
+<div class="css-1dbjc4n r-18u37iz"></div>
+</div></div>
+<div role="group" class="css-1dbjc4n r-18u37iz r-1w6e6rj">
+<div role="separator" class="css-1dbjc4n r-1dgieki r-1efd50x r-5kkj8d r-109y4c4 r-13qz1uu"></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/Metallica/status/1128068672289890305/retweets" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">171</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Retweets</span></span></a></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><a href="/Metallica/status/1128068672289890305/likes" dir="ltr" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-1loqt21 r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,424</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Likes</span></span></a></div>
+<div class="css-1dbjc4n r-1mf7evn r-1yzf0co"><div dir="ltr" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)">
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-1b43r93 r-b88u0q r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div> <span class="css-901oao css-16my406 r-14j79pv r-poiln3 r-1b43r93 r-1cwl3u0 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Bookmarks</span></span>
+</div></div>
+</div>
+<div class="css-1dbjc4n"><div role="group" class="css-1dbjc4n r-1oszu61 r-j5o65s r-rull8r r-qklmqi r-1dgieki r-1efd50x r-5kkj8d r-1ta3fxp r-18u37iz r-h3s6tt r-a2tzq0 r-3qxfft r-s1qlax" id="id__9qyczaa555">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="Bookmark" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="bookmark"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M4 4.5C4 3.12 5.119 2 6.5 2h11C18.881 2 20 3.12 20 4.5v18.44l-8-5.71-8 5.71V4.5zM6.5 4c-.276 0-.5.22-.5.5v14.56l6-4.29 6 4.29V4.5c0-.28-.224-.5-.5-.5h-11z"></path></g></svg>
+</div></div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-50lct3 r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1srniue"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128069274101276673" itemprop="identifier">
+<meta content="2" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-13T22:47:28.000Z" itemprop="dateCreated">
+<meta content="2019-05-13T22:47:28.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/LizzyHock1963/status/1128069274101276673" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="863480651881734144" itemprop="identifier">
+<meta content="LizzyHock1963" itemprop="additionalName">
+<meta content="🇺🇸 Lizzy H♡ck 🇺🇲" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/LizzyHock1963/status/1128069274101276673/likes" itemprop="url">
+<meta content="2" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/LizzyHock1963/status/1128069274101276673/retweets" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/LizzyHock1963/status/1128069274101276673/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/LizzyHock1963/status/1128069274101276673" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__umiud8mmr6 id__06c0rlsrz2p9 id__73c5jmc81qo id__o4vsxq3y8zk id__usqvf9jtsh id__jv9cu1e7mg id__2pzksfxvrrc id__5jo2n6agpgt id__mozy1dh7pun id__cfwjm4qmlv id__u9jds4ivrj id__bjvgxk8a9p id__ml7uhygofu id__72tuxiq2e82 id__31d3vl9kpcr id__gwl2zh5u44w id__75t82gy5ys6 id__en9rsfxujpg id__ntx1zknz4xa" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-LizzyHock1963">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/LizzyHock1963" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1525587715697389568/FvMoE7ge_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1525587715697389568/FvMoE7ge_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__usqvf9jtsh" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/LizzyHock1963" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><img alt="🇺🇸" draggable="false" src="https://abs-0.twimg.com/emoji/v2/svg/1f1fa-1f1f8.svg" class="r-4qtqp9 r-dflpy8 r-sjv1od r-zw8f10 r-10akycc r-h9hxbl"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> Lizzy H♡ck </span><img alt="🇺🇲" draggable="false" src="https://abs-0.twimg.com/emoji/v2/svg/1f1fa-1f1f2.svg" class="r-4qtqp9 r-dflpy8 r-sjv1od r-zw8f10 r-10akycc r-h9hxbl"></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/LizzyHock1963" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@LizzyHock1963</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/LizzyHock1963/status/1128069274101276673" dir="ltr" aria-label="May 13, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-13T22:47:28.000Z">May 13, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__u9jds4ivrj" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Thank you MetallicA, for being so generous!</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">💕</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">💞</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">💟</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🤘</span>
+</div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 Retweet, 2 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__ntx1zknz4xa">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="1 Retweet. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128070303274471424" itemprop="identifier">
+<meta content="3" itemprop="position">
+<meta content="1" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-13T22:51:33.000Z" itemprop="dateCreated">
+<meta content="2019-05-13T22:51:33.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/TomOlson8/status/1128070303274471424" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="623979006" itemprop="identifier">
+<meta content="TomOlson8" itemprop="additionalName">
+<meta content="Brutus" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/TomOlson8/status/1128070303274471424/likes" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/TomOlson8/status/1128070303274471424/retweets" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/TomOlson8/status/1128070303274471424/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/TomOlson8/status/1128070303274471424" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__jw9n37cumur id__3po4bdj3dfp id__xc0c8g88fy id__805jn6pbxgs id__omo4zugd3m id__an0a8bzjs76 id__tqc91oydnj id__ci4ebxw8yh4 id__oswdnpcxwld id__5mcwj4iplkq id__i28slfpg7vg id__7i30lpe1xsn id__64hcp9w7i57 id__ytyb57urfw id__428dyhevxmn id__vyqfo4m0xso id__44el5m164o9 id__7w7y0o6w67k id__giqsh5mqm7d" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-TomOlson8">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/TomOlson8" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/543212042631794688/lMegt8oL_400x400.jpeg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/543212042631794688/lMegt8oL_400x400.jpeg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__omo4zugd3m" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/TomOlson8" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Brutus</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/TomOlson8" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@TomOlson8</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/TomOlson8/status/1128070303274471424" dir="ltr" aria-label="May 13, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-13T22:51:33.000Z">May 13, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__i28slfpg7vg" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Orion </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">👍</span>
+</div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 reply, 1 Retweet, 1 like" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__giqsh5mqm7d">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Reply. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="1 Retweet. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Like. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128088308544876544" itemprop="identifier">
+<meta content="4" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-14T00:03:06.000Z" itemprop="dateCreated">
+<meta content="2019-05-14T00:03:06.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/BeeWall74/status/1128088308544876544" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1265540816" itemprop="identifier">
+<meta content="BeeWall74" itemprop="additionalName">
+<meta content="B" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/BeeWall74/status/1128088308544876544/likes" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/BeeWall74/status/1128088308544876544/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/BeeWall74/status/1128088308544876544/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/BeeWall74/status/1128088308544876544" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__obba3ujjrng id__uw1cw293hml id__ds3cnwtp4sv id__dgp8ivd4ef7 id__hmhdz0gvizo id__ccjo75a4oes id__54jlomzx5i4 id__ru3ptng7y9 id__hkmfro8uhuq id__x727z63h02r id__i51x2pk2ws id__i51am5vszdk id__okzl4s1swa id__txurxxvatxb id__s4bn14tual id__zselr6hja6c id__qfefnu8iv7a id__0dececs854o9" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-BeeWall74">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/BeeWall74" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1353056859406573571/EiBI0eSz_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1353056859406573571/EiBI0eSz_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__hmhdz0gvizo" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/BeeWall74" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">B</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/BeeWall74" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@BeeWall74</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/BeeWall74/status/1128088308544876544" dir="ltr" aria-label="May 14, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-14T00:03:06.000Z">May 14, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__i51x2pk2ws" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Love Papa Het but,,,,,he always looks like he's got a stomach problem in pics,,</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__6tsyak8lrhg">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128112059109953536" itemprop="identifier">
+<meta content="5" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-14T01:37:28.000Z" itemprop="dateCreated">
+<meta content="2019-05-14T01:37:28.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/sandymitt6/status/1128112059109953536" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="3021820380" itemprop="identifier">
+<meta content="sandymitt6" itemprop="additionalName">
+<meta content="S" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/sandymitt6/status/1128112059109953536/likes" itemprop="url">
+<meta content="1" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/sandymitt6/status/1128112059109953536/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/sandymitt6/status/1128112059109953536/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/sandymitt6/status/1128112059109953536" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__toy0ktlxsci id__xnkhbtqi5n id__8xwricbq1mc id__0j0udyipy2wa id__hey2l0b3a2 id__w5033p7fga id__cuqfg0dpa9d id__e6g8wrrw9q id__y308kzrdcpj id__p109m8r7tm id__qx0ct839hn id__w2liw37sygg id__bykwsul1g2l id__2qzxc54nmho id__du1dghchu9l id__x0gxbfp3s5i id__1avmy8dm2ke id__f91hz0vn94 id__t6lemjk2ma" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-sandymitt6">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/sandymitt6" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1603798240855748610/sO5ZDzYU_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1603798240855748610/sO5ZDzYU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__hey2l0b3a2" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/sandymitt6" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">S</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/sandymitt6" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@sandymitt6</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/sandymitt6/status/1128112059109953536" dir="ltr" aria-label="May 14, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-14T01:37:28.000Z">May 14, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="da" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__qx0ct839hn" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Sweet @VANS_66 Kirk.</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="1 like" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__t6lemjk2ma">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1 Like. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128160260307468288" itemprop="identifier">
+<meta content="6" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-14T04:49:00.000Z" itemprop="dateCreated">
+<meta content="2019-05-14T04:49:00.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/kaelgoth/status/1128160260307468288" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="702699632" itemprop="identifier">
+<meta content="kaelgoth" itemprop="additionalName">
+<meta content="Mika Chu" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/kaelgoth/status/1128160260307468288/likes" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/kaelgoth/status/1128160260307468288/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/kaelgoth/status/1128160260307468288/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/kaelgoth/status/1128160260307468288" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__5jj5weeggl3 id__2um4g1a2yca id__02ynu4dy4q2g id__df3rv70exs id__qqn1iqdhvgr id__29x6ig4e6ei id__n3lnk3wwf6f id__4067w7cs546 id__c88693uqgig id__lgcaor9t3ro id__j0236limgbs id__g28t9egty1o id__q57kfo0tue id__luvb76gdo89 id__18ekmf53drd id__3ifjo8s8wau id__lcclrz5b4ym id__ebons81jbn7" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-kaelgoth">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/kaelgoth" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/780634865641349120/G3fP0jhI_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/780634865641349120/G3fP0jhI_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__qqn1iqdhvgr" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/kaelgoth" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Mika Chu</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/kaelgoth" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@kaelgoth</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/kaelgoth/status/1128160260307468288" dir="ltr" aria-label="May 14, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-14T04:49:00.000Z">May 14, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__j0236limgbs" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Great move for 2 great causes.</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__syn04vc4jw">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128199343826018305" itemprop="identifier">
+<meta content="7" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-14T07:24:19.000Z" itemprop="dateCreated">
+<meta content="2019-05-14T07:24:19.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Ajkapoor2/status/1128199343826018305" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="1104301653392416769" itemprop="identifier">
+<meta content="Ajkapoor2" itemprop="additionalName">
+<meta content="Aj kapoor" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Ajkapoor2/status/1128199343826018305/likes" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Ajkapoor2/status/1128199343826018305/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Ajkapoor2/status/1128199343826018305/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Ajkapoor2/status/1128199343826018305" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__5de1tmxn0ei id__1tzfrepmn7m id__0h7edb9fjkzw id__1l281nsrhf6j id__e0xe9ow84yf id__x5xaqsfl62i id__ts81dh4kuv id__fpxwja8crea id__064b81odrqjk id__fhhcjhbhxws id__1u5w68o2vfh id__nln4w0peetk id__ahhat17u7gq id__6xagy4xdnpy id__4up1rr7frgr id__p5g73dmfw6 id__xwsepd4eibm id__7a3rr1ppht4" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Ajkapoor2">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Ajkapoor2" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1136530593829740545/F7waHoQn_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1136530593829740545/F7waHoQn_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__e0xe9ow84yf" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Ajkapoor2" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Aj kapoor</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Ajkapoor2" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Ajkapoor2</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Ajkapoor2/status/1128199343826018305" dir="ltr" aria-label="May 14, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-14T07:24:19.000Z">May 14, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__1u5w68o2vfh" data-testid="tweetText"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">ONE OF GREAT ROCK BAND</span></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__69xqgl5pslg">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1128299417537138689" itemprop="identifier">
+<meta content="8" itemprop="position">
+<meta content="0" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2019-05-14T14:01:58.000Z" itemprop="dateCreated">
+<meta content="2019-05-14T14:01:58.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/lchristinep/status/1128299417537138689" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="777529956" itemprop="identifier">
+<meta content="lchristinep" itemprop="additionalName">
+<meta content="Power of Three- Energy, Frequency, Vibration 🧬" itemprop="givenName">
+</div>
+<meta content="https://twitter.com/Metallica/status/1128068672289890305" itemprop="isPartOf">
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/lchristinep/status/1128299417537138689/likes" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/lchristinep/status/1128299417537138689/retweets" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/lchristinep/status/1128299417537138689/retweets/with_comments" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/lchristinep/status/1128299417537138689" itemprop="url">
+<meta content="0" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__xdkyxi9ih5 id__piz0yt4ik9 id__jrjsxpsxfl id__km2xgs0a2g id__0i6ys07xub4h id__z4v5vsiigyp id__0sn68k0lwxrj id__985xx2qtjb7 id__8wzeugwdqls id__y5imcplqvhd id__7vwovxnmo87 id__8bwsfs1i633 id__ukoe0jld2pl id__pzxa4vkl7mo id__3ryoy7ekps5 id__xfbx9aznvij id__9d8a0sz9bzq id__dr55puibj0l" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-lchristinep">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-ggadg3 r-1udh08x r-u8s1d r-8jfcpp" style="height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/lchristinep" aria-hidden="true" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-sdzlij r-1wyvozj r-1udh08x r-633pao r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1627331665717780480/_JsgNBBI_400x400.jpg")'></div>
+<img alt="" draggable="true" src="https://pbs.twimg.com/profile_images/1627331665717780480/_JsgNBBI_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-sdzlij r-1wyvozj r-1udh08x r-u8s1d r-1v2oles r-desppf" style="height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__0i6ys07xub4h" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/lchristinep" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Power of Three- Energy, Frequency, Vibration </span><img alt="🧬" draggable="false" src="https://abs-0.twimg.com/emoji/v2/svg/1f9ec.svg" class="r-4qtqp9 r-dflpy8 r-sjv1od r-zw8f10 r-10akycc r-h9hxbl"></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/lchristinep" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@lchristinep</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/lchristinep/status/1128299417537138689" dir="ltr" aria-label="May 14, 2019" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2019-05-14T14:01:58.000Z">May 14, 2019</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="qme" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__7vwovxnmo87" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🤘</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">💜</span>
+</div></div></div>
+<div class="css-1dbjc4n"><div aria-label="" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__tb9mlhxknp">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="0 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="0 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"></div>
+<div class="css-1dbjc4n r-1adg3ll r-1ny4l3l"><div class="css-1dbjc4n r-1wtj0ep r-1ny4l3l r-ymttw5 r-1f1sjgu">
+<h2 aria-level="2" role="heading" class="css-4rbku5 css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-k200y r-z80fyv r-1777fci"></div>
+<div dir="ltr" class="css-901oao css-cens5h r-37j5jr r-adyw6z r-1vr29t4 r-135wba7 r-bcqeeo r-qvutc0" style="-webkit-line-clamp:3;color:rgba(15,20,25,1.00);max-height:calc(3 * 24px)"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Discover more</span></div>
+<div class="css-1dbjc4n r-1kihuf0 r-18u37iz r-16y2uox r-17s6mgv"><div class="css-1dbjc4n"></div></div>
+</h2>
+<div dir="ltr" class="css-901oao css-cens5h r-k200y r-14j79pv r-37j5jr r-n6v787 r-16dba41 r-1cwl3u0 r-bcqeeo r-qvutc0" style="-webkit-line-clamp:2;max-height:calc(2 * 16px)"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Sourced from across Twitter</span></div>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1670883033954791424" itemprop="identifier">
+<meta content="9" itemprop="position">
+<meta content="37" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-06-19T19:55:33.000Z" itemprop="dateCreated">
+<meta content="2023-06-19T19:55:33.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="238475531" itemprop="identifier">
+<meta content="Metallica" itemprop="additionalName">
+<meta content="Metallica" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/ynEbXh65nu" itemprop="url">
+<meta content="http://youtu.be/YfouL5PyORU" itemprop="url">
+<meta content="https://t.co/Y88XIqBwW1" itemprop="url">
+<meta content="http://metallica.lnk.to/LiveInDonington2023Night2" itemprop="url">
+<meta content="https://t.co/MpX87C2hCO" itemprop="url">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424/video/1" itemprop="url">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424/likes" itemprop="url">
+<meta content="2296" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424/retweets" itemprop="url">
+<meta content="326" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424/retweets/with_comments" itemprop="url">
+<meta content="26" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670883033954791424" itemprop="url">
+<meta content="37" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__n1gj76kevkh id__sdihoc3zb4f id__9so69dxs4yn id__ds3wqj03kc id__53mu7adf8yl id__o52zs98gue id__p1x6v014hu id__jue6yokt2vl id__qdcyrjnnsgk id__9jdaqu47wfg id__hh9be7r6dff id__x07wp1rh04 id__xptwyy4gyvk id__94aqbdahqit id__bit8ephsr9c id__g3xrd4nwcn id__6m3rbu7qxpp id__k7g5gfb732k id__wmn66a2741l" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Metallica">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-ggadg3 r-u8s1d r-8jfcpp" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Square profile picture" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg")'></div>
+<img alt="Square profile picture" draggable="true" src="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-1wyvozj r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__53mu7adf8yl" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Metallica</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><lineargradient gradientunits="userSpaceOnUse" id="18691-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></lineargradient><lineargradient gradientunits="userSpaceOnUse" id="18691-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></lineargradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18691-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18691-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Metallica/status/1670883033954791424" dir="ltr" aria-label="Jun 19" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-06-19T19:55:33.000Z">Jun 19</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__hh9be7r6dff" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">“But the devil take that woman…” </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🏴󠁧󠁢󠁥󠁮󠁧󠁿</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72Donington?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72Donington</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> Night 2
 
+Watch the Full Video </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">⚡</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><a dir="ltr" href="https://t.co/ynEbXh65nu" rel="noopener noreferrer nofollow" target="_blank" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0"><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">http://</span>youtu.be/YfouL5PyORU</a><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
 
+Listen to the Full Show </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🎧</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><a dir="ltr" href="https://t.co/Y88XIqBwW1" rel="noopener noreferrer nofollow" target="_blank" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0"><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">http://</span>metallica.lnk.to/LiveInDoningto<span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">n2023Night2</span><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-lrvibr r-qvutc0">…</span></a><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
 
-      <input type="hidden" id="init-data" class="json-data" value="{&quot;keyboardShortcuts&quot;:[{&quot;name&quot;:&quot;Acciones&quot;,&quot;description&quot;:&quot;Atajos para acciones comunes.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;Enter&quot;],&quot;description&quot;:&quot;Abrir detalles del Tweet&quot;},{&quot;keys&quot;:[&quot;o&quot;],&quot;description&quot;:&quot;Expandir foto&quot;},{&quot;keys&quot;:[&quot;\/&quot;],&quot;description&quot;:&quot;Buscar&quot;}]},{&quot;name&quot;:&quot;Navegaci\u00f3n&quot;,&quot;description&quot;:&quot;Atajos para navegar entre elementos en las cronolog\u00edas.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;?&quot;],&quot;description&quot;:&quot;Este men\u00fa&quot;},{&quot;keys&quot;:[&quot;j&quot;],&quot;description&quot;:&quot;Siguiente Tweet&quot;},{&quot;keys&quot;:[&quot;k&quot;],&quot;description&quot;:&quot;Tweet anterior&quot;},{&quot;keys&quot;:[&quot;Space&quot;],&quot;description&quot;:&quot;Desplazar hacia abajo&quot;},{&quot;keys&quot;:[&quot;.&quot;],&quot;description&quot;:&quot;Cargar Tweets nuevos&quot;}]},{&quot;name&quot;:&quot;Cronolog\u00edas&quot;,&quot;description&quot;:&quot;Atajos para navegar a diferentes cronolog\u00edas o p\u00e1ginas.&quot;,&quot;shortcuts&quot;:[{&quot;keys&quot;:[&quot;g&quot;,&quot;u&quot;],&quot;description&quot;:&quot;Ir al usuario\u2026&quot;}]}],&quot;baseFoucClass&quot;:&quot;swift-loading&quot;,&quot;bodyFoucClassNames&quot;:&quot;swift-loading no-nav-banners&quot;,&quot;assetsBasePath&quot;:&quot;https:\/\/abs.twimg.com\/a\/1558678534\/&quot;,&quot;assetVersionKey&quot;:&quot;486a8f&quot;,&quot;emojiAssetsPath&quot;:&quot;https:\/\/abs.twimg.com\/emoji\/v2\/72x72\/&quot;,&quot;environment&quot;:&quot;production&quot;,&quot;formAuthenticityToken&quot;:&quot;b236e0558eecae44fa52b464d55738d5236980e7&quot;,&quot;loggedIn&quot;:false,&quot;screenName&quot;:null,&quot;fullName&quot;:null,&quot;userId&quot;:null,&quot;guestId&quot;:&quot;155925164498999276&quot;,&quot;createdAt&quot;:null,&quot;needsPhoneVerification&quot;:false,&quot;allowAdsPersonalization&quot;:true,&quot;scribeBufferSize&quot;:3,&quot;pageName&quot;:&quot;permalink&quot;,&quot;sectionName&quot;:&quot;permalink&quot;,&quot;scribeParameters&quot;:{},&quot;recaptchaApiUrl&quot;:&quot;https:\/\/www.google.com\/recaptcha\/api\/js\/recaptcha_ajax.js&quot;,&quot;internalReferer&quot;:null,&quot;geoEnabled&quot;:false,&quot;typeaheadData&quot;:{&quot;accounts&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;limit&quot;:6},&quot;trendLocations&quot;:{&quot;enabled&quot;:true},&quot;dmConversations&quot;:{&quot;enabled&quot;:false},&quot;followedSearches&quot;:{&quot;enabled&quot;:false},&quot;savedSearches&quot;:{&quot;enabled&quot;:false,&quot;items&quot;:[]},&quot;dmAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyDMable&quot;:true},&quot;mediaTagAccounts&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;onlyShowUsersWithCanMediaTag&quot;:false,&quot;currentUserId&quot;:-1},&quot;selectedUsers&quot;:{&quot;enabled&quot;:false},&quot;prefillUsers&quot;:{&quot;enabled&quot;:false},&quot;topics&quot;:{&quot;enabled&quot;:true,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:4},&quot;concierge&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:false,&quot;prefetchLimit&quot;:500,&quot;limit&quot;:6},&quot;recentSearches&quot;:{&quot;enabled&quot;:false},&quot;hashtags&quot;:{&quot;enabled&quot;:false,&quot;localQueriesEnabled&quot;:false,&quot;remoteQueriesEnabled&quot;:true,&quot;prefetchLimit&quot;:500},&quot;useIndexedDB&quot;:false,&quot;showSearchAccountSocialContext&quot;:false,&quot;showDebugInfo&quot;:false,&quot;useThrottle&quot;:true,&quot;accountsOnTop&quot;:false,&quot;remoteDebounceInterval&quot;:300,&quot;remoteThrottleInterval&quot;:300,&quot;tweetContextEnabled&quot;:false,&quot;fullNameMatchingInCompose&quot;:true,&quot;topicsWithFiltersEnabled&quot;:false},&quot;shellReferrer&quot;:null,&quot;rwebOptInCookieName&quot;:&quot;rweb_optin&quot;,&quot;rwebOptInCookieNewValue&quot;:&quot;on&quot;,&quot;dm&quot;:{&quot;notifications&quot;:false,&quot;usePushForNotifications&quot;:false,&quot;participant_max&quot;:50,&quot;welcome_message_add_to_conversation_enabled&quot;:true,&quot;poll_options&quot;:{&quot;foreground_poll_interval&quot;:3000,&quot;burst_poll_interval&quot;:3000,&quot;burst_poll_duration&quot;:300000,&quot;max_poll_interval&quot;:60000},&quot;card_prefetch&quot;:true,&quot;card_prefetch_interval_in_seconds&quot;:2000,&quot;dm_quick_reply_options_panel_dismiss_in_ms&quot;:2000,&quot;open_dm_enabled&quot;:false},&quot;autoplayDisabled&quot;:false,&quot;pushStatePageLimit&quot;:500000,&quot;routes&quot;:{&quot;profile&quot;:&quot;\/&quot;},&quot;pushState&quot;:true,&quot;viewContainer&quot;:&quot;#page-container&quot;,&quot;href&quot;:&quot;\/Metallica\/status\/1128068672289890305&quot;,&quot;searchPathWithQuery&quot;:&quot;\/search?q=query&amp;src=typd&quot;,&quot;composeAltText&quot;:false,&quot;night_mode_activated&quot;:false,&quot;user_color&quot;:null,&quot;deciders&quot;:{&quot;gdprAgeGateDialog&quot;:true,&quot;gdprSoftBounceDialog&quot;:true,&quot;geo_picker_incident_reset&quot;:true,&quot;custom_timeline_curation&quot;:false,&quot;native_notifications&quot;:true,&quot;disable_ajax_datatype_default_to_text&quot;:false,&quot;dm_polling_frequency_in_seconds&quot;:3000,&quot;dm_granular_mute_controls&quot;:true,&quot;enable_media_tag_prefetch&quot;:true,&quot;enableMacawNymizerConversionLanding&quot;:false,&quot;hqImageUploads&quot;:false,&quot;live_pipeline_consume&quot;:true,&quot;mqImageUploads&quot;:false,&quot;partnerIdSyncEnabled&quot;:true,&quot;sruMediaCategory&quot;:true,&quot;photoSruGifLimitMb&quot;:15,&quot;promoted_logging_force_post&quot;:true,&quot;promoted_video_logging_enabled&quot;:true,&quot;pushState&quot;:true,&quot;emojiNewCategory&quot;:false,&quot;contentEditablePlainTextOnly&quot;:false,&quot;web_client_api_stats&quot;:false,&quot;web_perftown_stats&quot;:true,&quot;web_perftown_ttft&quot;:false,&quot;web_client_events_ttft&quot;:false,&quot;log_push_state_ttft_metrics&quot;:false,&quot;web_sru_stats&quot;:false,&quot;web_upload_video&quot;:true,&quot;web_upload_video_advanced&quot;:false,&quot;upload_video_size&quot;:500,&quot;useVmapVariants&quot;:false,&quot;autoplayPreviewPreroll&quot;:true,&quot;moments_home_module&quot;:false,&quot;moments_lohp_enabled&quot;:true,&quot;enableNativePush&quot;:false,&quot;autoSubscribeNativePush&quot;:false,&quot;allowWebPushVapidUpgrade&quot;:true,&quot;stickersInteractivity&quot;:true,&quot;stickersInteractivityDuringLoading&quot;:true,&quot;stickersExperience&quot;:true,&quot;dynamic_video_ads_include_long_videos&quot;:true,&quot;push_state_size&quot;:1000,&quot;live_video_media_control_enabled&quot;:false,&quot;cards2_enable_periscope_card_transition&quot;:true,&quot;use_api_for_retweet_and_unretweet&quot;:false,&quot;use_api_for_follow_and_unfollow&quot;:true,&quot;edge_probe_enabled&quot;:false,&quot;like_over_http_client&quot;:true,&quot;enable_inline_location&quot;:true,&quot;enable_tweetstorm_creation&quot;:true,&quot;enable_tweetstorm_drafts&quot;:false,&quot;enable_tweetstorm_tooltip&quot;:true,&quot;twitter_text_emoji_counting_enabled&quot;:true,&quot;text_length_for_tweetstorm_tooltip&quot;:50,&quot;dm_report_webview_macaw_swift_enabled&quot;:true,&quot;page_title_unread_notification_count&quot;:false,&quot;page_title_badge_after_unread_tweets&quot;:20},&quot;experiments&quot;:{},&quot;toasts_dm&quot;:false,&quot;toasts_timeline&quot;:false,&quot;toasts_dm_poll_scale&quot;:60,&quot;defaultNotificationIcon&quot;:&quot;https:\/\/abs.twimg.com\/a\/1558678534\/img\/t1\/mobile\/wp7_app_icon.png&quot;,&quot;promptbirdData&quot;:{&quot;promptbirdEnabled&quot;:false,&quot;immediateTriggers&quot;:[&quot;PullToRefresh&quot;,&quot;Navigate&quot;],&quot;format&quot;:null},&quot;passwordResetAdvancedLoginForm&quot;:true,&quot;skipAutoSignupDialog&quot;:true,&quot;shouldReplaceSignupWithLogin&quot;:false,&quot;activeHashflags&quot;:{&quot;デレステxゆず&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/imascg_stage_May2019\/imascg_stage_May2019.png&quot;,&quot;ittfworlds2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITTFworld_2019\/ITTFworld_2019.png&quot;,&quot;growtogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GrowTogether_v4\/GrowTogether_v4.png&quot;,&quot;5sos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/5SOS_2019\/5SOS_2019.png&quot;,&quot;타노스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thanos\/Avengers_Endgame_2019_Thanos.png&quot;,&quot;infinitygauntlet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;loveisland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;showthempower&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UnitedColoursofBenetton_2019\/UnitedColoursofBenetton_2019.png&quot;,&quot;estonoestáchido&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CampaignsforChange_2019\/CampaignsforChange_2019.png&quot;,&quot;superligafan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SuperLigaFinal_2019\/SuperLigaFinal_2019.png&quot;,&quot;最後のxメン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_Xmen_Japan_2019\/FOX_Xmen_Japan_2019.png&quot;,&quot;thanos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thanos\/Avengers_Endgame_2019_Thanos.png&quot;,&quot;tresdeseos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;mightywest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_MightyWest\/AFL_2019_MightyWest.png&quot;,&quot;ausairforce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AusAirForce_2019\/AusAirForce_2019.png&quot;,&quot;benedictwong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wong\/Avengers_Endgame_2019_Wong.png&quot;,&quot;ヴァルキリー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;cmtmusicawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CMTMusicAwards_2019\/CMTMusicAwards_2019.png&quot;,&quot;asianpacificheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;tsm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TSM_filled_ext19\/Esports_AllAccessTeam_TSM_filled_ext19.png&quot;,&quot;eiropasvēlēšanas2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;princesajasmin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;euvolitve19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;vidasnegrasimportam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackLivesMatter_VidasNegrasImportam\/BlackLivesMatter_VidasNegrasImportam.png&quot;,&quot;ciudadesinteligentes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cabify_DecisionesInteligentes_2019\/Cabify_DecisionesInteligentes_2019.png&quot;,&quot;로키&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Loki\/Avengers_Endgame_2019_Loki.png&quot;,&quot;thewasp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;modernwarfare&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CallofDuty_ModernWarfare_2019_v2\/CallofDuty_ModernWarfare_2019_v2.png&quot;,&quot;orbisu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ORBIS_2019\/ORBIS_2019.png&quot;,&quot;swgalaxysedge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/disney_starwarsgalaxysedge_2019_v2\/disney_starwarsgalaxysedge_2019_v2.png&quot;,&quot;オコエ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Okoye\/Avengers_Endgame_2019_Okoye.png&quot;,&quot;blackdahlia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNT_IAmTheNight_2019_v2\/TNT_IAmTheNight_2019_v2.png&quot;,&quot;vsonwatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StephenCurry_2019\/StephenCurry_2019.png&quot;,&quot;令和ニッポンの愛国心&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbemaTV_2019\/AbemaTV_2019.png&quot;,&quot;bigramadhansale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShopeeRamadan_May_2019\/ShopeeRamadan_May_2019.png&quot;,&quot;зимнийсолдат&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;vidasecretadosbichos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_2018_Snowball_Brazil\/Pets2_2018_Snowball_Brazil.png&quot;,&quot;waltdisneyworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;digwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_DIG\/Esports_V2_19_DIG.png&quot;,&quot;heretheycome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_PHI\/NBA_18_PHI.png&quot;,&quot;맨티스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mantis\/Avengers_Endgame_2019_Mantis.png&quot;,&quot;щегол&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;oneteam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OneTeam_2018_Evergreen\/OneTeam_2018_Evergreen.png&quot;,&quot;amorlivre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmorLivre_2019\/AmorLivre_2019.png&quot;,&quot;こどもの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChildrensDay_2019\/ChildrensDay_2019.png&quot;,&quot;timetofly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_StLouis\/MLB_2019_StLouis.png&quot;,&quot;kolkataknightriders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KolkataKnights_2019\/KolkataKnights_2019.png&quot;,&quot;しまコレ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shimamura_2019\/Shimamura_2019.png&quot;,&quot;metcamp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VogueMetGala_2019_add\/VogueMetGala_2019_add.png&quot;,&quot;世界メディア情報リテラシーウィーク&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;marvelstudios&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_KevinFeige\/Avengers_Endgame_2019_KevinFeige.png&quot;,&quot;রমজান&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;3月28日は三ツ矢の日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Asahi_MitsuyaBrand_2019\/Asahi_MitsuyaBrand_2019.png&quot;,&quot;cg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_ClutchGaming\/LCS_2019_ClutchGaming.png&quot;,&quot;srh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Sunrisers\/IPL_2019_2_Sunrisers.png&quot;,&quot;알라딘&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;oppomoon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;timesup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimesUp_v4\/TimesUp_v4.png&quot;,&quot;kcon2019jp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019JAPAN\/KCON2019JAPAN.png&quot;,&quot;godzillailfilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;쿠키런&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CookieRunGame_2019\/CookieRunGame_2019.png&quot;,&quot;viratkohli&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_ViratKohli\/CricketWorldCup_2019_Players_ViratKohli.png&quot;,&quot;rexonanowunited&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RexonaNowUnited_72x72\/RexonaNowUnited_72x72.png&quot;,&quot;fafduplessis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_FafDuPlessis\/CricketWorldCup_2019_Players_FafDuPlessis.png&quot;,&quot;untethered&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;goldfinch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019_add\/WB_TheGoldfinch_2019_add.png&quot;,&quot;spotifypremium3ヶ月100円&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyJapan_TVCM\/SpotifyJapan_TVCM.png&quot;,&quot;2019wttc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITTFworld_2019\/ITTFworld_2019.png&quot;,&quot;gantdelinfinité&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;джинн&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;idolduets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmericanIdol_2019\/AmericanIdol_2019.png&quot;,&quot;頑張りすぎちゃう私へ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINGT_JP_2019_V3\/KIRINGT_JP_2019_V3.png&quot;,&quot;love放置少女&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/houchishoujo_2yearanniversary_v2\/houchishoujo_2yearanniversary_v2.png&quot;,&quot;dirtywater&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Boston\/MLB_2019_Boston.png&quot;,&quot;مو_قدها_لا_تلعبها&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/invasionarab1_Ramadan_2019\/invasionarab1_Ramadan_2019.png&quot;,&quot;shopeeserba10ribu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShopeeRamadan_May_2019\/ShopeeRamadan_May_2019.png&quot;,&quot;令和最初の乾杯&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Suntory_PremiumMalts_JP\/Suntory_PremiumMalts_JP.png&quot;,&quot;mntwins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Minn\/MLB_2019_Minn.png&quot;,&quot;avidasecretadosbichos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_2018_Snowball_Brazil\/Pets2_2018_Snowball_Brazil.png&quot;,&quot;brujaescarlata&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;スカーレットウィッチ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;地球日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;しまうさ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shimamura_2019\/Shimamura_2019.png&quot;,&quot;mickey90&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;yg4hunnid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;uglyox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Ox\/UglyDolls_Ox.png&quot;,&quot;eintraumwirdwahr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;foreverorange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_HOU\/MLS_19_HOU.png&quot;,&quot;pagodedopericao&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pericles_2019\/Pericles_2019.png&quot;,&quot;spiceworld2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpiceGirlsTour_2019\/SpiceGirlsTour_2019.png&quot;,&quot;미디어리터러시&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;lableedsblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Dodgers\/MLB_2019_Dodgers.png&quot;,&quot;bgt2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BritainsGotTalent_2019_star\/BritainsGotTalent_2019_star.png&quot;,&quot;تراها_سهلة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/taqa_sa_2019\/taqa_sa_2019.png&quot;,&quot;tfclive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_TFC\/MLS_19_TFC.png&quot;,&quot;miek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Miek\/Avengers_Endgame_2019_Miek.png&quot;,&quot;natgeohotzone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HotZone_NatGeoChannel_2019\/HotZone_NatGeoChannel_2019.png&quot;,&quot;diadaterra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;rapids96&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_CO\/MLS_19_CO.png&quot;,&quot;teamindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_TeamIndia\/CricketWorldCup_2019_Teams_TeamIndia.png&quot;,&quot;gobolts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bolts2019Playoffs\/Bolts2019Playoffs.png&quot;,&quot;oxtheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Ox\/UglyDolls_Ox.png&quot;,&quot;happytastesgood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DairyQueen_HappyTastesGood_2019\/DairyQueen_HappyTastesGood_2019.png&quot;,&quot;でっかいfire新登場&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINFIRE_ONEDAY_JP\/KIRINFIRE_ONEDAY_JP.png&quot;,&quot;bharatthiseid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BharatFilm_2019\/BharatFilm_2019.png&quot;,&quot;vidastarz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Vida_S2\/STARZ_Vida_S2.png&quot;,&quot;mightybombers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_MightyBombers\/AFL_2019_MightyBombers.png&quot;,&quot;alwaysroyal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Kansas\/MLB_2019_Kansas.png&quot;,&quot;mightythor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;korg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;princessjasmine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;vidalongaàsroupas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VidaLongaAsRoupas_Unilever\/VidaLongaAsRoupas_Unilever.png&quot;,&quot;justiceisserved&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Wash\/OWL_19_Wash.png&quot;,&quot;xメンが好き&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_Xmen_Japan_2019\/FOX_Xmen_Japan_2019.png&quot;,&quot;wnba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WNBA_2019\/WNBA_2019.png&quot;,&quot;باقات_موبايلي_مفوتر_الجديدة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mobily_CommercialRamadan_2019_add\/Mobily_CommercialRamadan_2019_add.png&quot;,&quot;captiamarvel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;バズライトイヤー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;periscope&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Periscope\/Periscope.png&quot;,&quot;rr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Royals\/IPL_2019_2_Royals.png&quot;,&quot;魔法のランプ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;stavoltavoto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;uglywage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Wage\/UglyDolls_Wage.png&quot;,&quot;thefalcon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;twitterforgoodday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FridayforGood_2019\/FridayforGood_2019.png&quot;,&quot;فانوس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;jbfa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JamesBeard_FoundationAwards_2019\/JamesBeard_FoundationAwards_2019.png&quot;,&quot;erstdenkendannteilen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;decisionesinteligentes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cabify_DecisionesInteligentes_2019\/Cabify_DecisionesInteligentes_2019.png&quot;,&quot;историяигрушекбазз&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;ngk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NGKFilm_2019\/NGKFilm_2019.png&quot;,&quot;ggswin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_GGS\/LCS_2019_GGS.png&quot;,&quot;nebulaavengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;occiodifalco&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;tuproposito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Adecco_2019\/Adecco_2019.png&quot;,&quot;killthislovewithblackpink&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_BLACKPINK_2019_add\/KPOP_BLACKPINK_2019_add.png&quot;,&quot;penseavantdecliquer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;bestoftweets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BestofTweetsPrize_2019\/BestofTweetsPrize_2019.png&quot;,&quot;gatormovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Crawl_2019\/Paramount_Crawl_2019.png&quot;,&quot;годзілла2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;nebula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;deixaaquímicarolar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaturaHumor_May2019_V2\/NaturaHumor_May2019_V2.png&quot;,&quot;미투&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_Korea_2018_v2\/MeToo_Korea_2018_v2.png&quot;,&quot;uglymoxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy\/UglyDolls_Moxy.png&quot;,&quot;bll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_BigLittleLies_Season2_2019\/HBO_BigLittleLies_Season2_2019.png&quot;,&quot;makemeaprince&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;donutlove&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dunkin_NationalDonutDay_2019\/Dunkin_NationalDonutDay_2019.png&quot;,&quot;onefamily&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MumbaiIndians_2018\/MumbaiIndians_2018.png&quot;,&quot;грут&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Groot\/Avengers_Endgame_2019_Groot.png&quot;,&quot;lightupyournight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VivoPHV15_2019\/VivoPHV15_2019.png&quot;,&quot;prado200&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MuseoDelPrado_2018\/MuseoDelPrado_2018.png&quot;,&quot;決勝で会おうぜ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YuGiOh_DL_INFO_May2019\/YuGiOh_DL_INFO_May2019.png&quot;,&quot;diewasp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;shopeeid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShopeeRamadan_May_2019\/ShopeeRamadan_May_2019.png&quot;,&quot;onepluslaunch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlus7_2019\/OnePlus7_2019.png&quot;,&quot;yeoldebucketlist&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BudLight_BudKnight_2019\/BudLight_BudKnight_2019.png&quot;,&quot;lovetwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveTwitter\/LoveTwitter.png&quot;,&quot;bendstudio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PlayStation_DaysGone\/PlayStation_DaysGone.png&quot;,&quot;got7_keepspinning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_GOT7_2019_GOT7WORLDTOUR\/KPOP_GOT7_2019_GOT7WORLDTOUR.png&quot;,&quot;pericles50&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pericles_2019\/Pericles_2019.png&quot;,&quot;weareengland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_England\/CricketWorldCup_2019_Teams_England.png&quot;,&quot;jordensdag&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;uglydollbabo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo\/UglyDolls_Babo.png&quot;,&quot;ευρωεκλογές2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;avengersendgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;detroitbasketball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_DET\/NBA_18_DET.png&quot;,&quot;quakes74&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_SJ\/MLS_19_SJ.png&quot;,&quot;artisttofollow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ArtistToFollow_2019\/ArtistToFollow_2019.png&quot;,&quot;rootedinoakland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Oakland\/MLB_2019_Oakland.png&quot;,&quot;jasmine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;thelamp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;budapest2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITTFworld_2019\/ITTFworld_2019.png&quot;,&quot;vivov15prolaunch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VivoPHV15_2019\/VivoPHV15_2019.png&quot;,&quot;happybirthdaygeorge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GeorgeHarrison_2019_v2\/GeorgeHarrison_2019_v2.png&quot;,&quot;mlbtheshow19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_TheShow19\/MLB_TheShow19.png&quot;,&quot;valquiria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;eusouliquid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TeamLiquid_ext19\/Esports_AllAccessTeam_TeamLiquid_ext19.png&quot;,&quot;nuestroplaneta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_OurPlanet_2019\/Netflix_OurPlanet_2019.png&quot;,&quot;korgpileofrocks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;человекпаук&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Spiderman\/Avengers_Endgame_2019_Spiderman.png&quot;,&quot;monterey5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_BigLittleLies_Season2_2019\/HBO_BigLittleLies_Season2_2019.png&quot;,&quot;togetherwe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Texas\/MLB_2019_Texas.png&quot;,&quot;激レアモンスターだぜ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YuGiOh_DL_INFO_May2019\/YuGiOh_DL_INFO_May2019.png&quot;,&quot;アイスクレマで贅沢なひとときを&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AIDAMITSUWO_2019\/AIDAMITSUWO_2019.png&quot;,&quot;s04win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Schalke04\/Riot_Schalke04.png&quot;,&quot;レッツデレステ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/imascg_stage_May2019\/imascg_stage_May2019.png&quot;,&quot;powerstone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;katyperry&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KatyPerry_May2019\/KatyPerry_May2019.png&quot;,&quot;cbj&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bluejacketsplayoffs2019\/Bluejacketsplayoffs2019.png&quot;,&quot;aapi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;ramadankareem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;teamiseverything&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_UTA\/NBA_18_UTA.png&quot;,&quot;blueandwhiteignite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OrlandoPlayoffs2019\/OrlandoPlayoffs2019.png&quot;,&quot;borntobaseball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Cincinnati\/MLB_2019_Cincinnati.png&quot;,&quot;uglydollmoxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy\/UglyDolls_Moxy.png&quot;,&quot;drstrange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;tiempodevolar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_StLouis\/MLB_2019_StLouis.png&quot;,&quot;suhurramadan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;annabelle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;teampixie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;valg2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DanishElection_2019\/DanishElection_2019.png&quot;,&quot;meilleursamispourlavie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;thisisnewdelhi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DelhiCapitals_IPL\/DelhiCapitals_IPL.png&quot;,&quot;thetethered&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;遊戯王wcs2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YuGiOh_DL_INFO_May2019\/YuGiOh_DL_INFO_May2019.png&quot;,&quot;stanleycup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StanleyCup_2019\/StanleyCup_2019.png&quot;,&quot;diabloguardian2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian\/Amazon_DiabloGuardian.png&quot;,&quot;воитель&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;endgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;nba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_logo\/NBA_18_logo.png&quot;,&quot;kkrhaitaiyaar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KolkataKnights_2019\/KolkataKnights_2019.png&quot;,&quot;earthday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;owl2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19\/OWL_19.png&quot;,&quot;peston&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PestonUK_2018_flight3\/PestonUK_2018_flight3.png&quot;,&quot;rgewin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Rogue\/Riot_Rogue.png&quot;,&quot;ゴジラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019_add\/Godzilla_WB_2019_add.png&quot;,&quot;paradisehotelonfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Fox_Summer_ParadiseHotel\/Fox_Summer_ParadiseHotel.png&quot;,&quot;valquíria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;ドラガリアロスト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/dragalialos_March2019_v2\/dragalialos_March2019_v2.png&quot;,&quot;رمضان_أجمل_هدية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qatar_charity2019\/Qatar_charity2019.png&quot;,&quot;超最高の働き方選手権&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINMetsJP_2019\/KIRINMetsJP_2019.png&quot;,&quot;марияхилл&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_MariaHill\/Avengers_Endgame_2019_MariaHill.png&quot;,&quot;uglydogtheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Dog\/UglyDolls_Dog.png&quot;,&quot;riseofthetigers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_RiseOfTheTigers\/CricketWorldCup_2019_Teams_RiseOfTheTigers.png&quot;,&quot;downtonabbeyfilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;lesoldatdelhiver&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;ncwtixfor20&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NationalConcertWeek_2019\/NationalConcertWeek_2019.png&quot;,&quot;tokyoafterdark&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nike_Japan_JDI_2019\/Nike_Japan_JDI_2019.png&quot;,&quot;gloriaeterna&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_2019\/Libertadores_2019.png&quot;,&quot;viuvanegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;playwithyourfears&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Diesel_OTB_Noe\/Diesel_OTB_Noe.png&quot;,&quot;افطار&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;guantedelinfinito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;mewtu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;コーグ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;xerifewoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;hollywoodweek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmericanIdol_2019\/AmericanIdol_2019.png&quot;,&quot;labergère&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;starwarsgalaxysedge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/disney_starwarsgalaxysedge_2019_v2\/disney_starwarsgalaxysedge_2019_v2.png&quot;,&quot;movietvawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Awards_May2019\/MTV_Awards_May2019.png&quot;,&quot;rocketmanofilme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;shieldsup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_LAG\/OWL_19_LAG.png&quot;,&quot;orgulloyankees&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Yankees\/MLB_2019_Yankees.png&quot;,&quot;chevyblazer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChevyBlazer_2019\/ChevyBlazer_2019.png&quot;,&quot;ドラゴン当たれ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/dragalialos_March2019_v2\/dragalialos_March2019_v2.png&quot;,&quot;bulbasaur&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;latenightthemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LateNight_2019\/Amazon_LateNight_2019.png&quot;,&quot;باقات_موبايلي_المفوترة_الجديدة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mobily_CommercialRamadan_2019\/Mobily_CommercialRamadan_2019.png&quot;,&quot;aquestavegadavoto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;معا_للحياة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zamzam_2019\/Zamzam_2019.png&quot;,&quot;aisplay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AIS_GameofThrones_2019\/AIS_GameofThrones_2019.png&quot;,&quot;mainerisesup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaineforVivo_2019\/MaineforVivo_2019.png&quot;,&quot;tymrazemglosuje&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;어버이날&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;مقاضي_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZadFresh_2019_v3\/ZadFresh_2019_v3.png&quot;,&quot;ilcardellino&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;mlbtheshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_TheShow19\/MLB_TheShow19.png&quot;,&quot;jesuistonmeilleurami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;халк&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hulk\/Avengers_Endgame_2019_Hulk.png&quot;,&quot;hornets30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_BCHA\/NBA_18_BCHA.png&quot;,&quot;errolspencejr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FoxSports_PBC\/FoxSports_PBC.png&quot;,&quot;loveislandaftersun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;infinitystones&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;goavsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AvsPlayoffs2019\/AvsPlayoffs2019.png&quot;,&quot;fiatlux&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Paris\/OWL_19_Paris.png&quot;,&quot;プリコネr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Priconne_Rezaro_2019_v2\/Priconne_Rezaro_2019_v2.png&quot;,&quot;galaxysedge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/disney_starwarsgalaxysedge_2019_v2\/disney_starwarsgalaxysedge_2019_v2.png&quot;,&quot;newbrew&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Carlsberg_NewBrew_2019\/Carlsberg_NewBrew_2019.png&quot;,&quot;metgala&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VogueMetGala_2019\/VogueMetGala_2019.png&quot;,&quot;7afl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_7AFL\/AFL_2019_7AFL.png&quot;,&quot;uglydollsfilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDollsMovie\/UglyDollsMovie.png&quot;,&quot;theintruder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SonyIntruder_2018\/SonyIntruder_2018.png&quot;,&quot;goodbagels&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Warburtons_Bagel_Boss\/Warburtons_Bagel_Boss.png&quot;,&quot;فوانيس_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;الخطوط_الجوية_القطرية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAirways_2019\/QatarAirways_2019.png&quot;,&quot;mapfrepreguntarafa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MapfreRafaNadal_2019\/MapfreRafaNadal_2019.png&quot;,&quot;discoveryreserve&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Budweiser_SpaceBeer_2019\/Budweiser_SpaceBeer_2019.png&quot;,&quot;스쿨미투&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_Korea_2018_v2\/MeToo_Korea_2018_v2.png&quot;,&quot;setforlifetnl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNL_SetforLife_2019\/TNL_SetforLife_2019.png&quot;,&quot;amtodmbfn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BuzzFeedMorning_2019ext\/BuzzFeedMorning_2019ext.png&quot;,&quot;cementeriomaldito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;uglydollwage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Wage\/UglyDolls_Wage.png&quot;,&quot;토이스토리보핍&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;kpop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOPTwitter2019_red\/KPOPTwitter2019_red.png&quot;,&quot;somespoilmoviesbutnotus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;diabloguardiánii&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian\/Amazon_DiabloGuardian.png&quot;,&quot;エムバク&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mbaku\/Avengers_Endgame_2019_Mbaku.png&quot;,&quot;riseupfromtheexpected&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaineforVivo_2019\/MaineforVivo_2019.png&quot;,&quot;jourdelaterre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;капитанамерика&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;backtheblackcaps&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_BACKTHEBLACKCAPS\/CricketWorldCup_2019_Teams_BACKTHEBLACKCAPS.png&quot;,&quot;лучшиедрузья&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;huaweip30pro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Huawei_P30_2019\/Huawei_P30_2019.png&quot;,&quot;staydangerous&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;ggs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_GGS\/LCS_2019_GGS.png&quot;,&quot;cricketmerijaan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MumbaiIndians_2018\/MumbaiIndians_2018.png&quot;,&quot;音楽さえあればいい&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyJapan_TVCM\/SpotifyJapan_TVCM.png&quot;,&quot;nationalpetsday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;metooindia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_India_2018\/MeToo_India_2018.png&quot;,&quot;pixarpalsparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;vainogas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CocaCola_VaiNoGas\/CocaCola_VaiNoGas.png&quot;,&quot;平成最後の漢字一文字&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewEra_2019_ext_add\/NewEra_2019_ext_add.png&quot;,&quot;juntosmiami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Miami\/MLB_2019_Miami.png&quot;,&quot;mickey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;окое&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Okoye\/Avengers_Endgame_2019_Okoye.png&quot;,&quot;teambabo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo_add\/UglyDolls_Babo_add.png&quot;,&quot;suhour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;surprisecelebration&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;cmonaussie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_CmonAussie\/CricketWorldCup_2019_Teams_CmonAussie.png&quot;,&quot;블랙팬서&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;tokratgremvolit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;iheartawards2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/iHeartAwards2019\/iHeartAwards2019.png&quot;,&quot;toystoryland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_ToyStoryLand\/DisneyParks_ToyStoryLand.png&quot;,&quot;euval2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;uglydog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Dog\/UglyDolls_Dog.png&quot;,&quot;toystorywoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;자스민&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;laysnachampions&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lays_UCL_2019\/Lays_UCL_2019.png&quot;,&quot;agrabah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;아빠사랑해요&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;lv52デス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMSecondBrand_2019\/LineageMSecondBrand_2019.png&quot;,&quot;mk2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;disneyaladdin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;operatingonchingonalevel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Vida_S2\/STARZ_Vida_S2.png&quot;,&quot;wttc2019budapest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITTFworld_2019\/ITTFworld_2019.png&quot;,&quot;アントマン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;letsgobucs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Pitts\/MLB_2019_Pitts.png&quot;,&quot;해피호건&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_HappyHogan\/Avengers_Endgame_2019_HappyHogan.png&quot;,&quot;مسابقة_طيران_ناس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlyNas_2019\/FlyNas_2019.png&quot;,&quot;gogovp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_Virtus\/Esports_V2_19_Virtus.png&quot;,&quot;ペッパーポッツ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_PepperPotts\/Avengers_Endgame_2019_PepperPotts.png&quot;,&quot;fncwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Fnatic\/Riot_Fnatic.png&quot;,&quot;cemitériomaldito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;brooklyn99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brooklyn99_2019\/Brooklyn99_2019.png&quot;,&quot;uglydollsmoxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy\/UglyDolls_Moxy.png&quot;,&quot;biglittlelies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_BigLittleLies_Season2_2019\/HBO_BigLittleLies_Season2_2019.png&quot;,&quot;fangoals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CapitalOne_MarchMadness_2019\/CapitalOne_MarchMadness_2019.png&quot;,&quot;wagetheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Wage\/UglyDolls_Wage.png&quot;,&quot;ffg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FridayforGood_2019\/FridayforGood_2019.png&quot;,&quot;ワスプ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;yellove&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PL_2019_2_CSK_v2\/PL_2019_2_CSK_v2.png&quot;,&quot;フシギダネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;оса&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;ayudaaunprimerizo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;iammighty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;telleurope&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019_add\/EUElections_VoterEngagement_2019_add.png&quot;,&quot;ما_نختلف&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mobily_Branding_2019\/Mobily_Branding_2019.png&quot;,&quot;dg2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian\/Amazon_DiabloGuardian.png&quot;,&quot;토이스토리포키&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;thisfreelife&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThisFreeLife_March_2019\/ThisFreeLife_March_2019.png&quot;,&quot;amtodm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BuzzFeedMorning_2019ext\/BuzzFeedMorning_2019ext.png&quot;,&quot;mantis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mantis\/Avengers_Endgame_2019_Mantis.png&quot;,&quot;bukapuasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;тор&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;got7&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_GOT7_2019_GOT7WORLDTOUR\/KPOP_GOT7_2019_GOT7WORLDTOUR.png&quot;,&quot;танос&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thanos\/Avengers_Endgame_2019_Thanos.png&quot;,&quot;proteafire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_ProteaFire\/CricketWorldCup_2019_Teams_ProteaFire.png&quot;,&quot;ガモーラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Gamora\/Avengers_Endgame_2019_Gamora.png&quot;,&quot;toystoryporzellinchen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;whatadelivery&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bundl_Swiggy_2019\/Bundl_Swiggy_2019.png&quot;,&quot;avispa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;iamopl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OPL_2019\/OPL_2019.png&quot;,&quot;watchuswatchnascar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xfinity_WatchUsWatchNASCAR_2019\/Xfinity_WatchUsWatchNASCAR_2019.png&quot;,&quot;shocktheworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_SF\/OWL_19_SF.png&quot;,&quot;šįkartąbalsuosiu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;brightburn\&quot;evilhasfounditssuperhero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_BB_2019\/Sony_Brightburn_BB_2019.png&quot;,&quot;raysbeisbol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Tampa\/MLB_2019_Tampa.png&quot;,&quot;prettyugly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDollsMovie\/UglyDollsMovie.png&quot;,&quot;edboon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;theworldisours&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiscoveryChannel_2019\/DiscoveryChannel_2019.png&quot;,&quot;snapforandroid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnapAndroid_Launch_2019\/SnapAndroid_Launch_2019.png&quot;,&quot;ghostrecon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GhostRecon_2019_v2\/GhostRecon_2019_v2.png&quot;,&quot;버즈라이트이어&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;祝ロマサガrs半周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/romasaga_rs_2019\/romasaga_rs_2019.png&quot;,&quot;cordoba2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SuperLigaFinal_2019\/SuperLigaFinal_2019.png&quot;,&quot;fearthedeer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_MIL\/NBA_18_MIL.png&quot;,&quot;am2dmbf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BuzzFeedMorning_2019ext\/BuzzFeedMorning_2019ext.png&quot;,&quot;tälläkertaaäänestän&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;flames&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlamesPlayoffs2019\/FlamesPlayoffs2019.png&quot;,&quot;алаяведьма&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;friarfaithful&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_SD\/MLB_2019_SD.png&quot;,&quot;schalkenullfear&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Schalke04\/Riot_Schalke04.png&quot;,&quot;gamora&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Gamora\/Avengers_Endgame_2019_Gamora.png&quot;,&quot;العلا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlUlaCity_2019\/AlUlaCity_2019.png&quot;,&quot;warburtonsbagels&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Warburtons_Bagel_Boss\/Warburtons_Bagel_Boss.png&quot;,&quot;fireワンデイブラック&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINFIRE_ONEDAY_JP\/KIRINFIRE_ONEDAY_JP.png&quot;,&quot;groot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Groot\/Avengers_Endgame_2019_Groot.png&quot;,&quot;俺達のnba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenTV_NBA_Logo_2019_v2\/RakutenTV_NBA_Logo_2019_v2.png&quot;,&quot;хэппихоган&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_HappyHogan\/Avengers_Endgame_2019_HappyHogan.png&quot;,&quot;bharatwithfamily&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BharatFilm_2019\/BharatFilm_2019.png&quot;,&quot;lasangraazul&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Dodgers\/MLB_2019_Dodgers.png&quot;,&quot;마리아힐&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_MariaHill\/Avengers_Endgame_2019_MariaHill.png&quot;,&quot;lalámpara&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;geng&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_GENG\/Esports_V2_19_GENG.png&quot;,&quot;falconavengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;드랙스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Drax\/Avengers_Endgame_2019_Drax.png&quot;,&quot;ミドガルズオルム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/dragalialos_March2019_v2\/dragalialos_March2019_v2.png&quot;,&quot;ロケット&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;rctid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_POR\/MLS_19_POR.png&quot;,&quot;thecontinentalhotel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;epvalg2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;downtonabbeytrailer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;qatar_charity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qatar_charity2019\/Qatar_charity2019.png&quot;,&quot;ramadan_lanterns&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;ourcultureouridentity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;feelthecharge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Guangzhou\/OWL_19_Guangzhou.png&quot;,&quot;sahur&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;pelopantene&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PG_Spain_Pantene_2019\/PG_Spain_Pantene_2019.png&quot;,&quot;booksmart&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Booksmart_2019\/Booksmart_2019.png&quot;,&quot;tflflauntit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThisFreeLife_March_2019\/ThisFreeLife_March_2019.png&quot;,&quot;mickeymouse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;vamosbravos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Atlanta\/MLB_2019_Atlanta.png&quot;,&quot;مافي_زي_stcpay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STCPay_2019\/STCPay_2019.png&quot;,&quot;mapfreyrafajuntos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MapfreRafaNadal_2019\/MapfreRafaNadal_2019.png&quot;,&quot;tictocnews&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/bloombergtictoc2018_ext19\/bloombergtictoc2018_ext19.png&quot;,&quot;adidasoriginals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Adidas_NiteJogger_2019_add\/Adidas_NiteJogger_2019_add.png&quot;,&quot;오코예&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Okoye\/Avengers_Endgame_2019_Okoye.png&quot;,&quot;ニックフューリー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;thebrandisbrolic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DesusandMero_2019\/DesusandMero_2019.png&quot;,&quot;يوم_الارض&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;toystorybuzz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;opporenouae&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;mbaku&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mbaku\/Avengers_Endgame_2019_Mbaku.png&quot;,&quot;放置少女2周年記念&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/houchishoujo_2yearanniversary_v2\/houchishoujo_2yearanniversary_v2.png&quot;,&quot;mickeytrueoriginal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;alampada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;petcemetarymovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;unserplanet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_OurPlanet_2019\/Netflix_OurPlanet_2019.png&quot;,&quot;alfombramágica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;housewendys&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HouseWendys_2019\/HouseWendys_2019.png&quot;,&quot;warmachine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;beardawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JamesBeard_FoundationAwards_2019\/JamesBeard_FoundationAwards_2019.png&quot;,&quot;годзилла2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;usmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;ありがとうアベンジャーズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;loveislandfinal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;haribumi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;c9win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_Cloud9_ext19\/Esports_AllAccessTeam_Cloud9_ext19.png&quot;,&quot;it2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;jabaritribe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mbaku\/Avengers_Endgame_2019_Mbaku.png&quot;,&quot;uglydollsmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDollsMovie\/UglyDollsMovie.png&quot;,&quot;زمزم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zamzam_2019\/Zamzam_2019.png&quot;,&quot;disneyland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;motoron&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Detroit_v2\/MLB_2019_Detroit_v2.png&quot;,&quot;thebrandisstrong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DesusandMero_2019\/DesusandMero_2019.png&quot;,&quot;premiosmtvmiaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Miaw_2019\/MTV_Miaw_2019.png&quot;,&quot;thinkau&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThinkAU_2019\/ThinkAU_2019.png&quot;,&quot;bharat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BharatFilm_2019\/BharatFilm_2019.png&quot;,&quot;thinkbeforeclicking&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;cf97&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_CHI\/MLS_19_CHI.png&quot;,&quot;ثقافتنا_هويتنا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;valchiria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;microsoftai&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Microsoft_APAC_2019_v2\/Microsoft_APAC_2019_v2.png&quot;,&quot;tagdererde&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;falcão&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;wong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wong\/Avengers_Endgame_2019_Wong.png&quot;,&quot;kohlscash&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kohls_Q2_2019\/Kohls_Q2_2019.png&quot;,&quot;nickfuria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;ダークフェニックス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/20thCenturyFox_DarkPhoenix\/20thCenturyFox_DarkPhoenix.png&quot;,&quot;スーパーゼウスとネコに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;pulitzer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PulitzerPrizes_2019\/PulitzerPrizes_2019.png&quot;,&quot;블랙위도우&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;sulamericana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sulamericana_2019\/Sulamericana_2019.png&quot;,&quot;uglydollox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Ox\/UglyDolls_Ox.png&quot;,&quot;onthehunt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Splyce\/Riot_Splyce.png&quot;,&quot;nrlw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2019_MidSeason_NRLW\/NRL_2019_MidSeason_NRLW.png&quot;,&quot;petsematary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;مفاجات_وااو&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SAIB_2019\/SAIB_2019.png&quot;,&quot;шури&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Shuri\/Avengers_Endgame_2019_Shuri.png&quot;,&quot;snapdroid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnapAndroid_Launch_2019\/SnapAndroid_Launch_2019.png&quot;,&quot;天下一武道会&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dragonball_2019\/Dragonball_2019.png&quot;,&quot;пепперпоттс&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_PepperPotts\/Avengers_Endgame_2019_PepperPotts.png&quot;,&quot;вуди&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;ソー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;riverdalecw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riverdale_S4_2019_v2\/Riverdale_S4_2019_v2.png&quot;,&quot;hawkeye&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;ninenine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brooklyn99_2019\/Brooklyn99_2019.png&quot;,&quot;先想再分享&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;doitbig&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_NOP\/NBA_18_NOP.png&quot;,&quot;prixbestoftweets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BestofTweetsPrize_2019\/BestofTweetsPrize_2019.png&quot;,&quot;いくぜ超刺激メッツ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINMetsJP_2019\/KIRINMetsJP_2019.png&quot;,&quot;알라딘지니&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;notjustpingpong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITTFworld_2019\/ITTFworld_2019.png&quot;,&quot;faze5&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FaZeClan_ext19\/Esports_AllAccessTeam_FaZeClan_ext19.png&quot;,&quot;αυτήτηφοράψηφίζω&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;pikapika&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pikachu_Pokemon_PartnerUp_2019\/Pikachu_Pokemon_PartnerUp_2019.png&quot;,&quot;pulitzerprize&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PulitzerPrizes_2019\/PulitzerPrizes_2019.png&quot;,&quot;anteup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Houston_change\/OWL_19_Houston_change.png&quot;,&quot;きのこの山&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KinokomeijiJP_2019\/KinokomeijiJP_2019.png&quot;,&quot;gulbadinnaib&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_GulbadinNaib\/CricketWorldCup_2019_Players_GulbadinNaib.png&quot;,&quot;ofertashotsale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;finaisnbb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBB2019Finals\/NBB2019Finals.png&quot;,&quot;teamluckybat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat_add\/UglyDolls_LuckyBat_add.png&quot;,&quot;ronin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;デスナイトへの道&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMSecondBrand_2019\/LineageMSecondBrand_2019.png&quot;,&quot;redv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_RedV\/NRL2019_RedV.png&quot;,&quot;thrivetogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_exceL_add\/Riot_exceL_add.png&quot;,&quot;booksmartmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Booksmart_2019\/Booksmart_2019.png&quot;,&quot;앤트맨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;чернаявдова&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;rallytogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Cleveland\/MLB_2019_Cleveland.png&quot;,&quot;mentellall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bachelorette_2019\/Bachelorette_2019.png&quot;,&quot;pulitzers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PulitzerPrizes_2019\/PulitzerPrizes_2019.png&quot;,&quot;ausarmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AusArmy_2019\/AusArmy_2019.png&quot;,&quot;чармандер&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;suhur&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;betterwithpets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PurinaBetterWithPets_2019\/PurinaBetterWithPets_2019.png&quot;,&quot;うまみいただきました&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINnamacya2019\/KIRINnamacya2019.png&quot;,&quot;azure&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Microsoft_APAC_2019_v2\/Microsoft_APAC_2019_v2.png&quot;,&quot;madeinheaven&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MadeInHeaven_Amazon_2019\/MadeInHeaven_Amazon_2019.png&quot;,&quot;сквиртл&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;sorrybaby&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KillingEve_US_2019\/KillingEve_US_2019.png&quot;,&quot;hashtaglatenightmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LateNight_2019\/Amazon_LateNight_2019.png&quot;,&quot;bostonup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Boston\/OWL_19_Boston.png&quot;,&quot;everybodyin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Cubs\/MLB_2019_Cubs.png&quot;,&quot;nowmorethanever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;apahm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;neverreallyover&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KatyPerry_May2019\/KatyPerry_May2019.png&quot;,&quot;redmisuperselfie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedmiY3_2019\/RedmiY3_2019.png&quot;,&quot;aladdín&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;bestoftweetsawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BestofTweetsPrize_2019\/BestofTweetsPrize_2019.png&quot;,&quot;ракета&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;timestone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;مصرفية_الراجحي_الرقمية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlRajhiBank_2019\/AlRajhiBank_2019.png&quot;,&quot;disneymagic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;まがつリリースは４月２３日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/magatsu_ver2_2019\/magatsu_ver2_2019.png&quot;,&quot;ee2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;世界ペンギンデー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;رمضان_كريم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;somosmibr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_MIBR\/Esports_V2_19_MIBR.png&quot;,&quot;jordanpeele&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;iamgroot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Groot\/Avengers_Endgame_2019_Groot.png&quot;,&quot;mikadoensérie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/France_MondelezMikado_2019\/France_MondelezMikado_2019.png&quot;,&quot;everupward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_NY\/OWL_19_NY.png&quot;,&quot;kcon2019japan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019JAPAN\/KCON2019JAPAN.png&quot;,&quot;rockets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_HOU\/NBA_18_HOU.png&quot;,&quot;movieandtvawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Awards_May2019\/MTV_Awards_May2019.png&quot;,&quot;ロケットマン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;teamsolomid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TSM_filled_ext19\/Esports_AllAccessTeam_TSM_filled_ext19.png&quot;,&quot;badmutha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;yadamnright&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;myfriendmiek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Miek\/Avengers_Endgame_2019_Miek.png&quot;,&quot;ネビュラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;secretlifeofmypet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;roarmacha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DelhiCapitals_IPL\/DelhiCapitals_IPL.png&quot;,&quot;flynas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlyNas_2019\/FlyNas_2019.png&quot;,&quot;fazeclan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FaZeClan_ext19\/Esports_AllAccessTeam_FaZeClan_ext19.png&quot;,&quot;withstkilda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_withstkilda\/AFL_2019_withstkilda.png&quot;,&quot;แอนนาเบลล์&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;pubg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PUBGKR2019\/PUBGKR2019.png&quot;,&quot;diadelatierra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;globalmilweek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;whislepodu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_CSK\/IPL_2019_2_CSK.png&quot;,&quot;ikstemdezekeer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;kandil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;sweepthenation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nissan_CWC_2019\/Nissan_CWC_2019.png&quot;,&quot;アラジン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;runskg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_SK\/Riot_SK.png&quot;,&quot;spotifyxtxt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_KPOP_2019_v2\/Spotify_KPOP_2019_v2.png&quot;,&quot;wunderlampe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;clg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_CounterLogicGaming\/LCS_2019_CounterLogicGaming.png&quot;,&quot;キリンレモントリビュート&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINLEMON_2019\/KIRINLEMON_2019.png&quot;,&quot;watchyourself&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;choosesnooze&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CasperChooseSnooze_2019\/CasperChooseSnooze_2019.png&quot;,&quot;小火龍&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;tobaccofreepride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThisFreeLife_March_2019\/ThisFreeLife_March_2019.png&quot;,&quot;sarfarazahmed&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_SarfarazAhmed\/CricketWorldCup_2019_Players_SarfarazAhmed.png&quot;,&quot;weareready&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_WeAreReady\/NRL2019_WeAreReady.png&quot;,&quot;loveislandpodcast&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;toystorygarfinho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;vivoxmaine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaineforVivo_2019\/MaineforVivo_2019.png&quot;,&quot;iftarramadan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;msfwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_MisfitsGaming\/Riot_MisfitsGaming.png&quot;,&quot;johnwick3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;onepursuit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Wash\/MLB_2019_Wash.png&quot;,&quot;deixeaquímicarolar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaturaHumor_May2019_V2\/NaturaHumor_May2019_V2.png&quot;,&quot;quieromicamion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Quality_Corona_May2019\/Quality_Corona_May2019.png&quot;,&quot;wearegeelong&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_WeAreGeelong\/AFL_2019_WeAreGeelong.png&quot;,&quot;indycaronnbc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBCSportsIndy500_MustBeMay\/NBCSportsIndy500_MustBeMay.png&quot;,&quot;dunkin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dunkin_NationalDonutDay_2019\/Dunkin_NationalDonutDay_2019.png&quot;,&quot;rocketman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;アナベル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;babo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo\/UglyDolls_Babo.png&quot;,&quot;thestonekeeper&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_RedSkull\/Avengers_Endgame_2019_RedSkull.png&quot;,&quot;wethenorth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_TOR\/NBA_18_TOR.png&quot;,&quot;соколиныйглаз&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;mingguliterasimedia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;excommunicado&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;discoverychannel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DiscoveryChannel_2019\/DiscoveryChannel_2019.png&quot;,&quot;nebulosa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;nicholasjfury&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;pennywise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;mustbemay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBCSportsIndy500_MustBeMay\/NBCSportsIndy500_MustBeMay.png&quot;,&quot;usmovieart&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018_add\/UsMovie_2018_add.png&quot;,&quot;parradise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_Parradise\/NRL2019_Parradise.png&quot;,&quot;libertadores&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_2019\/Libertadores_2019.png&quot;,&quot;askkhaled&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DJKhaled_May2019\/DJKhaled_May2019.png&quot;,&quot;noseson&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedNoseDay_2019\/RedNoseDay_2019.png&quot;,&quot;lvcruise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LouisVuittonCruiseMay2019\/LouisVuittonCruiseMay2019.png&quot;,&quot;まがつ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/magatsu_ver2_2019\/magatsu_ver2_2019.png&quot;,&quot;ڤيمتو&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_v2\/Vimto_Ramadan_2019_v2.png&quot;,&quot;gorabbitohs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_GoRabbitohs\/NRL2019_GoRabbitohs.png&quot;,&quot;gospursgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_SAS\/NBA_18_SAS.png&quot;,&quot;سحور_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;إفطار_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;boltonbagelboss&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Warburtons_Bagel_Boss\/Warburtons_Bagel_Boss.png&quot;,&quot;وزارة_الثقافة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;pikirsebelumsebar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;galaxyに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;bryceharper&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_TheShow19\/MLB_TheShow19.png&quot;,&quot;thesecretlifeofpets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;thenextidol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmericanIdol_2019\/AmericanIdol_2019.png&quot;,&quot;dubnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_GSW\/NBA_18_GSW.png&quot;,&quot;thelumineers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lumineers_May_2019\/Lumineers_May_2019.png&quot;,&quot;smugglersrun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/disney_starwarsgalaxysedge_2019_v2\/disney_starwarsgalaxysedge_2019_v2.png&quot;,&quot;šoreizesbalsošu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;برنامج_أصيل&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SAIB_2019\/SAIB_2019.png&quot;,&quot;マンティス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mantis\/Avengers_Endgame_2019_Mantis.png&quot;,&quot;небула&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;lionsroar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_LionsRoar\/CricketWorldCup_2019_Teams_LionsRoar.png&quot;,&quot;panteranegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;takenote&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Utah\/Utah.png&quot;,&quot;valkiria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;sweetbitterstarz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Sweetbitter_Season2\/STARZ_Sweetbitter_Season2.png&quot;,&quot;mtvmiaw2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Miaw_2019\/MTV_Miaw_2019.png&quot;,&quot;puasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;토이스토리버즈&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;godzillamovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;teamrocketman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Star\/Paramount_Rocketman_Star.png&quot;,&quot;パンテーンに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;3deseos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;dcu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_DCU\/MLS_19_DCU.png&quot;,&quot;con_canas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PG_Spain_Pantene_2019\/PG_Spain_Pantene_2019.png&quot;,&quot;standupflagsup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_StandUpFlagsUp\/NRL2019_StandUpFlagsUp.png&quot;,&quot;twice&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_TWICE_Fancy_2019\/KPOP_TWICE_Fancy_2019.png&quot;,&quot;cmonlittlelady&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Halsey_2019\/Halsey_2019.png&quot;,&quot;перчаткабесконечности&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;زاد_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZadFresh_2019_v3\/ZadFresh_2019_v3.png&quot;,&quot;avidasecretadosbichos2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_2018_Snowball_Brazil\/Pets2_2018_Snowball_Brazil.png&quot;,&quot;まがつリリースは4月23日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/magatsu_ver2_2019_add\/magatsu_ver2_2019_add.png&quot;,&quot;afl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019\/AFL_2019.png&quot;,&quot;ramadanmubarak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;euverkiezingen2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;気になりだしたら止まらないこと選手権&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/rakuma_official_brand_2019\/rakuma_official_brand_2019.png&quot;,&quot;blackpanther&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;افطارا_شهيا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;riverdale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riverdale_S4_2019_v2\/Riverdale_S4_2019_v2.png&quot;,&quot;оно2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;manopladoinfinito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;nos4a2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nos4a2_2019\/Nos4a2_2019.png&quot;,&quot;グリムエコーズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GrimmsEchoes_PR_2019\/GrimmsEchoes_PR_2019.png&quot;,&quot;cidadesinteligentes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cabify_DecisionesInteligentes_2019\/Cabify_DecisionesInteligentes_2019.png&quot;,&quot;toystory4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;iftar_ramadan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;pikaparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pikachu_Pokemon_PartnerUp_2019\/Pikachu_Pokemon_PartnerUp_2019.png&quot;,&quot;santiago2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Libertadores_2019\/Libertadores_2019.png&quot;,&quot;johnwick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;그것2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;ngkfire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NGKFilm_2019\/NGKFilm_2019.png&quot;,&quot;ngabuburit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;放置系美少女ゲーム&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/houchishoujo_2yearanniversary_v2\/houchishoujo_2yearanniversary_v2.png&quot;,&quot;soundersmatchday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_SEA\/MLS_19_SEA.png&quot;,&quot;secretlifeofpets2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;nowruz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;lawasp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;epcot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;ivetastedblood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Halsey_2019\/Halsey_2019.png&quot;,&quot;timetorise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_PHX\/NBA_18_PHX.png&quot;,&quot;pacers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_IND\/NBA_18_IND.png&quot;,&quot;ブラックパンサー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;rakutennba&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenTV_NBA_Logo_2019_v2\/RakutenTV_NBA_Logo_2019_v2.png&quot;,&quot;lewiscapaldi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LewisCapaldi_2019\/LewisCapaldi_2019.png&quot;,&quot;opintassilgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;برنامج_وااو&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SAIB_2019\/SAIB_2019.png&quot;,&quot;デレステ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/imascg_stage_May2019\/imascg_stage_May2019.png&quot;,&quot;블랙핑크&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_BLACKPINK_2019\/KPOP_BLACKPINK_2019.png&quot;,&quot;فكر_قبل_الضغط&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;thisismycrew&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Milwaukee\/MLB_2019_Milwaukee.png&quot;,&quot;charliemanx&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nos4a2_2019\/Nos4a2_2019.png&quot;,&quot;winecountrymovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WineCountry_Netflix\/WineCountry_Netflix.png&quot;,&quot;thesecretlifeofpets2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;mindstone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;生茶が変わった&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINnamacya2019\/KIRINnamacya2019.png&quot;,&quot;からあげクンに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;murmureuntweet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OuiGO_SNCF_2019\/OuiGO_SNCF_2019.png&quot;,&quot;親バカ部&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChildrensDay_2019\/ChildrensDay_2019.png&quot;,&quot;キリンレモンのうた2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINLEMON_2019\/KIRINLEMON_2019.png&quot;,&quot;dignitas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_DIG\/Esports_V2_19_DIG.png&quot;,&quot;wiredforwireless&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cisco_Avengers_2019\/Cisco_Avengers_2019.png&quot;,&quot;스칼렛위치&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;uglydollluckybat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat\/UglyDolls_LuckyBat.png&quot;,&quot;comisariowoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;whoarethesparks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lumineers_May_2019\/Lumineers_May_2019.png&quot;,&quot;capitánamérica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;hollywoodstudios30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;seeher&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SeeHer_2019\/SeeHer_2019.png&quot;,&quot;فطور&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;ogwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Origen\/Riot_Origen.png&quot;,&quot;しまむら&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shimamura_2019\/Shimamura_2019.png&quot;,&quot;三ツ矢&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Asahi_MitsuyaBrand_2019_add\/Asahi_MitsuyaBrand_2019_add.png&quot;,&quot;mtvmiaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Miaw_2019\/MTV_Miaw_2019.png&quot;,&quot;fuelthefire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FuelTheFire_SuperSport_2019\/FuelTheFire_SuperSport_2019.png&quot;,&quot;kombatkast&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;azurefriday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Microsoft_APAC_2019_v2_add\/Microsoft_APAC_2019_v2_add.png&quot;,&quot;antman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;hawkeyeavengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;whateverittakes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;folketingsvalg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DanishElection_2019\/DanishElection_2019.png&quot;,&quot;リネージュmは5月29日リリース&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMFirstBrand_2019\/LineageMFirstBrand_2019.png&quot;,&quot;shareourplanet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_OurPlanet_2019\/Netflix_OurPlanet_2019.png&quot;,&quot;desusandmero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DesusandMero_2019\/DesusandMero_2019.png&quot;,&quot;iontheprize&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Phil\/OWL_19_Phil.png&quot;,&quot;mytwitteranniversary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MyTwitterAnniversary\/MyTwitterAnniversary.png&quot;,&quot;brightburn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_BB_2019_add\/Sony_Brightburn_BB_2019_add.png&quot;,&quot;duniyahiladenge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MumbaiIndians_2018\/MumbaiIndians_2018.png&quot;,&quot;닉퓨리&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;allthemoods&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_AllTheMoods\/Spotify_AllTheMoods.png&quot;,&quot;傑尼龜&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;워머신&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;ヒトカゲ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;ジャスミン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;サランラップのくま&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiKaseiHP_2019\/AsahiKaseiHP_2019.png&quot;,&quot;لحظات_مكية_بالأشواق&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JODC_GreenDevice\/JODC_GreenDevice.png&quot;,&quot;おいしいついでに栄養補給&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRIN_Tropicana_JP\/KIRIN_Tropicana_JP.png&quot;,&quot;abematvに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;princesajasmín&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;モバレ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Elex_MobileLegendsJP_2019\/Elex_MobileLegendsJP_2019.png&quot;,&quot;redminote7&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XiaomiRedmi_Pro7_2019\/XiaomiRedmi_Pro7_2019.png&quot;,&quot;تطبيق_مصرف_الراجحي&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlRajhiBank_2019\/AlRajhiBank_2019.png&quot;,&quot;theboystv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonStudios_TheBoys_2019\/AmazonStudios_TheBoys_2019.png&quot;,&quot;loki&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Loki\/Avengers_Endgame_2019_Loki.png&quot;,&quot;nbbnotwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBB_2018_2019Season\/NBB_2018_2019Season.png&quot;,&quot;bestfriends4ever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;crawlmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Crawl_2019\/Paramount_Crawl_2019.png&quot;,&quot;amigosporsiempre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;derdistelfink&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;историяигрушеквуди&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;greenwall&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_Greenwall_ext19\/Esports_AllAccessTeam_Greenwall_ext19.png&quot;,&quot;thevalkyrie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;cheddarlive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CheddarLIVE_2019\/CheddarLIVE_2019.png&quot;,&quot;overwatchleague&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19\/OWL_19.png&quot;,&quot;七つの大罪グラクロ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netmarble_7deadlysins_2019\/Netmarble_7deadlysins_2019.png&quot;,&quot;golddontquit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IndianaPlayoffs2019\/IndianaPlayoffs2019.png&quot;,&quot;iambharat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BharatFilm_2019\/BharatFilm_2019.png&quot;,&quot;bravo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectRunway_Bravo\/ProjectRunway_Bravo.png&quot;,&quot;nebulaendgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;maineforvivo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VivoPHV15_2019\/VivoPHV15_2019.png&quot;,&quot;バッキ―&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;doutorestranho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;جمعية_زمزم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zamzam_2019\/Zamzam_2019.png&quot;,&quot;freshempirevibes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FreshEmpire_MayAugust_2019\/FreshEmpire_MayAugust_2019.png&quot;,&quot;elpoderdeunpelopantene&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PG_Spain_Pantene_2019\/PG_Spain_Pantene_2019.png&quot;,&quot;トロピカーナ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRIN_Tropicana_JP\/KIRIN_Tropicana_JP.png&quot;,&quot;spiderman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Spiderman\/Avengers_Endgame_2019_Spiderman.png&quot;,&quot;gosnapshot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PokemonGoJP_GoSnapshot_2019\/PokemonGoJP_GoSnapshot_2019.png&quot;,&quot;toystory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;itsbouttime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ESPN_UFC_2019_v3\/ESPN_UFC_2019_v3.png&quot;,&quot;letsgohunt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Chengdu\/OWL_19_Chengdu.png&quot;,&quot;thistimeimvoting&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;screamback&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SonyIntruder_2018\/SonyIntruder_2018.png&quot;,&quot;ホークアイ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;pulitzerprizes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PulitzerPrizes_2019\/PulitzerPrizes_2019.png&quot;,&quot;サランラップ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiKaseiHP_2019\/AsahiKaseiHP_2019.png&quot;,&quot;goninjas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_NIP\/Esports_V2_19_NIP.png&quot;,&quot;이상해씨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;viúvanegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;euválasztás2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;мбаку&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mbaku\/Avengers_Endgame_2019_Mbaku.png&quot;,&quot;fancyyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_TWICE_Fancy_2019\/KPOP_TWICE_Fancy_2019.png&quot;,&quot;walküre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;eskapitel2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;ウィンターソルジャー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;newyorkforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_NYK\/NBA_18_NYK.png&quot;,&quot;runasone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HoustonPlayoffs2019\/HoustonPlayoffs2019.png&quot;,&quot;elgeniodealaddín&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;keanureeves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;tsmwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TSM_filled_ext19\/Esports_AllAccessTeam_TSM_filled_ext19.png&quot;,&quot;mumbaiindians&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MumbaiIndians_2018\/MumbaiIndians_2018.png&quot;,&quot;sochkesharekaro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;ريالك_مبارك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZadFresh_2019_v3\/ZadFresh_2019_v3.png&quot;,&quot;uglydolluglydog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Dog\/UglyDolls_Dog.png&quot;,&quot;रमजान&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;가모라&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Gamora\/Avengers_Endgame_2019_Gamora.png&quot;,&quot;ペンギンの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;porzellinchen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;リネージュm開戦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMFirstBrand_2019\/LineageMFirstBrand_2019.png&quot;,&quot;dtid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_DTID\/MLS_19_DTID.png&quot;,&quot;hulk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hulk\/Avengers_Endgame_2019_Hulk.png&quot;,&quot;dunkincoffee&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dunkin_NationalDonutDay_2019\/Dunkin_NationalDonutDay_2019.png&quot;,&quot;toystoryforky&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;weareourownworstenemy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;스파이더맨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Spiderman\/Avengers_Endgame_2019_Spiderman.png&quot;,&quot;гамора&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Gamora\/Avengers_Endgame_2019_Gamora.png&quot;,&quot;milcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaLiterateCities_2018\/MediaLiterateCities_2018.png&quot;,&quot;アベンジャーズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;deixeaquimicarolar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaturaHumor_May2019_V2\/NaturaHumor_May2019_V2.png&quot;,&quot;americanidol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmericanIdol_2019\/AmericanIdol_2019.png&quot;,&quot;halseynightmare&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Halsey_2019\/Halsey_2019.png&quot;,&quot;euelections2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;しまむらコーデ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shimamura_2019\/Shimamura_2019.png&quot;,&quot;homemformiga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;weflyasone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_WeFlyAsOne\/AFL_2019_WeFlyAsOne.png&quot;,&quot;y3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedmiY3_2019\/RedmiY3_2019.png&quot;,&quot;сокол&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;forthepeopleabc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ForthePeople_ABC_2019\/ForthePeople_ABC_2019.png&quot;,&quot;godzillareidosmonstros&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;theuntethering&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;スポティファイ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SpotifyJapan_TVCM\/SpotifyJapan_TVCM.png&quot;,&quot;bachelorette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bachelorette_2019\/Bachelorette_2019.png&quot;,&quot;metgala2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VogueMetGala_2019\/VogueMetGala_2019.png&quot;,&quot;スパイダーマン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Spiderman\/Avengers_Endgame_2019_Spiderman.png&quot;,&quot;wwdc19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Apple_WWDC19\/Apple_WWDC19.png&quot;,&quot;sunrisers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Sunrisers\/IPL_2019_2_Sunrisers.png&quot;,&quot;妙蛙种子&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;世界ペンギンの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;alwaysfnatic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Fnatic\/Riot_Fnatic.png&quot;,&quot;gantdelinfini&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;projectrunway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectRunway_Bravo\/ProjectRunway_Bravo.png&quot;,&quot;cookierun&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CookieRunGame_2019\/CookieRunGame_2019.png&quot;,&quot;tchalla&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;sceriffowoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;takis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TAKIS_WILD_2019\/TAKIS_WILD_2019.png&quot;,&quot;newlies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_BigLittleLies_Season2_2019\/HBO_BigLittleLies_Season2_2019.png&quot;,&quot;человекмуравей&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;uglyluckybat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat\/UglyDolls_LuckyBat.png&quot;,&quot;killingeve&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KillingEve_US_2019\/KillingEve_US_2019.png&quot;,&quot;screambackscreenings&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SonyIntruder_2018\/SonyIntruder_2018.png&quot;,&quot;latenightmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LateNight_2019\/Amazon_LateNight_2019.png&quot;,&quot;ojodehalcon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;asklewiscapaldi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LewisCapaldi_2019\/LewisCapaldi_2019.png&quot;,&quot;canyadigit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;friendlikeme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;nitejogger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Adidas_NiteJogger_2019\/Adidas_NiteJogger_2019.png&quot;,&quot;foreverfreo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_ForeverFreo\/AFL_2019_ForeverFreo.png&quot;,&quot;anbuden&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PL_2019_2_CSK_v2\/PL_2019_2_CSK_v2.png&quot;,&quot;ドラゴンボールz_ブッチギリマッチ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dragonball_2019\/Dragonball_2019.png&quot;,&quot;saddapunjab&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_KXIP\/IPL_2019_2_KXIP.png&quot;,&quot;intrudermovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SonyIntruder_2018\/SonyIntruder_2018.png&quot;,&quot;netneutrality&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Net_Emoji_Evergreen\/Net_Emoji_Evergreen.png&quot;,&quot;latenightout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_LateNight_2019\/Amazon_LateNight_2019.png&quot;,&quot;超夢&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;asianamericanpacificislanderheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;takeitback&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Houston\/MLB_2019_Houston.png&quot;,&quot;мьюту&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;amazonprimevideo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonPrimeVideo_Dionysus_2019_v2\/AmazonPrimeVideo_Dionysus_2019_v2.png&quot;,&quot;bravoprojectrunway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectRunway_Bravo\/ProjectRunway_Bravo.png&quot;,&quot;thevoicekidsuk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;gloriasparks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Lumineers_May_2019\/Lumineers_May_2019.png&quot;,&quot;thevoicekids&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;amtodmbf&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BuzzFeedMorning_2019ext\/BuzzFeedMorning_2019ext.png&quot;,&quot;iamthenight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNT_IAmTheNight_2019_v2\/TNT_IAmTheNight_2019_v2.png&quot;,&quot;orangearmy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Sunrisers\/IPL_2019_2_Sunrisers.png&quot;,&quot;awholenewworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;vidasecretadosbichos2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_2018_Snowball_Brazil\/Pets2_2018_Snowball_Brazil.png&quot;,&quot;riseupwithvivov15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaineforVivo_2019\/MaineforVivo_2019.png&quot;,&quot;超梦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;ヴァルコネ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vconnect_jp_2019_V2\/Vconnect_jp_2019_V2.png&quot;,&quot;hallabol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Royals\/IPL_2019_2_Royals.png&quot;,&quot;frenchopen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FrenchOpen_RolandGarros_2019\/FrenchOpen_RolandGarros_2019.png&quot;,&quot;램프&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;فلاي_ناس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlyNas_2019\/FlyNas_2019.png&quot;,&quot;新きのこ党&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KinokomeijiJP_2019\/KinokomeijiJP_2019.png&quot;,&quot;鍛えろ筋肉とロマサガrs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/romasaga_rs_2019\/romasaga_rs_2019.png&quot;,&quot;リネm友達募集デス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMSecondBrand_2019\/LineageMSecondBrand_2019.png&quot;,&quot;mortalkombat11&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;europee2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;estonoestachido&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CampaignsforChange_2019\/CampaignsforChange_2019.png&quot;,&quot;mmas2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MYXMusicAwards_2019\/MYXMusicAwards_2019.png&quot;,&quot;cgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_ClutchGaming\/LCS_2019_ClutchGaming.png&quot;,&quot;лампа&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;ボーピープ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;sacramentoproud&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_SAC\/NBA_18_SAC.png&quot;,&quot;キャプテンアメリカ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;thunderup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_OKC\/NBA_18_OKC.png&quot;,&quot;kkrtaiyaar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KolkataKnights_2019\/KolkataKnights_2019.png&quot;,&quot;오분의일상탈출&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CookieRunGame_2019\/CookieRunGame_2019.png&quot;,&quot;nbatwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBATwitter_2018_RefreshEmoji\/NBATwitter_2018_RefreshEmoji.png&quot;,&quot;milcities&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaLiterateCities_2018\/MediaLiterateCities_2018.png&quot;,&quot;drax&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Drax\/Avengers_Endgame_2019_Drax.png&quot;,&quot;妙蛙種子&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;マッチングシーブリーズ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Matching_seabreeze_2019\/Matching_seabreeze_2019.png&quot;,&quot;бопип&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;thisisnotjust&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PercyPig_2019\/PercyPig_2019.png&quot;,&quot;díadelatierra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;buffaloranchtakis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TAKIS_WILD_2019\/TAKIS_WILD_2019.png&quot;,&quot;오븐브레이크챌린지&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CookieRunGame_2019\/CookieRunGame_2019.png&quot;,&quot;happyhogan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_HappyHogan\/Avengers_Endgame_2019_HappyHogan.png&quot;,&quot;neverhadafriendlikeme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;medialitwk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_MediaLitWk\/MediaInformationLiteracyWeeks_2018_MediaLitWk.png&quot;,&quot;upupcronulla&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_UpUpCronulla\/NRL2019_UpUpCronulla.png&quot;,&quot;f4glory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euroleague_Jan2019_add\/Euroleague_Jan2019_add.png&quot;,&quot;вонг&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wong\/Avengers_Endgame_2019_Wong.png&quot;,&quot;piensaantesdedarclick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;insanityrules&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bethesda_RAGE2_2019\/Bethesda_RAGE2_2019.png&quot;,&quot;dcfamily&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_DC\/NBA_18_DC.png&quot;,&quot;spencejrgarcia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FoxSports_PBC\/FoxSports_PBC.png&quot;,&quot;diabloguardian&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian\/Amazon_DiabloGuardian.png&quot;,&quot;wロマンシング祭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/romasaga_rs_2019\/romasaga_rs_2019.png&quot;,&quot;声でココロ診断&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AIDAMITSUWO_2019\/AIDAMITSUWO_2019.png&quot;,&quot;vingadores&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;mortalkombat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;mapfretenis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MapfreRafaNadal_2019\/MapfreRafaNadal_2019.png&quot;,&quot;g2win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_G2_ext19\/Esports_AllAccessTeam_G2_ext19.png&quot;,&quot;dontruintheendgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;buzzlightyear&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;hegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlUlaCity_2019\/AlUlaCity_2019.png&quot;,&quot;captainamerica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;wearetfl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThisFreeLife_March_2019\/ThisFreeLife_March_2019.png&quot;,&quot;オルビス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ORBIS_2019_add\/ORBIS_2019_add.png&quot;,&quot;tethered&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;whistlepodu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PL_2019_2_CSK_v2\/PL_2019_2_CSK_v2.png&quot;,&quot;دائماً_متألقة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_v2\/Vimto_Ramadan_2019_v2.png&quot;,&quot;ucl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChampionsLeague_Final_2019\/ChampionsLeague_Final_2019.png&quot;,&quot;luckybat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat\/UglyDolls_LuckyBat.png&quot;,&quot;schiggy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;星のドラゴンクエスト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hoshidora_May2019\/Hoshidora_May2019.png&quot;,&quot;optwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_Greenwall_add\/Esports_AllAccessTeam_Greenwall_add.png&quot;,&quot;teamuglydog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Dog_add\/UglyDolls_Dog_add.png&quot;,&quot;prixbestoftweet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BestofTweetsPrize_2019\/BestofTweetsPrize_2019.png&quot;,&quot;イット見えたら終わり&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;mothersday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;luckybattheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat\/UglyDolls_LuckyBat.png&quot;,&quot;kcon2019ny&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019USA_2019\/KCON2019USA_2019.png&quot;,&quot;celtics&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CelticsPlayoffs2019\/CelticsPlayoffs2019.png&quot;,&quot;ロマサガrs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/romasaga_rs_2019\/romasaga_rs_2019.png&quot;,&quot;takewarning&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CanesPlayoff2019\/CanesPlayoff2019.png&quot;,&quot;jw3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;nerevs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_NERevs\/MLS_19_NERevs.png&quot;,&quot;disneyparks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;friedhofderkuscheltiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;retomemos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Houston\/MLB_2019_Houston.png&quot;,&quot;gaviaoarqueiro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;jamesbeard&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JamesBeard_FoundationAwards_2019\/JamesBeard_FoundationAwards_2019.png&quot;,&quot;philaunite&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SixersPlayoffs2019v2\/SixersPlayoffs2019v2.png&quot;,&quot;amc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nos4a2_2019\/Nos4a2_2019.png&quot;,&quot;アイアンマン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;アースデー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;nro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KatyPerry_May2019\/KatyPerry_May2019.png&quot;,&quot;dutahe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LewisCapaldi_2019\/LewisCapaldi_2019.png&quot;,&quot;애나벨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;erstdenkendannklicken&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;ブラックウィドウ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;superherohorror&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_Mask_2019\/Sony_Brightburn_Mask_2019.png&quot;,&quot;theworldwillknowhisname&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_BB_2019\/Sony_Brightburn_BB_2019.png&quot;,&quot;laguepe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;rg19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FrenchOpen_RolandGarros_2019\/FrenchOpen_RolandGarros_2019.png&quot;,&quot;先想再點擊&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;twitterforgood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FridayforGood_2019\/FridayforGood_2019.png&quot;,&quot;diddarbasenivvota&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;garfinho&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;सोचकेशेयरकरो&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;arawngdaigdig&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;downtonabbeypelicula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;kcon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019\/KCON2019.png&quot;,&quot;annabelle3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;loswhitesox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Chicago\/MLB_2019_Chicago.png&quot;,&quot;lafc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_LAFC\/MLS_19_LAFC.png&quot;,&quot;homemdeferro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;윈터솔져&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;teamwill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;ミュウツー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;buckybarnes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;brightburnmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_BB_2019\/Sony_Brightburn_BB_2019.png&quot;,&quot;валькирия&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;ヴァルキリーコネクト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vconnect_jp_2019_V2\/Vconnect_jp_2019_V2.png&quot;,&quot;allflavorswelcome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbsolutPlanetEarthsFavoriteVodka_2019\/AbsolutPlanetEarthsFavoriteVodka_2019.png&quot;,&quot;サノス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thanos\/Avengers_Endgame_2019_Thanos.png&quot;,&quot;sweetbitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Sweetbitter_Season2\/STARZ_Sweetbitter_Season2.png&quot;,&quot;melbourneproud&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_MelbourneProud\/NRL2019_MelbourneProud.png&quot;,&quot;グルート&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Groot\/Avengers_Endgame_2019_Groot.png&quot;,&quot;scottlang&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_AntMan\/Avengers_Endgame_2019_AntMan.png&quot;,&quot;mtvawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Awards_May2019\/MTV_Awards_May2019.png&quot;,&quot;rsl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_RSL\/MLS_19_RSL.png&quot;,&quot;soldadoinvernal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;mffl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_DAL\/NBA_18_DAL.png&quot;,&quot;carapuce&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;헐크&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hulk\/Avengers_Endgame_2019_Hulk.png&quot;,&quot;sweetbitterpremiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Sweetbitter_Season2\/STARZ_Sweetbitter_Season2.png&quot;,&quot;djkhaled&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DJKhaled_May2019\/DJKhaled_May2019.png&quot;,&quot;فطور_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;ep19dk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;vidapremiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Vida_S2\/STARZ_Vida_S2.png&quot;,&quot;金翅雀&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;freshevents&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FreshEmpire_MayAugust_2019\/FreshEmpire_MayAugust_2019.png&quot;,&quot;isles&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IslandersPlayoffs2019\/IslandersPlayoffs2019.png&quot;,&quot;tweeptour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TweepTour_2019\/TweepTour_2019.png&quot;,&quot;f11proinegypt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_F11ProInEgypt_2019\/Oppo_F11ProInEgypt_2019.png&quot;,&quot;hotzone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HotZone_NatGeoChannel_2019\/HotZone_NatGeoChannel_2019.png&quot;,&quot;allin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ClemsonYearLongNatty19\/ClemsonYearLongNatty19.png&quot;,&quot;eljilguero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;buzzleclair&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;gengwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_GENG\/Esports_V2_19_GENG.png&quot;,&quot;downtonabbey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;aladdin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;sherifwoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;mihplannerchallenge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MadeInHeaven_Amazon_2019\/MadeInHeaven_Amazon_2019.png&quot;,&quot;平成を語ろう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewEra_2019\/NewEra_2019.png&quot;,&quot;diamondintherough&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;threestripelive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/adidas_ThreeStripeLive_2019\/adidas_ThreeStripeLive_2019.png&quot;,&quot;downtonabbeylapelicula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;城之内死す&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YuGiOh_DL_INFO_May2019\/YuGiOh_DL_INFO_May2019.png&quot;,&quot;takjil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;sfgiants&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_SFGiants\/MLB_2019_SFGiants.png&quot;,&quot;mashrafemortaza&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_MashrafeMortaza\/CricketWorldCup_2019_Players_MashrafeMortaza.png&quot;,&quot;doyoutrustme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;全球媒介和信息素养周&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;am2dm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BuzzFeedMorning_2019ext\/BuzzFeedMorning_2019ext.png&quot;,&quot;3stripelive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/adidas_ThreeStripeLive_2019\/adidas_ThreeStripeLive_2019.png&quot;,&quot;teamuglydolls&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDollsMovie\/UglyDollsMovie.png&quot;,&quot;buscando&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Itau_2019_v2\/Itau_2019_v2.png&quot;,&quot;kcon19la&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019USA_2019\/KCON2019USA_2019.png&quot;,&quot;토르&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;teamdanny&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;moxytheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy\/UglyDolls_Moxy.png&quot;,&quot;dschinni&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;さよなら僕らのxメン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_Xmen_Japan_2019\/FOX_Xmen_Japan_2019.png&quot;,&quot;woody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;letsgoliquid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TeamLiquid_ext19\/Esports_AllAccessTeam_TeamLiquid_ext19.png&quot;,&quot;callofduty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CallofDuty_ModernWarfare_2019_v2\/CallofDuty_ModernWarfare_2019_v2.png&quot;,&quot;pikirsebelumklik&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;ramazan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;villanelle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KillingEve_US_2019\/KillingEve_US_2019.png&quot;,&quot;シェアする前に考えよう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;مقاضي&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZadFresh_2019_v3\/ZadFresh_2019_v3.png&quot;,&quot;20年間ありがとう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_Xmen_Japan_2019\/FOX_Xmen_Japan_2019.png&quot;,&quot;fccincy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_CIN\/MLS_19_CIN.png&quot;,&quot;bodegahive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DesusandMero_2019\/DesusandMero_2019.png&quot;,&quot;iamironman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;suhoor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;assunção2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sulamericana_2019_add\/Sulamericana_2019_add.png&quot;,&quot;cmtawards2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CMTMusicAwards_2019\/CMTMusicAwards_2019.png&quot;,&quot;tuiteratura&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FeriaDelHilo_v2\/FeriaDelHilo_v2.png&quot;,&quot;burnblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Dallas\/OWL_19_Dallas.png&quot;,&quot;تراها_سهله&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/taqa_sa_2019\/taqa_sa_2019.png&quot;,&quot;マリアヒル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_MariaHill\/Avengers_Endgame_2019_MariaHill.png&quot;,&quot;트와이스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_TWICE_Fancy_2019\/KPOP_TWICE_Fancy_2019.png&quot;,&quot;csk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PL_2019_2_CSK_v2\/PL_2019_2_CSK_v2.png&quot;,&quot;egready&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_EG\/Esports_V2_19_EG.png&quot;,&quot;uclfinal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChampionsLeague_Final_2019\/ChampionsLeague_Final_2019.png&quot;,&quot;asuncion2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sulamericana_2019_add\/Sulamericana_2019_add.png&quot;,&quot;sweebitterseason2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Sweetbitter_Season2\/STARZ_Sweetbitter_Season2.png&quot;,&quot;sc30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StephenCurry_2019\/StephenCurry_2019.png&quot;,&quot;diablonomedesampares&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian\/Amazon_DiabloGuardian.png&quot;,&quot;alula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlUlaCity_2019\/AlUlaCity_2019.png&quot;,&quot;forky&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;prinzessinjasmin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;gottapartnerup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pikachu_Pokemon_PartnerUp_2019\/Pikachu_Pokemon_PartnerUp_2019.png&quot;,&quot;キリンレモンのうた&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINLEMON_2019\/KIRINLEMON_2019.png&quot;,&quot;penseantesdeclicar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;ブッチギリマッチ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dragonball_2019\/Dragonball_2019.png&quot;,&quot;absolutvodka&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbsolutPlanetEarthsFavoriteVodka_2019\/AbsolutPlanetEarthsFavoriteVodka_2019.png&quot;,&quot;oneplus7&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlus7_2019\/OnePlus7_2019.png&quot;,&quot;grindcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_MEM\/NBA_18_MEM.png&quot;,&quot;caveofwonders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;saddasquad&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_KXIP\/IPL_2019_2_KXIP.png&quot;,&quot;teamjessiej&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheVoice_UK_2019\/TheVoice_UK_2019.png&quot;,&quot;فوانيس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;페퍼포츠&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_PepperPotts\/Avengers_Endgame_2019_PepperPotts.png&quot;,&quot;teamwage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Wage_add\/UglyDolls_Wage_add.png&quot;,&quot;kurma&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;ramadan_lantern&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;デカうまい&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINFIRE_ONEDAY_JP\/KIRINFIRE_ONEDAY_JP.png&quot;,&quot;ファルコン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;soulstone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;skwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_SK\/Riot_SK.png&quot;,&quot;ahm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;salamèche&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;onebadmutha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;新元号考えてみた&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewEra_2019\/NewEra_2019.png&quot;,&quot;madeinheavenamazon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MadeInHeaven_Amazon_2019\/MadeInHeaven_Amazon_2019.png&quot;,&quot;genie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;жасмин&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;blackwidow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;午後の紅茶&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINGT_JP_2019_V3\/KIRINGT_JP_2019_V3.png&quot;,&quot;ジーニー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;tt30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TakeThatEuropeanTour_2019\/TakeThatEuropeanTour_2019.png&quot;,&quot;アイスクレマ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AIDAMITSUWO_2019\/AIDAMITSUWO_2019.png&quot;,&quot;뮤츠&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;oùestmachaussette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Monoprix_2019\/Monoprix_2019.png&quot;,&quot;simetierre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;ogme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TLOG_Season2\/TLOG_Season2.png&quot;,&quot;stlblues&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BluesPlayoffs2019\/BluesPlayoffs2019.png&quot;,&quot;johnwickch3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;evilgeniuses&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_EG\/Esports_V2_19_EG.png&quot;,&quot;xメンの魅力を広めたい&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FOX_Xmen_Japan_2019\/FOX_Xmen_Japan_2019.png&quot;,&quot;cmtawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CMTMusicAwards_2019\/CMTMusicAwards_2019.png&quot;,&quot;thelastog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TLOG_Season2\/TLOG_Season2.png&quot;,&quot;たぶんクマ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiKaseiHP_2019\/AsahiKaseiHP_2019.png&quot;,&quot;spencevsgarcia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FoxSports_PBC\/FoxSports_PBC.png&quot;,&quot;pericao50&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pericles_2019\/Pericles_2019.png&quot;,&quot;100win&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_100Thieves_ext19\/Esports_AllAccessTeam_100Thieves_ext19.png&quot;,&quot;0426逆襲へ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;b99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brooklyn99_2019\/Brooklyn99_2019.png&quot;,&quot;comigoninguemtoddy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ComigoNinguemToddy_2019\/ComigoNinguemToddy_2019.png&quot;,&quot;avespa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp_add\/Avengers_Endgame_2019_Wasp_add.png&quot;,&quot;ramadanlanterns&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;virtuspro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_Virtus\/Esports_V2_19_Virtus.png&quot;,&quot;kcon2019la&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019USA_2019\/KCON2019USA_2019.png&quot;,&quot;gotiges&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_GoTiges\/AFL_2019_GoTiges.png&quot;,&quot;デレステ10連ガシャ無料&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/imascg_stage_May2019\/imascg_stage_May2019.png&quot;,&quot;baikitumudah&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bukalapak_2019\/Bukalapak_2019.png&quot;,&quot;disneysaladdin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;apihm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;ミーク&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Miek\/Avengers_Endgame_2019_Miek.png&quot;,&quot;星のファンファーレ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hoshidora_May2019\/Hoshidora_May2019.png&quot;,&quot;rockies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Colorado\/MLB_2019_Colorado.png&quot;,&quot;elfutbolmesigue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Soccer_Google_2019\/Soccer_Google_2019.png&quot;,&quot;uglybabo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo\/UglyDolls_Babo.png&quot;,&quot;thewintersoldier&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;ridemcowboys&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_ridemcowboys\/NRL2019_ridemcowboys.png&quot;,&quot;homemaranha&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Spiderman\/Avengers_Endgame_2019_Spiderman.png&quot;,&quot;fourchette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;シュリ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Shuri\/Avengers_Endgame_2019_Shuri.png&quot;,&quot;thecrawlmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Crawl_2019\/Paramount_Crawl_2019.png&quot;,&quot;令和&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NewEra_2019_ext\/NewEra_2019_ext.png&quot;,&quot;spencegarcia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FoxSports_PBC\/FoxSports_PBC.png&quot;,&quot;историяигрушеквилкинс&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;星ドラギガミーティング&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hoshidora_May2019\/Hoshidora_May2019.png&quot;,&quot;dontspoiltheendgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;annabellecomeshome&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_Annabelle_3_v2\/WB_Annabelle_3_v2.png&quot;,&quot;teammoxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy_add\/UglyDolls_Moxy_add.png&quot;,&quot;ramadan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;downtonabbeymovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DowntonAbbey_2019\/DowntonAbbey_2019.png&quot;,&quot;المباشر_للأفراد&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlRajhiBank_2019\/AlRajhiBank_2019.png&quot;,&quot;stephencurryfacebookwatch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StephenCurry_2019\/StephenCurry_2019.png&quot;,&quot;فكر_قبل_المشاركة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;uglydollsox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Ox\/UglyDolls_Ox.png&quot;,&quot;mrwick&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;kcon19ny&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019USA_2019\/KCON2019USA_2019.png&quot;,&quot;scarletwitch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;ipromise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LeBronJames_IPromise_2018\/LeBronJames_IPromise_2018.png&quot;,&quot;fincに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;higherfurtherfaster&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_CaptainMarvel_May2019\/Disney_CaptainMarvel_May2019.png&quot;,&quot;ドラックス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Drax\/Avengers_Endgame_2019_Drax.png&quot;,&quot;truetoatlanta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_ATL\/NBA_18_ATL.png&quot;,&quot;xiaomi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XiaomiRedmi_Pro7_2019\/XiaomiRedmi_Pro7_2019.png&quot;,&quot;leveluptovivov15&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VivoPHV15_2019\/VivoPHV15_2019.png&quot;,&quot;슈리&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Shuri\/Avengers_Endgame_2019_Shuri.png&quot;,&quot;اوبو_رينو_يقرب_الجميع&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;goldenbuzzer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BritainsGotTalent_2019_buzzer\/BritainsGotTalent_2019_buzzer.png&quot;,&quot;thisfreelifepride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ThisFreeLife_March_2019\/ThisFreeLife_March_2019.png&quot;,&quot;星ドラ応援ソング&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hoshidora_May2019\/Hoshidora_May2019.png&quot;,&quot;bgt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BritainsGotTalent_2019_star\/BritainsGotTalent_2019_star.png&quot;,&quot;rage2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bethesda_RAGE2_2019\/Bethesda_RAGE2_2019.png&quot;,&quot;историяигрушекбопип&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;qatarairways&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/QatarAirways_2019\/QatarAirways_2019.png&quot;,&quot;アイデムに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;gohoos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UVAChampYearLong\/UVAChampYearLong.png&quot;,&quot;brooklynninenine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brooklyn99_2019\/Brooklyn99_2019.png&quot;,&quot;capitanamarvel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;お母さんありがとう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;somosmapfre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MapfreRafaNadal_2019\/MapfreRafaNadal_2019.png&quot;,&quot;piensaantesdecompartir&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;วันเพนกวินโลก&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;тозипътщегласувам&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;baikitumudahchallenge&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bukalapak_2019\/Bukalapak_2019.png&quot;,&quot;sidebyside&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_Part2_2019_SidebySide\/AFL_Part2_2019_SidebySide.png&quot;,&quot;blackpink&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_BLACKPINK_2019\/KPOP_BLACKPINK_2019.png&quot;,&quot;sandraoh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KillingEve_US_2019\/KillingEve_US_2019.png&quot;,&quot;うまみに和む&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINnamacya2019\/KIRINnamacya2019.png&quot;,&quot;sjsharks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sharksplayoffsv3\/Sharksplayoffsv3.png&quot;,&quot;leveluptov15pro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VivoPHV15_2019\/VivoPHV15_2019.png&quot;,&quot;trashpanda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;dhs30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;wearethewest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_WeAreTheWest_v2\/AFL_2019_WeAreTheWest_v2.png&quot;,&quot;maanpäivä&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;닥터스트레인지&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;네뷸라&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;xmenfênixnegra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/20thCenturyFox_DarkPhoenix\/20thCenturyFox_DarkPhoenix.png&quot;,&quot;호크아이&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;mk11&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBGames_MortalKombat_2019\/WBGames_MortalKombat_2019.png&quot;,&quot;pubg_mobile&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PUBGKR2019\/PUBGKR2019.png&quot;,&quot;toghcháinae2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;vidalongaasroupas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VidaLongaAsRoupas_Unilever\/VidaLongaAsRoupas_Unilever.png&quot;,&quot;hannahb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bachelorette_2019\/Bachelorette_2019.png&quot;,&quot;ユニクロ戦利品&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UNIQLO_Kanshasai_2019_v3\/UNIQLO_Kanshasai_2019_v3.png&quot;,&quot;لتبقى&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/taqa_sa_2019\/taqa_sa_2019.png&quot;,&quot;takiswild&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TAKIS_WILD_2019\/TAKIS_WILD_2019.png&quot;,&quot;デュエルリンクス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YuGiOh_DL_INFO_May2019\/YuGiOh_DL_INFO_May2019.png&quot;,&quot;iijmioに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;joehill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nos4a2_2019\/Nos4a2_2019.png&quot;,&quot;deixaaquimicarolar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NaturaHumor_May2019_V2\/NaturaHumor_May2019_V2.png&quot;,&quot;goodomens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_GoodOmens\/Amazon_GoodOmens.png&quot;,&quot;thebachelorette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bachelorette_2019\/Bachelorette_2019.png&quot;,&quot;europawal2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;risetogether&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Toronto\/OWL_19_Toronto.png&quot;,&quot;letitreign&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Atlanta\/OWL_19_Atlanta.png&quot;,&quot;مصرف_الراجحي_applepay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlRajhiBank_2019\/AlRajhiBank_2019.png&quot;,&quot;gostars&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DallasNHLPlayoffs2019\/DallasNHLPlayoffs2019.png&quot;,&quot;powerofeighteen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Powerof18_India\/Powerof18_India.png&quot;,&quot;thinkbeforesharing&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;وسع_افاق_رؤيتك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;smallactsoflove&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Unilever_LXP_smallactsoflove_2019\/Unilever_LXP_smallactsoflove_2019.png&quot;,&quot;세계팽귄의날&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;chopon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Atlanta\/MLB_2019_Atlanta.png&quot;,&quot;wintersoldier&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;wehavewewill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_WeHaveWeWill\/CricketWorldCup_2019_Teams_WeHaveWeWill.png&quot;,&quot;goloko&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;madeinheavenhashtags&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MadeInHeaven_Amazon_2019\/MadeInHeaven_Amazon_2019.png&quot;,&quot;snapchatandroid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnapAndroid_Launch_2019\/SnapAndroid_Launch_2019.png&quot;,&quot;saelections2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SouthAfrican_Election_2019\/SouthAfrican_Election_2019.png&quot;,&quot;forceofnature&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Vancouver\/OWL_19_Vancouver.png&quot;,&quot;feriadehilos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FeriaDelHilo_v2\/FeriaDelHilo_v2.png&quot;,&quot;hollywoodstudios&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;honoramongthieves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_100Thieves_ext19\/Esports_AllAccessTeam_100Thieves_ext19.png&quot;,&quot;twice_fancy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_TWICE_Fancy_2019\/KPOP_TWICE_Fancy_2019.png&quot;,&quot;euvaalit2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;sweetrabbit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;hockeytwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HockeyTwitter_2018\/HockeyTwitter_2018.png&quot;,&quot;vidafyc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Vida_S2\/STARZ_Vida_S2.png&quot;,&quot;caroldanvers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;qlder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2019_MidSeason_QLDER\/NRL_2019_MidSeason_QLDER.png&quot;,&quot;liveinlevis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spain_Levis_2019\/Spain_Levis_2019.png&quot;,&quot;bopeep&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;got7_spinningtop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_GOT7_2019_GOT7WORLDTOUR\/KPOP_GOT7_2019_GOT7WORLDTOUR.png&quot;,&quot;suenalacampana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Phil\/MLB_2019_Phil.png&quot;,&quot;бульбазавр&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;ourjungle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_OurJungle\/NRL2019_OurJungle.png&quot;,&quot;어벤져스&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;asianheritagemonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;عالم_من_القصص&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ToyotaStories_2019\/ToyotaStories_2019.png&quot;,&quot;خلنا_نجتمع&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_v2\/Vimto_Ramadan_2019_v2.png&quot;,&quot;fv19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DanishElection_2019\/DanishElection_2019.png&quot;,&quot;penguinday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;gaviãoarqueiro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;thelongnight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoT_S8_Tree\/GoT_S8_Tree.png&quot;,&quot;サランラップのクマ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiKaseiHP_2019\/AsahiKaseiHP_2019.png&quot;,&quot;ドン勝tv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PUBGKR2019\/PUBGKR2019.png&quot;,&quot;リゼロプリコネrコラボ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Priconne_Rezaro_2019_v2\/Priconne_Rezaro_2019_v2.png&quot;,&quot;proudtobeabulldog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_Proudtobeabulldog\/NRL2019_Proudtobeabulldog.png&quot;,&quot;capitanamerica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;oneplus7series&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlus7_2019\/OnePlus7_2019.png&quot;,&quot;ハッピーホーガン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_HappyHogan\/Avengers_Endgame_2019_HappyHogan.png&quot;,&quot;историяигрушек4&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;freshempire&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FreshEmpire_MayAugust_2019\/FreshEmpire_MayAugust_2019.png&quot;,&quot;rednoseday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedNoseDay_2019\/RedNoseDay_2019.png&quot;,&quot;nowapocalypsepremiere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_NowApocalypse_2019\/STARZ_NowApocalypse_2019.png&quot;,&quot;諦めたくない夢&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenTV_NBA_Logo_2019_v2\/RakutenTV_NBA_Logo_2019_v2.png&quot;,&quot;ナイキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nike_Japan_JDI_2019\/Nike_Japan_JDI_2019.png&quot;,&quot;illuminationsfarewell&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;فيمتو&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_v2\/Vimto_Ramadan_2019_v2.png&quot;,&quot;escolhasinteligentes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cabify_DecisionesInteligentes_2019\/Cabify_DecisionesInteligentes_2019.png&quot;,&quot;ひらめいてロマサガ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/romasaga_rs_2019\/romasaga_rs_2019.png&quot;,&quot;nébula&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Nebula\/Avengers_Endgame_2019_Nebula.png&quot;,&quot;dunkindonuts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dunkin_NationalDonutDay_2019\/Dunkin_NationalDonutDay_2019.png&quot;,&quot;foxfam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_EchoFox_add\/LCS_2019_EchoFox_add.png&quot;,&quot;nightmarehalsey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Halsey_2019\/Halsey_2019.png&quot;,&quot;penseavantdepartager&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;heforshe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HeForShe_fixed\/HeForShe_fixed.png&quot;,&quot;proudlysydney&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_Part2_2019_ProudlySydney\/AFL_Part2_2019_ProudlySydney.png&quot;,&quot;walkure&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;estavezvoto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;imfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_IMFC\/MLS_19_IMFC.png&quot;,&quot;令和最初の夢&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;elpoderdelascanas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PG_Spain_Pantene_2019\/PG_Spain_Pantene_2019.png&quot;,&quot;lionesses&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LionessesEnglandFootball2019\/LionessesEnglandFootball2019.png&quot;,&quot;budknightsback&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BudLight_BudKnight_2019\/BudLight_BudKnight_2019.png&quot;,&quot;dennegangstemmerjeg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;primevideo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonPrimeVideo_Dionysus_2019_v2\/AmazonPrimeVideo_Dionysus_2019_v2.png&quot;,&quot;إبداعات_ڤيمتو&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_add\/Vimto_Ramadan_2019_add.png&quot;,&quot;theonlywayisessex&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TOWIE_Essex_2019\/TOWIE_Essex_2019.png&quot;,&quot;heatculture&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_MIA\/NBA_18_MIA.png&quot;,&quot;ligadia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spain_LigaDia_2018\/Spain_LigaDia_2018.png&quot;,&quot;theshow19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_TheShow19\/MLB_TheShow19.png&quot;,&quot;hechoenoakland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Oakland\/MLB_2019_Oakland.png&quot;,&quot;seekordlähenvalima&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;4hunnid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;3wishes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;tracymorgan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TLOG_Season2\/TLOG_Season2.png&quot;,&quot;rompiendoestereotipos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PG_Spain_Pantene_2019\/PG_Spain_Pantene_2019.png&quot;,&quot;البنك_السعودي_للاستثمار&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SAIB_2019\/SAIB_2019.png&quot;,&quot;ルージュミニ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Maquillage_rouge_2019\/Maquillage_rouge_2019.png&quot;,&quot;vimto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vimto_Ramadan_2019_v2\/Vimto_Ramadan_2019_v2.png&quot;,&quot;happymothersday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;kanewilliamson&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_KaneWilliamson\/CricketWorldCup_2019_Players_KaneWilliamson.png&quot;,&quot;로켓&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;음바쿠&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mbaku\/Avengers_Endgame_2019_Mbaku.png&quot;,&quot;indiaeisley&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNT_IAmTheNight_2019_v2\/TNT_IAmTheNight_2019_v2.png&quot;,&quot;danishpilsner&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Carlsberg_NewBrew_2019\/Carlsberg_NewBrew_2019.png&quot;,&quot;untethering&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;bbsightings&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sony_Brightburn_Mask_2019\/Sony_Brightburn_Mask_2019.png&quot;,&quot;toystorymania&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_ToyStoryLand\/DisneyParks_ToyStoryLand.png&quot;,&quot;worldpenguinday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;мантис&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Mantis\/Avengers_Endgame_2019_Mantis.png&quot;,&quot;بريال&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ZadFresh_2019_v3\/ZadFresh_2019_v3.png&quot;,&quot;rocketmanes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;wholenewworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Jasmine\/Disney_Aladdin_Jasmine.png&quot;,&quot;докторстрэндж&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;slinkydogdash&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_ToyStoryLand\/DisneyParks_ToyStoryLand.png&quot;,&quot;三ツ矢サイダー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Asahi_MitsuyaBrand_2019_add\/Asahi_MitsuyaBrand_2019_add.png&quot;,&quot;uglydollsluckybat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_LuckyBat\/UglyDolls_LuckyBat.png&quot;,&quot;riseoftheresistance&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/disney_starwarsgalaxysedge_2019_v2\/disney_starwarsgalaxysedge_2019_v2.png&quot;,&quot;放置少女に願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;charmander&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;happybirthdaymickey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;hotsaleamazon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;absolut&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbsolutPlanetEarthsFavoriteVodka_2019\/AbsolutPlanetEarthsFavoriteVodka_2019.png&quot;,&quot;strengthinnumbers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WarriorsPlayoffsv3\/WarriorsPlayoffsv3.png&quot;,&quot;フォーキー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;aiだみつを&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AIDAMITSUWO_2019\/AIDAMITSUWO_2019.png&quot;,&quot;whywewearblack&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TimesUp_v4\/TimesUp_v4.png&quot;,&quot;spotifyxbts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_KPOP_2019_v2\/Spotify_KPOP_2019_v2.png&quot;,&quot;bstudios&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BStudios_2019\/BStudios_2019.png&quot;,&quot;encendiendomotores&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Detroit_v2\/MLB_2019_Detroit_v2.png&quot;,&quot;lgm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Mets\/MLB_2019_Mets.png&quot;,&quot;wethebest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DJKhaled_May2019\/DJKhaled_May2019.png&quot;,&quot;freegameswithprime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitchPrime_2019\/TwitchPrime_2019.png&quot;,&quot;nossoplaneta&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_OurPlanet_2019\/Netflix_OurPlanet_2019.png&quot;,&quot;pubg_jp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PUBGKR2019\/PUBGKR2019.png&quot;,&quot;geniotangenial&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;evepolastri&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KillingEve_US_2019\/KillingEve_US_2019.png&quot;,&quot;absolutplanet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbsolutPlanetEarthsFavoriteVodka_2019\/AbsolutPlanetEarthsFavoriteVodka_2019.png&quot;,&quot;doop&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_PHIL\/MLS_19_PHIL.png&quot;,&quot;winecountrynetflix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WineCountry_Netflix\/WineCountry_Netflix.png&quot;,&quot;spotifyxblackpink&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_KPOP_2019_v2\/Spotify_KPOP_2019_v2.png&quot;,&quot;子どもの日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ChildrensDay_2019\/ChildrensDay_2019.png&quot;,&quot;禍つヴァールハイト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/magatsu_ver2_2019\/magatsu_ver2_2019.png&quot;,&quot;아이언맨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;rewritetherules&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Huawei_P30_2019\/Huawei_P30_2019.png&quot;,&quot;nohayungeniotangenial&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;teamox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Ox_add\/UglyDolls_Ox_add.png&quot;,&quot;letsgopens&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PensPlayoffs2019\/PensPlayoffs2019.png&quot;,&quot;팽귄의날&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WorldPenguinDay_2019\/WorldPenguinDay_2019.png&quot;,&quot;breakthrough&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Shanghai\/OWL_19_Shanghai.png&quot;,&quot;asklewis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LewisCapaldi_2019\/LewisCapaldi_2019.png&quot;,&quot;losrockies&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Colorado\/MLB_2019_Colorado.png&quot;,&quot;loveislandreunion&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;аладдин&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;خدمة_حسابي&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SaudiElectricity_2019\/SaudiElectricity_2019.png&quot;,&quot;افطار_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;uglydolls&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDollsMovie\/UglyDollsMovie.png&quot;,&quot;itmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;butnotus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;bravotv&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectRunway_Bravo\/ProjectRunway_Bravo.png&quot;,&quot;maquinadeguerra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;levis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spain_Levis_2019\/Spain_Levis_2019.png&quot;,&quot;anuairseobeidhméagvótáil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;しまパト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shimamura_2019\/Shimamura_2019.png&quot;,&quot;twitchprime&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitchPrime_2019\/TwitchPrime_2019.png&quot;,&quot;gorogue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Rogue\/Riot_Rogue.png&quot;,&quot;oppoksa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;ناس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlyNas_2019\/FlyNas_2019.png&quot;,&quot;smoreslife&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Starbucks_Canada_SummerFrapp\/Starbucks_Canada_SummerFrapp.png&quot;,&quot;wakandaforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;نوروز&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;onlywayisessex&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TOWIE_Essex_2019\/TOWIE_Essex_2019.png&quot;,&quot;penseantesdecompartilhar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing\/MediaInformationLiteracyWeeks_2018_ThinkBeforeSharing.png&quot;,&quot;lagalaxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_LAGalaxy\/MLS_19_LAGalaxy.png&quot;,&quot;divinelyuninspiredtoahellishextent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LewisCapaldi_2019\/LewisCapaldi_2019.png&quot;,&quot;bringthemayhem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Florida\/OWL_19_Florida.png&quot;,&quot;çachapitre2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;warburtons&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Warburtons_Bagel_Boss\/Warburtons_Bagel_Boss.png&quot;,&quot;nhlbruins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BruinsPlayoffs19\/BruinsPlayoffs19.png&quot;,&quot;flywin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FlyQuest_add\/Esports_AllAccessTeam_FlyQuest_add.png&quot;,&quot;diesmalwähleich&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;bgmt&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BritainsGotTalent_2019_star_add\/BritainsGotTalent_2019_star_add.png&quot;,&quot;iftar&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;blackhistorymonth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;infinitystone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;aapihm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsianHeritageMonth_2019\/AsianHeritageMonth_2019.png&quot;,&quot;cwc19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Trophy\/CricketWorldCup_2019_Trophy.png&quot;,&quot;wdw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;nycfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_NYCFC\/MLS_19_NYCFC.png&quot;,&quot;スターフェス200連無料&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Vconnect_jp_2019_V2\/Vconnect_jp_2019_V2.png&quot;,&quot;와스프&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;absolutpride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbsolutPlanetEarthsFavoriteVodka_2019\/AbsolutPlanetEarthsFavoriteVodka_2019.png&quot;,&quot;千川ちひろ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/imascg_stage_May2019\/imascg_stage_May2019.png&quot;,&quot;unitedbyvote&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UnitedColoursofBenetton_2019\/UnitedColoursofBenetton_2019.png&quot;,&quot;oneplus7pro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OnePlus7_2019\/OnePlus7_2019.png&quot;,&quot;ep2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;인피&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;spacestone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;баззлайтер&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Buzz\/Disney_ToyStory4_Buzz.png&quot;,&quot;xlwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_exceL\/Riot_exceL.png&quot;,&quot;vegasborn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/VegasPlayoffs19\/VegasPlayoffs19.png&quot;,&quot;nationalpetday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;squirtle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;발키리&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Valkyrie\/Avengers_Endgame_2019_Valkyrie.png&quot;,&quot;delhicapitals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DelhiCapitals_IPL\/DelhiCapitals_IPL.png&quot;,&quot;実はきのこ派でした&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KinokomeijiJP_2019\/KinokomeijiJP_2019.png&quot;,&quot;ovajputglasam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;قطر_الخيرية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Qatar_charity2019\/Qatar_charity2019.png&quot;,&quot;askyg&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;theprocess&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JoelFace2018\/JoelFace2018.png&quot;,&quot;metoo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MeToo_v3\/MeToo_v3.png&quot;,&quot;kpopdaebak&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Spotify_KPOP_2019_v2\/Spotify_KPOP_2019_v2.png&quot;,&quot;железныйчеловек&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;movilidadinteligente&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Cabify_DecisionesInteligentes_2019\/Cabify_DecisionesInteligentes_2019.png&quot;,&quot;ゼニガメ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;クリックする前に考えよう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking\/MediaInformationLiteracyWeeks_2018_ThinkBeforeClicking.png&quot;,&quot;thebachelorettefinale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bachelorette_2019\/Bachelorette_2019.png&quot;,&quot;wemetontwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WeMetOnt_Emoji\/WeMetOnt_Emoji.png&quot;,&quot;wingsout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_LAV\/OWL_19_LAV.png&quot;,&quot;lionkingcelebration&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;adoptaunprimerizo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;magiccarpetride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;ウォン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wong\/Avengers_Endgame_2019_Wong.png&quot;,&quot;pattyjenkins&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNT_IAmTheNight_2019_v2\/TNT_IAmTheNight_2019_v2.png&quot;,&quot;bestoftweet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BestofTweetsPrize_2019\/BestofTweetsPrize_2019.png&quot;,&quot;dunkout&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Dunkin_NationalDonutDay_2019\/Dunkin_NationalDonutDay_2019.png&quot;,&quot;rocketfans&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Star\/Paramount_Rocketman_Star.png&quot;,&quot;epvalimised2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;100thieves&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_100Thieves_ext19\/Esports_AllAccessTeam_100Thieves_ext19.png&quot;,&quot;ramadanlantern&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;avengersengame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_add\/Avengers_Endgame_2019_add.png&quot;,&quot;超ラジオ体操&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINMetsJP_2019\/KIRINMetsJP_2019.png&quot;,&quot;꼬부기&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;파이리&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;artfulepcot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;ogfamily&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Origen\/Riot_Origen.png&quot;,&quot;captainmarvel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;woodylunchbox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_ToyStoryLand\/DisneyParks_ToyStoryLand.png&quot;,&quot;secretlifeofpets&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;로켓맨&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;mnufc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_MNUFC\/MLS_19_MNUFC.png&quot;,&quot;4aklondike&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Unilever_4AKlondike_2019\/Unilever_4AKlondike_2019.png&quot;,&quot;weareorigen&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Origen\/Riot_Origen.png&quot;,&quot;redmi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XiaomiRedmi_Pro7_2019\/XiaomiRedmi_Pro7_2019.png&quot;,&quot;fatherofasahd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DJKhaled_May2019\/DJKhaled_May2019.png&quot;,&quot;north150&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_2019_North150\/AFL_2019_North150.png&quot;,&quot;オルビスユー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ORBIS_2019\/ORBIS_2019.png&quot;,&quot;wyboryeuropejskie2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;unamicocomeme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;vwfc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_VAN\/MLS_19_VAN.png&quot;,&quot;feeleuphoria&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_Euphoria_2019\/HBO_Euphoria_2019.png&quot;,&quot;dontlethimin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SonyIntruder_2018\/SonyIntruder_2018.png&quot;,&quot;kcon2019usa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019USA_2019\/KCON2019USA_2019.png&quot;,&quot;tokyolitmap&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nike_Japan_JDI_2019\/Nike_Japan_JDI_2019.png&quot;,&quot;oppo60xzoom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Oppo_KSA_RenoLaunch_Q2_2019\/Oppo_KSA_RenoLaunch_Q2_2019.png&quot;,&quot;bulanpuasa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;budknightbucketlist&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BudLight_BudKnight_2019\/BudLight_BudKnight_2019.png&quot;,&quot;epvolby2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;wearemanly&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_WeAreManly\/NRL2019_WeAreManly.png&quot;,&quot;七つの大罪&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netmarble_7deadlysins_2019\/Netmarble_7deadlysins_2019.png&quot;,&quot;redmi32mp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedmiY3_2019\/RedmiY3_2019.png&quot;,&quot;thehustle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheHustle_2019\/TheHustle_2019.png&quot;,&quot;livenation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NationalConcertWeek_2019\/NationalConcertWeek_2019.png&quot;,&quot;shaftmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;haroldhogan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_HappyHogan\/Avengers_Endgame_2019_HappyHogan.png&quot;,&quot;kingsxipunjab&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_KXIP\/IPL_2019_2_KXIP.png&quot;,&quot;cementeriodeanimales&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;primedayamazon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;平成ノブコブ最後の日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbemaTV_2019\/AbemaTV_2019.png&quot;,&quot;perfectlybalanced&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thanos\/Avengers_Endgame_2019_Thanos.png&quot;,&quot;никфьюри&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;destavezeuvoto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;uglydollswage&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Wage\/UglyDolls_Wage.png&quot;,&quot;wegohard&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_BKN\/NBA_18_BKN.png&quot;,&quot;alegeriue2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;母の日&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;roaron&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Seoul\/OWL_19_Seoul.png&quot;,&quot;vengadores&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;紅茶派&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRINGT_JP_2019_V3\/KIRINGT_JP_2019_V3.png&quot;,&quot;mlsishere&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ESPN_MLS_2019\/ESPN_MLS_2019.png&quot;,&quot;redmi32mpsuperselfie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedmiY3_2019\/RedmiY3_2019.png&quot;,&quot;放置少女百花繚乱&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/houchishoujo_2yearanniversary_v2\/houchishoujo_2yearanniversary_v2.png&quot;,&quot;joganogoogle&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoogleSoccer_Brazil_2019\/GoogleSoccer_Brazil_2019.png&quot;,&quot;capitãmarvel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;스타로드&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;ナイトジョガー&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Adidas_NiteJogger_2019_add\/Adidas_NiteJogger_2019_add.png&quot;,&quot;thisismay&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBCSportsIndy500_MustBeMay\/NBCSportsIndy500_MustBeMay.png&quot;,&quot;redminote7pro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XiaomiRedmi_Pro7_2019\/XiaomiRedmi_Pro7_2019.png&quot;,&quot;あんスタ4周年&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ansta4th_2019\/Ansta4th_2019.png&quot;,&quot;cmtawards19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CMTMusicAwards_2019\/CMTMusicAwards_2019.png&quot;,&quot;euroleague&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Euroleague_Jan2019\/Euroleague_Jan2019.png&quot;,&quot;paradisehotel&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Fox_Summer_ParadiseHotel\/Fox_Summer_ParadiseHotel.png&quot;,&quot;soldadodelinvierno&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WinterSoldier\/Avengers_Endgame_2019_WinterSoldier.png&quot;,&quot;絶好調はおぎなえる&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KIRIN_Tropicana_JP\/KIRIN_Tropicana_JP.png&quot;,&quot;clgwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_CounterLogicGaming\/LCS_2019_CounterLogicGaming.png&quot;,&quot;babotheuglydoll&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo\/UglyDolls_Babo.png&quot;,&quot;放置少女の萌姫たち&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/houchishoujo_2yearanniversary_v2\/houchishoujo_2yearanniversary_v2.png&quot;,&quot;s04&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Schalke04\/Riot_Schalke04.png&quot;,&quot;رمضان_الصقور_غير&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/invasionarab1_Ramadan_2019\/invasionarab1_Ramadan_2019.png&quot;,&quot;serbuseru&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bukalapak_2019\/Bukalapak_2019.png&quot;,&quot;bhm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;mi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MumbaiIndians_2018\/MumbaiIndians_2018.png&quot;,&quot;pepperpotts&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_PepperPotts\/Avengers_Endgame_2019_PepperPotts.png&quot;,&quot;toystoryfourchette&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;chrispine&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TNT_IAmTheNight_2019_v2\/TNT_IAmTheNight_2019_v2.png&quot;,&quot;masterchef&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Masterchef_March_2019\/Masterchef_March_2019.png&quot;,&quot;elgeniodealadd&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;fazeup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FaZeClan_ext19\/Esports_AllAccessTeam_FaZeClan_ext19.png&quot;,&quot;صقور_العرب&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/invasionarab1_Ramadan_2019\/invasionarab1_Ramadan_2019.png&quot;,&quot;winecountryus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WineCountry_Netflix\/WineCountry_Netflix.png&quot;,&quot;4real4real&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;snapchatforandroid&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnapAndroid_Launch_2019\/SnapAndroid_Launch_2019.png&quot;,&quot;lalampara&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;lampada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;إفطارًا_شهيًا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;capitaoamerica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;microsoft&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Microsoft_APAC_2019_v2\/Microsoft_APAC_2019_v2.png&quot;,&quot;بطاقة_السفر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SAIB_2019\/SAIB_2019.png&quot;,&quot;eleccionesue2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;eprinkimai2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;celebratemickey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;gojetsgo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHLJetsPlayoffs2019\/NHLJetsPlayoffs2019.png&quot;,&quot;hotzoneshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HotZone_NatGeoChannel_2019\/HotZone_NatGeoChannel_2019.png&quot;,&quot;petsematarymovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;気になった時がはじめ時&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Livita_JP_2019_V3\/Livita_JP_2019_V3.png&quot;,&quot;bullsnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_CHI\/NBA_18_CHI.png&quot;,&quot;twinsbeisbol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Minn\/MLB_2019_Minn.png&quot;,&quot;nrl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_NRL\/NRL2019_NRL.png&quot;,&quot;eleicoeseuropeias2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;азизбирамес2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;nfl100&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NFL100AnniversaryEmoji\/NFL100AnniversaryEmoji.png&quot;,&quot;サランラップ漫画劇場&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AsahiKaseiHP_2019\/AsahiKaseiHP_2019.png&quot;,&quot;herohighfive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedNoseDay_2019\/RedNoseDay_2019.png&quot;,&quot;pericao&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pericles_2019\/Pericles_2019.png&quot;,&quot;血盟ジョイン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMFirstBrand_2019\/LineageMFirstBrand_2019.png&quot;,&quot;ilovemi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/XiaomiRedmi_Pro7_2019\/XiaomiRedmi_Pro7_2019.png&quot;,&quot;letsgoc9&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_Cloud9_ext19\/Esports_AllAccessTeam_Cloud9_ext19.png&quot;,&quot;lalampe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;glumanda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;リゼロコラボ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Priconne_Rezaro_2019_v2\/Priconne_Rezaro_2019_v2.png&quot;,&quot;moremagic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;teamenvy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_Envy_ext2\/Esports_AllAccessTeam_Envy_ext2.png&quot;,&quot;myxmusicawards2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MYXMusicAwards_2019\/MYXMusicAwards_2019.png&quot;,&quot;ドン勝&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PUBGKR2019\/PUBGKR2019.png&quot;,&quot;nottoday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GoT_S8_Tree\/GoT_S8_Tree.png&quot;,&quot;ハルク&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hulk\/Avengers_Endgame_2019_Hulk.png&quot;,&quot;الحجر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlUlaCity_2019\/AlUlaCity_2019.png&quot;,&quot;itchaptertwo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;breakpoint&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GhostRecon_2019_breakpoint\/GhostRecon_2019_breakpoint.png&quot;,&quot;forgloryforcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_SKC_v2\/MLS_19_SKC_v2.png&quot;,&quot;britainsgottalent&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BritainsGotTalent_2019_star\/BritainsGotTalent_2019_star.png&quot;,&quot;ofertasprimeday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AmazonHotSale2019\/AmazonHotSale2019.png&quot;,&quot;carlsbergpilsner&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Carlsberg_NewBrew_2019\/Carlsberg_NewBrew_2019.png&quot;,&quot;disneyworld&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;womeninfootball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WomenInFootball_Flight3\/WomenInFootball_Flight3.png&quot;,&quot;पृथ्वीदिवस&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;izborieu2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;포키&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;vcnuncaviunadaigual&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBB_2018_2019Season\/NBB_2018_2019Season.png&quot;,&quot;アラジンと新しい世界へ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;kpoptwitter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOPTwitter2019\/KPOPTwitter2019.png&quot;,&quot;vacinabrasil&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brasil_InfluenzaVaccination\/Brasil_InfluenzaVaccination.png&quot;,&quot;mewtwo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Mewtwo\/WBPikachu_Mewtwo.png&quot;,&quot;지구의날&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;powerof18&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Powerof18_India\/Powerof18_India.png&quot;,&quot;blacklivesmatter&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BlackHistoryMonth\/BlackHistoryMonth.png&quot;,&quot;foxwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_EchoFox\/LCS_2019_EchoFox.png&quot;,&quot;wearewarriors&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_WeAreWarriors\/NRL2019_WeAreWarriors.png&quot;,&quot;pinkcarpetmtvmiaw&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Miaw_2019\/MTV_Miaw_2019.png&quot;,&quot;senhordasestrelas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;グラクロ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netmarble_7deadlysins_2019\/Netmarble_7deadlysins_2019.png&quot;,&quot;ourplanet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netflix_OurPlanet_2019\/Netflix_OurPlanet_2019.png&quot;,&quot;toandroidlovesnapchat&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SnapAndroid_Launch_2019\/SnapAndroid_Launch_2019.png&quot;,&quot;moc&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;僕はおもちゃじゃない&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;gonip&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_NIP\/Esports_V2_19_NIP.png&quot;,&quot;インフィニティガントレット&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;teusegredo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pericles_2019\/Pericles_2019.png&quot;,&quot;보핍&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;projectrunwaybravo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ProjectRunway_Bravo\/ProjectRunway_Bravo.png&quot;,&quot;starlord&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;nickfury&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_NickFury\/Avengers_Endgame_2019_NickFury.png&quot;,&quot;rocketmanmovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;preds&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PredsPlayoffs2019\/PredsPlayoffs2019.png&quot;,&quot;feriadelhilo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FeriaDelHilo_v2\/FeriaDelHilo_v2.png&quot;,&quot;звёздныйлорд&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;eoinmorgan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_EoinMorgan\/CricketWorldCup_2019_Players_EoinMorgan.png&quot;,&quot;ドクターストレンジ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;サントリーに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;xfinitywatchathon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Xfinity_Watchathon_2019\/Xfinity_Watchathon_2019.png&quot;,&quot;リネmプレイ中デス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMSecondBrand_2019\/LineageMSecondBrand_2019.png&quot;,&quot;hawkeyeavenger&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;disneycruise&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;,&quot;cettefoisjevote&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;nrlmagicround&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2019_MidSeason_NRLWMagicRound\/NRL_2019_MidSeason_NRLWMagicRound.png&quot;,&quot;allcaps&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NHL_2017_2018_Caps_v3\/NHL_2017_2018_Caps_v3.png&quot;,&quot;дракс&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Drax\/Avengers_Endgame_2019_Drax.png&quot;,&quot;kevinfeige&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_KevinFeige\/Avengers_Endgame_2019_KevinFeige.png&quot;,&quot;eaststowin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_EastsToWin\/NRL2019_EastsToWin.png&quot;,&quot;alâmpada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;nrgfam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_NRG_ext19\/Esports_AllAccessTeam_NRG_ext19.png&quot;,&quot;ngkfrommay31&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NGKFilm_2019\/NGKFilm_2019.png&quot;,&quot;wehaveahulk&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hulk\/Avengers_Endgame_2019_Hulk.png&quot;,&quot;キャプテンマーベル&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;杰尼龟&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Squirtle_v2\/WBPikachu_Squirtle_v2.png&quot;,&quot;vitwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_TeamVitality\/Riot_TeamVitality.png&quot;,&quot;milehighbasketball&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_DEN\/NBA_18_DEN.png&quot;,&quot;캡틴아메리카&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;ドラガリ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/dragalialos_March2019_v2\/dragalialos_March2019_v2.png&quot;,&quot;إفطار&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;paradisehotelfox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Fox_Summer_ParadiseHotel\/Fox_Summer_ParadiseHotel.png&quot;,&quot;powerof18india&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Powerof18_India\/Powerof18_India.png&quot;,&quot;diabloguardián&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Amazon_DiabloGuardian_add\/Amazon_DiabloGuardian_add.png&quot;,&quot;therevengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheHustle_2019\/TheHustle_2019.png&quot;,&quot;winecountryfilm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WineCountry_Netflix\/WineCountry_Netflix.png&quot;,&quot;aisxlisa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AISXLISA_2019\/AISXLISA_2019.png&quot;,&quot;ويش_بتسوي_لو_صرت_الحاكم&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/invasionarab1_Ramadan_2019\/invasionarab1_Ramadan_2019.png&quot;,&quot;bronxnation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_Bronxnation\/NRL2019_Bronxnation.png&quot;,&quot;inclusionishappening&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TwitterTogether_InclusionIsHappening_v2\/TwitterTogether_InclusionIsHappening_v2.png&quot;,&quot;hilanderos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FeriaDelHilo_v2\/FeriaDelHilo_v2.png&quot;,&quot;七つの大罪光と闇の交戦&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Netmarble_7deadlysins_2019\/Netmarble_7deadlysins_2019.png&quot;,&quot;magiclamp&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;starbuckssummersippin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Starbucks_Canada_SummerFrapp_add\/Starbucks_Canada_SummerFrapp_add.png&quot;,&quot;lec&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_LEC\/Riot_LEC.png&quot;,&quot;draxthedestroyer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Drax\/Avengers_Endgame_2019_Drax.png&quot;,&quot;okoye&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Okoye\/Avengers_Endgame_2019_Okoye.png&quot;,&quot;mtvaward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MTV_Awards_May2019\/MTV_Awards_May2019.png&quot;,&quot;pileofrocks&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;วันคุ้มครองโลก&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EarthDay_2019_fixed\/EarthDay_2019_fixed.png&quot;,&quot;リネm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMFirstBrand_2019\/LineageMFirstBrand_2019.png&quot;,&quot;تبرعك_أسهل&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zamzam_2019\/Zamzam_2019.png&quot;,&quot;рокетмен&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;tlwin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_TeamLiquid_ext19\/Esports_AllAccessTeam_TeamLiquid_ext19.png&quot;,&quot;ロキ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Loki\/Avengers_Endgame_2019_Loki.png&quot;,&quot;flyquest&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FlyQuest_ext19\/Esports_AllAccessTeam_FlyQuest_ext19.png&quot;,&quot;pets2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pets2_Max_v2_ext\/Pets2_Max_v2_ext.png&quot;,&quot;mariahill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_MariaHill\/Avengers_Endgame_2019_MariaHill.png&quot;,&quot;캡틴마블&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;رمضان_مبارك&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;euroekloges2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;미에크&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Miek\/Avengers_Endgame_2019_Miek.png&quot;,&quot;うさピヨ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Usapiyo_2019\/Usapiyo_2019.png&quot;,&quot;чернаяпантера&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackPanther\/Avengers_Endgame_2019_BlackPanther.png&quot;,&quot;freshepcot&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;thisworldcomesforyou&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PlayStation_DaysGone\/PlayStation_DaysGone.png&quot;,&quot;puremagic&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_ORL\/NBA_18_ORL.png&quot;,&quot;nbaplayoffs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAPlayoffs2019v2\/NBAPlayoffs2019v2.png&quot;,&quot;bulbizarre&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;rocketfan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Star\/Paramount_Rocketman_Star.png&quot;,&quot;spywin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_Splyce\/Riot_Splyce.png&quot;,&quot;thehotzonenatgeo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HotZone_NatGeoChannel_2019\/HotZone_NatGeoChannel_2019.png&quot;,&quot;maquinadecombate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;オルビスユーローション&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ORBIS_2019_add\/ORBIS_2019_add.png&quot;,&quot;got7worldtour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_GOT7_2019_GOT7WORLDTOUR\/KPOP_GOT7_2019_GOT7WORLDTOUR.png&quot;,&quot;thecontinental&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;alfombramágicatour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;ministryofculture&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;leafsforever&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LeafsPlayoffs2019\/LeafsPlayoffs2019.png&quot;,&quot;rattleon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Arizona\/MLB_2019_Arizona.png&quot;,&quot;อิท2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;loveislandday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LoveIsland_May2019\/LoveIsland_May2019.png&quot;,&quot;rexonadancestudio&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RexonaNowUnited_72x72\/RexonaNowUnited_72x72.png&quot;,&quot;スターロード&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;uglydollsbabo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Babo\/UglyDolls_Babo.png&quot;,&quot;локи&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Loki\/Avengers_Endgame_2019_Loki.png&quot;,&quot;мстители&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;thehustlemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheHustle_2019\/TheHustle_2019.png&quot;,&quot;ripcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_POR\/NBA_18_POR.png&quot;,&quot;zacharyquinto&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Nos4a2_2019\/Nos4a2_2019.png&quot;,&quot;100t&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_100Thieves_ext19\/Esports_AllAccessTeam_100Thieves_ext19.png&quot;,&quot;mikeygarcia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FoxSports_PBC\/FoxSports_PBC.png&quot;,&quot;stonekeeper&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_RedSkull\/Avengers_Endgame_2019_RedSkull.png&quot;,&quot;todosjuntos&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Texas\/MLB_2019_Texas.png&quot;,&quot;ringthebell&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Phil\/MLB_2019_Phil.png&quot;,&quot;hustlemovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TheHustle_2019\/TheHustle_2019.png&quot;,&quot;risewithus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_Sunrisers\/IPL_2019_2_Sunrisers.png&quot;,&quot;엄마사랑해요&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/2019_MothersDay\/2019_MothersDay.png&quot;,&quot;jamesbeardawards&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JamesBeard_FoundationAwards_2019\/JamesBeard_FoundationAwards_2019.png&quot;,&quot;lakeshow&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_LAL\/NBA_18_LAL.png&quot;,&quot;toystorybetty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;showtimelatenight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DesusandMero_2019\/DesusandMero_2019.png&quot;,&quot;magiccarpet&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;fridayforgood&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FridayforGood_2019\/FridayforGood_2019.png&quot;,&quot;nosebowl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedNoseDay_2019\/RedNoseDay_2019.png&quot;,&quot;flyq&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_FlyQuest_ext19\/Esports_AllAccessTeam_FlyQuest_ext19.png&quot;,&quot;szavaznifogok&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;popsdiner&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riverdale_S4_2019_v2\/Riverdale_S4_2019_v2.png&quot;,&quot;budknightreturn&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BudLight_BudKnight_2019\/BudLight_BudKnight_2019.png&quot;,&quot;rbny&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_RBNY\/MLS_19_RBNY.png&quot;,&quot;magiccarpettour&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;dedataastavotez&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;makethefuture&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Shell_makethefuture_2019\/Shell_makethefuture_2019.png&quot;,&quot;ユニクロ感謝祭&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UNIQLO_Kanshasai_2019_v3\/UNIQLO_Kanshasai_2019_v3.png&quot;,&quot;raysbéisbol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Tampa\/MLB_2019_Tampa.png&quot;,&quot;kohlscashsweepstakes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Kohls_Q2_2019\/Kohls_Q2_2019.png&quot;,&quot;darkphoenix&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/20thCenturyFox_DarkPhoenix\/20thCenturyFox_DarkPhoenix.png&quot;,&quot;mihplanner&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MadeInHeaven_Amazon_2019\/MadeInHeaven_Amazon_2019.png&quot;,&quot;cmtaward&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CMTMusicAwards_2019\/CMTMusicAwards_2019.png&quot;,&quot;nowapocalypsestarz&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_NowApocalypse_2019\/STARZ_NowApocalypse_2019.png&quot;,&quot;bang&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_Hangzhou\/OWL_19_Hangzhou.png&quot;,&quot;パパジャニwestに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;elezzjonijietue2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;itsus&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UsMovie_2018\/UsMovie_2018.png&quot;,&quot;semainemondialeemi&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;faceofcity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_ORL\/MLS_19_ORL.png&quot;,&quot;팔콘&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Falcon\/Avengers_Endgame_2019_Falcon.png&quot;,&quot;vainogás&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CocaCola_VaiNoGas\/CocaCola_VaiNoGas.png&quot;,&quot;sheriffwoody&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;코르그&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;星ドラ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Hoshidora_May2019\/Hoshidora_May2019.png&quot;,&quot;bulbassauro&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;dragalialost&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/dragalialos_March2019_v2\/dragalialos_March2019_v2.png&quot;,&quot;shaftsays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_ShaftMovie_2019\/WB_ShaftMovie_2019.png&quot;,&quot;ilguantodellinfinito&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;lastog&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TLOG_Season2\/TLOG_Season2.png&quot;,&quot;いつかきっとここで&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RakutenTV_NBA_Logo_2019_v2\/RakutenTV_NBA_Logo_2019_v2.png&quot;,&quot;realitystone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_InfinityGauntlet\/Avengers_Endgame_2019_InfinityGauntlet.png&quot;,&quot;boundbyblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_Part2_2019_BoundByBlue\/AFL_Part2_2019_BoundByBlue.png&quot;,&quot;سحور&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Iftar\/Ramadan_2019_Iftar.png&quot;,&quot;peterquill&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Starlord\/Avengers_Endgame_2019_Starlord.png&quot;,&quot;itchapter2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;mapfreandrafa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MapfreRafaNadal_2019\/MapfreRafaNadal_2019.png&quot;,&quot;alligatormovie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Crawl_2019\/Paramount_Crawl_2019.png&quot;,&quot;全球媒介和信息素養週&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;오븐브레이크&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CookieRunGame_2019\/CookieRunGame_2019.png&quot;,&quot;georgeharrison&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GeorgeHarrison_2019_v3\/GeorgeHarrison_2019_v3.png&quot;,&quot;ramadán&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;行くぜ令和&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbemaTV_2019\/AbemaTV_2019.png&quot;,&quot;bethefight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_CLE\/NBA_18_CLE.png&quot;,&quot;clippernation&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_LAC\/NBA_18_LAC.png&quot;,&quot;openingday&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019\/MLB_2019.png&quot;,&quot;bisasam&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Bulbasaur\/WBPikachu_Bulbasaur.png&quot;,&quot;tredesideri&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;copasuperliga&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/SuperLigaFinal_2019\/SuperLigaFinal_2019.png&quot;,&quot;thefutureischingona&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_Vida_S2\/STARZ_Vida_S2.png&quot;,&quot;denhärgångenröstarjag&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;sudamericana&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Sulamericana_2019\/Sulamericana_2019.png&quot;,&quot;avengerendgame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_add2\/Avengers_Endgame_2019_add2.png&quot;,&quot;갓세븐&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_GOT7_2019_GOT7WORLDTOUR\/KPOP_GOT7_2019_GOT7WORLDTOUR.png&quot;,&quot;livevictoriously&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GreyGoose_REBRAND_2019\/GreyGoose_REBRAND_2019.png&quot;,&quot;capitãoamérica&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;rocketmannl&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Rocket\/Paramount_Rocketman_Rocket.png&quot;,&quot;ジョジョピタ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Jojos_PitaPataHop_2019\/Jojos_PitaPataHop_2019.png&quot;,&quot;budknight&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/BudLight_BudKnight_2019\/BudLight_BudKnight_2019.png&quot;,&quot;nbafinals&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBAFinals2019\/NBAFinals2019.png&quot;,&quot;halsey&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Halsey_2019\/Halsey_2019.png&quot;,&quot;raysup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Tampa\/MLB_2019_Tampa.png&quot;,&quot;ironman&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;weareraiders&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_WeAreRaiders\/NRL2019_WeAreRaiders.png&quot;,&quot;tentorazidemvolit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;rocketraccoon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Rocket\/Avengers_Endgame_2019_Rocket.png&quot;,&quot;máquinadeguerra&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;デスナイト&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMSecondBrand_2019\/LineageMSecondBrand_2019.png&quot;,&quot;ウォーマシン&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;uptheblues&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL_2019_MidSeason_UpTheBlues\/NRL_2019_MidSeason_UpTheBlues.png&quot;,&quot;ausnavy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AusNavy_DFR_2019\/AusNavy_DFR_2019.png&quot;,&quot;キャッシュレス&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Aomaru2019\/Aomaru2019.png&quot;,&quot;truetotheblue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Seattle\/MLB_2019_Seattle.png&quot;,&quot;капитанмарвел&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainMarvel\/Avengers_Endgame_2019_CaptainMarvel.png&quot;,&quot;リネージュm&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LineageMFirstBrand_2019\/LineageMFirstBrand_2019.png&quot;,&quot;lalampada&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Lamp\/Disney_Aladdin_Lamp.png&quot;,&quot;tonystark&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_IronMan\/Avengers_Endgame_2019_IronMan.png&quot;,&quot;myheartbeatstrue&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AFL_Part2_2019_MyHeartBeatsTrue\/AFL_Part2_2019_MyHeartBeatsTrue.png&quot;,&quot;stephenvsthegame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StephenCurry_2019\/StephenCurry_2019.png&quot;,&quot;moxy&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/UglyDolls_Moxy\/UglyDolls_Moxy.png&quot;,&quot;compartilheobem&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pedigree_DogBots_2019\/Pedigree_DogBots_2019.png&quot;,&quot;alienswirlingsaucers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_ToyStoryLand\/DisneyParks_ToyStoryLand.png&quot;,&quot;threewishes&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;nitegoods&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Adidas_NiteJogger_2019_add\/Adidas_NiteJogger_2019_add.png&quot;,&quot;فانوس_رمضان&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019_Lantern\/Ramadan_2019_Lantern.png&quot;,&quot;jasonholder&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_JasonHolder\/CricketWorldCup_2019_Players_JasonHolder.png&quot;,&quot;towie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TOWIE_Essex_2019\/TOWIE_Essex_2019.png&quot;,&quot;facetheintensity&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/TAKIS_WILD_2019\/TAKIS_WILD_2019.png&quot;,&quot;laguêpe&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wasp\/Avengers_Endgame_2019_Wasp.png&quot;,&quot;tgit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ABC_TGIT_Spring2019\/ABC_TGIT_Spring2019.png&quot;,&quot;diamondgeezer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bethesda_RAGE2_2019\/Bethesda_RAGE2_2019.png&quot;,&quot;aceshigh&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/OWL_19_London\/OWL_19_London.png&quot;,&quot;mouseparty&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_NowMoreThanEver_v2\/DisneyParks_NowMoreThanEver_v2.png&quot;,&quot;vivoxmaineriseup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MaineforVivo_2019\/MaineforVivo_2019.png&quot;,&quot;persiannewyear&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/nowruz2018_v4\/nowruz2018_v4.png&quot;,&quot;вилкинс&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Forky\/Disney_ToyStory4_Forky.png&quot;,&quot;letskcon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019\/KCON2019.png&quot;,&quot;letsgobluejays&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Toronto\/MLB_2019_Toronto.png&quot;,&quot;electionsue19&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;steverogers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_CaptainAmerica\/Avengers_Endgame_2019_CaptainAmerica.png&quot;,&quot;siemprereal&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Kansas\/MLB_2019_Kansas.png&quot;,&quot;tentokratbuduvolit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EUElections_VoterEngagement_2019\/EUElections_VoterEngagement_2019.png&quot;,&quot;spacebeer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Budweiser_SpaceBeer_2019\/Budweiser_SpaceBeer_2019.png&quot;,&quot;msinnovationsummit&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Microsoft_APAC_2019_v2\/Microsoft_APAC_2019_v2.png&quot;,&quot;parabellum&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/JohnWick_3_ext\/JohnWick_3_ext.png&quot;,&quot;nbb&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBB_2018_2019Season\/NBB_2018_2019Season.png&quot;,&quot;stopsnitchin&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/YG_2019\/YG_2019.png&quot;,&quot;bk99&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Brooklyn99_2019\/Brooklyn99_2019.png&quot;,&quot;平成最後にありがとう&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbemaTV_2019\/AbemaTV_2019.png&quot;,&quot;europawahl2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;máquinadecombate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_WarMachine\/Avengers_Endgame_2019_WarMachine.png&quot;,&quot;グリムノーツ&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/GrimmsEchoes_PR_2019\/GrimmsEchoes_PR_2019.png&quot;,&quot;uniteandconquer&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_ATL\/MLS_19_ATL.png&quot;,&quot;meninmaroon&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_MenInMaroon\/CricketWorldCup_2019_Teams_MenInMaroon.png&quot;,&quot;aaronfinch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_AaronFinch\/CricketWorldCup_2019_Players_AaronFinch.png&quot;,&quot;bll2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HBO_BigLittleLies_Season2_2019\/HBO_BigLittleLies_Season2_2019.png&quot;,&quot;kkr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KolkataKnights_2019\/KolkataKnights_2019.png&quot;,&quot;ojodehalcón&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Hawkeye\/Avengers_Endgame_2019_Hawkeye.png&quot;,&quot;g2army&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_AllAccessTeam_G2_ext19\/Esports_AllAccessTeam_G2_ext19.png&quot;,&quot;rolandgarros&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FrenchOpen_RolandGarros_2019\/FrenchOpen_RolandGarros_2019.png&quot;,&quot;whitesox&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Chicago\/MLB_2019_Chicago.png&quot;,&quot;mibr&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Esports_V2_19_MIBR\/Esports_V2_19_MIBR.png&quot;,&quot;daysgone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PlayStation_DaysGone\/PlayStation_DaysGone.png&quot;,&quot;therookie&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ABC_TheRookie_2018_ext\/ABC_TheRookie_2018_ext.png&quot;,&quot;mickeymouseclub&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Mickey90th_2018\/Mickey90th_2018.png&quot;,&quot;nbatwitterlive&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBATwitterLive2019\/NBATwitterLive2019.png&quot;,&quot;kcon2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KCON2019\/KCON2019.png&quot;,&quot;neverordinary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_Rocketman_Star\/Paramount_Rocketman_Star.png&quot;,&quot;معمل_الصراحة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FairFactory_Jawwy\/FairFactory_Jawwy.png&quot;,&quot;serba10ribu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShopeeRamadan_May_2019\/ShopeeRamadan_May_2019.png&quot;,&quot;vedovanera&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_BlackWidow\/Avengers_Endgame_2019_BlackWidow.png&quot;,&quot;محافظة_العلا&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AlUlaCity_2019\/AlUlaCity_2019.png&quot;,&quot;birdland&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Baltimore\/MLB_2019_Baltimore.png&quot;,&quot;nowapocalypse&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/STARZ_NowApocalypse_2019\/STARZ_NowApocalypse_2019.png&quot;,&quot;pinstripepride&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Yankees\/MLB_2019_Yankees.png&quot;,&quot;nationalconcertweek&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NationalConcertWeek_2019\/NationalConcertWeek_2019.png&quot;,&quot;semanadeeducaçãoemmídia&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;princeali&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;hilanderas&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FeriaDelHilo_v2\/FeriaDelHilo_v2.png&quot;,&quot;من_الرابح_الأكبر&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/invasionarab1_Ramadan_2019\/invasionarab1_Ramadan_2019.png&quot;,&quot;طيران_ناس&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/FlyNas_2019\/FlyNas_2019.png&quot;,&quot;afriendlikeme&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_Genie\/Disney_Aladdin_Genie.png&quot;,&quot;crew96&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLS_19_COL\/MLS_19_COL.png&quot;,&quot;studentsstandup&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Parkland_Extension\/Parkland_Extension.png&quot;,&quot;petcemetary&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Paramount_PetSematary_2019_v2\/Paramount_PetSematary_2019_v2.png&quot;,&quot;vforvictory&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Riot_TeamVitality\/Riot_TeamVitality.png&quot;,&quot;ruinthegame&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/StephenCurry_2019\/StephenCurry_2019.png&quot;,&quot;twinsbéisbol&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Minn\/MLB_2019_Minn.png&quot;,&quot;killthislove&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_BLACKPINK_2019\/KPOP_BLACKPINK_2019.png&quot;,&quot;toystorybopeep&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_BoPeep\/Disney_ToyStory4_BoPeep.png&quot;,&quot;itcapítulo2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_It_Chp2\/WB_It_Chp2.png&quot;,&quot;lechardonneret&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;smashperrier&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NestlePerrier_May2019\/NestlePerrier_May2019.png&quot;,&quot;redmiy3&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/RedmiY3_2019\/RedmiY3_2019.png&quot;,&quot;guccicruise20&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Gucci_Cruise20\/Gucci_Cruise20.png&quot;,&quot;كفاءة_الطاقة&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/taqa_sa_2019\/taqa_sa_2019.png&quot;,&quot;وزارة_الثقافة_السعودية&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MOCSaudi_2019\/MOCSaudi_2019.png&quot;,&quot;afghanatalan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Teams_AfghanAtalan\/CricketWorldCup_2019_Teams_AfghanAtalan.png&quot;,&quot;thegoldfinch&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WB_TheGoldfinch_2019\/WB_TheGoldfinch_2019.png&quot;,&quot;令和ニッポンの未来&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/AbemaTV_2019\/AbemaTV_2019.png&quot;,&quot;dimuthkarunaratne&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/CricketWorldCup_2019_Players_DimuthKarunaratne\/CricketWorldCup_2019_Players_DimuthKarunaratne.png&quot;,&quot;thehaloway&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_LA\/MLB_2019_LA.png&quot;,&quot;lcs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/LCS_2019_change\/LCS_2019_change.png&quot;,&quot;dontknowwhattodo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KPOP_BLACKPINK_2019\/KPOP_BLACKPINK_2019.png&quot;,&quot;booksmartbffs&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Booksmart_2019\/Booksmart_2019.png&quot;,&quot;princealiababwa&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_Aladdin_2019\/Disney_Aladdin_2019.png&quot;,&quot;orbis&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ORBIS_2019\/ORBIS_2019.png&quot;,&quot;shuri&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Shuri\/Avengers_Endgame_2019_Shuri.png&quot;,&quot;wastelandsuperhero&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Bethesda_RAGE2_2019\/Bethesda_RAGE2_2019.png&quot;,&quot;huaweip30&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Huawei_P30_2019\/Huawei_P30_2019.png&quot;,&quot;gohardgoknights&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NRL2019_GoHardGoKnights\/NRL2019_GoHardGoKnights.png&quot;,&quot;shopeebigramadhansale&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ShopeeRamadan_May_2019\/ShopeeRamadan_May_2019.png&quot;,&quot;semanaglobalami&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks\/MediaInformationLiteracyWeeks_2018_GlobalMILWeeks.png&quot;,&quot;feiticeiraescarlate&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_ScarletWitch\/Avengers_Endgame_2019_ScarletWitch.png&quot;,&quot;thor&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Thor\/Avengers_Endgame_2019_Thor.png&quot;,&quot;wakanda&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Okoye\/Avengers_Endgame_2019_Okoye.png&quot;,&quot;mymarksfave&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/PercyPig_2019\/PercyPig_2019.png&quot;,&quot;alleyesnorth&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/NBA_18_MIN\/NBA_18_MIN.png&quot;,&quot;корг&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Korg\/Avengers_Endgame_2019_Korg.png&quot;,&quot;그루트&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Groot\/Avengers_Endgame_2019_Groot.png&quot;,&quot;小火龙&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/WBPikachu_Charmander\/WBPikachu_Charmander.png&quot;,&quot;ramadhan&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Ramadan_2019\/Ramadan_2019.png&quot;,&quot;thehotzone&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/HotZone_NatGeoChannel_2019\/HotZone_NatGeoChannel_2019.png&quot;,&quot;festadopikachu&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Pikachu_Pokemon_PartnerUp_2019\/Pikachu_Pokemon_PartnerUp_2019.png&quot;,&quot;шерифву&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Disney_ToyStory4_Woody\/Disney_ToyStory4_Woody.png&quot;,&quot;korbolorbojeetbo&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/KolkataKnights_2019\/KolkataKnights_2019.png&quot;,&quot;avengers&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019\/Avengers_Endgame_2019.png&quot;,&quot;ドルフロに願いよ届け&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Japan_DreamsComeTrue_2019\/Japan_DreamsComeTrue_2019.png&quot;,&quot;kxip&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/IPL_2019_2_KXIP\/IPL_2019_2_KXIP.png&quot;,&quot;evropskévolby2019&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/EU_Election_2019\/EU_Election_2019.png&quot;,&quot;itcanwait&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/ITCanWait_2019\/ITCanWait_2019.png&quot;,&quot;ボスからtea&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Suntory_CraftBossTea\/Suntory_CraftBossTea.png&quot;,&quot;desde1869&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/MLB_2019_Cincinnati\/MLB_2019_Cincinnati.png&quot;,&quot;doctorstrange&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_DoctorStrange\/Avengers_Endgame_2019_DoctorStrange.png&quot;,&quot;웡&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Avengers_Endgame_2019_Wong\/Avengers_Endgame_2019_Wong.png&quot;,&quot;together_for_life&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Zamzam_2019\/Zamzam_2019.png&quot;,&quot;godzilla2&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/Godzilla_WB_2019\/Godzilla_WB_2019.png&quot;,&quot;magickingdom&quot;:&quot;https:\/\/abs.twimg.com\/hashflags\/DisneyParks_MickeyEars_Flight2\/DisneyParks_MickeyEars_Flight2.png&quot;},&quot;tweetId&quot;:&quot;1128068672289890305&quot;,&quot;profile_id&quot;:238475531,&quot;endpoint&quot;:&quot;\/i\/Metallica\/conversation\/1128068672289890305&quot;,&quot;overlayCapable&quot;:false,&quot;finagleTraceId&quot;:&quot;000c3ae1003af840&quot;,&quot;isThreaded&quot;:true,&quot;inOverlay&quot;:true,&quot;trendsCacheKey&quot;:null,&quot;decider_personalized_trends&quot;:false,&quot;trendsEndpoint&quot;:&quot;\/i\/trends&quot;,&quot;initialState&quot;:{&quot;title&quot;:&quot;Metallica en Twitter: \&quot;Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp; @PompiersParis. #AWMH #MetalicaGivesBack\u2026 https:\/\/t.co\/00ZbffUluP\&quot;&quot;,&quot;section&quot;:null,&quot;module&quot;:&quot;app\/pages\/permalink&quot;,&quot;cache_ttl&quot;:300,&quot;body_class_names&quot;:&quot;three-col logged-out user-style-Metallica western es PermalinkPage&quot;,&quot;doc_class_names&quot;:&quot;route-permalink&quot;,&quot;route_name&quot;:&quot;permalink&quot;,&quot;page_container_class_names&quot;:&quot;AppContent wrapper wrapper-permalink&quot;,&quot;ttft_navigation&quot;:false}}">
+</span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/Metallica?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#Metallica</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/MetOnTour?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#MetOnTour</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/DL20?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#DL20</a></span>
+</div></div></div>
+<div aria-labelledby="id__cd9397h0xvu id__ebnmc84ddvr" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__xptwyy4gyvk"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg"><a href="/Metallica/status/1670883033954791424/mediaviewer" aria-label="Embedded video" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1ny4l3l r-o7ynqc r-6416eg" data-testid="tweet-media-video-interaction-link-1670883033954791424"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-1adg3ll r-pm9dpa r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:56.25%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Embedded video" class="css-1dbjc4n r-1awozwy r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af" data-testid="previewInterstitial">
+<div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Embedded video" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/ext_tw_video_thumb/1670869246434504704/pu/img/C1oncFY5i-wmLSY7?format=jpg&amp;name=large")'></div>
+<img alt="Embedded video" draggable="true" src="https://pbs.twimg.com/ext_tw_video_thumb/1670869246434504704/pu/img/C1oncFY5i-wmLSY7?format=jpg&amp;name=large" class="css-9pa8cd">
+</div></div>
+<div class="css-1dbjc4n r-rki7wi r-18u37iz r-161ttwi r-633pao r-u8s1d">
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-6t5ypu r-zmljjp r-z2wwpe r-kicko2 r-t12b5v r-z80fyv r-1777fci r-a5pmau r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-16dba41 r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1:00</span></div></div>
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-pm2fo r-1dpl46z r-z2wwpe r-ou6ah9 r-notknq r-z80fyv r-1777fci r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-16dba41 r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0">41.7K views</div></div>
+</div>
+<div aria-label="Play this video" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-11mg6pl r-sdzlij r-1phboty r-14f9gny r-e6wyp1 r-1ny4l3l r-o7ynqc r-6416eg r-1p15a4t" data-testid="playButton"><div class="css-1dbjc4n r-1awozwy r-1pi2tsx r-1777fci r-u8s1d r-13qz1uu"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-jwli3a r-4qtqp9 r-yyyyoo r-1sa8knb r-dnmrzs r-1dsia8u r-bnwqim r-1plcrui r-lrvibr r-gcko2u"><g><path d="M21 12L4 2v20l17-10z"></path></g></svg></div></div>
+</div></div>
+</div></div>
+<div itemprop="video" itemscope="" itemtype="https://schema.org/VideoObject">
+<meta content="@Metallica's video Tweet" itemprop="name">
+<meta content="Embedded video" itemprop="description">
+<meta content="https://platform.twitter.com/embed/Tweet.html?dnt=false&amp;embedId=twitter-widget-1&amp;frame=false&amp;hideCard=false&amp;hideThread=false&amp;lang=en&amp;id=1670883033954791424" itemprop="embedUrl">
+<meta content="https://pbs.twimg.com/ext_tw_video_thumb/1670869246434504704/pu/img/C1oncFY5i-wmLSY7.jpg" itemprop="thumbnailUrl">
+<meta content="Embedded video" itemprop="caption">
+<meta content="2023-06-19T19:55:33.000Z" itemprop="uploadDate">
+<meta content="PT0H1M0S" itemprop="duration">
+</div>
+</div></a></div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="37 replies, 352 Retweets, 2296 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__wmn66a2741l">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="37 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">37</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="352 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">352</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="2296 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">2,296</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1670325471379169280" itemprop="identifier">
+<meta content="10" itemprop="position">
+<meta content="39" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-06-18T07:00:00.000Z" itemprop="dateCreated">
+<meta content="2023-06-18T07:00:00.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="238475531" itemprop="identifier">
+<meta content="Metallica" itemprop="additionalName">
+<meta content="Metallica" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/ThDPnKJkdk" itemprop="url">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280/photo/1" itemprop="url">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280/likes" itemprop="url">
+<meta content="1693" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280/retweets" itemprop="url">
+<meta content="151" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280/retweets/with_comments" itemprop="url">
+<meta content="6" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670325471379169280" itemprop="url">
+<meta content="39" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__nwm98f1a4q id__mxymsha6hnf id__5ycjj3yqpdw id__flam2r3m45n id__7oeedbz3gg6 id__ncu1hmpuec9 id__dqmbpavum3j id__nb1cpzis8z id__1o4vb27wjmy id__7sw98pfn9ig id__nsb5llyukr id__988rlf9keq7 id__ayqu6i8xht id__r3j21gfnej id__52g4und8t3g id__wtpp006dd5p id__idqceuy6uc id__vgc8mb2zfl id__la8mmm1chat" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Metallica">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-ggadg3 r-u8s1d r-8jfcpp" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Square profile picture" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg")'></div>
+<img alt="Square profile picture" draggable="true" src="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-1wyvozj r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__7oeedbz3gg6" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Metallica</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><lineargradient gradientunits="userSpaceOnUse" id="18692-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></lineargradient><lineargradient gradientunits="userSpaceOnUse" id="18692-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></lineargradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18692-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18692-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Metallica/status/1670325471379169280" dir="ltr" aria-label="Jun 18" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-06-18T07:00:00.000Z">Jun 18</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__nsb5llyukr" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🇸🇪</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> TONIGHT </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🇸🇪</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
 
+The final </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> show in Europe for 2023! We’ll pick things back up in North America in August, &amp; return to Europe in May 2024.
 
+Show us what you've been up to with </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72Gothenburg?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72Gothenburg</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">.
 
-    <input type="hidden" class="swift-boot-module" value="app/pages/permalink">
-  <input type="hidden" id="swift-module-path" value="https://abs.twimg.com/k/swift/es">
+Posters by </span><div class="css-1dbjc4n r-xoduu5"><span class="r-18u37iz"><a dir="ltr" href="/milestsang" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">@milestsang</a></span></div>
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> from both shows are only available for purchase at the venue.</span>
+</div></div></div>
+<div aria-labelledby="id__zbi2vw826pr id__pbuv2ciw9j" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__ayqu6i8xht"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/Fy2dKRBagAAINZH?format=jpg&amp;name=4096x4096")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/Fy2dKRBagAAINZH?format=jpg&amp;name=4096x4096" class="css-9pa8cd">
+</div></div>
+</div></div></div></div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/Fy2dKRBagAAINZH.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/Fy2dKRBagAAINZH?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="3600" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+</div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="39 replies, 157 Retweets, 1693 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__la8mmm1chat">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="39 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">39</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="157 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">157</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1693 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,693</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1671246544035610627" itemprop="identifier">
+<meta content="11" itemprop="position">
+<meta content="25" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-06-20T20:00:01.000Z" itemprop="dateCreated">
+<meta content="2023-06-20T20:00:01.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="238475531" itemprop="identifier">
+<meta content="Metallica" itemprop="additionalName">
+<meta content="Metallica" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/2aoeiuOIr4" itemprop="url">
+<meta content="http://youtu.be/BWug_HXBXKg" itemprop="url">
+<meta content="https://t.co/Y88XIqAZ6t" itemprop="url">
+<meta content="http://metallica.lnk.to/LiveInDonington2023Night2" itemprop="url">
+<meta content="https://t.co/NBomonxWcg" itemprop="url">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627/video/1" itemprop="url">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627/likes" itemprop="url">
+<meta content="1522" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627/retweets" itemprop="url">
+<meta content="232" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627/retweets/with_comments" itemprop="url">
+<meta content="21" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1671246544035610627" itemprop="url">
+<meta content="25" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__nuhay6zpmm id__yfxq5j5d5s id__6wpi67f7yem id__ham3r15rlsc id__of6rfcaos3 id__ypw5jb1oiq id__98zo6liekq4 id__bdxqcun0zkr id__xmkcci47izb id__nwbuk3xiu3k id__lmbosmqekb id__vcp9bak88x id__llxphgyigi id__a42k37vycx id__j7fx3kv2ays id__lphjcngfb9 id__w164xjnh61c id__41gqe8k0p24 id__llqmz6w7dwr" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Metallica">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-ggadg3 r-u8s1d r-8jfcpp" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Square profile picture" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg")'></div>
+<img alt="Square profile picture" draggable="true" src="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-1wyvozj r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__of6rfcaos3" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Metallica</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><lineargradient gradientunits="userSpaceOnUse" id="18693-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></lineargradient><lineargradient gradientunits="userSpaceOnUse" id="18693-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></lineargradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18693-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18693-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Metallica/status/1671246544035610627" dir="ltr" aria-label="6 hours ago" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-06-20T20:00:01.000Z">6h</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__lmbosmqekb" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">“Now the world is gone, I’m just one…” </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🏴󠁧󠁢󠁥󠁮󠁧󠁿</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72Donington?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72Donington</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> Night 2
 
+Watch the Full Video </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">⚡</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><a dir="ltr" href="https://t.co/2aoeiuOIr4" rel="noopener noreferrer nofollow" target="_blank" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0"><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">http://</span>youtu.be/BWug_HXBXKg</a><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
 
-    <script src="https://abs.twimg.com/k/es/init.es.385f8696ec56dc29cfc0.js" async></script>
+Listen to the Full Show </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">🎧</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><a dir="ltr" href="https://t.co/Y88XIqAZ6t" rel="noopener noreferrer nofollow" target="_blank" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0"><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">http://</span>metallica.lnk.to/LiveInDoningto<span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">n2023Night2</span><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-lrvibr r-qvutc0">…</span></a><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
 
-  </body>
+</span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/Metallica?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#Metallica</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/MetOnTour?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#MetOnTour</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/DL20?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#DL20</a></span>
+</div></div></div>
+<div aria-labelledby="id__w2fq2kb2aua id__pbm0lik7xj9" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__llxphgyigi"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg"><a href="/Metallica/status/1671246544035610627/mediaviewer" aria-label="Embedded video" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1ny4l3l r-o7ynqc r-6416eg" data-testid="tweet-media-video-interaction-link-1671246544035610627"><div class="css-1dbjc4n">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-1adg3ll r-pm9dpa r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:56.25%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Embedded video" class="css-1dbjc4n r-1awozwy r-1p0dtai r-1777fci r-1d2f490 r-u8s1d r-zchlnj r-ipm5af" data-testid="previewInterstitial">
+<div class="css-1dbjc4n r-1p0dtai r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af"><div aria-label="Embedded video" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/ext_tw_video_thumb/1671215998647832576/pu/img/u_TB-J3wjdFUe5WM?format=jpg&amp;name=large")'></div>
+<img alt="Embedded video" draggable="true" src="https://pbs.twimg.com/ext_tw_video_thumb/1671215998647832576/pu/img/u_TB-J3wjdFUe5WM?format=jpg&amp;name=large" class="css-9pa8cd">
+</div></div>
+<div class="css-1dbjc4n r-rki7wi r-18u37iz r-161ttwi r-633pao r-u8s1d">
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-6t5ypu r-zmljjp r-z2wwpe r-kicko2 r-t12b5v r-z80fyv r-1777fci r-a5pmau r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-16dba41 r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1:00</span></div></div>
+<div class="css-1dbjc4n r-1awozwy r-k200y r-loe9s5 r-pm2fo r-1dpl46z r-z2wwpe r-ou6ah9 r-notknq r-z80fyv r-1777fci r-s1qlax r-633pao"><div dir="ltr" class="css-901oao r-jwli3a r-37j5jr r-n6v787 r-16dba41 r-1cwl3u0 r-bcqeeo r-q4m81j r-lrvibr r-qvutc0">23K views</div></div>
+</div>
+<div aria-label="Play this video" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-l5o3uw r-11mg6pl r-sdzlij r-1phboty r-14f9gny r-e6wyp1 r-1ny4l3l r-o7ynqc r-6416eg r-1p15a4t" data-testid="playButton"><div class="css-1dbjc4n r-1awozwy r-1pi2tsx r-1777fci r-u8s1d r-13qz1uu"><svg viewbox="0 0 24 24" aria-hidden="true" class="r-jwli3a r-4qtqp9 r-yyyyoo r-1sa8knb r-dnmrzs r-1dsia8u r-bnwqim r-1plcrui r-lrvibr r-gcko2u"><g><path d="M21 12L4 2v20l17-10z"></path></g></svg></div></div>
+</div></div>
+</div></div>
+<div itemprop="video" itemscope="" itemtype="https://schema.org/VideoObject">
+<meta content="@Metallica's video Tweet" itemprop="name">
+<meta content="Embedded video" itemprop="description">
+<meta content="https://platform.twitter.com/embed/Tweet.html?dnt=false&amp;embedId=twitter-widget-1&amp;frame=false&amp;hideCard=false&amp;hideThread=false&amp;lang=en&amp;id=1671246544035610627" itemprop="embedUrl">
+<meta content="https://pbs.twimg.com/ext_tw_video_thumb/1671215998647832576/pu/img/u_TB-J3wjdFUe5WM.jpg" itemprop="thumbnailUrl">
+<meta content="Embedded video" itemprop="caption">
+<meta content="2023-06-20T20:00:01.000Z" itemprop="uploadDate">
+<meta content="PT0H1M0S" itemprop="duration">
+</div>
+</div></a></div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="25 replies, 253 Retweets, 1522 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__llqmz6w7dwr">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="25 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">25</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="253 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">253</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="1522 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">1,522</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-j5o65s r-qklmqi r-1adg3ll r-1ny4l3l"><div itemprop="hasPart" itemscope="" itemtype="https://schema.org/SocialMediaPosting">
+<meta content="1670857104733913088" itemprop="identifier">
+<meta content="12" itemprop="position">
+<meta content="7" itemprop="commentCount">
+<meta content="" itemprop="contentRating">
+<meta content="2023-06-19T18:12:31.000Z" itemprop="dateCreated">
+<meta content="2023-06-19T18:12:31.000Z" itemprop="datePublished">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088" itemprop="url">
+<div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+<meta content="238475531" itemprop="identifier">
+<meta content="Metallica" itemprop="additionalName">
+<meta content="Metallica" itemprop="givenName">
+</div>
+<div itemprop="sharedContent" itemscope="" itemtype="https://schema.org/CreativeWork">
+<meta content="Expanded Tweet URLs" itemprop="name">
+<meta content="https://t.co/oPRIsN8ZDf" itemprop="url">
+<meta content="http://metallica.com/store/summer-blowout-sale" itemprop="url">
+<meta content="https://t.co/a4FaLT2RCq" itemprop="url">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088/photo/1" itemprop="url">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/LikeAction" itemprop="interactionType">
+<meta content="Likes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088/likes" itemprop="url">
+<meta content="984" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Retweets" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088/retweets" itemprop="url">
+<meta content="71" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Quotes" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088/retweets/with_comments" itemprop="url">
+<meta content="5" itemprop="userInteractionCount">
+</div>
+<div itemprop="interactionStatistic" itemscope="" itemtype="https://schema.org/InteractionCounter">
+<meta content="https://schema.org/InteractAction" itemprop="interactionType">
+<meta content="Replies" itemprop="name">
+<meta content="https://twitter.com/Metallica/status/1670857104733913088" itemprop="url">
+<meta content="7" itemprop="userInteractionCount">
+</div>
+<article aria-labelledby="id__q7t8l8ex2cm id__6ihm538qomy id__cn2y0evtngj id__9r1hed31bac id__8whwxjf2mwp id__brd984q9deb id__gb74n2owlqi id__p217l0l1jm id__x4sfpu0f1xa id__1t4x4qiiwbx id__osoitzof3f id__hj30chsezfw id__32cjqqo1hjj id__s5z5vq0ua0b id__2sda7pjemjq id__1xx52jw976pj id__1vc9wcw808v id__6tgz73g58so id__1qewno0xfnq" role="article" tabindex="-1" class="css-1dbjc4n r-18u37iz r-1ny4l3l r-1udh08x r-1qhn6m8 r-i023vh" data-testid="tweet"><div class="css-1dbjc4n r-eqz5dr r-16y2uox r-1wbh5a2"><div class="css-1dbjc4n r-16y2uox r-1wbh5a2 r-1ny4l3l">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-18u37iz"><div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-ttdzmv"></div></div></div>
+<div class="css-1dbjc4n r-18u37iz">
+<div class="css-1dbjc4n r-1awozwy r-1hwvwag r-18kxxzh r-1b7u577"><div class="css-1dbjc4n" data-testid="Tweet-User-Avatar"><div class="css-1dbjc4n r-18kxxzh r-1wbh5a2 r-13qz1uu"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1adg3ll r-h3s6tt r-bztko3" style="width:48px" data-testid="UserAvatar-Container-Metallica">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-1adg3ll r-1pi2tsx r-1wyvozj r-bztko3 r-u8s1d r-1v2oles r-desppf r-13qz1uu">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div class="css-1dbjc4n r-ggadg3 r-u8s1d r-8jfcpp" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - -4px);width:calc(100% - -4px)"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1niwhzg r-1loqt21 r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"><div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square);clip-path:url(#shape-square);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1niwhzg r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-14lw9ot r-1pi2tsx r-13qz1uu"></div></div>
+<div class="css-1dbjc4n r-14lw9ot r-1wyvozj r-633pao r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-1adg3ll r-1udh08x" style="background-color:rgba(185,202,211,1.00)">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Square profile picture" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg")'></div>
+<img alt="Square profile picture" draggable="true" src="https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_400x400.jpg" class="css-9pa8cd">
+</div></div>
+</div></div>
+<div class="css-1dbjc4n r-1wyvozj r-u8s1d r-1v2oles r-desppf" style="-webkit-clip-path:url(#shape-square-rx-8);clip-path:url(#shape-square-rx-8);height:calc(100% - 4px);width:calc(100% - 4px)"><div class="css-1dbjc4n r-12181gd r-1pi2tsx r-1ny4l3l r-o7ynqc r-6416eg r-13qz1uu"></div></div></a></div></div>
+</div></div>
+</div></div></div></div></div>
+<div class="css-1dbjc4n r-1iusvr4 r-16y2uox r-1777fci r-kzbkwu">
+<div class="css-1dbjc4n r-zl2h9q"><div class="css-1dbjc4n r-k4xj1c r-18u37iz r-1wtj0ep"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs r-1ny4l3l" id="id__8whwxjf2mwp" data-testid="User-Name">
+<div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs"><div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div class="css-1dbjc4n r-1awozwy r-18u37iz r-1wbh5a2 r-dnmrzs">
+<div dir="ltr" class="css-901oao r-1awozwy r-6koalj r-37j5jr r-a023e6 r-b88u0q r-rjixqe r-bcqeeo r-1udh08x r-3s2u2q r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 css-1hf3ou5 r-poiln3 r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">Metallica</span></span></div>
+<div dir="ltr" class="css-901oao r-xoduu5 r-18u37iz r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0" style="color:rgba(15,20,25,1.00)"><span class="css-901oao css-16my406 r-1awozwy r-xoduu5 r-poiln3 r-bcqeeo r-qvutc0"><svg viewbox="0 0 22 22" aria-label="Verified account" role="img" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-9cviqr r-f9ja8p r-og9te1 r-bnwqim r-1plcrui r-lrvibr" data-testid="icon-verified"><g><lineargradient gradientunits="userSpaceOnUse" id="18694-a" x1="4.411" x2="18.083" y1="2.495" y2="21.508"><stop offset="0" stop-color="#f4e72a"></stop><stop offset=".539" stop-color="#cd8105"></stop><stop offset=".68" stop-color="#cb7b00"></stop><stop offset="1" stop-color="#f4ec26"></stop><stop offset="1" stop-color="#f4e72a"></stop></lineargradient><lineargradient gradientunits="userSpaceOnUse" id="18694-b" x1="5.355" x2="16.361" y1="3.395" y2="19.133"><stop offset="0" stop-color="#f9e87f"></stop><stop offset=".406" stop-color="#e2b719"></stop><stop offset=".989" stop-color="#e2b719"></stop></lineargradient><g clip-rule="evenodd" fill-rule="evenodd"><path d="M13.324 3.848L11 1.6 8.676 3.848l-3.201-.453-.559 3.184L2.06 8.095 3.48 11l-1.42 2.904 2.856 1.516.559 3.184 3.201-.452L11 20.4l2.324-2.248 3.201.452.559-3.184 2.856-1.516L18.52 11l1.42-2.905-2.856-1.516-.559-3.184zm-7.09 7.575l3.428 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18694-a)"></path><path d="M13.101 4.533L11 2.5 8.899 4.533l-2.895-.41-.505 2.88-2.583 1.37L4.2 11l-1.284 2.627 2.583 1.37.505 2.88 2.895-.41L11 19.5l2.101-2.033 2.895.41.505-2.88 2.583-1.37L17.8 11l1.284-2.627-2.583-1.37-.505-2.88zm-6.868 6.89l3.429 3.428 5.683-6.206-1.347-1.247-4.4 4.795-2.072-2.072z" fill="url(#18694-b)"></path><path d="M6.233 11.423l3.429 3.428 5.65-6.17.038-.033-.005 1.398-5.683 6.206-3.429-3.429-.003-1.405.005.003z" fill="#d18800"></path></g></g></svg></span></div>
+</div></a></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1wbh5a2 r-13hce6t"><div class="css-1dbjc4n r-1d09ksm r-18u37iz r-1wbh5a2">
+<div class="css-1dbjc4n r-1wbh5a2 r-dnmrzs"><a href="/Metallica" role="link" tabindex="-1" class="css-4rbku5 css-18t94o4 css-1dbjc4n r-1loqt21 r-1wbh5a2 r-dnmrzs r-1ny4l3l"><div dir="ltr" class="css-901oao css-1hf3ou5 r-14j79pv r-18u37iz r-37j5jr r-1wvb978 r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">@Metallica</span></div></a></div>
+<div dir="ltr" aria-hidden="true" class="css-901oao r-14j79pv r-1q142lx r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-s1qlax r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">·</span></div>
+<div class="css-1dbjc4n r-18u37iz r-1q142lx"><a href="/Metallica/status/1670857104733913088" dir="ltr" aria-label="Jun 19" role="link" class="css-4rbku5 css-18t94o4 css-901oao r-14j79pv r-1loqt21 r-xoduu5 r-1q142lx r-1w6e6rj r-37j5jr r-a023e6 r-16dba41 r-9aw3ui r-rjixqe r-bcqeeo r-3s2u2q r-qvutc0"><time datetime="2023-06-19T18:12:31.000Z">Jun 19</time></a></div>
+</div></div>
+</div></div></div></div></div>
+<div itemprop="articleBody" data-testid="tweetTextAnnotations"><div class="css-1dbjc4n"><div dir="auto" lang="en" class="css-901oao r-37j5jr r-a023e6 r-16dba41 r-rjixqe r-bcqeeo r-bnwqim r-qvutc0" style="color:rgba(15,20,25,1.00)" id="id__osoitzof3f" data-testid="tweetText">
+<span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">The Summer Blowout Sale has arrived! </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">☀️</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">
+
+Stock up on your favorite shirts, grab something to wear on the </span><span class="r-18u37iz"><a dir="ltr" href="/hashtag/M72?src=hashtag_click" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0">#M72</a></span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> World Tour, take home a mystery tour shirt for $6.99, and more!
+
+Shop The Met Store </span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">➡️</span><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0"> </span><a dir="ltr" href="https://t.co/oPRIsN8ZDf" rel="noopener noreferrer nofollow" target="_blank" role="link" class="css-4rbku5 css-18t94o4 css-901oao css-16my406 r-1cvl2hr r-1loqt21 r-poiln3 r-bcqeeo r-qvutc0"><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">http://</span>metallica.com/store/summer-b<span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-hiw28u r-qvk6io r-bcqeeo r-qvutc0">lowout-sale</span><span aria-hidden="true" class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-lrvibr r-qvutc0">…</span></a>
+</div></div></div>
+<div aria-labelledby="id__0d2lf38vx71u id__p7xwriqrsq" class="css-1dbjc4n r-1ssbvtb r-1s2bzr4" id="id__32cjqqo1hjj"><div class="css-1dbjc4n r-9aw3ui"><div class="css-1dbjc4n"><div class="css-1dbjc4n r-1ets6dv r-1867qdf r-1phboty r-rs99b7 r-1ny4l3l r-1udh08x r-o7ynqc r-6416eg">
+<div class="css-1dbjc4n"><div class="css-1dbjc4n r-16y2uox r-1pi2tsx r-13qz1uu"><div role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1pi2tsx r-1ny4l3l"><div class="css-1dbjc4n r-1adg3ll r-1udh08x">
+<div class="r-1adg3ll r-13qz1uu" style="padding-bottom:100%"></div>
+<div class="r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-ipm5af r-13qz1uu"><div aria-label="Image" class="css-1dbjc4n r-1p0dtai r-1mlwlqe r-1d2f490 r-1udh08x r-u8s1d r-zchlnj r-ipm5af r-417010" data-testid="tweetPhoto">
+<div class="css-1dbjc4n r-1niwhzg r-vvn4in r-u6sd8q r-4gszlv r-1p0dtai r-1pi2tsx r-1d2f490 r-u8s1d r-zchlnj r-ipm5af r-13qz1uu r-1wyyakw" style='background-image:url("https://pbs.twimg.com/media/FzATqXSaIAANy4B?format=jpg&amp;name=medium")'></div>
+<img alt="Image" draggable="true" src="https://pbs.twimg.com/media/FzATqXSaIAANy4B?format=jpg&amp;name=medium" class="css-9pa8cd">
+</div></div>
+</div></div></div></div>
+<div itemprop="image" itemscope="" itemtype="https://schema.org/ImageObject">
+<meta content="Image" itemprop="caption">
+<meta content="https://pbs.twimg.com/media/FzATqXSaIAANy4B.jpg" itemprop="contentUrl">
+<meta content="https://pbs.twimg.com/media/FzATqXSaIAANy4B?format=jpg&amp;name=thumb" itemprop="thumbnailUrl">
+<meta content="1200" itemprop="width">
+<meta content="" itemprop="contentRating">
+</div>
+</div></div></div></div>
+<div class="css-1dbjc4n"><div aria-label="7 replies, 76 Retweets, 984 likes" role="group" class="css-1dbjc4n r-1ta3fxp r-18u37iz r-1wtj0ep r-1s2bzr4 r-1mdbhws" id="id__1qewno0xfnq">
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="7 Replies. Reply" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="reply"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M1.751 10c0-4.42 3.584-8 8.005-8h4.366c4.49 0 8.129 3.64 8.129 8.13 0 2.96-1.607 5.68-4.196 7.11l-8.054 4.46v-3.69h-.067c-4.49.1-8.183-3.51-8.183-8.01zm8.005-6c-3.317 0-6.005 2.69-6.005 6 0 3.37 2.77 6.08 6.138 6.01l.351-.01h1.761v2.3l5.087-2.81c1.951-1.08 3.163-3.13 3.163-5.36 0-3.39-2.744-6.13-6.129-6.13H9.756z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">7</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="76 Retweets. Retweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="retweet"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M4.5 3.88l4.432 4.14-1.364 1.46L5.5 7.55V16c0 1.1.896 2 2 2H13v2H7.5c-2.209 0-4-1.79-4-4V7.55L1.432 9.48.068 8.02 4.5 3.88zM16.5 6H11V4h5.5c2.209 0 4 1.79 4 4v8.45l2.068-1.93 1.364 1.46-4.432 4.14-4.432-4.14 1.364-1.46 2.068 1.93V8c0-1.1-.896-2-2-2z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">76</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-label="984 Likes. Like" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr" data-testid="like"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0">
+<div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M16.697 5.5c-1.222-.06-2.679.51-3.89 2.16l-.805 1.09-.806-1.09C9.984 6.01 8.526 5.44 7.304 5.5c-1.243.07-2.349.78-2.91 1.91-.552 1.12-.633 2.78.479 4.82 1.074 1.97 3.257 4.27 7.129 6.61 3.87-2.34 6.052-4.64 7.126-6.61 1.111-2.04 1.03-3.7.477-4.82-.561-1.13-1.666-1.84-2.908-1.91zm4.187 7.69c-1.351 2.48-4.001 5.12-8.379 7.67l-.503.3-.504-.3c-4.379-2.55-7.029-5.19-8.382-7.67-1.36-2.5-1.41-4.86-.514-6.67.887-1.79 2.647-2.91 4.601-3.01 1.651-.09 3.368.56 4.798 2.01 1.429-1.45 3.146-2.1 4.796-2.01 1.954.1 3.714 1.22 4.601 3.01.896 1.81.846 4.17-.514 6.67z"></path></g></svg>
+</div>
+<div class="css-1dbjc4n r-xoduu5 r-1udh08x"><span data-testid="app-text-transition-container" style="transition-property:transform;transition-duration:0.3s;transform:translate3d(0, 0, 0)"><span class="css-901oao css-16my406 r-poiln3 r-n6v787 r-1cwl3u0 r-vc7bo5 r-1pn2ns4 r-qvutc0"><span class="css-901oao css-16my406 r-poiln3 r-bcqeeo r-qvutc0">984</span></span></span></div>
+</div></div></div>
+<div class="css-1dbjc4n" style="display:inline-grid;-webkit-justify-content:inherit;justify-content:inherit;-webkit-transform:rotate(0deg) scale(1) translate3d(0, 0, 0);transform:rotate(0deg) scale(1) translate3d(0, 0, 0);-ms-flex-pack:inherit;-webkit-box-pack:inherit"><div class="css-1dbjc4n r-18u37iz r-1h0z5md"><div aria-expanded="false" aria-haspopup="menu" aria-label="Share Tweet" role="button" tabindex="0" class="css-18t94o4 css-1dbjc4n r-1777fci r-bt1l66 r-1ny4l3l r-bztko3 r-lrvibr"><div dir="ltr" class="css-901oao r-1awozwy r-14j79pv r-6koalj r-37j5jr r-a023e6 r-16dba41 r-1h0z5md r-rjixqe r-bcqeeo r-o7ynqc r-clp7b1 r-3s2u2q r-qvutc0"><div class="css-1dbjc4n r-xoduu5">
+<div class="css-1dbjc4n r-1niwhzg r-sdzlij r-1p0dtai r-xoduu5 r-1d2f490 r-xf4iuw r-1ny4l3l r-u8s1d r-zchlnj r-ipm5af r-o7ynqc r-6416eg"></div>
+<svg viewbox="0 0 24 24" aria-hidden="true" class="r-4qtqp9 r-yyyyoo r-1xvli5t r-dnmrzs r-bnwqim r-1plcrui r-lrvibr r-1hdv0qi"><g><path d="M12 2.59l5.7 5.7-1.41 1.42L13 6.41V16h-2V6.41l-3.3 3.3-1.41-1.42L12 2.59zM21 15l-.02 3.51c0 1.38-1.12 2.49-2.5 2.49H5.5C4.11 21 3 19.88 3 18.5V15h2v3.5c0 .28.22.5.5.5h12.98c.28 0 .5-.22.5-.5L19 15h2z"></path></g></svg>
+</div></div></div></div></div>
+</div></div>
+</div>
+</div>
+</div></div></article>
+</div></div>
+<div class="css-1dbjc4n r-o52ifk"><div class="css-1dbjc4n r-o52ifk"></div></div>
+</div></div></section>
+</div></div></div></div></div></div></main><div aria-valuemax="1" aria-valuemin="0" role="progressbar" class="css-1dbjc4n r-1awozwy r-1777fci" style="width:300px"><div class="css-1dbjc4n r-17bb2tj r-1muvv40 r-127358a r-1ldzwu0" style="height:26px;width:26px"><svg height="100%" viewbox="0 0 32 32" width="100%"><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;opacity:0.2"></circle><circle cx="16" cy="16" fill="none" r="14" stroke-width="4" style="stroke:#1D9BF0;stroke-dasharray:80;stroke-dashoffset:60"></circle></svg></div></div>
+</div></div></div></div>
+</body>
 </html>

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -118,9 +118,9 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
     let(:link) { "https://twitter.com/discourse/status/1428031057186627589" }
     let(:html) { described_class.new(link).to_html }
 
-    it "does not match the url" do
+    it "does match the url" do
       onebox = Onebox::Matcher.new(link, { allowed_iframe_regexes: [/.*/] }).oneboxed
-      expect(onebox).not_to be(described_class)
+      expect(onebox).to be(described_class)
     end
 
     it "logs a warn message if rate limited" do

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+include ActionView::Helpers::NumberHelper
 
 RSpec.describe Onebox::Engine::TwitterStatusOnebox do
   shared_examples_for "#to_html" do
@@ -57,13 +58,11 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
   shared_context "with quoted tweet info" do
     before do
-      @link = "https://twitter.com/metallica/status/1128068672289890305"
+      @link = "https://twitter.com/Metallica/status/1128068672289890305"
       @onebox_fixture = "twitterstatus_quoted"
 
-      stub_request(:get, @link.downcase).to_return(
-        status: 200,
-        body: onebox_response(@onebox_fixture),
-      )
+      stub_request(:head, @link)
+      stub_request(:get, @link).to_return(status: 200, body: onebox_response(@onebox_fixture))
     end
 
     let(:full_name) { "Metallica" }
@@ -154,7 +153,6 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
           status: api_response,
           prettify_tweet: tweet_content,
           twitter_credentials_missing?: false,
-          prettify_number: favorite_count,
         )
 
       @previous_options = Onebox.options.to_h

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -42,17 +42,17 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
   shared_context "with standard tweet info" do
     before do
-      @link = "https://twitter.com/vyki_e/status/363116819147538433"
+      @link = "https://twitter.com/MKBHD/status/1625192182859632661"
       @onebox_fixture = "twitterstatus"
     end
 
-    let(:full_name) { "Vyki Englert" }
-    let(:screen_name) { "vyki_e" }
-    let(:avatar) { "732349210264133632/RTNgZLrm_400x400.jpg" }
-    let(:timestamp) { "6:59 PM - 1 Aug 2013" }
+    let(:full_name) { "Marques Brownlee" }
+    let(:screen_name) { "MKBHD" }
+    let(:avatar) { "https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_normal.jpg" }
+    let(:timestamp) { "5:56 PM - 13 Feb 2023" }
     let(:link) { @link }
-    let(:favorite_count) { "0" }
-    let(:retweets_count) { "0" }
+    let(:favorite_count) { "47K" }
+    let(:retweets_count) { "1.5K" }
   end
 
   shared_context "with quoted tweet info" do
@@ -68,11 +68,11 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
     let(:full_name) { "Metallica" }
     let(:screen_name) { "Metallica" }
-    let(:avatar) { "profile_images/766360293953802240/kt0hiSmv_400x400.jpg" }
+    let(:avatar) { "https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_normal.jpg" }
     let(:timestamp) { "10:45 PM - 13 May 2019" }
     let(:link) { @link }
-    let(:favorite_count) { "1.7K" }
-    let(:retweets_count) { "201" }
+    let(:favorite_count) { "1.4K" }
+    let(:retweets_count) { "170" }
   end
 
   shared_context "with featured image info" do
@@ -88,11 +88,11 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
     let(:full_name) { "Jeff Atwood" }
     let(:screen_name) { "codinghorror" }
-    let(:avatar) { "" }
+    let(:avatar) { "https://pbs.twimg.com/profile_images/1517287320235298816/Qx-O6UCY_normal.jpg" }
     let(:timestamp) { "3:02 PM - 27 Jun 2021" }
     let(:link) { @link }
     let(:favorite_count) { "90" }
-    let(:retweets_count) { "0" }
+    let(:retweets_count) { "5" }
   end
 
   shared_examples "includes quoted tweet data" do
@@ -137,7 +137,7 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
       stub_request(
         :get,
-        "https://api.twitter.com/1.1/statuses/show.json?id=1428031057186627589&tweet_mode=extended",
+        "https://api.twitter.com/2/tweets/1428031057186627589?tweet.fields=id,author_id,text,created_at,entities,referenced_tweets,public_metrics&user.fields=id,name,username,profile_image_url&media.fields=type,height,width,variants,preview_image_url,url&expansions=attachments.media_keys,referenced_tweets.id.author_id",
       ).to_return(status: 429, body: "{}", headers: {})
 
       Rails.logger.expects(:warn).with(regexp_matches(/rate limit/)).at_least_once
@@ -164,118 +164,47 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
     after { Onebox.options = @previous_options }
 
     context "with a standard tweet" do
-      let(:tweet_content) do
-        "I'm a sucker for pledges.  <a href='https://twitter.com/Peers' target='_blank'>@Peers</a> Pledge <a href='https://twitter.com/search?q=%23sharingeconomy' target='_blank'>#sharingeconomy</a> <a target='_blank' href='http://www.peers.org/action/peers-pledgea/'>peers.org/action/peers-p…</a>"
-      end
+      let(:tweet_content) { "I've never played Minecraft" }
 
       let(:api_response) do
         {
-          created_at: "Fri Aug 02 01:59:30 +0000 2013",
-          id: 363_116_819_147_538_400,
-          id_str: "363116819147538433",
-          text: "I'm a sucker for pledges. @Peers Pledge #sharingeconomy http://t.co/T4Sc47KAzh",
-          truncated: false,
-          entities: {
-            hashtags: [{ text: "sharingeconomy", indices: [41, 56] }],
-            symbols: [],
-            user_mentions: [
-              {
-                screen_name: "peers",
-                name: "Peers",
-                id: 1_428_357_889,
-                id_str: "1428357889",
-                indices: [27, 33],
-              },
-            ],
-            urls: [
-              {
-                url: "http://t.co/T4Sc47KAzh",
-                expanded_url: "http://www.peers.org/action/peers-pledgea/",
-                display_url: "peers.org/action/peers-p…",
-                indices: [57, 79],
-              },
-            ],
-          },
-          source:
-            "<a href=\"https://dev.twitter.com/docs/tfw\" rel=\"nofollow\">Twitter for Websites</a>",
-          in_reply_to_status_id: nil,
-          in_reply_to_status_id_str: nil,
-          in_reply_to_user_id: nil,
-          in_reply_to_user_id_str: nil,
-          in_reply_to_screen_name: nil,
-          user: {
-            id: 1_087_064_150,
-            id_str: "1087064150",
-            name: "Vyki Englert",
-            screen_name: "vyki_e",
-            location: "Los Angeles, CA",
-            description:
-              "Rides bikes, writes code, likes maps. @CompilerLA / @CityGrows / Brigade Captain @HackforLA",
-            url: "http://t.co/YCAP3asRG1",
-            entities: {
-              url: {
-                urls: [
-                  {
-                    url: "http://t.co/YCAP3asRG1",
-                    expanded_url: "http://www.compiler.la",
-                    display_url: "compiler.la",
-                    indices: [0, 22],
-                  },
-                ],
-              },
-              description: {
-                urls: [],
-              },
+          data: {
+            edit_history_tweet_ids: ["1625192182859632661"],
+            created_at: "2023-02-13T17:56:25.000Z",
+            author_id: "29873662",
+            public_metrics: {
+              retweet_count: 1460,
+              reply_count: 2734,
+              like_count: 46_756,
+              quote_count: 477,
+              bookmark_count: 168,
+              impression_count: 4_017_878,
             },
-            protected: false,
-            followers_count: 1128,
-            friends_count: 2244,
-            listed_count: 83,
-            created_at: "Sun Jan 13 19:53:00 +0000 2013",
-            favourites_count: 2928,
-            utc_offset: -25_200,
-            time_zone: "Pacific Time (US & Canada)",
-            geo_enabled: true,
-            verified: false,
-            statuses_count: 3295,
-            lang: "en",
-            contributors_enabled: false,
-            is_translator: false,
-            is_translation_enabled: false,
-            profile_background_color: "ACDED6",
-            profile_background_image_url: "http://abs.twimg.com/images/themes/theme18/bg.gif",
-            profile_background_image_url_https:
-              "https://abs.twimg.com/images/themes/theme18/bg.gif",
-            profile_background_tile: false,
-            profile_image_url:
-              "http://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_normal.jpg",
-            profile_image_url_https:
-              "https://pbs.twimg.com/profile_images/732349210264133632/RTNgZLrm_normal.jpg",
-            profile_banner_url: "https://pbs.twimg.com/profile_banners/1087064150/1424315468",
-            profile_link_color: "4E99D1",
-            profile_sidebar_border_color: "EEEEEE",
-            profile_sidebar_fill_color: "F6F6F6",
-            profile_text_color: "333333",
-            profile_use_background_image: true,
-            has_extended_profile: false,
-            default_profile: false,
-            default_profile_image: false,
-            following: false,
-            follow_request_sent: false,
-            notifications: false,
+            text: "I've never played Minecraft",
+            entities: {
+              annotations: [
+                {
+                  start: 18,
+                  end: 26,
+                  probability: 0.9807,
+                  type: "Other",
+                  normalized_text: "Minecraft",
+                },
+              ],
+            },
+            id: "1625192182859632661",
           },
-          geo: nil,
-          coordinates: nil,
-          place: nil,
-          contributors: nil,
-          is_quote_status: false,
-          retweet_count: 0,
-          favorite_count: 0,
-          favorited: false,
-          retweeted: false,
-          possibly_sensitive: false,
-          possibly_sensitive_appealable: false,
-          lang: "en",
+          includes: {
+            users: [
+              {
+                name: "Marques Brownlee",
+                id: "29873662",
+                profile_image_url:
+                  "https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_normal.jpg",
+                username: "MKBHD",
+              },
+            ],
+          },
         }
       end
 
@@ -293,372 +222,167 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
       let(:api_response) do
         {
-          created_at: "Mon May 13 22:45:04 +0000 2019",
-          id: 1_128_068_672_289_890_305,
-          id_str: "1128068672289890305",
-          full_text:
-            "Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp; @PompiersParis. #AWMH #MetalicaGivesBack https://t.co/gLtZSdDFmN",
-          truncated: false,
-          display_text_range: [0, 148],
-          entities: {
-            hashtags: [
-              { text: "MetInParis", indices: [39, 50] },
-              { text: "AWMH", indices: [124, 129] },
-              { text: "MetalicaGivesBack", indices: [130, 148] },
-            ],
-            symbols: [],
-            user_mentions: [
-              {
-                screen_name: "EMMAUSolidarite",
-                name: "EMMAÜS Solidarité",
-                id: 2_912_493_406,
-                id_str: "2912493406",
-                indices: [85, 101],
-              },
-              {
-                screen_name: "PompiersParis",
-                name: "Pompiers de Paris",
-                id: 1_342_191_438,
-                id_str: "1342191438",
-                indices: [108, 122],
-              },
-            ],
-            urls: [
-              {
-                url: "https://t.co/gLtZSdDFmN",
-                expanded_url: "https://twitter.com/AWMHFoundation/status/1127646016931487744",
-                display_url: "twitter.com/AWMHFoundation…",
-                indices: [149, 172],
-              },
-            ],
-          },
-          source: "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
-          in_reply_to_status_id: nil,
-          in_reply_to_status_id_str: nil,
-          in_reply_to_user_id: nil,
-          in_reply_to_user_id_str: nil,
-          in_reply_to_screen_name: nil,
-          user: {
-            id: 238_475_531,
-            id_str: "238475531",
-            name: "Metallica",
-            screen_name: "Metallica",
-            location: "San Francisco, CA",
-            description: "http://t.co/EAkqroM0OA | http://t.co/BEu6OVRhKG",
-            url: "http://t.co/kVxaQpmqSI",
+          data: {
+            text:
+              "Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp; @PompiersParis. #AWMH #MetalicaGivesBack https://t.co/gLtZSdDFmN",
+            edit_history_tweet_ids: ["1128068672289890305"],
             entities: {
-              url: {
-                urls: [
-                  {
-                    url: "http://t.co/kVxaQpmqSI",
-                    expanded_url: "http://www.metallica.com",
-                    display_url: "metallica.com",
-                    indices: [0, 22],
-                  },
-                ],
-              },
-              description: {
-                urls: [
-                  {
-                    url: "http://t.co/EAkqroM0OA",
-                    expanded_url: "http://metallica.com",
-                    display_url: "metallica.com",
-                    indices: [0, 22],
-                  },
-                  {
-                    url: "http://t.co/BEu6OVRhKG",
-                    expanded_url: "http://livemetallica.com",
-                    display_url: "livemetallica.com",
-                    indices: [25, 47],
-                  },
-                ],
-              },
-            },
-            protected: false,
-            followers_count: 5_760_661,
-            friends_count: 31,
-            listed_count: 12_062,
-            created_at: "Sat Jan 15 07:34:59 +0000 2011",
-            favourites_count: 567,
-            utc_offset: nil,
-            time_zone: nil,
-            geo_enabled: true,
-            verified: true,
-            statuses_count: 3764,
-            lang: nil,
-            contributors_enabled: false,
-            is_translator: false,
-            is_translation_enabled: false,
-            profile_background_color: "000000",
-            profile_background_image_url: "http://abs.twimg.com/images/themes/theme9/bg.gif",
-            profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme9/bg.gif",
-            profile_background_tile: false,
-            profile_image_url:
-              "http://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_normal.jpg",
-            profile_image_url_https:
-              "https://pbs.twimg.com/profile_images/766360293953802240/kt0hiSmv_normal.jpg",
-            profile_banner_url: "https://pbs.twimg.com/profile_banners/238475531/1479538295",
-            profile_link_color: "2FC2EF",
-            profile_sidebar_border_color: "000000",
-            profile_sidebar_fill_color: "252429",
-            profile_text_color: "666666",
-            profile_use_background_image: false,
-            has_extended_profile: false,
-            default_profile: false,
-            default_profile_image: false,
-            following: false,
-            follow_request_sent: false,
-            notifications: false,
-            translator_type: "regular",
-          },
-          geo: nil,
-          coordinates: nil,
-          place: nil,
-          contributors: nil,
-          is_quote_status: true,
-          quoted_status_id: 1_127_646_016_931_487_744,
-          quoted_status_id_str: "1127646016931487744",
-          quoted_status_permalink: {
-            url: "https://t.co/gLtZSdDFmN",
-            expanded: "https://twitter.com/AWMHFoundation/status/1127646016931487744",
-            display: "twitter.com/AWMHFoundation…",
-          },
-          quoted_status: {
-            created_at: "Sun May 12 18:45:35 +0000 2019",
-            id: 1_127_646_016_931_487_744,
-            id_str: "1127646016931487744",
-            full_text:
-              "If you bought a ticket for tonight’s @Metallica show at Stade de France, you have helped contribute to @EMMAUSolidarite &amp; @PompiersParis. #MetallicaGivesBack #AWMH #MetInParis https://t.co/wlUtDQbQEK",
-            truncated: false,
-            display_text_range: [0, 179],
-            entities: {
+              mentions: [
+                { start: 85, end: 101, username: "EMMAUSolidarite", id: "2912493406" },
+                { start: 108, end: 122, username: "PompiersParis", id: "1342191438" },
+              ],
+              urls: [
+                {
+                  start: 149,
+                  end: 172,
+                  url: "https://t.co/gLtZSdDFmN",
+                  expanded_url: "https://twitter.com/AWMHFoundation/status/1127646016931487744",
+                  display_url: "twitter.com/AWMHFoundation…",
+                },
+              ],
               hashtags: [
-                { text: "MetallicaGivesBack", indices: [142, 161] },
-                { text: "AWMH", indices: [162, 167] },
-                { text: "MetInParis", indices: [168, 179] },
+                { start: 39, end: 50, tag: "MetInParis" },
+                { start: 124, end: 129, tag: "AWMH" },
+                { start: 130, end: 148, tag: "MetalicaGivesBack" },
               ],
-              symbols: [],
-              user_mentions: [
+              annotations: [
                 {
-                  screen_name: "Metallica",
-                  name: "Metallica",
-                  id: 238_475_531,
-                  id_str: "238475531",
-                  indices: [37, 47],
+                  start: 40,
+                  end: 49,
+                  probability: 0.6012,
+                  type: "Other",
+                  normalized_text: "MetInParis",
                 },
                 {
-                  screen_name: "EMMAUSolidarite",
-                  name: "EMMAÜS Solidarité",
-                  id: 2_912_493_406,
-                  id_str: "2912493406",
-                  indices: [103, 119],
+                  start: 125,
+                  end: 128,
+                  probability: 0.5884,
+                  type: "Other",
+                  normalized_text: "AWMH",
                 },
                 {
-                  screen_name: "PompiersParis",
-                  name: "Pompiers de Paris",
-                  id: 1_342_191_438,
-                  id_str: "1342191438",
-                  indices: [126, 140],
-                },
-              ],
-              urls: [],
-              media: [
-                {
-                  id: 1_127_645_176_183_250_944,
-                  id_str: "1127645176183250944",
-                  indices: [180, 203],
-                  media_url: "http://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg",
-                  media_url_https: "https://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg",
-                  url: "https://t.co/wlUtDQbQEK",
-                  display_url: "pic.twitter.com/wlUtDQbQEK",
-                  expanded_url:
-                    "https://twitter.com/AWMHFoundation/status/1127646016931487744/photo/1",
-                  type: "photo",
-                  sizes: {
-                    large: {
-                      w: 2048,
-                      h: 1498,
-                      resize: "fit",
-                    },
-                    thumb: {
-                      w: 150,
-                      h: 150,
-                      resize: "crop",
-                    },
-                    medium: {
-                      w: 1200,
-                      h: 877,
-                      resize: "fit",
-                    },
-                    small: {
-                      w: 680,
-                      h: 497,
-                      resize: "fit",
-                    },
-                  },
+                  start: 131,
+                  end: 147,
+                  probability: 0.6366,
+                  type: "Other",
+                  normalized_text: "MetalicaGivesBack",
                 },
               ],
             },
-            extended_entities: {
-              media: [
-                {
-                  id: 1_127_645_176_183_250_944,
-                  id_str: "1127645176183250944",
-                  indices: [180, 203],
-                  media_url: "http://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg",
-                  media_url_https: "https://pbs.twimg.com/media/D6YzUC8V4AApDdF.jpg",
-                  url: "https://t.co/wlUtDQbQEK",
-                  display_url: "pic.twitter.com/wlUtDQbQEK",
-                  expanded_url:
-                    "https://twitter.com/AWMHFoundation/status/1127646016931487744/photo/1",
-                  type: "photo",
-                  sizes: {
-                    large: {
-                      w: 2048,
-                      h: 1498,
-                      resize: "fit",
-                    },
-                    thumb: {
-                      w: 150,
-                      h: 150,
-                      resize: "crop",
-                    },
-                    medium: {
-                      w: 1200,
-                      h: 877,
-                      resize: "fit",
-                    },
-                    small: {
-                      w: 680,
-                      h: 497,
-                      resize: "fit",
-                    },
-                  },
-                },
-                {
-                  id: 1_127_645_195_384_774_657,
-                  id_str: "1127645195384774657",
-                  indices: [180, 203],
-                  media_url: "http://pbs.twimg.com/media/D6YzVKeV4AEPpSQ.jpg",
-                  media_url_https: "https://pbs.twimg.com/media/D6YzVKeV4AEPpSQ.jpg",
-                  url: "https://t.co/wlUtDQbQEK",
-                  display_url: "pic.twitter.com/wlUtDQbQEK",
-                  expanded_url:
-                    "https://twitter.com/AWMHFoundation/status/1127646016931487744/photo/1",
-                  type: "photo",
-                  sizes: {
-                    thumb: {
-                      w: 150,
-                      h: 150,
-                      resize: "crop",
-                    },
-                    medium: {
-                      w: 1200,
-                      h: 922,
-                      resize: "fit",
-                    },
-                    small: {
-                      w: 680,
-                      h: 522,
-                      resize: "fit",
-                    },
-                    large: {
-                      w: 2048,
-                      h: 1574,
-                      resize: "fit",
-                    },
-                  },
-                },
-              ],
+            id: "1128068672289890305",
+            referenced_tweets: [{ type: "quoted", id: "1127646016931487744" }],
+            created_at: "2019-05-13T22:45:04.000Z",
+            public_metrics: {
+              retweet_count: 171,
+              reply_count: 21,
+              like_count: 1424,
+              quote_count: 0,
+              bookmark_count: 2,
+              impression_count: 0,
             },
-            source: "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
-            in_reply_to_status_id: nil,
-            in_reply_to_status_id_str: nil,
-            in_reply_to_user_id: nil,
-            in_reply_to_user_id_str: nil,
-            in_reply_to_screen_name: nil,
-            user: {
-              id: 886_959_980_254_871_552,
-              id_str: "886959980254871552",
-              name: "All Within My Hands Foundation",
-              screen_name: "AWMHFoundation",
-              location: "",
-              description: "",
-              url: "https://t.co/KgwIPrVVhg",
-              entities: {
-                url: {
+            author_id: "238475531",
+          },
+          includes: {
+            users: [
+              {
+                profile_image_url:
+                  "https://pbs.twimg.com/profile_images/1597280886809952256/gsJvGiqU_normal.jpg",
+                name: "Metallica",
+                id: "238475531",
+                username: "Metallica",
+              },
+              {
+                profile_image_url:
+                  "https://pbs.twimg.com/profile_images/935181032185241600/D8FoOIRJ_normal.jpg",
+                name: "All Within My Hands Foundation",
+                id: "886959980254871552",
+                username: "AWMHFoundation",
+              },
+            ],
+            tweets: [
+              {
+                text:
+                  "If you bought a ticket for tonight’s @Metallica show at Stade de France, you have helped contribute to @EMMAUSolidarite &amp; @PompiersParis. #MetallicaGivesBack #AWMH #MetInParis https://t.co/wlUtDQbQEK",
+                edit_history_tweet_ids: ["1127646016931487744"],
+                entities: {
+                  mentions: [
+                    { start: 37, end: 47, username: "Metallica", id: "238475531" },
+                    { start: 103, end: 119, username: "EMMAUSolidarite", id: "2912493406" },
+                    { start: 126, end: 140, username: "PompiersParis", id: "1342191438" },
+                  ],
                   urls: [
                     {
-                      url: "https://t.co/KgwIPrVVhg",
-                      expanded_url: "http://allwithinmyhands.org",
-                      display_url: "allwithinmyhands.org",
-                      indices: [0, 23],
+                      start: 180,
+                      end: 203,
+                      url: "https://t.co/wlUtDQbQEK",
+                      expanded_url:
+                        "https://twitter.com/AWMHFoundation/status/1127646016931487744/photo/1",
+                      display_url: "pic.twitter.com/wlUtDQbQEK",
+                      media_key: "3_1127645176183250944",
+                    },
+                    {
+                      start: 180,
+                      end: 203,
+                      url: "https://t.co/wlUtDQbQEK",
+                      expanded_url:
+                        "https://twitter.com/AWMHFoundation/status/1127646016931487744/photo/1",
+                      display_url: "pic.twitter.com/wlUtDQbQEK",
+                      media_key: "3_1127645195384774657",
+                    },
+                  ],
+                  hashtags: [
+                    { start: 142, end: 161, tag: "MetallicaGivesBack" },
+                    { start: 162, end: 167, tag: "AWMH" },
+                    { start: 168, end: 179, tag: "MetInParis" },
+                  ],
+                  annotations: [
+                    {
+                      start: 56,
+                      end: 70,
+                      probability: 0.7845,
+                      type: "Place",
+                      normalized_text: "Stade de France",
+                    },
+                    {
+                      start: 143,
+                      end: 160,
+                      probability: 0.5569,
+                      type: "Organization",
+                      normalized_text: "MetallicaGivesBack",
+                    },
+                    {
+                      start: 163,
+                      end: 166,
+                      probability: 0.4496,
+                      type: "Other",
+                      normalized_text: "AWMH",
+                    },
+                    {
+                      start: 169,
+                      end: 178,
+                      probability: 0.3784,
+                      type: "Place",
+                      normalized_text: "MetInParis",
                     },
                   ],
                 },
-                description: {
-                  urls: [],
+                id: "1127646016931487744",
+                created_at: "2019-05-12T18:45:35.000Z",
+                attachments: {
+                  media_keys: %w[3_1127645176183250944 3_1127645195384774657],
                 },
+                public_metrics: {
+                  retweet_count: 34,
+                  reply_count: 5,
+                  like_count: 241,
+                  quote_count: 9,
+                  bookmark_count: 0,
+                  impression_count: 0,
+                },
+                author_id: "886959980254871552",
               },
-              protected: false,
-              followers_count: 5962,
-              friends_count: 6,
-              listed_count: 15,
-              created_at: "Mon Jul 17 14:45:13 +0000 2017",
-              favourites_count: 30,
-              utc_offset: nil,
-              time_zone: nil,
-              geo_enabled: true,
-              verified: false,
-              statuses_count: 241,
-              lang: nil,
-              contributors_enabled: false,
-              is_translator: false,
-              is_translation_enabled: false,
-              profile_background_color: "000000",
-              profile_background_image_url: "http://abs.twimg.com/images/themes/theme1/bg.png",
-              profile_background_image_url_https:
-                "https://abs.twimg.com/images/themes/theme1/bg.png",
-              profile_background_tile: false,
-              profile_image_url:
-                "http://pbs.twimg.com/profile_images/935181032185241600/D8FoOIRJ_normal.jpg",
-              profile_image_url_https:
-                "https://pbs.twimg.com/profile_images/935181032185241600/D8FoOIRJ_normal.jpg",
-              profile_banner_url:
-                "https://pbs.twimg.com/profile_banners/886959980254871552/1511799663",
-              profile_link_color: "000000",
-              profile_sidebar_border_color: "000000",
-              profile_sidebar_fill_color: "000000",
-              profile_text_color: "000000",
-              profile_use_background_image: false,
-              has_extended_profile: false,
-              default_profile: false,
-              default_profile_image: false,
-              following: false,
-              follow_request_sent: false,
-              notifications: false,
-              translator_type: "none",
-            },
-            geo: nil,
-            coordinates: nil,
-            place: nil,
-            contributors: nil,
-            is_quote_status: false,
-            retweet_count: 46,
-            favorite_count: 275,
-            favorited: false,
-            retweeted: false,
-            possibly_sensitive: false,
-            possibly_sensitive_appealable: false,
-            lang: "en",
+            ],
           },
-          retweet_count: 201,
-          favorite_count: 1664,
-          favorited: false,
-          retweeted: false,
-          possibly_sensitive: false,
-          possibly_sensitive_appealable: false,
-          lang: "en",
         }
       end
 

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -755,7 +755,7 @@ RSpec.describe Oneboxer do
 
       stub_request(
         :get,
-        "https://api.twitter.com/1.1/statuses/show.json?id=1428031057186627589&tweet_mode=extended",
+        "https://api.twitter.com/2/tweets/1428031057186627589?tweet.fields=id,author_id,text,created_at,entities,referenced_tweets,public_metrics&user.fields=id,name,username,profile_image_url&media.fields=type,height,width,variants,preview_image_url,url&expansions=attachments.media_keys,referenced_tweets.id.author_id",
       ).to_return(status: 429, body: "{}", headers: {})
 
       stub_request(:post, "https://api.twitter.com/oauth2/token").to_return(


### PR DESCRIPTION
This PR migrates from Twitter API V1.1 to V2 and reintroduces a standard OpenGraph onebox fallback.

### Twitter V2 API
![2023-06-21_08-27](https://github.com/discourse/discourse/assets/66427541/7b8dcbdf-fa67-47f0-bd31-4be24a811142)
### OpenGraph fallback
![2023-06-21_08-28](https://github.com/discourse/discourse/assets/66427541/8c25f327-1adc-46b1-a135-51db1e9e1cf1)
---
### Twitter V2 API
![2023-06-21_08-27_1](https://github.com/discourse/discourse/assets/66427541/d3f0b9d1-edc9-4be8-94eb-c97b8f41f13e)
### OpenGraph fallback
![2023-06-21_08-28_1](https://github.com/discourse/discourse/assets/66427541/e0432bb9-6eda-42dc-8da6-bdb9e102c547)