### PR TITLE
DEV: Update `transitionTo` on Route

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-api-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-api-index.js
@@ -1,7 +1,10 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AdminApiIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.transitionTo("adminApiKeys");
+    this.router.transitionTo("adminApiKeys");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-api-keys.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-api-keys.js
@@ -1,14 +1,17 @@
 import { action } from "@ember/object";
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AdminApiKeysRoute extends Route {
+  @service router;
+
   @action
   show(apiKey) {
-    this.transitionTo("adminApiKeys.show", apiKey.id);
+    this.router.transitionTo("adminApiKeys.show", apiKey.id);
   }
 
   @action
   new() {
-    this.transitionTo("adminApiKeys.new");
+    this.router.transitionTo("adminApiKeys.new");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-backups.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-backups.js
@@ -16,6 +16,7 @@ const LOG_CHANNEL = "/admin/backups/logs";
 
 export default class AdminBackupsRoute extends DiscourseRoute {
   @service dialog;
+  @service router;
 
   activate() {
     this.messageBus.subscribe(LOG_CHANNEL, this.onMessage);
@@ -71,7 +72,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
 
   @action
   startBackup(withUploads) {
-    this.transitionTo("admin.backups.logs");
+    this.router.transitionTo("admin.backups.logs");
     Backup.start(withUploads).then((result) => {
       if (!result.success) {
         this.dialog.alert(result.message);
@@ -100,7 +101,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
     this.dialog.yesNoConfirm({
       message: I18n.t("admin.backups.operations.restore.confirm"),
       didConfirm: () => {
-        this.transitionTo("admin.backups.logs");
+        this.router.transitionTo("admin.backups.logs");
         backup.restore();
       },
     });

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-email-templates.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-email-templates.js
@@ -1,5 +1,5 @@
 import Route from "@ember/routing/route";
-import { action } from "@ember/object"
+import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeEmailTemplatesRoute extends Route {
@@ -20,7 +20,7 @@ export default class AdminCustomizeEmailTemplatesRoute extends Route {
     );
 
     if (!editController.emailTemplate) {
-      this.router.transitionTo
+      this.router.transitionTo(
         "adminCustomizeEmailTemplates.edit",
         this.controller.get("sortedTemplates.firstObject")
       );

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-email-templates.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-email-templates.js
@@ -1,7 +1,10 @@
 import Route from "@ember/routing/route";
-import { action } from "@ember/object";
+import { action } from "@ember/object"
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeEmailTemplatesRoute extends Route {
+  @service router;
+
   model() {
     return this.store.findAll("email-template");
   }
@@ -17,7 +20,7 @@ export default class AdminCustomizeEmailTemplatesRoute extends Route {
     );
 
     if (!editController.emailTemplate) {
-      this.transitionTo(
+      this.router.transitionTo
         "adminCustomizeEmailTemplates.edit",
         this.controller.get("sortedTemplates.firstObject")
       );

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
@@ -1,5 +1,6 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
+
 export default class AdminCustomizeIndexRoute extends Route {
   @service router;
 

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
@@ -1,11 +1,13 @@
 import Route from "@ember/routing/route";
-
+import { inject as service } from "@ember/service";
 export default class AdminCustomizeIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
     if (this.currentUser.admin) {
-      this.transitionTo("adminCustomizeThemes");
+      this.router.transitionTo("adminCustomizeThemes");
     } else {
-      this.transitionTo("adminWatchedWords");
+      this.router.transitionTo("adminWatchedWords");
     }
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
@@ -5,6 +5,7 @@ import Route from "@ember/routing/route";
 
 export default class AdminCustomizeThemesEditRoute extends Route {
   @service dialog;
+  @service router;
 
   model(params) {
     const all = this.modelFor("adminCustomizeThemes");
@@ -32,11 +33,11 @@ export default class AdminCustomizeThemesEditRoute extends Route {
       .get("fields")
       [wrapper.target].map((f) => f.name);
     if (wrapper.model.remote_theme && wrapper.model.remote_theme.is_git) {
-      this.transitionTo("adminCustomizeThemes.index");
+      this.router.transitionTo("adminCustomizeThemes.index");
       return;
     }
     if (!fields.includes(wrapper.field_name)) {
-      this.transitionTo(
+      this.router.transitionTo(
         "adminCustomizeThemes.edit",
         wrapper.model.id,
         wrapper.target,

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes.js
@@ -7,6 +7,7 @@ import { next } from "@ember/runloop";
 
 export default class AdminCustomizeThemesRoute extends Route {
   @service dialog;
+  @service router;
 
   queryParams = {
     repoUrl: null,
@@ -54,7 +55,7 @@ export default class AdminCustomizeThemesRoute extends Route {
   addTheme(theme) {
     this.refresh();
     theme.setProperties({ recentlyInstalled: true });
-    this.transitionTo("adminCustomizeThemes.show", theme.get("id"), {
+    this.router.transitionTo("adminCustomizeThemes.show", theme.get("id"), {
       queryParams: {
         repoName: null,
         repoUrl: null,

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-index.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminLogsIndexRoute extends DiscourseRoute {
+  @service router;
+
   redirect() {
-    this.transitionTo("adminLogs.staffActionLogs");
+    this.router.transitionTo("adminLogs.staffActionLogs");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import EmberObject, { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class AdminLogsStaffActionLogsRoute extends DiscourseRoute {
+  @service router;
+
   queryParams = {
     filters: { refreshModel: true },
   };
@@ -36,7 +39,7 @@ export default class AdminLogsStaffActionLogsRoute extends DiscourseRoute {
 
   @action
   onFiltersChange(filters) {
-    this.transitionTo("adminLogs.staffActionLogs", {
+    this.router.transitionTo("adminLogs.staffActionLogs", {
       queryParams: { filters },
     });
   }

--- a/app/assets/javascripts/admin/addon/routes/admin-plugins.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-plugins.js
@@ -1,7 +1,10 @@
 import { action } from "@ember/object";
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AdminPluginsRoute extends Route {
+  @service router;
+
   model() {
     return this.store.findAll("plugin");
   }
@@ -9,15 +12,17 @@ export default class AdminPluginsRoute extends Route {
   @action
   showSettings(plugin) {
     const controller = this.controllerFor("adminSiteSettings");
-    this.transitionTo("adminSiteSettingsCategory", "plugins").then(() => {
-      if (plugin) {
-        // filterContent() is normally on a debounce from typing.
-        // Because we don't want the default of "All Results", we tell it
-        // to skip the next debounce.
-        controller.set("filter", `plugin:${plugin.id}`);
-        controller.set("_skipBounce", true);
-        controller.filterContentNow("plugins");
-      }
-    });
+    this.router
+      .transitionTo("adminSiteSettingsCategory", "plugins")
+      .then(() => {
+        if (plugin) {
+          // filterContent() is normally on a debounce from typing.
+          // Because we don't want the default of "All Results", we tell it
+          // to skip the next debounce.
+          controller.set("filter", `plugin:${plugin.id}`);
+          controller.set("_skipBounce", true);
+          controller.filterContentNow("plugins");
+        }
+      });
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-reports-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports-index.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminReportsIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.transitionTo("admin.dashboardReports");
+    this.router.transitionTo("admin.dashboardReports");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
@@ -1,7 +1,10 @@
 import { action } from "@ember/object";
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminReportsShowRoute extends DiscourseRoute {
+  @service router;
+
   queryParams = {
     start_date: { refreshModel: true },
     end_date: { refreshModel: true },
@@ -68,6 +71,6 @@ export default class AdminReportsShowRoute extends DiscourseRoute {
         : null,
     };
 
-    this.transitionTo("adminReports.show", { queryParams });
+    this.router.transitionTo("adminReports.show", { queryParams });
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-users-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-index.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminUsersIndexRoute extends DiscourseRoute {
+  @service router;
+
   redirect() {
-    this.transitionTo("adminUsersList");
+    this.router.transitionTo("adminUsersList");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-users-list-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list-index.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminUsersListIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.transitionTo("adminUsersList.show", "active");
+    this.router.transitionTo("adminUsersList.show", "active");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-users-list.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list.js
@@ -3,8 +3,11 @@ import AdminUser from "admin/models/admin-user";
 import DiscourseRoute from "discourse/routes/discourse";
 import { exportEntity } from "discourse/lib/export-csv";
 import { outputExportResult } from "discourse/lib/export-result";
+import { inject as service } from "@ember/service";
 
 export default class AdminUsersListRoute extends DiscourseRoute {
+  @service router;
+
   @action
   exportUsers() {
     exportEntity("user_list", {
@@ -14,7 +17,7 @@ export default class AdminUsersListRoute extends DiscourseRoute {
 
   @action
   sendInvites() {
-    this.transitionTo("userInvited", this.currentUser);
+    this.router.transitionTo("userInvited", this.currentUser);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -45,6 +45,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
   composer: service(),
   modal: service(),
   loadingSlider: service(),
+  router: service(),
 
   @action
   loading(transition) {
@@ -124,7 +125,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       }
 
       if (xhrOrErr && xhrOrErr.status === 404) {
-        return this.transitionTo("exception-unknown");
+        return this.router.transitionTo("exception-unknown");
       }
 
       exceptionController.setProperties({

--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -11,8 +11,11 @@ import { hash } from "rsvp";
 import { next } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
 import Session from "discourse/models/session";
+import { inject as service } from "@ember/service";
 
 const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
+  router: service(),
+
   renderTemplate() {
     this.render("navigation/categories", { outlet: "navigation-bar" });
     this.render("discovery/categories", { outlet: "list-container" });
@@ -144,7 +147,7 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
 
   @action
   createCategory() {
-    this.transitionTo("newCategory");
+    this.router.transitionTo("newCategory");
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/group-activity-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-activity-index.js
@@ -1,12 +1,15 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default Route.extend({
+  router: service(),
+
   beforeModel() {
     const group = this.modelFor("group");
     if (group.can_see_members) {
-      this.transitionTo("group.activity.posts");
+      this.router.transitionTo("group.activity.posts");
     } else {
-      this.transitionTo("group.activity.mentions");
+      this.router.transitionTo("group.activity.mentions");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/group-manage-email.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-email.js
@@ -1,13 +1,15 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   beforeModel() {
     // cannot configure IMAP without SMTP being enabled
     if (!this.siteSettings.enable_smtp) {
-      return this.transitionTo("group.manage.profile");
+      return this.router.transitionTo("group.manage.profile");
     }
   },
 

--- a/app/assets/javascripts/discourse/app/routes/group-manage-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-index.js
@@ -1,9 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   beforeModel() {
-    this.transitionTo("group.manage.profile");
+    this.router.transitionTo("group.manage.profile");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/group-manage.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage.js
@@ -1,7 +1,9 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   titleToken() {
@@ -18,7 +20,7 @@ export default DiscourseRoute.extend({
       (!(this.modelFor("group").can_admin_group && group.get("automatic")) &&
         !this.currentUser.canManageGroup(group))
     ) {
-      this.transitionTo("group.members", group);
+      this.router.transitionTo("group.members", group);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/routes/group-members.js
+++ b/app/assets/javascripts/discourse/app/routes/group-members.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   beforeModel() {
-    this.transitionTo("group.index");
+    this.router.transitionTo("group.index");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/group-messages-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-messages-index.js
@@ -1,6 +1,10 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
+
 export default Route.extend({
+  router: service(),
+
   beforeModel() {
-    this.transitionTo("group.messages.inbox");
+    this.router.transitionTo("group.messages.inbox");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/group-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/group-messages.js
@@ -1,8 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   titleToken() {
     return I18n.t("groups.messages");
   },
@@ -16,7 +19,7 @@ export default DiscourseRoute.extend({
       !group.get("is_group_user") &&
       !(this.currentUser && this.currentUser.admin)
     ) {
-      this.transitionTo("group.members", group);
+      this.router.transitionTo("group.members", group);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/routes/group-permissions.js
+++ b/app/assets/javascripts/discourse/app/routes/group-permissions.js
@@ -2,8 +2,10 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { buildPermissionDescription } from "discourse/models/permission-type";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   titleToken() {
@@ -23,7 +25,7 @@ export default DiscourseRoute.extend({
         return { permissions };
       })
       .catch(() => {
-        this.transitionTo("group.members", group);
+        this.router.transitionTo("group.members", group);
       });
   },
 

--- a/app/assets/javascripts/discourse/app/routes/groups-new.js
+++ b/app/assets/javascripts/discourse/app/routes/groups-new.js
@@ -1,8 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import Group from "discourse/models/group";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   titleToken() {
@@ -23,7 +25,7 @@ export default DiscourseRoute.extend({
 
   afterModel() {
     if (!this.get("currentUser.can_create_group")) {
-      this.transitionTo("groups");
+      this.router.transitionTo("groups");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/preferences-index.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-index.js
@@ -1,9 +1,11 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
+import { inject as service } from "@ember/service";
 
 export default RestrictedUserRoute.extend({
+  router: service(),
   showFooter: true,
 
   redirect() {
-    this.transitionTo("preferences.account");
+    this.router.transitionTo("preferences.account");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/tag-groups-new.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-groups-new.js
@@ -1,12 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   showFooter: true,
 
   beforeModel() {
     if (!this.siteSettings.tagging_enabled) {
-      this.transitionTo("tagGroups");
+      this.router.transitionTo("tagGroups");
     }
   },
 

--- a/app/assets/javascripts/discourse/app/routes/tags-index.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-index.js
@@ -2,8 +2,11 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import Tag from "discourse/models/tag";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   model() {
     return this.store.findAll("tag").then((result) => {
       if (result.extras) {
@@ -43,7 +46,7 @@ export default DiscourseRoute.extend({
 
   @action
   showTagGroups() {
-    this.transitionTo("tagGroups");
+    this.router.transitionTo("tagGroups");
     return true;
   },
 

--- a/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
@@ -1,7 +1,13 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default Route.extend({
+  router: service(),
+
   beforeModel() {
-    this.transitionTo("tag.show", this.paramsFor("tags.legacyRedirect").tag_id);
+    this.router.transitionTo(
+      "tag.show",
+      this.paramsFor("tags.legacyRedirect").tag_id
+    );
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks-with-reminders.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks-with-reminders.js
@@ -1,11 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   queryParams: {
     q: { replace: true },
   },
 
   redirect() {
-    this.transitionTo("userActivity.bookmarks");
+    this.router.transitionTo("userActivity.bookmarks");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-pending.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-pending.js
@@ -1,8 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   beforeModel() {
     this.username = this.modelFor("user").username_lower;
   },
@@ -42,7 +45,7 @@ export default DiscourseRoute.extend({
   _handleCountChange(count) {
     this.refresh();
     if (count <= 0) {
-      this.transitionTo("userActivity");
+      this.router.transitionTo("userActivity");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-index.js
@@ -17,7 +17,7 @@ export default DiscourseRoute.extend({
     if (this.site.mobileView) {
       this.replaceWith(destination);
     } else {
-      this.router.transitionTodestination);
+      this.router.transitionTo(destination);
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-index.js
@@ -1,6 +1,9 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   beforeModel() {
     const { currentUser } = this;
     const viewingMe =
@@ -14,7 +17,7 @@ export default DiscourseRoute.extend({
     if (this.site.mobileView) {
       this.replaceWith(destination);
     } else {
-      this.transitionTo(destination);
+      this.router.transitionTodestination);
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
@@ -1,7 +1,9 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   controllerName: "user-notifications",
   templateName: "user/notifications-index",
 
@@ -11,7 +13,7 @@ export default DiscourseRoute.extend({
 
   afterModel(model) {
     if (!model) {
-      this.transitionTo("userNotifications.responses");
+      this.router.transitionTo("userNotifications.responses");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages-group.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages-group.js
@@ -1,6 +1,9 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class extends DiscourseRoute {
+  @service router;
+
   model(params) {
     return this.modelFor("user")
       .get("groups")
@@ -11,7 +14,7 @@ export default class extends DiscourseRoute {
 
   afterModel(model) {
     if (!model) {
-      this.transitionTo("exception-unknown");
+      this.router.transitionTo("exception-unknown");
       return;
     }
   }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
@@ -5,10 +5,11 @@ import { defaultHomepage } from "discourse/lib/utilities";
 export default class ChatBrowseIndexRoute extends DiscourseRoute {
   @service chat;
   @service siteSettings;
+  @service router;
 
   beforeModel() {
     if (!this.siteSettings.enable_public_channels) {
-      return this.transitionTo(`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo`discovery.${defaultHomepage()}`);
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
@@ -9,7 +9,7 @@ export default class ChatBrowseIndexRoute extends DiscourseRoute {
 
   beforeModel() {
     if (!this.siteSettings.enable_public_channels) {
-      return this.router.transitionTo`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-draft-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-draft-channel.js
@@ -3,10 +3,11 @@ import { inject as service } from "@ember/service";
 
 export default class ChatDraftChannelRoute extends DiscourseRoute {
   @service chat;
+  @service router;
 
   beforeModel() {
     if (!this.chat.userCanDirectMessage) {
-      this.transitionTo("chat");
+      this.router.transitionTo("chat");
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
@@ -5,11 +5,12 @@ import { inject as service } from "@ember/service";
 
 export default class ChatMessageRoute extends DiscourseRoute {
   @service chat;
+  @service router;
 
   async model(params) {
     return ajax(`/chat/message/${params.messageId}.json`)
       .then((response) => {
-        this.transitionTo(
+        this.router.transitionTo
           "chat.channel.near-message",
           response.chat_channel_title,
           response.chat_channel_id,
@@ -21,7 +22,7 @@ export default class ChatMessageRoute extends DiscourseRoute {
 
   beforeModel() {
     if (!this.chat.userCanChat) {
-      return this.transitionTo(`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo`discovery.${defaultHomepage()}`);
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
@@ -10,7 +10,7 @@ export default class ChatMessageRoute extends DiscourseRoute {
   async model(params) {
     return ajax(`/chat/message/${params.messageId}.json`)
       .then((response) => {
-        this.router.transitionTo
+        this.router.transitionTo(
           "chat.channel.near-message",
           response.chat_channel_title,
           response.chat_channel_id,
@@ -22,7 +22,7 @@ export default class ChatMessageRoute extends DiscourseRoute {
 
   beforeModel() {
     if (!this.chat.userCanChat) {
-      return this.router.transitionTo`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
@@ -4,12 +4,13 @@ import { inject as service } from "@ember/service";
 
 export default class PreferencesChatRoute extends RestrictedUserRoute {
   @service chat;
+  @service router;
 
   showFooter = true;
 
   setupController(controller, user) {
     if (!user?.can_chat && !this.currentUser.admin) {
-      return this.transitionTo(`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo`discovery.${defaultHomepage()}`);
     }
     controller.set("model", user);
   }

--- a/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
@@ -10,7 +10,7 @@ export default class PreferencesChatRoute extends RestrictedUserRoute {
 
   setupController(controller, user) {
     if (!user?.can_chat && !this.currentUser.admin) {
-      return this.router.transitionTo`discovery.${defaultHomepage()}`);
+      return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
     controller.set("model", user);
   }


### PR DESCRIPTION
Per https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods

We are upgrading all `this.transitionTo` calls on routes to directly call the router service (`this.router.transitionTo`)