### PR TITLE
DEV: Add a test for api scope routes

### DIFF
--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -435,7 +435,26 @@ RSpec.describe Admin::ApiController do
           "wordpress",
         )
 
-        expect(scopes["topics"].any? { |h| h["urls"].include?("/latest.rss (GET)") }).to be_truthy
+        topic_routes = [
+          "/t/:id (GET)",
+          "/t/external_id/:external_id (GET)",
+          "/t/:slug/:topic_id/print (GET)",
+          "/t/:slug/:topic_id/summary (GET)",
+          "/t/:topic_id/summary (GET)",
+          "/t/:topic_id/:post_number (GET)",
+          "/t/:topic_id/last (GET)",
+          "/t/:slug/:topic_id.rss (GET)",
+          "/t/:slug/:topic_id (GET)",
+          "/t/:slug/:topic_id/:post_number (GET)",
+          "/t/:slug/:topic_id/last (GET)",
+          "/t/:topic_id/posts (GET)",
+          "/latest.rss (GET)",
+        ]
+
+        topic_routes.each do |route|
+          expect(scopes["topics"].any? { |h| h["urls"].include?(route) }).to be_truthy
+        end
+
         expect(scopes["posts"].any? { |h| h["urls"].include?("/posts (GET)") }).to be_truthy
         expect(scopes["posts"].any? { |h| h["urls"].include?("/private-posts (GET)") }).to be_truthy
       end


### PR DESCRIPTION
Follow up to: 56e792d

Adds a test to check that there is an api scope for the t/external_id
route. Plus checks many other topic routes that should have scopes.
