### PR TITLE
DEV: Fix ember-cli proxy assets

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -516,6 +516,15 @@ to serve API requests. For example:
       return false;
     }
 
+    // All JS assets are served by Ember CLI, except for
+    // plugin assets which end in _extra.js
+    if (
+      request.path.startsWith(`${baseURL}assets/`) &&
+      !request.path.endsWith("_extra.js")
+    ) {
+      return false;
+    }
+
     if (request.path.startsWith(`${baseURL}_lr/`)) {
       return false;
     }


### PR DESCRIPTION
We were proxying all `/assets/*` requests through to the origin. In local development that was fine, because Rails was able to serve files from the `dist/` directory. But when proxying to a remote origin, we want the local ember-cli to serve its own JS assets

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
