### PR TITLE
DEV: Move all scroll position reset/remember logic to a shared service

### DIFF
--- a/app/assets/javascripts/discourse/app/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/basic-topic-list.hbs
@@ -10,8 +10,6 @@
       @canBulkSelect={{this.canBulkSelect}}
       @selected={{this.selected}}
       @tagsForUser={{this.tagsForUser}}
-      @onScroll={{this.onScroll}}
-      @scrollOnLoad={{this.scrollOnLoad}}
       @toggleBulkSelect={{this.toggleBulkSelect}}
       @updateAutoAddTopicsToBulkSelect={{this.updateAutoAddTopicsToBulkSelect}}
     />

--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -1,47 +1,18 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
-import { next, schedule } from "@ember/runloop";
 import { openBookmarkModal } from "discourse/controllers/bookmark";
 import { ajax } from "discourse/lib/ajax";
 import {
   openLinkInNewTab,
   shouldOpenInNewTab,
 } from "discourse/lib/click-track";
-import Scrolling from "discourse/mixins/scrolling";
 import I18n from "I18n";
 import { Promise } from "rsvp";
 import { inject as service } from "@ember/service";
 
-export default Component.extend(Scrolling, {
+export default Component.extend({
   dialog: service(),
   classNames: ["bookmark-list-wrapper"],
-
-  didInsertElement() {
-    this._super(...arguments);
-    this.bindScrolling();
-    this.scrollToLastPosition();
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-    this.unbindScrolling();
-  },
-
-  scrollToLastPosition() {
-    const scrollTo = this.session.bookmarkListScrollPosition;
-    if (scrollTo >= 0) {
-      schedule("afterRender", () => {
-        if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo));
-        }
-      });
-    }
-  },
-
-  scrolled() {
-    this._super(...arguments);
-    this.session.set("bookmarkListScrollPosition", window.scrollY);
-  },
 
   @action
   removeBookmark(bookmark) {

--- a/app/assets/javascripts/discourse/app/components/d-section.js
+++ b/app/assets/javascripts/discourse/app/components/d-section.js
@@ -1,6 +1,4 @@
-import deprecated from "discourse-common/lib/deprecated";
 import Component from "@ember/component";
-import { scrollTop } from "discourse/mixins/scroll-top";
 import { scheduleOnce } from "@ember/runloop";
 
 // Can add a body class from within a component, also will scroll to the top automatically.
@@ -8,28 +6,7 @@ export default class extends Component {
   tagName = null;
   pageClass = null;
   bodyClass = null;
-  scrollTop = true;
   currentClasses = new Set();
-
-  didInsertElement() {
-    this._super(...arguments);
-
-    if (this.scrollTop === "false") {
-      deprecated("Uses boolean instead of string for scrollTop.", {
-        since: "2.8.0.beta9",
-        dropFrom: "2.9.0.beta1",
-        id: "discourse.d-section.scroll-top-boolean",
-      });
-
-      return;
-    }
-
-    if (!this.scrollTop) {
-      return;
-    }
-
-    scrollTop();
-  }
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/components/d-section.js
+++ b/app/assets/javascripts/discourse/app/components/d-section.js
@@ -1,7 +1,7 @@
 import Component from "@ember/component";
 import { scheduleOnce } from "@ember/runloop";
 
-// Can add a body class from within a component, also will scroll to the top automatically.
+// Can add a body class from within a component
 export default class extends Component {
   tagName = null;
   pageClass = null;

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.hbs
@@ -1,1 +1,0 @@
-{{yield (hash saveScrollPosition=this.saveScrollPosition)}}

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -1,5 +1,4 @@
 import { observes, on } from "discourse-common/utils/decorators";
-import { next, schedule, scheduleOnce } from "@ember/runloop";
 import Component from "@ember/component";
 import LoadMore from "discourse/mixins/load-more";
 import UrlRefresh from "discourse/mixins/url-refresh";
@@ -9,21 +8,6 @@ export default Component.extend(UrlRefresh, LoadMore, {
   classNames: ["contents"],
   eyelineSelector: ".topic-list-item",
   documentTitle: service(),
-
-  @on("didInsertElement")
-  @observes("model")
-  _readjustScrollPosition() {
-    const scrollTo = this.session.topicListScrollPosition;
-    if (scrollTo >= 0) {
-      schedule("afterRender", () => {
-        if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo));
-        }
-      });
-    } else {
-      scheduleOnce("afterRender", this, this.loadMoreUnlessFull);
-    }
-  },
 
   @on("didInsertElement")
   _monitorTrackingState() {
@@ -48,10 +32,6 @@ export default Component.extend(UrlRefresh, LoadMore, {
     this.documentTitle.updateContextCount(this.incomingCount);
   },
 
-  saveScrollPosition() {
-    this.session.set("topicListScrollPosition", $(window).scrollTop());
-  },
-
   actions: {
     loadMore() {
       this.documentTitle.updateContextCount(0);
@@ -64,7 +44,6 @@ export default Component.extend(UrlRefresh, LoadMore, {
         ) {
           this.addTopicsToBulkSelect(newTopics);
         }
-        schedule("afterRender", () => this.saveScrollPosition());
         if (moreTopicsUrl && $(window).height() >= $(document).height()) {
           this.send("loadMore");
         }

--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -1,9 +1,4 @@
-<DSection
-  @pageClass="has-sidebar"
-  @id="d-sidebar"
-  @class="sidebar-container"
-  @scrollTop={{false}}
->
+<DSection @pageClass="has-sidebar" @id="d-sidebar" @class="sidebar-container">
   <Sidebar::Sections
     @currentUser={{this.currentUser}}
     @collapsableSections={{true}}

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -13,6 +13,7 @@ import { schedule } from "@ember/runloop";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { htmlSafe } from "@ember/template";
+import { inject as service } from "@ember/service";
 
 export function showEntrance(e) {
   let target = $(e.target);
@@ -39,11 +40,18 @@ export function navigateToTopic(topic, href) {
     // so skip setting it early.
     this.appEvents.trigger("header:update-topic", topic);
   }
+
+  this.session.set("lastTopicIdViewed", {
+    topicId: topic.id,
+    historyUuid: this.router.location.getState?.().uuid,
+  });
+
   DiscourseURL.routeTo(href || topic.get("url"));
   return false;
 }
 
 export default Component.extend({
+  router: service(),
   tagName: "tr",
   classNameBindings: [":topic-list-item", "unboundClassNames", "topic.visited"],
   attributeBindings: ["data-topic-id", "role", "ariaLevel:aria-level"],
@@ -328,7 +336,14 @@ export default Component.extend({
 
   _highlightIfNeeded: on("didInsertElement", function () {
     // highlight the last topic viewed
-    if (this.session.get("lastTopicIdViewed") === this.get("topic.id")) {
+    const lastViewedTopicInfo = this.session.get("lastTopicIdViewed");
+
+    const isLastViewedTopic =
+      lastViewedTopicInfo?.topicId === this.topic.id &&
+      lastViewedTopicInfo?.historyUuid ===
+        this.router.location.getState?.().uuid;
+
+    if (isLastViewedTopic) {
       this.session.set("lastTopicIdViewed", null);
       this.highlight({ isLastViewedTopic: true });
     } else if (this.get("topic.highlight")) {

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -13,7 +13,6 @@ import { schedule } from "@ember/runloop";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { htmlSafe } from "@ember/template";
-import { inject as service } from "@ember/service";
 
 export function showEntrance(e) {
   let target = $(e.target);
@@ -40,18 +39,11 @@ export function navigateToTopic(topic, href) {
     // so skip setting it early.
     this.appEvents.trigger("header:update-topic", topic);
   }
-
-  this.session.set("lastTopicIdViewed", {
-    topicId: topic.id,
-    historyUuid: this.router.location.getState?.().uuid,
-  });
-
   DiscourseURL.routeTo(href || topic.get("url"));
   return false;
 }
 
 export default Component.extend({
-  router: service(),
   tagName: "tr",
   classNameBindings: [":topic-list-item", "unboundClassNames", "topic.visited"],
   attributeBindings: ["data-topic-id", "role", "ariaLevel:aria-level"],
@@ -336,14 +328,7 @@ export default Component.extend({
 
   _highlightIfNeeded: on("didInsertElement", function () {
     // highlight the last topic viewed
-    const lastViewedTopicInfo = this.session.get("lastTopicIdViewed");
-
-    const isLastViewedTopic =
-      lastViewedTopicInfo?.topicId === this.topic.id &&
-      lastViewedTopicInfo?.historyUuid ===
-        this.router.location.getState?.().uuid;
-
-    if (isLastViewedTopic) {
+    if (this.session.get("lastTopicIdViewed") === this.get("topic.id")) {
       this.session.set("lastTopicIdViewed", null);
       this.highlight({ isLastViewedTopic: true });
     } else if (this.get("topic.highlight")) {

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -3,7 +3,6 @@ import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import LoadMore from "discourse/mixins/load-more";
 import { on } from "@ember/object/evented";
-import { next, schedule } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
 
 export default Component.extend(LoadMore, {
@@ -65,26 +64,6 @@ export default Component.extend(LoadMore, {
     }
 
     onScroll.call(this);
-  },
-
-  scrollToLastPosition() {
-    if (!this.scrollOnLoad) {
-      return;
-    }
-
-    const scrollTo = this.session.topicListScrollPosition;
-    if (scrollTo >= 0) {
-      schedule("afterRender", () => {
-        if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo));
-        }
-      });
-    }
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-    this.scrollToLastPosition();
   },
 
   _updateLastVisitedTopic(topics, order, ascending, top) {

--- a/app/assets/javascripts/discourse/app/components/user-stream.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream.js
@@ -6,10 +6,8 @@ import I18n from "I18n";
 import LoadMore from "discourse/mixins/load-more";
 import Post from "discourse/models/post";
 import { NEW_TOPIC_KEY } from "discourse/models/composer";
-import { observes } from "discourse-common/utils/decorators";
 import { on } from "@ember/object/evented";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { next, schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 
 export default Component.extend(LoadMore, {
@@ -32,14 +30,7 @@ export default Component.extend(LoadMore, {
   eyelineSelector: ".user-stream .item",
   classNames: ["user-stream"],
 
-  @observes("stream.user.id")
-  _scrollTopOnModelChange() {
-    schedule("afterRender", () => $(document).scrollTop(0));
-  },
-
   _inserted: on("didInsertElement", function () {
-    $(window).on("resize.discourse-on-scroll", () => this.scrolled());
-
     $(this.element).on(
       "click.details-disabled",
       "details.disabled",
@@ -49,12 +40,10 @@ export default Component.extend(LoadMore, {
       return ClickTrack.trackClick(e, this.siteSettings);
     });
     this._updateLastDecoratedElement();
-    this._scrollToLastPosition();
   }),
 
   // This view is being removed. Shut down operations
   _destroyed: on("willDestroyElement", function () {
-    $(window).unbind("resize.discourse-on-scroll");
     $(this.element).off("click.details-disabled", "details.disabled");
 
     // Unbind link tracking
@@ -71,22 +60,6 @@ export default Component.extend(LoadMore, {
       return;
     }
     this._lastDecoratedElement = lastElement;
-  },
-
-  _scrollToLastPosition() {
-    const scrollTo = this.session.userStreamScrollPosition;
-    if (scrollTo >= 0) {
-      schedule("afterRender", () => {
-        if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo));
-        }
-      });
-    }
-  },
-
-  scrolled() {
-    this._super(...arguments);
-    this.session.set("userStreamScrollPosition", window.scrollY);
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
@@ -25,10 +25,6 @@ export default Controller.extend(BulkTopicSelection, {
     return topicsLength === 0 && incomingCount === 0;
   },
 
-  saveScrollPosition() {
-    this.session.set("topicListScrollPosition", $(window).scrollTop());
-  },
-
   @observes("model.canLoadMore")
   _showFooter() {
     this.set("application.showFooter", !this.get("model.canLoadMore"));

--- a/app/assets/javascripts/discourse/app/instance-initializers/init-route-scroll-manager.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/init-route-scroll-manager.js
@@ -1,0 +1,5 @@
+export default {
+  initialize(owner) {
+    owner.lookup("service:route-scroll-manager");
+  },
+};

--- a/app/assets/javascripts/discourse/app/lib/cached-topic-list.js
+++ b/app/assets/javascripts/discourse/app/lib/cached-topic-list.js
@@ -9,7 +9,6 @@ export function getCachedTopicList(session) {
 export function resetCachedTopicList(session) {
   session.setProperties({
     topicList: null,
-    topicListScrollPosition: null,
   });
 }
 

--- a/app/assets/javascripts/discourse/app/lib/discourse-location.js
+++ b/app/assets/javascripts/discourse/app/lib/discourse-location.js
@@ -6,6 +6,17 @@ let popstateFired = false;
 const supportsHistoryState = window.history && "state" in window.history;
 const popstateCallbacks = [];
 
+function _uuid() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    let r, v;
+    /* eslint-disable no-bitwise */
+    r = (Math.random() * 16) | 0;
+    v = c === "x" ? r : (r & 3) | 8;
+    /* eslint-enable no-bitwise */
+    return v.toString(16);
+  });
+}
+
 /**
   `Ember.DiscourseLocation` implements the location API using the browser's
   `history.pushState` API.
@@ -130,7 +141,7 @@ const DiscourseLocation = EmberObject.extend({
    @param path {String}
   */
   pushState(path) {
-    const state = { path };
+    const state = { path, uuid: _uuid() };
 
     // store state if browser doesn't support `history.state`
     if (!supportsHistoryState) {
@@ -152,7 +163,7 @@ const DiscourseLocation = EmberObject.extend({
    @param path {String}
   */
   replaceState(path) {
-    const state = { path };
+    const state = { path, uuid: _uuid() };
 
     // store state if browser doesn't support `history.state`
     if (!supportsHistoryState) {

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -56,7 +56,7 @@ async function findTopicList(
     session.set("topicList", null);
   } else {
     // Clear the cache
-    session.setProperties({ topicList: null, topicListScrollPosition: null });
+    session.setProperties({ topicList: null });
   }
 
   if (!list) {

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -5,7 +5,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import OpenComposer from "discourse/mixins/open-composer";
 import User from "discourse/models/user";
-import { scrollTop } from "discourse/mixins/scroll-top";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
 import { action } from "@ember/object";
 
@@ -56,9 +55,6 @@ export default DiscourseRoute.extend(OpenComposer, {
   @action
   loadingComplete() {
     this.controllerFor("discovery").loadingComplete();
-    if (!this.session.get("topicListScrollPosition")) {
-      scrollTop();
-    }
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -7,6 +7,7 @@ import OpenComposer from "discourse/mixins/open-composer";
 import User from "discourse/models/user";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
 import { action } from "@ember/object";
+import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
 
 export default DiscourseRoute.extend(OpenComposer, {
   queryParams: {
@@ -93,6 +94,11 @@ export default DiscourseRoute.extend(OpenComposer, {
       categoryId: controller.get("category.id"),
       includeSubcategories: !controller.noSubcategories,
     });
+  },
+
+  refresh() {
+    resetCachedTopicList(this.session);
+    this._super();
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -323,9 +323,6 @@ const TopicRoute = DiscourseRoute.extend({
   activate() {
     this._super(...arguments);
     this.set("isTransitioning", false);
-
-    const topic = this.modelFor("topic");
-    this.session.set("lastTopicIdViewed", parseInt(topic.get("id"), 10));
   },
 
   deactivate() {

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -21,6 +21,12 @@ const TopicRoute = DiscourseRoute.extend({
   lastScrollPos: null,
   isTransitioning: false,
 
+  buildRouteInfoMetadata() {
+    return {
+      scrollOnTransition: false,
+    };
+  },
+
   redirect() {
     return this.redirectIfLoginRequired();
   },

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -323,6 +323,9 @@ const TopicRoute = DiscourseRoute.extend({
   activate() {
     this._super(...arguments);
     this.set("isTransitioning", false);
+
+    const topic = this.modelFor("topic");
+    this.session.set("lastTopicIdViewed", parseInt(topic.get("id"), 10));
   },
 
   deactivate() {

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -25,7 +25,6 @@ export default DiscourseRoute.extend({
 
     this.session.setProperties({
       bookmarksModel: null,
-      bookmarkListScrollPosition: null,
     });
 
     controller.set("loading", true);

--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -24,12 +24,6 @@ export default UserTopicListRoute.extend({
       });
   },
 
-  afterModel(model, transition) {
-    if (!this.isPoppedState(transition)) {
-      this.session.set("topicListScrollPosition", null);
-    }
-  },
-
   emptyState() {
     const title = I18n.t("user_activity.no_read_topics_title");
     const body = htmlSafe(

--- a/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
@@ -21,10 +21,6 @@ export default DiscourseRoute.extend(ViewingActionType, {
   },
 
   afterModel(model, transition) {
-    if (!this.isPoppedState(transition)) {
-      this.session.set("userStreamScrollPosition", null);
-    }
-
     return model.stream.filterBy({
       filter: this.userActionType,
       actingUsername: transition.to.queryParams.acting_username,

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -24,12 +24,6 @@ export default UserTopicListRoute.extend({
       });
   },
 
-  afterModel(model, transition) {
-    if (!this.isPoppedState(transition)) {
-      this.session.set("topicListScrollPosition", null);
-    }
-  },
-
   emptyState() {
     const user = this.modelFor("user");
     let title, body;

--- a/app/assets/javascripts/discourse/app/routes/user-activity.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity.js
@@ -11,12 +11,6 @@ export default DiscourseRoute.extend({
     return user;
   },
 
-  afterModel(_model, transition) {
-    if (!this.isPoppedState(transition)) {
-      this.session.set("userStreamScrollPosition", null);
-    }
-  },
-
   setupController(controller, user) {
     this.controllerFor("user-activity").set("model", user);
   },

--- a/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
+++ b/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
@@ -51,7 +51,7 @@ export default class RouteScrollManager extends Service {
 
   #pruneOldScrollLocations() {
     while (this.scrollLocationHistory.size > MAX_SCROLL_LOCATIONS) {
-      // JS Set guarantees keys will be returned in insertion order
+      // JS Map guarantees keys will be returned in insertion order
       const oldestUUID = this.scrollLocationHistory.keys().next().value;
       this.scrollLocationHistory.delete(oldestUUID);
     }

--- a/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
+++ b/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
@@ -1,0 +1,48 @@
+import Service, { inject as service } from "@ember/service";
+import { bind } from "discourse-common/utils/decorators";
+import { schedule } from "@ember/runloop";
+const MAX_SCROLL_LOCATIONS = 100;
+
+export default class RouteScrollManager extends Service {
+  @service router;
+
+  scrollLocationHistory = new Map();
+  uuid;
+
+  @bind
+  routeWillChange() {
+    if (!this.uuid) {
+      return;
+    }
+    this.scrollLocationHistory.set(this.uuid, [window.scrollX, window.scrollY]);
+    this.#pruneOldScrollLocations();
+  }
+
+  @bind
+  routeDidChange() {
+    this.uuid = this.router.location.getState?.().uuid;
+
+    const scrollLocation = this.scrollLocationHistory.get(this.uuid) || [0, 0];
+    schedule("afterRender", () => {
+      window.scrollTo(...scrollLocation);
+    });
+  }
+
+  #pruneOldScrollLocations() {
+    while (this.scrollLocationHistory.size > MAX_SCROLL_LOCATIONS) {
+      const oldestUUID = this.scrollLocationHistory.keys().next().value;
+      this.scrollLocationHistory.delete(oldestUUID);
+    }
+  }
+
+  init() {
+    super.init(...arguments);
+    this.router.on("routeDidChange", this.routeDidChange);
+    this.router.on("routeWillChange", this.routeWillChange);
+  }
+
+  willDestroy() {
+    this.router.off("routeDidChange", this.routeDidChange);
+    this.router.off("routeWillChange", this.routeWillChange);
+  }
+}

--- a/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
+++ b/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
@@ -5,6 +5,15 @@ import { isTesting } from "discourse-common/config/environment";
 
 const MAX_SCROLL_LOCATIONS = 100;
 
+/**
+ * This service is responsible for managing scroll position when transitioning.
+ * When visiting a new route, this service will scroll to the top of the page.
+ * When returning to a previously-visited route via the browser back button,
+ * this service will scroll to the previous scroll position.
+ *
+ * To opt-out of the behaviour, individual routes can add a scrollOnTransition
+ * boolean to their RouteInfo metadata using Ember's `buildRouteInfoMetadata` hook.
+ */
 export default class RouteScrollManager extends Service {
   @service router;
 

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -31,7 +31,6 @@
   @autoAddTopicsToBulkSelect={{this.autoAddTopicsToBulkSelect}}
   @bulkSelectEnabled={{this.bulkSelectEnabled}}
   @addTopicsToBulkSelect={{action "addTopicsToBulkSelect"}}
-  as |discoveryTopicList|
 >
   {{#if this.top}}
     <div class="top-lists">
@@ -90,8 +89,6 @@
       @category={{this.category}}
       @topics={{this.model.topics}}
       @discoveryList={{true}}
-      @scrollOnLoad={{true}}
-      @onScroll={{discoveryTopicList.saveScrollPosition}}
       @focusLastVisitedTopic={{true}}
     />
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
@@ -11,7 +11,6 @@
   @model={{this.model}}
   @refresh={{action "refresh"}}
   @incomingCount={{this.topicTrackingState.incomingCount}}
-  as |discoveryTopicList|
 >
   {{#if this.top}}
     <div class="top-lists">
@@ -56,8 +55,6 @@
       @expandAllPinned={{this.expandAllPinned}}
       @category={{this.category}}
       @topics={{this.model.topics}}
-      @scrollOnLoad={{true}}
-      @onScroll={{discoveryTopicList.saveScrollPosition}}
     />
   {{/if}}
 </DiscoveryTopicsList>

--- a/app/assets/javascripts/discourse/app/templates/navigation/default.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/default.hbs
@@ -1,8 +1,4 @@
-<DSection
-  @bodyClass="navigation-topics"
-  @class="navigation-container"
-  @scrollTop={{false}}
->
+<DSection @bodyClass="navigation-topics" @class="navigation-container">
   <DNavigation
     @filterMode={{this.filterMode}}
     @canCreateTopic={{this.canCreateTopic}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/filter.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/filter.hbs
@@ -1,8 +1,4 @@
-<DSection
-  @bodyClass="navigation-filter"
-  @class="navigation-container"
-  @scrollTop={{false}}
->
+<DSection @bodyClass="navigation-filter" @class="navigation-container">
   <div class="topic-query-filter">
     <div class="topic-query-filter__input">
       {{d-icon "filter" class="topic-query-filter__icon"}}

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -95,7 +95,6 @@
               @autoAddTopicsToBulkSelect={{this.autoAddTopicsToBulkSelect}}
               @bulkSelectEnabled={{this.bulkSelectEnabled}}
               @addTopicsToBulkSelect={{action "addTopicsToBulkSelect"}}
-              as |discoveryTopicList|
             >
               {{#if this.top}}
                 <div class="top-lists">
@@ -140,8 +139,6 @@
                   @order={{this.order}}
                   @ascending={{this.ascending}}
                   @changeSort={{action "changeSort"}}
-                  @onScroll={{discoveryTopicList.saveScrollPosition}}
-                  @scrollOnLoad={{true}}
                   @focusLastVisitedTopic={{true}}
                 />
               {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
@@ -43,9 +43,7 @@
       @bulkSelectAction={{action "refresh"}}
       @selected={{this.selected}}
       @tagsForUser={{this.tagsForUser}}
-      @onScroll={{this.saveScrollPosition}}
       @canBulkSelect={{this.canBulkSelect}}
-      @scrollOnLoad={{true}}
       @toggleBulkSelect={{action "toggleBulkSelect"}}
       @updateAutoAddTopicsToBulkSelect={{action
         "updateAutoAddTopicsToBulkSelect"

--- a/spec/system/page_objects/components/topic_list.rb
+++ b/spec/system/page_objects/components/topic_list.rb
@@ -10,8 +10,12 @@ module PageObjects
         TOPIC_LIST_BODY_SELECTOR
       end
 
-      def has_topics?(count:)
-        page.has_css?(TOPIC_LIST_ITEM_SELECTOR, count: count)
+      def has_topics?(count: nil)
+        if count.nil?
+          page.has_css?(TOPIC_LIST_ITEM_SELECTOR)
+        else
+          page.has_css?(TOPIC_LIST_ITEM_SELECTOR, count: count)
+        end
       end
 
       def has_no_topics?

--- a/spec/system/scroll_manager_service_spec.rb
+++ b/spec/system/scroll_manager_service_spec.rb
@@ -3,7 +3,7 @@
 describe "Ember route-scroll-manager service", type: :system do
   before do
     Fabricate(:admin)
-    50.times { Fabricate(:post) }
+    Fabricate.times(50, :post)
   end
 
   let(:discovery) { PageObjects::Pages::Discovery.new }

--- a/spec/system/scroll_manager_service_spec.rb
+++ b/spec/system/scroll_manager_service_spec.rb
@@ -10,9 +10,7 @@ describe "Ember route-scroll-manager service", type: :system do
   let(:topic) { PageObjects::Pages::Topic.new }
 
   def current_scroll_y
-    page.execute_script <<~JS
-      return window.scrollY
-    JS
+    page.evaluate_script("window.scrollY")
   end
 
   it "scrolls to top when navigating to new routes, and remembers scroll position when going back" do

--- a/spec/system/scroll_manager_service_spec.rb
+++ b/spec/system/scroll_manager_service_spec.rb
@@ -31,7 +31,7 @@ describe "Ember route-scroll-manager service", type: :system do
 
     try_until_success { expect(current_scroll_y).to eq(0) }
 
-    page.driver.browser.navigate.back
+    page.go_back
 
     expect(page).to have_css("body.navigation-topics")
     expect(discovery.topic_list).to have_topics

--- a/spec/system/scroll_manager_service_spec.rb
+++ b/spec/system/scroll_manager_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe "Ember route-scroll-manager service", type: :system do
+  before do
+    Fabricate(:admin)
+    50.times { Fabricate(:post) }
+  end
+
+  let(:discovery) { PageObjects::Pages::Discovery.new }
+  let(:topic) { PageObjects::Pages::Topic.new }
+
+  def current_scroll_y
+    page.execute_script <<~JS
+      return window.scrollY
+    JS
+  end
+
+  it "scrolls to top when navigating to new routes, and remembers scroll position when going back" do
+    visit("/")
+    expect(page).to have_css("body.navigation-topics")
+    expect(discovery.topic_list).to have_topics
+
+    page.execute_script <<~JS
+      document.querySelectorAll('.topic-list-item')[10].scrollIntoView(true);
+    JS
+
+    topic_list_scroll_y = current_scroll_y
+    try_until_success { expect(topic_list_scroll_y).to be > 0 }
+
+    find(".sidebar-section-link[data-link-name='all-categories']").click
+
+    expect(page).to have_css("body.navigation-categories")
+
+    try_until_success { expect(current_scroll_y).to eq(0) }
+
+    page.driver.browser.navigate.back
+
+    expect(page).to have_css("body.navigation-topics")
+    expect(discovery.topic_list).to have_topics
+
+    try_until_success { expect(current_scroll_y).to eq(topic_list_scroll_y) }
+
+    # Clicking site logo triggers refresh and scrolls to top
+    find("#site-logo").click
+    try_until_success { expect(current_scroll_y).to eq(0) }
+  end
+end


### PR DESCRIPTION
Previously we were implementing scroll reset/memorization on a per-page basis. Many of these approaches relied on the `didInsertElement` hook, which is no longer appropriate since Discourse changed to use the 'loading slider' strategy for page transitions.

This commit rips out all of our custom scroll resetting/memorizing, and implements those things in a generic service. There are two features:

1. After every route transition, scroll to the top of the page
2. When using browser back/forward buttons, restore the last known scroll position for those routes

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
