### PR TITLE
DEV: Add endpoint for dismissing outdated translations

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
@@ -16,6 +16,11 @@ export default Controller.extend(bufferedProperty("siteText"), {
     return this.siteText.value === value;
   },
 
+  @discourseComputed("siteText.status")
+  isOutdated(status) {
+    return status === "outdated";
+  },
+
   @action
   saveChanges() {
     const attrs = this.buffered.getProperties("value");
@@ -47,6 +52,16 @@ export default Controller.extend(bufferedProperty("siteText"), {
           .catch(popupAjaxError);
       },
     });
+  },
+
+  @action
+  dismissOutdated() {
+    this.siteText
+      .dismissOutdated(this.locale)
+      .then(() => {
+        this.siteText.set("status", "up_to_date");
+      })
+      .catch(popupAjaxError);
   },
 
   get interpolationKeys() {

--- a/app/assets/javascripts/admin/addon/models/site-text.js
+++ b/app/assets/javascripts/admin/addon/models/site-text.js
@@ -8,4 +8,13 @@ export default class SiteText extends RestModel {
       type: "DELETE",
     }).then((result) => getProperties(result.site_text, "value", "can_revert"));
   }
+
+  dismissOutdated(locale) {
+    return ajax(
+      `/admin/customize/site_texts/${this.id}/dismiss_outdated?locale=${locale}`,
+      {
+        type: "PUT",
+      }
+    );
+  }
 }

--- a/app/assets/javascripts/admin/addon/templates/site-text-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-edit.hbs
@@ -7,6 +7,22 @@
     <h4>{{i18n "admin.site_text.locale"}} {{this.localeFullName}}</h4>
   </div>
 
+  {{#if this.isOutdated}}
+    <div class="outdated">
+      <h4>{{i18n "admin.site_text.outdated.title"}}</h4>
+      <p>{{i18n "admin.site_text.outdated.description"}}</p>
+      <h5>{{i18n "admin.site_text.outdated.old_default"}}</h5>
+      <p>{{this.siteText.old_default}}</p>
+      <h5>{{i18n "admin.site_text.outdated.new_default"}}</h5>
+      <p>{{this.siteText.new_default}}</p>
+      <DButton
+        @class="btn-default"
+        @action={{action "dismissOutdated"}}
+        @label="admin.site_text.outdated.dismiss"
+      />
+    </div>
+  {{/if}}
+
   <ExpandingTextArea
     @value={{this.buffered.value}}
     @rows="1"

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -295,6 +295,18 @@ $mobile-breakpoint: 700px;
       line-height: var(--line-height-large);
       color: var(--primary-medium);
     }
+    .outdated {
+      border: 1px solid var(--primary-low);
+      box-sizing: border-box;
+      color: var(--primary);
+      margin-bottom: 1em;
+      max-width: 800px;
+      padding: 1em;
+
+      p {
+        color: var(--primary-high);
+      }
+    }
   }
   p.warning {
     color: var(--danger);

--- a/app/serializers/site_text_serializer.rb
+++ b/app/serializers/site_text_serializer.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class SiteTextSerializer < ApplicationSerializer
-  attributes :id, :value, :interpolation_keys, :has_interpolation_keys?, :overridden?, :can_revert?
+  attributes :id,
+             :value,
+             :status,
+             :old_default,
+             :new_default,
+             :interpolation_keys,
+             :has_interpolation_keys?,
+             :overridden?,
+             :can_revert?
 
   def id
     object[:id]
@@ -9,6 +17,22 @@ class SiteTextSerializer < ApplicationSerializer
 
   def value
     object[:value]
+  end
+
+  def status
+    if override.present?
+      override.status
+    else
+      "up_to_date"
+    end
+  end
+
+  def old_default
+    override.original_translation if override.present?
+  end
+
+  def new_default
+    override.current_default if override.present?
   end
 
   def interpolation_keys
@@ -23,9 +47,15 @@ class SiteTextSerializer < ApplicationSerializer
     if options[:overridden_keys]
       options[:overridden_keys].include?(object[:id])
     else
-      TranslationOverride.exists?(locale: object[:locale], translation_key: object[:id])
+      override.present?
     end
   end
 
   alias_method :can_revert?, :overridden?
+
+  private
+
+  def override
+    TranslationOverride.find_by(locale: object[:locale], translation_key: object[:id])
+  end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6094,6 +6094,12 @@ en:
         locale: "Language:"
         more_than_50_results: "There are more than 50 results. Please refine your search."
         interpolation_keys: "Available interpolation keys:"
+        outdated:
+          title: "This translation is outdated"
+          description: "The default translation for this key has changed since this override was created. Please check below that your translation matches any changes that have been made to the original intent."
+          old_default: "Old default"
+          new_default: "New default"
+          dismiss: "Dismiss"
 
       settings: # used by theme and site settings
         show_overriden: "Only show overridden"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,6 +257,14 @@ Discourse::Application.routes.draw do
                  id: /[\w.\-\+\%\&]+/i,
                }
         delete "site_texts/:id" => "site_texts#revert", :constraints => { id: /[\w.\-\+\%\&]+/i }
+        put "site_texts/:id/dismiss_outdated" => "site_texts#dismiss_outdated",
+            :constraints => {
+              id: /[\w.\-\+\%\&]+/i,
+            }
+        put "site_texts/:id/dismiss_outdated.json" => "site_texts#dismiss_outdated",
+            :constraints => {
+              id: /[\w.\-\+\%\&]+/i,
+            }
 
         get "reseed" => "site_texts#get_reseed_options"
         post "reseed" => "site_texts#reseed"

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -224,6 +224,9 @@ RSpec.describe Admin::SiteTextsController do
                 {
                   id: "colour.#{key}",
                   value: value,
+                  status: "up_to_date",
+                  old_default: nil,
+                  new_default: nil,
                   can_revert: overridden,
                   overridden: overridden,
                   interpolation_keys: interpolation_keys,

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -815,6 +815,70 @@ RSpec.describe Admin::SiteTextsController do
     end
   end
 
+  describe "#dismiss_outdated" do
+    before { sign_in(admin) }
+
+    context "when using a key which isn't overridden" do
+      it "returns a not found error" do
+        put "/admin/customize/site_texts/title/dismiss_outdated.json",
+            params: {
+              locale: default_locale,
+            }
+
+        expect(response.status).to eq(404)
+
+        json = response.parsed_body
+        expect(json["error_type"]).to eq("not_found")
+      end
+    end
+
+    context "when the override isn't outdated" do
+      before do
+        Fabricate(
+          :translation_override,
+          locale: default_locale,
+          translation_key: "title",
+          value: "My Forum",
+        )
+      end
+
+      it "returns an unprocessable entity error" do
+        put "/admin/customize/site_texts/title/dismiss_outdated.json",
+            params: {
+              locale: default_locale,
+            }
+
+        expect(response.status).to eq(422)
+
+        json = response.parsed_body
+        expect(json["failed"]).to eq("FAILED")
+        expect(json["message"]).to eq("Can only dismiss outdated translations")
+      end
+    end
+
+    context "when the override is outdated" do
+      before do
+        Fabricate(
+          :translation_override,
+          locale: default_locale,
+          translation_key: "title",
+          value: "My Forum",
+          status: "outdated",
+        )
+      end
+
+      it "returns success" do
+        put "/admin/customize/site_texts/title/dismiss_outdated.json",
+            params: {
+              locale: default_locale,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+      end
+    end
+  end
+
   context "when reseeding" do
     before do
       staff_category = Fabricate(:category, name: "Staff EN", user: Discourse.system_user)


### PR DESCRIPTION
### Background

Recently we started giving admins a notice in the advice panel when their translations have become outdated due to changes in core. However, we didn't include any additional information.

### What is this change?

This PR adds more information about the outdated translation inside the site text edit page, together with an option to dismiss the warning:

<img width="711" alt="Screenshot 2023-07-13 at 9 50 02 PM" src="https://github.com/discourse/discourse/assets/5259935/5ee78a97-0f07-4a73-9d9f-e49ba26ec2fe">
