### PR TITLE
UX: double scroll fix for keyboard shortcuts modal

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -33,13 +33,14 @@
   }
 }
 
+.modal-body:has(#keyboard-shortcuts-help) {
+  overflow-y: hidden;
+}
+
 #keyboard-shortcuts-help {
   box-sizing: border-box;
-  padding: 1em;
   overflow-x: hidden;
   overflow-y: auto;
-  width: 80vw;
-  max-width: 1500px;
   max-height: 85vh !important; // overrides a default modal !important for extra space
 
   .keyboard-shortcuts-help__container {


### PR DESCRIPTION
Both container and inner element had overflow-y:auto which led to double scrollbars.
Also improved alignment and removed some double declared CSS.
