### PR TITLE
FIX: prevent default event on touchend reaction

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
@@ -90,6 +90,8 @@ export default class ChatMessageReaction extends Component {
 
   @action
   onTouchEnd(event) {
+    event.preventDefault();
+
     if (this.touching) {
       this.handleClick(event);
     }


### PR DESCRIPTION
This was causing this event to cause other touch events down the road. For example click a reaction above the composer when the message action was opened could cause the composer to gain focus after the reaction was made.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
