### PR TITLE
FIX: A mobile header regression in 9cc2b5c

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -37,7 +37,8 @@
   }
 
   // Hide header avatar + icons while topic title is visible in mobile header
-  .extra-info-wrapper + .panel {
+  .extra-info-wrapper ~ .panel {
+    .before-header-panel-outlet,
     .header-buttons,
     .d-header-icons {
       display: none;


### PR DESCRIPTION
Hiding extra UI when topic title is visible broke when the plugin outlet was added.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
