### PR TITLE
FIX: show only context menu on img long press

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -281,8 +281,12 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  onLongPressStart() {
+  onLongPressStart(element, event) {
     if (!this.args.message.expanded) {
+      return;
+    }
+
+    if (event.target.tagName === "IMG") {
       return;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -312,7 +312,11 @@ export default class ChatMessage extends Component {
   }
 
   @action
-  onLongPressEnd() {
+  onLongPressEnd(element, event) {
+    if (event.target.tagName === "IMG") {
+      return;
+    }
+
     cancel(this._makeMessageActiveHandler);
     this.isActive = false;
 


### PR DESCRIPTION
Prior to this commit a long press on the image of a chat message would trigger both the actions menu and the contextual menu. This commit ensures we only show the contextual menu in this case.

No test as it's a quite complex behavior to reproduce (would need android for example).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
