### PR TITLE
UX: z-index for for tippy box in chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -226,6 +226,10 @@
     }
   }
 
+  &:has(.tippy-box) {
+    position: relative;
+    z-index: 1;
+  }
   .chat-message-reaction-list .chat-message-react-btn {
     display: none;
   }


### PR DESCRIPTION
Stacking context of tippybox is tied to `chat-message-container`.

So got to do something to enhance the z-index of the container which has a tippy box, relatively to the following elements.
