### PR TITLE
DEV: Remove deprecated Category#url_with_id method

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -893,16 +893,6 @@ class Category < ActiveRecord::Base
     end
   end
 
-  def url_with_id
-    Discourse.deprecate(
-      "Category#url_with_id is deprecated. Use `Category#url` instead.",
-      output_in_test: true,
-      drop_from: "2.9.0",
-    )
-
-    url
-  end
-
   # If the name changes, try and update the category definition topic too if it's an exact match
   def rename_category_definition
     return unless topic.present?


### PR DESCRIPTION
### What is this change?

This method has been deprecated (replaced by `Category#url`) and marked for removal in 2.9.0. This PR removes it.

### Verification

- [x] Searched through logs for all hosting for deprecation warnings. None found.
- [x] Searched through all public and private Discourse repos for usage. Only used in `discourse-tagging` plugin which was pulled into core 7 years ago, and has since been archived. 