### PR TITLE
DEV: Fix reply to spec

### DIFF
--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: tru
 
       expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(1)
 
-      channel_page.reply_to(original_message)
+      channel_page.message_thread_indicator(original_message).click
       thread_page.send_message("reply to message")
 
       expect(thread_page.messages).to have_message(text: message_1.message)


### PR DESCRIPTION
Not sure how this was even working previously, since it's trying
to press the reply button on a thread original message, which doesn't
work, you need to click the indicator to open the thread.
