### PR TITLE
FIX: ensures lightbox sends valid color to react-native

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lightbox/helpers/site-theme-color.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox/helpers/site-theme-color.js
@@ -6,7 +6,7 @@ export async function getSiteThemeColor() {
 }
 
 export async function setSiteThemeColor(color = "000000") {
-  const _color = `#${color}`;
+  const _color = `#${color.replace(/^#*/, "")}`;
 
   const siteThemeColor = document.querySelector('meta[name="theme-color"]');
 


### PR DESCRIPTION
Prior to this commit the `setSiteThemeColor` could mistakenly receive a color with a leading `#` which would cause an invalid color to be send to `postRNWebviewMessage` and would eventually cause a crash if we try to interpolate between this color and another.

This commit ensures that whatever format is given to `setSiteThemeColor` we will have a proper color:

```
675645 // #675645
#675645 // #675645
##675645 // #675645
```