### PR TITLE
DEV: Remove transition-methods deprecation

### DIFF
--- a/app/assets/javascripts/discourse/config/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/config/deprecation-workflow.js
@@ -4,7 +4,6 @@ globalThis.deprecationWorkflow.config = {
   // `throwOnUnhandled` here since it is easier to toggle.
   workflow: [
     { handler: "silence", matchId: "route-render-template" },
-    { handler: "silence", matchId: "routing.transition-methods" },
     { handler: "silence", matchId: "route-disconnect-outlet" },
     { handler: "silence", matchId: "this-property-fallback" },
     { handler: "silence", matchId: "discourse.select-kit" },


### PR DESCRIPTION
All https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods deprecations have been resolved.