### PR TITLE
DEV: Add more helpful assertions for flaky system tests in CI

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe "Navigation", type: :system do
         expect(side_panel_page).to have_open_thread(thread)
         expect(thread_page).to have_back_link_to_thread_list(category_channel)
         thread_page.back_to_previous_route
+        expect(page).to have_current_path("#{category_channel.relative_url}/t")
         expect(thread_list_page).to have_loaded
       end
 
@@ -164,6 +165,7 @@ RSpec.describe "Navigation", type: :system do
           expect(side_panel_page).to have_open_thread(thread)
           expect(thread_page).to have_back_link_to_thread_list(category_channel)
           thread_page.back_to_previous_route
+          expect(page).to have_current_path("#{category_channel.relative_url}/t")
           expect(thread_list_page).to have_loaded
         end
       end
@@ -177,6 +179,7 @@ RSpec.describe "Navigation", type: :system do
         expect(side_panel_page).to have_open_thread(thread)
         expect(thread_page).to have_back_link_to_thread_list(category_channel)
         thread_page.back_to_previous_route
+        expect(page).to have_current_path("#{category_channel.relative_url}/t")
         expect(thread_list_page).to have_loaded
       end
 
@@ -189,6 +192,7 @@ RSpec.describe "Navigation", type: :system do
           expect(side_panel_page).to have_open_thread(thread)
           expect(thread_page).to have_back_link_to_channel(category_channel)
           thread_page.back_to_previous_route
+          expect(page).to have_current_path("#{category_channel.relative_url}")
           expect(side_panel_page).not_to be_open
         end
       end


### PR DESCRIPTION
Why this change?

In CI, we know we're clicking a link to a chat channel's threads list.
However, the threads list is not loaded and we want to add more
assertions here to try and figure out why. By asserting for the current
URL, we will at least know that the transition to the URL is successful.