### PR TITLE
DEV: Refactor updating parent/child relationships between themes

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -215,13 +215,11 @@ class Admin::ThemesController < Admin::AdminController
       @theme.public_send("#{field}=", theme_params[field]) if theme_params.key?(field)
     end
 
-    if theme_params.key?(:child_theme_ids)
-      add_relative_themes!(:child, theme_params[:child_theme_ids])
-    end
+    @theme.child_theme_ids = theme_params[:child_theme_ids] if theme_params.key?(:child_theme_ids)
 
-    if theme_params.key?(:parent_theme_ids)
-      add_relative_themes!(:parent, theme_params[:parent_theme_ids])
-    end
+    @theme.parent_theme_ids = theme_params[:parent_theme_ids] if theme_params.key?(
+      :parent_theme_ids,
+    )
 
     set_fields
     update_settings
@@ -317,24 +315,6 @@ class Admin::ThemesController < Admin::AdminController
 
   def ban_for_remote_theme!
     raise Discourse::InvalidAccess if @theme.remote_theme&.is_git?
-  end
-
-  def add_relative_themes!(kind, ids)
-    expected = ids.map(&:to_i)
-
-    relation = kind == :child ? @theme.child_theme_relation : @theme.parent_theme_relation
-
-    relation.to_a.each do |relative|
-      if kind == :child && expected.include?(relative.child_theme_id)
-        expected.reject! { |id| id == relative.child_theme_id }
-      elsif kind == :parent && expected.include?(relative.parent_theme_id)
-        expected.reject! { |id| id == relative.parent_theme_id }
-      else
-        relative.destroy
-      end
-    end
-
-    Theme.where(id: expected).each { |theme| @theme.add_relative_theme!(kind, theme) }
   end
 
   def update_default_theme

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -527,6 +527,16 @@ class Theme < ActiveRecord::Base
     end
   end
 
+  def child_theme_ids=(theme_ids)
+    super(theme_ids)
+    DB.after_commit { Theme.clear_cache! }
+  end
+
+  def parent_theme_ids=(theme_ids)
+    super(theme_ids)
+    DB.after_commit { Theme.clear_cache! }
+  end
+
   def add_relative_theme!(kind, theme)
     new_relation =
       if kind == :child


### PR DESCRIPTION
The prior add_relative_themes! method was confusing and cleared the cache repeatedly instead of once for the whole operation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
