### PR TITLE
DEV: Use documentation format for core specs on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: bin/turbo_rspec --use-runtime-info --verbose
+        run: bin/turbo_rspec --use-runtime-info --verbose --format documentation
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'


### PR DESCRIPTION
The documentation format makes it easier to link a failing test to the
process it was launched in.