### PR TITLE
DEV: Remove ember-rfc176-data

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -47,7 +47,6 @@
     "ember-modifier": "^4.1.0",
     "ember-on-resize-modifier": "^1.1.0",
     "ember-production-deprecations": "1.0.0",
-    "ember-rfc176-data": "^0.3.18",
     "ember-source": "~3.28.12",
     "ember-test-selectors": "^6.0.0",
     "handlebars": "^4.7.7",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -4196,7 +4196,7 @@ ember-resolver@^10.1.1:
   dependencies:
     ember-cli-babel "^7.26.11"
 
-ember-rfc176-data@^0.3.17, ember-rfc176-data@^0.3.18:
+ember-rfc176-data@^0.3.17:
   version "0.3.18"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.18.tgz#bb6fdcef49999981317ea81b6cc9210fb4108d65"
   integrity sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==


### PR DESCRIPTION
No longer directly used

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
