### PR TITLE
FEATURE: allow sidebar section api to create external links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
@@ -17,6 +17,7 @@
         @route={{link.route}}
         @model={{link.model}}
         @models={{link.models}}
+        @href={{link.href}}
         @title={{link.title}}
         @contentCSSClass={{link.contentCSSClass}}
         @prefixColor={{link.prefixColor}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section-link.js
@@ -19,9 +19,12 @@ export default class BaseCustomSidebarSectionLink {
   /**
    * @returns {string} The Ember route which the section link should link to.
    */
-  get route() {
-    this._notImplemented();
-  }
+  get route() {}
+
+  /**
+   * @returns {string} URL to external website which the section link should link to.
+   */
+  get href() {}
 
   /**
    * @returns {Object} `model` argument for the <LinkTo> component. See https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo.

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -206,6 +206,28 @@ acceptance("Sidebar - Plugin API", function (needs) {
                     return "hover button title attribute";
                   }
                 })(),
+
+                new (class extends BaseCustomSidebarSectionLink {
+                  get name() {
+                    return "homepage";
+                  }
+
+                  get classNames() {
+                    return "my-class-name";
+                  }
+
+                  get href() {
+                    return "https://www.discourse.org";
+                  }
+
+                  get title() {
+                    return "Homepage";
+                  }
+
+                  get text() {
+                    return "Homepage";
+                  }
+                })(),
               ];
             }
           };
@@ -347,6 +369,18 @@ acceptance("Sidebar - Plugin API", function (needs) {
       links[2].children[0].children[0].getAttribute("src"),
       "/test.png",
       "uses correct prefix image url"
+    );
+
+    assert.strictEqual(
+      links[3].title,
+      "Homepage",
+      "displays external link with correct title attribute"
+    );
+
+    assert.strictEqual(
+      links[3].href,
+      "https://www.discourse.org/",
+      "displays external link with correct href attribute"
     );
 
     assert.strictEqual(


### PR DESCRIPTION
Right now, sidebar API allows creating sections with internal links. 
It should be extended to allow creating links to external URLs as well.

