### PR TITLE
DEV: Add plugin outlet to latest-topic-list-item component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
@@ -26,6 +26,11 @@
   </div>
 </div>
 <div class="topic-stats">
+  <PluginOutlet
+    @name="above-latest-topic-list-item-post-count"
+    @connectorTagName="div"
+    @outletArgs={{hash topic=this.topic}}
+  />
   {{raw "list/posts-count-column" topic=this.topic tagName="div"}}
   <div class="topic-last-activity">
     <a


### PR DESCRIPTION
Introduces a new above-latest-topic-list-item-post-count outlet, providing a clean way to add other useful elements to the topic-stats section of the latest-topic-list-item template.

One example use case is replacing the post count with a view count as requested in [this Meta topic](https://meta.discourse.org/t/show-views-instead-of-replies/187146):

<img width="568" alt="Screenshot 2023-06-21 at 5 21 31 PM" src="https://github.com/discourse/discourse/assets/22733864/912b77ed-887e-4402-a50d-0079ef61666d">
