### PR TITLE
FIX: Mark threads read when threading enabled for a channel

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/mark_all_channel_threads_read.rb
+++ b/plugins/chat/app/jobs/regular/chat/mark_all_channel_threads_read.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jobs
+  module Chat
+    class MarkAllChannelThreadsRead < Jobs::Base
+      sidekiq_options queue: "critical"
+
+      def execute(args = {})
+        return if !SiteSetting.enable_experimental_chat_threaded_discussions
+        channel = ::Chat::Channel.find_by(id: args[:channel_id])
+        return if channel.blank?
+        channel.mark_all_threads_as_read
+      end
+    end
+  end
+end

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -165,6 +165,10 @@ module Chat
     end
 
     def mark_all_threads_as_read(user: nil)
+      if !(self.threading_enabled || SiteSetting.enable_experimental_chat_threaded_discussions)
+        return
+      end
+
       DB.exec(<<~SQL, channel_id: self.id)
         UPDATE user_chat_thread_memberships
         SET last_read_message_id = subquery.last_message_id

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -164,6 +164,27 @@ module Chat
       SQL
     end
 
+    def mark_all_threads_as_read(user: nil)
+      DB.exec(<<~SQL, channel_id: self.id)
+        UPDATE user_chat_thread_memberships
+        SET last_read_message_id = subquery.last_message_id
+        FROM (
+          SELECT chat_threads.id AS thread_id, MAX(chat_messages.id) AS last_message_id
+          FROM chat_threads
+          INNER JOIN chat_messages ON chat_messages.thread_id = chat_threads.id
+          WHERE chat_threads.channel_id = :channel_id
+          AND chat_messages.deleted_at IS NULL
+          GROUP BY chat_threads.id
+        ) subquery
+        WHERE user_chat_thread_memberships.thread_id = subquery.thread_id
+        #{user ? "AND user_chat_thread_memberships.user_id = #{user.id}" : ""}
+        AND (
+          user_chat_thread_memberships.last_read_message_id < subquery.last_message_id OR
+          user_chat_thread_memberships.last_read_message_id IS NULL
+        )
+      SQL
+    end
+
     private
 
     def change_status(acting_user, target_status)

--- a/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
+++ b/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
@@ -31,20 +31,16 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
       thread_2.add(user_2)
     end
 
+    def unread_count(user)
+      Chat::ThreadUnreadsQuery.call(channel_ids: [channel.id], user_id: user.id).first.unread_count
+    end
+
     it "marks all threads as read across all users in the channel" do
+      expect(unread_count(user_1)).to eq(3)
+      expect(unread_count(user_2)).to eq(2)
       described_class.new.execute(channel_id: channel.id)
-      expect(
-        Chat::ThreadUnreadsQuery
-          .call(channel_ids: [channel.id], user_id: user_1.id)
-          .first
-          .unread_count,
-      ).to eq(0)
-      expect(
-        Chat::ThreadUnreadsQuery
-          .call(channel_ids: [channel.id], user_id: user_2.id)
-          .first
-          .unread_count,
-      ).to eq(0)
+      expect(unread_count(user_1)).to eq(0)
+      expect(unread_count(user_2)).to eq(0)
     end
   end
 end

--- a/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
+++ b/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
+  fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
+
+  context "when enable_experimental_chat_threaded_discussions is false" do
+    before { SiteSetting.enable_experimental_chat_threaded_discussions = false }
+
+    it "does nothing" do
+      Chat::Channel.any_instance.expects(:mark_all_threads_as_read).never
+      described_class.new.execute(channel_id: channel.id)
+    end
+  end
+
+  context "when enable_experimental_chat_threaded_discussions is true" do
+    fab!(:thread_1) { Fabricate(:chat_thread, channel: channel) }
+    fab!(:thread_2) { Fabricate(:chat_thread, channel: channel) }
+    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_2) { Fabricate(:user) }
+    fab!(:thread_1_message_1) { Fabricate(:chat_message, thread: thread_1) }
+    fab!(:thread_1_message_2) { Fabricate(:chat_message, thread: thread_1) }
+    fab!(:thread_1_message_3) { Fabricate(:chat_message, thread: thread_1) }
+    fab!(:thread_2_message_1) { Fabricate(:chat_message, thread: thread_2) }
+    fab!(:thread_2_message_2) { Fabricate(:chat_message, thread: thread_2) }
+
+    before do
+      SiteSetting.enable_experimental_chat_threaded_discussions = true
+      channel.add(user_1)
+      channel.add(user_2)
+      thread_1.add(user_1)
+      thread_2.add(user_2)
+    end
+
+    it "marks all threads as read across all users in the channel" do
+      described_class.new.execute(channel_id: channel.id)
+      expect(
+        Chat::ThreadUnreadsQuery
+          .call(channel_ids: [channel.id], user_id: user_1.id)
+          .first
+          .unread_count,
+      ).to eq(0)
+      expect(
+        Chat::ThreadUnreadsQuery
+          .call(channel_ids: [channel.id], user_id: user_2.id)
+          .first
+          .unread_count,
+      ).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Since we create threads in the background regardless of whether
threading is enabled for a channel, we get the unexpected behaviour
of everyone having a lot of unread threads when threading is enabled
for the channel.

To counteract this, when the admin enables threads for a channel
we can just run a high priority background job to mark all threads
as read in the channel for all users, so they are essentially
starting from a clean slate.
