### PR TITLE
FIX: fix normalize_raw method for nil inputs in migration scripts

### DIFF
--- a/script/import_scripts/bespoke_1.rb
+++ b/script/import_scripts/bespoke_1.rb
@@ -160,6 +160,8 @@ class ImportScripts::Bespoke < ImportScripts::Base
   end
 
   def normalize_raw!(raw)
+    return "<missing>" if raw.blank?
+
     # purple and #1223f3
     raw.gsub!(/\[color=[#a-z0-9]+\]/i, "")
     raw.gsub!(%r{\[/color\]}i, "")

--- a/script/import_scripts/jive.rb
+++ b/script/import_scripts/jive.rb
@@ -196,6 +196,8 @@ class ImportScripts::Jive < ImportScripts::Base
   end
 
   def normalize_raw!(raw)
+    return "<missing>" if raw.blank?
+
     raw = raw.dup
     raw = raw[5..-6]
 

--- a/script/import_scripts/yammer.rb
+++ b/script/import_scripts/yammer.rb
@@ -468,6 +468,8 @@ class ImportScripts::Yammer < ImportScripts::Base
   end
 
   def normalize_raw(raw)
+    return "<missing>" if raw.blank?
+
     raw = raw.gsub('\n', "")
     raw.gsub!(/\[\[user:(\d+)\]\]/) do
       u = Regexp.last_match(1)

--- a/script/import_scripts/zendesk.rb
+++ b/script/import_scripts/zendesk.rb
@@ -211,7 +211,8 @@ class ImportScripts::Zendesk < ImportScripts::Base
   end
 
   def normalize_raw(raw)
-    return '' if raw.nil?
+    return "<missing>" if raw.blank?
+
     raw = raw.gsub('\n', "")
     raw = ReverseMarkdown.convert(raw)
     raw

--- a/script/import_scripts/zendesk.rb
+++ b/script/import_scripts/zendesk.rb
@@ -211,6 +211,7 @@ class ImportScripts::Zendesk < ImportScripts::Base
   end
 
   def normalize_raw(raw)
+    return '' if raw.nil?
     raw = raw.gsub('\n', "")
     raw = ReverseMarkdown.convert(raw)
     raw

--- a/script/import_scripts/zendesk_api.rb
+++ b/script/import_scripts/zendesk_api.rb
@@ -345,6 +345,8 @@ class ImportScripts::ZendeskApi < ImportScripts::Base
   end
 
   def normalize_raw(raw, user_id)
+    return "<missing>" if raw.blank?
+
     raw = raw.gsub('\n', "")
     raw = ReverseMarkdown.convert(raw)
 


### PR DESCRIPTION
Various migration scripts define a `normalize_raw` method to do custom processing of post contents before storing it in the `Post.raw` and other fields.

They normally do not handle `nil` inputs, but it's a relatively common occurrence in data dumps.

Since this method is used from various points in the migration script, as it stands, the experience of using a migration script is that it will fail multiple times at different points, forcing you to fix the data or apply logic hacks every time then restarting.

This PR generalizes handling of nil input by returning a `<missing>` string.

Pros:
- no more messy repeated crashes + restarts
- consistency

Cons:
- it might hide data issues
  - OTOH we can't print a warning on that method because it will flood the console since it's called from inside loops.
