### PR TITLE
DEV: Fix flaky system test when expanding chat message actions on mobile

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -64,7 +64,7 @@ module PageObjects
       end
 
       def expand_message_actions_mobile(message, delay: 2)
-        message_by_id(message.id).click(delay: delay)
+        find(message_by_id_selector(message.id)).find(".chat-message-content").click(delay: delay)
       end
 
       def click_message_action_mobile(message, message_action)


### PR DESCRIPTION
Why this change?

Chat system tests that opens the message actions on mobile have been
flaky on our CI. Those system test usually fails when the message
actions do not show up as expected causing subsequent actions to fail.

In the case of the `Reply to message - channel - mobile when the message has an existing thread replies to the existing thread`
system test, failure screenshot shows that we ended up navigating to the
thread instead of opening the message actions button. To understand why
this happens, we first need to understand that by default Capybara clicks
on the centre of an element. Also, we need to note that the HTML structure of
a chat message is like so:

```
<div class="chat-message-container">
  <div class="chat-message">
    <div class="chat-message-avatar" />
    <div class="chat-message-content" />
    <div class="chat-message-thread-indicator" />
  </div>
</div>
```

Since `PageObjects::Pages::ChatChannel#expand_message_actions_mobile`
attempts to click on the `.chat-message-contaier`, there is a
possibility that the center of that element is the
`.chat-message-thread-indicator` element which would explain why we
navigated to the thread list instead of opening up the message actions.
This is possible because the content of the original chat message as
well as the message excerpt in the thread is randomly generated where the
length of the message and how the text wraps on mobile can affect the
height of the `.chat-message-content` element as thus its position in
the `.chat-message-container` element. In most cases, the middle of the
`.chat-message-container` happens to be the `.chat-message-content`
which is why this test "flakes" sometimes.

What is the solution?

Instead of clicking on the `.chat-message-container`, we be more
specific and click on the `.chat-message-content` element instead.