### PR TITLE
DEV: Ensure browser network conditions is reset in system tests

### DIFF
--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Chat composer", type: :system do
 
       expect(page).to have_css(".chat-composer-upload--in-progress")
       expect(page).to have_css(".chat-composer.is-send-disabled")
-
+    ensure
       page.driver.browser.network_conditions = { latency: 0 }
     end
   end

--- a/spec/system/network_disconnected_spec.rb
+++ b/spec/system/network_disconnected_spec.rb
@@ -2,9 +2,12 @@
 
 RSpec.describe "Network Disconnected", type: :system do
   def with_network_disconnected
-    page.driver.browser.network_conditions = { offline: true }
-    yield
-    page.driver.browser.network_conditions = { offline: false }
+    begin
+      page.driver.browser.network_conditions = { offline: true }
+      yield
+    ensure
+      page.driver.browser.network_conditions = { offline: false }
+    end
   end
 
   it "NetworkConnectivity service adds class to DOM and displays offline indicator" do


### PR DESCRIPTION
Why this change?

By ensuring the reset happens in an `ensure` code block, we ensure that
the code will always be run even if code fails or an error is raised.
This helps to prevent leaking custom network condition states and
improves the stability of our system tests.