### PR TITLE
FIX: Set test transaction to before_all transaction

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -149,7 +149,12 @@ module TestSetup
   end
 end
 
-TestProf::BeforeAll.configure { |config| config.before(:begin) { TestSetup.test_setup } }
+TestProf::BeforeAll.configure do |config|
+  config.after(:begin) do
+    TestSetup.test_setup
+    DB.test_transaction = ActiveRecord::Base.connection.current_transaction
+  end
+end
 
 if ENV["PREFABRICATION"] == "0"
   module Prefabrication


### PR DESCRIPTION
So that after_commit hooks work correctly for pre-fabricated objects.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
