### PR TITLE
DEV: Roll back MessageBus version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "http_accept_language", require: false
 
 gem "discourse-fonts", require: "discourse_fonts"
 
-gem "message_bus"
+gem "message_bus", "4.3.2"
 
 gem "rails_multisite"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     matrix (0.4.2)
     maxminddb (0.1.22)
     memory_profiler (1.0.1)
-    message_bus (4.3.3)
+    message_bus (4.3.2)
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -594,7 +594,7 @@ DEPENDENCIES
   mail
   maxminddb
   memory_profiler
-  message_bus
+  message_bus (= 4.3.2)
   mini_mime
   mini_racer
   mini_scheduler


### PR DESCRIPTION
We are having issues with a lot of MessageBus updates not coming
through, it seems like the poll is not reconnecting after hanging
up. Pinning to the version before this commit to check:

https://github.com/discourse/message_bus/commit/a2a46fde87f4c9c6cff806db5d84c2544befaa6d
