### PR TITLE
FEATURE: Extend the topics:read API scope to allow read by external_id

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -35,8 +35,8 @@ class ApiKeyScope < ActiveRecord::Base
             actions: %w[topics#destroy],
           },
           read: {
-            actions: %w[topics#show topics#feed topics#posts],
-            params: %i[topic_id],
+            actions: %w[topics#show topics#feed topics#posts topics#show_by_external_id],
+            params: %i[topic_id external_id],
             aliases: {
               topic_id: :id,
             },


### PR DESCRIPTION
- Allow an API key created with the `topics:read` API scope to get a topic by `external_id`
- This allows the API key to access the "[Get topic by external_id endpoint](https://docs.discourse.org/#tag/Topics/operation/getTopicByExternalId)". This seems to be the only endpoint to `GET` a topic that is not covered by this scope.