### PR TITLE
DEV: Improve `PageObjects::Modals::SidebarEditTags#has_tag_checkboxes?`

### DIFF
--- a/spec/system/page_objects/modals/sidebar_edit_tags.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_tags.rb
@@ -6,12 +6,10 @@ module PageObjects
   module Modals
     class SidebarEditTags < SidebarEditNavigationModal
       def has_tag_checkboxes?(tags)
-        tag_names = tags.map(&:name)
+        tag_checkboxes =
+          all(".sidebar-tags-form .sidebar-tags-form__tag-label-name", count: tags.length)
 
-        has_css?(".sidebar-tags-form .sidebar-tags-form__tag", count: tag_names.length) &&
-          all(".sidebar-tags-form .sidebar-tags-form__tag").all? do |row|
-            tag_names.include?(row["data-tag-name"].to_s)
-          end
+        expect(tag_checkboxes.map(&:text)).to eq(tags.map(&:name))
       end
 
       def has_no_tag_checkboxes?


### PR DESCRIPTION
Why this change?

Improves the error message when stuff fails.

Before:

expected `#<PageObjects::Modals::SidebarEditTags:0x00007fa3877135e0>.has_tag_checkboxes?([#<Tag id: 1, name: "tag", created_at: "2023-07-04 05:21:12.914149000 +0000", updated_at: "2023-07-04..._topic_count: 0, target_tag_id: nil, description: nil, public_topic_count: 1, staff_topic_count: 1>])` to be truthy, got false

After:

expected to find visible css ".sidebar-tags-form .sidebar-tags-form__tag-label-name" 3 times, found 4 matches: "tag", "tag2", "tag3", "tag4"