### PR TITLE
DEV: invert admin/wizard build logic

### DIFF
--- a/app/assets/javascripts/admin/index.js
+++ b/app/assets/javascripts/admin/index.js
@@ -1,13 +1,24 @@
 "use strict";
 
 const calculateCacheKeyForTree = require("calculate-cache-key-for-tree");
+const path = require("path");
 
 module.exports = {
   name: require("./package").name,
-  treeForAddon(tree) {
-    let app = this._findHost();
-    app.options.adminTree = this._super.treeForAddon.call(this, tree);
+
+  // return an empty tree here as we do not want the addon modules to be
+  // included into vendor.js; instead, we will produce a separate bundle
+  // (admin.js) to be included via a script tag as needed
+  treeForAddon() {
     return;
+  },
+
+  // custom method to produce the tree for admin.js
+  // called by ember-cli-build.js in discourse core
+  treeForAddonBundle() {
+    let addonTreePath = path.resolve(this.root, this.treePaths.addon);
+    let addonTree = this.treeGenerator(addonTreePath);
+    return this._super.treeForAddon.call(this, addonTree);
   },
 
   cacheKeyForTree(tree) {

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -182,6 +182,10 @@ module.exports = function (defaults) {
     .findAddonByName("discourse-plugins")
     .generatePluginsTree();
 
+  const adminTree = app.project.findAddonByName("admin").treeForAddonBundle();
+
+  const wizardTree = app.project.findAddonByName("wizard").treeForAddonBundle();
+
   const terserPlugin = app.project.findAddonByName("ember-cli-terser");
   const applyTerser = (tree) => terserPlugin.postprocessTree("all", tree);
 
@@ -196,13 +200,13 @@ module.exports = function (defaults) {
     }),
     generateWorkboxTree(),
     applyTerser(
-      concat(mergeTrees([app.options.adminTree]), {
+      concat(adminTree, {
         inputFiles: ["**/*.js"],
         outputFile: `assets/admin.js`,
       })
     ),
     applyTerser(
-      concat(mergeTrees([app.options.wizardTree]), {
+      concat(wizardTree, {
         inputFiles: ["**/*.js"],
         outputFile: `assets/wizard.js`,
       })

--- a/app/assets/javascripts/wizard/index.js
+++ b/app/assets/javascripts/wizard/index.js
@@ -1,13 +1,24 @@
 "use strict";
 
 const calculateCacheKeyForTree = require("calculate-cache-key-for-tree");
+const path = require("path");
 
 module.exports = {
   name: require("./package").name,
-  treeForAddon(tree) {
-    let app = this._findHost();
-    app.options.wizardTree = this._super.treeForAddon.call(this, tree);
+
+  // return an empty tree here as we do not want the addon modules to be
+  // included into vendor.js; instead, we will produce a separate bundle
+  // (wizard.js) to be included via a script tag as needed
+  treeForAddon() {
     return;
+  },
+
+  // custom method to produce the tree for wizard.js
+  // called by ember-cli-build.js in discourse core
+  treeForAddonBundle() {
+    let addonTreePath = path.resolve(this.root, this.treePaths.addon);
+    let addonTree = this.treeGenerator(addonTreePath);
+    return this._super.treeForAddon.call(this, addonTree);
   },
 
   cacheKeyForTree(tree) {


### PR DESCRIPTION
Currently, the admin/wizard build relies on the addon build getting triggered first, so that its `treeForAddon()` hook will be called, and then it can stash the result on the app's options, which is super fragile. In Embroider the timing works differently so the trees end up being `undefined`.

This inverts the logic so that it will be discourse core's build calling these hooks at a specific timing and return the result rather than coordinating through the options bag.

```
$ diff dist/assets/admin.js dist-after/assets/admin.js
$ diff dist/assets/wizard.js dist-after/assets/wizard.js
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
