### PR TITLE
DEV: Rename method PageObjects::Pages::Chat

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe "Navigation", type: :system do
         sidebar_page.open_channel(category_channel_2)
         find("#site-logo").click
 
-        expect(chat_page).to have_right_header_href(chat_channel_path)
+        expect(chat_page).to have_header_href(chat_channel_path)
 
         chat_page.open_from_header
 

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -21,7 +21,7 @@ module PageObjects
         find(".chat-header-icon").click
       end
 
-      def has_right_header_href?(href)
+      def has_header_href?(href)
         find(".chat-header-icon").has_link?(href: href)
       end
 


### PR DESCRIPTION
`has_right_header_href?` is a little verbose and `has_header_href?` has
the same meaning.