### PR TITLE
Revert "Build(deps): Bump @uppy/aws-s3-multipart from 3.1.3 to 3.4.0 in /app/assets/javascripts (#22190)"

### DIFF
--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ember/string": "^3.1.1",
     "@uppy/aws-s3": "3.2.0",
-    "@uppy/aws-s3-multipart": "3.4.0",
+    "@uppy/aws-s3-multipart": "3.1.3",
     "@uppy/core": "3.0.4",
     "@uppy/drop-target": "2.0.1",
     "@uppy/utils": "5.4.0",

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -77,7 +77,7 @@
     "@babel/standalone": "^7.22.5",
     "@ember/optional-features": "^2.0.0",
     "@uppy/aws-s3": "3.2.0",
-    "@uppy/aws-s3-multipart": "3.4.0",
+    "@uppy/aws-s3-multipart": "3.1.3",
     "@uppy/core": "3.0.4",
     "@uppy/drop-target": "2.0.1",
     "@uppy/utils": "5.4.0",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -1713,7 +1713,15 @@
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
   integrity sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==
 
-"@uppy/aws-s3-multipart@3.4.0", "@uppy/aws-s3-multipart@^3.4.0":
+"@uppy/aws-s3-multipart@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@uppy/aws-s3-multipart/-/aws-s3-multipart-3.1.3.tgz#eb4e9f40686444cf8fa4d35c6bb5f36947bd7f6b"
+  integrity sha512-V1s9526efZz1T8YWT3g+Y4pZlazoH0mR4R6fql+PdzwYNvlchPe4b/+zFuEiymhHvoQk8pZM6kqI34Cf7FzqrQ==
+  dependencies:
+    "@uppy/companion-client" "^3.1.2"
+    "@uppy/utils" "^5.2.0"
+
+"@uppy/aws-s3-multipart@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@uppy/aws-s3-multipart/-/aws-s3-multipart-3.4.0.tgz#1830ac6a019764f35dda2b5c078c852d101ea04a"
   integrity sha512-/aJzs3pKaPTtM8Y94hWaW+gvPif/9d8l3e0ECQgX+sB9EWzctjUbn7a6HrNb98PDxwiG1+v84Uj4AwBwio5lqg==


### PR DESCRIPTION
This reverts commit d8f0f17b5030ee3f87bf6c487e6d128e34a4875d.

This causes errors when uploading to S3 because we are missing
a getFilesByIds function in core which we have not updated
yet c.f. https://github.com/discourse/discourse/pull/22195

Tests don't catch this because tests only try uploads.json
uploading.
