### PR TITLE
FIX: Ensure dialogs are still rendered if triggered during boot

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/services/dialog.js
+++ b/app/assets/javascripts/dialog-holder/addon/services/dialog.js
@@ -1,6 +1,7 @@
 import Service from "@ember/service";
 import A11yDialog from "a11y-dialog";
 import { bind } from "discourse-common/utils/decorators";
+import { next } from "@ember/runloop";
 
 export default Service.extend({
   dialogInstance: null,
@@ -26,7 +27,7 @@ export default Service.extend({
   class: null,
   _confirming: false,
 
-  dialog(params) {
+  async dialog(params) {
     const {
       message,
       bodyComponent,
@@ -48,7 +49,19 @@ export default Service.extend({
       buttons,
     } = params;
 
-    const element = document.getElementById("dialog-holder");
+    let element = document.getElementById("dialog-holder");
+    if (!element) {
+      await new Promise((resolve) => next(resolve));
+      element = document.getElementById("dialog-holder");
+    }
+
+    if (!element) {
+      const msg =
+        "dialog-holder wrapper element not found. Unable to render dialog";
+      // eslint-disable-next-line no-console
+      console.error(msg, params);
+      throw new Error(msg);
+    }
 
     this.setProperties({
       message,

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Visit channel", type: :system do
       end
 
       context "when channel is not found" do
-        xit "shows an error" do
+        it "shows an error" do
           visit("/chat/c/-/999")
 
           expect(page).to have_content("Not Found") # this is not a translated key
@@ -78,7 +78,7 @@ RSpec.describe "Visit channel", type: :system do
 
       context "when channel is not accessible" do
         context "when category channel" do
-          xit "shows an error" do
+          it "shows an error" do
             chat.visit_channel(private_category_channel_1)
 
             expect(page).to have_content(I18n.t("invalid_access"))
@@ -86,7 +86,7 @@ RSpec.describe "Visit channel", type: :system do
         end
 
         context "when direct message channel" do
-          xit "shows an error" do
+          it "shows an error" do
             chat.visit_channel(inaccessible_dm_channel_1)
 
             expect(page).to have_content(I18n.t("invalid_access"))
@@ -111,7 +111,7 @@ RSpec.describe "Visit channel", type: :system do
           )
         end
 
-        xit "shows an error" do
+        it "shows an error" do
           chat.visit_channel(inaccessible_dm_channel_1)
 
           expect(page).to have_content(I18n.t("invalid_access"))


### PR DESCRIPTION
When the loading slider is enabled, the rendering of `application.hbs` is slightly delayed compared to the old 'spinner' strategy. This means that if a route tried to render a dialog during its `model()` hook, the dialog wrapper element would not be present and an error would occur.

This commit detects that situation and delays rendering the error until the next runloop iteration. If the element is still not found, we print a useful error to the console.

In the long term, we should ideally convert the dialog service to use a pure-ember rendering strategy instead of leaning on a11y-dialog. But for now, this workaround should resolve the problems identified by the chat system specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
