### PR TITLE
DEV: Bump plugin-api.js to 1.7.0

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -125,7 +125,7 @@ import { registerHashtagType } from "discourse/lib/hashtag-autocomplete";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.6.1";
+export const PLUGIN_API_VERSION = "1.7.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -1813,7 +1813,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Support for adding a navigation link to Sidebar Community section under the "More..." links drawer by returning a
    * class which extends from the BaseSectionLink class interface. See `lib/sidebar/user/community-section/base-section-link.js`
    * for documentation on the BaseSectionLink class interface.
@@ -1873,7 +1872,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Registers a new countable for section links under Sidebar Categories section on top of the default countables of
    * unread topics count and new topics count.
    *
@@ -1942,7 +1940,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Changes the lock icon used for a sidebar category section link to indicate that a category is read restricted.
    *
    * @param {String} Name of a FontAwesome 5 icon
@@ -1952,7 +1949,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Register a custom prefix for a sidebar category section link.
    *
    * Example:
@@ -1991,7 +1987,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Register a custom prefix for a sidebar tag section link.
    *
    * Example:
@@ -2023,7 +2018,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Triggers a refresh of the counts for all category section links under the categories section for a logged in user.
    */
   refreshUserSidebarCategoriesSectionCounts() {
@@ -2035,7 +2029,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Support for adding a Sidebar section by returning a class which extends from the BaseCustomSidebarSection
    * class interface. See `lib/sidebar/user/base-custom-sidebar-section.js` for documentation on the BaseCustomSidebarSection class
    * interface.
@@ -2159,7 +2152,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Register a custom renderer for a notification type or override the
    * renderer of an existing type. See lib/notification-types/base.js for
    * documentation and the default renderer.
@@ -2223,7 +2215,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Apply transformation using a callback on a list of model instances of a
    * specific type. Currently, this API only works on lists rendered in the
    * user menu such as notifications, bookmarks and topics (i.e. messages), but
@@ -2254,7 +2245,6 @@ class PluginApi {
   }
 
   /**
-   * EXPERIMENTAL. Do not use.
    * Adds a row to the dropdown used on the `userPrivateMessages` route used to navigate between the different user
    * messages pages.
    *

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,41 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2023-07-17
+
+### Added
+
+- Adds `addCommunitySectionLink` which allows plugins to add a navigation link to the Sidebar community section under
+  the "More..." links drawer.
+
+- Adds `registerUserCategorySectionLinkCountable` which allows plugins to register a new countable for section links
+  under Sidebar Categories section on top of the default countables of unread topics count and new topics count.
+
+- Adds `registerCustomCategorySectionLinkLockIcon` which allows plugins to change the lock icon used for a sidebar
+  category section link to indicate that a category is read restricted.
+
+- Adds `registerCustomCategorySectionLinkPrefix` which allows plugins to register a custom prefix for a sidebar category
+  section link.
+
+- Adds `registerCustomTagSectionLinkPrefixValue` which allows plugins to register a custom prefix for a sidebar tag
+  section link.
+
+- Adds `refreshUserSidebarCategoriesSectionCounts` which allows plugins to trigger a refresh of the counts for all
+  category section links under the categories section for a logged in user.
+
+- Adds `addSidebarSection` which allows plugins to add a Sidebar section.
+
+- Adds `registerNotificationTypeRenderer` which allows plugins to register a custom renderer for a notification type
+  or override the renderer of an existing type. See lib/notification-types/base.js for documentation and the default
+  renderer.
+
+- Adds `registerModelTransformer` which allows plugins to apply transformation using a callback on a list of model
+  instances of a specific type. Currently, this API only works on lists rendered in the user menu such as notifications,
+  bookmarks and topics (i.e. messages), but it may be extended to other lists in other parts of the app.
+
+- Adds `addUserMessagesNavigationDropdownRow` which allows plugins to add a row to the dropdown used on the
+  `userPrivateMessages` route used to navigate between the different user messages pages.
+
 ## [1.6.0] - 2022-12-13
 
 ### Added


### PR DESCRIPTION
What does this change do?

This commit removes the experimental label for a bunch of APIs that have
been used in production for quite some time at Discourse so that the
APIs can be released as part of Discourse 3.1