### PR TITLE
A11Y: Don't output `aria-labelledby` when card is empty

### DIFF
--- a/app/assets/javascripts/discourse/app/components/card-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/card-container.hbs
@@ -9,7 +9,6 @@
   @composePrivateMessage={{route-action "composePrivateMessage"}}
   @createNewMessageViaParams={{route-action "createNewMessageViaParams"}}
   role="dialog"
-  aria-labelledby="discourse-user-card-title"
 />
 
 <GroupCardContents

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -30,6 +30,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
     "usernameClass",
     "primaryGroup",
   ],
+  attributeBindings: ["labelledBy:aria-labelledby"],
   allowBackgrounds: setting("allow_profile_backgrounds"),
   showBadges: setting("enable_badges"),
 
@@ -45,6 +46,11 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   showMoreBadges: gt("moreBadgesCount", 0),
   showDelete: and("viewingAdmin", "showName", "user.canBeDeleted"),
   linkWebsite: not("user.isBasic"),
+
+  @discourseComputed("user")
+  labelledBy(user) {
+    return user ? "discourse-user-card-title" : null;
+  },
 
   @discourseComputed("user")
   hasLocaleOrWebsite(user) {


### PR DESCRIPTION
The user card is always present in the DOM. Therefore we only need to add the `aria-labelledby` attribute when there is a user (and a title) to point to.

Fixes this error raised under WAVE: 

<img width="368" alt="image" src="https://github.com/discourse/discourse/assets/368961/1c81bd74-6476-4560-b616-3db5b78f94f0">
