### PR TITLE
FIX: render plugin's commit URL correctly and open in new window.

### DIFF
--- a/app/assets/javascripts/admin/addon/components/plugin-commit-hash.hbs
+++ b/app/assets/javascripts/admin/addon/components/plugin-commit-hash.hbs
@@ -1,6 +1,6 @@
 {{#if this.commitHash}}
   <a
-    href={{this.commitUrl}}
+    href={{@plugin.commit_url}}
     target="_blank"
     rel="noopener noreferrer"
     class="current commit-hash"

--- a/app/assets/javascripts/admin/addon/components/plugin-commit-hash.hbs
+++ b/app/assets/javascripts/admin/addon/components/plugin-commit-hash.hbs
@@ -1,6 +1,8 @@
 {{#if this.commitHash}}
   <a
-    href={{this.plugin.commit_url}}
+    href={{this.commitUrl}}
+    target="_blank"
+    rel="noopener noreferrer"
     class="current commit-hash"
     title={{this.commitHash}}
   >{{this.shortCommitHash}}</a>

--- a/app/assets/javascripts/admin/addon/components/plugin-commit-hash.js
+++ b/app/assets/javascripts/admin/addon/components/plugin-commit-hash.js
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
+import { alias } from "@ember/object/computed";
 
 export default class PluginCommitHash extends Component {
+  @alias("args.plugin.commit_url") commitUrl;
+
   get shortCommitHash() {
     return this.commitHash?.slice(0, 7);
   }

--- a/app/assets/javascripts/admin/addon/components/plugin-commit-hash.js
+++ b/app/assets/javascripts/admin/addon/components/plugin-commit-hash.js
@@ -1,9 +1,6 @@
 import Component from "@glimmer/component";
-import { alias } from "@ember/object/computed";
 
 export default class PluginCommitHash extends Component {
-  @alias("args.plugin.commit_url") commitUrl;
-
   get shortCommitHash() {
     return this.commitHash?.slice(0, 7);
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
@@ -28,6 +28,9 @@ acceptance("Admin - Plugins", function (needs) {
             enabled_setting: "testplugin_enabled",
             has_settings: true,
             is_official: true,
+            commit_hash: "1234567890abcdef",
+            commit_url:
+              "https://github.com/username/some-test-plugin/commit/1234567890abcdef",
           },
         ],
       })
@@ -46,6 +49,12 @@ acceptance("Admin - Plugins", function (needs) {
     assert.true(
       exists(".admin-plugins .admin-container .alert-error"),
       "displays an error for unknown routes"
+    );
+
+    assert.strictEqual(
+      table.querySelector("tr .version a.commit-hash").href,
+      "https://github.com/username/some-test-plugin/commit/1234567890abcdef",
+      "displays a commit hash with a link to commit url"
     );
   });
 });


### PR DESCRIPTION
Previously, the URLs are missed in the commit links in version column. Follow up to: https://github.com/discourse/discourse/pull/22176