### PR TITLE
UX: adds small delay before making message active

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -35,8 +35,8 @@
     {{on "mouseleave" this.onMouseLeave passive=true}}
     {{on "mousemove" this.onMouseMove passive=true}}
     {{chat/on-long-press
-      this.handleLongPressStart
-      this.handleLongPressEnd
+      this.onLongPressStart
+      this.onLongPressEnd
       this.onLongPressCancel
     }}
     {{chat/track-message


### PR DESCRIPTION
This should prevent the message to show as active on mobile when making a touch to start scrolling.

This commit also makes naming of touch lifecycle functions coherent.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
