### PR TITLE
DEV: add ruby-gemset to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@
 
 # We provide a .sample but people can use newer versions if they want to
 .ruby-version
+.ruby-gemset
 
 # Front-end
 dist


### PR DESCRIPTION
Prevent git from tracking changes to the `.ruby-gemset` file.