### PR TITLE
FIX: improve performance of post alerter job

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -271,10 +271,10 @@ class PostAlerter
 
   def category_or_tag_muters(topic)
     user_ids_sql = <<~SQL
-    SELECT user_id FROM category_users WHERE category_id = #{topic.category_id.to_i} AND notification_level = #{CategoryUser.notification_levels[:muted]}
+      SELECT user_id FROM category_users WHERE category_id = #{topic.category_id.to_i} AND notification_level = #{CategoryUser.notification_levels[:muted]}
       UNION
-    SELECT user_id FROM tag_users tu JOIN topic_tags tt ON tt.tag_id = tu.tag_id AND tt.topic_id = #{topic.id} AND tu.notification_level = #{TagUser.notification_levels[:muted]}
-      SQL
+      SELECT user_id FROM tag_users tu JOIN topic_tags tt ON tt.tag_id = tu.tag_id AND tt.topic_id = #{topic.id} AND tu.notification_level = #{TagUser.notification_levels[:muted]}
+    SQL
     User.where("id IN (#{user_ids_sql})")
   end
 


### PR DESCRIPTION
Recently, SQL query returning users who have muted category or tag were introduced, and it is causing performance issues.

It is much more effective to first get IDs of users who have CategoryUser/TagUsers related to specific topic and then in second query get relevant users.

It is faster because the new query is operating on a smaller subset of rows and avoid costly left join.

old query:
```
Hash Left Join  (cost=45.71..62.26 rows=224 width=389)
   Hash Cond: ((users.id = tag_users.user_id) AND (topic_tags.tag_id = tag_users.tag_id))
   Filter: ((category_users.id IS NOT NULL) OR (tag_users.id IS NOT NULL))
   ->  Nested Loop Left Join  (cost=18.61..33.98 rows=224 width=397)
         ->  Hash Left Join  (cost=14.40..16.81 rows=32 width=393)
               Hash Cond: (users.id = category_users.user_id)
               ->  Seq Scan on users  (cost=0.00..2.32 rows=32 width=389)
               ->  Hash  (cost=14.39..14.39 rows=1 width=8)
                     ->  Bitmap Heap Scan on category_users  (cost=4.21..14.39 rows=1 width=8)
                           Recheck Cond: (category_id = 33)
                           Filter: (notification_level = 0)
                           ->  Bitmap Index Scan on idx_category_users_category_id_user_id  (cost=0.00..4.21 rows=8 width=0)
                                 Index Cond: (category_id = 33)
         ->  Materialize  (cost=4.21..14.39 rows=7 width=4)
               ->  Bitmap Heap Scan on topic_tags  (cost=4.21..14.35 rows=7 width=4)
                     Recheck Cond: (topic_id = 106)
                     ->  Bitmap Index Scan on index_topic_tags_on_topic_id_and_tag_id  (cost=0.00..4.21 rows=7 width=0)
                           Index Cond: (topic_id = 106)
   ->  Hash  (cost=27.00..27.00 rows=7 width=12)
         ->  Seq Scan on tag_users  (cost=0.00..27.00 rows=7 width=12)
               Filter: (notification_level = 0)

```
new query:
```
Unique  (cost=55.89..55.90 rows=2 width=4)
  ->  Sort  (cost=55.89..55.89 rows=2 width=4)
        Sort Key: category_users.user_id
        ->  Append  (cost=4.21..55.88 rows=2 width=4)
              ->  Bitmap Heap Scan on category_users  (cost=4.21..14.39 rows=1 width=4)
                    Recheck Cond: (category_id = 33)
                    Filter: (notification_level = 0)
                    ->  Bitmap Index Scan on idx_category_users_category_id_user_id  (cost=0.00..4.21 rows=8 width=0)
                          Index Cond: (category_id = 33)
              ->  Hash Join  (cost=14.44..41.46 rows=1 width=4)
                    Hash Cond: (tag_users.tag_id = topic_tags.tag_id)
                    ->  Seq Scan on tag_users  (cost=0.00..27.00 rows=7 width=8)
                          Filter: (notification_level = 0)
                    ->  Hash  (cost=14.35..14.35 rows=7 width=4)
                          ->  Bitmap Heap Scan on topic_tags  (cost=4.21..14.35 rows=7 width=4)
                                Recheck Cond: (topic_id = 106)
                                ->  Bitmap Index Scan on index_topic_tags_on_topic_id_and_tag_id  (cost=0.00..4.21 rows=7 width=0)
                                      Index Cond: (topic_id = 106)
```