### PR TITLE
DEV: Set ember edition to Octane

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/component-templates.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/component-templates.js
@@ -1,5 +1,6 @@
 import DiscourseTemplateMap from "discourse-common/lib/discourse-template-map";
 import * as GlimmerManager from "@glimmer/manager";
+import ClassicComponent from "@ember/component";
 
 const COLOCATED_TEMPLATE_OVERRIDES = new Map();
 
@@ -38,6 +39,10 @@ export default {
         const overrideTemplate = require(finalOverrideModuleName).default;
 
         COLOCATED_TEMPLATE_OVERRIDES.set(component, overrideTemplate);
+      } else if (!component) {
+        // Plugin/theme component template with no backing class.
+        // Treat as classic component to emulate pre-template-only-glimmer-component behaviour.
+        owner.register(`component:${componentName}`, ClassicComponent);
       }
     });
   },

--- a/app/assets/javascripts/discourse/config/optional-features.json
+++ b/app/assets/javascripts/discourse/config/optional-features.json
@@ -1,4 +1,6 @@
 {
   "application-template-wrapper": false,
-  "default-async-observers": true
+  "default-async-observers": true,
+  "jquery-integration": true,
+  "template-only-glimmer-components": true
 }

--- a/app/assets/javascripts/discourse/lib/deprecation-silencer.js
+++ b/app/assets/javascripts/discourse/lib/deprecation-silencer.js
@@ -1,7 +1,5 @@
 const SILENCED_WARN_PREFIXES = [
   "Setting the `jquery-integration` optional feature flag",
-  "The Ember Classic edition has been deprecated",
-  "Setting the `template-only-glimmer-components` optional feature flag to `false`",
   "DEPRECATION: Invoking the `<LinkTo>` component with positional arguments is deprecated",
 ];
 

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -112,6 +112,6 @@
     "yarn": ">= 1.21.1"
   },
   "ember": {
-    "edition": "default"
+    "edition": "octane"
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/component-templates-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/component-templates-test.js
@@ -82,7 +82,39 @@ function registerOtherPluginOverrides() {
   );
 }
 
-module("Integration | Initializers | template-overrides", function () {
+function registerTemplateOnlyComponents() {
+  registerTemporaryModule(
+    `discourse/templates/components/core-template-only-definition`,
+    hbs`glimmer template-only component`
+  );
+
+  registerTemporaryModule(
+    `discourse/plugins/some-plugin-name/discourse/templates/components/plugin-template-only-definition`,
+    hbs`classic component`
+  );
+}
+
+module("Integration | Initializers | plugin-component-templates", function () {
+  module("template-only component definition behaviour", function (hooks) {
+    hooks.beforeEach(() => registerTemplateOnlyComponents());
+    setupRenderingTest(hooks);
+
+    test("treats plugin template-only definition as classic component", async function () {
+      await render(hbs`<PluginTemplateOnlyDefinition class='test-class'/>`);
+      assert
+        .dom("div.test-class")
+        .hasText("classic component", "renders as classic component");
+    });
+
+    test("leaves core template-only definition as glimmer template-only component", async function () {
+      await render(hbs`<CoreTemplateOnlyDefinition class='test-class'/>`);
+      assert
+        .dom("div.test-class")
+        .doesNotExist("no classic component rendered");
+      assert.dom().hasText("glimmer template-only component");
+    });
+  });
+
   module("with no overrides", function (hooks) {
     hooks.beforeEach(() => registerBaseComponents());
     setupRenderingTest(hooks);
@@ -178,6 +210,7 @@ module("Integration | Initializers | template-overrides", function () {
   });
 
   module("with theme and plugin overrides", function (hooks) {
+    hooks.beforeEach(() => registerBaseComponents());
     hooks.beforeEach(registerPluginOverrides);
     hooks.beforeEach(registerThemeOverrides);
     setupRenderingTest(hooks);


### PR DESCRIPTION
- explicitly enables the jquery-integration. This was previously enabled by default, so no change in behavior for us

- enable template-only-glimmer-components. In core, we don't have any component templates under `templates/components`, so this flag has no effect. A shim, with associated tests, is introduced to preserve the old template-only 'classic component' behavior for themes and plugins.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
