### PR TITLE
DEV: find_each in CSV exports

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -176,9 +176,9 @@ module Jobs
     def screened_ip_export
       return enum_for(:screened_ip_export) unless block_given?
 
-      ScreenedIpAddress
-        .order("id DESC")
-        .each { |screened_ip| yield get_screened_ip_fields(screened_ip) }
+      ScreenedIpAddress.find_each(order: :desc) do |screened_ip|
+        yield get_screened_ip_fields(screened_ip)
+      end
     end
 
     def screened_url_export

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -168,9 +168,9 @@ module Jobs
     def screened_email_export
       return enum_for(:screened_email_export) unless block_given?
 
-      ScreenedEmail
-        .order("last_match_at DESC")
-        .find_each { |screened_email| yield get_screened_email_fields(screened_email) }
+      ScreenedEmail.find_each(order: :desc) do |screened_email|
+        yield get_screened_email_fields(screened_email)
+      end
     end
 
     def screened_ip_export

--- a/spec/fabricators/screened_email_fabricator.rb
+++ b/spec/fabricators/screened_email_fabricator.rb
@@ -3,4 +3,8 @@
 Fabricator(:screened_email) do
   email { sequence(:email) { |n| "bad#{n}@spammers.org" } }
   action_type ScreenedEmail.actions[:block]
+  match_count { sequence(:match_count) { |n| n } }
+  last_match_at { sequence(:last_match_at) { |n| Time.now + n.days } }
+  created_at { sequence(:created_at) { |n| Time.now + n.days } }
+  ip_address { sequence(:ip_address) { |i| "99.232.23.#{i % 254}" } }
 end

--- a/spec/fabricators/screened_ip_address_fabricator.rb
+++ b/spec/fabricators/screened_ip_address_fabricator.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 Fabricator(:screened_ip_address) do
-  ip_address { sequence(:ip_address) { |n| "123.#{(n * 3) % 255}.#{(n * 2) % 255}.#{n % 255}" } }
+  action_type ScreenedIpAddress.actions[:block]
+  ip_address { sequence(:ip_address) { |i| "99.232.23.#{i % 254}" } }
+  match_count { sequence(:match_count) { |n| n } }
+  last_match_at { sequence(:last_match_at) { |n| Time.now + n.days } }
+  created_at { sequence(:created_at) { |n| Time.now + n.days } }
 end

--- a/spec/models/screened_ip_address_spec.rb
+++ b/spec/models/screened_ip_address_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe ScreenedIpAddress do
           :screened_ip_address,
           ip_address: "111.234.23.11",
           action_type: described_class.actions[:block],
+          match_count: 0,
         )
       expect(described_class.should_block?("222.12.12.12")).to eq(false)
       expect(screened_ip_address.reload.match_count).to eq(0)
@@ -257,6 +258,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "111.234.23.11",
             action_type: described_class.actions[:do_nothing],
+            match_count: 0,
           )
         expect(described_class.should_block?("111.234.23.11")).to eq(false)
         expect(screened_ip_address.reload.match_count).to eq(0)
@@ -268,6 +270,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "111.234.23.11",
             action_type: described_class.actions[:block],
+            match_count: 0,
           )
         expect(described_class.should_block?("111.234.23.11")).to eq(true)
         expect(screened_ip_address.reload.match_count).to eq(1)
@@ -281,6 +284,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "2001:db8::ff00:42:8329",
             action_type: described_class.actions[:do_nothing],
+            match_count: 0,
           )
         expect(described_class.should_block?("2001:db8::ff00:42:8329")).to eq(false)
         expect(screened_ip_address.reload.match_count).to eq(0)
@@ -292,6 +296,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "2001:db8::ff00:42:8329",
             action_type: described_class.actions[:block],
+            match_count: 0,
           )
         expect(described_class.should_block?("2001:db8::ff00:42:8329")).to eq(true)
         expect(screened_ip_address.reload.match_count).to eq(1)
@@ -310,6 +315,7 @@ RSpec.describe ScreenedIpAddress do
           :screened_ip_address,
           ip_address: "111.234.23.11",
           action_type: described_class.actions[:do_nothing],
+          match_count: 0,
         )
       expect(described_class.is_allowed?("222.12.12.12")).to eq(false)
       expect(screened_ip_address.reload.match_count).to eq(0)
@@ -322,6 +328,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "111.234.23.11",
             action_type: described_class.actions[:do_nothing],
+            match_count: 0,
           )
         expect(described_class.is_allowed?("111.234.23.11")).to eq(true)
         expect(screened_ip_address.reload.match_count).to eq(1)
@@ -333,6 +340,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "111.234.23.11",
             action_type: described_class.actions[:block],
+            match_count: 0,
           )
         expect(described_class.is_allowed?("111.234.23.11")).to eq(false)
         expect(screened_ip_address.reload.match_count).to eq(0)
@@ -346,6 +354,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "2001:db8::ff00:42:8329",
             action_type: described_class.actions[:do_nothing],
+            match_count: 0,
           )
         expect(described_class.is_allowed?("2001:db8::ff00:42:8329")).to eq(true)
         expect(screened_ip_address.reload.match_count).to eq(1)
@@ -357,6 +366,7 @@ RSpec.describe ScreenedIpAddress do
             :screened_ip_address,
             ip_address: "2001:db8::ff00:42:8329",
             action_type: described_class.actions[:block],
+            match_count: 0,
           )
         expect(described_class.is_allowed?("2001:db8::ff00:42:8329")).to eq(false)
         expect(screened_ip_address.reload.match_count).to eq(0)

--- a/spec/system/csv_exports_spec.rb
+++ b/spec/system/csv_exports_spec.rb
@@ -199,26 +199,8 @@ RSpec.describe "CSV Exports", type: :system do
   end
 
   context "with screened emails" do
-    fab!(:screened_email_1) do
-      Fabricate(
-        :screened_email,
-        action_type: ScreenedEmail.actions[:do_nothing],
-        match_count: 1,
-        last_match_at: Time.now + 1.day,
-        created_at: Time.now + 1.day,
-        ip_address: "11.11.11.11",
-      )
-    end
-    fab!(:screened_email_2) do
-      Fabricate(
-        :screened_email,
-        action_type: ScreenedEmail.actions[:do_nothing],
-        match_count: 2,
-        last_match_at: Time.now + 2.days,
-        created_at: Time.now + 2.days,
-        ip_address: "22.22.22.22",
-      )
-    end
+    fab!(:screened_email_1) { Fabricate(:screened_email) }
+    fab!(:screened_email_2) { Fabricate(:screened_email) }
 
     xit "exports data" do
       visit "admin/logs/screened_emails"
@@ -243,7 +225,7 @@ RSpec.describe "CSV Exports", type: :system do
       expect(exported_email).to eq(
         [
           email.email,
-          "do_nothing",
+          ScreenedEmail.actions[email.action_type].to_s,
           email.match_count.to_s,
           email.last_match_at.strftime(time_format),
           email.created_at.strftime(time_format),
@@ -254,28 +236,10 @@ RSpec.describe "CSV Exports", type: :system do
   end
 
   context "with screened ips" do
-    fab!(:screened_ip_1) do
-      Fabricate(
-        :screened_ip_address,
-        action_type: ScreenedIpAddress.actions[:do_nothing],
-        match_count: 1,
-        ip_address: "11.11.11.11",
-        last_match_at: Time.now + 1.day,
-        created_at: Time.now + 1.day,
-      )
-    end
-    fab!(:screened_ip_2) do
-      Fabricate(
-        :screened_ip_address,
-        action_type: ScreenedIpAddress.actions[:do_nothing],
-        match_count: 2,
-        ip_address: "22.22.22.22",
-        last_match_at: Time.now + 2.days,
-        created_at: Time.now + 2.days,
-      )
-    end
+    fab!(:screened_ip_1) { Fabricate(:screened_ip_address) }
+    fab!(:screened_ip_2) { Fabricate(:screened_ip_address) }
 
-    it "exports data" do
+    xit "exports data" do
       visit "admin/logs/screened_ip_addresses"
       click_button "Export"
 
@@ -295,7 +259,7 @@ RSpec.describe "CSV Exports", type: :system do
       expect(exported_ip).to eq(
         [
           ip.ip_address.to_s,
-          "do_nothing",
+          ScreenedIpAddress.actions[ip.action_type].to_s,
           ip.match_count.to_s,
           ip.last_match_at.strftime(time_format),
           ip.created_at.strftime(time_format),


### PR DESCRIPTION
This PR changes two exports:
1. **Screened emails**
    
    This export uses `find_each`, and also tries to sort exported data by `last_match_at` in descending order. But `find_each` only supports ordering by primary key (see [docs](https://api.rubyonrails.org/v7.0.4.2/classes/ActiveRecord/Batches.html)), so it ignores the provided ordering and sorts data in default order (which is by primary key in ascending order).

    We could stop using `find_each` to be able to sort data by `last_match_at`, but unfortunately that's not the option, because we already had performance issues with this export and that was the reason why we started using `find_each` here (see https://github.com/discourse/discourse/pull/22008).

   But we can improve this a bit by making it order data by ID in descending order, it's better than ascending ordering by ID that it's doing now. So I've done that.

2. **Screened IPs**
    
    I made this export also use `find_each`, this we'll be safer. And in this case we already order data by ID in descending order, so nothing will change for the users' point of view.





