### PR TITLE
FIX: Attempt to reconnect to server when browser visibility changes

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -19,7 +19,7 @@ workbox.setConfig({
   debug: false
 });
 
-var authUrls = ["auth", "session/sso_login", "session/sso"].map(path => `<%= Discourse.base_path %>/${path}`);
+var authUrls = ["auth", "session/sso_login", "session/sso", "srv/status"].map(path => `<%= Discourse.base_path %>/${path}`);
 var chatRegex = /\/chat\/channel\/(\d+)\//;
 var inlineReplyIcon = "<%= UrlHelper.absolute("/images/push-notifications/inline_reply.png") %>";
 


### PR DESCRIPTION
This adds another event listener, listening for `visibilitychange` events. When one fires and 1. browser is visible and 2. network connectivity service is disconnected, we then ping the server to ensure we are actually offline, and if not set service as connected again.

This adds `/srv/status` to the `authUrls` var in service worker. Could rename variable... but these routes are ones we do not want to cache a response for.