### PR TITLE
UX: chat message thread indicator v2 design & refactor

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -30,38 +30,4 @@
   <div class="chat-message-thread-indicator__last-reply-excerpt">
     {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
   </div>
-
-  {{!-- <div class="chat-message-thread-indicator__body">
-    <div class="chat-message-thread-indicator__last-reply-metadata">
-      <div class="chat-message-thread-indicator__last-reply-user">
-        {{#if (or this.site.mobileView this.chatStateManager.isDrawerActive)}}
-          <span
-            class="chat-message-thread-indicator__last-reply-avatar -mobile"
-          >
-            <ChatUserAvatar
-              @user={{@message.thread.preview.lastReplyUser}}
-              @avatarSize="tiny"
-            />
-          </span>
-        {{/if}}
-        <span class="chat-message-thread-indicator__last-reply-username">
-          {{@message.thread.preview.lastReplyUser.username}}
-        </span>
-      </div>
-      <span class="chat-message-thread-indicator__last-reply-container">
-        {{format-date
-          @message.thread.preview.lastReplyCreatedAt
-          leaveAgo="true"
-        }}
-      </span>
-      <span class="chat-message-thread-indicator__replies-count">
-        {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
-      </span>
-
-    </div>
-    <div class="chat-message-thread-indicator__last-reply-excerpt">
-      {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
-    </div>
-  </div> --}}
-
 </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -9,14 +9,13 @@
   title={{i18n "chat.threads.open"}}
 >
 
-  {{#unless this.chatStateManager.isDrawerActive}}
-    <div class="chat-message-thread-indicator__last-reply-avatar">
-      <ChatUserAvatar
-        @user={{@message.thread.preview.lastReplyUser}}
-        @avatarSize="small"
-      />
-    </div>
-  {{/unless}}
+  <div class="chat-message-thread-indicator__last-reply-avatar">
+    <ChatUserAvatar
+      @user={{@message.thread.preview.lastReplyUser}}
+      @avatarSize="small"
+    />
+  </div>
+
   <div class="chat-message-thread-indicator__last-reply-info">
     <span class="chat-message-thread-indicator__last-reply-username">
       {{@message.thread.preview.lastReplyUser.username}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -24,9 +24,7 @@
       {{format-date @message.thread.preview.lastReplyCreatedAt leaveAgo="true"}}
     </span>
   </div>
-  {{! <div class="chat-message-thread-indicator__participants"> }}
   <Chat::Thread::Participants @thread={{@message.thread}} />
-  {{! </div> }}
   <div class="chat-message-thread-indicator__last-reply-excerpt">
     {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
   </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -37,7 +37,6 @@
         {{format-date
           @message.thread.preview.lastReplyCreatedAt
           leaveAgo="true"
-          prefix=(i18n "chat.thread.last_reply")
         }}
       </span>
       <span class="separator">|</span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -25,9 +25,9 @@
       {{format-date @message.thread.preview.lastReplyCreatedAt leaveAgo="true"}}
     </span>
   </div>
-  <div class="chat-message-thread-indicator__participants">
-    <Chat::Thread::Participants @thread={{@message.thread}} />
-  </div>
+  {{! <div class="chat-message-thread-indicator__participants"> }}
+  <Chat::Thread::Participants @thread={{@message.thread}} />
+  {{! </div> }}
   <div class="chat-message-thread-indicator__last-reply-excerpt">
     {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
   </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -8,6 +8,7 @@
   role="button"
   title={{i18n "chat.threads.open"}}
 >
+
   {{#unless this.chatStateManager.isDrawerActive}}
     <div class="chat-message-thread-indicator__last-reply-avatar">
       <ChatUserAvatar
@@ -16,7 +17,22 @@
       />
     </div>
   {{/unless}}
-  <div class="chat-message-thread-indicator__body">
+  <div class="chat-message-thread-indicator__last-reply-info">
+    <span class="chat-message-thread-indicator__last-reply-username">
+      {{@message.thread.preview.lastReplyUser.username}}
+    </span>
+    <span class="chat-message-thread-indicator__last-reply-timestamp">
+      {{format-date @message.thread.preview.lastReplyCreatedAt leaveAgo="true"}}
+    </span>
+  </div>
+  <div class="chat-message-thread-indicator__participants">
+    <Chat::Thread::Participants @thread={{@message.thread}} />
+  </div>
+  <div class="chat-message-thread-indicator__last-reply-excerpt">
+    {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
+  </div>
+
+  {{!-- <div class="chat-message-thread-indicator__body">
     <div class="chat-message-thread-indicator__last-reply-metadata">
       <div class="chat-message-thread-indicator__last-reply-user">
         {{#if (or this.site.mobileView this.chatStateManager.isDrawerActive)}}
@@ -39,7 +55,6 @@
           leaveAgo="true"
         }}
       </span>
-      <span class="separator">|</span>
       <span class="chat-message-thread-indicator__replies-count">
         {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
       </span>
@@ -48,9 +63,6 @@
     <div class="chat-message-thread-indicator__last-reply-excerpt">
       {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
     </div>
-  </div>
+  </div> --}}
 
-  <div class="chat-message-thread-indicator__participants">
-    <Chat::Thread::Participants @thread={{@message.thread}} />
-  </div>
 </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
@@ -1,4 +1,7 @@
 {{#if (gt @thread.preview.participantUsers.length 1)}}
+  <div class="chat-message-thread-indicator__replies-count">
+    {{i18n "chat.thread.replies" count=@thread.preview.replyCount}}
+  </div>
   <div class="chat-thread-participants">
     <div class="chat-thread-participants__avatar-group">
       {{#each @thread.preview.participantUsers as |user|}}
@@ -8,14 +11,11 @@
           @showPresence={{false}}
         />
       {{/each}}
+      {{#if @thread.preview.otherParticipantCount}}
+        <div class="chat-thread-participants__other-count">
+          {{@thread.preview.otherParticipantCount}}
+        </div>
+      {{/if}}
     </div>
-    {{#if @thread.preview.otherParticipantCount}}
-      <div class="chat-thread-participants__other-count">
-        {{i18n
-          "chat.thread.participants_other_count"
-          count=@thread.preview.otherParticipantCount
-        }}
-      </div>
-    {{/if}}
   </div>
 {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
@@ -13,7 +13,7 @@
       {{/each}}
       {{#if @thread.preview.otherParticipantCount}}
         <div class="chat-thread-participants__other-count">
-          {{@thread.preview.otherParticipantCount}}
+          +{{@thread.preview.otherParticipantCount}}
         </div>
       {{/if}}
     </div>

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -43,8 +43,8 @@
   }
 
   &__last-reply-timestamp {
-    color: var(--primary-medium);
-    font-size: var(--font-down-1);
+    color: var(--primary-high);
+    font-size: var(--font-down-2);
   }
 
   &__last-reply-info {
@@ -76,7 +76,6 @@
 
   &__last-reply-excerpt {
     @include ellipsis;
-    line-height: 1.8rem;
   }
 
   &__body {

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -1,11 +1,16 @@
+.chat-message {
+  container-type: inline-size;
+}
+
 .chat-message-thread-indicator {
   cursor: pointer;
   grid-area: threadindicator;
-  max-width: 600px;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
   background-color: var(--primary-very-low);
   margin: 4px 0 -2px calc(var(--message-left-width) - 0.25rem);
-  padding-block: 0.5rem;
-  padding-inline: 0.5rem;
+  padding: 0.5rem;
   border-radius: 8px;
   color: var(--primary);
 
@@ -16,6 +21,12 @@
   &:visited,
   &:hover {
     color: var(--primary);
+  }
+
+  &:hover {
+    .chat-message-thread-indicator__replies-count {
+      text-decoration: underline;
+    }
   }
 
   .touch & {
@@ -30,16 +41,26 @@
     }
   }
 
-  &__participants {
-    flex-shrink: 0;
-    align-self: flex-start;
-  }
-
   &__last-reply-avatar {
-    align-self: flex-start;
+    grid-area: avatar;
+    margin-right: 0.5rem;
+
     .chat-user-avatar {
       width: auto !important;
     }
+  }
+
+  &__last-reply-username {
+    font-weight: bold;
+    color: var(--primary-very-high);
+    margin-right: 0.25rem;
+  }
+
+  &__last-reply-info {
+    grid-area: info;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
   }
 
   &__last-reply-timestamp {
@@ -47,52 +68,24 @@
     font-size: var(--font-down-2);
   }
 
-  &__last-reply-info {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-  }
-
-  &__last-reply-container {
-    display: inline-flex;
-    align-items: flex-end;
-    font-size: var(--font-down-1);
-    min-width: 0;
-
-    .relative-date {
-      @include ellipsis;
-    }
-  }
-
-  &__last-reply-user {
-    font-weight: bold;
-    color: var(--secondary-low);
-  }
-
-  &__last-reply-username {
-    font-weight: bold;
-    color: var(--secondary-low);
-  }
-
   &__last-reply-excerpt {
     @include ellipsis;
+    grid-area: excerpt;
   }
 
-  &__body {
-    overflow: hidden;
-    white-space: nowrap;
-    flex-shrink: 1;
-  }
-
-  &:hover {
-    .chat-message-thread-indicator__replies-count {
-      text-decoration: underline;
-    }
+  .chat-thread-participants {
+    grid-area: participants;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
   }
 
   &__replies-count {
     @include ellipsis;
     color: var(--tertiary);
     font-size: var(--font-down-1);
+    text-align: right;
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -51,6 +51,7 @@
   }
 
   &__last-reply-username {
+    @include ellipsis;
     font-weight: bold;
     color: var(--primary-very-high);
     margin-right: 0.25rem;

--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -1,10 +1,7 @@
 .chat-message-thread-indicator {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
   cursor: pointer;
   grid-area: threadindicator;
-  max-width: 1000px;
+  max-width: 600px;
   background-color: var(--primary-very-low);
   margin: 4px 0 -2px calc(var(--message-left-width) - 0.25rem);
   padding-block: 0.5rem;
@@ -45,15 +42,15 @@
     }
   }
 
-  &__last-reply-metadata {
-    display: flex;
-    align-items: flex-end;
-    gap: 0.25rem;
+  &__last-reply-timestamp {
     color: var(--primary-medium);
+    font-size: var(--font-down-1);
+  }
 
-    .separator {
-      font-size: var(--font-down-1);
-    }
+  &__last-reply-info {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
   }
 
   &__last-reply-container {

--- a/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
@@ -36,7 +36,7 @@
       flex-direction: row-reverse;
       justify-content: flex-start;
       .chat-user-avatar:not(:first-child) {
-        margin-right: -15px;
+        margin-right: -12px;
 
         .avatar {
           border: 1px solid var(--primary-very-low);
@@ -44,7 +44,9 @@
       }
     }
     &__other-count {
-      margin-right: -15px;
+      width: 22px;
+      height: 22px;
+      margin-right: -12px;
       z-index: 1;
       border: 1px solid var(--primary-very-low);
     }

--- a/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
@@ -1,22 +1,30 @@
 .chat-thread-participants {
   margin-left: 0.5rem;
   &__other-count {
-    width: 24px;
-    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
     border: 1px solid rgba(0, 0, 0, 0);
     box-sizing: border-box;
-    font-size: var(--font-down-1);
+    font-size: var(--font-down-2);
     color: var(--primary-very-low);
     background: var(--secondary-high);
     padding: 0.21em 0.42em;
     border-radius: 1em;
     text-align: center;
+    white-space: nowrap;
   }
 
   &__avatar-group {
     display: flex;
     align-items: center;
     justify-content: flex-end;
+
+    .chat-user-avatar-container {
+      padding: 0;
+    }
 
     .chat-user-avatar {
       width: auto !important;
@@ -35,9 +43,10 @@
     &__avatar-group {
       flex-direction: row-reverse;
       justify-content: flex-start;
-      .chat-user-avatar:not(:first-child) {
-        margin-right: -12px;
-
+      .chat-user-avatar {
+        &:not(:first-child) {
+          margin-right: -12px;
+        }
         .avatar {
           width: 22px;
           height: 22px;

--- a/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
@@ -1,7 +1,9 @@
 .chat-thread-participants {
+  margin-left: 0.5rem;
   &__other-count {
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
+    border: 1px solid rgba(0, 0, 0, 0);
     box-sizing: border-box;
     font-size: var(--font-down-1);
     color: var(--primary-very-low);
@@ -24,6 +26,27 @@
         height: 24px;
         padding: 0;
       }
+    }
+  }
+}
+
+@container (max-width: 400px) {
+  .chat-thread-participants {
+    &__avatar-group {
+      flex-direction: row-reverse;
+      justify-content: flex-start;
+      .chat-user-avatar:not(:first-child) {
+        margin-right: -15px;
+
+        .avatar {
+          border: 1px solid var(--primary-very-low);
+        }
+      }
+    }
+    &__other-count {
+      margin-right: -15px;
+      z-index: 1;
+      border: 1px solid var(--primary-very-low);
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
@@ -1,12 +1,19 @@
 .chat-thread-participants {
   &__other-count {
-    font-size: var(--font-down-2);
-    text-align: right;
-    color: var(--primary-medium);
+    width: 22px;
+    height: 22px;
+    box-sizing: border-box;
+    font-size: var(--font-down-1);
+    color: var(--primary-very-low);
+    background: var(--secondary-high);
+    padding: 0.21em 0.42em;
+    border-radius: 1em;
+    text-align: center;
   }
 
   &__avatar-group {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
 
     .chat-user-avatar {

--- a/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-participants.scss
@@ -39,6 +39,8 @@
         margin-right: -12px;
 
         .avatar {
+          width: 22px;
+          height: 22px;
           border: 1px solid var(--primary-very-low);
         }
       }

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -1,5 +1,9 @@
 .chat-message-thread-indicator {
   max-width: 600px;
+  display: grid;
+  grid-template-areas:
+    "avatar info participants"
+    "avatar excerpt excerpt";
 
   .chat-drawer & {
     align-items: stretch;
@@ -11,6 +15,8 @@
   }
 
   &__last-reply-avatar {
+    grid-area: avatar;
+    margin-right: 1rem;
     .chat-drawer & {
       display: inline-block;
     }
@@ -27,13 +33,15 @@
     }
   }
 
-  &__last-reply-metadata {
+  &__last-reply-info {
+    grid-area: info;
     .chat-drawer & {
       flex-wrap: wrap;
     }
   }
 
   &__last-reply-excerpt {
+    grid-area: excerpt;
     .chat-drawer & {
       white-space: wrap;
       display: -webkit-box;
@@ -49,6 +57,10 @@
     }
   }
   &__participants {
+    grid-area: participants;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     margin-left: auto;
 
     .chat-drawer & {

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -1,9 +1,14 @@
+.chat-message {
+  container-type: inline-size;
+}
 .chat-message-thread-indicator {
   max-width: 600px;
+  box-sizing: border-box;
   display: grid;
   grid-template-areas:
-    "avatar info participants"
-    "avatar excerpt excerpt";
+    "avatar info replies participants"
+    "avatar excerpt excerpt excerpt";
+  grid-template-columns: auto 1fr auto auto;
 
   .chat-drawer & {
     align-items: stretch;
@@ -40,6 +45,12 @@
     }
   }
 
+  &__replies-count {
+    display: flex;
+    align-self: center;
+    justify-content: center;
+  }
+
   &__last-reply-excerpt {
     grid-area: excerpt;
     .chat-drawer & {
@@ -60,12 +71,26 @@
     grid-area: participants;
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 0.5rem;
     margin-left: auto;
 
     .chat-drawer & {
       align-self: flex-end;
       flex-basis: 100%;
+    }
+  }
+}
+
+@container (max-width: 400px) {
+  .chat-message-thread-indicator {
+    grid-template-areas:
+      "avatar info info participants"
+      "avatar excerpt excerpt replies";
+    &__replies-count {
+      align-self: flex-start;
+      grid-area: replies;
+      justify-content: flex-end;
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -25,6 +25,7 @@
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       margin-top: 0.5rem;
+      margin-right: 0.25rem;
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -1,45 +1,11 @@
-.chat-message {
-  container-type: inline-size;
-}
 .chat-message-thread-indicator {
-  max-width: 600px;
-  box-sizing: border-box;
-  display: grid;
   grid-template-areas:
     "avatar info replies participants"
     "avatar excerpt excerpt excerpt";
-  grid-template-columns: auto 1fr auto auto;
-
-  &__last-reply-avatar {
-    grid-area: avatar;
-    margin-right: 0.5rem;
-  }
-
-  &__last-reply-user {
-    margin-right: 0.25rem;
-  }
-
-  &__last-reply-info {
-    grid-area: info;
-  }
 
   &__replies-count {
     display: flex;
     align-self: center;
-    justify-content: center;
-  }
-
-  &__last-reply-excerpt {
-    grid-area: excerpt;
-  }
-
-  &__participants {
-    grid-area: participants;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    margin-left: auto;
   }
 }
 

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -10,39 +10,17 @@
     "avatar excerpt excerpt excerpt";
   grid-template-columns: auto 1fr auto auto;
 
-  .chat-drawer & {
-    align-items: stretch;
-    flex-wrap: wrap;
-    width: auto;
-    max-width: 100%;
-    min-width: auto;
-    gap: 0.25rem;
-  }
-
   &__last-reply-avatar {
     grid-area: avatar;
-    margin-right: 1rem;
-    .chat-drawer & {
-      display: inline-block;
-    }
+    margin-right: 0.5rem;
   }
 
   &__last-reply-user {
     margin-right: 0.25rem;
-
-    .chat-drawer & {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      margin-right: auto;
-    }
   }
 
   &__last-reply-info {
     grid-area: info;
-    .chat-drawer & {
-      flex-wrap: wrap;
-    }
   }
 
   &__replies-count {
@@ -53,20 +31,8 @@
 
   &__last-reply-excerpt {
     grid-area: excerpt;
-    .chat-drawer & {
-      white-space: wrap;
-      display: -webkit-box;
-      -webkit-line-clamp: 3;
-      -webkit-box-orient: vertical;
-      margin-left: calc(26px + 0.5rem);
-    }
   }
 
-  &__body {
-    .chat-drawer & {
-      flex-grow: 1;
-    }
-  }
   &__participants {
     grid-area: participants;
     display: flex;
@@ -74,11 +40,6 @@
     justify-content: flex-end;
     gap: 0.5rem;
     margin-left: auto;
-
-    .chat-drawer & {
-      align-self: flex-end;
-      flex-basis: 100%;
-    }
   }
 }
 
@@ -86,11 +47,17 @@
   .chat-message-thread-indicator {
     grid-template-areas:
       "avatar info info participants"
-      "avatar excerpt excerpt replies";
+      "excerpt excerpt excerpt replies";
     &__replies-count {
       align-self: flex-start;
       grid-area: replies;
       justify-content: flex-end;
+    }
+    &__last-reply-excerpt {
+      white-space: wrap;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -24,6 +24,7 @@
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
+      margin-top: 0.5rem;
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
@@ -16,6 +16,7 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     margin-top: 0.5rem;
+    margin-right: 0.25rem;
   }
   &__replies-count {
     grid-area: replies;

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
@@ -1,39 +1,22 @@
 .chat-message-thread-indicator {
-  &__participants,
-  &__last-reply-avatar:not(.-mobile) {
-    display: none;
-  }
+  grid-template-areas:
+    "avatar info info participants"
+    "excerpt excerpt excerpt replies";
 
-  &__last-reply-metadata {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    margin-bottom: 0.25rem;
-  }
-
-  &__last-reply-user {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-right: auto;
-  }
-
-  &__last-reply-avatar {
-    align-self: center;
+  .chat-thread-participants {
     .avatar {
-      width: 18px;
-      height: 18px;
+      width: 22px;
+      height: 22px;
     }
-  }
-
-  &__last-reply-username {
-    margin-right: auto;
   }
 
   &__last-reply-excerpt {
     white-space: wrap;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+  }
+  &__replies-count {
+    grid-area: replies;
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-thread-indicator.scss
@@ -15,6 +15,7 @@
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    margin-top: 0.5rem;
   }
   &__replies-count {
     grid-area: replies;


### PR DESCRIPTION
This PR contains:
* gridified the thread message indicator, alleviating some problems with positioning and overflow
* participant avatars will overlap/smush on smaller size and mobile
* the excerpt went from 3 > 2 lines of wrapping on smaller size, still 1 line on large size
* dropped the copy of "last reply"
* fixed wrong line height
* moved the "x replies" over to the right near the participants, as that makes more sense
* using a bubble to indicate other participants, instead of copy

### desktop & drawer
![image](https://github.com/discourse/discourse/assets/101828855/3f325fbd-fcc0-40ba-838f-a287228c3001)

<img width="438" alt="image" src="https://github.com/discourse/discourse/assets/101828855/d497e917-babc-46be-996e-e7ceec02e496">


<img width="589" alt="image" src="https://github.com/discourse/discourse/assets/101828855/e365c810-66b0-4648-8780-dee6a5987e23">

### mobile
identical to drawer/small screen

And before anyone asks: it IS centered, so misalignment you may see is an optical illusion.
![image](https://github.com/discourse/discourse/assets/101828855/0f7889c5-1f9e-4ee0-a254-134964d0133d)

And as a footnote: this PR introduces the `@container` query, which is experimental. Nothing will break when it's being viewed in a not-supported browser, but it will be less elegant.


