### PR TITLE
UX: indicate main sidebar section is always public

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
@@ -73,15 +73,22 @@
         />
 
       {{/if}}
-      {{#if
-        (and this.currentUser.staff (not this.transformedModel.sectionType))
-      }}
-        <div class="row-wrapper mark-public-wrapper">
+      {{#if (and this.currentUser.staff)}}
+        <div
+          class="row-wrapper mark-public-wrapper
+            {{if this.transformedModel.sectionType '-disabled'}}"
+        >
           <label class="checkbox-label">
+            {{#if this.transformedModel.sectionType}}
+              <DTooltip @placement="top-start">
+                {{i18n "sidebar.sections.custom.always_public"}}
+              </DTooltip>
+            {{/if}}
             <Input
               @type="checkbox"
               @checked={{this.transformedModel.public}}
               class="mark-public"
+              disabled={{this.transformedModel.sectionType}}
             />
             {{i18n "sidebar.sections.custom.public"}}
           </label>

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -190,6 +190,11 @@
       grid-column: 2;
     }
     &.mark-public-wrapper {
+      margin-top: 1em;
+      padding-bottom: 0;
+      &.-disabled label {
+        cursor: not-allowed;
+      }
       label {
         grid-column: 1 / -1;
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4415,6 +4415,7 @@ en:
           delete_confirm: "Are you sure you want to delete this section?"
           reset_confirm: "Are you sure you want to reset this section to default?"
           public: "Make this section public and visible to everyone"
+          always_public: "Content in this section is always public"
           more_menu: "More menu"
           links:
             add: "Add another link"


### PR DESCRIPTION
This displays the "Make section public and visible to everyone" checkbox, but disables it and a tooltip further clarifies that this section's content is always public. 

![Screenshot 2023-07-07 at 4 44 13 PM](https://github.com/discourse/discourse/assets/1681963/2f9667fc-6826-4cb2-b7ac-03b3655eb4cb)
