### PR TITLE
FIX: Render excerpt HTML for chat replies and edit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
@@ -8,7 +8,7 @@
     <Chat::UserAvatar @user={{@message.user}} />
     <span class="chat-reply__username">{{@message.user.username}}</span>
     <span class="chat-reply__excerpt">
-      {{replace-emoji @message.excerpt}}
+      {{replace-emoji (html-safe @message.excerpt)}}
     </span>
   </div>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-in-reply-to-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-in-reply-to-indicator.hbs
@@ -13,7 +13,7 @@
     {{/if}}
 
     <span class="chat-reply__excerpt">
-      {{replace-emoji @message.inReplyTo.excerpt}}
+      {{replace-emoji (html-safe @message.inReplyTo.excerpt)}}
     </span>
   </LinkTo>
 {{/if}}

--- a/plugins/chat/spec/system/chat/composer/channel_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/channel_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Chat | composer | channel", type: :system, js: true do
 
       expect(channel_page.composer.message_details).to have_message(
         id: message_1.id,
-        exact_text: "&lt;mark&gt;not marked&lt;/mark&gt;",
+        exact_text: "<mark>not marked</mark>",
       )
     end
 

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -241,7 +241,17 @@ RSpec.describe "Chat channel", type: :system do
       chat.visit_channel(channel_1)
 
       expect(find(".chat-reply .chat-reply__excerpt")["innerHTML"].strip).to eq(
-        "&amp;lt;mark&amp;gt;not marked&amp;lt;/mark&amp;gt;",
+        "&lt;mark&gt;not marked&lt;/mark&gt;",
+      )
+    end
+
+    it "renders safe HTML like mentions (which are just links) in the reply-to" do
+      message_2.update!(message: "@#{other_user.username} <mark>not marked</mark>")
+      message_2.rebake!
+      chat.visit_channel(channel_1)
+
+      expect(find(".chat-reply .chat-reply__excerpt")["innerHTML"].strip).to eq(
+        "<a class=\"mention\" href=\"/u/#{other_user.username}\">@#{other_user.username}</a> &lt;mark&gt;not marked&lt;/mark&gt;",
       )
     end
   end

--- a/plugins/chat/spec/system/chat_composer_draft_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_draft_spec.rb
@@ -3,7 +3,13 @@
 RSpec.describe "Chat composer draft", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
-  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+  fab!(:message_1) do
+    Fabricate(
+      :chat_message,
+      chat_channel: channel_1,
+      message: "This is a message for draft and replies",
+    )
+  end
 
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }

--- a/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "Reply to message - channel - drawer", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }
   fab!(:original_message) do
-    Fabricate(:chat_message, chat_channel: channel_1, user: Fabricate(:user))
+    Fabricate(
+      :chat_message,
+      chat_channel: channel_1,
+      user: Fabricate(:user),
+      message: "This is a message to reply to!",
+    )
   end
 
   before do

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }
   fab!(:original_message) do
-    Fabricate(:chat_message, chat_channel: channel_1, user: Fabricate(:user))
+    Fabricate(
+      :chat_message,
+      chat_channel: channel_1,
+      user: Fabricate(:user),
+      message: "This is a message to reply to!",
+    )
   end
 
   before do

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -100,5 +100,22 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
 
       expect(channel_page).to have_message(text: "reply to message")
     end
+
+    it "renders safe HTML from the original message excerpt" do
+      other_user = Fabricate(:user)
+      original_message.update!(message: "@#{other_user.username} <mark>not marked</mark>")
+      original_message.rebake!
+      chat_page.visit_channel(channel_1)
+      channel_page.reply_to(original_message)
+
+      expect(find(".chat-reply .chat-reply__excerpt")["innerHTML"].strip).to eq(
+        "<a class=\"mention\" href=\"/u/#{other_user.username}\">@#{other_user.username}</a> &lt;mark&gt;not marked&lt;/mark&gt;",
+      )
+
+      channel_page.fill_composer("reply to message")
+      channel_page.click_send_message
+
+      expect(channel_page).to have_message(text: "reply to message")
+    end
   end
 end

--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: tru
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }
   fab!(:original_message) do
-    Fabricate(:chat_message, chat_channel: channel_1, user: Fabricate(:user))
+    Fabricate(
+      :chat_message,
+      chat_channel: channel_1,
+      user: Fabricate(:user),
+      message: "This is a message to reply to!",
+    )
   end
 
   before do


### PR DESCRIPTION
Followup to 58c8f91d9acf20bbd8d4ef3bd88ed719564769ec

It is now safe to render the message excerpt as HTML since
it is no longer using text_entities: true in the server
PrettyText.excerpt call when creating the message excerpt
from the cooked HTML.

This will fix the issue of things like mentions showing
HTML code instead of the actual mention when replying,
and cannot be used to inject improper HTML like style tags
via XSS.

<img width="1108" alt="image" src="https://github.com/discourse/discourse/assets/920448/14401f44-70a4-4501-8bb8-8c3b3e386e30">

