### PR TITLE
UX: Align chat separators, increase mobile chat width

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
@@ -5,7 +5,7 @@
   &-new {
     display: flex;
     justify-content: center;
-    padding: 20px 0 20px 1em;
+    padding: 20px 0 20px var(--scrollbarWidth);
     position: relative;
 
     .chat-message-separator__text-container {
@@ -44,7 +44,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    padding-left: 1rem;
+    padding-left: var(--scrollbarWidth);
     pointer-events: none;
 
     &.with-last-visit {
@@ -125,7 +125,7 @@
     }
 
     & + .chat-message-separator__line-container {
-      padding: 20px 0;
+      padding: 20px 0 20px var(--scrollbarWidth);
       box-sizing: border-box;
 
       .chat-message-separator__line {

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel.scss
@@ -1,5 +1,5 @@
 .chat-channel {
   .chat-messages-scroll {
-    padding: 0 10px 10px 10px;
+    padding-bottom: 5px;
   }
 }


### PR DESCRIPTION
cc: @discourse/designers 

Separators - before/after

<img width="754" alt="Screenshot 2023-06-27 at 13 09 26" src="https://github.com/discourse/discourse/assets/66961/9598e7f3-f008-4cad-886f-3c8dfea81676">
<img width="754" alt="Screenshot 2023-06-27 at 13 09 08" src="https://github.com/discourse/discourse/assets/66961/87579632-9bee-4023-81f5-4d1a96df49cf">

---

Mobile chat width - before/after

<img width="306" alt="Screenshot 2023-06-27 at 13 32 09" src="https://github.com/discourse/discourse/assets/66961/2536ffb6-7032-455f-b2dd-d0a8f95e2ce5"> <img width="306" alt="Screenshot 2023-06-27 at 13 31 47" src="https://github.com/discourse/discourse/assets/66961/5512a63a-5ec8-4f84-bf64-72e98b7e1b33">

<img width="306" alt="Screenshot 2023-06-27 at 13 32 26" src="https://github.com/discourse/discourse/assets/66961/bb77d204-053d-47f8-a0dd-0528a89a0d55"> <img width="306" alt="Screenshot 2023-06-27 at 13 32 42" src="https://github.com/discourse/discourse/assets/66961/52b5a7e0-6329-495c-b493-35176c6a856e">
