### PR TITLE
FIX: Missing time increments in time-input component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/time-input.js
+++ b/app/assets/javascripts/discourse/app/components/time-input.js
@@ -93,7 +93,7 @@ export default Component.extend({
       // while diff with minimumTime is less than one hour
       // use 15 minutes steps and then 30 minutes
       const minutes = this.minimumTime ? (i <= 4 ? 15 : 30) : 15;
-      const option = start + ((minutes === 15) ? (i * minutes) : ((i-2) * minutes));
+      const option = start + (minutes === 15 ? i * minutes : (i - 2) * minutes);
 
       // when start is higher than 0 we will reach 1440 minutes
       // before the 96 iterations

--- a/app/assets/javascripts/discourse/app/components/time-input.js
+++ b/app/assets/javascripts/discourse/app/components/time-input.js
@@ -93,7 +93,7 @@ export default Component.extend({
       // while diff with minimumTime is less than one hour
       // use 15 minutes steps and then 30 minutes
       const minutes = this.minimumTime ? (i <= 4 ? 15 : 30) : 15;
-      const option = start + i * minutes;
+      const option = start + ((minutes === 15) ? (i * minutes) : ((i-2) * minutes));
 
       // when start is higher than 0 we will reach 1440 minutes
       // before the 96 iterations

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -49,4 +49,26 @@ module("Integration | Component | time-input", function (hooks) {
     await this.subject.selectRowByIndex(3);
     assert.strictEqual(this.subject.header().name(), "00:45");
   });
+
+  test("dropdown values", async function (assert) {
+    this.setProperties({
+      hours: "22",
+      minutes: "19",
+      relativeDate: moment("2032-01-01 20:40")
+    });
+    this.set("onChange", setTime);
+
+    await render(
+      hbs`<TimeInput @hours={{this.hours}} @minutes={{this.minutes}} @relativeDate={{this.relativeDate}}/>`
+    );
+
+    await this.subject.expand();
+    const rows = this.subject.rows();
+    assert.deepEqual(
+      Array.from(rows).map((r) => {
+        return parseInt(r.dataset.value);
+      }),
+      [1240,1255,1270,1285,1300,1330,1339,1360,1390,1420]
+    );
+  });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -54,7 +54,7 @@ module("Integration | Component | time-input", function (hooks) {
     this.setProperties({
       hours: "22",
       minutes: "19",
-      relativeDate: moment("2032-01-01 20:40")
+      relativeDate: moment("2032-01-01 20:40"),
     });
     this.set("onChange", setTime);
 
@@ -66,9 +66,9 @@ module("Integration | Component | time-input", function (hooks) {
     const rows = this.subject.rows();
     assert.deepEqual(
       Array.from(rows).map((r) => {
-        return parseInt(r.dataset.value);
+        return parseInt(r.dataset.value, 10);
       }),
-      [1240,1255,1270,1285,1300,1330,1339,1360,1390,1420]
+      [1240, 1255, 1270, 1285, 1300, 1330, 1339, 1360, 1390, 1420]
     );
   });
 });


### PR DESCRIPTION
**PR Summary**:
This PR addresses an issue with the time-input component's dropdown menu, specifically the missing 1.5 and 2 hour increments. The described issue was first reported at the [Discourse Meta forum](https://meta.discourse.org/t/event-times-missing-1-1-2-and-2-hour-increments/269456) (related to the Discourse calendar plugin).

The problem was identified within the `timeOptions` method's `while` loop, which generates the dropdown options based on the minutes. The loop initially uses 15-minute steps and then switches to 30-minute steps. However, the iteration variable `i` was not correctly updated when transitioning to the 30-minute increments. To fix this, the suggested solution updates the iteration variable to `i-2` when the loop switches to the 30-minute increments. This ensures that the dropdown options are generated correctly with the appropriate time intervals.

I have added a test which checks for this issue. To make the code change more clear, please consider the following comparison between the original code and the suggest solution:
```
Old output: [1240,1255,1270,1285,1300,1339,1390,1420]
New output: [1240,1255,1270,1285,1300,1330,1339,1360,1390,1420]
```

If you believe that a different approach should be taken, such as rewriting this section of the code, kindly provide your feedback.
