### PR TITLE
UX: Fix overridden setting highlight color

### DIFF
--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -109,7 +109,7 @@
     }
   }
   .setting.overridden {
-    input {
+    .values input {
       background-color: var(--highlight-bg);
     }
     h3 {


### PR DESCRIPTION
Don't apply to inputs outside values.

Before

<img width="752" alt="image" src="https://github.com/discourse/discourse/assets/368961/650200ca-237c-4c08-9285-3c7c77f6c643">

After

<img width="767" alt="image" src="https://github.com/discourse/discourse/assets/368961/9476a7de-df82-4287-b3fd-7be563e07822">
