### PR TITLE
FIX: Typo in an output message of uploads.rake

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -385,7 +385,7 @@ end
 
 task "uploads:stop_migration" => :environment do
   SiteSetting.migrate_to_new_scheme = false
-  puts "Migration stoped!"
+  puts "Migration stopped!"
 end
 
 task "uploads:analyze", %i[cache_path limit] => :environment do |_, args|


### PR DESCRIPTION
**PR Summary**:
The PR contains a simple fix to typo found in a printed message inside `lib/tasks/uploads.rake`.