### PR TITLE
UX: size down unread indicators for drawer/mobile

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-index.scss
@@ -206,10 +206,15 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: auto;
-        height: auto;
-        min-width: 0.6em;
-        padding: 0.3em 0.5em;
+        width: 8px;
+        height: 8px;
+
+        &.-urgent {
+          width: auto;
+          height: auto;
+          min-width: 0.6em;
+          padding: 0.3em 0.5em;
+        }
       }
     }
 


### PR DESCRIPTION
Blue dot needs some fixes after removing the count
<img width="421" alt="image" src="https://github.com/discourse/discourse/assets/101828855/443e8a26-3764-4dfa-bd55-2b7ecb55b8a4">

to this
<img width="513" alt="image" src="https://github.com/discourse/discourse/assets/101828855/7eeccdc2-55d6-4a08-a0d3-af70c42d4019">


