### PR TITLE
A11Y: Fix focus state style for date button in composer

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -50,7 +50,6 @@ html {
   }
 
   // Composer
-
   #reply-control .reply-to .reply-details .d-icon {
     opacity: 1;
     color: var(--primary-low-mid);
@@ -63,6 +62,11 @@ html {
         &:hover {
           color: var(--secondary);
         }
+      }
+    }
+    .btn-icon:not(.btn-flat, .btn-danger, .btn-primary):focus {
+      .d-icon {
+        color: currentColor;
       }
     }
   }


### PR DESCRIPTION
When using a WCAG color scheme. 

Before

<img width="747" alt="image" src="https://github.com/discourse/discourse/assets/368961/110e6475-8561-49f9-8851-384c3ec7b3d4">

After

<img width="747" alt="image" src="https://github.com/discourse/discourse/assets/368961/f7d8af08-6c36-4923-b9b4-4a48be058fe1">
