### PR TITLE
DEV: Ignore requests to `/favicon.ico` requests in test env

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,9 +28,14 @@ Discourse::Application.routes.draw do
     get "/404-body" => "exceptions#not_found_body"
 
     get "/bootstrap" => "bootstrap#index"
+
     if Rails.env.test? || Rails.env.development?
       get "/bootstrap/plugin-css-for-tests.css" => "bootstrap#plugin_css_for_tests"
     end
+
+    # This is not a valid production route and is causing routing errors to be raised in
+    # the test env adding noise to the logs. Just handle it here so we eliminate the noise.
+    get "/favicon.ico", to: proc { [200, {}, [""]] } if Rails.env.test?
 
     post "webhooks/aws" => "webhooks#aws"
     post "webhooks/mailgun" => "webhooks#mailgun"


### PR DESCRIPTION
This is not a valid route and is causing routing errors to be raised in
the test env adding noise to the logs. We'll just "handle" the route in
the test env.