### PR TITLE
FEATURE: Add input filter for editing tags in navigation menu modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/tags-form-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/tags-form-modal.hbs
@@ -3,32 +3,50 @@
   @class="sidebar-tags-form-modal"
 >
   <form class="sidebar-tags-form">
-    {{#each this.tags as |tag|}}
-      <div class="sidebar-tags-form__tag" data-tag-name={{tag.name}}>
-        <Input
-          id={{concat "sidebar-tags-form__input--" tag.name}}
-          class="sidebar-tags-form__input"
-          @type="checkbox"
-          @checked={{includes this.selectedTags tag.name}}
-          {{on "click" (action "toggleTag" tag.name)}}
-        />
+    <div class="sidebar-tags-form__filter">
+      {{d-icon "search" class="sidebar-tags-form__filter-input-icon"}}
 
-        <label
-          class="sidebar-tags-form__tag-label"
-          for={{concat "sidebar-tags-form__input--" tag.name}}
-        >
-          <p>
-            <span class="sidebar-tags-form__tag-label-name">
-              {{tag.name}}
-            </span>
+      <Input
+        class="sidebar-tags-form__filter-input-field"
+        placeholder={{i18n "sidebar.tags_form_modal.filter_placeholder"}}
+        @type="text"
+        @value={{this.filter}}
+        {{on "input" (action "onFilterInput" value="target.value")}}
+      />
+    </div>
 
-            <span class="sidebar-tags-form__tag-label-count">
-              ({{tag.count}})
-            </span>
-          </p>
-        </label>
+    {{#if (gt this.filteredTags.length 0)}}
+      {{#each this.filteredTags as |tag|}}
+        <div class="sidebar-tags-form__tag" data-tag-name={{tag.name}}>
+          <Input
+            id={{concat "sidebar-tags-form__input--" tag.name}}
+            class="sidebar-tags-form__input"
+            @type="checkbox"
+            @checked={{includes this.selectedTags tag.name}}
+            {{on "click" (action "toggleTag" tag.name)}}
+          />
+
+          <label
+            class="sidebar-tags-form__tag-label"
+            for={{concat "sidebar-tags-form__input--" tag.name}}
+          >
+            <p>
+              <span class="sidebar-tags-form__tag-label-name">
+                {{tag.name}}
+              </span>
+
+              <span class="sidebar-tags-form__tag-label-count">
+                ({{tag.count}})
+              </span>
+            </p>
+          </label>
+        </div>
+      {{/each}}
+    {{else}}
+      <div class="sidebar-tags-form__no-tags">
+        {{i18n "sidebar.tags_form_modal.no_tags"}}
       </div>
-    {{/each}}
+    {{/if}}
   </form>
 </DModalBody>
 

--- a/app/assets/stylesheets/common/components/sidebar-tags-form.scss
+++ b/app/assets/stylesheets/common/components/sidebar-tags-form.scss
@@ -31,4 +31,32 @@
   .sidebar-tags-form__tag-label-count {
     color: var(--primary-medium);
   }
+
+  .sidebar-tags-form__filter {
+    display: flex;
+    flex-direction: row;
+    margin-right: auto;
+    width: 100%;
+    position: relative;
+  }
+
+  .sidebar-tags-form__filter-input-icon {
+    position: absolute;
+    left: 0.5em;
+    top: 0.65em;
+    color: var(--primary-low-mid);
+  }
+
+  .sidebar-tags-form__filter-input-field {
+    border-color: var(--primary-low-mid);
+    padding-left: 1.75em;
+    width: 100%;
+
+    &:focus {
+      border-color: var(--tertiary);
+      outline: none;
+      outline-offset: 0;
+      box-shadow: inset 0px 0px 0px 1px var(--tertiary);
+    }
+  }
 }

--- a/app/assets/stylesheets/mobile/components/sidebar-tags-form.scss
+++ b/app/assets/stylesheets/mobile/components/sidebar-tags-form.scss
@@ -1,3 +1,9 @@
+.sidebar-tags-form-modal {
+  .modal-inner-container {
+    width: 35em;
+  }
+}
+
 .sidebar-tags-form {
   .sidebar-tags-form__tag {
     flex-basis: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4399,6 +4399,8 @@ en:
         reset_to_defaults: "Reset to defaults"
       tags_form_modal:
         title: "Edit tags navigation"
+        filter_placeholder: "Filter tags"
+        no_tags: "There are no tags matching the given term."
 
       sections:
         custom:

--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -49,4 +49,24 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     expect(sidebar).to have_no_section_link(tag2.name)
     expect(sidebar).to have_no_section_link(tag3.name)
   end
+
+  it "allows a user to filter the tags in the modal by the tag's name" do
+    visit "/latest"
+
+    expect(sidebar).to have_tags_section
+
+    modal = sidebar.click_edit_tags_button
+
+    modal.filter("tag")
+
+    expect(modal).to have_tag_checkboxes([tag, tag2, tag3])
+
+    modal.filter("tag2")
+
+    expect(modal).to have_tag_checkboxes([tag2])
+
+    modal.filter("someinvalidterm")
+
+    expect(modal).to have_no_tag_checkboxes
+  end
 end

--- a/spec/system/page_objects/modals/sidebar_edit_tags.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_tags.rb
@@ -20,6 +20,14 @@ module PageObjects
           end
       end
 
+      def has_no_tag_checkboxes?
+        has_no_css?(".sidebar-tags-form-modal .sidebar-tags-form__tag") &&
+          has_css?(
+            ".sidebar-tags-form-modal .sidebar-tags-form__no-tags",
+            text: I18n.t("js.sidebar.tags_form_modal.no_tags"),
+          )
+      end
+
       def toggle_tag_checkbox(tag)
         find(
           ".sidebar-tags-form-modal .sidebar-tags-form__tag[data-tag-name='#{tag.name}'] .sidebar-tags-form__input",
@@ -30,6 +38,11 @@ module PageObjects
 
       def save
         find(".sidebar-tags-form-modal .sidebar-tags-form__save-button").click
+        self
+      end
+
+      def filter(text)
+        find(".sidebar-tags-form-modal .sidebar-tags-form__filter-input-field").fill_in(with: text)
         self
       end
     end


### PR DESCRIPTION
What does this change do?

This commit adds an input filter to filter through the tag checkboxes in the
modal to edit tags that are shown in the user's navigation menu. The
filtering is a simple matching of the given filter term against the
names of the tags.