### PR TITLE
FIX: don't block lightbox setup while first image loads

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-lightbox.js
+++ b/app/assets/javascripts/discourse/app/components/d-lightbox.js
@@ -192,7 +192,7 @@ export default class DLightbox extends Component {
   }
 
   @bind
-  async open({ items, startingIndex, callbacks, options }) {
+  open({ items, startingIndex, callbacks, options }) {
     this.options = options;
 
     this.items = items;
@@ -202,7 +202,7 @@ export default class DLightbox extends Component {
     this.isLoading = true;
     this.isVisible = true;
 
-    await this.#setCurrentItem(this.currentIndex);
+    this.#setCurrentItem(this.currentIndex);
 
     if (
       this.options.zoomOnOpen &&


### PR DESCRIPTION
### The Problem

Clicking on a large image opens lightbox, however the new lightbox currently waits for the first image to finish loading before it finishes loading the lightbox UI correctly (ie. background color). This makes the visual experience feel broken.

Because `open()` is waiting for the image to load, it doesn't trigger the `onOpen` callback, which appends a `.has-lightbox` class to the html tag. The lightbox background color requires that css class to be set for the styles to be applied correctly.

### The Solution
 
This PR prevents blocking when loading loading the first image (image that was clicked) within the lightbox, and therefore allows the css class to be appended to the html tag correctly and as a result fixing the styling issues.

The `#setCurrentItem ` function is async and awaits the loading of `preloadItemImages` already, so the image will load correctly when complete despite the rest of the UI loading in advance.

Note:
There is no tests added for this because it's quite a minimal change and also difficult to test. It's tricky because it requires a large image file size and a slow connection speed to see the issue (ie. throttling the connection).

In theory we could have a test that checks for the class on the html tag like but would potentially create a race condition:
```
assert.strictEqual(
  document.documentElement.classList.contains("has-lightbox"),
  true,
  "html tag has correct class appended"
);
```
