### PR TITLE
PERF: improves perf of select-kit in long list

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/track-node-visibility.js
+++ b/app/assets/javascripts/discourse/app/modifiers/track-node-visibility.js
@@ -2,7 +2,7 @@ import Modifier from "ember-modifier";
 import { registerDestructor } from "@ember/destroyable";
 import { bind } from "discourse-common/utils/decorators";
 
-export default class ChatTrackMessage extends Modifier {
+export default class TrackNodeVisibilityModifier extends Modifier {
   didEnterViewport = null;
   didLeaveViewport = null;
 
@@ -17,10 +17,7 @@ export default class ChatTrackMessage extends Modifier {
 
     this.intersectionObserver = new IntersectionObserver(
       this._intersectionObserverCallback,
-      {
-        root: document,
-        threshold: 0,
-      }
+      { root: document, threshold: 0 }
     );
 
     this.intersectionObserver.observe(element);

--- a/app/assets/javascripts/discourse/tests/integration/modifiers/track-node-visibility-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/modifiers/track-node-visibility-test.js
@@ -1,0 +1,46 @@
+import { module, test } from "qunit";
+import { render } from "@ember/test-helpers";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Modifier | track-node-visibility", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("didEnterViewport", async function (assert) {
+    const done = assert.async();
+
+    this.didEnterViewPort = () => {
+      assert.step("didEnterViewport");
+      assert.verifySteps(["didLeaveViewport", "didEnterViewport"]);
+      done();
+    };
+    this.didLeaveViewport = () => assert.step("didLeaveViewport");
+
+    await render(hbs`
+      <div class="tracker" style="display: none" {{track-node-visibility this.didEnterViewPort this.didLeaveViewport}}>
+        test
+      </div>
+     `);
+
+    document.querySelector(".tracker").style.display = "block";
+  });
+
+  test("didLeaveViewport", async function (assert) {
+    const done = assert.async();
+
+    this.didEnterViewPort = () => assert.step("didEnterViewport");
+    this.didLeaveViewport = () => {
+      assert.step("didLeaveViewport");
+      assert.verifySteps(["didEnterViewport", "didLeaveViewport"]);
+      done();
+    };
+
+    await render(hbs`
+      <div class="tracker" {{track-node-visibility this.didEnterViewPort this.didLeaveViewport}}>
+        test
+      </div>
+     `);
+
+    document.querySelector(".tracker").style.display = "none";
+  });
+});

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
@@ -1,6 +1,6 @@
-{{#if this.collection.content.length}}
+{{#if this.renderedContent.length}}
   <ul class="select-kit-collection" aria-live="polite" role="menu">
-    {{#each this.collection.content as |item index|}}
+    {{#each this.renderedContent as |item index|}}
       {{component
         (component-for-row this.collection.identifier item this.selectKit)
         index=index
@@ -8,6 +8,13 @@
         value=this.value
         selectKit=this.selectKit
       }}
+
+      {{#if (eq item this.renderedContent.lastObject)}}
+        <div
+          class="select-kit-collection__bottom-tracker"
+          {{track-node-visibility this.bottomReached}}
+        ></div>
+      {{/if}}
     {{/each}}
   </ul>
 {{/if}}

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
@@ -1,5 +1,27 @@
 import Component from "@ember/component";
+import { action, computed } from "@ember/object";
+
+const STEP = 20;
 
 export default Component.extend({
   tagName: "",
+
+  limit: 0,
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    this.set("limit", STEP);
+  },
+
+  @computed("limit", "collection.content.[]")
+  get renderedContent() {
+    return this.collection.content.slice(0, this.limit);
+  },
+
+  @action
+  bottomReached() {
+    console.log("bottom reached");
+    this.set("limit", this.limit + STEP);
+  },
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
@@ -21,7 +21,6 @@ export default Component.extend({
 
   @action
   bottomReached() {
-    console.log("bottom reached");
     this.set("limit", this.limit + STEP);
   },
 });

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -244,6 +244,11 @@
     max-height: 250px;
     width: 100%;
 
+    &__bottom-tracker {
+      margin-top: -1px;
+      width: 100%;
+    }
+
     &:hover .select-kit-row.is-highlighted:hover {
       background: var(--d-hover);
     }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -39,7 +39,7 @@
       this.onLongPressEnd
       this.onLongPressCancel
     }}
-    {{chat/track-message
+    {{track-node-visibility
       (fn (mut @message.visible) true)
       (fn (mut @message.visible) false)
     }}


### PR DESCRIPTION
This commit limits the number of initial items displayed in a select-kit dropdown, as you scroll it will add more items. This is NOT a virtual list and ultimately if you scroll through hundreds of items slowness might happen, however for most classic use cases it should improve the performance in long list very significantly.

To simplify the implementation, a modifier used in chat: `{{chat//track-message}}` has been ported to core under the name of `{{track-node-visibility}}` with the following example usage:

```
<div
  {{track-node-visibility this.didEnterViewport this.didLeaveViewport}}
>
  TRACK ME
</div>
```

Even a very long list opens instantly now:

https://github.com/discourse/discourse/assets/339945/bc8b4e9c-e13e-4d79-8e00-982332231dbe

