### PR TITLE
FIX: Chat threads mentions/user status N1

### DIFF
--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -132,8 +132,10 @@ module Chat
           original_message_user: :user_status,
           original_message: [
             :chat_webhook_event,
-            :chat_mentions,
             :chat_channel,
+            chat_mentions: {
+              user: :user_status,
+            },
             user: :user_status,
           ],
         )


### PR DESCRIPTION
Followup to 1526d1f97d4617b5de03db8b71cd02cb1802d49c

This commit fixes an N1 for mentions/user status
when querying chat threads. This only happened if
any of the thread OMs had mentions.
