### PR TITLE
FEATURE: enable_public_channels site setting

### DIFF
--- a/plugins/chat/app/services/chat/create_category_channel.rb
+++ b/plugins/chat/app/services/chat/create_category_channel.rb
@@ -27,6 +27,7 @@ module Chat
     #   @option params_to_create [Boolean] threading_enabled
     #   @return [Service::Base::Context]
 
+    policy :public_channels_enabled
     policy :can_create_channel
     contract
     model :category, :fetch_category
@@ -56,6 +57,10 @@ module Chat
     end
 
     private
+
+    def public_channels_enabled
+      SiteSetting.enabled_public_channels
+    end
 
     def can_create_channel(guardian:, **)
       guardian.can_create_chat_channel?

--- a/plugins/chat/app/services/chat/search_chatable.rb
+++ b/plugins/chat/app/services/chat/search_chatable.rb
@@ -56,6 +56,7 @@ module Chat
 
     def fetch_category_channels(guardian:, **)
       return if context.mode == :user
+      return if !SiteSetting.enable_public_channels
 
       context.category_channels =
         ::Chat::ChannelFetcher.secured_public_channel_search(

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list.js
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list.js
@@ -12,6 +12,7 @@ export default class ChannelsList extends Component {
   @service chatStateManager;
   @service chatChannelsManager;
   @service site;
+  @service siteSettings;
   @service session;
   @service currentUser;
   @service modal;
@@ -71,6 +72,10 @@ export default class ChannelsList extends Component {
   }
 
   get displayPublicChannels() {
+    if (!this.siteSettings.enable_public_channels) {
+      return false;
+    }
+
     if (this.publicMessageChannelsEmpty) {
       return (
         this.currentUser?.staff ||

--- a/plugins/chat/assets/javascripts/discourse/components/chat/message-creator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message-creator.js
@@ -113,6 +113,7 @@ export default class ChatMessageCreator extends Component {
   @service site;
   @service router;
   @service currentUser;
+  @service siteSettings;
 
   @tracked selection = new TrackedArray();
   @tracked activeSelection = new TrackedArray();
@@ -124,10 +125,25 @@ export default class ChatMessageCreator extends Component {
   @tracked _activeResultIdentifier = null;
 
   get placeholder() {
-    if (this.hasSelectedUsers) {
-      return I18n.t("chat.new_message_modal.user_search_placeholder");
-    } else {
-      return I18n.t("chat.new_message_modal.default_search_placeholder");
+    if (
+      this.siteSettings.enable_public_channels &&
+      this.chat.userCanDirectMessage
+    ) {
+      if (this.hasSelectedUsers) {
+        return I18n.t("chat.new_message_modal.user_search_placeholder");
+      } else {
+        return I18n.t("chat.new_message_modal.default_search_placeholder");
+      }
+    } else if (this.siteSettings.enable_public_channels) {
+      return I18n.t(
+        "chat.new_message_modal.default_channel_search_placeholder"
+      );
+    } else if (this.chat.userCanDirectMessage) {
+      if (this.hasSelectedUsers) {
+        return I18n.t("chat.new_message_modal.user_search_placeholder");
+      } else {
+        return I18n.t("chat.new_message_modal.default_user_search_placeholder");
+      }
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.hbs
@@ -1,8 +1,10 @@
-<DModal
-  @closeModal={{@closeModal}}
-  class="chat-modal-new-message"
-  @title="chat.new_message_modal.title"
-  @inline={{@inline}}
->
-  <Chat::MessageCreator @onClose={{@closeModal}} />
-</DModal>
+{{#if this.shouldRender}}
+  <DModal
+    @closeModal={{@closeModal}}
+    class="chat-modal-new-message"
+    @title="chat.new_message_modal.title"
+    @inline={{@inline}}
+  >
+    <Chat::MessageCreator @onClose={{@closeModal}} />
+  </DModal>
+{{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.js
@@ -1,0 +1,14 @@
+import Component from "@glimmer/component";
+
+import { inject as service } from "@ember/service";
+
+export default class ChatModalNewMessage extends Component {
+  @service chat;
+  @service siteSettings;
+
+  get shouldRender() {
+    return (
+      this.siteSettings.enable_public_channels || this.chat.userCanDirectMessage
+    );
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -21,155 +21,159 @@ export default {
       return;
     }
 
+    this.siteSettings = container.lookup("service:site-settings");
+
     withPluginApi("1.3.0", (api) => {
-      api.addSidebarSection(
-        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
-          const SidebarChatChannelsSectionLink = class extends BaseCustomSidebarSectionLink {
-            constructor({ channel, chatService }) {
-              super(...arguments);
-              this.channel = channel;
-              this.chatService = chatService;
-            }
-
-            get name() {
-              return dasherize(this.channel.slugifiedTitle);
-            }
-
-            get classNames() {
-              const classes = [];
-
-              if (this.channel.currentUserMembership.muted) {
-                classes.push("sidebar-section-link--muted");
+      if (this.siteSettings.enable_public_channels) {
+        api.addSidebarSection(
+          (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+            const SidebarChatChannelsSectionLink = class extends BaseCustomSidebarSectionLink {
+              constructor({ channel, chatService }) {
+                super(...arguments);
+                this.channel = channel;
+                this.chatService = chatService;
               }
 
-              if (this.channel.id === this.chatService.activeChannel?.id) {
-                classes.push("sidebar-section-link--active");
+              get name() {
+                return dasherize(this.channel.slugifiedTitle);
               }
 
-              classes.push(`channel-${this.channel.id}`);
+              get classNames() {
+                const classes = [];
 
-              return classes.join(" ");
-            }
+                if (this.channel.currentUserMembership.muted) {
+                  classes.push("sidebar-section-link--muted");
+                }
 
-            get route() {
-              return "chat.channel";
-            }
+                if (this.channel.id === this.chatService.activeChannel?.id) {
+                  classes.push("sidebar-section-link--active");
+                }
 
-            get models() {
-              return this.channel.routeModels;
-            }
+                classes.push(`channel-${this.channel.id}`);
 
-            get text() {
-              return htmlSafe(emojiUnescape(this.channel.escapedTitle));
-            }
-
-            get prefixType() {
-              return "icon";
-            }
-
-            get prefixValue() {
-              return "d-chat";
-            }
-
-            get prefixColor() {
-              return this.channel.chatable.color;
-            }
-
-            get title() {
-              return this.channel.escapedDescription
-                ? htmlSafe(this.channel.escapedDescription)
-                : `${this.channel.escapedTitle} ${I18n.t("chat.title")}`;
-            }
-
-            get prefixBadge() {
-              return this.channel.chatable.read_restricted ? "lock" : "";
-            }
-
-            get suffixType() {
-              return "icon";
-            }
-
-            get suffixValue() {
-              return this.channel.tracking.unreadCount > 0 ? "circle" : "";
-            }
-
-            get suffixCSSClass() {
-              return this.channel.tracking.mentionCount > 0
-                ? "urgent"
-                : "unread";
-            }
-          };
-
-          const SidebarChatChannelsSection = class extends BaseCustomSidebarSection {
-            @tracked currentUserCanJoinPublicChannels =
-              this.sidebar.currentUser &&
-              (this.sidebar.currentUser.staff ||
-                this.sidebar.currentUser.has_joinable_public_channels);
-
-            constructor() {
-              super(...arguments);
-
-              if (container.isDestroyed) {
-                return;
+                return classes.join(" ");
               }
-              this.chatService = container.lookup("service:chat");
-              this.chatChannelsManager = container.lookup(
-                "service:chat-channels-manager"
-              );
-              this.router = container.lookup("service:router");
-            }
 
-            get sectionLinks() {
-              return this.chatChannelsManager.publicMessageChannels.map(
-                (channel) =>
-                  new SidebarChatChannelsSectionLink({
-                    channel,
-                    chatService: this.chatService,
-                  })
-              );
-            }
+              get route() {
+                return "chat.channel";
+              }
 
-            get name() {
-              return "chat-channels";
-            }
+              get models() {
+                return this.channel.routeModels;
+              }
 
-            get title() {
-              return I18n.t("chat.chat_channels");
-            }
+              get text() {
+                return htmlSafe(emojiUnescape(this.channel.escapedTitle));
+              }
 
-            get text() {
-              return I18n.t("chat.chat_channels");
-            }
+              get prefixType() {
+                return "icon";
+              }
 
-            get actions() {
-              return [
-                {
-                  id: "browseChannels",
-                  title: I18n.t("chat.channels_list_popup.browse"),
-                  action: () => this.router.transitionTo("chat.browse.open"),
-                },
-              ];
-            }
+              get prefixValue() {
+                return "d-chat";
+              }
 
-            get actionsIcon() {
-              return "pencil-alt";
-            }
+              get prefixColor() {
+                return this.channel.chatable.color;
+              }
 
-            get links() {
-              return this.sectionLinks;
-            }
+              get title() {
+                return this.channel.escapedDescription
+                  ? htmlSafe(this.channel.escapedDescription)
+                  : `${this.channel.escapedTitle} ${I18n.t("chat.title")}`;
+              }
 
-            get displaySection() {
-              return (
-                this.sectionLinks.length > 0 ||
-                this.currentUserCanJoinPublicChannels
-              );
-            }
-          };
+              get prefixBadge() {
+                return this.channel.chatable.read_restricted ? "lock" : "";
+              }
 
-          return SidebarChatChannelsSection;
-        }
-      );
+              get suffixType() {
+                return "icon";
+              }
+
+              get suffixValue() {
+                return this.channel.tracking.unreadCount > 0 ? "circle" : "";
+              }
+
+              get suffixCSSClass() {
+                return this.channel.tracking.mentionCount > 0
+                  ? "urgent"
+                  : "unread";
+              }
+            };
+
+            const SidebarChatChannelsSection = class extends BaseCustomSidebarSection {
+              @tracked currentUserCanJoinPublicChannels =
+                this.sidebar.currentUser &&
+                (this.sidebar.currentUser.staff ||
+                  this.sidebar.currentUser.has_joinable_public_channels);
+
+              constructor() {
+                super(...arguments);
+
+                if (container.isDestroyed) {
+                  return;
+                }
+                this.chatService = container.lookup("service:chat");
+                this.chatChannelsManager = container.lookup(
+                  "service:chat-channels-manager"
+                );
+                this.router = container.lookup("service:router");
+              }
+
+              get sectionLinks() {
+                return this.chatChannelsManager.publicMessageChannels.map(
+                  (channel) =>
+                    new SidebarChatChannelsSectionLink({
+                      channel,
+                      chatService: this.chatService,
+                    })
+                );
+              }
+
+              get name() {
+                return "chat-channels";
+              }
+
+              get title() {
+                return I18n.t("chat.chat_channels");
+              }
+
+              get text() {
+                return I18n.t("chat.chat_channels");
+              }
+
+              get actions() {
+                return [
+                  {
+                    id: "browseChannels",
+                    title: I18n.t("chat.channels_list_popup.browse"),
+                    action: () => this.router.transitionTo("chat.browse.open"),
+                  },
+                ];
+              }
+
+              get actionsIcon() {
+                return "pencil-alt";
+              }
+
+              get links() {
+                return this.sectionLinks;
+              }
+
+              get displaySection() {
+                return (
+                  this.sectionLinks.length > 0 ||
+                  this.currentUserCanJoinPublicChannels
+                );
+              }
+            };
+
+            return SidebarChatChannelsSection;
+          }
+        );
+      }
 
       api.addSidebarSection(
         (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
@@ -1,8 +1,16 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { inject as service } from "@ember/service";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class ChatBrowseIndexRoute extends DiscourseRoute {
   @service chat;
+  @service siteSettings;
+
+  beforeModel() {
+    if (!this.siteSettings.enable_public_channels) {
+      return this.transitionTo(`discovery.${defaultHomepage()}`);
+    }
+  }
 
   activate() {
     this.chat.activeChannel = null;

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -330,6 +330,8 @@ en:
         add_user_short: <span>Add user</span>
         open_channel: <span>Open channel</span>
         default_search_placeholder: "#a-channel, @somebody or anything"
+        default_channel_search_placeholder: "#a-channel"
+        default_user_search_placeholder: "@somebody"
         user_search_placeholder: "...add more users"
         disabled_user: "has disabled chat"
         no_items: "No items"

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     chat_enabled: "Enable the chat plugin."
+    enable_public_channels: "Enable public channels."
     chat_allowed_groups: "Users in these groups can chat. Note that staff can always access chat."
     chat_channel_retention_days: "Chat messages in regular channels will be retained for this many days. Set to '0' to retain messages forever."
     chat_dm_retention_days: "Chat messages in personal chat channels will be retained for this many days. Set to '0' to retain messages forever."

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -2,6 +2,9 @@ chat:
   chat_enabled:
     default: true
     client: true
+  enable_public_channels:
+    default: true
+    client: true
   chat_allowed_groups:
     client: true
     type: group_list

--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -86,6 +86,8 @@ module Chat
     end
 
     def self.secured_public_channel_search(guardian, options = {})
+      return ::Chat::Channel.none if !SiteSetting.enable_public_channels
+
       allowed_channel_ids = generate_allowed_channel_ids_sql(guardian, exclude_dm_channels: true)
 
       channels = Chat::Channel.includes(chatable: [:topic_only_relative_url])

--- a/plugins/chat/lib/chat/channel_hashtag_data_source.rb
+++ b/plugins/chat/lib/chat/channel_hashtag_data_source.rb
@@ -23,7 +23,7 @@ module Chat
     end
 
     def self.lookup(guardian, slugs)
-      if SiteSetting.enable_experimental_hashtag_autocomplete
+      if SiteSetting.enable_experimental_hashtag_autocomplete && SiteSetting.enable_public_channels
         return [] if !guardian.can_chat?
         Chat::ChannelFetcher
           .secured_public_channel_slug_lookup(guardian, slugs)
@@ -39,7 +39,7 @@ module Chat
       limit,
       condition = HashtagAutocompleteService.search_conditions[:contains]
     )
-      if SiteSetting.enable_experimental_hashtag_autocomplete
+      if SiteSetting.enable_experimental_hashtag_autocomplete && SiteSetting.enable_public_channels
         return [] if !guardian.can_chat?
         Chat::ChannelFetcher
           .secured_public_channel_search(
@@ -61,7 +61,7 @@ module Chat
     end
 
     def self.search_without_term(guardian, limit)
-      if SiteSetting.enable_experimental_hashtag_autocomplete
+      if SiteSetting.enable_experimental_hashtag_autocomplete && SiteSetting.enable_public_channels
         return [] if !guardian.can_chat?
         allowed_channel_ids_sql =
           Chat::ChannelFetcher.generate_allowed_channel_ids_sql(guardian, exclude_dm_channels: true)

--- a/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
@@ -201,6 +201,12 @@ describe Chat::ChannelFetcher do
       ).to match_array([category_channel.id])
     end
 
+    it "returns an empty array when public channels are disabled" do
+      SiteSetting.enable_public_channels = false
+
+      expect(described_class.secured_public_channels(guardian, following: nil)).to be_empty
+    end
+
     it "can filter by channel name, or category name" do
       expect(
         described_class.secured_public_channels(

--- a/plugins/chat/spec/lib/chat/channel_hashtag_data_source_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_hashtag_data_source_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe Chat::ChannelHashtagDataSource do
       Group.refresh_automatic_groups!
       expect(described_class.lookup(Guardian.new(user), ["random"])).to be_empty
     end
+
+    it "returns an empty array if public channels are disabled" do
+      SiteSetting.enable_public_channels = false
+      expect(described_class.lookup(guardian, ["random"])).to eq([])
+    end
   end
 
   describe "#search" do
@@ -144,6 +149,11 @@ RSpec.describe Chat::ChannelHashtagDataSource do
       Group.refresh_automatic_groups!
       expect(described_class.search(Guardian.new(user), "rand", 10)).to be_empty
     end
+
+    it "returns an empty array if public channels are disabled" do
+      SiteSetting.enable_public_channels = false
+      expect(described_class.search(guardian, "rand", 10)).to eq([])
+    end
   end
 
   describe "#search_without_term" do
@@ -170,6 +180,11 @@ RSpec.describe Chat::ChannelHashtagDataSource do
       expect(described_class.search_without_term(guardian, 5).map(&:slug)).to eq(
         %w[chat code-review random general],
       )
+    end
+
+    it "returns an empty array if public channels are disabled" do
+      SiteSetting.enable_public_channels = false
+      expect(described_class.search_without_term(guardian, 5)).to eq([])
     end
 
     it "does not return channels the user does not have permission to view" do

--- a/plugins/chat/spec/services/chat/create_category_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_category_channel_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Chat::CreateCategoryChannel do
     let(:guardian) { Guardian.new(current_user) }
     let(:params) { { guardian: guardian, category_id: category_id, name: "cool channel" } }
 
+    context "when public channels are disabled" do
+      fab!(:current_user) { Fabricate(:user) }
+
+      before { SiteSetting.enable_public_channels = false }
+
+      it { is_expected.to fail_a_policy(:public_channels_enabled) }
+    end
+
     context "when the current user cannot make a channel" do
       fab!(:current_user) { Fabricate(:user) }
 

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Chat::SearchChatable do
           expect(result.category_channels).to_not include(private_channel_1)
         end
       end
+
+      context "when public channels are disabled" do
+        it "does not return category channels" do
+          SiteSetting.enable_public_channels = false
+
+          expect(described_class.call(params).category_channels).to be_blank
+        end
+      end
     end
 
     context "when term is prefixed with #" do

--- a/plugins/chat/spec/system/browse_page_spec.rb
+++ b/plugins/chat/spec/system/browse_page_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe "Browse page", type: :system do
     end
   end
 
+  context "when public channels are disabled" do
+    before { SiteSetting.enable_public_channels = false }
+
+    it "redirects to homepage" do
+      visit("/chat/browse") # no page object here as we actually don't load it
+      expect(page).to have_current_path("/latest")
+    end
+  end
+
   context "when user has chat enabled" do
     context "when visiting browse page" do
       it "defaults to open filer" do

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -25,9 +25,9 @@ module PageObjects
         visit("/chat")
       end
 
-      def open_new_message
+      def open_new_message(check: true)
         send_keys([PLATFORM_KEY_MODIFIER, "k"])
-        find(".chat-modal-new-message")
+        find(".chat-modal-new-message") if check
       end
 
       def has_drawer?(channel_id: nil, expanded: true)

--- a/plugins/chat/spec/system/page_objects/chat/components/message_creator.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message_creator.rb
@@ -24,6 +24,10 @@ module PageObjects
           page.has_css?(SELECTOR)
         end
 
+        def closed?
+          page.has_no_css?(SELECTOR)
+        end
+
         def enter_shortcut
           input.send_keys(:enter)
         end

--- a/plugins/chat/spec/system/page_objects/sidebar/sidebar.rb
+++ b/plugins/chat/spec/system/page_objects/sidebar/sidebar.rb
@@ -3,19 +3,27 @@
 module PageObjects
   module Pages
     class Sidebar < PageObjects::Pages::Base
+      PUBLIC_CHANNELS_SECTION_SELECTOR = ".sidebar-section[data-section-name='chat-channels']"
+      DM_CHANNELS_SECTION_SELECTOR = ".sidebar-section[data-section-name='chat-dms']"
+
+      def has_no_public_channels_section?
+        has_no_css?(PUBLIC_CHANNELS_SECTION_SELECTOR)
+      end
+
       def channels_section
-        find(".sidebar-section[data-section-name='chat-channels']")
+        find(PUBLIC_CHANNELS_SECTION_SELECTOR)
+      end
+
+      def channels_section
+        find(PUBLIC_CHANNELS_SECTION_SELECTOR)
       end
 
       def dms_section
-        find(".sidebar-section[data-section-name='chat-dms']")
+        find(DM_CHANNELS_SECTION_SELECTOR)
       end
 
       def open_browse
-        find(
-          ".sidebar-section[data-section-name='chat-channels'] .sidebar-section-header-button",
-          visible: false,
-        ).click
+        channels_section.find(".sidebar-section-header-button", visible: false).click
       end
 
       def open_channel(channel)

--- a/plugins/chat/spec/system/sidebars_spec.rb
+++ b/plugins/chat/spec/system/sidebars_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Navigation", type: :system do
   fab!(:category_channel) { Fabricate(:category_channel) }
   fab!(:category_channel_2) { Fabricate(:category_channel) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:sidebar_page) { PageObjects::Pages::Sidebar.new }
 
   before do
     chat_system_bootstrap(user, [category_channel, category_channel_2])
@@ -38,6 +39,16 @@ RSpec.describe "Navigation", type: :system do
         chat_page.visit_channel(category_channel_2)
 
         expect(page).to have_no_css("#d-sidebar")
+      end
+    end
+
+    context "when public channels are disabled" do
+      before { SiteSetting.enable_public_channels = false }
+
+      it "has public channels section" do
+        visit("/")
+
+        expect(sidebar_page).to have_no_public_channels_section
       end
     end
   end


### PR DESCRIPTION
`SiteSetting.enable_public_channels` allows site admin to decide if public channels are available at all. There's no distinction between admins or not as we expect admins to create private category channels if they want to limit usage.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
