### PR TITLE
DEV: experimental API to add buttons to sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -4,9 +4,29 @@
   @class="sidebar-container"
   @scrollTop={{false}}
 >
+
+  {{#each this.topSidebarButtons as |button|}}
+    <DButton
+      @action={{action button.action}}
+      @class="sidebar__api-button"
+      @translatedLabel={{button.label}}
+      @icon={{button.icon}}
+    />
+  {{/each}}
+
   <Sidebar::Sections
     @currentUser={{this.currentUser}}
     @collapsableSections={{true}}
   />
+
+  {{#each this.bottomSidebarButtons as |button|}}
+    <DButton
+      @action={{action button.action}}
+      @class="sidebar__api-button"
+      @translatedLabel={{button.label}}
+      @icon={{button.icon}}
+    />
+  {{/each}}
+
   <Sidebar::Footer />
 </DSection>

--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -1,7 +1,7 @@
 <DSection
   @pageClass="has-sidebar"
   @id="d-sidebar"
-  @class="sidebar-container"
+  @class={{concat-class "sidebar-container" this.joinedCustomCssClasses}}
   @scrollTop={{false}}
 >
 

--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -6,12 +6,15 @@ import {
   topSidebarButtons,
 } from "discourse/lib/sidebar/custom-buttons";
 import { getOwner, setOwner } from "@ember/application";
+import { tracked } from "@glimmer/tracking";
 
 export default class Sidebar extends Component {
   @service appEvents;
   @service site;
   @service router;
   @service currentUser;
+
+  @tracked customCssClasses = [];
 
   constructor() {
     super(...arguments);
@@ -31,6 +34,19 @@ export default class Sidebar extends Component {
       setOwner(button, getOwner(this));
       return button;
     });
+  }
+
+  get joinedCustomCssClasses() {
+    return this.customCssClasses.join(" ");
+  }
+
+  @bind
+  toggleCssClass(className) {
+    if (this.customCssClasses.includes(className)) {
+      this.customCssClasses.removeObject(className);
+    } else {
+      this.customCssClasses.pushObject(className);
+    }
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -1,10 +1,16 @@
 import Component from "@glimmer/component";
 import { bind } from "discourse-common/utils/decorators";
 import { inject as service } from "@ember/service";
+import {
+  bottomSidebarButtons,
+  topSidebarButtons,
+} from "discourse/lib/sidebar/custom-buttons";
+import { getOwner, setOwner } from "@ember/application";
 
 export default class Sidebar extends Component {
   @service appEvents;
   @service site;
+  @service router;
   @service currentUser;
 
   constructor() {
@@ -13,6 +19,18 @@ export default class Sidebar extends Component {
     if (this.site.mobileView) {
       document.addEventListener("click", this.collapseSidebar);
     }
+
+    this.topSidebarButtons = topSidebarButtons.map((customButton) => {
+      const button = new customButton({ sidebar: this, router: this.router });
+      setOwner(button, getOwner(this));
+      return button;
+    });
+
+    this.bottomSidebarButtons = bottomSidebarButtons.map((customButton) => {
+      const button = new customButton({ sidebar: this, router: this.router });
+      setOwner(button, getOwner(this));
+      return button;
+    });
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -106,6 +106,7 @@ import { downloadCalendar } from "discourse/lib/download-calendar";
 import { consolePrefix } from "discourse/lib/source-identifier";
 import { addSectionLink as addCustomCommunitySectionLink } from "discourse/lib/sidebar/custom-community-section-links";
 import { addSidebarSection } from "discourse/lib/sidebar/custom-sections";
+import { addSidebarButton } from "discourse/lib/sidebar/custom-buttons";
 import {
   registerCustomCategoryLockIcon,
   registerCustomCategorySectionLinkPrefix,
@@ -125,7 +126,7 @@ import { registerHashtagType } from "discourse/lib/hashtag-autocomplete";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.6.1";
+export const PLUGIN_API_VERSION = "1.7.1";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -2156,6 +2157,63 @@ class PluginApi {
    */
   addSidebarSection(func) {
     addSidebarSection(func);
+  }
+
+  /**
+   * EXPERIMENTAL. Do not use.
+   * Support for adding a Sidebar button by returning a class which extends from the BaseCustomSidebarButton
+   * class interface. See `lib/sidebar/base-custom-sidebar-button.js` for documentation on the BaseCustomSidebarButton class
+   * interface.
+   *
+   * ```
+   * api.addSidebarButton("bottom", (BaseCustomSidebarButton) => {
+   *   const ToggleButton = class extends BaseCustomSidebarButton {
+   *     @service chatStateManager;
+   *     @tracked currentMode;
+   *
+   *     constructor() {
+   *       super(...arguments);
+   *
+   *       if (this.router.currentURL.startsWith("/chat/")) {
+   *         this.currentMode = "chat";
+   *       } else {
+   *         this.currentMode = "forum";
+   *       }
+   *     }
+   *
+   *     get label() {
+   *       if (this.currentMode === "chat") {
+   *         return "Forum";
+   *       } else {
+   *         return "Chat";
+   *       }
+   *     }
+   *
+   *     get icon() {
+   *       if (this.currentMode === "chat") {
+   *         return "random";
+   *       } else {
+   *         return "d-chat";
+   *       }
+   *     }
+   *
+   *     @action
+   *     action() {
+   *       if (this.currentMode === "chat") {
+   *         this.currentMode = "forum";
+   *         this.router.transitionTo(this.chatStateManager.lastKnownAppURL);
+   *       } else if (this.currentMode === "forum") {
+   *         this.currentMode = "chat";
+   *         this.router.transitionTo(this.chatStateManager.lastKnownChatURL);
+   *       }
+   *     }
+   *   };
+   *   return ToggleButton;
+   * });
+   * ```
+   */
+  addSidebarButton(position, func) {
+    addSidebarButton(position, func);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-button.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-button.js
@@ -1,0 +1,34 @@
+/**
+ * Base class representing a sidebar section button interface.
+ */
+export default class BaseCustomSidebarSectionButton {
+  constructor({ sidebar, router } = {}) {
+    this.sidebar = sidebar;
+    this.router = router;
+  }
+
+  /**
+   * @returns {string} The label of the section button
+   */
+  get label() {
+    this._notImplemented();
+  }
+
+  /**
+   * @returns {string} The icon of the section button
+   */
+  get icon() {
+    this._notImplemented();
+  }
+
+  /**
+   * @returns {Function} Action for button
+   */
+  get action() {
+    this._notImplemented();
+  }
+
+  _notImplemented() {
+    throw "not implemented";
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-button.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-button.js
@@ -11,24 +11,24 @@ export default class BaseCustomSidebarSectionButton {
    * @returns {string} The label of the section button
    */
   get label() {
-    this._notImplemented();
+    this.#notImplemented();
   }
 
   /**
    * @returns {string} The icon of the section button
    */
   get icon() {
-    this._notImplemented();
+    this.#notImplemented();
   }
 
   /**
    * @returns {Function} Action for button
    */
   get action() {
-    this._notImplemented();
+    this.#notImplemented();
   }
 
-  _notImplemented() {
+  #notImplemented() {
     throw "not implemented";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/custom-buttons.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/custom-buttons.js
@@ -1,0 +1,12 @@
+import BaseCustomSidebarButton from "discourse/lib/sidebar/base-custom-sidebar-button";
+
+export const topSidebarButtons = [];
+export const bottomSidebarButtons = [];
+
+export function addSidebarButton(position, func) {
+  if (position === "top") {
+    topSidebarButtons.push(func.call(this, BaseCustomSidebarButton));
+  } else {
+    bottomSidebarButtons.push(func.call(this, BaseCustomSidebarButton));
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/custom-buttons.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/custom-buttons.js
@@ -10,3 +10,8 @@ export function addSidebarButton(position, func) {
     bottomSidebarButtons.push(func.call(this, BaseCustomSidebarButton));
   }
 }
+
+export function resetCustomButtons() {
+  topSidebarButtons.length = 0;
+  bottomSidebarButtons.length = 0;
+}

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -914,9 +914,11 @@ acceptance("Sidebar - Plugin API", function (needs) {
             if (this.currentMode === "latest") {
               this.currentMode = "categories";
               this.router.transitionTo("discovery.categories");
+              this.sidebar.toggleCssClass("red");
             } else if (this.currentMode === "new") {
               this.currentMode = "latest";
               this.router.transitionTo("discovery.latest");
+              this.sidebar.toggleCssClass("red");
             }
           }
         };
@@ -931,6 +933,7 @@ acceptance("Sidebar - Plugin API", function (needs) {
       "Categories",
       "displays button with correct text"
     );
+    assert.dom(".sidebar-container").hasNoClass("red");
 
     await click(".sidebar__api-button");
 
@@ -939,5 +942,6 @@ acceptance("Sidebar - Plugin API", function (needs) {
       "Latest",
       "displays button with correct text"
     );
+    assert.dom(".sidebar-container").hasClass("red");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -886,23 +886,23 @@ acceptance("Sidebar - Plugin API", function (needs) {
           constructor() {
             super(...arguments);
 
-            if (this.router.currentURL.startsWith("/chat/")) {
-              this.currentMode = "chat";
+            if (this.router.currentURL.startsWith("/latest")) {
+              this.currentMode = "latest";
             } else {
-              this.currentMode = "forum";
+              this.currentMode = "categories";
             }
           }
 
           get label() {
-            if (this.currentMode === "chat") {
-              return "Forum";
+            if (this.currentMode === "categories") {
+              return "Latest";
             } else {
-              return "Chat";
+              return "Categories";
             }
           }
 
           get icon() {
-            if (this.currentMode === "chat") {
+            if (this.currentMode === "categories") {
               return "random";
             } else {
               return "d-chat";
@@ -911,12 +911,12 @@ acceptance("Sidebar - Plugin API", function (needs) {
 
           @action
           action() {
-            if (this.currentMode === "chat") {
-              this.currentMode = "forum";
+            if (this.currentMode === "latest") {
+              this.currentMode = "categories";
+              this.router.transitionTo("discovery.categories");
+            } else if (this.currentMode === "new") {
+              this.currentMode = "latest";
               this.router.transitionTo("discovery.latest");
-            } else if (this.currentMode === "forum") {
-              this.currentMode = "chat";
-              this.router.transitionTo("chat");
             }
           }
         };
@@ -924,11 +924,11 @@ acceptance("Sidebar - Plugin API", function (needs) {
       });
     });
 
-    await visit("/");
+    await visit("/latest");
 
     assert.strictEqual(
       query(".sidebar__api-button").textContent.trim(),
-      "Chat",
+      "Categories",
       "displays button with correct text"
     );
 
@@ -936,7 +936,7 @@ acceptance("Sidebar - Plugin API", function (needs) {
 
     assert.strictEqual(
       query(".sidebar__api-button").textContent.trim(),
-      "Forum",
+      "Latest",
       "displays button with correct text"
     );
   });

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -265,3 +265,6 @@
     }
   }
 }
+.sidebar__api-button {
+  margin: 1em 1.3em;
+}


### PR DESCRIPTION
API to add custom buttons to top or bottom of sidebar. It can be used for `chat` plugin to add button to switch between forum and chat.

Demo when button is mount on the top:
https://github.com/discourse/discourse/assets/72780/3d4b6575-606f-47bf-9eac-8db7cdf66fc0

Demo when button is mount on the bottom:
https://github.com/discourse/discourse/assets/72780/dd01b80c-20c7-452b-9800-d0b4380d0136


