### PR TITLE
FIX: sometimes stuck of sidebar reorder

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -84,12 +84,13 @@ export default class SectionLink {
   dragMove(event) {
     this.startMouseY = this.#calcMouseY(event);
 
+    event.stopPropagation();
+    event.preventDefault();
+
     if (!this.drag) {
       return;
     }
 
-    event.stopPropagation();
-    event.preventDefault();
     const currentMouseY = this.#calcMouseY(event);
     const distance = currentMouseY - this.mouseY;
 


### PR DESCRIPTION
When the mouse was moved quickly, the browser stayed in drag and drop mode and an additional click was required to exit drag and drop mode.
