### PR TITLE
UX: adding max height to image in chat blockquote

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -10,7 +10,8 @@ $max_image_height: 150px;
   .chat-message-collapser .chat-uploads img,
   .chat-message-collapser p img,
   aside.onebox .onebox-body .aspect-image-full-size,
-  aside.onebox .onebox-body .aspect-image-full-size img {
+  aside.onebox .onebox-body .aspect-image-full-size img,
+  .chat-message-text p img:not(.emoji) {
     object-fit: contain;
     max-height: $max_image_height;
     max-width: 100%;

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -73,7 +73,6 @@
     p img:not(.emoji) {
       max-width: 100%;
       height: auto;
-      max-height: 50vh;
     }
 
     ul,

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -73,6 +73,7 @@
     p img:not(.emoji) {
       max-width: 100%;
       height: auto;
+      max-height: 50vh;
     }
 
     ul,


### PR DESCRIPTION
Large images can be a tiny bit overwhelming in chat when using blockquote
<img width="1727" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c06eb12f-afa7-4d2f-82b9-5a1e4f979f30">

obscuring almost the whole screen.

Added this selector to the existing img controlling css, providing max heights
