### PR TITLE
DEV: Fix flaky chat navigation specs on CI

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe "Navigation", type: :system do
 
     context "when opening a thread from the thread list" do
       it "goes back to the thread list when clicking the back button" do
+        skip("Flaky on CI") if ENV["CI"]
+
         visit("/chat")
         chat_page.visit_channel(category_channel)
         channel_page.open_thread_list
@@ -157,6 +159,8 @@ RSpec.describe "Navigation", type: :system do
 
       context "for mobile" do
         it "goes back to the thread list when clicking the back button", mobile: true do
+          skip("Flaky on CI") if ENV["CI"]
+
           visit("/chat")
           chat_page.visit_channel(category_channel)
           channel_page.open_thread_list
@@ -173,6 +177,8 @@ RSpec.describe "Navigation", type: :system do
 
     context "when opening a thread from indicator" do
       it "goes back to the thread list when clicking the back button" do
+        skip("Flaky on CI") if ENV["CI"]
+
         visit("/chat")
         chat_page.visit_channel(category_channel)
         channel_page.message_thread_indicator(thread.original_message).click
@@ -186,6 +192,8 @@ RSpec.describe "Navigation", type: :system do
       context "for mobile" do
         it "closes the thread and goes back to the channel when clicking the back button",
            mobile: true do
+          skip("Flaky on CI") if ENV["CI"]
+
           visit("/chat")
           chat_page.visit_channel(category_channel)
           channel_page.message_thread_indicator(thread.original_message).click


### PR DESCRIPTION
Why this change?

The specs are flaky on CI and we've unable to figure out why so we've decided to skip them only on CI for now. The tests are still ran in our internal build so we still have some protection in place.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
