### PR TITLE
FIX: Set `Jobs::BackfillSidebarSiteSettings` cluster concurrency to 1

### DIFF
--- a/app/jobs/regular/backfill_sidebar_site_settings.rb
+++ b/app/jobs/regular/backfill_sidebar_site_settings.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Jobs::BackfillSidebarSiteSettings < Jobs::Base
+  # There should only be one of these jobs running at a time and it will be ordered based on the order in which the job
+  # was enqueued.
+  cluster_concurrency 1
+
   def execute(args)
     SidebarSiteSettingsBackfiller.new(
       args[:setting_name],

--- a/spec/jobs/backfill_sidebar_site_settings_spec.rb
+++ b/spec/jobs/backfill_sidebar_site_settings_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::BackfillSidebarSiteSettings do
+  it "should have a cluster concurrency of 1" do
+    expect(Jobs::BackfillSidebarSiteSettings.get_cluster_concurrency).to eq(1)
+  end
+end


### PR DESCRIPTION
What is the problem?

When an admin changes the default_sidebar_categories or default_sidebar_tags site settings and opts to backfill the setting,
we currently enqueue a sidekiq job to run the backfilling operation. When an admin changes those settings multiple times
within a short time frame, multiple sidekiq jobs with different backfilling parameters will be enqueued.
This is problematic if multiple jobs are executed concurrently as it may lead to situations where a job
with “outdated” site setting values is completed after a job with the “latest” site setting values.

What is the fix?

By setting `cluster_concurrency` to `1`, we ensure that only one of such
backfilling job will execute across all the sidekiq processes that are
deployed at any point in time. Since Sidekiq pops off job in the order
in which they are pushed, limiting the cluster concurrency here will
allow us to execute the enqueued `Jobs::BackfillSidebarSiteSettings`
jobs serially.