### PR TITLE
DEV: Fix flaky thread navigation spec

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Navigation", type: :system do
     before do
       SiteSetting.enable_experimental_chat_threaded_discussions = true
       category_channel.update!(threading_enabled: true)
-      Fabricate(:chat_message, thread: thread)
+      Fabricate(:chat_message, thread: thread, chat_channel: thread.channel)
       thread.add(current_user)
     end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
@@ -13,6 +13,7 @@ module PageObjects
         else
           has_css?(".chat-side-panel .chat-thread")
         end
+        PageObjects::Pages::ChatThread.new.has_no_loading_skeleton?
       end
 
       def has_no_open_thread?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -433,7 +433,18 @@ RSpec.configure do |config|
           if logs.empty?
             lines << "(no logs)"
           else
-            logs.each { |log| lines << log.message }
+            logs.each do |log|
+              # System specs are full of image load errors that are just noise, no need
+              # to log this.
+              if (
+                   log.message.include?("Failed to load resource: net::ERR_CONNECTION_REFUSED") &&
+                     (log.message.include?("uploads") || log.message.include?("images"))
+                 ) || log.message.include?("favicon.ico")
+                next
+              end
+
+              lines << log.message
+            end
           end
           lines << "~~~~~ END JS LOGS ~~~~~"
         end


### PR DESCRIPTION
Introduced in cec68b3e2c1e779b1fa0a70dc57bae045df4aebd,
this is flaky because if you click the back button before
the route is fully transitioned to the loaded thread,
we end up going to the history _before_ the thread list,
which ends up being the channel.

We need to make sure that everything is loaded for the
thread first, meaning the skeleton is not there.

Also exclude some noise from the capybara logs (image load failures)
