### PR TITLE
DEV: Raise error instead of warning in testing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -349,7 +349,7 @@ class ApplicationController < ActionController::Base
       if plugin = Discourse.plugins_by_name[plugin_name]
         raise PluginDisabled.new if !plugin.enabled?
       elsif Rails.env.test?
-        raise "Required plugin '#{plugin_name}' not found"
+        raise "Required plugin '#{plugin_name}' not found. The string passed to requires_plugin should match the plugin's name at the top of plugin.rb"
       else
         Rails.logger.warn("Required plugin '#{plugin_name}' not found")
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -348,6 +348,8 @@ class ApplicationController < ActionController::Base
     before_action do
       if plugin = Discourse.plugins_by_name[plugin_name]
         raise PluginDisabled.new if !plugin.enabled?
+      elsif Rails.env.test?
+        raise "Required plugin '#{plugin_name}' not found"
       else
         Rails.logger.warn("Required plugin '#{plugin_name}' not found")
       end


### PR DESCRIPTION
Some plugins call require_plugin with a wrong argument instead of the plugin name. In the production environment that used to be a warning, but there is no reason to keep it like that in a testing environment because the issue will continue to be ignored.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
