### PR TITLE
FIX: Conditionally hide `Add Alternate Email` based on site setting

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -140,6 +140,14 @@ export default Controller.extend(CanCheckEmails, {
     return findAll().length > 0;
   },
 
+  @discourseComputed(
+    "siteSettings.max_allowed_secondary_emails",
+    "model.can_edit_email"
+  )
+  canAddEmail(maxAllowedSecondaryEmails, canEditEmail) {
+    return maxAllowedSecondaryEmails > 0 && canEditEmail;
+  },
+
   @action
   resendConfirmationEmail(email, event) {
     event?.preventDefault();

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
@@ -67,7 +67,7 @@
           {{/each}}
         </div>
 
-        {{#if this.model.can_edit_email}}
+        {{#if this.canAddEmail}}
           <LinkTo
             @route="preferences.email"
             @query={{hash new=1}}

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -235,3 +235,15 @@ acceptance(
     });
   }
 );
+
+acceptance("User Preference - No Secondary Emails Allowed", function (needs) {
+  needs.user();
+  needs.pretender(preferencesPretender);
+  needs.settings({ max_allowed_secondary_emails: 0 });
+
+  test("Add Alternate Email Button is unvailable", async function (assert) {
+    await visit("/u/eviltrout/preferences");
+
+    assert.dom(".pref-email a").doesNotExist();
+  });
+});

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2019,6 +2019,7 @@ rate_limits:
   max_allowed_secondary_emails:
     default: 10
     hidden: true
+    client: true
   max_batch_presign_multipart_per_minute:
     default: 20
     hidden: true


### PR DESCRIPTION
Hide button in UI if `max_allowed_secondary_emails` site setting is 0.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
