### PR TITLE
DEV: Add missing report filter type in bookmarks report

### DIFF
--- a/app/models/concerns/reports/bookmarks.rb
+++ b/app/models/concerns/reports/bookmarks.rb
@@ -8,7 +8,7 @@ module Reports::Bookmarks
       report.icon = "bookmark"
 
       category_filter = report.filters.dig(:category)
-      report.add_filter("category", default: category_filter)
+      report.add_filter("category", type: "category", default: category_filter)
 
       report.data = []
       Bookmark

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -129,14 +129,6 @@ class Report
   end
 
   def add_filter(name, options = {})
-    if options[:type].blank?
-      options[:type] = name
-      Discourse.deprecate(
-        "#{name} filter should define a `:type` option. Temporarily setting type to #{name}.",
-        drop_from: "2.9.0",
-      )
-    end
-
     available_filters[name] = options
   end
 


### PR DESCRIPTION
### What is this change?

Adding a filter without a `type` parameter has been deprecated for the last three years, and was marked for removal in 2.9.0. 

During this time we have had a few deprecation warnings in logs coming from `Reports::Bookmarks`.

The fallback was to set the type to the name of the filter. This change just passes the type (same as name) explicitly instead, and removes the deprecation fallback.

### Verification

- [x] I have searched the logs of all our hosting. There are a total of 5 deprecation warnings. All from `Reports::Bookmarks` usage.
- [x] I have searched the public and private GitHub repos for additional usages without `type`. None found. 