### PR TITLE
DEV: Add `order:title` filter to experimental `/filter` route

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -490,6 +490,9 @@ class TopicsFilter
     "posters" => {
       column: "topics.participant_count",
     },
+    "title" => {
+      column: "LOWER(topics.title)",
+    },
     "views" => {
       column: "topics.views",
     },
@@ -508,7 +511,7 @@ class TopicsFilter
           @scope = instance_exec(&scope)
         end
 
-        @scope = @scope.order(column_name => match_data[:asc] ? :asc : :desc)
+        @scope = @scope.order("#{column_name} #{match_data[:asc] ? "ASC" : "DESC"}")
       end
     end
   end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1336,6 +1336,14 @@ RSpec.describe TopicsFilter do
         include_examples "ordering topics filters", "category", "category name"
       end
 
+      describe "when ordering by topics's title" do
+        fab!(:topic3) { Fabricate(:topic, title: "This is topic number 1") }
+        fab!(:topic2) { Fabricate(:topic, title: "This is topic Number 3") }
+        fab!(:topic) { Fabricate(:topic, title: "This is topic number 2") }
+
+        include_examples "ordering topics filters", "title", "topic's title"
+      end
+
       describe "composing multiple order filters" do
         fab!(:topic) { Fabricate(:topic, created_at: Time.zone.local(2023, 1, 1), views: 2) }
         fab!(:topic2) { Fabricate(:topic, created_at: Time.zone.local(2024, 1, 1), views: 2) }


### PR DESCRIPTION
This has been requested multiple times by users so it makes sense for us
to support this as well.

See https://meta.discourse.org/t/sort-display-of-topics-alphabetically/53911