### PR TITLE
FIX: more consistent composer focus and replying indicator

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -132,6 +132,8 @@ export default class ChatLivePane extends Component {
       this.resetComposerMessage();
     }
 
+    this.composer.focus();
+
     this.loadMessages();
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
@@ -65,7 +65,6 @@
             {{on "focusin" (fn this.computeIsFocused true)}}
             {{on "focusout" (fn this.computeIsFocused false)}}
             {{did-insert this.setupAutocomplete}}
-            {{did-insert this.composer.focus}}
             data-chat-composer-context={{this.context}}
           />
         </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -44,10 +44,6 @@ export default class ChatComposer extends Component {
   @tracked inProgressUploadsCount = 0;
   @tracked presenceChannelName;
 
-  get shouldRenderReplyingIndicator() {
-    return this.args.channel;
-  }
-
   get shouldRenderMessageDetails() {
     return (
       this.currentMessage?.editing ||

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -45,6 +45,7 @@ export default class ChatThreadPanel extends Component {
   @action
   didUpdateThread() {
     this.subscribeToUpdates();
+    this.chatThreadComposer.focus();
     this.loadMessages();
     this.resetComposerMessage();
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
@@ -14,6 +14,10 @@ export default class ChatComposerChannel extends ChatComposer {
 
   composerId = "channel-composer";
 
+  get shouldRenderReplyingIndicator() {
+    return this.args.channel;
+  }
+
   get presenceChannelName() {
     const channel = this.args.channel;
     return `/chat-reply/${channel.id}`;

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
@@ -18,6 +18,10 @@ export default class ChatComposerThread extends ChatComposer {
     this.composer.reset(this.args.thread);
   }
 
+  get shouldRenderReplyingIndicator() {
+    return this.args.thread;
+  }
+
   get disabled() {
     return (
       !this.chat.userCanInteractWithChat ||

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
@@ -15,7 +15,7 @@ export default class ChatChannelComposer extends Service {
 
   @action
   focus(options = {}) {
-    this.textarea.focus(options);
+    this.textarea?.focus(options);
   }
 
   @action


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
