### PR TITLE
DEV: Avoid waiting full capybara default wait time

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "Navigation", type: :system do
           expect(thread_page).to have_back_link_to_channel(category_channel)
           thread_page.back_to_previous_route
           expect(page).to have_current_path("#{category_channel.relative_url}")
-          expect(side_panel_page).not_to be_open
+          expect(side_panel_page).to be_closed
         end
       end
     end

--- a/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_side_panel.rb
@@ -7,6 +7,10 @@ module PageObjects
         has_css?(".chat-side-panel")
       end
 
+      def closed?
+        has_no_css?(".chat-side-panel")
+      end
+
       def has_open_thread?(thread = nil)
         if thread
           has_css?(".chat-side-panel .chat-thread[data-id='#{thread.id}']")


### PR DESCRIPTION
Why this change?

`not_to be_open` ends up calling `has_css?` on a selector that will
never appear so it ends up waiting the full default wait time.