### PR TITLE
DEV: Add more chrome options for system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -676,7 +676,22 @@ def apply_base_chrome_options(options)
   options.add_argument("--no-sandbox")
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--mute-audio")
-  options.add_argument("--force-device-scale-factor=1")
+
+  # A file that contains just a list of paths like so:
+  #
+  # /home/me/.config/google-chrome/Default/Extensions/bmdblncegkenkacieihfhpjfppoconhi/4.9.1_0
+  #
+  # These paths can be found for each individual extension via the
+  # chrome://extensions/ page.
+  if ENV["CHROME_LOAD_EXTENSIONS_MANIFEST"].present?
+    File
+      .readlines(ENV["CHROME_LOAD_EXTENSIONS_MANIFEST"])
+      .each { |path| options.add_argument("--load-extension=#{path}") }
+  end
+
+  if ENV["CHROME_DISABLE_FORCE_DEVICE_SCALE_FACTOR"].blank?
+    options.add_argument("--force-device-scale-factor=1")
+  end
 end
 
 class SpecSecureRandom


### PR DESCRIPTION
* CHROME_LOAD_EXTENSIONS_MANIFEST - An env var with a path to a file
  that contains one path per line. These are paths to extensions installed
  in chrome that the user wants to load while running system specs.
  Useful to run things like Ember Inspector.
* CHROME_DISABLE_FORCE_DEVICE_SCALE_FACTOR - On some systems the
  --force-device-scale-factor=1 argument makes the UI for chrome
  super small, add a way to disable this.

Extension path:

![image](https://github.com/discourse/discourse/assets/920448/013111fa-09d4-4131-ba82-f85cad46b361)
