### PR TITLE
FEATURE: Add default site settings to control the defaults of navigation menu preferences

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -69,6 +69,8 @@ const DEFAULT_USER_PREFERENCES = [
   "default_title_count_mode",
   "default_navigation_menu_categories",
   "default_navigation_menu_tags",
+  "default_sidebar_link_to_filtered_list",
+  "default_sidebar_show_count_of_new_items",
 ];
 
 export default Mixin.create({

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -255,6 +255,8 @@ class Admin::SiteSettingsController < Admin::AdminController
       default_text_size: "text_size_key",
       default_title_count_mode: "title_count_mode_key",
       default_hide_profile_and_presence: "hide_profile_and_presence",
+      default_sidebar_link_to_filtered_list: "sidebar_link_to_filtered_list",
+      default_sidebar_show_count_of_new_items: "sidebar_show_count_of_new_items",
     }
   end
 

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -89,6 +89,8 @@ class UserOption < ActiveRecord::Base
     self.title_count_mode = SiteSetting.default_title_count_mode
 
     self.hide_profile_and_presence = SiteSetting.default_hide_profile_and_presence
+    self.sidebar_link_to_filtered_list = SiteSetting.default_sidebar_link_to_filtered_list
+    self.sidebar_show_count_of_new_items = SiteSetting.default_sidebar_show_count_of_new_items
 
     true
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2352,7 +2352,7 @@ en:
     default_title_count_mode: "Default mode for the page title counter"
     enable_offline_indicator: "Display a message to users when it is detected that they have no network connection"
     default_sidebar_link_to_filtered_list: "Make navigation menu link link to filtered list by default."
-    default_sidebar_show_count_of_new_items: "Make sidebar items show count of new items instead of badges by default."
+    default_sidebar_show_count_of_new_items: "Make navigation menu links show count of new items instead of badges by default."
 
     retain_web_hook_events_period_days: "Number of days to retain web hook event records."
     retry_web_hook_events: "Automatically retry failed web hook events for 4 times. Time gaps between the retries are 1, 5, 25 and 125 minutes."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2351,7 +2351,7 @@ en:
 
     default_title_count_mode: "Default mode for the page title counter"
     enable_offline_indicator: "Display a message to users when it is detected that they have no network connection"
-    default_sidebar_link_to_filtered_list: "Make sidebar items link to filtered list by default."
+    default_sidebar_link_to_filtered_list: "Make navigation menu link link to filtered list by default."
     default_sidebar_show_count_of_new_items: "Make sidebar items show count of new items instead of badges by default."
 
     retain_web_hook_events_period_days: "Number of days to retain web hook event records."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2351,6 +2351,8 @@ en:
 
     default_title_count_mode: "Default mode for the page title counter"
     enable_offline_indicator: "Display a message to users when it is detected that they have no network connection"
+    default_sidebar_link_to_filtered_list: "Make sidebar items link to filtered list by default."
+    default_sidebar_show_count_of_new_items: "Make sidebar items show count of new items instead of badges by default."
 
     retain_web_hook_events_period_days: "Number of days to retain web hook event records."
     retry_web_hook_events: "Automatically retry failed web hook events for 4 times. Time gaps between the retries are 1, 5, 25 and 125 minutes."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2351,7 +2351,7 @@ en:
 
     default_title_count_mode: "Default mode for the page title counter"
     enable_offline_indicator: "Display a message to users when it is detected that they have no network connection"
-    default_sidebar_link_to_filtered_list: "Make navigation menu link link to filtered list by default."
+    default_sidebar_link_to_filtered_list: "Make navigation menu links link to filtered list by default."
     default_sidebar_show_count_of_new_items: "Make navigation menu links show count of new items instead of badges by default."
 
     retain_web_hook_events_period_days: "Number of days to retain web hook event records."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2727,6 +2727,9 @@ user_preferences:
   enable_offline_indicator:
     default: false
     client: true
+  default_sidebar_link_to_filtered_list: false
+  default_sidebar_show_count_of_new_items: false
+
 api:
   retain_web_hook_events_period_days:
     default: 30

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -166,7 +166,9 @@ def insert_user_options
                   notification_level_when_replying,
                   like_notification_frequency,
                   skip_new_user_tips,
-                  hide_profile_and_presence
+                  hide_profile_and_presence,
+                  sidebar_link_to_filtered_list,
+                  sidebar_show_count_of_new_items
                 )
              SELECT u.id
                   , #{SiteSetting.default_email_mailing_list_mode}
@@ -188,6 +190,8 @@ def insert_user_options
                   , #{SiteSetting.default_other_like_notification_frequency}
                   , #{SiteSetting.default_other_skip_new_user_tips}
                   , #{SiteSetting.default_hide_profile_and_presence}
+                  , #{SiteSetting.default_sidebar_link_to_filtered_list}
+                  , #{SiteSetting.default_sidebar_show_count_of_new_items}
                FROM users u
           LEFT JOIN user_options uo ON uo.user_id = u.id
               WHERE uo.user_id IS NULL

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UserOption do
       expect(user.user_option.digest_after_minutes).to eq(0)
     end
 
-    it "should correctly set sidebar_link_to_filtered_list when enabled" do
+    it "should correctly set sidebar_link_to_filtered_list when `default_sidebar_link_to_filtered_list` site setting is enabled" do
       SiteSetting.default_sidebar_link_to_filtered_list = true
       user = Fabricate(:user)
       expect(user.user_option.sidebar_link_to_filtered_list).to eq(true)

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe UserOption do
       expect(user.user_option.email_digests).to eq(false)
       expect(user.user_option.digest_after_minutes).to eq(0)
     end
+
+    it "should correctly set sidebar_link_to_filtered_list when enabled" do
+      SiteSetting.default_sidebar_link_to_filtered_list = true
+      user = Fabricate(:user)
+      expect(user.user_option.sidebar_link_to_filtered_list).to eq(true)
+    end
+
+    it "should correctly set sidebar_link_to_filtered_list when disabled" do
+      SiteSetting.default_sidebar_link_to_filtered_list = false
+      user = Fabricate(:user)
+      expect(user.user_option.sidebar_link_to_filtered_list).to eq(false)
+    end
+
+    it "should correctly set sidebar_show_count_of_new_items when enabled" do
+      SiteSetting.default_sidebar_show_count_of_new_items = true
+      user = Fabricate(:user)
+      expect(user.user_option.sidebar_show_count_of_new_items).to eq(true)
+    end
+
+    it "should correctly set sidebar_show_count_of_new_items when disabled" do
+      SiteSetting.default_sidebar_show_count_of_new_items = false
+      user = Fabricate(:user)
+      expect(user.user_option.sidebar_show_count_of_new_items).to eq(false)
+    end
   end
 
   describe "site settings" do

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -51,19 +51,19 @@ RSpec.describe UserOption do
       expect(user.user_option.sidebar_link_to_filtered_list).to eq(true)
     end
 
-    it "should correctly set sidebar_link_to_filtered_list when disabled" do
+    it "should correctly set sidebar_link_to_filtered_list when `default_sidebar_link_to_filtered_list` site setting is disabled" do
       SiteSetting.default_sidebar_link_to_filtered_list = false
       user = Fabricate(:user)
       expect(user.user_option.sidebar_link_to_filtered_list).to eq(false)
     end
 
-    it "should correctly set sidebar_show_count_of_new_items when enabled" do
+    it "should correctly set sidebar_show_count_of_new_items when `default_sidebar_show_count_of_new_items` site setting is enabled" do
       SiteSetting.default_sidebar_show_count_of_new_items = true
       user = Fabricate(:user)
       expect(user.user_option.sidebar_show_count_of_new_items).to eq(true)
     end
 
-    it "should correctly set sidebar_show_count_of_new_items when disabled" do
+    it "should correctly set sidebar_show_count_of_new_items when `default_sidebar_show_count_of_new_items` site setting is disabled" do
       SiteSetting.default_sidebar_show_count_of_new_items = false
       user = Fabricate(:user)
       expect(user.user_option.sidebar_show_count_of_new_items).to eq(false)


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/b27e12445dc9b27cc5063044b65d7adcb5d6d3fa

This PR adds 2 new site settings `default_sidebar_link_to_filtered_list` and `default_sidebar_show_count_of_new_items` to control the default values for the navigation menu preferences that were added in the linked commit (`sidebar_link_to_filtered_list` and `sidebar_show_count_of_new_items` respectively).