### PR TITLE
FEATURE: Add probe-only functionality to SSO Provider protocol

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2520,6 +2520,7 @@ en:
     email_error: "An account could not be registered with the email address <b>%{email}</b>. Please contact the site's administrator."
     missing_secret: "Authentication failed due to missing secret. Contact the site administrators to fix this problem."
     invite_redeem_failed: "Invite redemption failed. Please contact the site's administrator."
+    invalid_parameter_value: "Authentication failed due to invalid value for `%{param}` parameter. Contact the site administrators to fix this problem."
 
   original_poster: "Original Poster"
   most_recent_poster: "Most Recent Poster"

--- a/lib/discourse_connect_base.rb
+++ b/lib/discourse_connect_base.rb
@@ -7,7 +7,6 @@ class DiscourseConnectBase
   ACCESSORS = %i[
     add_groups
     admin
-    moderator
     avatar_force_update
     avatar_url
     bio
@@ -15,14 +14,17 @@ class DiscourseConnectBase
     confirmed_2fa
     email
     external_id
+    failed
     groups
     locale
     locale_force_update
     location
     logout
+    moderator
     name
     no_2fa_methods
     nonce
+    prompt
     profile_background_url
     remove_groups
     require_2fa
@@ -40,6 +42,7 @@ class DiscourseConnectBase
     admin
     avatar_force_update
     confirmed_2fa
+    failed
     locale_force_update
     logout
     moderator

--- a/lib/discourse_connect_provider.rb
+++ b/lib/discourse_connect_provider.rb
@@ -5,8 +5,17 @@ class DiscourseConnectProvider < DiscourseConnectBase
   end
   class BlankReturnUrl < RuntimeError
   end
+  class InvalidParameterValueError < RuntimeError
+    attr_reader :param
+    def initialize(param)
+      @param = param
+      super("Invalid value for parameter `#{param}`")
+    end
+  end
 
   def self.parse(payload, sso_secret = nil, **init_kwargs)
+    # We extract the return_sso_url parameter early; we need the URL's host
+    # in order to lookup the correct SSO secret in our site settings.
     parsed_payload = Rack::Utils.parse_query(payload)
     return_sso_url = lookup_return_sso_url(parsed_payload)
 
@@ -32,7 +41,12 @@ class DiscourseConnectProvider < DiscourseConnectBase
       raise BlankSecret
     end
 
-    super(payload, sso_secret, **init_kwargs)
+    sso = super(payload, sso_secret, **init_kwargs)
+
+    # Do general parameter validation now, after signature-verification has succeeded.
+    raise InvalidParameterValueError.new("prompt") if (sso.prompt != nil) && (sso.prompt != "none")
+
+    sso
   end
 
   def self.lookup_return_sso_url(parsed_payload)


### PR DESCRIPTION
This commit adds support for an optional "probe" parameter in the payload of the /session/sso_provider endpoint.  If an SSO Consumer adds a "probe=true" parameter to the encoded/signed "sso" payload, then Discourse will avoid trying to login a not-logged-in user:

 * If the user is already logged in, Discourse will immediately redirect back to the Consumer with the user's credentials in a signed payload, as usual.

 * If the user is not logged in, Discourse will immediately redirect back to the Consumer with a signed payload bearing the parameter "failed=true".

This allows the SSO Consumer to simply test whether or not a user is logged in, without forcing the user to try to log in.  This is useful when the SSO Consumer allows both anonymous and authenticated access. (E.g., users that are already logged-in to Discourse can be seamlessly logged-in to the Consumer site, and anonymous users can remain anonymous until they explicitly ask to log in.)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
