### PR TITLE
FIX: 'in all topics' should search in all topics

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.js
@@ -93,7 +93,8 @@ export default class AssistantItem extends Component {
     const inTopicContext = this.search.searchContext?.type === "topic";
     this.args.searchTermChanged(updatedValue, {
       searchTopics: !inTopicContext || this.search.activeGlobalSearchTerm,
-      ...(inTopicContext && { setTopicContext: true }),
+      ...(inTopicContext &&
+        !this.args.searchAllTopics && { setTopicContext: true }),
     });
     focusSearchInput();
   }

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.hbs
@@ -13,6 +13,7 @@
         <SearchMenu::Results::AssistantItem
           @suffix={{i18n "search.in_topics_posts"}}
           @closeSearchMenu={{@closeSearchMenu}}
+          @searchAllTopics={{true}}
           @extraHint={{true}}
           @searchTermChanged={{@searchTermChanged}}
           @suggestionKeyword={{this.contextTypeKeyword}}

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
@@ -234,6 +234,34 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     );
   });
 
+  test("initial options - topic search scope - 'in all topics' searches in all topics", async function (assert) {
+    await visit("/t/internationalization-localization/280/1");
+    await click("#search-button");
+    await fillIn("#search-term", "foo");
+    // select 'in all topics and posts'
+    await click(
+      ".search-menu .results .search-menu-initial-options .search-menu-assistant-item:first-child"
+    );
+    assert.ok(
+      exists(".search-result-topic"),
+      "search result is a list of topics"
+    );
+  });
+
+  test("initial options - topic search scope - 'in this topic' searches posts within topic", async function (assert) {
+    await visit("/t/internationalization-localization/280/1");
+    await click("#search-button");
+    await fillIn("#search-term", "foo");
+    // select 'in this topic'
+    await click(
+      ".search-menu .results .search-menu-initial-options .search-menu-assistant-item:nth-child(2)"
+    );
+    assert.ok(
+      exists(".search-result-post"),
+      "search result is a list of posts"
+    );
+  });
+
   test("initial options - topic search scope - keep 'in this topic' filter in full page search", async function (assert) {
     await visit("/t/internationalization-localization/280/1");
     await click("#search-button");
@@ -241,7 +269,6 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
     await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
     await click(document.activeElement);
-
     await click(".show-advanced-search");
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
@@ -267,7 +267,7 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "proper");
     await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
-    await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
+    await triggerKeyEvent(document.activeElement, "keydown", "ArrowDown");
     await click(document.activeElement);
     await click(".show-advanced-search");
 
@@ -349,7 +349,7 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "a proper");
     await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
-    await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
+    await triggerKeyEvent(document.activeElement, "keydown", "ArrowDown");
     await click(document.activeElement);
 
     assert.ok(
@@ -384,7 +384,7 @@ acceptance("Search - Glimmer - Anonymous", function (needs) {
     await fillIn("#search-term", "dev");
     await query("#search-term").focus();
     await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
-    await triggerKeyEvent(document.activeElement, "keyup", "ArrowDown");
+    await triggerKeyEvent(document.activeElement, "keydown", "ArrowDown");
     await click(document.activeElement);
 
     assert.ok(


### PR DESCRIPTION
When searching in the context of a topic the <kbd>in all topics</kbd> link would not search globally for the given term and instead it would always search within the current topic. This PR fixes the link to properly update the search context and search globally for the given term.

This fix reveals some _secretly_ broken tests. Update these as well.