### PR TITLE
DEV: Add backwards-compatibility following i18n export change

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -1,5 +1,17 @@
-define("I18n", ["exports"], function (exports) {
+define("I18n", ["exports", "discourse-common/lib/deprecated"], function (
+  exports,
+  deprecated
+) {
   exports.default = I18n;
+  exports.t = function () {
+    deprecated.default(
+      "Importing t from I18n is deprecated. Use the default export instead.",
+      {
+        id: "discourse.i18n-t-import",
+      }
+    );
+    return I18n.t(...arguments);
+  };
 });
 
 define("htmlbars-inline-precompile", ["exports"], function (exports) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
@@ -1,5 +1,6 @@
 import { module, test } from "qunit";
 import I18n from "I18n";
+import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
 
 module("Unit | Utility | i18n", function (hooks) {
   hooks.beforeEach(function () {
@@ -287,5 +288,12 @@ module("Unit | Utility | i18n", function (hooks) {
       }),
       "customtest"
     );
+  });
+
+  test("legacy require support", function (assert) {
+    withSilencedDeprecations("discourse.i18n-t-import", () => {
+      const myI18n = require("I18n");
+      assert.strictEqual(myI18n.t("topic.reply.title"), "Répondre");
+    });
   });
 });


### PR DESCRIPTION
Some themes were doing `require("i18n").t()`, which was never recommended, but did work prior to f8483295. This commit restores that functionality with a deprecation notice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
