### PR TITLE
FIX: allows to focus thread's composer on ipad

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -276,9 +276,9 @@ export default class ChatComposer extends Component {
       return;
     }
 
-    // hack to prevent the whole viewport
-    // to move on focus input
-    textarea = document.querySelector(".chat-composer__input");
+    // hack to prevent the whole viewport to move on focus input
+    // we need access to native node
+    textarea = this.composer.textarea.textarea;
     textarea.style.transform = "translateY(-99999px)";
     textarea.focus();
     window.requestAnimationFrame(() => {


### PR DESCRIPTION
On iOS we have a hack to prevent the viewport to move when focusing an input, however this code was target the textarea node through a global selector which is working fine on iOS as we only show one composer at a time but was failing on iPad as we show both channel and thread on the same screen. As a result `document.querySelector(".chat-composer__input")` was always targeting the first textarea on the screen which was the channel's composer, making it impossible to focus the thread's one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
