### PR TITLE
UX: dynamic sizing of composer to fit sidebar on wide screens

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -17,6 +17,13 @@ html.composer-open {
   max-width: $reply-area-max-width;
   width: 100%;
 
+  .has-sidebar-page & {
+    @media screen and (min-width: $reply-area-max-width) {
+      max-width: calc(100vw - var(--d-sidebar-width) - 1rem);
+      margin-right: 1rem;
+    }
+  }
+
   &.hide-preview {
     max-width: 740px;
   }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -73,6 +73,10 @@
     overflow-x: hidden;
     // allows sidebar to scroll to the bottom when the composer is open
     height: calc(100% - var(--composer-height, 0px));
+
+    @media screen and (min-width: $reply-area-max-width) {
+      height: auto;
+    }
   }
 
   .sidebar-sections {


### PR DESCRIPTION
Works best on full width because there we know full width = 100vw so it can be neatly aligned.
On default it's slightly less elegant because the alignment isn't possible to achieve and therefor jumps to the old display format a bit faster.


https://github.com/discourse/discourse/assets/101828855/348c6ac8-07a5-4aee-99ce-99a1c0df1f2e




