### PR TITLE
DEV: Skip a flaky system test

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Navigation", type: :system do
     end
 
     context "when opening a thread from the thread list" do
-      it "goes back to the thread list when clicking the back button" do
+      xit "goes back to the thread list when clicking the back button" do
         visit("/chat")
         chat_page.visit_channel(category_channel)
         channel_page.open_thread_list


### PR DESCRIPTION
This has been flagged by our internal system as well and has been
failing on CI. Skip this for now to improve the stability of our system
test runs while we figure out why it is flaky.