### PR TITLE
DEV: adds `touchMove` support for widgets

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -17,6 +17,7 @@ const MOUSE_OVER_ATTRIBUTE_NAME = "_discourse_mouse_over_widget";
 const MOUSE_OUT_ATTRIBUTE_NAME = "_discourse_mouse_out_widget";
 const TOUCH_START_ATTRIBUTE_NAME = "_discourse_touch_start_widget";
 const TOUCH_END_ATTRIBUTE_NAME = "_discourse_touch_end_widget";
+const TOUCH_MOVE_ATTRIBUTE_NAME = "_discourse_touch_move_widget";
 
 class WidgetBaseHook {
   constructor(widget) {
@@ -64,6 +65,7 @@ export const WidgetMouseMoveHook = buildHook(MOUSE_MOVE_ATTRIBUTE_NAME);
 export const WidgetMouseOverHook = buildHook(MOUSE_OVER_ATTRIBUTE_NAME);
 export const WidgetMouseOutHook = buildHook(MOUSE_OUT_ATTRIBUTE_NAME);
 export const WidgetTouchEndHook = buildHook(TOUCH_END_ATTRIBUTE_NAME);
+export const WidgetTouchMoveHook = buildHook(TOUCH_MOVE_ATTRIBUTE_NAME);
 
 // `touchstart` and `touchmove` events are particularly performance sensitive because
 // they block scrolling on mobile. Therefore we want to avoid registering global non-passive
@@ -258,6 +260,12 @@ WidgetClickHook.setupDocumentCallback = function () {
 
   $(document).on("touchend.discourse-widget", (e) => {
     nodeCallback(e.target, TOUCH_END_ATTRIBUTE_NAME, (w) => w.touchEnd(e), {
+      rerender: false,
+    });
+  });
+
+  $(document).on("touchmove.discourse-widget", (e) => {
+    nodeCallback(e.target, TOUCH_MOVE_ATTRIBUTE_NAME, (w) => w.touchMove(e), {
       rerender: false,
     });
   });

--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -65,7 +65,6 @@ export const WidgetMouseMoveHook = buildHook(MOUSE_MOVE_ATTRIBUTE_NAME);
 export const WidgetMouseOverHook = buildHook(MOUSE_OVER_ATTRIBUTE_NAME);
 export const WidgetMouseOutHook = buildHook(MOUSE_OUT_ATTRIBUTE_NAME);
 export const WidgetTouchEndHook = buildHook(TOUCH_END_ATTRIBUTE_NAME);
-export const WidgetTouchMoveHook = buildHook(TOUCH_MOVE_ATTRIBUTE_NAME);
 
 // `touchstart` and `touchmove` events are particularly performance sensitive because
 // they block scrolling on mobile. Therefore we want to avoid registering global non-passive
@@ -74,6 +73,9 @@ export const WidgetTouchMoveHook = buildHook(TOUCH_MOVE_ATTRIBUTE_NAME);
 // the specific widget DOM elements when required.
 function touchStartHandler(e) {
   return e.currentTarget[TOUCH_START_ATTRIBUTE_NAME].touchStart(e);
+}
+function touchMoveHandler(e) {
+  return e.currentTarget[TOUCH_MOVE_ATTRIBUTE_NAME].touchMove(e);
 }
 
 export class WidgetTouchStartHook extends WidgetBaseHook {
@@ -91,6 +93,24 @@ export class WidgetTouchStartHook extends WidgetBaseHook {
     if (!newValue) {
       // Element removed from DOM
       node.removeEventListener("touchstart", touchStartHandler);
+    }
+  }
+}
+export class WidgetTouchMoveHook extends WidgetBaseHook {
+  hook(node, propertyName, previousValue) {
+    node[TOUCH_MOVE_ATTRIBUTE_NAME] = this.widget;
+    if (!previousValue) {
+      // Element added to DOM
+      node.addEventListener("touchmove", touchMoveHandler, {
+        passive: false,
+      });
+    }
+  }
+
+  unhook(node, propertyName, newValue) {
+    if (!newValue) {
+      // Element removed from DOM
+      node.removeEventListener("touchmove", touchMoveHandler);
     }
   }
 }
@@ -260,12 +280,6 @@ WidgetClickHook.setupDocumentCallback = function () {
 
   $(document).on("touchend.discourse-widget", (e) => {
     nodeCallback(e.target, TOUCH_END_ATTRIBUTE_NAME, (w) => w.touchEnd(e), {
-      rerender: false,
-    });
-  });
-
-  $(document).on("touchmove.discourse-widget", (e) => {
-    nodeCallback(e.target, TOUCH_MOVE_ATTRIBUTE_NAME, (w) => w.touchMove(e), {
       rerender: false,
     });
   });

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -14,6 +14,7 @@ import {
   WidgetMouseOverHook,
   WidgetMouseUpHook,
   WidgetTouchEndHook,
+  WidgetTouchMoveHook,
   WidgetTouchStartHook,
 } from "discourse/widgets/hooks";
 import DecoratorHelper from "discourse/widgets/decorator-helper";
@@ -479,6 +480,10 @@ export default class Widget {
 
     if (this.touchEnd) {
       properties["widget-touch-end"] = new WidgetTouchEndHook(this);
+    }
+
+    if (this.touchMove) {
+      properties["widget-touch-move"] = new WidgetTouchMoveHook(this);
     }
 
     const attributes = properties["attributes"] || {};


### PR DESCRIPTION
No tests as widgets are in maintenance mode until we can remove and this is also hard to test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
