### PR TITLE
DEV: Fix and re-enable chat flakys

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list.js
@@ -140,6 +140,10 @@ export default class ChatThreadList extends Component {
 
   #unsubscribe() {
     // TODO (joffrey) In drawer we won't have channel anymore at this point
+    if (!this.args.channel) {
+      return;
+    }
+
     this.messageBus.unsubscribe(
       `/chat/${this.args.channel.id}`,
       this.onMessageBus

--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Thread tracking state | drawer", type: :system do
+  include ActiveSupport::Testing::TimeHelpers
+
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:other_user) { Fabricate(:user) }
@@ -61,6 +63,7 @@ describe "Thread tracking state | drawer", type: :system do
       drawer_page.open_thread_list
       expect(drawer_page).to have_no_unread_thread_indicator
       expect(thread_list_page).to have_no_unread_item(thread.id)
+      travel_to(1.minute.from_now)
       Fabricate(:chat_message, chat_channel: channel, thread: thread, user: other_user)
       expect(drawer_page).to have_unread_thread_indicator(count: 1)
       expect(thread_list_page).to have_unread_item(thread.id)
@@ -109,6 +112,7 @@ describe "Thread tracking state | drawer", type: :system do
         drawer_page.open_channel(channel)
         drawer_page.back
         expect(drawer_page).to have_no_unread_channel(channel)
+        travel_to(1.minute.from_now)
         Fabricate(:chat_message, thread: thread, user: other_user)
         expect(drawer_page).to have_unread_channel(channel)
       end

--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -15,6 +15,7 @@ describe "Thread tracking state | drawer", type: :system do
   before do
     SiteSetting.enable_experimental_chat_threaded_discussions = true
     chat_system_bootstrap(current_user, [channel])
+    chat_system_user_bootstrap(user: other_user, channel: channel)
     sign_in(current_user)
     thread.add(current_user)
   end
@@ -53,12 +54,6 @@ describe "Thread tracking state | drawer", type: :system do
     end
 
     it "shows unread indicators for the header icon and the list when a new unread arrives" do
-      skip(<<~TEXT)
-      Flaky at the following assertion:
-
-      expected `#<PageObjects::Components::Chat::ThreadList:0x00007f082393ada0>.has_unread_item?(2)` to be truthy, got false
-      TEXT
-
       thread.membership_for(current_user).update!(last_read_message_id: message_2.id)
       visit("/")
       chat_page.open_from_header
@@ -66,7 +61,7 @@ describe "Thread tracking state | drawer", type: :system do
       drawer_page.open_thread_list
       expect(drawer_page).to have_no_unread_thread_indicator
       expect(thread_list_page).to have_no_unread_item(thread.id)
-      Fabricate(:chat_message, chat_channel: channel, thread: thread)
+      Fabricate(:chat_message, chat_channel: channel, thread: thread, user: other_user)
       expect(drawer_page).to have_unread_thread_indicator(count: 1)
       expect(thread_list_page).to have_unread_item(thread.id)
     end
@@ -103,18 +98,18 @@ describe "Thread tracking state | drawer", type: :system do
         chat_page.open_from_header
         expect(drawer_page).to have_unread_channel(channel)
         drawer_page.open_channel(channel)
-        Fabricate(:chat_message, thread: thread)
+        Fabricate(:chat_message, thread: thread, user: other_user)
         drawer_page.back
         expect(drawer_page).to have_no_unread_channel(channel)
       end
 
-      xit "shows an unread indicator for the channel index if a new thread message arrives while the user is not looking at the channel" do
+      it "shows an unread indicator for the channel index if a new thread message arrives while the user is not looking at the channel" do
         visit("/")
         chat_page.open_from_header
         drawer_page.open_channel(channel)
         drawer_page.back
         expect(drawer_page).to have_no_unread_channel(channel)
-        Fabricate(:chat_message, thread: thread)
+        Fabricate(:chat_message, thread: thread, user: other_user)
         expect(drawer_page).to have_unread_channel(channel)
       end
     end


### PR DESCRIPTION
The early return in JS was added to prevent an error
from channel being null, and it's better to use known
users for the message fabrications in the specs.
