### PR TITLE
DEV: fixes flakey due to unordered array

### DIFF
--- a/plugins/chat/spec/serializer/chat/structured_channel_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/structured_channel_serializer_spec.rb
@@ -135,29 +135,32 @@ RSpec.describe Chat::StructuredChannelSerializer do
       it "calls MessageBus.last_ids with all the required channels for each public and DM chat chat channel" do
         MessageBus
           .expects(:last_ids)
-          .with(
-            Chat::Publisher::CHANNEL_METADATA_MESSAGE_BUS_CHANNEL,
-            Chat::Publisher::CHANNEL_EDITS_MESSAGE_BUS_CHANNEL,
-            Chat::Publisher::CHANNEL_STATUS_MESSAGE_BUS_CHANNEL,
-            Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL,
-            Chat::Publisher::CHANNEL_ARCHIVE_STATUS_MESSAGE_BUS_CHANNEL,
-            Chat::Publisher.user_tracking_state_message_bus_channel(user1.id),
-            Chat::Publisher.new_messages_message_bus_channel(channel1.id),
-            Chat::Publisher.new_mentions_message_bus_channel(channel1.id),
-            Chat::Publisher.kick_users_message_bus_channel(channel1.id),
-            Chat::Publisher.root_message_bus_channel(channel1.id),
-            Chat::Publisher.new_messages_message_bus_channel(channel2.id),
-            Chat::Publisher.new_mentions_message_bus_channel(channel2.id),
-            Chat::Publisher.kick_users_message_bus_channel(channel2.id),
-            Chat::Publisher.root_message_bus_channel(channel2.id),
-            Chat::Publisher.new_messages_message_bus_channel(channel3.id),
-            Chat::Publisher.new_mentions_message_bus_channel(channel3.id),
-            Chat::Publisher.root_message_bus_channel(channel3.id),
-            Chat::Publisher.new_messages_message_bus_channel(channel4.id),
-            Chat::Publisher.new_mentions_message_bus_channel(channel4.id),
-            Chat::Publisher.root_message_bus_channel(channel4.id),
-          )
+          .with do |*args|
+            [
+              Chat::Publisher::CHANNEL_METADATA_MESSAGE_BUS_CHANNEL,
+              Chat::Publisher::CHANNEL_EDITS_MESSAGE_BUS_CHANNEL,
+              Chat::Publisher::CHANNEL_STATUS_MESSAGE_BUS_CHANNEL,
+              Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL,
+              Chat::Publisher::CHANNEL_ARCHIVE_STATUS_MESSAGE_BUS_CHANNEL,
+              Chat::Publisher.user_tracking_state_message_bus_channel(user1.id),
+              Chat::Publisher.new_messages_message_bus_channel(channel1.id),
+              Chat::Publisher.new_mentions_message_bus_channel(channel1.id),
+              Chat::Publisher.kick_users_message_bus_channel(channel1.id),
+              Chat::Publisher.root_message_bus_channel(channel1.id),
+              Chat::Publisher.new_messages_message_bus_channel(channel2.id),
+              Chat::Publisher.new_mentions_message_bus_channel(channel2.id),
+              Chat::Publisher.kick_users_message_bus_channel(channel2.id),
+              Chat::Publisher.root_message_bus_channel(channel2.id),
+              Chat::Publisher.new_messages_message_bus_channel(channel3.id),
+              Chat::Publisher.new_mentions_message_bus_channel(channel3.id),
+              Chat::Publisher.root_message_bus_channel(channel3.id),
+              Chat::Publisher.new_messages_message_bus_channel(channel4.id),
+              Chat::Publisher.new_mentions_message_bus_channel(channel4.id),
+              Chat::Publisher.root_message_bus_channel(channel4.id),
+            ].to_set == args.to_set
+          end
           .returns({})
+
         described_class.new(fetch_data, scope: guardian).as_json
       end
 


### PR DESCRIPTION
The `message_bus_channels` given to `MessageBus.last_ids(*message_bus_channels)` is not ordered, as a result the expectation of the tests could fail, this commit ensures we check the contain of the input instead of content+order.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
