### PR TITLE
DEV: Delete `uglify` asset codepath

### DIFF
--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -278,11 +278,7 @@ task "javascript:update" => "clean_up" do
 
     STDERR.puts "New dependency added: #{dest}" unless File.exist?(dest)
 
-    if f[:uglify]
-      File.write(dest, Uglifier.new.compile(File.read(src)))
-    else
-      FileUtils.cp_r(src, dest)
-    end
+    FileUtils.cp_r(src, dest)
   end
 
   write_template("discourse/app/lib/public-js-versions.js", "update", <<~JS)


### PR DESCRIPTION
We no longer process any thrid-party assets with uglify

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
