### PR TITLE
FIX: Update `last_read_message_id` when moving chat messages

### DIFF
--- a/plugins/chat/lib/chat/message_mover.rb
+++ b/plugins/chat/lib/chat/message_mover.rb
@@ -66,6 +66,7 @@ module Chat
         update_references
         delete_source_messages
         update_reply_references
+        update_tracking_state
         update_thread_references
       end
 
@@ -206,6 +207,10 @@ module Chat
       SET in_reply_to_id = NULL
       WHERE in_reply_to_id IN (:deleted_reply_to_ids)
     SQL
+    end
+
+    def update_tracking_state
+      ::Chat::Action::ResetUserLastReadChannelMessage.call(@source_message_ids, @source_channel.id)
     end
 
     def update_thread_references

--- a/plugins/chat/spec/lib/chat/message_mover_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_mover_spec.rb
@@ -183,6 +183,31 @@ describe Chat::MessageMover do
         expect(message3.reload.thread).to eq(thread)
       end
 
+      it "updates the tracking to the last non-deleted channel message for users whose last_read_message_id was the moved message" do
+        membership_1 =
+          Fabricate(
+            :user_chat_channel_membership,
+            chat_channel: source_channel,
+            last_read_message: message1,
+          )
+        membership_2 =
+          Fabricate(
+            :user_chat_channel_membership,
+            chat_channel: source_channel,
+            last_read_message: message2,
+          )
+        membership_3 =
+          Fabricate(
+            :user_chat_channel_membership,
+            chat_channel: source_channel,
+            last_read_message: message3,
+          )
+        move!([message2.id])
+        expect(membership_1.reload.last_read_message_id).to eq(message1.id)
+        expect(membership_2.reload.last_read_message_id).to eq(message3.id)
+        expect(membership_3.reload.last_read_message_id).to eq(message3.id)
+      end
+
       context "when a thread original message is moved" do
         it "creates a new thread for the messages left behind in the old channel" do
           message4 =


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
