### PR TITLE
FIX: Add missing chat translations

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -86,6 +86,8 @@ en:
         one: "You can't create a direct message with more than %{count} other user."
         other: "You can't create a direct message with more than %{count} other users."
       original_message_not_found: "The ancestor of the message you are replying cannot be found or has been deleted."
+      thread_invalid_for_channel: "Thread is not part of the provided channel."
+      thread_does_not_match_parent: "Thread does not match parent message."
     reviewables:
       message_already_handled: "Thanks, but we've already reviewed this message and determined it does not need to be flagged again."
       actions:


### PR DESCRIPTION
Some error messages when creating a new chat message were not defined.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
