### PR TITLE
DEV: Use the main default session for main test assertion

### DIFF
--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -78,10 +78,8 @@ RSpec.describe "React to message", type: :system do
               chat.visit_channel(category_channel_1)
             end
 
-            using_session(:tab_2) do
-              sign_in(current_user)
-              chat.visit_channel(category_channel_1)
-            end
+            sign_in(current_user)
+            chat.visit_channel(category_channel_1)
 
             using_session(:tab_1) do |session|
               channel.hover_message(message_1)
@@ -92,10 +90,7 @@ RSpec.describe "React to message", type: :system do
               session.quit
             end
 
-            using_session(:tab_2) do |session|
-              expect(channel).to have_reaction(message_1, reaction.emoji)
-              session.quit
-            end
+            expect(channel).to have_reaction(message_1, reaction.emoji)
           end
         end
       end


### PR DESCRIPTION
Why this change?

The test being changed in question has been flaky on our CI. However, we
are unable to view the screenshot of why it failed because
ActionDispatch will only take a screenshot of the default session upon
failure. At the same time, taking screenshot of all sessions
automatically upon failure is not possible via the official Capybara or
Rails APIs at the moment. Therefore, we're changing this system test to
avoid using two custom session and instead have the main assertion use
the default session such that any failures will provide us with a
screenshot.