### PR TITLE
DEV: add before-header-panel plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/before-header-icons-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/before-header-icons-outlet.js
@@ -1,8 +1,0 @@
-import { hbs } from "ember-cli-htmlbars";
-import { registerWidgetShim } from "discourse/widgets/render-glimmer";
-
-registerWidgetShim(
-  "before-header-icons-outlet",
-  "div.before-header-icons-outlet",
-  hbs`<PluginOutlet @name="before-header-icons" @outletArgs={{hash attrs=@data}} /> `
-);

--- a/app/assets/javascripts/discourse/app/widgets/before-header-icons-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/before-header-icons-outlet.js
@@ -1,0 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
+import { registerWidgetShim } from "discourse/widgets/render-glimmer";
+
+registerWidgetShim(
+  "before-header-icons-outlet",
+  "div.before-header-icons-outlet",
+  hbs`<PluginOutlet @name="before-header-icons" @outletArgs={{hash attrs=@data}} /> `
+);

--- a/app/assets/javascripts/discourse/app/widgets/before-header-panel-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/before-header-panel-outlet.js
@@ -1,0 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
+import { registerWidgetShim } from "discourse/widgets/render-glimmer";
+
+registerWidgetShim(
+  "before-header-panel-outlet",
+  "div.before-header-panel-outlet",
+  hbs`<PluginOutlet @name="before-header-panel" @outletArgs={{hash attrs=@data}} /> `
+);

--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -25,7 +25,7 @@ createWidget("header-contents", {
       {{/if}}
     {{/if}}
 
-    {{before-header-icons-outlet attrs=attrs}}
+    {{before-header-panel-outlet attrs=attrs}}
 
     <div class="panel clearfix" role="navigation">{{yield}}</div>
   `,

--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -25,6 +25,8 @@ createWidget("header-contents", {
       {{/if}}
     {{/if}}
 
+    {{before-header-icons-outlet attrs=attrs}}
+
     <div class="panel clearfix" role="navigation">{{yield}}</div>
   `,
 });


### PR DESCRIPTION
This adds a plugin outlet so content can be added to the header without relying on `decorateWidget`. 

While we can add components to widgets now, `decorateWidget` isn't ideal because you always end up contained within another div... decorating the site-logo widget puts you inside the `.title` div, and decorating the `.header-icons` puts you inside of `.panel`... this can make alignment of theme-added content trickier than it needs to be. 