### PR TITLE
FIX: Show replies count on thread indicator regardless of participants

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -24,6 +24,9 @@
       {{format-date @message.thread.preview.lastReplyCreatedAt leaveAgo="true"}}
     </span>
   </div>
+  <div class="chat-message-thread-indicator__replies-count">
+    {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
+  </div>
   <Chat::Thread::Participants @thread={{@message.thread}} />
   <div class="chat-message-thread-indicator__last-reply-excerpt">
     {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/participants.hbs
@@ -1,7 +1,4 @@
 {{#if (gt @thread.preview.participantUsers.length 1)}}
-  <div class="chat-message-thread-indicator__replies-count">
-    {{i18n "chat.thread.replies" count=@thread.preview.replyCount}}
-  </div>
   <div class="chat-thread-participants">
     <div class="chat-thread-participants__avatar-group">
       {{#each @thread.preview.participantUsers as |user|}}

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -74,6 +74,20 @@ describe "Thread indicator for chat messages", type: :system do
       )
     end
 
+    it "it shows the reply count but no participant avatars when there is only one participant" do
+      single_user_thread =
+        Fabricate(:chat_thread, channel: channel, original_message_user: current_user)
+      Fabricate(:chat_message, thread: single_user_thread, user: current_user)
+      Fabricate(:chat_message, thread: single_user_thread, user: current_user)
+      chat_page.visit_channel(channel)
+      expect(
+        channel_page.message_thread_indicator(single_user_thread.original_message),
+      ).to have_reply_count(2)
+      expect(
+        channel_page.message_thread_indicator(single_user_thread.original_message),
+      ).to have_no_participants
+    end
+
     it "clicking a thread indicator opens the thread panel" do
       chat_page.visit_channel(channel)
       channel_page.message_thread_indicator(thread_1.original_message).click
@@ -116,7 +130,7 @@ describe "Thread indicator for chat messages", type: :system do
       )
     end
 
-    it "shows participants of the thread" do
+    it "shows avatars for the participants of the thread" do
       chat_page.visit_channel(channel)
       expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_participant(
         current_user,

--- a/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
@@ -37,6 +37,10 @@ module PageObjects
           )
         end
 
+        def has_no_participants?
+          find(@context).has_no_css?(".chat-thread-participants")
+        end
+
         def excerpt
           find(@context).find("#{SELECTOR}__last-reply-excerpt")
         end


### PR DESCRIPTION
Followup to 802fb3b19456c26464ec7f9a9715d1ea7826c7f0

We should not hide the replies count if there is only 1 participant
for a thread, because this makes it look like the last reply is the
only reply.

Before:

![image](https://github.com/discourse/discourse/assets/920448/eab310f0-fc1f-40b3-b24f-7839a263a44e)

After:

![image](https://github.com/discourse/discourse/assets/920448/ec0a66a6-078e-42c9-ab57-26e454d5cb3b)
