### PR TITLE
DEV: Remove AJAX usage in chat-channel model 

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -548,7 +548,21 @@ export default class ChatLivePane extends Component {
         }
       }
 
-      this.args.channel.updateLastReadMessage(lastUnreadVisibleMessage.id);
+      if (!this.args.channel.isFollowing || !lastUnreadVisibleMessage.id) {
+        return;
+      }
+
+      if (
+        this.args.channel.currentUserMembership.lastReadMessageId >=
+        lastUnreadVisibleMessage.id
+      ) {
+        return;
+      }
+
+      return this.chatApi.markChannelAsRead(
+        this.args.channel.id,
+        lastUnreadVisibleMessage.id
+      );
     });
   }
 

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -1,6 +1,5 @@
 import UserChatChannelMembership from "discourse/plugins/chat/discourse/models/user-chat-channel-membership";
 import { TrackedSet } from "@ember-compat/tracked-built-ins";
-import { ajax } from "discourse/lib/ajax";
 import { escapeExpression } from "discourse/lib/utilities";
 import { tracked } from "@glimmer/tracking";
 import slugifyChannel from "discourse/plugins/chat/discourse/lib/slugify-channel";
@@ -323,22 +322,6 @@ export default class ChatChannel {
     this.currentUserMembership.mobileNotificationLevel =
       membership.mobile_notification_level;
     this.currentUserMembership.muted = membership.muted;
-  }
-
-  updateLastReadMessage(messageId) {
-    if (!this.isFollowing || !messageId) {
-      return;
-    }
-
-    if (this.currentUserMembership.lastReadMessageId >= messageId) {
-      return;
-    }
-
-    // TODO (martin) Change this to use chatApi service markChannelAsRead once we change this
-    // class not to use RestModel.
-    return ajax(`/chat/api/channels/${this.id}/read/${messageId}`, {
-      method: "PUT",
-    });
   }
 
   clearSelectedMessages() {


### PR DESCRIPTION
Addressing TODO about using chatApi in the ChatChannel model,
but since it's a model we cannot easily use the chatApi service.
The model function is only called in one place so we may as well
just move the call there since the component can use chatApi