### PR TITLE
DEV: Skip flaky visit-channel system tests

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Navigation", type: :system do
   end
 
   context "when collapsing full page with previous state" do
-    it "redirects to previous state" do
+    xit "redirects to previous state" do
       visit("/t/-/#{topic.id}")
       chat_page.open_from_header
       chat_drawer_page.maximize

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Visit channel", type: :system do
       end
 
       context "when channel is not found" do
-        it "shows an error" do
+        xit "shows an error" do
           visit("/chat/c/-/999")
 
           expect(page).to have_content("Not Found") # this is not a translated key
@@ -78,7 +78,7 @@ RSpec.describe "Visit channel", type: :system do
 
       context "when channel is not accessible" do
         context "when category channel" do
-          it "shows an error" do
+          xit "shows an error" do
             chat.visit_channel(private_category_channel_1)
 
             expect(page).to have_content(I18n.t("invalid_access"))
@@ -86,7 +86,7 @@ RSpec.describe "Visit channel", type: :system do
         end
 
         context "when direct message channel" do
-          it "shows an error" do
+          xit "shows an error" do
             chat.visit_channel(inaccessible_dm_channel_1)
 
             expect(page).to have_content(I18n.t("invalid_access"))
@@ -111,7 +111,7 @@ RSpec.describe "Visit channel", type: :system do
           )
         end
 
-        it "shows an error" do
+        xit "shows an error" do
           chat.visit_channel(inaccessible_dm_channel_1)
 
           expect(page).to have_content(I18n.t("invalid_access"))


### PR DESCRIPTION
Consistently seeing failures on 
- visit-channel
- navigation

specs
