### PR TITLE
FIX: Editing tags in sidebar should show all tags visible to user

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -104,7 +104,7 @@ class TagsController < ::ApplicationController
 
   def list
     offset = params[:offset].to_i || 0
-    tags = guardian.can_admin_tags? ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
+    tags = guardian.can_admin_tags? ? Tag.all : Tag.visible(guardian)
 
     load_more_query_params = { offset: offset + 1 }
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1443,19 +1443,15 @@ RSpec.describe TagsController do
   end
 
   describe "#list" do
-    fab!(:tag3) do
-      Fabricate(:tag, name: "tag3").tap { |tag| Fabricate.times(1, :topic, tags: [tag]) }
-    end
+    fab!(:tag3) { Fabricate(:tag, name: "tag3") }
+    fab!(:tag2) { Fabricate(:tag, name: "tag2") }
+    fab!(:tag1) { Fabricate(:tag, name: "tag") }
 
-    fab!(:tag2) do
-      Fabricate(:tag, name: "tag2").tap { |tag| Fabricate.times(1, :topic, tags: [tag]) }
-    end
+    fab!(:staff_only_tag) { Fabricate(:tag, name: "tag4") }
 
-    fab!(:tag1) do
-      Fabricate(:tag, name: "tag").tap { |tag| Fabricate.times(1, :topic, tags: [tag]) }
+    let!(:staff_tag_group) do
+      Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [staff_only_tag.name])
     end
-
-    fab!(:tag_not_used_in_topics) { Fabricate(:tag, name: "tag4") }
 
     it "should return 403 for an anonymous user" do
       get "/tags/list.json"
@@ -1473,7 +1469,7 @@ RSpec.describe TagsController do
       expect(response.status).to eq(404)
     end
 
-    it "should only return tags used in topics for non admin users" do
+    it "should only return tags that are visible to the user for non admin users" do
       stub_const(TagsController, "LIST_LIMIT", 2) do
         sign_in(user)
 
@@ -1525,7 +1521,7 @@ RSpec.describe TagsController do
         expect(response.status).to eq(200)
 
         expect(response.parsed_body["list_tags"].map { |tag| tag["name"] }).to eq(
-          [tag3.name, tag_not_used_in_topics.name],
+          [tag3.name, staff_only_tag.name],
         )
 
         expect(response.parsed_body["meta"]["total_rows_list_tags"]).to eq(4)


### PR DESCRIPTION
Why this change?

Prior to this change, we would only return tags that are used in at
least one public topic. However, this is confusing for users because the
tag could be used in a restricted category and that is not considered a
"public" topic. Instead, we will just display all the tags in the edit
tags navigation modal as long as it is visible to the user.