### PR TITLE
FEATURE: Add admin dashboard warning for `legacy` navigation menu

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -207,7 +207,8 @@ class AdminDashboardData
                       :unreachable_themes,
                       :watched_words_check,
                       :google_analytics_version_check,
-                      :translation_overrides_check
+                      :translation_overrides_check,
+                      :legacy_navigation_menu_check
 
     register_default_scheduled_problem_checks
 
@@ -364,6 +365,12 @@ class AdminDashboardData
   def translation_overrides_check
     if TranslationOverride.exists?(status: %i[outdated invalid_interpolation_keys])
       I18n.t("dashboard.outdated_translations_warning", base_path: Discourse.base_path)
+    end
+  end
+
+  def legacy_navigation_menu_check
+    if SiteSetting.navigation_menu == "legacy"
+      I18n.t("dashboard.legacy_navigation_menu_deprecated", base_path: Discourse.base_path)
     end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1491,6 +1491,7 @@ en:
     unreachable_themes: "We were unable to check for updates on the following themes:"
     watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
     v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
+    legacy_navigation_menu_deprecated: "Your Discourse is currently using the 'legacy' navigation menu which <a href='https://meta.discourse.org/t/removing-the-legacy-hamburger-navigation-menu-option/265274'>will be removed in the first beta release of Discourse 3.2</a>. Migrate to the new 'sidebar' navigation menu by updating your <a href='%{base_path}/admin/site_settings/category/all_results?filter=navigation_menu'>navigation menu site setting</a>."
 
   site_settings:
     allow_bulk_invite: "Allow bulk invites by uploading a CSV file"

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe AdminDashboardData do
         expect(problems.map(&:to_s)).to include("a problem was found")
       end
     end
+
+    describe "when `navigation_menu` site setting is `legacy`" do
+      it "should include the right problem message" do
+        SiteSetting.set(:navigation_menu, "legacy")
+
+        problem = AdminDashboardData.fetch_problems.last
+
+        expect(problem.message).to include(
+          I18n.t("dashboard.legacy_navigation_menu_deprecated", base_path: Discourse.base_path),
+        )
+      end
+    end
   end
 
   describe "adding scheduled checks" do


### PR DESCRIPTION
Why this change?

The `legacy` navigation menu option for the `navigation_menu` site
setting will be removed shortly after the release of Discourse 3.1 in
the first beta release of Discourse 3.2. Therefore, we're adding an
admin dashboard warning to give sites on the `legacy` navigation menu a
heads up.