### PR TITLE
FIX: Minor Twitter onebox improvements

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -682,7 +682,7 @@ aside.onebox.twitterstatus .onebox-body {
 
   .is-reply {
     color: var(--primary-medium);
-    margin-right: 0.5em;
+    margin-right: 0.25em;
   }
 }
 

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -679,6 +679,11 @@ aside.onebox.twitterstatus .onebox-body {
       margin-right: 0.25em;
     }
   }
+
+  .is-reply {
+    color: var(--primary-medium);
+    margin-right: 0.5em;
+  }
 }
 
 // Onebox - Imgur/Flickr - Album

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -141,6 +141,12 @@ module Onebox
         end
       end
 
+      def is_reply
+        if twitter_api_credentials_present?
+          raw.dig(:data, :referenced_tweets)&.any? { |tweet| tweet.dig(:type) == "replied_to" }
+        end
+      end
+
       def quoted_full_name
         if twitter_api_credentials_present? && quoted_tweet_author.present?
           quoted_tweet_author[:name]
@@ -216,6 +222,7 @@ module Onebox
           avatar: avatar,
           likes: likes,
           retweets: retweets,
+          is_reply: is_reply,
           quoted_text: quoted_text,
           quoted_full_name: quoted_full_name,
           quoted_screen_name: quoted_screen_name,

--- a/lib/onebox/templates/twitterstatus.mustache
+++ b/lib/onebox/templates/twitterstatus.mustache
@@ -3,6 +3,11 @@
 <div class="twitter-screen-name"><a href="{{link}}" target="_blank" rel="noopener">@{{screen_name}}</a></div>
 
 <div class="tweet">
+  {{#is_reply}}
+    <span class="reply">
+      <svg class="fa d-icon d-icon-reply svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#reply"></use></svg>
+    </span>
+  {{/is_reply}}
   <span class="tweet-description">{{{tweet}}}</span>
   {{#quoted_text}}
     <div class="quoted">

--- a/lib/onebox/templates/twitterstatus.mustache
+++ b/lib/onebox/templates/twitterstatus.mustache
@@ -4,7 +4,7 @@
 
 <div class="tweet">
   {{#is_reply}}
-    <span class="reply">
+    <span class="is-reply">
       <svg class="fa d-icon d-icon-reply svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#reply"></use></svg>
     </span>
   {{/is_reply}}

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -15,15 +15,17 @@ class TwitterApi
       text = tweet[:data][:text].dup.to_s
       if (entities = tweet[:data][:entities]) && (urls = entities[:urls])
         urls.each do |url|
-          text.gsub!(
-            url[:url],
-            "<a target='_blank' href='#{url[:expanded_url]}'>#{url[:display_url]}</a>",
-          )
+          if !url[:display_url].start_with?("pic.twitter.com")
+            text.gsub!(
+              url[:url],
+              "<a target='_blank' href='#{url[:expanded_url]}'>#{url[:display_url]}</a>",
+            )
+          else
+            text.gsub!(url[:url], "")
+          end
         end
       end
-
       text = link_hashtags_in link_handles_in text
-
       result = Rinku.auto_link(text, :all, 'target="_blank"').to_s
 
       if tweet[:includes] && media = tweet[:includes][:media]


### PR DESCRIPTION
- Excludes pic.twitter.com URL from the text
- Adds reply icon to tweet replies
<div align="center">

<b>Before / After</b>

![2023-07-03_10-33](https://github.com/discourse/discourse/assets/66427541/944c6b70-bf7a-4c62-9952-88a43e1767a0)

</div>