### PR TITLE
redirect to /login after account delete to prevent recreation of sso account

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/logout.js
+++ b/app/assets/javascripts/discourse/app/lib/logout.js
@@ -12,5 +12,5 @@ export default function logout({ redirect } = {}) {
     return;
   }
 
-  window.location.href = getURL("/");
+  window.location.href = getURL("/login");
 }


### PR DESCRIPTION
context: https://meta.discourse.org/t/self-deleting-an-account-with-sso-only-login-does-not-redirect-to-logout-redirect-but-the-auth-url-causing-a-loop/270443