### PR TITLE
UX: Remove horizontal scroll on mobile for edit categories nav modal

### DIFF
--- a/app/assets/stylesheets/common/components/sidebar-categories-form.scss
+++ b/app/assets/stylesheets/common/components/sidebar-categories-form.scss
@@ -81,6 +81,11 @@
   }
 
   .sidebar-categories-form__category-badge {
+    .badge-category {
+      white-space: normal;
+      word-wrap: break-word;
+    }
+
     .category-name {
       color: var(--primary);
       font-size: var(--font-up-1);


### PR DESCRIPTION
What does this commit do?

Prior to this change, a long category name on mobile would cause a
horizontal scroll to appear because the category name was overflowing
its element. This commit changes it such that the category name will
wrap around instead.

### Before 
![Screenshot from 2023-06-20 07-56-39](https://github.com/discourse/discourse/assets/4335742/f8f6d0e7-f38b-4b70-97a3-736d2a782f05)

### After

![Screenshot from 2023-06-20 07-57-27](https://github.com/discourse/discourse/assets/4335742/81ad6a24-5aa6-474f-9b0b-9a60d063e8f1)
