### PR TITLE
A11Y: Adjust contrast and font size for mini profiler widget

### DIFF
--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -9,6 +9,10 @@ div.profiler-results.profiler-top {
   top: var(--header-offset);
   z-index: z("header") - 1;
 
+  .profiler-result {
+    font-size: var(--font-down-1);
+  }
+
   .profiler-button {
     background-color: var(--header_background);
     color: var(--header_primary);
@@ -19,7 +23,11 @@ div.profiler-results.profiler-top {
     }
 
     .profiler-unit {
-      color: var(--header_primary-medium);
+      color: var(--header_primary);
+    }
+
+    .profiler-reqs {
+      font-size: var(--font-down-1);
     }
   }
 

--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -18,10 +18,7 @@ div.profiler-results.profiler-top {
     color: var(--header_primary);
     border-bottom: 1px solid var(--header_primary-low);
 
-    .profiler-number {
-      color: var(--header_primary);
-    }
-
+    .profiler-number,
     .profiler-unit {
       color: var(--header_primary);
     }


### PR DESCRIPTION
This is very minor, only visible to admins, but it shows up in automated A11Y checkers (like WAVE).

<img width="303" alt="image" src="https://github.com/discourse/discourse/assets/368961/12563189-1827-4b4d-b032-e18a58ae9d01">

Before

<img width="189" alt="image" src="https://github.com/discourse/discourse/assets/368961/a2abbf23-1cb3-42bf-a570-b15ced89c123">


After

<img width="190" alt="image" src="https://github.com/discourse/discourse/assets/368961/74bb4982-43b6-423c-a437-95795a0d61e9">


