### PR TITLE
FIX: longer touch for active message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -290,6 +290,17 @@ export default class ChatMessage extends Component {
   onLongPressCancel() {
     cancel(this._makeMessageActiveHandler);
     this.isActive = false;
+
+    // this a tricky bit of code which is needed to prevent the long press
+    // from triggering a click on the message actions panel when releasing finger press
+    // we can't prevent default as we need to keep the event passive for performance reasons
+    // this class will prevent any click from being triggered until removed
+    // this number has been chosen from testing but might need to be increased
+    this._disableMessageActionsHandler = discourseLater(() => {
+      document.documentElement.classList.remove(
+        "disable-message-actions-touch"
+      );
+    }, 200);
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -283,24 +283,13 @@ export default class ChatMessage extends Component {
     // capture the touch event instead of a scroll
     this._makeMessageActiveHandler = discourseLater(() => {
       this.isActive = true;
-    }, 50);
+    }, 125);
   }
 
   @action
   onLongPressCancel() {
     cancel(this._makeMessageActiveHandler);
     this.isActive = false;
-
-    // this a tricky bit of code which is needed to prevent the long press
-    // from triggering a click on the message actions panel when releasing finger press
-    // we can't prevent default as we need to keep the event passive for performance reasons
-    // this class will prevent any click from being triggered until removed
-    // this number has been chosen from testing but might need to be increased
-    this._disableMessageActionsHandler = discourseLater(() => {
-      document.documentElement.classList.remove(
-        "disable-message-actions-touch"
-      );
-    }, 200);
   }
 
   @action

--- a/plugins/chat/assets/stylesheets/mobile/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message.scss
@@ -1,4 +1,12 @@
 .mobile-view.has-full-page-chat {
+  &.disable-message-actions-touch {
+    .chat-message-actions {
+      > * {
+        pointer-events: none;
+      }
+    }
+  }
+
   #skip-link {
     @include user-select(none);
   }

--- a/plugins/chat/assets/stylesheets/mobile/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message.scss
@@ -1,12 +1,4 @@
 .mobile-view.has-full-page-chat {
-  &.disable-message-actions-touch {
-    .chat-message-actions {
-      > * {
-        pointer-events: none;
-      }
-    }
-  }
-
   #skip-link {
     @include user-select(none);
   }


### PR DESCRIPTION
Moving from 50ms to 125ms, it should limit cases where message is activated during scroll. Also removes the touch hack which was preventing release of long press to generate a click on the displayed menu. This shouldn't be needed anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
