### PR TITLE
FIX: created_at datetime format inconsistencies in chat

### DIFF
--- a/plugins/chat/app/serializers/chat/last_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/last_message_serializer.rb
@@ -7,5 +7,9 @@ module Chat
     # created_at. In future we may want to serialize more for this, at which
     # point we need to check existing code so we don't introduce N1s.
     attributes *Chat::MessageSerializer::BASIC_ATTRIBUTES
+
+    def created_at
+      object.created_at.iso8601
+    end
   end
 end

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -111,8 +111,12 @@ module Chat
       object.revisions.any?
     end
 
+    def created_at
+      object.created_at.iso8601
+    end
+
     def deleted_at
-      object.user ? object.deleted_at : Time.zone.now
+      object.user ? object.deleted_at.iso8601 : Time.zone.now
     end
 
     def deleted_by_id

--- a/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
@@ -20,7 +20,7 @@ module Chat
     end
 
     def last_reply_created_at
-      object.last_message.created_at
+      object.last_message.created_at.iso8601
     end
 
     def last_reply_id

--- a/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
@@ -295,7 +295,8 @@ RSpec.describe Chat::Api::ChannelsController do
               }
           messages = response.parsed_body["chat_messages"]
           expect(messages.count).to eq(page_size)
-          expect(messages.first["created_at"].to_time).to be < messages.last["created_at"].to_time
+          expect(messages.first["id"]).to eq(message_40.id)
+          expect(messages.last["id"]).to eq(message_69.id)
         end
 
         it "returns `can_flag=true` for public channels" do
@@ -437,8 +438,8 @@ RSpec.describe Chat::Api::ChannelsController do
                 }
             messages = response.parsed_body["chat_messages"]
             expect(messages.count).to eq(page_size)
-            expect(messages.first["created_at"].to_time).to eq_time(message_10.created_at)
-            expect(messages.last["created_at"].to_time).to eq_time(message_39.created_at)
+            expect(messages.first["id"]).to eq(message_10.id)
+            expect(messages.last["id"]).to eq(message_39.id)
           end
 
           it "returns 'can_load...' properly when there are more past messages" do
@@ -477,8 +478,8 @@ RSpec.describe Chat::Api::ChannelsController do
                 }
             messages = response.parsed_body["chat_messages"]
             expect(messages.count).to eq(page_size)
-            expect(messages.first["created_at"].to_time).to eq_time(message_11.created_at)
-            expect(messages.last["created_at"].to_time).to eq_time(message_40.created_at)
+            expect(messages.first["id"]).to eq(message_11.id)
+            expect(messages.last["id"]).to eq(message_40.id)
           end
 
           it "return 'can_load..' properly when there are future messages" do

--- a/plugins/chat/spec/system/page_objects/chat/components/thread_list.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_list.rb
@@ -40,7 +40,7 @@ module PageObjects
         end
 
         def last_reply_datetime_selector(last_reply)
-          ".chat-thread-list-item__last-reply .relative-date[data-time='#{(last_reply.created_at.to_f * 1000).to_i}']"
+          ".chat-thread-list-item__last-reply .relative-date[data-time='#{(last_reply.created_at.iso8601.to_time.to_f * 1000).to_i}']"
         end
 
         def has_no_unread_item?(id)


### PR DESCRIPTION
This commit attempts to fix an issue where we are ending
up with bad created_at date formats for last messages, which
is breaking the DM sort order and sometimes causing DM channels
to fall off the list, or show "Invalid date" on mobile.

I have not been able to consistently reproduce these issues
locally, however the serialzier for the channels index uses
MultiJSON.dump() and the Chat::Publisher uses .to_json, both of
which format created_at differently for messages.

The former is `2023-07-05T06:53:25.977Z` (iso8601).

The latter is `2023-07-14 03:59:22 UTC` (.to_s default).

Since we are doing comparison and sorting of these dates on the UI
we need consistent formatting for the JS Date parsers (and moment)
to deal with.

If the issue still occurs after this we can investigate further.
