### PR TITLE
DEV: Improve skip test comment

### DIFF
--- a/spec/system/network_disconnected_spec.rb
+++ b/spec/system/network_disconnected_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe "Network Disconnected", type: :system do
   before { skip(<<~TEXT) }
     This group of tests is flaky and needs to be fixed. Example of error:
 
-    Failures:
-
-     1) Network Disconnected Doesn't show the offline indicator when the site setting isn't present
      Failure/Error: expect(page).to have_css("html.message-bus-offline")
        expected to find css "html.message-bus-offline" but there were no matches
     TEXT


### PR DESCRIPTION
Why this change?

The comment consists of an output that was copied from RSpec's default
output. This has the potential to mess with systems that are parsing
RSpec's output to fetch the spec failures as those systems are usually
looking for the first occurence of `Failures:`