### PR TITLE
DEV: Remove deprecated Reviewable#post_options method

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -367,14 +367,6 @@ class Reviewable < ActiveRecord::Base
     status_previously_changed?(from: "pending")
   end
 
-  def post_options
-    Discourse.deprecate(
-      "Reviewable#post_options is deprecated. Please use #payload instead.",
-      output_in_test: true,
-      drop_from: "2.9.0",
-    )
-  end
-
   def self.bulk_perform_targets(performed_by, action, type, target_ids, args = nil)
     args ||= {}
     viewable_by(performed_by)


### PR DESCRIPTION
### What is this change?

The attribute `Reviewable#post_options` was deprecated (and replaced by `#payload`) four years ago, and marked for deletion in 2.9.0. This commit removes it.

### Verification.

- [x] Searched through the logs of all hosting for deprecation notices. None found.
- [x] Searched public and private repositories in Discourse for usages. None found.
- [x] The method is a no-op with a deprecation warning, so no-one can be relying on it anyway.