### PR TITLE
FIX: check if dominant color is set before updating site theme color

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-lightbox.js
+++ b/app/assets/javascripts/discourse/app/components/d-lightbox.js
@@ -249,7 +249,9 @@ export default class DLightbox extends Component {
   #onAfterItemChange() {
     this.isLoading = false;
 
-    setSiteThemeColor(this.currentItem.dominantColor);
+    if (this.currentItem.dominantColor) {
+      setSiteThemeColor(this.currentItem.dominantColor);
+    }
 
     setCarouselScrollPosition({
       behavior: "smooth",


### PR DESCRIPTION
Currently the dominant color attribute is only set for post images (not chat).

As a result, clicking lightbox images in chat will load the image within lightbox but also shows a JS error.

This change ensures that the dominant color is set before attempting to update the site theme color.

Omitted tests as it's very small change and testing for this offers no real advantage at this stage.