### PR TITLE
DEV: Add process pid to `bin/turbo_tests --format documentation` output

### DIFF
--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -37,7 +37,8 @@ module TurboTests
     private
 
     def output_example(example)
-      output = +"[#{example.process_id}] #{example.full_description}"
+      output =
+        +"[#{example.process_id}] (##{example.metadata[:process_pid]}) #{example.full_description}"
 
       if run_duration_ms = example.metadata[:run_duration_ms]
         output << " (#{run_duration_ms}ms)"

--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -55,6 +55,7 @@ module TurboTests
             example.metadata[:shared_group_inclusion_backtrace].map(&method(:stack_frame_to_json)),
           extra_failure_lines: example.metadata[:extra_failure_lines],
           run_duration_ms: example.metadata[:run_duration_ms],
+          process_pid: Process.pid,
         },
         location_rerun_argument: example.location_rerun_argument,
       }


### PR DESCRIPTION
Why this change?

The process's pid is useful when we're trying to link output from
different processes together. In this case, we want to be able to link
the Rails server logs to the right rspec process.

Before:

`[2] Viewing sidebar mobile collapses the sidebar when clicking outside of it`

After:

`[2] (#176342) Viewing sidebar mobile collapses the sidebar when clicking outside of it`

### Reviewer notes

This is a follow up to 858cc6aff2623eb795af9ce01850805299556a65. We started printing out errors encountered by the server but we couldn't link them with the right test.
