### PR TITLE
DEV: Attempt to fix flaky chat system test

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -286,16 +286,19 @@ RSpec.describe "Navigation", type: :system do
 
     context "when re-opening full page chat after navigating to a channel" do
       it "opens full page chat on correct channel" do
+        chat_channel_path = chat.channel_path(category_channel_2.slug, category_channel_2.id)
+
         visit("/")
         chat_page.open_from_header
         chat_drawer_page.maximize
         sidebar_page.open_channel(category_channel_2)
         find("#site-logo").click
+
+        expect(chat_page).to have_right_header_href(chat_channel_path)
+
         chat_page.open_from_header
 
-        expect(page).to have_current_path(
-          chat.channel_path(category_channel_2.slug, category_channel_2.id),
-        )
+        expect(page).to have_current_path(chat_channel_path)
         expect(page).to have_content(category_channel_2.title)
       end
     end

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -21,6 +21,10 @@ module PageObjects
         find(".chat-header-icon").click
       end
 
+      def has_right_header_href?(href)
+        find(".chat-header-icon").has_link?(href: href)
+      end
+
       def open
         visit("/chat")
       end


### PR DESCRIPTION
Why this change?

The following test is flaky on our CI:

```
  1) Navigation when sidebar is configured as the navigation menu when re-opening full page chat after navigating to a channel opens full page chat on correct channel
     Failure/Error: measurement = Benchmark.measure { example.run }
       expected "/" to equal "/chat/c/random-9/17"
```

The theory here is that system tests is running too fast that we're not
giving the href for the chat header icon a chance to update before
clicking on it. Therefore, we're adding an additional assertion to
assert that the link has the right href before clicking on it.