### PR TITLE
FIX: correctly respects full name settings in channel title

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
@@ -19,7 +19,9 @@
             <span class="chat-channel-title__name">{{this.usernames}}</span>
           {{else}}
             {{#let @channel.chatable.users.firstObject as |user|}}
-              <span class="chat-channel-title__name">{{user.username}}</span>
+              <span class="chat-channel-title__name">
+                <ChatUserDisplayName @user={{user}} />
+              </span>
               {{#if this.showUserStatus}}
                 <UserStatusMessage
                   @class="chat-channel-title__user-status-message"
@@ -35,8 +37,6 @@
               />
             {{/let}}
           {{/if}}
-        {{else}}
-          <span class="chat-channel-title__name">Add users</span>
         {{/if}}
       </div>
     </div>

--- a/plugins/chat/test/javascripts/components/chat-channel-title-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-title-test.js
@@ -80,6 +80,24 @@ module("Discourse Chat | Component | chat-channel-title", function (hooks) {
     );
   });
 
+  test("direct message channel - one user showing full name", async function (assert) {
+    this.siteSettings.prioritize_username_in_ux = true;
+    this.user = fabricators.user({
+      username: "joffrey",
+      name: "Joffrey Baratheon",
+    });
+    this.channel = fabricators.directMessageChannel({
+      chatable: fabricators.directMessage({ users: [this.user] }),
+    });
+
+    await render(hbs`<ChatChannelTitle @channel={{this.channel}} />`);
+
+    assert
+      .dom(".chat-user-display-name__username.-first")
+      .hasText(this.user.username);
+    assert.dom(".chat-user-display-name__name").hasText(this.user.name);
+  });
+
   test("direct message channel - multiple users", async function (assert) {
     const channel = fabricators.directMessageChannel();
 


### PR DESCRIPTION
Before:
![Screenshot 2023-07-12 at 16 36 27](https://github.com/discourse/discourse/assets/339945/a8614157-9e45-4118-bbaf-a65c92da7679)


After:
![Screenshot 2023-07-12 at 16 28 10](https://github.com/discourse/discourse/assets/339945/9e7e45b9-e9cd-474a-8853-2c58c4c50b7e)

