### PR TITLE
UX: Fix margin for group label

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -266,9 +266,9 @@
 
     .participant-group-wrapper {
       display: flex;
+      margin-left: 0.5em;
 
       .participant-group {
-        margin-left: 0.5em;
         padding: 0 5px;
         border: 1px solid var(--primary-low);
         border-radius: 0.25em;


### PR DESCRIPTION
Before:

<img width="1116" alt="Screenshot 2023-07-10 at 3 34 48 PM" src="https://github.com/discourse/discourse/assets/11170663/c513ab7f-0007-48b0-9ded-bbae4332147a">

After:

<img width="1131" alt="Screenshot 2023-07-10 at 3 35 02 PM" src="https://github.com/discourse/discourse/assets/11170663/15f4f522-a9d5-4233-bf7a-e3bc3ffd935f">
