### PR TITLE
UX: fix sidebar dot color when chat is off

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -49,6 +49,15 @@
     .sidebar-section-link-suffix {
       margin-left: 1em;
       font-size: var(--font-down-4);
+      &.icon {
+        &.urgent svg {
+          color: var(--success);
+        }
+
+        &.unread svg {
+          color: var(--tertiary-med-or-tertiary);
+        }
+      }
     }
 
     .sidebar-section-link-content-text {

--- a/plugins/chat/assets/stylesheets/common/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/sidebar-extensions.scss
@@ -136,16 +136,6 @@
 }
 
 .chat-enabled {
-  .sidebar-section-link-suffix.icon {
-    &.urgent svg {
-      color: var(--success);
-    }
-
-    &.unread svg {
-      color: var(--tertiary-med-or-tertiary);
-    }
-  }
-
   .sidebar-section-link-prefix {
     .prefix-image {
       border: 1px solid transparent;


### PR DESCRIPTION
Moving this to a non-chat scope so it applies when chat is disabled too. 

Before:
![Screenshot 2023-06-23 at 6 54 52 PM](https://github.com/discourse/discourse/assets/1681963/b80cf652-eb79-4214-8942-45b6eadd32c1)


After:
![Screenshot 2023-06-23 at 6 51 43 PM](https://github.com/discourse/discourse/assets/1681963/2c9a5038-2547-4a3e-ac56-2b901bf15d2d)
