### PR TITLE
DEV: Fix number of chars for chat message content in fabricator

### DIFF
--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -66,7 +66,7 @@ Fabricator(:chat_message, class_name: "Chat::MessageCreator") do
     resolved_class.create(
       chat_channel: channel,
       user: user,
-      content: transients[:message] || Faker::Lorem.paragraph,
+      content: transients[:message] || Faker::Lorem.paragraph_by_chars(number: 500),
       thread_id: transients[:thread]&.id,
       in_reply_to_id: transients[:in_reply_to]&.id,
       upload_ids: transients[:upload_ids],


### PR DESCRIPTION
Why this change?

`Faker::Lorem.paragraph` generates a differrent length of string
every time. When a string happens to be long, it can change the UI
across system test runs making it harder to reason about our system
tests across multiple runs since the state is never really consistent.

We will just generate a paragraph with a fixed length going forward so
that the UI remains consistent. This should make certain tests which
relies on the UI being in a certain state to become less flaky.