### PR TITLE
DEV: Skip two flaky system tests

### DIFF
--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -53,6 +53,12 @@ describe "Thread tracking state | drawer", type: :system do
     end
 
     it "shows unread indicators for the header icon and the list when a new unread arrives" do
+      skip(<<~TEXT)
+      Flaky at the following assertion:
+
+      expected `#<PageObjects::Components::Chat::ThreadList:0x00007f082393ada0>.has_unread_item?(2)` to be truthy, got false
+      TEXT
+
       thread.membership_for(current_user).update!(last_read_message_id: message_2.id)
       visit("/")
       chat_page.open_from_header

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -7,6 +7,13 @@ describe "Viewing top topics on categories page", type: :system, js: true do
   fab!(:topic) { Fabricate(:topic, category: category) }
 
   it "displays and updates new counter" do
+    skip(<<~TEXT)
+    Flaky at the following step:
+
+    expect(category_list).to have_no_new_posts_badge
+       expected `#<PageObjects::Components::CategoryList:0x00007fe27a3d2340>.has_no_new_posts_badge?` to be truthy, got false
+    TEXT
+
     sign_in(user)
 
     visit("/categories")


### PR DESCRIPTION
Why this change?

These tests have shown to be flaky and are being skipped for now while
we look into it.