### PR TITLE
FIX: Show tag chooser in composer for PM on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -27,7 +27,11 @@
         aria-label={{I18n this.composer.saveLabel}}
         class="reply-area
           {{if this.composer.canEditTags 'with-tags' 'without-tags'}}
-          {{if this.composer.model.showCategoryChooser 'with-category' 'without-category'}}"
+          {{if
+            this.composer.model.showCategoryChooser
+            'with-category'
+            'without-category'
+          }}"
       >
         <span class="composer-open-plugin-outlet-container">
           <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -26,7 +26,8 @@
         role="form"
         aria-label={{I18n this.composer.saveLabel}}
         class="reply-area
-          {{if this.composer.canEditTags 'with-tags' 'without-tags'}}"
+          {{if this.composer.canEditTags 'with-tags' 'without-tags'}}
+          {{if this.composer.model.showCategoryChooser 'with-category' 'without-category'}}"
       >
         <span class="composer-open-plugin-outlet-container">
           <PluginOutlet

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -237,10 +237,6 @@ export default class ComposerController extends Controller {
 
   @discourseComputed("model.canEditTitle", "model.creatingPrivateMessage")
   canEditTags(canEditTitle, creatingPrivateMessage) {
-    if (creatingPrivateMessage && this.site.mobileView) {
-      return false;
-    }
-
     const isPrivateMessage =
       creatingPrivateMessage || this.get("model.topic.isPrivateMessage");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -963,10 +963,10 @@ acceptance(
       can_tag_topics: true,
     });
 
-    test("tags are not present on private messages - Mobile mode", async function (assert) {
+    test("tags are present on private messages - Mobile mode", async function (assert) {
       await visit("/u/eviltrout/messages");
       await click(".new-private-message");
-      assert.ok(!exists("#reply-control .mini-tag-chooser"));
+      assert.ok(exists("#reply-control .mini-tag-chooser"));
     });
   }
 );

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -278,7 +278,7 @@ html.composer-open {
     }
   }
 
-  .with-tags {
+  .with-tags.with-category {
     .title-and-category {
       flex-wrap: wrap;
     }
@@ -319,7 +319,6 @@ html.composer-open {
 
   .mini-tag-chooser {
     flex-grow: 1;
-    max-width: calc(50% - 4px);
     margin: 0 0 8px 0px;
     z-index: z("composer", "dropdown");
     .select-kit-header {

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -206,7 +206,7 @@
     }
 
     .mini-tag-chooser {
-      margin: 0 0 8px 6px;
+      margin: 0 0 6px 6px;
       max-width: calc(50% - 3px);
     }
 
@@ -217,10 +217,6 @@
           font-size: var(--font-0);
         }
       }
-    }
-
-    .formatted-selection {
-      font-size: var(--font-down-1);
     }
   }
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -206,7 +206,7 @@
     }
 
     .mini-tag-chooser {
-      margin: 0 0 6px 6px;
+      margin: 0 0 8px 6px;
       max-width: calc(50% - 3px);
     }
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -94,7 +94,7 @@
   }
 
   .category-input,
-  .with-tags .category-input {
+  .with-tags.with-category .category-input {
     margin-bottom: 6px;
     max-width: calc(50% - 3px);
   }
@@ -208,15 +208,6 @@
     .mini-tag-chooser {
       margin: 0 0 6px 6px;
       max-width: calc(50% - 3px);
-    }
-
-    .selected-name {
-      .name {
-        font-size: var(--font-down-1);
-        .badge-wrapper {
-          font-size: var(--font-0);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
This was not displayed on mobile due to space constraints. With better organization of the title, category and tags inputs, it can be displayed.

New topic with category and tag
<img width="789" alt="new-topic-with-category-and-tag" src="https://github.com/discourse/discourse/assets/23153890/64703b1a-b6a7-49b9-b361-d51d2eac2c85">

New topic with category
<img width="789" alt="new-topic-with-category" src="https://github.com/discourse/discourse/assets/23153890/1df86217-8445-492a-9ffd-7a039b72d409">

New PM with tag
<img width="789" alt="new-pm-with-tag" src="https://github.com/discourse/discourse/assets/23153890/b6b5ac71-6d0d-4d77-bf3c-6ad3f9a4ce36">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
