### PR TITLE
FIX: Show preview of Arial/System font in wizard

### DIFF
--- a/app/assets/javascripts/wizard/addon/components/wizard-preview-base.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-preview-base.js
@@ -87,6 +87,10 @@ export default Component.extend({
     const fontVariantData = this.fontMap[font.id];
 
     // System font for example does not need to load from a remote source.
+    if (!fontVariantData) {
+      this.loadedFonts.add(font.id);
+    }
+
     if (fontVariantData && !this.loadedFonts.has(font.id)) {
       this.loadingFontVariants = true;
       const fontFaces = fontVariantData.map((fontVariant) => {


### PR DESCRIPTION
Followup to db80a8ce7959dfec9db1aec668939170037e9289

The previous commit broke previewing the Arial and System fonts (which do
not have variant URLs to load).
