### PR TITLE
DEV: Fix flaky core backend spec

### DIFF
--- a/spec/fixtures/json/vanilla-rich-posts.json
+++ b/spec/fixtures/json/vanilla-rich-posts.json
@@ -3,7 +3,7 @@
     "insert": "This is a message.\nAnd a second line.\n"
   }],
   "mention": [
-    { "insert": { "mention": { "name": "Gandalf The Grey", "userID": 666 } } },
+    { "insert": { "mention": { "name": "Gandalf The Grey", "userID": 999999999 } } },
     {
       "insert": ", what do you think?\n"
     }

--- a/spec/script/import_scripts/vanilla_body_parser_spec.rb
+++ b/spec/script/import_scripts/vanilla_body_parser_spec.rb
@@ -96,6 +96,7 @@ this starts with spaces but IS NOT a quote" \
           { "Format" => "Rich", "Body" => rich_bodies[:mention].to_json },
           user_id,
         ).parse
+
       expect(parsed).to eq "@Gandalf The Grey, what do you think?"
     end
 
@@ -107,9 +108,10 @@ this starts with spaces but IS NOT a quote" \
           name: "Gandalf The Grey",
           username: "gandalf_the_grey",
         )
+
       lookup.add_user(mentioned.id.to_s, mentioned)
 
-      body = rich_bodies[:mention].to_json.gsub("666", mentioned.id.to_s)
+      body = rich_bodies[:mention].to_json.gsub("999999999", mentioned.id.to_s)
       parsed = VanillaBodyParser.new({ "Format" => "Rich", "Body" => body }, user_id).parse
       expect(parsed).to eq "@gandalf_the_grey, what do you think?"
     end
@@ -120,6 +122,7 @@ this starts with spaces but IS NOT a quote" \
           { "Format" => "Rich", "Body" => rich_bodies[:links].to_json },
           user_id,
         ).parse
+
       expect(
         parsed,
       ).to eq "We can link to the <a href=\"https:\/\/www.discourse.org\/\">Discourse home page</a> and it works."


### PR DESCRIPTION
Why this change?

The user id in a fixture file was hardcoded to 666. Once we've
fabricated enough user objects until the sequence for `User#id` reaches
666, the specs in vanilla_body_parser_spec.rb will fail.

What is the fix here?

This commit increases the user id to a large integer which we will
likely never hit in the next 10-20 years.