### PR TITLE
FIX: consistent sidebar section external links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -8,13 +8,14 @@
   @class={{this.section.dragCss}}
 >
   {{#each this.section.links as |link|}}
-    {{#if link.external}}
+    {{#if (or link.external link.fullReload)}}
       <Sidebar::SectionLink
         @shouldDisplay={{link.shouldDisplay}}
         @linkName={{link.name}}
         @content={{replace-emoji link.text}}
         @prefixType="icon"
         @prefixValue={{link.prefixValue}}
+        @fullReload={{link.fullReload}}
         @href={{link.value}}
         @class={{link.linkDragCss}}
         {{(if

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -8,7 +8,7 @@
   @class={{this.section.dragCss}}
 >
   {{#each this.section.links as |link|}}
-    {{#if (or link.external link.fullReload)}}
+    {{#if link.externalOrFullReload}}
       <Sidebar::SectionLink
         @shouldDisplay={{link.shouldDisplay}}
         @linkName={{link.name}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
@@ -1,4 +1,4 @@
-{{#if (or @sectionLink.external @sectionLink.fullReload)}}
+{{#if @sectionLink.externalOrFullReload}}
   <Sidebar::SectionLink
     @shouldDisplay={{@sectionLink.shouldDisplay}}
     @linkName={{@sectionLink.name}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-link.hbs
@@ -1,10 +1,11 @@
-{{#if @sectionLink.external}}
+{{#if (or @sectionLink.external @sectionLink.fullReload)}}
   <Sidebar::SectionLink
     @shouldDisplay={{@sectionLink.shouldDisplay}}
     @linkName={{@sectionLink.name}}
     @content={{replace-emoji @sectionLink.text}}
     @prefixType="icon"
     @prefixValue={{@sectionLink.prefixValue}}
+    @fullReload={{@sectionLink.fullReload}}
     @href={{@sectionLink.value}}
   />
 {{else}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -50,6 +50,9 @@ export default class SectionLink extends Component {
   }
 
   get target() {
+    if (this.args.fullReload) {
+      return "_self";
+    }
     return this.currentUser?.user_option?.external_links_in_new_tab
       ? "_blank"
       : "_self";

--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -9,8 +9,13 @@ const MOUSE_DELAY = 250;
 export default class SectionLink {
   @tracked linkDragCss;
 
-  constructor({ external, icon, id, name, value }, section, router) {
+  constructor(
+    { external, full_reload, icon, id, name, value },
+    section,
+    router
+  ) {
     this.external = external;
+    this.fullReload = full_reload;
     this.prefixValue = icon;
     this.id = id;
     this.name = name;
@@ -18,7 +23,7 @@ export default class SectionLink {
     this.value = value;
     this.section = section;
 
-    if (!this.external) {
+    if (!this.external && !this.fullReload) {
       const routeInfoHelper = new RouteInfoHelper(router, value);
       this.route = routeInfoHelper.route;
       this.models = routeInfoHelper.models;

--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -23,7 +23,7 @@ export default class SectionLink {
     this.value = value;
     this.section = section;
 
-    if (!this.external && !this.fullReload) {
+    if (!this.externalOrFullReload) {
       const routeInfoHelper = new RouteInfoHelper(router, value);
       this.route = routeInfoHelper.route;
       this.models = routeInfoHelper.models;
@@ -33,6 +33,10 @@ export default class SectionLink {
 
   get shouldDisplay() {
     return true;
+  }
+
+  get externalOrFullReload() {
+    return this.external || this.fullReload;
   }
 
   @bind

--- a/app/serializers/sidebar_url_serializer.rb
+++ b/app/serializers/sidebar_url_serializer.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class SidebarUrlSerializer < ApplicationSerializer
-  attributes :id, :name, :value, :icon, :external, :segment
+  attributes :id, :name, :value, :icon, :external, :full_reload, :segment
 
   def external
-    object.external? || object.full_reload?
+    object.external?
+  end
+
+  def full_reload
+    object.full_reload?
   end
 end

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -6,6 +6,8 @@ describe "Custom sidebar sections", type: :system do
   let(:section_modal) { PageObjects::Modals::SidebarSectionForm.new }
   let(:sidebar) { PageObjects::Components::Sidebar.new }
 
+  before { user.user_option.update!(external_links_in_new_tab: true) }
+
   it "allows the user to create custom section" do
     visit("/latest")
 
@@ -40,7 +42,7 @@ describe "Custom sidebar sections", type: :system do
     section_modal.save
 
     expect(sidebar).to have_section("My section")
-    expect(sidebar).to have_section_link("My preferences")
+    expect(sidebar).to have_section_link("My preferences", target: "_self")
   end
 
   it "allows the user to create custom section with /pub link" do
@@ -53,7 +55,7 @@ describe "Custom sidebar sections", type: :system do
     section_modal.save
 
     expect(sidebar).to have_section("My section")
-    expect(sidebar).to have_section_link("Published Page")
+    expect(sidebar).to have_section_link("Published Page", target: "_self")
   end
 
   it "allows the user to create custom section with external link" do
@@ -76,7 +78,11 @@ describe "Custom sidebar sections", type: :system do
     section_modal.save
 
     expect(sidebar).to have_section("My section")
-    expect(sidebar).to have_section_link("Discourse Homepage", href: "https://discourse.org")
+    expect(sidebar).to have_section_link(
+      "Discourse Homepage",
+      href: "https://discourse.org",
+      target: "_blank",
+    )
   end
 
   it "allows the user to edit custom section" do

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -57,8 +57,8 @@ module PageObjects
         has_css?(".#{SIDEBAR_SECTION_LINK_SELECTOR}--active", count: 1)
       end
 
-      def has_section_link?(name, href: nil, active: false)
-        section_link_present?(name, href: href, active: active, present: true)
+      def has_section_link?(name, href: nil, active: false, target: nil)
+        section_link_present?(name, href: href, active: active, target: target, present: true)
       end
 
       def has_no_section_link?(name, href: nil, active: false)
@@ -119,11 +119,12 @@ module PageObjects
 
       private
 
-      def section_link_present?(name, href: nil, active: false, present:)
+      def section_link_present?(name, href: nil, active: false, target: nil, present:)
         attributes = { exact_text: name }
         attributes[:href] = href if href
         attributes[:class] = SIDEBAR_SECTION_LINK_SELECTOR
         attributes[:class] += "--active" if active
+        attributes[:target] = target if target
         page.public_send(present ? :has_link? : :has_no_link?, **attributes)
       end
 


### PR DESCRIPTION
Before this change, links which required full reload because they are not in ember routes like `/my/preferences` or links to docs like `/pub/*` were treated as real external links. Therefore, they were opening in self window or new tab based on user  `external_links_in_new_tab` setting.

To be consistent with behavior when full reload links are in the post, they are treated as internal and always open in the same window.
