### PR TITLE
DEV: there is no need anymore to wrap export methods into enumerators

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -120,8 +120,6 @@ module Jobs
     end
 
     def user_list_export
-      return enum_for(:user_list_export) unless block_given?
-
       user_field_ids = UserField.pluck(:id)
 
       condition = {}
@@ -148,8 +146,6 @@ module Jobs
     end
 
     def staff_action_export
-      return enum_for(:staff_action_export) unless block_given?
-
       staff_action_data =
         if @current_user.admin?
           UserHistory.only_staff_actions
@@ -163,24 +159,18 @@ module Jobs
     end
 
     def screened_email_export
-      return enum_for(:screened_email_export) unless block_given?
-
       ScreenedEmail.find_each(order: :desc) do |screened_email|
         yield get_screened_email_fields(screened_email)
       end
     end
 
     def screened_ip_export
-      return enum_for(:screened_ip_export) unless block_given?
-
       ScreenedIpAddress.find_each(order: :desc) do |screened_ip|
         yield get_screened_ip_fields(screened_ip)
       end
     end
 
     def screened_url_export
-      return enum_for(:screened_url_export) unless block_given?
-
       ScreenedUrl
         .select(
           "domain, sum(match_count) as match_count, max(last_match_at) as last_match_at, min(created_at) as created_at",
@@ -191,8 +181,6 @@ module Jobs
     end
 
     def report_export
-      return enum_for(:report_export) unless block_given?
-
       # If dates are invalid consider then `nil`
       if @extra[:start_date].is_a?(String)
         @extra[:start_date] = begin

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Jobs::ExportCsvFile do
 
       group = Fabricate(:group)
       user1 = Fabricate(:user)
-      group_user = Fabricate(:group_user, group: group, user: user1)
+      Fabricate(:group_user, group: group, user: user1)
       user1.user_visits.create!(visited_at: "2010-01-03", posts_read: 420)
 
       exporter.extra["name"] = "visits"
@@ -140,7 +140,7 @@ RSpec.describe Jobs::ExportCsvFile do
 
       exporter.extra["name"] = "top_referred_topics"
       post1 = Fabricate(:post)
-      post2 = Fabricate(:post)
+      Fabricate(:post)
       IncomingLink.add(
         host: "a.com",
         referer: "http://twitter.com",


### PR DESCRIPTION
After fbe0e4c7 we always pass a block into these methods, here:

https://github.com/discourse/discourse/blob/aa9c7dc924ac59a7bb9a45e9ab96f56defbb2037/app/jobs/regular/export_csv_file.rb#L471

So `yield` inside the export methods works and there is no need anymore to wrap them into enumerators. 
