### PR TITLE
FIX: bind selector to event listener callback for lightbox

### DIFF
--- a/app/assets/javascripts/discourse/app/services/lightbox.js
+++ b/app/assets/javascripts/discourse/app/services/lightbox.js
@@ -147,7 +147,9 @@ export default class LightboxService extends Service {
     const handlerOptions = { capture: true };
     container.addEventListener(
       "click",
-      this.handleClickEvent.bind(this, this.selector),
+      (event) => {
+        this.handleClickEvent(event, selector);
+      },
       handlerOptions
     );
 
@@ -233,7 +235,7 @@ export default class LightboxService extends Service {
     );
   }
 
-  handleClickEvent(trigger) {
+  handleClickEvent(event, trigger) {
     const isLightboxClick = event
       .composedPath()
       .find(


### PR DESCRIPTION
Fixes an issue where `this.selector` value was not binded at the time of adding the event listener. Therefore when someone opens a chat channel that has images, the value of selector would change. I also moved the callback to a named function (rather than the default `handleEvent`).

For images within topics/posts the selector is:
`*:not(.spoiler):not(.spoiled) a.lightbox`

Whereas in chat our selector for lightbox is:
`img:not(.emoji, .avatar)`

Because the value of `this.selector` is changing when the user opens a chat channel that contains images, the initial image to load was defaulting to the first image in the gallery when clicking within a post. This is because the startingIndex would default to 0 due to [not finding any images](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/lightbox/process-html.js#L10:L16) using the selector (ie. using chat lightbox selector when it should be using the topic lightbox selector.

This is pretty tricky due to test due to the overlap with chat so I've skipped tests for now.

More details of issue and how to repro here:
/t/106866/19