### PR TITLE
DEV: Bump oj from 3.13.14 to 3.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,7 @@ gem "omniauth-oauth2", require: false
 
 gem "omniauth-google-oauth2"
 
-# pending: https://github.com/ohler55/oj/issues/789
-gem "oj", "3.13.14"
+gem "oj"
 
 gem "pg"
 gem "mini_sql"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-    oj (3.13.14)
+    oj (3.15.0)
     omniauth (1.9.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -611,7 +611,7 @@ DEPENDENCIES
   net-pop
   net-smtp
   nokogiri
-  oj (= 3.13.14)
+  oj
   omniauth
   omniauth-facebook
   omniauth-github


### PR DESCRIPTION
https://github.com/ohler55/oj/issues/789 has been fixed and SSE4.2 is disabled by default.