### PR TITLE
DEV: fix flaky specs for user status tooltip

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
@@ -178,12 +178,16 @@ acceptance("Post inline mentions – user status tooltip", function (needs) {
     );
 
     await mouseEnter(".user-status-message");
-    const statusTooltipDescription = document.querySelector(
-      ".user-status-message-tooltip .user-status-tooltip-description"
+    const statusTooltip = document.querySelector(
+      ".user-status-message-tooltip"
     );
-
+    assert.ok(statusTooltip, "status tooltip is shown");
+    assert.ok(
+      statusTooltip.querySelector("img").src.includes(status.emoji),
+      "emoji is correct"
+    );
     assert.equal(
-      statusTooltipDescription.innerText,
+      statusTooltip.querySelector(".user-status-tooltip-description").innerText,
       status.description,
       "status description is correct"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
@@ -5,7 +5,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { triggerEvent, visit } from "@ember/test-helpers";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import { cloneJSON } from "discourse-common/lib/object";
 import topicFixtures from "../fixtures/topic";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
@@ -51,7 +51,7 @@ acceptance("Post inline mentions", function (needs) {
     ends_at: null,
   };
 
-  skip("shows user status on inline mentions", async function (assert) {
+  test("shows user status on inline mentions", async function (assert) {
     pretender.get(`/t/${topicId}.json`, () => {
       return response(topicWithUserStatus(topicId, mentionedUserId, status));
     });
@@ -83,7 +83,7 @@ acceptance("Post inline mentions", function (needs) {
     );
   });
 
-  skip("inserts user status on message bus message", async function (assert) {
+  test("inserts user status on message bus message", async function (assert) {
     pretender.get(`/t/${topicId}.json`, () => {
       return response(topicWithoutUserStatus(topicId, mentionedUserId));
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
@@ -36,10 +36,6 @@ async function mouseenter() {
   await triggerEvent(query(".user-status-message"), "mouseenter");
 }
 
-async function mouseleave() {
-  await triggerEvent(query(".user-status-message"), "mouseleave");
-}
-
 acceptance("Post inline mentions", function (needs) {
   needs.user();
 
@@ -62,24 +58,12 @@ acceptance("Post inline mentions", function (needs) {
       exists(".topic-post .cooked .mention .user-status-message"),
       "user status is shown"
     );
-
     const statusElement = query(
       ".topic-post .cooked .mention .user-status-message img"
     );
     assert.ok(
       statusElement.src.includes(status.emoji),
       "status emoji is correct"
-    );
-
-    await mouseenter();
-    const statusTooltipDescription = document.querySelector(
-      ".user-status-message-tooltip .user-status-tooltip-description"
-    );
-
-    assert.equal(
-      statusTooltipDescription.innerText,
-      status.description,
-      "status description is correct"
     );
   });
 
@@ -105,7 +89,6 @@ acceptance("Post inline mentions", function (needs) {
       exists(".topic-post .cooked .mention .user-status-message"),
       "user status is shown"
     );
-
     const statusElement = query(
       ".topic-post .cooked .mention .user-status-message img"
     );
@@ -113,19 +96,6 @@ acceptance("Post inline mentions", function (needs) {
       statusElement.src.includes(status.emoji),
       "status emoji is correct"
     );
-
-    await mouseenter();
-    const statusTooltipDescription = document.querySelector(
-      ".user-status-message-tooltip .user-status-tooltip-description"
-    );
-    assert.equal(
-      statusTooltipDescription.innerText,
-      status.description,
-      "status description is correct"
-    );
-
-    // Needed to remove the tooltip in between tests
-    await mouseleave();
   });
 
   test("updates user status on message bus message", async function (assert) {
@@ -150,13 +120,10 @@ acceptance("Post inline mentions", function (needs) {
       },
     });
 
-    await mouseenter();
-
     assert.ok(
       exists(".topic-post .cooked .mention .user-status-message"),
       "updated user status is shown"
     );
-
     const statusElement = query(
       ".topic-post .cooked .mention .user-status-message img"
     );
@@ -164,18 +131,6 @@ acceptance("Post inline mentions", function (needs) {
       statusElement.src.includes(newStatus.emoji),
       "updated status emoji is correct"
     );
-
-    const statusTooltipDescription = document.querySelector(
-      ".user-status-message-tooltip .user-status-tooltip-description"
-    );
-    assert.equal(
-      statusTooltipDescription.innerText,
-      newStatus.description,
-      "updated status description is correct"
-    );
-
-    // Needed to remove the tooltip in between tests
-    await mouseleave();
   });
 
   test("removes user status on message bus message", async function (assert) {
@@ -196,6 +151,41 @@ acceptance("Post inline mentions", function (needs) {
     assert.notOk(
       exists(".topic-post .cooked .mention .user-status-message"),
       "updated user has disappeared"
+    );
+  });
+});
+
+acceptance("Post inline mentions – user status tooltip", function (needs) {
+  needs.user();
+
+  const topicId = 130;
+  const mentionedUserId = 1;
+  const status = {
+    description: "Surfing",
+    emoji: "surfing_man",
+    ends_at: null,
+  };
+
+  test("shows user status tooltip", async function (assert) {
+    pretender.get(`/t/${topicId}.json`, () => {
+      return response(topicWithUserStatus(topicId, mentionedUserId, status));
+    });
+
+    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+    assert.ok(
+      exists(".topic-post .cooked .mention .user-status-message"),
+      "user status is shown"
+    );
+
+    await mouseenter();
+    const statusTooltipDescription = document.querySelector(
+      ".user-status-message-tooltip .user-status-tooltip-description"
+    );
+
+    assert.equal(
+      statusTooltipDescription.innerText,
+      status.description,
+      "status description is correct"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
@@ -32,10 +32,6 @@ function topicWithUserStatus(topicId, mentionedUserId, status) {
   return topic;
 }
 
-async function mouseenter() {
-  await triggerEvent(query(".user-status-message"), "mouseenter");
-}
-
 acceptance("Post inline mentions", function (needs) {
   needs.user();
 
@@ -166,6 +162,10 @@ acceptance("Post inline mentions – user status tooltip", function (needs) {
     ends_at: null,
   };
 
+  async function mouseEnter(selector) {
+    await triggerEvent(query(selector), "mouseenter");
+  }
+
   test("shows user status tooltip", async function (assert) {
     pretender.get(`/t/${topicId}.json`, () => {
       return response(topicWithUserStatus(topicId, mentionedUserId, status));
@@ -177,7 +177,7 @@ acceptance("Post inline mentions – user status tooltip", function (needs) {
       "user status is shown"
     );
 
-    await mouseenter();
+    await mouseEnter(".user-status-message");
     const statusTooltipDescription = document.querySelector(
       ".user-status-message-tooltip .user-status-tooltip-description"
     );


### PR DESCRIPTION
A follow-up to 585a2e4e. A couple of tests with the new rich tooltip were flaky. We suppose the reason is some problem related to widgets lifecycle. This PR doesn't fix the issue, but isolates testing of the tooltip related logic related inside its own test, which should make it not flaky.

This is a temporal solution, we're going to move all these code to using glimmer components.