### PR TITLE
DEV: Update MessageBus to 4.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     matrix (0.4.2)
     maxminddb (0.1.22)
     memory_profiler (1.0.1)
-    message_bus (4.3.2)
+    message_bus (4.3.7)
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)


### PR DESCRIPTION
Follow-up to 351005ef1bbca6df61356da1bbf0f2212d1b6a55 which didn't
actually upgrade MessageBus to the latest version.