### PR TITLE
DEV: new plugin outlet to render after 'latest' user group PMs nav link.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-private-messages-group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-private-messages-group.hbs
@@ -9,6 +9,11 @@
     <span>{{i18n "categories.latest"}}</span>
   </DNavigationItem>
 
+  <PluginOutlet
+    @name="user-group-messages-after-latest"
+    @outletArgs={{hash group=this.group}}
+  />
+
   {{#if this.viewingSelf}}
     <DNavigationItem
       @route="userPrivateMessages.group.new"


### PR DESCRIPTION
This commit will introduce a new plugin outlet in the `user-private-messages-group` handlebar. So we can add a new navigation link after the 'Latest` menu using this plugin outlet.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
