### PR TITLE
DEV: Cleanup several unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,9 +120,6 @@ Discourse::Application.routes.draw do
         collection { put "automatic_membership_count" => "groups#automatic_membership_count" }
       end
 
-      get "groups/:type" => "groups#show", :constraints => AdminConstraint.new
-      get "groups/:type/:id" => "groups#show", :constraints => AdminConstraint.new
-
       resources :users, id: RouteFormat.username, only: %i[index destroy] do
         collection do
           get "list" => "users#index"
@@ -1122,12 +1119,7 @@ Discourse::Application.routes.draw do
 
     resources :post_action_users, only: %i[index]
     resources :post_readers, only: %i[index]
-    resources :post_actions, only: %i[create destroy] do
-      collection do
-        get "users"
-        post "defer_flags"
-      end
-    end
+    resources :post_actions, only: %i[create destroy]
     resources :user_actions, only: %i[index show]
 
     resources :badges, only: [:index]
@@ -1193,9 +1185,8 @@ Discourse::Application.routes.draw do
       get "top/#{period}", to: redirect("top?period=#{period}", status: 301)
     end
 
-    Discourse.anonymous_filters.each do |filter|
-      get "#{filter}.rss" => "list##{filter}_feed", :format => :rss
-    end
+    get "latest.rss" => "list#latest_feed", :format => :rss
+    get "top.rss" => "list#top_feed", :format => :rss
 
     Discourse.filters.each { |filter| get "#{filter}" => "list##{filter}" }
 


### PR DESCRIPTION
This commit removes these these routes that do not have a corresponding
controller action:

```
admin/groups#show
admin/groups#show
post_actions#users
post_actions#defer_flags
list#categories_feed
```
