### PR TITLE
DEV: Fix flaky chat drawer system test

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -73,7 +73,10 @@ module PageObjects
       end
 
       def hover_message(message)
-        message_by_id(message.id).hover
+        message = message_by_id(message.id)
+        # Scroll to top of message so that the actions are not hidden
+        page.scroll_to(message, align: :top)
+        message.hover
       end
 
       def bookmark_message(message)


### PR DESCRIPTION
Why this change?

This change ensures that we scroll to the top of the message when
hovering over a message to ensure that the message actions container
that appears on hover is not hidden in the chat drawer when the content
of the chat message is long.