### PR TITLE
DEV: Fix flaky edit nav menu tags system test

### DIFF
--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     expect(sidebar).to have_no_section_link(tag4.name)
   end
 
-  xit "allows a user to filter the tag in the modal by selection" do
+  it "allows a user to filter the tag in the modal by selection" do
     Fabricate(:tag_sidebar_section_link, linkable: tag1, user: user)
     Fabricate(:tag_sidebar_section_link, linkable: tag2, user: user)
 

--- a/spec/system/page_objects/modals/sidebar_edit_tags.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_tags.rb
@@ -6,10 +6,9 @@ module PageObjects
   module Modals
     class SidebarEditTags < SidebarEditNavigationModal
       def has_tag_checkboxes?(tags)
-        tag_checkboxes =
-          all(".sidebar-tags-form .sidebar-tags-form__tag-label-name", count: tags.length)
-
-        expect(tag_checkboxes.map(&:text)).to eq(tags.map(&:name))
+        find(".sidebar-tags-form").has_content?(
+          tags.map { |tag| "#{tag.name} (#{tag.public_topic_count})" }.join("\n"),
+        )
       end
 
       def has_no_tag_checkboxes?


### PR DESCRIPTION
Previously , the test was flaky and failing with a selenium stale
element error because we were retrieving the tag nodes with `all` and
then calling `.map(&:text)` on it. However, there is a chance that a
re-render happens and those nodes will end up being stale resulting in
the selenium error.