### PR TITLE
DEV: Set owner on widget instances

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
@@ -42,5 +42,7 @@ export function getRegister(obj) {
     },
   };
 
+  setOwner(register, owner);
+
   return register;
 }

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -24,6 +24,7 @@ import { get } from "@ember/object";
 import { h } from "virtual-dom";
 import { isProduction } from "discourse-common/config/environment";
 import { consolePrefix } from "discourse/lib/source-identifier";
+import { getOwner, setOwner } from "@ember/application";
 
 const _registry = {};
 
@@ -146,6 +147,7 @@ export default class Widget {
     this.dirtyKeys = opts.dirtyKeys;
 
     register.deprecateContainer(this);
+    setOwner(this, getOwner(register));
 
     this.key = this.buildKey ? this.buildKey(attrs) : null;
     this.site = register.lookup("service:site");


### PR DESCRIPTION
This allows us to use `getOwner(this)` on widgets (without needing to resort to our custom `discourse-common/lib/get-owner` implementation which has a hacky fallback)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
