### PR TITLE
FIX: Track thread in UI when user sends first message

### DIFF
--- a/plugins/chat/app/controllers/chat/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat/chat_controller.rb
@@ -148,7 +148,7 @@ module Chat
         )
 
       Chat::Publisher.publish_user_tracking_state!(current_user, @chat_channel, message)
-      render json: success_json
+      render json: success_json.merge(message_id: message.id)
     end
 
     def edit_message

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -275,13 +275,11 @@ export default class ChatThreadPanel extends Component {
           staged_thread_id: message.thread.staged ? message.thread.id : null,
         })
         .then((response) => {
-          if (!this.args.thread.currentUserMembership) {
-            this.args.thread.currentUserMembership =
-              UserChatThreadMembership.create({
-                notification_level: NotificationLevels.TRACKING,
-                last_read_message_id: response.message_id,
-              });
-          }
+          this.args.thread.currentUserMembership ??=
+            UserChatThreadMembership.create({
+              notification_level: NotificationLevels.TRACKING,
+              last_read_message_id: response.message_id,
+            });
         })
         .catch((error) => {
           this.#onSendError(message.id, error);

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -1,4 +1,6 @@
 import Component from "@glimmer/component";
+import { NotificationLevels } from "discourse/lib/notification-levels";
+import UserChatThreadMembership from "discourse/plugins/chat/discourse/models/user-chat-thread-membership";
 import { Promise } from "rsvp";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
@@ -271,6 +273,15 @@ export default class ChatThreadPanel extends Component {
           upload_ids: message.uploads.map((upload) => upload.id),
           thread_id: message.thread.staged ? null : message.thread.id,
           staged_thread_id: message.thread.staged ? message.thread.id : null,
+        })
+        .then((response) => {
+          if (!this.args.thread.currentUserMembership) {
+            this.args.thread.currentUserMembership =
+              UserChatThreadMembership.create({
+                notification_level: NotificationLevels.TRACKING,
+                last_read_message_id: response.message_id,
+              });
+          }
         })
         .catch((error) => {
           this.#onSendError(message.id, error);

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -157,6 +157,7 @@ Fabricator(:chat_thread, class_name: "Chat::Thread") do
     thread.channel = original_message.chat_channel
   end
 
+  transient :with_replies
   transient :channel
   transient :original_message_user
 
@@ -168,9 +169,13 @@ Fabricator(:chat_thread, class_name: "Chat::Thread") do
     )
   end
 
-  after_create do |thread|
+  after_create do |thread, transients|
     thread.original_message.update!(thread_id: thread.id)
     thread.add(thread.original_message_user)
+
+    if transients[:with_replies]
+      Fabricate.times(transients[:with_replies], :chat_message, thread: thread)
+    end
   end
 end
 

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -127,6 +127,16 @@ describe "Single thread in side panel", type: :system do
         expect(channel_page).not_to have_css(channel_page.message_by_id_selector(thread_message.id))
       end
 
+      it "changes the tracking bell to be Tracking level in the thread panel" do
+        new_thread = Fabricate(:chat_thread, channel: channel, with_replies: 1)
+        chat_page.visit_channel(channel)
+        channel_page.message_thread_indicator(new_thread.original_message).click
+        expect(side_panel).to have_open_thread(new_thread)
+        expect(thread_page).to have_notification_level("normal")
+        thread_page.send_message("new thread message")
+        expect(thread_page).to have_notification_level("tracking")
+      end
+
       it "handles updates from multiple users sending messages in the thread" do
         using_session(:tab_1) do
           sign_in(current_user)


### PR DESCRIPTION
When a user sends their first message in a thread we
automatically track the thread in the backend, but we
don't reflect this in the UI until the user re-opens
the thread. This commit fixes that by showing the new
tracking level in the UI. The bell will change from an outline
to blue.

![image](https://github.com/discourse/discourse/assets/920448/cb2c29aa-c55c-4173-8353-3bbbe5fe35ec)
