### PR TITLE
FIX: Do not follow redirects for twitter oneboxes

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -29,6 +29,7 @@ module Oneboxer
       "http://store.steampowered.com",
       "http://vimeo.com",
       "https://www.youtube.com",
+      "https://twitter.com",
       Discourse.base_url,
     ]
   end


### PR DESCRIPTION
Twitter is now redirecting anonymous users (with a browser-like user agent, which FinalDestination uses) to the login page. Skipping redirect-following for twitter.com will allow us to continue oneboxing tweets via the OpenGraph data and the API (when credentials are present).

https://meta.discourse.org/t/269371/17

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
