### PR TITLE
DEV: Remove ActiveRecord connection pool busy check in tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -339,10 +339,6 @@ RSpec.configure do |config|
 
     unfreeze_time
     ActionMailer::Base.deliveries.clear
-
-    if ActiveRecord::Base.connection_pool.stat[:busy] > 1
-      raise ActiveRecord::Base.connection_pool.stat.inspect
-    end
   end
 
   config.after(:suite) do


### PR DESCRIPTION
This was added way back in bdf3da8f80b7dc32dd90e1d3673c273f65eae5b9 but
has never been useful in any meaningful way for us. Therefore, we're
dropping this check.