### PR TITLE
DEV: Update default modal alert class

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -70,7 +70,7 @@
               role="alert"
               class={{concat-class
                 "alert"
-                (concat "alert-" (or @flashType "success"))
+                (if @flashType (concat "alert-" @flashType))
               }}
             >
               {{~@flash~}}

--- a/app/assets/javascripts/discourse/tests/integration/components/d-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-modal-test.js
@@ -39,10 +39,15 @@ module("Integration | Component | d-modal", function (hooks) {
   });
 
   test("flash", async function (assert) {
+    await render(hbs`<DModal @inline={{true}} @flash="Some message"/>`);
+    assert.dom(".d-modal .alert").hasText("Some message");
+  });
+
+  test("flash type", async function (assert) {
     await render(
-      hbs`<DModal @inline={{true}} @flash="Some message" @flashType="error"/> `
+      hbs`<DModal @inline={{true}} @flash="Some message" @flashType="success"/>`
     );
-    assert.dom(".d-modal .alert.alert-error").hasText("Some message");
+    assert.dom(".d-modal .alert").hasClass("alert-success");
   });
 
   test("dismissable", async function (assert) {


### PR DESCRIPTION
This PR changes the default to not append any classes (when `@flashType` isn't present) and instead leans on the `alert` class for styling the alert which is a 1 to 1 match of the `alert-error` class.

https://github.com/discourse/discourse/blob/8f21d2cf4031f2b7b8a4a759507d34c0ff11800e/app/assets/stylesheets/common/base/alert.scss#L1-L4

https://github.com/discourse/discourse/blob/8f21d2cf4031f2b7b8a4a759507d34c0ff11800e/app/assets/stylesheets/common/base/alert.scss#L22-L24

In essence this changes the default modal alert styling from `success` to `error` if not overridden by `@flashType`