### PR TITLE
FIX: Allow to use `%h%m%s` for youtube `t` param

### DIFF
--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
@@ -6,7 +6,7 @@ export default class LazyVideo extends Component {
       case "youtube":
         let url = `https://www.youtube.com/embed/${this.args.videoId}?autoplay=1`;
         if (this.args.startTime) {
-          url += `&start=${this.args.startTime}`;
+          url += `&start=${this.convertToSeconds(this.args.startTime)}`;
         }
         return url;
       case "vimeo":
@@ -16,5 +16,19 @@ export default class LazyVideo extends Component {
       case "tiktok":
         return `https://www.tiktok.com/embed/v2/${this.args.videoId}`;
     }
+  }
+
+  convertToSeconds(startTime) {
+    const match = startTime.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/).slice(1);
+    const [hours, minutes, seconds] = match;
+
+    if (hours || minutes || seconds) {
+      const h = parseInt(hours, 10) || 0;
+      const m = parseInt(minutes, 10) || 0;
+      const s = parseInt(seconds, 10) || 0;
+
+      return h * 3600 + m * 60 + s;
+    }
+    return startTime;
   }
 }

--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
@@ -18,9 +18,9 @@ export default class LazyVideo extends Component {
     }
   }
 
-  convertToSeconds(startTime) {
-    const match = startTime.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/).slice(1);
-    const [hours, minutes, seconds] = match;
+  convertToSeconds(time) {
+    const match = time.toString().match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
+    const [hours, minutes, seconds] = match.slice(1);
 
     if (hours || minutes || seconds) {
       const h = parseInt(hours, 10) || 0;
@@ -29,6 +29,6 @@ export default class LazyVideo extends Component {
 
       return h * 3600 + m * 60 + s;
     }
-    return startTime;
+    return time;
   }
 }

--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
@@ -5,7 +5,7 @@ export default class LazyVideo extends Component {
     switch (this.args.providerName) {
       case "youtube":
         let url = `https://www.youtube.com/embed/${this.args.videoId}?autoplay=1`;
-        if (this.args.startTime > 0) {
+        if (this.args.startTime) {
           url += `&start=${this.args.startTime}`;
         }
         return url;

--- a/plugins/discourse-lazy-videos/assets/javascripts/lib/lazy-video-attributes.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/lib/lazy-video-attributes.js
@@ -8,7 +8,7 @@ export default function getVideoAttributes(cooked) {
   const thumbnail = img?.getAttribute("src");
   const dominantColor = img?.dataset?.dominantColor;
   const title = cooked.dataset.videoTitle;
-  const startTime = cooked.dataset.videoStartTime || 0;
+  const startTime = cooked.dataset.videoStartTime;
   const providerName = cooked.dataset.providerName;
   const id = cooked.dataset.videoId;
 

--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
@@ -21,7 +21,8 @@ class Onebox::Engine::YoutubeOnebox
       end
 
       escaped_title = ERB::Util.html_escape(video_title)
-      escaped_start_time = ERB::Util.html_escape(params["t"] || 0)
+      escaped_start_time = ERB::Util.html_escape(params["t"])
+      t_param = escaped_start_time.present? ? "&t=#{escaped_start_time}" : nil
 
       <<~HTML
         <div class="youtube-onebox lazy-video-container"
@@ -29,7 +30,7 @@ class Onebox::Engine::YoutubeOnebox
           data-video-title="#{escaped_title}"
           data-video-start-time="#{escaped_start_time}"
           data-provider-name="youtube">
-          <a href="https://www.youtube.com/watch?v=#{video_id}" target="_blank">
+          <a href="https://www.youtube.com/watch?v=#{video_id}#{t_param}" target="_blank">
             <img class="youtube-thumbnail"
               src="#{thumbnail_url}"
               title="#{escaped_title}">

--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
@@ -22,7 +22,7 @@ class Onebox::Engine::YoutubeOnebox
 
       escaped_title = ERB::Util.html_escape(video_title)
       escaped_start_time = ERB::Util.html_escape(params["t"])
-      t_param = escaped_start_time.present? ? "&t=#{escaped_start_time}" : nil
+      t_param = "&t=#{escaped_start_time}" if escaped_start_time.present?
 
       <<~HTML
         <div class="youtube-onebox lazy-video-container"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
