### PR TITLE
UX: change z-index of thread resizer to be below emoji popup

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
@@ -4,7 +4,7 @@
   left: -3px;
   width: 5px;
   position: absolute;
-  z-index: z("max");
+  z-index: calc(z("header") - 1);
   transition: background-color 0.15s 0.15s;
   background-color: transparent;
 


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse/assets/101828855/af9b4336-c800-4ef2-b265-1f8b522d574d)

After:
<img width="733" alt="image" src="https://github.com/discourse/discourse/assets/101828855/6618ee8c-2555-40fc-af4d-14b2077b82ed">

