### PR TITLE
FEATURE: Warn about outdated translation overrides in admin dashboard

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
@@ -8,10 +8,11 @@ export default class AdminSiteTextIndexController extends Controller {
   searching = false;
   siteTexts = null;
   preferred = false;
-  queryParams = ["q", "overridden", "locale"];
+  queryParams = ["q", "overridden", "outdated", "locale"];
   locale = null;
   q = null;
   overridden = false;
+  outdated = false;
 
   init() {
     super.init(...arguments);
@@ -21,7 +22,10 @@ export default class AdminSiteTextIndexController extends Controller {
 
   _performSearch() {
     this.store
-      .find("site-text", this.getProperties("q", "overridden", "locale"))
+      .find(
+        "site-text",
+        this.getProperties("q", "overridden", "outdated", "locale")
+      )
       .then((results) => {
         this.set("siteTexts", results);
       })
@@ -54,6 +58,13 @@ export default class AdminSiteTextIndexController extends Controller {
   @action
   toggleOverridden() {
     this.toggleProperty("overridden");
+    this.set("searching", true);
+    discourseDebounce(this, this._performSearch, 400);
+  }
+
+  @action
+  toggleOutdated() {
+    this.toggleProperty("outdated");
     this.set("searching", true);
     discourseDebounce(this, this._performSearch, 400);
   }

--- a/app/assets/javascripts/admin/addon/routes/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-text-index.js
@@ -6,13 +6,14 @@ export default class AdminSiteTextIndexRoute extends Route {
   queryParams = {
     q: { replace: true },
     overridden: { replace: true },
+    outdated: { replace: true },
     locale: { replace: true },
   };
 
   model(params) {
     return this.store.find(
       "site-text",
-      getProperties(params, "q", "overridden", "locale")
+      getProperties(params, "q", "overridden", "outdated", "locale")
     );
   }
 

--- a/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
@@ -34,11 +34,22 @@
 
     <label>
       <Input
+        id="toggle-overridden"
         @type="checkbox"
         @checked={{this.overridden}}
         {{on "click" (action "toggleOverridden")}}
       />
       {{i18n "admin.site_text.show_overriden"}}
+    </label>
+
+    <label>
+      <Input
+        id="toggle-outdated"
+        @type="checkbox"
+        @checked={{this.outdated}}
+        {{on "click" this.toggleOutdated}}
+      />
+      {{i18n "admin.site_text.show_outdated"}}
     </label>
   </p>
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -24,7 +24,7 @@ acceptance("Admin - Site Texts", function (needs) {
     assert.ok(exists(".site-text.overridden"));
 
     // Only show overridden
-    await click(".search-area .filter-options input");
+    await click(".search-area .filter-options #toggle-overridden");
     assert.strictEqual(
       currentURL(),
       "/admin/customize/site_texts?overridden=true&q=Test"
@@ -32,6 +32,14 @@ acceptance("Admin - Site Texts", function (needs) {
 
     assert.ok(!exists(".site-text:not(.overridden)"));
     assert.ok(exists(".site-text.overridden"));
+    await click(".search-area .filter-options #toggle-overridden");
+
+    // Only show outdated
+    await click(".search-area .filter-options #toggle-outdated");
+    assert.strictEqual(
+      currentURL(),
+      "/admin/customize/site_texts?outdated=true&q=Test"
+    );
   });
 
   test("edit and revert a site text by key", async function (assert) {

--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -20,17 +20,18 @@ class Admin::SiteTextsController < Admin::AdminController
 
   def index
     overridden = params[:overridden] == "true"
+    outdated = params[:outdated] == "true"
     extras = {}
 
     query = params[:q] || ""
 
     locale = fetch_locale(params[:locale])
 
-    if query.blank? && !overridden
+    if query.blank? && !overridden && !outdated
       extras[:recommended] = true
       results = self.class.preferred_keys.map { |k| record_for(key: k, locale: locale) }
     else
-      results = find_translations(query, overridden, locale)
+      results = find_translations(query, overridden, outdated, locale)
 
       if results.any?
         extras[:regex] = I18n::Backend::DiscourseI18n.create_search_regexp(query, as_string: true)
@@ -188,9 +189,17 @@ class Admin::SiteTextsController < Admin::AdminController
     raise Discourse::NotFound
   end
 
-  def find_translations(query, overridden, locale)
+  def find_translations(query, overridden, outdated, locale)
     translations = Hash.new { |hash, key| hash[key] = {} }
     search_results = I18n.with_locale(locale) { I18n.search(query, only_overridden: overridden) }
+
+    if outdated
+      outdated_keys =
+        TranslationOverride.where(status: %i[outdated invalid_interpolation_keys]).pluck(
+          :translation_key,
+        )
+      search_results.select! { |k, _| outdated_keys.include?(k) }
+    end
 
     search_results.each do |key, value|
       if PLURALIZED_REGEX.match(key)

--- a/app/jobs/scheduled/check_translation_overrides.rb
+++ b/app/jobs/scheduled/check_translation_overrides.rb
@@ -9,11 +9,9 @@ module Jobs
       outdated_ids = []
 
       TranslationOverride.find_each do |override|
-        override.check_interpolation_keys
-
-        if override.invalid?
+        if override.invalid_interpolation_keys.present?
           invalid_ids << override.id
-        elsif override.check_outdated
+        elsif override.original_translation_updated?
           outdated_ids << override.id
         end
       end

--- a/app/jobs/scheduled/check_translation_overrides.rb
+++ b/app/jobs/scheduled/check_translation_overrides.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CheckTranslationOverrides < ::Jobs::Scheduled
+    every 1.day
+
+    def execute(args)
+      invalid_ids = []
+      outdated_ids = []
+
+      TranslationOverride.find_each do |override|
+        override.check_interpolation_keys
+
+        if override.invalid?
+          invalid_ids << override.id
+        elsif override.check_outdated
+          outdated_ids << override.id
+        end
+      end
+
+      TranslationOverride.where(id: outdated_ids).update_all(status: "outdated")
+      TranslationOverride.where(id: invalid_ids).update_all(status: "invalid_interpolation_keys")
+    end
+  end
+end

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -206,7 +206,8 @@ class AdminDashboardData
                       :out_of_date_themes,
                       :unreachable_themes,
                       :watched_words_check,
-                      :google_analytics_version_check
+                      :google_analytics_version_check,
+                      :translation_overrides_check
 
     register_default_scheduled_problem_checks
 
@@ -357,6 +358,12 @@ class AdminDashboardData
     if (GlobalSetting.use_s3? || SiteSetting.enable_s3_uploads) &&
          SiteSetting.Upload.s3_cdn_url.blank?
       I18n.t("dashboard.s3_cdn_warning")
+    end
+  end
+
+  def translation_overrides_check
+    if TranslationOverride.exists?(status: %i[outdated invalid_interpolation_keys])
+      I18n.t("dashboard.outdated_translations_warning", base_path: Discourse.base_path)
     end
   end
 

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -53,8 +53,10 @@ class TranslationOverride < ActiveRecord::Base
     translation_override = find_or_initialize_by(params)
     sanitized_value =
       translation_override.sanitize_field(value, additional_attributes: ["data-auto-route"])
+    original_translation =
+      I18n.overrides_disabled { I18n.t(transform_pluralized_key(key), locale: :en) }
 
-    data = { value: sanitized_value }
+    data = { value: sanitized_value, original_translation: original_translation }
     if key.end_with?("_MF")
       _, filename = JsLocaleHelper.find_message_format_locale([locale], fallback_to_english: false)
       data[:compiled_js] = JsLocaleHelper.compile_message_format(filename, locale, sanitized_value)

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -45,6 +45,8 @@ class TranslationOverride < ActiveRecord::Base
 
   validate :check_interpolation_keys
 
+  enum :status, %i[up_to_date outdated invalid_interpolation_keys]
+
   def self.upsert!(locale, key, value)
     params = { locale: locale, translation_key: key }
 
@@ -165,13 +167,15 @@ end
 #
 # Table name: translation_overrides
 #
-#  id              :integer          not null, primary key
-#  locale          :string           not null
-#  translation_key :string           not null
-#  value           :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  compiled_js     :text
+#  id                   :integer          not null, primary key
+#  locale               :string           not null
+#  translation_key      :string           not null
+#  value                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  compiled_js          :text
+#  original_translation :text
+#  status               :integer          default("up_to_date"), not null
 #
 # Indexes
 #

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -127,7 +127,13 @@ class TranslationOverride < ActiveRecord::Base
   private_class_method :i18n_changed
   private_class_method :expire_cache
 
-  private
+  def check_outdated
+    return false if original_translation.blank?
+
+    transformed_key = self.class.transform_pluralized_key(translation_key)
+
+    original_translation != I18n.overrides_disabled { I18n.t(transformed_key, locale: :en) }
+  end
 
   def check_interpolation_keys
     transformed_key = self.class.transform_pluralized_key(translation_key)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6067,6 +6067,7 @@ en:
         go_back: "Back to Search"
         recommended: "We recommend customizing the following text to suit your needs:"
         show_overriden: "Only show overridden"
+        show_outdated: "Only show outdated/invalid"
         locale: "Language:"
         more_than_50_results: "There are more than 50 results. Please refine your search."
         interpolation_keys: "Available interpolation keys:"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1478,7 +1478,7 @@ en:
     image_magick_warning: 'The server is configured to create thumbnails of large images, but ImageMagick is not installed. Install ImageMagick using your favorite package manager or <a href="https://www.imagemagick.org/script/download.php" target="_blank">download the latest release</a>.'
     failing_emails_warning: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="%{base_path}/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
     subfolder_ends_in_slash: "Your subfolder setup is incorrect; the DISCOURSE_RELATIVE_URL_ROOT ends in a slash."
-    outdated_translations_warning: "Some of your translation overrides are out of date. Please check your <a href='%{base_path}/admin/customize/site_texts'>text customizations</a>."
+    outdated_translations_warning: "Some of your translation overrides are out of date. Please check your <a href='%{base_path}/admin/customize/site_texts?outdated=true'>text customizations</a>."
     email_polling_errored_recently:
       one: "Email polling has generated an error in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
       other: "Email polling has generated %{count} errors in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1478,6 +1478,7 @@ en:
     image_magick_warning: 'The server is configured to create thumbnails of large images, but ImageMagick is not installed. Install ImageMagick using your favorite package manager or <a href="https://www.imagemagick.org/script/download.php" target="_blank">download the latest release</a>.'
     failing_emails_warning: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="%{base_path}/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
     subfolder_ends_in_slash: "Your subfolder setup is incorrect; the DISCOURSE_RELATIVE_URL_ROOT ends in a slash."
+    outdated_translations_warning: "Some of your translation overrides are out of date. Please check your <a href='%{base_path}/admin/customize/site_texts'>text customizations</a>."
     email_polling_errored_recently:
       one: "Email polling has generated an error in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
       other: "Email polling has generated %{count} errors in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."

--- a/db/migrate/20230703035052_add_status_to_translation_overrides.rb
+++ b/db/migrate/20230703035052_add_status_to_translation_overrides.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddStatusToTranslationOverrides < ActiveRecord::Migration[7.0]
+  def change
+    add_column :translation_overrides, :original_translation, :text
+    add_column :translation_overrides, :status, :integer, null: false, default: 0
+  end
+end

--- a/spec/fabricators/translation_override_fabricator.rb
+++ b/spec/fabricators/translation_override_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator(:translation_override) do
+  translation_key "title"
+  value "Discourse"
+  locale "en"
+end

--- a/spec/jobs/check_translation_overrides_spec.rb
+++ b/spec/jobs/check_translation_overrides_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::CheckTranslationOverrides do
+  fab!(:up_to_date_translation) { Fabricate(:translation_override, translation_key: "title") }
+  fab!(:outdated_translation) do
+    Fabricate(:translation_override, translation_key: "posts", original_translation: "outdated")
+  end
+  fab!(:invalid_translation) { Fabricate(:translation_override, translation_key: "topics") }
+
+  it "marks translations with invalid interpolation keys" do
+    invalid_translation.update_attribute("value", "Invalid %{foo}")
+
+    expect { described_class.new.execute({}) }.to change { invalid_translation.reload.status }.from(
+      "up_to_date",
+    ).to("invalid_interpolation_keys")
+  end
+
+  it "marks translations that are outdated" do
+    expect { described_class.new.execute({}) }.to change {
+      outdated_translation.reload.status
+    }.from("up_to_date").to("outdated")
+  end
+
+  it "does not mark up to date translations" do
+    expect { described_class.new.execute({}) }.not_to change {
+      up_to_date_translation.reload.status
+    }
+  end
+end

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -345,4 +345,26 @@ RSpec.describe AdminDashboardData do
       expect(dashboard_data.out_of_date_themes).to eq(nil)
     end
   end
+
+  describe "#translation_overrides_check" do
+    subject(:dashboard_data) { described_class.new }
+
+    context "when there are outdated translations" do
+      before { Fabricate(:translation_override, translation_key: "foo.bar", status: "outdated") }
+
+      it "outputs the correct message" do
+        expect(dashboard_data.translation_overrides_check).to eq(
+          I18n.t("dashboard.outdated_translations_warning", base_path: Discourse.base_path),
+        )
+      end
+    end
+
+    context "when there are no outdated translations" do
+      before { Fabricate(:translation_override, status: "up_to_date") }
+
+      it "outputs nothing" do
+        expect(dashboard_data.translation_overrides_check).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -284,11 +284,11 @@ RSpec.describe TranslationOverride do
     end
   end
 
-  describe "#check_outdated" do
+  describe "#original_translation_updated?" do
     context "when the translation is up to date" do
       fab!(:translation) { Fabricate(:translation_override, translation_key: "title") }
 
-      it { expect(translation.check_outdated).to eq(false) }
+      it { expect(translation.original_translation_updated?).to eq(false) }
     end
 
     context "when the translation is outdated" do
@@ -296,7 +296,7 @@ RSpec.describe TranslationOverride do
         Fabricate(:translation_override, translation_key: "title", original_translation: "outdated")
       end
 
-      it { expect(translation.check_outdated).to eq(true) }
+      it { expect(translation.original_translation_updated?).to eq(true) }
     end
 
     context "when we can't tell because the translation is too old" do
@@ -304,7 +304,22 @@ RSpec.describe TranslationOverride do
         Fabricate(:translation_override, translation_key: "title", original_translation: nil)
       end
 
-      it { expect(translation.check_outdated).to eq(false) }
+      it { expect(translation.original_translation_updated?).to eq(false) }
+    end
+  end
+
+  describe "invalid_interpolation_keys" do
+    fab!(:translation) do
+      Fabricate(
+        :translation_override,
+        translation_key: "system_messages.welcome_user.subject_template",
+      )
+    end
+
+    it "picks out invalid keys and ignores known and custom keys" do
+      translation.update_attribute("value", "Hello, %{name}! Welcome to %{site_name}. %{foo}")
+
+      expect(translation.invalid_interpolation_keys).to contain_exactly("foo")
     end
   end
 end

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -283,4 +283,28 @@ RSpec.describe TranslationOverride do
       end
     end
   end
+
+  describe "#check_outdated" do
+    context "when the translation is up to date" do
+      fab!(:translation) { Fabricate(:translation_override, translation_key: "title") }
+
+      it { expect(translation.check_outdated).to eq(false) }
+    end
+
+    context "when the translation is outdated" do
+      fab!(:translation) do
+        Fabricate(:translation_override, translation_key: "title", original_translation: "outdated")
+      end
+
+      it { expect(translation.check_outdated).to eq(true) }
+    end
+
+    context "when we can't tell because the translation is too old" do
+      fab!(:translation) do
+        Fabricate(:translation_override, translation_key: "title", original_translation: nil)
+      end
+
+      it { expect(translation.check_outdated).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
### Background

This PR adds a feature to help admins stay up-to-date with their translations. We already have protections preventing admins from problems when they update their overrides. This change adds some protection in the other direction (where translations change in core due to an upgrade) by creating a notice for admins when defaults have changed.

**Terms:**

- In the case where Discourse core changes the default translation, the translation override is considered "outdated".
- In the case above where interpolation keys were changed from the ones the override is using, it is considered "invalid".
- If none of the above applies, the override is considered "up to date".

### How does it work?

There are a few pieces that makes this work:

1. When an admin creates or updates a translation override, we store the original translation at the time of write. (This is used to detect changes later on.)
2. There is a background job that runs once every day and checks for outdated and invalid overrides, and marks them as such.
3. When there are any outdated or invalid overrides, a notice is shown in admin dashboard with a link to the text customization page.

<img width="641" alt="Screenshot 2023-07-05 at 2 50 35 PM" src="https://github.com/discourse/discourse/assets/5259935/5a6004e0-ea8f-42a9-841b-43f1f2447c59">

On the text customization page there is a new filter to easily find out-of-date overrides:

<img width="599" alt="Screenshot 2023-07-05 at 2 56 53 PM" src="https://github.com/discourse/discourse/assets/5259935/77725c83-b9e9-458e-b0b2-7a6fc5e2274a">

### What about existing overrides?

This PR leaves the option of back-filling open. Currently any override with the `original_translation` missing will be considered "up to date".

### Can I dismiss the warnings without changing the translation?

I first thought this would not be a good idea, but I am starting to come around to think that we should allow this for "outdated" overrides, but obviously not for "invalid" ones.

### Known limitations

- The link from the dashboard links to the default locale text customization page. Given there might be invalid overrides in multiple languages, I'm not sure what we could do here. Consideration for future improvement.