### PR TITLE
DEV: Make max length of template and name admin configurable

### DIFF
--- a/app/models/form_template.rb
+++ b/app/models/form_template.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
 class FormTemplate < ActiveRecord::Base
-  validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
-  validates :template, presence: true, length: { maximum: 2000 }
+  validates :name,
+            presence: true,
+            uniqueness: true,
+            length: {
+              maximum: SiteSetting.max_form_template_title_length,
+            }
+  validates :template,
+            presence: true,
+            length: {
+              maximum: SiteSetting.max_form_template_content_length,
+            }
   validates_with FormTemplateYamlValidator
 
   has_many :category_form_templates, dependent: :destroy

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1556,6 +1556,8 @@ en:
     fixed_category_positions_on_create: "If checked, category ordering will be maintained on topic creation dialog (requires fixed_category_positions)."
     add_rel_nofollow_to_user_content: 'Add rel nofollow to all submitted user content, except for internal links (including parent domains). If you change this, you must rebake all posts with: "rake posts:rebake"'
     exclude_rel_nofollow_domains: "A list of domains where nofollow should not be added to links. example.com will automatically allow sub.example.com as well. As a minimum, you should add the domain of this site to help web crawlers find all content. If other parts of your website are at other domains, add those too."
+    max_form_template_title_length: "Maximum allowed length for form template titles."
+    max_form_template_content_length: "Maximum allowed length for form template content."
 
     post_excerpt_maxlength: "Maximum length of a post excerpt / summary."
     topic_excerpt_maxlength: "Maximum length of a topic excerpt / summary, generated from the first post in a topic."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1108,6 +1108,13 @@ posting:
   max_draft_length:
     default: 400_000
     hidden: true
+  max_form_template_title_length:
+    default: 100
+    min: 5
+    max: 255
+  max_form_template_content_length:
+    default: 2000
+    max: 150000
 
 email:
   email_time_window_mins:


### PR DESCRIPTION
This PR allows the maximum length of form template's title and content be admin configurable.