### PR TITLE
Refactor deprecation silencer

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -17,9 +17,8 @@ module.exports = function (defaults) {
   const vendorJs = discourseRoot + "/vendor/assets/javascripts/";
 
   // Silence deprecations which we are aware of - see `lib/deprecation-silencer.js`
-  const ui = defaults.project.ui;
-  DeprecationSilencer.silenceUiWarn(ui);
-  DeprecationSilencer.silenceConsoleWarn();
+  DeprecationSilencer.silence(console, "warn");
+  DeprecationSilencer.silence(defaults.project.ui, "writeWarnLine");
 
   const isProduction = EmberApp.env().includes("production");
   const isTest = EmberApp.env().includes("test");
@@ -95,7 +94,7 @@ module.exports = function (defaults) {
     },
 
     babel: {
-      plugins: [DeprecationSilencer.generateBabelPlugin()],
+      plugins: [require.resolve("./lib/deprecation-silencer")],
     },
 
     // We need to build tests in prod for theme tests


### PR DESCRIPTION
- Unify the silencing methods, use a WeakMap to remember the seen objects
- Export a proper plugin and use the absolute path in the config, instead of the proprietary config from `broccoli-babel-transpiler`

The latter causes problems in Embroider which doesn't use the broccoli based babel pipeline.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
