### PR TITLE
FIX: limits legacy sidebar height

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
@@ -1,7 +1,7 @@
 .has-full-page-chat:not(.discourse-sidebar) {
   .full-page-chat {
     .channels-list {
-      height: 100%;
+      height: calc(100vh - var(--header-offset));
       border-right: 1px solid var(--primary-low);
       background: var(--primary-very-low);
 


### PR DESCRIPTION
Prior to this fix the sidebar was taking unlimited height.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
