### PR TITLE
DEV: use explicit default export in I18n shim

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -1,5 +1,5 @@
 define("I18n", ["exports"], function (exports) {
-  return I18n;
+  exports.default = I18n;
 });
 
 define("htmlbars-inline-precompile", ["exports"], function (exports) {


### PR DESCRIPTION
Currently the I18n module shim return an object. Per AMD/loader.js, the properties on the object becomes named exports of the module, i.e. `import { t } from 'I18n';`.

However, this is not how we actually consume this module. We always do `import I18n from 'I18n';`.

The returned object from the shim (`window.I18n`) does NOT have a `default` property on it. This is only working because loader.js has a `makeDefaultExport` feature that defaults to true, which we are relying on to synthesize the default export for us.

That feature has been noted as undesirable and may some day be deprecated. In Embroider, it specifically disables the feature in loader.js.

https://github.com/embroider-build/embroider/issues/539

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
