### PR TITLE
DEV: Remove header floats and clearfixes

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -2,7 +2,7 @@ import { createWidget } from "discourse/widgets/widget";
 import hbs from "discourse/widgets/hbs-compiler";
 
 createWidget("header-contents", {
-  tagName: "div.contents.clearfix",
+  tagName: "div.contents",
   transform() {
     return {
       showBootstrapMode: this.currentUser?.staff && this.site.desktopView,
@@ -27,6 +27,6 @@ createWidget("header-contents", {
 
     {{before-header-panel-outlet attrs=attrs}}
 
-    <div class="panel clearfix" role="navigation">{{yield}}</div>
+    <div class="panel" role="navigation">{{yield}}</div>
   `,
 });

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -464,7 +464,7 @@ createWidget("glimmer-search-menu-wrapper", {
 });
 
 export default createWidget("header", {
-  tagName: "header.d-header.clearfix",
+  tagName: "header.d-header",
   buildKey: () => `header`,
   services: ["router", "search"],
 

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -124,13 +124,10 @@
 }
 
 .d-header-icons {
-  text-align: center;
+  display: flex;
   margin: 0 0 0 0.5em;
   list-style: none;
 
-  > li {
-    float: left;
-  }
   .icon {
     box-sizing: content-box;
     appearance: none;


### PR DESCRIPTION
The clearfixes on `.contents` and `.d-header` weren't being used because we aren't floating any child elements, so they were just adding some before/after psuedo-elements (which tend to interfere with grid and flexbox).

`.d-header-icons` was still using a float for the header icons, but we can use flex there too... 

🪓 
