### PR TITLE
DEV: Resolve poll plugin deprecation

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/controllers/poll-ui-builder.js
+++ b/plugins/poll/assets/javascripts/discourse/controllers/poll-ui-builder.js
@@ -2,7 +2,8 @@ import { gt, or } from "@ember/object/computed";
 import Controller from "@ember/controller";
 import EmberObject, { action } from "@ember/object";
 import { next } from "@ember/runloop";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed from "discourse-common/utils/decorators";
+import { observes } from "@ember-decorators/object";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import I18n from "I18n";
 


### PR DESCRIPTION
When using native class syntax, `observes` must be imported from `@ember-decorators/object`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
