### PR TITLE
DEV: Try fix category form template flaky

### DIFF
--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -9,6 +9,10 @@ class SiteCategorySerializer < BasicCategorySerializer
 
   has_many :category_required_tag_groups, key: :required_tag_groups, embed: :objects
 
+  def form_template_ids
+    object.form_template_ids.sort
+  end
+
   def include_allowed_tags?
     SiteSetting.tagging_enabled
   end

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -51,7 +51,7 @@ module PageObjects
       end
 
       def has_selected_template?(template_name)
-        find(".select-category-template .select-kit-header")["data-name"] == template_name
+        has_css?(".select-category-template .select-kit-header[data-name='#{template_name}']")
       end
 
       def toggle_form_templates


### PR DESCRIPTION
  1) Edit Category when editing a category with form templates set should have form templates enabled and showing the selected templates
     Failure/Error: expect(category_page).to have_selected_template(selected_templates)
       expected `#<PageObjects::Pages::Category:0x00007fdb278fbd30>.has_selected_template?("template_0,template_1")` to be truthy, got false

Wait for CSS rather than trying to compare attr directly
and also make sure the ids are always in order.
