### PR TITLE
DEV: Upgrade MessageBus to latest version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "http_accept_language", require: false
 
 gem "discourse-fonts", require: "discourse_fonts"
 
-gem "message_bus", "4.3.2"
+gem "message_bus"
 
 gem "rails_multisite"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,7 +596,7 @@ DEPENDENCIES
   mail
   maxminddb
   memory_profiler
-  message_bus (= 4.3.2)
+  message_bus
   mini_mime
   mini_racer
   mini_scheduler


### PR DESCRIPTION
Previously it was pinned to 4.3.2 because 4.3.3 was broken. This has now
been resolved so we no longer need to pin MessageBus.