### PR TITLE
FIX: Chat thread race condition issues

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
@@ -36,7 +36,7 @@ export default class ChatChannelPaneSubscriptionsManager extends ChatPaneBaseSub
 
   handleThreadOriginalMessageUpdate(data) {
     const message = this.messagesManager.findMessage(data.original_message_id);
-    if (message) {
+    if (message.thread) {
       message.thread.preview = ChatThreadPreview.create(data.preview);
     }
   }

--- a/plugins/chat/lib/chat/message_creator.rb
+++ b/plugins/chat/lib/chat/message_creator.rb
@@ -191,15 +191,6 @@ module Chat
         @chat_message.in_reply_to.thread_id = thread.id
       end
 
-      if @chat_message.chat_channel.threading_enabled
-        Chat::Publisher.publish_thread_created!(
-          @chat_message.chat_channel,
-          @chat_message.in_reply_to,
-          thread.id,
-          @staged_thread_id,
-        )
-      end
-
       @chat_message.thread_id = thread.id
 
       # NOTE: We intentionally do not try to correct thread IDs within the chain
@@ -223,6 +214,15 @@ module Chat
         FROM thread_updater
         WHERE thread_id IS NULL AND chat_messages.id = thread_updater.id
       SQL
+
+      if @chat_message.chat_channel.threading_enabled
+        Chat::Publisher.publish_thread_created!(
+          @chat_message.chat_channel,
+          @chat_message.in_reply_to,
+          thread.id,
+          @staged_thread_id,
+        )
+      end
     end
 
     def resolved_thread


### PR DESCRIPTION
Trying to fix two issues:

1. Sometimes the publish_new! event for update_thread_original_message
   finishes running on the UI before the one for thread_created, in this
   case we just want to do nothing because thread_created will fetch the
   new thread along with its preview from the server if needed
2. Sometimes the thread GET and /read events were erroring because
   last_reply on the thread was nil, this was potentially occuring because
   the thread_created event was coming through to the UI before the rest
   of MessageCreator was done, so we just move that after the big update
   to set thread_id for the new and existing messages in the reply
   chain
