### PR TITLE
FEATURE: Show first notification tip to all users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -811,17 +811,9 @@ class User < ActiveRecord::Base
   TRACK_FIRST_NOTIFICATION_READ_DURATION = 1.week.to_i
 
   def read_first_notification?
-    if (
-         trust_level > TrustLevel[1] ||
-           (
-             first_seen_at.present? &&
-               first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago
-           ) || user_option.skip_new_user_tips
-       )
-      return true
-    end
-
-    self.seen_notification_id == 0 ? false : true
+    (
+      first_seen_at.present? && first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago
+    ) || user_option.skip_new_user_tips || self.seen_notification_id != 0
   end
 
   def publish_notifications_state

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -808,12 +808,8 @@ class User < ActiveRecord::Base
     MessageBus.publish("/reviewable_counts/#{self.id}", data, user_ids: [self.id])
   end
 
-  TRACK_FIRST_NOTIFICATION_READ_DURATION = 1.week.to_i
-
   def read_first_notification?
-    (
-      first_seen_at.present? && first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago
-    ) || user_option.skip_new_user_tips || self.seen_notification_id != 0
+    self.seen_notification_id != 0 || user_option.skip_new_user_tips
   end
 
   def publish_notifications_state

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2208,14 +2208,6 @@ RSpec.describe User do
       end
     end
 
-    describe "when user is an old user" do
-      it "should return the right value" do
-        user.update!(first_seen_at: 1.year.ago)
-
-        expect(user.read_first_notification?).to eq(true)
-      end
-    end
-
     describe "when user skipped new user tips" do
       it "should return the right value" do
         user.user_option.update!(skip_new_user_tips: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2208,14 +2208,6 @@ RSpec.describe User do
       end
     end
 
-    describe "when user is trust level 2" do
-      it "should return the right value" do
-        user.update!(trust_level: TrustLevel[2])
-
-        expect(user.read_first_notification?).to eq(true)
-      end
-    end
-
     describe "when user is an old user" do
       it "should return the right value" do
         user.update!(first_seen_at: 1.year.ago)


### PR DESCRIPTION
It used to show only to users with trust level 0 or 1 and users with a higher trust level would never see the user tip.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
