### PR TITLE
FIX: Termless hashtag search when a type is disabled

### DIFF
--- a/app/services/hashtag_autocomplete_service.rb
+++ b/app/services/hashtag_autocomplete_service.rb
@@ -57,7 +57,10 @@ class HashtagAutocompleteService
   end
 
   def self.ordered_types_for_context(context)
-    find_priorities_for_context(context).sort_by { |ctp| -ctp[:priority] }.map { |ctp| ctp[:type] }
+    find_priorities_for_context(context)
+      .sort_by { |ctp| -ctp[:priority] }
+      .map { |ctp| ctp[:type] }
+      .reject { |type| data_source_types.exclude?(type) }
   end
 
   def self.contexts_with_ordered_types
@@ -230,16 +233,16 @@ class HashtagAutocompleteService
   )
     raise Discourse::InvalidParameters.new(:order) if !types_in_priority_order.is_a?(Array)
     limit = [limit, SEARCH_MAX_LIMIT].min
+    types_in_priority_order =
+      types_in_priority_order.select do |type|
+        HashtagAutocompleteService.data_source_types.include?(type)
+      end
 
     return search_without_term(types_in_priority_order, limit) if term.blank?
 
     limited_results = []
     top_ranked_type = nil
     term = term.downcase
-    types_in_priority_order =
-      types_in_priority_order.select do |type|
-        HashtagAutocompleteService.data_source_types.include?(type)
-      end
 
     # Float exact matches by slug to the top of the list, any of these will be excluded
     # from further results.

--- a/spec/services/hashtag_autocomplete_service_spec.rb
+++ b/spec/services/hashtag_autocomplete_service_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe HashtagAutocompleteService do
         { "topic-composer" => %w[category tag], "awesome-composer" => %w[tag category] },
       )
     end
+
+    it "does not return types which have been disabled" do
+      SiteSetting.tagging_enabled = false
+      expect(HashtagAutocompleteService.contexts_with_ordered_types).to eq(
+        { "topic-composer" => %w[category] },
+      )
+    end
   end
 
   describe ".data_source_icon_map" do
@@ -294,6 +301,13 @@ RSpec.describe HashtagAutocompleteService do
             "great-books",
             "book",
           ],
+        )
+      end
+
+      it "does not error if a type provided for priority order has been disabled" do
+        SiteSetting.tagging_enabled = false
+        expect(service.search(nil, %w[category tag]).map(&:ref)).to eq(
+          %w[book-dome book-zone media book uncategorized the-book-club],
         )
       end
     end


### PR DESCRIPTION
When a type was disabled, the hashtag search _without_ a
term was erroring. This was because we weren't filtering
out the disabled types from types_in_priority_order first
like we were if there was a term provided.

This commit fixes that issue, and also makes it so
contexts_with_ordered_types and ordered_types_for_context
will only return hashtag types which are enabled.
