### PR TITLE
DEV: Fix flaky tests by specifying tag names in asc order

### DIFF
--- a/spec/system/viewing_sidebar_as_anonymous_user_spec.rb
+++ b/spec/system/viewing_sidebar_as_anonymous_user_spec.rb
@@ -1,12 +1,29 @@
 # frozen_string_literal: true
 
 describe "Viewing sidebar as anonymous user", type: :system do
-  fab!(:tag1) { Fabricate(:tag).tap { |tag| Fabricate.times(1, :topic, tags: [tag]) } }
-  fab!(:tag2) { Fabricate(:tag).tap { |tag| Fabricate.times(2, :topic, tags: [tag]) } }
-  fab!(:tag3) { Fabricate(:tag).tap { |tag| Fabricate.times(3, :topic, tags: [tag]) } }
-  fab!(:tag4) { Fabricate(:tag).tap { |tag| Fabricate.times(2, :topic, tags: [tag]) } }
-  fab!(:tag5) { Fabricate(:tag).tap { |tag| Fabricate.times(2, :topic, tags: [tag]) } }
-  fab!(:tag6) { Fabricate(:tag).tap { |tag| Fabricate.times(1, :topic, tags: [tag]) } }
+  fab!(:tag1) do
+    Fabricate(:tag, name: "tag 1").tap { |tag| Fabricate.times(1, :topic, tags: [tag]) }
+  end
+
+  fab!(:tag2) do
+    Fabricate(:tag, name: "tag 2").tap { |tag| Fabricate.times(2, :topic, tags: [tag]) }
+  end
+
+  fab!(:tag3) do
+    Fabricate(:tag, name: "tag 3").tap { |tag| Fabricate.times(3, :topic, tags: [tag]) }
+  end
+
+  fab!(:tag4) do
+    Fabricate(:tag, name: "tag 4").tap { |tag| Fabricate.times(2, :topic, tags: [tag]) }
+  end
+
+  fab!(:tag5) do
+    Fabricate(:tag, name: "tag 5").tap { |tag| Fabricate.times(2, :topic, tags: [tag]) }
+  end
+
+  fab!(:tag6) do
+    Fabricate(:tag, name: "tag 6").tap { |tag| Fabricate.times(1, :topic, tags: [tag]) }
+  end
 
   let(:sidebar) { PageObjects::Components::Sidebar.new }
 


### PR DESCRIPTION
Why is this change required?

Previously, the tests in `viewing_sidebar_as_anonymous_user_spec.rb` was
flaky because the ordering of the tags changes depending on what the
auto generated tag names are. If a tag name is generated with the name
`tag10`, it would then be sorted before `tag9` which messes up the
ordering specified in our tests. This commit fixes the problem by
specifying the tag names instead of relying on the auto generated ones
by fabricator.