### PR TITLE
DEV: Improve ember-cli 'LOAD_PLUGINS' behavior

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -7,7 +7,7 @@ const path = require("path");
 const fs = require("fs");
 const fsPromises = fs.promises;
 const { JSDOM } = require("jsdom");
-const { shouldLoadPluginTestJs } = require("discourse-plugins");
+const { shouldLoadPlugins } = require("discourse-plugins");
 const { Buffer } = require("node:buffer");
 const { cwd, env } = require("node:process");
 
@@ -390,7 +390,7 @@ module.exports = {
   },
 
   contentFor(type, config) {
-    if (shouldLoadPluginTestJs() && type === "test-plugin-js") {
+    if (shouldLoadPlugins() && type === "test-plugin-js") {
       const scripts = [];
 
       const pluginInfos = this.app.project
@@ -431,7 +431,7 @@ module.exports = {
             `<script src="${config.rootURL}assets/${src}" data-discourse-plugin="${name}"></script>`
         )
         .join("\n");
-    } else if (shouldLoadPluginTestJs() && type === "test-plugin-tests-js") {
+    } else if (shouldLoadPlugins() && type === "test-plugin-tests-js") {
       return this.app.project
         .findAddonByName("discourse-plugins")
         .pluginInfos()
@@ -441,7 +441,7 @@ module.exports = {
             `<script src="${config.rootURL}assets/plugins/test/${directoryName}_tests.js" data-discourse-plugin="${pluginName}"></script>`
         )
         .join("\n");
-    } else if (shouldLoadPluginTestJs() && type === "test-plugin-css") {
+    } else if (shouldLoadPlugins() && type === "test-plugin-css") {
       return `<link rel="stylesheet" href="${config.rootURL}bootstrap/plugin-css-for-tests.css" data-discourse-plugin="_all" />`;
     }
   },

--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -135,6 +135,9 @@ module.exports = {
   },
 
   generatePluginsTree() {
+    if (!this.shouldLoadPlugins()) {
+      return mergeTrees([]);
+    }
     const appTree = this._generatePluginAppTree();
     const testTree = this._generatePluginTestTree();
     const adminTree = this._generatePluginAdminTree();
@@ -227,7 +230,16 @@ module.exports = {
     return;
   },
 
-  shouldLoadPluginTestJs() {
-    return EmberApp.env() === "development" || process.env.LOAD_PLUGINS === "1";
+  // Matches logic from GlobalSetting.load_plugins? in the ruby app
+  shouldLoadPlugins() {
+    if (process.env.LOAD_PLUGINS === "1") {
+      return true;
+    } else if (process.env.LOAD_PLUGINS === "0") {
+      return false;
+    } else if (EmberApp.env() === "test") {
+      return false;
+    } else {
+      return true;
+    }
   },
 };

--- a/app/assets/javascripts/discourse/lib/site-settings-plugin.js
+++ b/app/assets/javascripts/discourse/lib/site-settings-plugin.js
@@ -5,7 +5,7 @@ const concat = require("broccoli-concat");
 const mergeTrees = require("broccoli-merge-trees");
 const deepmerge = require("deepmerge");
 const glob = require("glob");
-const { shouldLoadPluginTestJs } = require("discourse-plugins");
+const { shouldLoadPlugins } = require("discourse-plugins");
 
 let built = false;
 
@@ -72,7 +72,7 @@ module.exports.parsePluginClientSettings = function (
 ) {
   let settings = [discourseRoot + "/config"];
 
-  if (shouldLoadPluginTestJs()) {
+  if (shouldLoadPlugins()) {
     const pluginInfos = app.project
       .findAddonByName("discourse-plugins")
       .pluginInfos();

--- a/app/assets/javascripts/discourse/lib/translation-plugin.js
+++ b/app/assets/javascripts/discourse/lib/translation-plugin.js
@@ -6,7 +6,7 @@ const mergeTrees = require("broccoli-merge-trees");
 const MessageFormat = require("messageformat");
 const deepmerge = require("deepmerge");
 const glob = require("glob");
-const { shouldLoadPluginTestJs } = require("discourse-plugins");
+const { shouldLoadPlugins } = require("discourse-plugins");
 
 let built = false;
 
@@ -96,7 +96,7 @@ module.exports = function translatePlugin(...params) {
 module.exports.createI18nTree = function (discourseRoot, vendorJs) {
   let translations = [discourseRoot + "/config/locales"];
 
-  if (shouldLoadPluginTestJs()) {
+  if (shouldLoadPlugins()) {
     translations = translations.concat(
       glob
         .sync(discourseRoot + "/plugins/*/config/locales/client.en.yml")

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -1,5 +1,5 @@
 const TapReporter = require("testem/lib/reporters/tap_reporter");
-const { shouldLoadPluginTestJs } = require("discourse-plugins");
+const { shouldLoadPlugins } = require("discourse-plugins");
 const fs = require("fs");
 
 class Reporter {
@@ -139,7 +139,7 @@ if (process.argv.includes("-t")) {
       });
     },
   ];
-} else if (shouldLoadPluginTestJs()) {
+} else if (shouldLoadPlugins()) {
   // Running with ember cli, but we want to pass through plugin request to Rails
   module.exports.proxies = {
     "/assets/plugins/*_extra.js": {


### PR DESCRIPTION
Our ember-cli config now follows the same behavior as Discourse core. LOAD_PLUGINS=0 will prevent any plugin assets from being compiled/served.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
