### PR TITLE
FIX: Embedding checkbox bug

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embedding-setting.js
+++ b/app/assets/javascripts/admin/addon/components/embedding-setting.js
@@ -26,7 +26,7 @@ export default class EmbeddingSetting extends Component {
     return !!this.value;
   }
 
-  set(value) {
+  set checked(value) {
     this.set("value", value);
     return value;
   }


### PR DESCRIPTION
**Context**
Discourse allows embedding so people can embed discourse in their own site

**Problem**
After adding a site in `admin/customize/embedding`  the user can configure additional settings. However, some settings using checkboxes could not be updated

**Solution**
The setter method responsible for updating the checkboxes values was not implemented correctly, fixing this fixed the issue