### PR TITLE
UX: add max-width to thread indicator

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message-thread-indicator.scss
@@ -1,4 +1,5 @@
 .chat-message-thread-indicator {
+  max-width: 600px;
   grid-template-areas:
     "avatar info replies participants"
     "avatar excerpt excerpt excerpt";


### PR DESCRIPTION
Must have been dropped accidentally during refactor.
Readding max-width:600px for desktop.
