### PR TITLE
DEV: upgrade `transitionToRoute` on Controller

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys-new.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys-new.js
@@ -79,7 +79,7 @@ export default class AdminApiKeysNewController extends Controller {
 
   @action
   continue() {
-    this.router.transitionToRoute("adminApiKeys.show", this.model.id);
+    this.router.transitionTo("adminApiKeys.show", this.model.id);
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys-new.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys-new.js
@@ -7,8 +7,11 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { action, get } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import { ajax } from "discourse/lib/ajax";
+import { inject as service } from "@ember/service";
 
 export default class AdminApiKeysNewController extends Controller {
+  @service router;
+
   userModes = [
     { id: "all", name: I18n.t("admin.api.all_users") },
     { id: "single", name: I18n.t("admin.api.single_user") },
@@ -76,7 +79,7 @@ export default class AdminApiKeysNewController extends Controller {
 
   @action
   continue() {
-    this.transitionToRoute("adminApiKeys.show", this.model.id);
+    this.router.transitionToRoute("adminApiKeys.show", this.model.id);
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys-show.js
@@ -5,10 +5,13 @@ import { bufferedProperty } from "discourse/mixins/buffered-content";
 import { isEmpty } from "@ember/utils";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import showModal from "discourse/lib/show-modal";
+import { inject as service } from "@ember/service";
 
 export default class AdminApiKeysShowController extends Controller.extend(
   bufferedProperty("model")
 ) {
+  @service router;
+
   @empty("model.id") isNew;
 
   @action
@@ -53,7 +56,7 @@ export default class AdminApiKeysShowController extends Controller.extend(
   deleteKey(key) {
     key
       .destroyRecord()
-      .then(() => this.transitionToRoute("adminApiKeys.index"))
+      .then(() => this.router.transitionToRoute("adminApiKeys.index"))
       .catch(popupAjaxError);
   }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys-show.js
@@ -56,7 +56,7 @@ export default class AdminApiKeysShowController extends Controller.extend(
   deleteKey(key) {
     key
       .destroyRecord()
-      .then(() => this.router.transitionToRoute("adminApiKeys.index"))
+      .then(() => this.router.transitionTo("adminApiKeys.index"))
       .catch(popupAjaxError);
   }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -206,7 +206,7 @@ export default class AdminBadgesShowController extends Controller.extend(
             if (!adminBadges.includes(model)) {
               adminBadges.pushObject(model);
             }
-            this.transitionToRoute("adminBadges.show", model.get("id"));
+            this.router.transitionToRoute("adminBadges.show", model.get("id"));
           } else {
             this.commitBuffer();
             this.savingStatus = I18n.t("saved");
@@ -237,7 +237,7 @@ export default class AdminBadgesShowController extends Controller.extend(
           .destroy()
           .then(() => {
             adminBadges.removeObject(model);
-            this.transitionToRoute("adminBadges.index");
+            this.router.transitionToRoute("adminBadges.index");
           })
           .catch(() => {
             this.dialog.alert(I18n.t("generic_error"));

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -206,7 +206,7 @@ export default class AdminBadgesShowController extends Controller.extend(
             if (!adminBadges.includes(model)) {
               adminBadges.pushObject(model);
             }
-            this.router.transitionToRoute("adminBadges.show", model.get("id"));
+            this.router.transitionTo("adminBadges.show", model.get("id"));
           } else {
             this.commitBuffer();
             this.savingStatus = I18n.t("saved");
@@ -237,7 +237,7 @@ export default class AdminBadgesShowController extends Controller.extend(
           .destroy()
           .then(() => {
             adminBadges.removeObject(model);
-            this.router.transitionToRoute("adminBadges.index");
+            this.router.transitionTo("adminBadges.index");
           })
           .catch(() => {
             this.dialog.alert(I18n.t("generic_error"));

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-email-templates.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-email-templates.js
@@ -11,9 +11,6 @@ export default class AdminCustomizeEmailTemplatesController extends Controller {
 
   @action
   onSelectTemplate(template) {
-    this.router.transitionToRoute(
-      "adminCustomizeEmailTemplates.edit",
-      template
-    );
+    this.router.transitionTo("adminCustomizeEmailTemplates.edit", template);
   }
 }

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-email-templates.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-email-templates.js
@@ -1,13 +1,19 @@
 import { sort } from "@ember/object/computed";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeEmailTemplatesController extends Controller {
+  @service router;
+
   titleSorting = ["title"];
   @sort("emailTemplates", "titleSorting") sortedTemplates;
 
   @action
   onSelectTemplate(template) {
-    this.transitionToRoute("adminCustomizeEmailTemplates.edit", template);
+    this.router.transitionToRoute(
+      "adminCustomizeEmailTemplates.edit",
+      template
+    );
   }
 }

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-form-templates-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-form-templates-index.js
@@ -1,10 +1,13 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeFormTemplatesIndex extends Controller {
+  @service router;
+
   @action
   newTemplate() {
-    this.transitionToRoute("adminCustomizeFormTemplates.new");
+    this.router.transitionToRoute("adminCustomizeFormTemplates.new");
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-form-templates-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-form-templates-index.js
@@ -7,7 +7,7 @@ export default class AdminCustomizeFormTemplatesIndex extends Controller {
 
   @action
   newTemplate() {
-    this.router.transitionToRoute("adminCustomizeFormTemplates.new");
+    this.router.transitionTo("adminCustomizeFormTemplates.new");
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -21,6 +21,7 @@ const THEME_UPLOAD_VAR = 2;
 
 export default class AdminCustomizeThemesShowController extends Controller {
   @service dialog;
+  @service router;
 
   editRouteName = "adminCustomizeThemes.edit";
 
@@ -226,7 +227,7 @@ export default class AdminCustomizeThemesShowController extends Controller {
   }
 
   transitionToEditRoute() {
-    this.transitionToRoute(
+    this.router.transitionToRoute(
       this.editRouteName,
       this.get("model.id"),
       "common",
@@ -383,7 +384,7 @@ export default class AdminCustomizeThemesShowController extends Controller {
         model.setProperties({ recentlyInstalled: false });
         model.destroyRecord().then(() => {
           this.allThemes.removeObject(model);
-          this.transitionToRoute("adminCustomizeThemes");
+          this.router.transitionToRoute("adminCustomizeThemes");
         });
       },
     });

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -227,7 +227,7 @@ export default class AdminCustomizeThemesShowController extends Controller {
   }
 
   transitionToEditRoute() {
-    this.router.transitionToRoute(
+    this.router.transitionTo(
       this.editRouteName,
       this.get("model.id"),
       "common",
@@ -384,7 +384,7 @@ export default class AdminCustomizeThemesShowController extends Controller {
         model.setProperties({ recentlyInstalled: false });
         model.destroyRecord().then(() => {
           this.allThemes.removeObject(model);
-          this.router.transitionToRoute("adminCustomizeThemes");
+          this.router.transitionTo("adminCustomizeThemes");
         });
       },
     });

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -6,8 +6,11 @@ import { isEmpty } from "@ember/utils";
 import { debounce } from "discourse-common/utils/decorators";
 import { observes } from "@ember-decorators/object";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class AdminSiteSettingsController extends Controller {
+  @service router;
+
   filter = null;
 
   @alias("model") allSiteSettings;
@@ -117,7 +120,7 @@ export default class AdminSiteSettingsController extends Controller {
     if (isEmpty(this.filter) && !this.onlyOverridden) {
       this.set("visibleSiteSettings", this.allSiteSettings);
       if (this.categoryNameKey === "all_results") {
-        this.transitionToRoute("adminSiteSettings");
+        this.router.transitionToRoute("adminSiteSettings");
       }
       return;
     }
@@ -138,7 +141,7 @@ export default class AdminSiteSettingsController extends Controller {
     }
 
     this.set("visibleSiteSettings", matchesGroupedByCategory);
-    this.transitionToRoute(
+    this.router.transitionToRoute(
       "adminSiteSettingsCategory",
       category || "all_results"
     );

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -120,7 +120,7 @@ export default class AdminSiteSettingsController extends Controller {
     if (isEmpty(this.filter) && !this.onlyOverridden) {
       this.set("visibleSiteSettings", this.allSiteSettings);
       if (this.categoryNameKey === "all_results") {
-        this.router.transitionToRoute("adminSiteSettings");
+        this.router.transitionTo("adminSiteSettings");
       }
       return;
     }
@@ -141,7 +141,7 @@ export default class AdminSiteSettingsController extends Controller {
     }
 
     this.set("visibleSiteSettings", matchesGroupedByCategory);
-    this.router.transitionToRoute(
+    this.router.transitionTo(
       "adminSiteSettingsCategory",
       category || "all_results"
     );

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
@@ -52,7 +52,7 @@ export default class AdminSiteTextIndexController extends Controller {
 
   @action
   edit(siteText) {
-    this.router.transitionToRoute("adminSiteText.edit", siteText.get("id"), {
+    this.router.transitionTo("adminSiteText.edit", siteText.get("id"), {
       queryParams: {
         locale: this.locale,
       },

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
@@ -2,9 +2,13 @@ import { action } from "@ember/object";
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import discourseDebounce from "discourse-common/lib/debounce";
+import { inject as service } from "@ember/service";
 let lastSearch;
 
 export default class AdminSiteTextIndexController extends Controller {
+  @service router;
+  @service siteSettings;
+
   searching = false;
   siteTexts = null;
   preferred = false;
@@ -48,7 +52,7 @@ export default class AdminSiteTextIndexController extends Controller {
 
   @action
   edit(siteText) {
-    this.transitionToRoute("adminSiteText.edit", siteText.get("id"), {
+    this.router.transitionToRoute("adminSiteText.edit", siteText.get("id"), {
       queryParams: {
         locale: this.locale,
       },

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-edit.js
@@ -97,7 +97,7 @@ export default class AdminWebHooksEditController extends Controller {
 
       this.set("saved", true);
       this.adminWebHooks.model.addObject(this.model);
-      this.router.transitionToRoute("adminWebHooks.show", this.model);
+      this.router.transitionTo("adminWebHooks.show", this.model);
     } catch (e) {
       popupAjaxError(e);
     }

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-edit.js
@@ -9,6 +9,9 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default class AdminWebHooksEditController extends Controller {
   @service dialog;
+  @service router;
+  @service siteSettings;
+
   @controller adminWebHooks;
 
   @alias("adminWebHooks.eventTypes") eventTypes;
@@ -94,7 +97,7 @@ export default class AdminWebHooksEditController extends Controller {
 
       this.set("saved", true);
       this.adminWebHooks.model.addObject(this.model);
-      this.transitionToRoute("adminWebHooks.show", this.model);
+      this.router.transitionToRoute("adminWebHooks.show", this.model);
     } catch (e) {
       popupAjaxError(e);
     }

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
@@ -22,7 +22,7 @@ export default class AdminWebHooksShowController extends Controller {
         try {
           await this.model.destroyRecord();
           this.adminWebHooks.model.removeObject(this.model);
-          this.transitionToRoute("adminWebHooks");
+          this.router.transitionToRoute("adminWebHooks");
         } catch (e) {
           popupAjaxError(e);
         }

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
@@ -22,7 +22,7 @@ export default class AdminWebHooksShowController extends Controller {
         try {
           await this.model.destroyRecord();
           this.adminWebHooks.model.removeObject(this.model);
-          this.router.transitionToRoute("adminWebHooks");
+          this.router.transitionTo("adminWebHooks");
         } catch (e) {
           popupAjaxError(e);
         }

--- a/app/assets/javascripts/discourse/app/controllers/account-created-edit-email.js
+++ b/app/assets/javascripts/discourse/app/controllers/account-created-edit-email.js
@@ -2,8 +2,10 @@ import Controller from "@ember/controller";
 import { changeEmail } from "discourse/lib/user-activation";
 import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
   accountCreated: null,
   newEmail: null,
 
@@ -18,13 +20,13 @@ export default Controller.extend({
       changeEmail({ email })
         .then(() => {
           this.set("accountCreated.email", email);
-          this.transitionToRoute("account-created.resent");
+          this.router.transitionToRoute("account-created.resent");
         })
         .catch(popupAjaxError);
     },
 
     cancel() {
-      this.transitionToRoute("account-created.index");
+      this.router.transitionToRoute("account-created.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/account-created-edit-email.js
+++ b/app/assets/javascripts/discourse/app/controllers/account-created-edit-email.js
@@ -20,13 +20,13 @@ export default Controller.extend({
       changeEmail({ email })
         .then(() => {
           this.set("accountCreated.email", email);
-          this.router.transitionToRoute("account-created.resent");
+          this.router.transitionTo("account-created.resent");
         })
         .catch(popupAjaxError);
     },
 
     cancel() {
-      this.router.transitionToRoute("account-created.index");
+      this.router.transitionTo("account-created.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/account-created-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/account-created-index.js
@@ -23,11 +23,11 @@ export default Controller.extend({
   actions: {
     sendActivationEmail() {
       resendActivationEmail(this.get("accountCreated.username")).then(() => {
-        this.router.transitionToRoute("account-created.resent");
+        this.router.transitionTo("account-created.resent");
       });
     },
     editActivationEmail() {
-      this.router.transitionToRoute("account-created.edit-email");
+      this.router.transitionTo("account-created.edit-email");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/account-created-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/account-created-index.js
@@ -4,8 +4,10 @@ import getUrl from "discourse-common/lib/get-url";
 import discourseComputed from "discourse-common/utils/decorators";
 import { resendActivationEmail } from "discourse/lib/user-activation";
 import { wavingHandURL } from "discourse/lib/waving-hand-url";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
   envelopeImageUrl: getUrl("/images/envelope.svg"),
 
   @discourseComputed
@@ -21,11 +23,11 @@ export default Controller.extend({
   actions: {
     sendActivationEmail() {
       resendActivationEmail(this.get("accountCreated.username")).then(() => {
-        this.transitionToRoute("account-created.resent");
+        this.router.transitionToRoute("account-created.resent");
       });
     },
     editActivationEmail() {
-      this.transitionToRoute("account-created.edit-email");
+      this.router.transitionToRoute("account-created.edit-email");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/associate-account-confirm.js
+++ b/app/assets/javascripts/discourse/app/controllers/associate-account-confirm.js
@@ -2,8 +2,12 @@ import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend(ModalFunctionality, {
+  router: service(),
+  currentUser: service(),
+
   actions: {
     finishConnect() {
       ajax({
@@ -12,7 +16,7 @@ export default Controller.extend(ModalFunctionality, {
       })
         .then((result) => {
           if (result.success) {
-            this.transitionToRoute(
+            this.router.transitionToRoute(
               "preferences.account",
               this.currentUser.findDetails()
             );

--- a/app/assets/javascripts/discourse/app/controllers/associate-account-confirm.js
+++ b/app/assets/javascripts/discourse/app/controllers/associate-account-confirm.js
@@ -16,7 +16,7 @@ export default Controller.extend(ModalFunctionality, {
       })
         .then((result) => {
           if (result.success) {
-            this.router.transitionToRoute(
+            this.router.transitionTo(
               "preferences.account",
               this.currentUser.findDetails()
             );

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -112,10 +112,7 @@ export default Controller.extend({
               notification_level: NotificationLevels.REGULAR,
             });
             this.site.updateCategory(model);
-            this.router.transitionToRoute(
-              "editCategory",
-              Category.slugFor(model)
-            );
+            this.router.transitionTo("editCategory", Category.slugFor(model));
           }
         })
         .catch((error) => {
@@ -132,7 +129,7 @@ export default Controller.extend({
           this.model
             .destroy()
             .then(() => {
-              this.router.transitionToRoute("discovery.categories");
+              this.router.transitionTo("discovery.categories");
             })
             .catch(() => {
               this.displayErrors([I18n.t("category.delete_error")]);

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -12,6 +12,9 @@ import { inject as service } from "@ember/service";
 
 export default Controller.extend({
   dialog: service(),
+  site: service(),
+  router: service(),
+
   selectedTab: "general",
   saving: false,
   deleting: false,
@@ -109,7 +112,10 @@ export default Controller.extend({
               notification_level: NotificationLevels.REGULAR,
             });
             this.site.updateCategory(model);
-            this.transitionToRoute("editCategory", Category.slugFor(model));
+            this.router.transitionToRoute(
+              "editCategory",
+              Category.slugFor(model)
+            );
           }
         })
         .catch((error) => {
@@ -126,7 +132,7 @@ export default Controller.extend({
           this.model
             .destroy()
             .then(() => {
-              this.transitionToRoute("discovery.categories");
+              this.router.transitionToRoute("discovery.categories");
             })
             .catch(() => {
               this.displayErrors([I18n.t("category.delete_error")]);

--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -20,6 +20,9 @@ const Tab = EmberObject.extend({
 export default Controller.extend({
   application: controller(),
   dialog: service(),
+  currentUser: service(),
+  router: service(),
+
   counts: null,
   showing: "members",
   destroying: null,
@@ -146,7 +149,7 @@ export default Controller.extend({
       didConfirm: () => {
         model
           .destroy()
-          .then(() => this.transitionToRoute("groups.index"))
+          .then(() => this.router.transitionToRoute("groups.index"))
           .catch((error) => {
             // eslint-disable-next-line no-console
             console.error(error);

--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -149,7 +149,7 @@ export default Controller.extend({
       didConfirm: () => {
         model
           .destroy()
-          .then(() => this.router.transitionToRoute("groups.index"))
+          .then(() => this.router.transitionTo("groups.index"))
           .catch((error) => {
             // eslint-disable-next-line no-console
             console.error(error);

--- a/app/assets/javascripts/discourse/app/controllers/groups-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/groups-index.js
@@ -4,8 +4,10 @@ import { INPUT_DELAY } from "discourse-common/config/environment";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import discourseDebounce from "discourse-common/lib/debounce";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
   application: controller(),
   queryParams: ["order", "asc", "filter", "type"],
   order: null,
@@ -55,7 +57,7 @@ export default Controller.extend({
 
   @action
   new() {
-    this.transitionToRoute("groups.new");
+    this.router.transitionToRoute("groups.new");
   },
 
   _debouncedFilter(filter) {

--- a/app/assets/javascripts/discourse/app/controllers/groups-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/groups-index.js
@@ -57,7 +57,7 @@ export default Controller.extend({
 
   @action
   new() {
-    this.router.transitionToRoute("groups.new");
+    this.router.transitionTo("groups.new");
   },
 
   _debouncedFilter(filter) {

--- a/app/assets/javascripts/discourse/app/controllers/groups-new.js
+++ b/app/assets/javascripts/discourse/app/controllers/groups-new.js
@@ -63,7 +63,7 @@ export default Controller.extend({
     group
       .create()
       .then(() => {
-        this.router.transitionToRoute("group.members", group.name);
+        this.router.transitionTo("group.members", group.name);
       })
       .catch(popupAjaxError)
       .finally(() => this.set("saving", false));

--- a/app/assets/javascripts/discourse/app/controllers/groups-new.js
+++ b/app/assets/javascripts/discourse/app/controllers/groups-new.js
@@ -37,6 +37,7 @@ export function popupAutomaticMembershipAlert(group_id, email_domains) {
 
 export default Controller.extend({
   dialog: service(),
+  router: service(),
   saving: null,
 
   @discourseComputed("model.ownerUsernames")
@@ -62,7 +63,7 @@ export default Controller.extend({
     group
       .create()
       .then(() => {
-        this.transitionToRoute("group.members", group.name);
+        this.router.transitionToRoute("group.members", group.name);
       })
       .catch(popupAjaxError)
       .finally(() => this.set("saving", false));

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups-edit.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups-edit.js
@@ -10,7 +10,7 @@ export default Controller.extend({
       const tagGroups = this.tagGroups.model;
       tagGroups.removeObject(this.model);
 
-      this.router.transitionToRoute("tagGroups.index");
+      this.router.transitionTo("tagGroups.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups-edit.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups-edit.js
@@ -1,6 +1,8 @@
 import Controller, { inject as controller } from "@ember/controller";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
   tagGroups: controller(),
 
   actions: {
@@ -8,7 +10,7 @@ export default Controller.extend({
       const tagGroups = this.tagGroups.model;
       tagGroups.removeObject(this.model);
 
-      this.transitionToRoute("tagGroups.index");
+      this.router.transitionToRoute("tagGroups.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups-new.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups-new.js
@@ -1,6 +1,8 @@
 import Controller, { inject as controller } from "@ember/controller";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
   tagGroups: controller(),
 
   actions: {
@@ -8,7 +10,7 @@ export default Controller.extend({
       const tagGroups = this.tagGroups.model;
       tagGroups.pushObject(this.model);
 
-      this.transitionToRoute("tagGroups.index");
+      this.router.transitionToRoute("tagGroups.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups-new.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups-new.js
@@ -10,7 +10,7 @@ export default Controller.extend({
       const tagGroups = this.tagGroups.model;
       tagGroups.pushObject(this.model);
 
-      this.router.transitionToRoute("tagGroups.index");
+      this.router.transitionTo("tagGroups.index");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups.js
@@ -6,7 +6,7 @@ export default Controller.extend({
 
   actions: {
     newTagGroup() {
-      this.router.transitionToRoute("tagGroups.new");
+      this.router.transitionTo("tagGroups.new");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-groups.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-groups.js
@@ -1,9 +1,12 @@
 import Controller from "@ember/controller";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
+
   actions: {
     newTagGroup() {
-      this.transitionToRoute("tagGroups.new");
+      this.router.transitionToRoute("tagGroups.new");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -181,7 +181,7 @@ export default DiscoverySortableController.extend(
         didConfirm: () => {
           return this.tag
             .destroyRecord()
-            .then(() => this.router.transitionToRoute("tags.index"))
+            .then(() => this.router.transitionTo("tags.index"))
             .catch(() => this.dialog.alert(I18n.t("generic_error")));
         },
       });

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -19,6 +19,9 @@ export default DiscoverySortableController.extend(
   {
     application: controller(),
     dialog: service(),
+    router: service(),
+    currentUser: service(),
+    siteSettings: service(),
 
     tag: null,
     additionalTags: null,
@@ -178,7 +181,7 @@ export default DiscoverySortableController.extend(
         didConfirm: () => {
           return this.tag
             .destroyRecord()
-            .then(() => this.transitionToRoute("tags.index"))
+            .then(() => this.router.transitionToRoute("tags.index"))
             .catch(() => this.dialog.alert(I18n.t("generic_error")));
         },
       });

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -570,7 +570,7 @@ export default Controller.extend(bufferedProperty("model"), {
         .removeAllowedUser(user)
         .then(() => {
           if (this.currentUser.id === user.id) {
-            this.router.transitionToRoute("userPrivateMessages", user);
+            this.router.transitionTo("userPrivateMessages", user);
           }
         });
     },

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -59,6 +59,11 @@ export default Controller.extend(bufferedProperty("model"), {
   documentTitle: service(),
   screenTrack: service(),
   modal: service(),
+  currentUser: service(),
+  router: service(),
+  siteSettings: service(),
+  site: service(),
+  appEvents: service(),
 
   multiSelect: false,
   selectedPostIds: null,
@@ -565,7 +570,7 @@ export default Controller.extend(bufferedProperty("model"), {
         .removeAllowedUser(user)
         .then(() => {
           if (this.currentUser.id === user.id) {
-            this.transitionToRoute("userPrivateMessages", user);
+            this.router.transitionToRoute("userPrivateMessages", user);
           }
         });
     },

--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -53,7 +53,7 @@ export default Controller.extend({
 
   @action
   search() {
-    this.router.transitionToRoute({
+    this.router.transitionTo({
       queryParams: { q: this.searchTerm },
     });
   },

--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -8,11 +8,13 @@ import Bookmark from "discourse/models/bookmark";
 import I18n from "I18n";
 import { Promise } from "rsvp";
 import { htmlSafe } from "@ember/template";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
   queryParams: ["q"],
   q: null,
 
+  router: service(),
   application: controller(),
   user: controller(),
   loading: false,
@@ -51,7 +53,7 @@ export default Controller.extend({
 
   @action
   search() {
-    this.transitionToRoute({
+    this.router.transitionToRoute({
       queryParams: { q: this.searchTerm },
     });
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -143,7 +143,7 @@ acceptance("Admin - Site Settings", function (needs) {
     await visit("admin/site_settings/category/basic?filter=menu");
     assert.strictEqual(
       currentURL(),
-      "admin/site_settings/category/basic?filter=menu"
+      "/admin/site_settings/category/basic?filter=menu"
     );
   });
 

--- a/app/assets/javascripts/wizard/addon/controllers/wizard-step.js
+++ b/app/assets/javascripts/wizard/addon/controllers/wizard-step.js
@@ -16,14 +16,14 @@ export default Controller.extend({
     if (response?.refresh_required) {
       document.location = getUrl(`/wizard/steps/${next}`);
     } else if (response?.success && next) {
-      this.router.transitionToRoute("wizard.step", next);
+      this.router.transitionTo("wizard.step", next);
     } else if (response?.success) {
-      this.router.transitionToRoute("discovery.latest");
+      this.router.transitionTo("discovery.latest");
     }
   },
 
   @action
   goBack() {
-    this.router.transitionToRoute("wizard.step", this.step.previous);
+    this.router.transitionTo("wizard.step", this.step.previous);
   },
 });

--- a/app/assets/javascripts/wizard/addon/controllers/wizard-step.js
+++ b/app/assets/javascripts/wizard/addon/controllers/wizard-step.js
@@ -1,8 +1,11 @@
 import getUrl from "discourse-common/lib/get-url";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
+  router: service(),
+
   wizard: null,
   step: null,
 
@@ -13,14 +16,14 @@ export default Controller.extend({
     if (response?.refresh_required) {
       document.location = getUrl(`/wizard/steps/${next}`);
     } else if (response?.success && next) {
-      this.transitionToRoute("wizard.step", next);
+      this.router.transitionToRoute("wizard.step", next);
     } else if (response?.success) {
-      this.transitionToRoute("discovery.latest");
+      this.router.transitionToRoute("discovery.latest");
     }
   },
 
   @action
   goBack() {
-    this.transitionToRoute("wizard.step", this.step.previous);
+    this.router.transitionToRoute("wizard.step", this.step.previous);
   },
 });


### PR DESCRIPTION
Per https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods

We are upgrading all `this.transitionToRoute` calls on controllers to directly call the router service (`this.router.transitionTo`)