### PR TITLE
DEV: fix flakeyness with drawer specs

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -464,7 +464,7 @@ const DiscourseURL = EmberObject.extend({
     transition._discourse_original_url = path;
 
     const promise = transition.promise || transition;
-    promise.then(() => this.jumpToElement(elementId));
+    return promise.then(() => this.jumpToElement(elementId));
   },
 
   jumpToElement(elementId) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -825,13 +825,11 @@ export default class ChatLivePane extends Component {
   onCloseFullScreen() {
     this.chatStateManager.prefersDrawer();
 
-    DiscourseURL.routeTo(this.chatStateManager.lastKnownAppURL, {
-      afterRouteComplete: () => {
-        this.appEvents.trigger(
-          "chat:open-url",
-          this.chatStateManager.lastKnownChatURL
-        );
-      },
+    DiscourseURL.routeTo(this.chatStateManager.lastKnownAppURL).then(() => {
+      this.appEvents.trigger(
+        "chat:open-url",
+        this.chatStateManager.lastKnownChatURL
+      );
     });
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -826,10 +826,7 @@ export default class ChatLivePane extends Component {
     this.chatStateManager.prefersDrawer();
 
     DiscourseURL.routeTo(this.chatStateManager.lastKnownAppURL).then(() => {
-      this.appEvents.trigger(
-        "chat:open-url",
-        this.chatStateManager.lastKnownChatURL
-      );
+      DiscourseURL.routeTo(this.chatStateManager.lastKnownChatURL);
     });
   }
 

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Navigation", type: :system do
   end
 
   context "when collapsing full page with previous state" do
-    xit "redirects to previous state" do
+    it "redirects to previous state" do
       visit("/t/-/#{topic.id}")
       chat_page.open_from_header
       chat_drawer_page.maximize


### PR DESCRIPTION
Chat drawer was using the `DiscourseURL` hook `afterRouteComplete`. This hook suffers from a very poor implementation which makes it very unreliable:

```javascript
if (typeof opts.afterRouteComplete === "function") {
  schedule("afterRender", opts.afterRouteComplete);
}
```

This commit attempts to return the promise from `handleURL` to directly use it and have a very reliable after transition hook.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
