### PR TITLE
Fix structural problems with the openapi spec

### DIFF
--- a/spec/requests/api/schemas/json/category_create_request.json
+++ b/spec/requests/api/schemas/json/category_create_request.json
@@ -42,7 +42,7 @@
     },
     "form_template_ids": {
       "type": "array",
-      "items": []
+      "items": {}
     }
   },
   "required": [

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -76,7 +76,7 @@
         },
         "form_template_ids": {
           "type": "array",
-          "items": []
+          "items": {}
         },
         "has_children": {
           "type": [

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -79,7 +79,7 @@
         },
         "form_template_ids": {
           "type": "array",
-          "items": []
+          "items": {}
         },
         "has_children": {
           "type": [

--- a/spec/requests/api/schemas/json/post_show_response.json
+++ b/spec/requests/api/schemas/json/post_show_response.json
@@ -207,9 +207,7 @@
     },
     "mentioned_users": {
       "type": "array",
-      "items": [
-
-      ]
+      "items": {}
     },
     "name": {
       "type": [

--- a/spec/requests/api/schemas/json/post_show_response.json
+++ b/spec/requests/api/schemas/json/post_show_response.json
@@ -126,33 +126,31 @@
     },
     "actions_summary": {
       "type": "array",
-      "items": [
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "id": {
-              "type": "integer",
-              "description": "`2`: like, `3`, `4`, `6`, `7`, `8`: flag"
-            },
-            "count": {
-              "type": "integer"
-            },
-            "acted": {
-              "type": "boolean"
-            },
-            "can_undo": {
-              "type": "boolean"
-            },
-            "can_act": {
-              "type": "boolean"
-            }
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "`2`: like, `3`, `4`, `6`, `7`, `8`: flag"
           },
-          "required": [
-            "id"
-          ]
-        }
-      ]
+          "count": {
+            "type": "integer"
+          },
+          "acted": {
+            "type": "boolean"
+          },
+          "can_undo": {
+            "type": "boolean"
+          },
+          "can_act": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
     },
     "moderator": {
       "type": "boolean"

--- a/spec/requests/api/schemas/json/post_update_response.json
+++ b/spec/requests/api/schemas/json/post_update_response.json
@@ -205,9 +205,7 @@
         },
         "mentioned_users": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": {}
         },
         "name": {
           "type": [

--- a/spec/requests/api/schemas/json/post_update_response.json
+++ b/spec/requests/api/schemas/json/post_update_response.json
@@ -130,24 +130,22 @@
         },
         "actions_summary": {
           "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "can_act": {
-                  "type": "boolean"
-                }
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "integer"
               },
-              "required": [
-                "id",
-                "can_act"
-              ]
-            }
-          ]
+              "can_act": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "can_act"
+            ]
+          }
         },
         "moderator": {
           "type": "boolean"

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -712,7 +712,7 @@
             },
             "form_template_ids": {
               "type": "array",
-              "items": []
+              "items": {}
             }
           },
           "required": [


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

rswag is extremely permissive; way moreso than the actual OAS standard, or JSON schema!

It will cause a downstream parsing issue which using openapi.json produced by this repo. (Hosted here https://github.com/discourse/discourse_api_docs)

See more info here: https://github.com/mattpolzin/OpenAPIKit/issues/277#issuecomment-1599019608

Historically, we have fixed such problems, but they have not been completely repaired. And such problems may be added again later.
> See history fix: https://github.com/discourse/discourse/pull/16710
> See bug introduce: https://github.com/discourse/discourse/pull/21028

Some follow up needed:
- After this PR is merged. Please trigger a bot to make an update for https://github.com/discourse/discourse_api_docs repo.
- Add some strict OpenAPI spec test in case such permissive syntax show up again in a later commit/PR.