### PR TITLE
PERF: Paginate loading of tags in edit nav menu tags modal

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/list-tag.js
+++ b/app/assets/javascripts/discourse/app/adapters/list-tag.js
@@ -1,0 +1,7 @@
+import RESTAdapter from "discourse/adapters/rest";
+
+export default class extends RESTAdapter {
+  pathFor(_store, _type, findArgs) {
+    return this.appendQueryParams("/tags/list", findArgs);
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.hbs
@@ -1,4 +1,5 @@
 <Sidebar::EditNavigationMenu::Modal
+  @class="sidebar__edit-navigation-menu__categories-modal"
   @title="sidebar.categories_form_modal.title"
   @disableSaveButton={{this.saving}}
   @save={{this.save}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.hbs
@@ -1,5 +1,5 @@
 <DModal
-  class="sidebar__edit-navigation-menu__modal"
+  class={{concat-class "sidebar__edit-navigation-menu__modal" @class}}
   @title={{i18n @title}}
   @closeModal={{@closeModal}}
 >

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.hbs
@@ -1,4 +1,5 @@
 <Sidebar::EditNavigationMenu::Modal
+  @class="sidebar__edit-navigation-menu__tags-modal"
   @title="sidebar.tags_form_modal.title"
   @saving={{this.saving}}
   @save={{this.save}}
@@ -19,9 +20,13 @@
     {{#if this.tagsLoading}}
       <div class="spinner"></div>
     {{else}}
-      {{#if (gt this.filteredTags.length 0)}}
-        {{#each this.filteredTags as |tag|}}
-          <div class="sidebar-tags-form__tag" data-tag-name={{tag.name}}>
+      {{#if (gt this.tags.length 0)}}
+        {{#each this.tags as |tag|}}
+          <div
+            class="sidebar-tags-form__tag"
+            data-tag-name={{tag.name}}
+            {{did-insert this.didInsertTag}}
+          >
             <Input
               id={{concat "sidebar-tags-form__input--" tag.name}}
               class="sidebar-tags-form__input"
@@ -40,7 +45,7 @@
                 </span>
 
                 <span class="sidebar-tags-form__tag-label-count">
-                  ({{tag.count}})
+                  ({{tag.topic_count}})
                 </span>
               </p>
             </label>
@@ -53,4 +58,6 @@
       {{/if}}
     {{/if}}
   </form>
+
+  <ConditionalLoadingSpinner @condition={{this.tags.loadingMore}} />
 </Sidebar::EditNavigationMenu::Modal>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -104,16 +104,6 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     );
   });
 
-  test("clicking on section header button", async function (assert) {
-    await visit("/");
-
-    await click(
-      ".sidebar-section[data-section-name='tags'] .sidebar-section-header-button"
-    );
-
-    assert.true(exists(".sidebar-tags-form"), "it shows the tags form modal");
-  });
-
   test("tags section is displayed with site's top tags when user has not added any tags and there are no default tags configured", async function (assert) {
     updateCurrentUser({
       sidebar_tags: [],

--- a/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/modal.scss
+++ b/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/modal.scss
@@ -1,6 +1,6 @@
 .sidebar__edit-navigation-menu__modal {
   .modal-body {
-    min-height: 50vh;
+    min-height: 25vh;
   }
 }
 

--- a/app/assets/stylesheets/desktop/components/sidebar/edit-navigation-menu/tags-modal.scss
+++ b/app/assets/stylesheets/desktop/components/sidebar/edit-navigation-menu/tags-modal.scss
@@ -1,4 +1,4 @@
-.sidebar-tags-form-modal {
+.sidebar__edit-navigation-menu__tags-modal {
   .modal-inner-container {
     min-width: var(--modal-max-width);
   }

--- a/app/assets/stylesheets/mobile/components/sidebar/edit-navigation-menu/tags-modal.scss
+++ b/app/assets/stylesheets/mobile/components/sidebar/edit-navigation-menu/tags-modal.scss
@@ -1,4 +1,4 @@
-.sidebar-tags-form-modal {
+.sidebar__edit-navigation-menu__tags-modal {
   .modal-inner-container {
     width: 35em;
   }

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -27,6 +27,7 @@ class TagsController < ::ApplicationController
                   update_notifications
                   personal_messages
                   info
+                  list
                 ]
 
   before_action :fetch_tag, only: %i[info create_synonyms destroy_synonym]
@@ -97,6 +98,46 @@ class TagsController < ::ApplicationController
 
       format.json { render json: { tags: @tags, extras: @extras } }
     end
+  end
+
+  LIST_LIMIT = 51
+
+  def list
+    offset = params[:offset].to_i || 0
+    tags = guardian.can_admin_tags? ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
+
+    load_more_query_params = { offset: offset + 1 }
+
+    if filter = params[:filter]
+      tags = tags.where("LOWER(tags.name) ILIKE ?", "%#{filter.downcase}%")
+      load_more_query_params[:filter] = filter
+    end
+
+    if only_tags = params[:only_tags]
+      tags = tags.where("LOWER(tags.name) IN (?)", only_tags.split(",").map(&:downcase))
+      load_more_query_params[:only_tags] = only_tags
+    end
+
+    if exclude_tags = params[:exclude_tags]
+      tags = tags.where("LOWER(tags.name) NOT IN (?)", exclude_tags.split(",").map(&:downcase))
+      load_more_query_params[:exclude_tags] = exclude_tags
+    end
+
+    tags_count = tags.count
+    tags = tags.order("LOWER(tags.name) ASC").limit(LIST_LIMIT).offset(offset * LIST_LIMIT)
+
+    load_more_url = URI("/tags/list.json")
+    load_more_url.query = URI.encode_www_form(load_more_query_params)
+
+    render_serialized(
+      tags,
+      TagSerializer,
+      root: "list_tags",
+      meta: {
+        total_rows_list_tags: tags_count,
+        load_more_list_tags: load_more_url.to_s,
+      },
+    )
   end
 
   Discourse.filters.each do |filter|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1480,6 +1480,7 @@ Discourse::Application.routes.draw do
       get "/" => "tags#index"
       get "/filter/list" => "tags#index"
       get "/filter/search" => "tags#search"
+      get "/list" => "tags#list"
       get "/personal_messages/:username" => "tags#personal_messages",
           :constraints => {
             username: RouteFormat.username,

--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -88,16 +88,6 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     include_examples "a user can edit the sidebar tags navigation", true
   end
 
-  it "displays the all tags in the modal when `tags_listed_by_group` site setting is true" do
-    SiteSetting.tags_listed_by_group = true
-
-    visit "/latest"
-
-    modal = sidebar.click_edit_tags_button
-
-    expect(modal).to have_tag_checkboxes([tag1, tag2, tag3, tag4])
-  end
-
   it "allows a user to filter the tags in the modal by the tag's name" do
     visit "/latest"
 
@@ -185,5 +175,17 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     modal.filter_by_all
 
     expect(modal).to have_tag_checkboxes([tag1, tag2, tag3, tag4])
+  end
+
+  it "loads more tags when the user scrolls views the last tag in the modal and there is more tags to load" do
+    stub_const(TagsController, "LIST_LIMIT", 2) do
+      visit "/latest"
+
+      expect(sidebar).to have_tags_section
+
+      modal = sidebar.click_edit_tags_button
+
+      expect(modal).to have_tag_checkboxes([tag1, tag2, tag3, tag4])
+    end
   end
 end


### PR DESCRIPTION
What is the problem?

Before this change, we were relying on the  `/tags` endpoint which 
returned all the tags that are visible to a give user on the site leading to potential performance problems. 
The attribute keys of the response also changes based on the `tags_listed_by_group` site setting. 

What is the fix?

This commit fixes the problems listed above by creating a dedicate `#list` action in the
`TagsController` to handle the listing of the tags in the edit
navigation menu tags modal. This is because the `TagsController#index`
action was created specifically for the `/tags` route and the response
body does not really map well to what we need. The `TagsController#list`
action added here is also much safer since the response is paginated and
we avoid loading a whole bunch of tags upfront.

### Recordings

![Peek 2023-07-03 13-45](https://github.com/discourse/discourse/assets/4335742/4912a747-467c-470c-a41b-8adf1388ad8b)
