### PR TITLE
DEV: Add plugin_modifier for groups in `users_controller#search_users`

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1234,7 +1234,7 @@ class UsersController < ApplicationController
         groups = block.call(groups, current_user) if params[param_name.to_s]
       end
 
-      # the plugin registery callbacks registered above are only evaluted when a param
+      # the plugin registry callbacks above are only evaluated when a param
       # is present matching the name of the callback. Any modifier registered using
       # register_modifier(:groups_for_users_search) will be evaluated without needing the
       # param.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1234,6 +1234,7 @@ class UsersController < ApplicationController
         groups = block.call(groups, current_user) if params[param_name.to_s]
       end
 
+      groups = DiscoursePluginRegistry.apply_modifier(:groups_for_users_search, groups)
       groups = Group.search_groups(term, groups: groups, sort: :auto)
 
       to_render[:groups] = groups.map { |m| { name: m.name, full_name: m.full_name } }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1234,6 +1234,10 @@ class UsersController < ApplicationController
         groups = block.call(groups, current_user) if params[param_name.to_s]
       end
 
+      # the plugin registery callbacks registered above are only evaluted when a param
+      # is present matching the name of the callback. Any modifier registered using
+      # register_modifier(:groups_for_users_search) will be evaluated without needing the
+      # param.
       groups = DiscoursePluginRegistry.apply_modifier(:groups_for_users_search, groups)
       groups = Group.search_groups(term, groups: groups, sort: :auto)
 


### PR DESCRIPTION
There is already a DiscoursePluginRegistry thing to manipulate core's list of groups.. but that's annoying b/c you _have_ to fiddle with the frontend. The new `register_modifier` API is so much easier to work with and I don't see the harm in having both for now!