### PR TITLE
DEV: Upgrade `replaceRoute` on Controller

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
@@ -7,6 +7,7 @@ import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeColorsShowController extends Controller {
   @service dialog;
+  @service router;
   onlyOverridden = false;
 
   @computed("model.colors.[]", "onlyOverridden")
@@ -58,7 +59,7 @@ export default class AdminCustomizeColorsShowController extends Controller {
     );
     newColorScheme.save().then(() => {
       this.allColors.pushObject(newColorScheme);
-      this.replaceRoute("adminCustomize.colors.show", newColorScheme);
+      this.router.replaceRoute("adminCustomize.colors.show", newColorScheme);
     });
   }
 
@@ -79,7 +80,7 @@ export default class AdminCustomizeColorsShowController extends Controller {
       didConfirm: () => {
         return this.model.destroy().then(() => {
           this.allColors.removeObject(this.model);
-          this.replaceRoute("adminCustomize.colors");
+          this.router.replaceRoute("adminCustomize.colors");
         });
       },
     });

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -3,8 +3,11 @@ import EmberObject, { action } from "@ember/object";
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import showModal from "discourse/lib/show-modal";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeColorsController extends Controller {
+  @service router;
+
   @discourseComputed("model.@each.id")
   baseColorScheme() {
     return this.model.findBy("is_base", true);
@@ -35,7 +38,7 @@ export default class AdminCustomizeColorsController extends Controller {
     newColorScheme.save().then(() => {
       this.model.pushObject(newColorScheme);
       newColorScheme.set("savingStatus", null);
-      this.replaceRoute("adminCustomize.colors.show", newColorScheme);
+      this.router.replaceRoute("adminCustomize.colors.show", newColorScheme);
     });
   }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-edit.js
@@ -3,8 +3,11 @@ import Controller from "@ember/controller";
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { url } from "discourse/lib/computed";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeThemesEditController extends Controller {
+  @service router;
+
   section = null;
   currentTarget = 0;
   maximized = false;
@@ -48,7 +51,12 @@ export default class AdminCustomizeThemesEditController extends Controller {
 
   @action
   fieldAdded(target, name) {
-    this.replaceRoute(this.editRouteName, this.get("model.id"), target, name);
+    this.router.replaceRoute(
+      this.editRouteName,
+      this.get("model.id"),
+      target,
+      name
+    );
   }
 
   @action
@@ -60,7 +68,7 @@ export default class AdminCustomizeThemesEditController extends Controller {
           (f) => f.edited
         );
 
-        this.replaceRoute(
+        this.router.replaceRoute(
           this.editRouteName,
           this.get("model.id"),
           firstTarget.name,
@@ -72,6 +80,6 @@ export default class AdminCustomizeThemesEditController extends Controller {
 
   @action
   goBack() {
-    this.replaceRoute(this.showRouteName, this.model.id);
+    this.router.replaceRoute(this.showRouteName, this.model.id);
   }
 }

--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard-general.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard-general.js
@@ -8,6 +8,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import getURL from "discourse-common/lib/get-url";
 import { makeArray } from "discourse-common/lib/helpers";
 import { setting } from "discourse/lib/computed";
+import { inject as service } from "@ember/service";
 
 function staticReport(reportType) {
   return computed("reports.[]", function () {
@@ -19,6 +20,8 @@ export default class AdminDashboardGeneralController extends Controller.extend(
   PeriodComputationMixin
 ) {
   @controller("exception") exceptionController;
+  @service router;
+  @service siteSettings;
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -137,7 +140,7 @@ export default class AdminDashboardGeneralController extends Controller.extend(
         })
         .catch((e) => {
           this.exceptionController.set("thrown", e.jqXHR);
-          this.replaceRoute("exception");
+          this.router.replaceRoute("exception");
         })
         .finally(() => this.set("isLoading", false));
     }

--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard-general.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard-general.js
@@ -19,9 +19,9 @@ function staticReport(reportType) {
 export default class AdminDashboardGeneralController extends Controller.extend(
   PeriodComputationMixin
 ) {
-  @controller("exception") exceptionController;
   @service router;
   @service siteSettings;
+  @controller("exception") exceptionController;
 
   isLoading = false;
   dashboardFetchedAt = null;

--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
@@ -4,11 +4,14 @@ import AdminDashboard from "admin/models/admin-dashboard";
 import VersionCheck from "admin/models/version-check";
 import discourseComputed from "discourse-common/utils/decorators";
 import { setting } from "discourse/lib/computed";
+import { inject as service } from "@ember/service";
 
 const PROBLEMS_CHECK_MINUTES = 1;
 
 export default class AdminDashboardController extends Controller {
   @controller("exception") exceptionController;
+  @service router;
+  @service siteSettings;
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -88,7 +91,7 @@ export default class AdminDashboardController extends Controller {
         })
         .catch((e) => {
           this.exceptionController.set("thrown", e.jqXHR);
-          this.replaceRoute("exception");
+          this.router.replaceRoute("exception");
         })
         .finally(() => {
           this.set("isLoading", false);

--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
@@ -9,9 +9,9 @@ import { inject as service } from "@ember/service";
 const PROBLEMS_CHECK_MINUTES = 1;
 
 export default class AdminDashboardController extends Controller {
-  @controller("exception") exceptionController;
   @service router;
   @service siteSettings;
+  @controller("exception") exceptionController;
 
   isLoading = false;
   dashboardFetchedAt = null;


### PR DESCRIPTION
Per https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods

We are upgrading all `this.replaceRoute` calls on controllers to directly call the router service (`this.router.replaceRoute`)