### PR TITLE
FIX: Spelling mistake for disableSubmit in ComposerSaveButton

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-save-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.hbs
@@ -4,6 +4,6 @@
   @action={{@action}}
   @icon={{@icon}}
   @forwardEvent={{@forwardEvent}}
-  class="btn-primary create {{if @disabledSubmit 'disabled'}}"
+  class="btn-primary create {{if @disableSubmit 'disabled'}}"
   ...attributes
 />


### PR DESCRIPTION
- see https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/composer-container.hbs#L247
- this bug also exists in previous versions
  - see https://github.com/discourse/discourse/blob/v2.8.14/app/assets/javascripts/discourse/app/templates/composer.hbs#LL163C24-L163C24