### PR TITLE
CSS: Add background color to signin header

### DIFF
--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -437,7 +437,9 @@
       width: 100%;
     }
 
-    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(.poll-breakdown) {
+    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(
+        .poll-breakdown
+      ) {
       max-height: 90vh !important; // overrides base/modal.scss
     }
     .login-welcome-header,

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -274,7 +274,7 @@
   .login-welcome-header {
     grid-area: header;
     padding: 3em 2em 1em;
-
+    background-color: var(--secondary);
     .login-title {
       font-size: var(--font-up-6);
       line-height: var(--line-height-medium);
@@ -437,9 +437,7 @@
       width: 100%;
     }
 
-    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(
-        .poll-breakdown
-      ) {
+    .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(.poll-breakdown) {
       max-height: 90vh !important; // overrides base/modal.scss
     }
     .login-welcome-header,


### PR DESCRIPTION
This fixes the lack of a background when an SSO option is available for signing into a site.

**Before**
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/70f8ab8f-5b03-4852-97ef-7abab0b3ff94">

**After**
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/55ba7c35-697b-448b-818c-5eadc9dc45d2">
