### PR TITLE
FIX: ActiveModel::Types :array load error in production

### DIFF
--- a/plugins/chat/lib/chat/types/array.rb
+++ b/plugins/chat/lib/chat/types/array.rb
@@ -18,3 +18,5 @@ module Chat
     end
   end
 end
+
+ActiveSupport.on_load(:active_record) { ActiveModel::Type.register(:array, Chat::Types::Array) }

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -32,6 +32,7 @@ module ::Chat
 end
 
 require_relative "lib/chat/engine"
+require_relative "lib/chat/types/array"
 
 after_initialize do
   register_seedfu_fixtures(Rails.root.join("plugins", "chat", "db", "fixtures"))
@@ -496,8 +497,6 @@ after_initialize do
   )
 
   register_bookmarkable(Chat::MessageBookmarkable)
-
-  ActiveModel::Type.register(:array, Chat::Types::Array)
 end
 
 if Rails.env == "test"


### PR DESCRIPTION
Followup to 3f1024de7698fa357d5b517b37fcb96647fcbe6e

The ActiveModel::Types.register(:array) call for chat was
called too late in the Zeitwerk load order in production,
causing this error:

> `lookup': Unknown type :array (ArgumentError)
> raise ArgumentError, "Unknown type #{symbol.inspect}"
> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

We need to load the type and register it manually before the rest
of the chat files are loaded via the engine and Zeitwerk.
