### PR TITLE
DEV: Skip srcset for onebox thumbnails

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -238,7 +238,7 @@ class CookedPostProcessor
       srcset = +""
 
       # Skip srcset for onebox images. Because onebox thumbnails by default
-      # are fairly small the width and height of the image is likely larger
+      # are fairly small the width/height of the smallest thumbnail is likely larger
       # than what the onebox thumbnail size will be displayed at, so we shouldn't
       # need to upscale for retina devices
       if !onebox

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -228,6 +228,7 @@ class CookedPostProcessor
 
   def optimize_image!(img, upload, cropped: false)
     w, h = img["width"].to_i, img["height"].to_i
+    onebox = img.ancestors(".onebox, .onebox-body").first
 
     # note: optimize_urls cooks the src further after this
     thumbnail = upload.thumbnail(w, h)
@@ -236,21 +237,27 @@ class CookedPostProcessor
 
       srcset = +""
 
-      each_responsive_ratio do |ratio|
-        resized_w = (w * ratio).to_i
-        resized_h = (h * ratio).to_i
+      # Skip srcset for onebox images. Because onebox thumbnails by default
+      # are fairly small the width and height of the image is likely larger
+      # than what the onebox thumbnail size will be displayed at, so we shouldn't
+      # need to upscale for retina devices
+      if !onebox
+        each_responsive_ratio do |ratio|
+          resized_w = (w * ratio).to_i
+          resized_h = (h * ratio).to_i
 
-        if !cropped && upload.width && resized_w > upload.width
-          cooked_url = UrlHelper.cook_url(upload.url, secure: @post.with_secure_uploads?)
-          srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0\z/, "")}x"
-        elsif t = upload.thumbnail(resized_w, resized_h)
-          cooked_url = UrlHelper.cook_url(t.url, secure: @post.with_secure_uploads?)
-          srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0\z/, "")}x"
+          if !cropped && upload.width && resized_w > upload.width
+            cooked_url = UrlHelper.cook_url(upload.url, secure: @post.with_secure_uploads?)
+            srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0\z/, "")}x"
+          elsif t = upload.thumbnail(resized_w, resized_h)
+            cooked_url = UrlHelper.cook_url(t.url, secure: @post.with_secure_uploads?)
+            srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0\z/, "")}x"
+          end
+
+          img[
+            "srcset"
+          ] = "#{UrlHelper.cook_url(img["src"], secure: @post.with_secure_uploads?)}#{srcset}" if srcset.present?
         end
-
-        img[
-          "srcset"
-        ] = "#{UrlHelper.cook_url(img["src"], secure: @post.with_secure_uploads?)}#{srcset}" if srcset.present?
       end
     else
       img["src"] = upload.url

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1042,7 +1042,9 @@ RSpec.describe CookedPostProcessor do
 
       doc = Nokogiri::HTML5.fragment(cpp.html)
       expect(doc.css(".lightbox-wrapper").size).to eq(0)
-      expect(doc.css("img").first["srcset"]).to_not eq(nil)
+      expect(doc.css("img").first["srcset"]).to eq(nil)
+      expect(doc.css("img").first["src"]).to include("optimized")
+      expect(doc.css("img").first["src"]).to include("512x384")
     end
   end
 


### PR DESCRIPTION
In an effort to preserve bandwidth especially for mobile devices this
change will prevent upscaled srcset attributes from being added to
onebox thumbnail images.

Besides checking the html for onebox classes, our database structure for
uploads does not distinguish between regular images and onebox thumbnail
images, but all upload images in discourse do have a thumbnail. By
default this thumbnail is what is used for the non-upscaled image for
onebox images, so we should only use that thumbnail. Because the
rendered onebox image size is likely smaller than the upload thumbnail
size there really shouldn't be a need to upscale.
