### PR TITLE
FIX: error when CategoryList tried to find relevant topics

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -86,12 +86,17 @@ class CategoryList
 
     if @guardian.authenticated?
       @all_topics =
-        @all_topics.joins(
-          "LEFT JOIN topic_users tu ON topics.id = tu.topic_id AND tu.user_id = #{@guardian.user.id.to_i}",
-        ).where(
-          "COALESCE(tu.notification_level,1) > :muted",
-          muted: TopicUser.notification_levels[:muted],
-        )
+        @all_topics
+          .joins(
+            "LEFT JOIN topic_users tu ON topics.id = tu.topic_id AND tu.user_id = #{@guardian.user.id.to_i}",
+          )
+          .where(
+            "COALESCE(tu.notification_level,1) > :muted",
+            muted: TopicUser.notification_levels[:muted],
+          )
+          .joins(
+            "LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{@guardian.user.id}",
+          )
     end
 
     @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user).includes(:last_poster)

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -90,12 +90,12 @@ class CategoryList
           .joins(
             "LEFT JOIN topic_users tu ON topics.id = tu.topic_id AND tu.user_id = #{@guardian.user.id.to_i}",
           )
+          .joins(
+            "LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{@guardian.user.id}",
+          )
           .where(
             "COALESCE(tu.notification_level,1) > :muted",
             muted: TopicUser.notification_levels[:muted],
-          )
-          .joins(
-            "LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{@guardian.user.id}",
           )
     end
 

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe CategoryList do
       SiteSetting.default_tags_muted = muted_tag.name
       Fabricate(:topic, category: public_cat, tags: [muted_tag])
 
+      muted_tag_2 = Fabricate(:tag)
+      TagUser.create!(
+        tag: muted_tag_2,
+        user: user,
+        notification_level: TagUser.notification_levels[:muted],
+      )
+
       CategoryFeaturedTopic.feature_topics
 
       expect(


### PR DESCRIPTION
Recently, we added the option for watched tag/categories to take precedence over muted tag/categories. Therefore, `remove_muted_tags` is using `category_users` to check if categories are not watched. There was missing join in CategoryList which was causing an error.
