### PR TITLE
FIX: Avoid transitioning when a chat thread component is destroyed

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -166,10 +166,11 @@ export default class ChatThreadPanel extends Component {
     return this.chatApi
       .channel(this.args.thread.channel.id, findArgs)
       .then((result) => {
-        if (
-          this._selfDeleted ||
-          this.args.thread.channel.id !== result.meta.channel_id
-        ) {
+        if (this._selfDeleted) {
+          return;
+        }
+
+        if (this.args.thread.channel.id !== result.meta.channel_id) {
           if (this.chatHistory.previousRoute?.name === "chat.channel.index") {
             this.router.transitionTo(
               "chat.channel",


### PR DESCRIPTION
Why this change?

Before this commit, there is a chance that we will transition the user
to a different route if the chat thread component has been destroyed
prior to the request for fetching messasges in a chat thread returning.

This commit makes it such that we simply ignore the request if the chat
thread component has been destroyed.

We believe this is the cause of the flaky system tests in plugins/chat/spec/system/navigation_spec.rb
which we've been seeing on CI.