### PR TITLE
FEATURE: new watched_precedence_over_muted setting

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -272,24 +272,11 @@ class PostAlerter
   def category_or_tag_muters(topic)
     User
       .joins(
-        "LEFT JOIN category_users ON users.id = category_users.user_id AND #{
-          DB.sql_fragment(
-            "category_users.category_id = :category_id AND category_users.notification_level = :muted",
-            category_id: topic.category_id,
-            muted: CategoryUser.notification_levels[:muted],
-          )
-        }",
+        "LEFT JOIN category_users ON users.id = category_users.user_id AND category_users.category_id = #{topic.category_id.to_i} AND category_users.notification_level = #{CategoryUser.notification_levels[:muted].to_i}",
       )
+      .joins("LEFT JOIN topic_tags ON topic_tags.topic_id = #{topic.id.to_i}")
       .joins(
-        "LEFT JOIN topic_tags ON topic_tags.topic_id = #{topic.id.to_i}"
-      )
-      .joins(
-        "LEFT JOIN tag_users ON users.id = tag_users.user_id AND #{
-          DB.sql_fragment(
-            "tag_users.tag_id IN (topic_tags.tag_id) AND tag_users.notification_level = :muted",
-            muted: TagUser.notification_levels[:muted],
-          )
-        }",
+        "LEFT JOIN tag_users ON users.id = tag_users.user_id AND tag_users.tag_id IN (tag_users.tag_id) AND tag_users.notification_level = #{TagUser.notification_levels[:muted].to_i}",
       )
       .where("category_users.id IS NOT NULL OR tag_users.id IS NOT NULL")
   end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -281,7 +281,7 @@ class PostAlerter
         }",
       )
       .joins(
-        "#{DB.sql_fragment("LEFT JOIN topic_tags ON topic_tags.topic_id = :topic_id", topic_id: topic.id)}",
+        "LEFT JOIN topic_tags ON topic_tags.topic_id = #{topic.id.to_i}"
       )
       .joins(
         "LEFT JOIN tag_users ON users.id = tag_users.user_id AND #{

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -276,7 +276,7 @@ class PostAlerter
       )
       .joins("LEFT JOIN topic_tags ON topic_tags.topic_id = #{topic.id.to_i}")
       .joins(
-        "LEFT JOIN tag_users ON users.id = tag_users.user_id AND tag_users.tag_id IN (tag_users.tag_id) AND tag_users.notification_level = #{TagUser.notification_levels[:muted].to_i}",
+        "LEFT JOIN tag_users ON users.id = tag_users.user_id AND tag_users.tag_id = topic_tags.tag_id AND tag_users.notification_level = #{TagUser.notification_levels[:muted].to_i}",
       )
       .where("category_users.id IS NOT NULL OR tag_users.id IS NOT NULL")
   end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -286,7 +286,7 @@ class PostAlerter
       .joins(
         "LEFT JOIN tag_users ON users.id = tag_users.user_id AND #{
           DB.sql_fragment(
-            "tag_users.tag_id IN (tag_users.tag_id) AND tag_users.notification_level = :muted",
+            "tag_users.tag_id IN (topic_tags.tag_id) AND tag_users.notification_level = :muted",
             muted: TagUser.notification_levels[:muted],
           )
         }",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2380,6 +2380,7 @@ en:
     remove_muted_tags_from_latest: "Don't show topics tagged only with muted tags in the latest topic list."
     force_lowercase_tags: "Force all new tags to be entirely lowercase."
     create_post_for_category_and_tag_changes: "Create a small action post when a topic's category or tags change"
+    watched_precedence_over_muted: "Notify me about topics in categories or tags I’m Watching that also belong to one I have Muted"
 
     company_name: "Company Name"
     governing_law: "Governing Law"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2380,7 +2380,7 @@ en:
     remove_muted_tags_from_latest: "Don't show topics tagged only with muted tags in the latest topic list."
     force_lowercase_tags: "Force all new tags to be entirely lowercase."
     create_post_for_category_and_tag_changes: "Create a small action post when a topic's category or tags change"
-    watched_precedence_over_muted: "Notify me about topics in categories or tags I’m Watching that also belong to one I have Muted"
+    watched_precedence_over_muted: "Notify me about topics in categories or tags I’m watching that also belong to one I have muted"
 
     company_name: "Company Name"
     governing_law: "Governing Law"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2820,6 +2820,10 @@ tags:
     type: enum
     default: always
     enum: RemoveMutedTagsFromLatestSiteSetting
+  watched_precedence_over_muted:
+    client: true
+    default: true
+
   force_lowercase_tags:
     default: true
     client: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2822,7 +2822,7 @@ tags:
     enum: RemoveMutedTagsFromLatestSiteSetting
   watched_precedence_over_muted:
     client: true
-    default: true
+    default: false
 
   force_lowercase_tags:
     default: true

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -915,7 +915,8 @@ class TopicQuery
       if watched_tag_ids.present?
         list =
           list.joins(
-            "LEFT JOIN topic_tags watched_topic_tags ON topic_tags.topic_id = topics.id AND #{DB.sql_fragment("topic_tags.tag_id IN (?)", watched_tag_ids)}",
+            "LEFT JOIN topic_tags watched_topic_tags ON topic_tags.topic_id = topics.id"
+          ).where("topic_tags.tag_id IN (?)", watched_tag_ids)
           )
       end
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -915,8 +915,7 @@ class TopicQuery
       if watched_tag_ids.present?
         list =
           list.joins(
-            "LEFT JOIN topic_tags watched_topic_tags ON topic_tags.topic_id = topics.id"
-          ).where("topic_tags.tag_id IN (?)", watched_tag_ids)
+            "LEFT JOIN topic_tags watched_topic_tags ON watched_topic_tags.topic_id = topics.id AND #{DB.sql_fragment("watched_topic_tags.tag_id IN (?)", watched_tag_ids)}",
           )
       end
 

--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -49,7 +49,7 @@ class TopicQuery
 
     def list_private_messages_new(user, type = :user)
       list = filter_private_message_new(user, type)
-      list = TopicQuery.remove_muted_tags(list, user)
+      list = TopicQuery.remove_muted_tags(list, user, skip_categories: true)
       list = remove_dismissed(list, user)
 
       create_list(:private_messages, {}, list)

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2094,7 +2094,15 @@ RSpec.describe TopicQuery do
   end
 
   describe "precedence of categories and tag setting" do
-    fab!(:watched_category) { Fabricate(:category) }
+    fab!(:watched_category) do 
+      Fabricate(:category).tap do |category|
+        CategoryUser.create!(
+          user: user,
+          category: category,
+          notification_level: CategoryUser.notification_levels[:watching],
+        )
+      end
+    end
     fab!(:muted_category) { Fabricate(:category) }
     fab!(:watched_tag) { Fabricate(:tag) }
     fab!(:muted_tag) { Fabricate(:tag) }

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2132,25 +2132,14 @@ RSpec.describe TopicQuery do
     end
     fab!(:topic) { Fabricate(:topic) }
     fab!(:topic_in_watched_category_and_muted_tag) do
-      Fabricate(:topic, category: watched_category).tap do |topic|
-        Fabricate(:topic_tag, topic: topic, tag: muted_tag)
-      end
+      Fabricate(:topic, category: watched_category, tags: [muted_tag])
     end
     fab!(:topic_in_muted_category_and_watched_tag) do
-      Fabricate(:topic, category: muted_category).tap do |topic|
-        Fabricate(:topic_tag, topic: topic, tag: watched_tag)
-      end
+      Fabricate(:topic, category: muted_category, tags: [watched_tag])
     end
-    fab!(:topic_in_watched_and_muted_tag) do
-      Fabricate(:topic).tap do |topic|
-        Fabricate(:topic_tag, topic: topic, tag: watched_tag)
-        Fabricate(:topic_tag, topic: topic, tag: muted_tag)
-      end
-    end
+    fab!(:topic_in_watched_and_muted_tag) { Fabricate(:topic, tags: [watched_tag, muted_tag]) }
     fab!(:topic_in_muted_category) { Fabricate(:topic, category: muted_category) }
-    fab!(:topic_in_muted_tag) do
-      Fabricate(:topic).tap { |topic| Fabricate(:topic_tag, topic: topic, tag: muted_tag) }
-    end
+    fab!(:topic_in_muted_tag) { Fabricate(:topic, tags: [muted_tag]) }
 
     context "when enabled" do
       it "returns topics even if category or tag is muted but another tag or category is watched" do

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2094,7 +2094,7 @@ RSpec.describe TopicQuery do
   end
 
   describe "precedence of categories and tag setting" do
-    fab!(:watched_category) do 
+    fab!(:watched_category) do
       Fabricate(:category).tap do |category|
         CategoryUser.create!(
           user: user,
@@ -2103,51 +2103,53 @@ RSpec.describe TopicQuery do
         )
       end
     end
-    fab!(:muted_category) { Fabricate(:category) }
-    fab!(:watched_tag) { Fabricate(:tag) }
-    fab!(:muted_tag) { Fabricate(:tag) }
-
+    fab!(:muted_category) do
+      Fabricate(:category).tap do |category|
+        CategoryUser.create!(
+          user: user,
+          category: category,
+          notification_level: CategoryUser.notification_levels[:muted],
+        )
+      end
+    end
+    fab!(:watched_tag) do
+      Fabricate(:tag).tap do |tag|
+        TagUser.create!(
+          user: user,
+          tag: tag,
+          notification_level: TagUser.notification_levels[:watching],
+        )
+      end
+    end
+    fab!(:muted_tag) do
+      Fabricate(:tag).tap do |tag|
+        TagUser.create!(
+          user: user,
+          tag: tag,
+          notification_level: TagUser.notification_levels[:muted],
+        )
+      end
+    end
     fab!(:topic) { Fabricate(:topic) }
-    fab!(:topic_in_watched_category_and_muted_tag) { Fabricate(:topic, category: watched_category) }
-    fab!(:topic_in_muted_category_and_watched_tag) { Fabricate(:topic, category: muted_category) }
-    fab!(:topic_in_watched_and_muted_tag) { Fabricate(:topic) }
+    fab!(:topic_in_watched_category_and_muted_tag) do
+      Fabricate(:topic, category: watched_category).tap do |topic|
+        Fabricate(:topic_tag, topic: topic, tag: muted_tag)
+      end
+    end
+    fab!(:topic_in_muted_category_and_watched_tag) do
+      Fabricate(:topic, category: muted_category).tap do |topic|
+        Fabricate(:topic_tag, topic: topic, tag: watched_tag)
+      end
+    end
+    fab!(:topic_in_watched_and_muted_tag) do
+      Fabricate(:topic).tap do |topic|
+        Fabricate(:topic_tag, topic: topic, tag: watched_tag)
+        Fabricate(:topic_tag, topic: topic, tag: muted_tag)
+      end
+    end
     fab!(:topic_in_muted_category) { Fabricate(:topic, category: muted_category) }
-    fab!(:topic_in_muted_tag) { Fabricate(:topic) }
-    fab!(:topic_tag_1) do
-      Fabricate(:topic_tag, topic: topic_in_watched_category_and_muted_tag, tag: muted_tag)
-    end
-    fab!(:topic_tag_2) do
-      Fabricate(:topic_tag, topic: topic_in_muted_category_and_watched_tag, tag: watched_tag)
-    end
-    fab!(:topic_tag_3) do
-      Fabricate(:topic_tag, topic: topic_in_watched_and_muted_tag, tag: watched_tag)
-    end
-    fab!(:topic_tag_4) do
-      Fabricate(:topic_tag, topic: topic_in_watched_and_muted_tag, tag: muted_tag)
-    end
-    fab!(:topic_tag_5) { Fabricate(:topic_tag, topic: topic_in_muted_tag, tag: muted_tag) }
-
-    before do
-      CategoryUser.create!(
-        user: user,
-        category: watched_category,
-        notification_level: CategoryUser.notification_levels[:watching],
-      )
-      CategoryUser.create!(
-        user: user,
-        category: muted_category,
-        notification_level: CategoryUser.notification_levels[:muted],
-      )
-      TagUser.create!(
-        user: user,
-        tag: watched_tag,
-        notification_level: TagUser.notification_levels[:watching],
-      )
-      TagUser.create!(
-        user: user,
-        tag: muted_tag,
-        notification_level: TagUser.notification_levels[:muted],
-      )
+    fab!(:topic_in_muted_tag) do
+      Fabricate(:topic).tap { |topic| Fabricate(:topic_tag, topic: topic, tag: muted_tag) }
     end
 
     context "when enabled" do

--- a/spec/models/tag_user_spec.rb
+++ b/spec/models/tag_user_spec.rb
@@ -230,6 +230,8 @@ RSpec.describe TagUser do
       end
 
       it "sets notification level to the highest one if there are multiple tags" do
+        SiteSetting.watched_precedence_over_muted = true
+
         TagUser.create!(
           user: user,
           tag: tracked_tag,


### PR DESCRIPTION
New setting which allow admin to define behavior when topic is in watched category and muted topic and vice versa.

If watched_precedence_over_muted setting is true, that topic is still visible in list of topics and notification is created.

If watched_precedence_over_muted setting is false, that topic is not still visible in list of topics and notification is skipped as well.
