### PR TITLE
DEV: Simplify qunit target selection

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-load-dynamic-js.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-load-dynamic-js.js
@@ -1,7 +1,8 @@
 const dynamicJsTemplate = document.querySelector("#dynamic-test-js");
 
 const params = new URLSearchParams(document.location.search);
-const skipPlugins = params.get("qunit_skip_plugins");
+const target = params.get("target");
+const skipPlugins = !target || target === "core";
 
 (async function setup() {
   for (const element of dynamicJsTemplate.content.childNodes) {

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -25,7 +25,8 @@ document.addEventListener("discourse-booted", () => {
   }
 
   const params = new URLSearchParams(window.location.search);
-  const skipCore = params.get("qunit_skip_core") === "1";
+  const target = params.get("target");
+  const testingCore = !target || target === "core";
   const disableAutoStart = params.get("qunit_disable_auto_start") === "1";
 
   Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = false;
@@ -60,7 +61,7 @@ document.addEventListener("discourse-booted", () => {
     setupTestContainer: false,
     loadTests: false,
     startTests: !disableAutoStart,
-    setupEmberOnerrorValidation: !skipCore,
+    setupEmberOnerrorValidation: testingCore,
     setupTestIsolationValidation: true,
   });
 });

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -209,14 +209,17 @@ task "plugin:qunit", %i[plugin timeout] do |t, args|
   rake = "#{Rails.root}/bin/rake"
 
   cmd = "LOAD_PLUGINS=1 "
-  cmd += "QUNIT_SKIP_CORE=1 "
 
-  if args[:plugin] == "*"
-    puts "Running qunit tests for all plugins"
-  else
-    puts "Running qunit tests for #{args[:plugin]}"
-    cmd += "QUNIT_SINGLE_PLUGIN='#{args[:plugin]}' "
-  end
+  target =
+    if args[:plugin] == "*"
+      puts "Running qunit tests for all plugins"
+      "plugins"
+    else
+      puts "Running qunit tests for #{args[:plugin]}"
+      args[:plugin]
+    end
+
+  cmd += "TARGET='#{target}' "
 
   cmd += "#{rake} qunit:test"
   cmd += "[#{args[:timeout]}]" if args[:timeout]

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -69,6 +69,7 @@ task "qunit:test", %i[timeout qunit_path filter] do |_, args|
       theme_name
       theme_url
       theme_id
+      target
     ].each { |arg| options[arg] = ENV[arg.upcase] if ENV[arg.upcase].present? }
 
     options["report_requests"] = "1" if report_requests


### PR DESCRIPTION
Previously we had three query parameters to control which tests would be run. The default was to run all core/plugin tests together, which would almost always lead to errors and does not match the way we run tests in CI.

This commit removes the three old parameters (skip_core, skip_plugins and single_plugin), and introduces a new 'target' parameter. This can have a value of 'core', 'plugins', or a specific plugin name. The default is 'core'. Attempting to use the old parameters will raise an error.

Before:

<img width="730" alt="SCR-20230713-leal" src="https://github.com/discourse/discourse/assets/6270921/8b505a8c-f247-4ca0-908a-44fa72f03526">

After:

<img width="547" alt="SCR-20230713-ldns" src="https://github.com/discourse/discourse/assets/6270921/4aec8736-d4fb-4e48-af08-5e4f9479c623">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
