### PR TITLE
DEV: Fix bookmark system spec flaky

### DIFF
--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -108,6 +108,7 @@ describe "Bookmarking posts and topics", type: :system do
       expect(dialog).to have_content(I18n.t("js.bookmarks.confirm_clear"))
       dialog.click_yes
       expect(dialog).to be_closed
+      expect(topic_page).to have_no_bookmarks
       expect(Bookmark.where(user: current_user).count).to eq(0)
     end
   end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -88,6 +88,10 @@ module PageObjects
         has_css?("#{topic_footer_button_id("bookmark")}.bookmarked", text: "Edit Bookmark")
       end
 
+      def has_no_bookmarks?
+        has_no_css?("#{topic_footer_button_id("bookmark")}.bookmarked")
+      end
+
       def find_topic_footer_button(button)
         find(topic_footer_button_id(button))
       end


### PR DESCRIPTION
Need to check more page CSS before checking the DB.

```
1) Bookmarking posts and topics topic level bookmarks clears all topic bookmarks from the topic bookmark button if more than one post is bookmarked
     Failure/Error: expect(Bookmark.where(user: current_user).count).to eq(0)

       expected: 0
            got: 2
```
