### PR TITLE
DEV: Use thumbnail url for wikimedia onebox image

### DIFF
--- a/lib/onebox/templates/wikimedia.mustache
+++ b/lib/onebox/templates/wikimedia.mustache
@@ -1,3 +1,3 @@
-{{#image}}<img src="{{image}}" class="thumbnail">{{/image}}
+{{#image}}<img src="{{thumbnail}}" class="thumbnail">{{/image}}
 
 <h3><a href="{{link}}" target="_blank" rel="noopener">{{title}}</a></h3>

--- a/spec/lib/onebox/engine/wikimedia_onebox_spec.rb
+++ b/spec/lib/onebox/engine/wikimedia_onebox_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Onebox::Engine::WikimediaOnebox do
 
   it "has the image" do
     expect(html).to include(
-      "https://upload.wikimedia.org/wikipedia/commons/a/af/Stones_members_montage2.jpg",
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/Stones_members_montage2.jpg/500px-Stones_members_montage2.jpg",
     )
   end
 end


### PR DESCRIPTION
Wikimedia provides a thumbnail url for its images, so we should use that
for oneboxes instead of the full-size image. Because the size of the
  onebox image we display is quite small anyways the thumbnail wikimedia
  provides should suffice and will save bandwidth.

See: https://meta.discourse.org/t/264039
