### PR TITLE
DEV: Use the main default session for main test assertions

### DIFF
--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -146,30 +146,26 @@ describe "Single thread in side panel", type: :system do
 
         other_user = Fabricate(:user)
         chat_system_user_bootstrap(user: other_user, channel: channel)
-        using_session(:tab_2) do
-          sign_in(other_user)
-          chat_page.visit_channel(channel)
-          channel_page.message_thread_indicator(thread.original_message).click
-        end
+        sign_in(other_user)
+        chat_page.visit_channel(channel)
+        channel_page.message_thread_indicator(thread.original_message).click
 
-        using_session(:tab_2) do
-          expect(side_panel).to have_open_thread(thread)
-          thread_page.send_message("the other user message")
-          expect(thread_page).to have_message(thread_id: thread.id, text: "the other user message")
-        end
+        expect(side_panel).to have_open_thread(thread)
 
-        using_session(:tab_1) do |session|
+        thread_page.send_message("the other user message")
+
+        expect(thread_page).to have_message(thread_id: thread.id, text: "the other user message")
+
+        using_session(:tab_1) do
           expect(side_panel).to have_open_thread(thread)
           expect(thread_page).to have_message(thread_id: thread.id, text: "the other user message")
+
           thread_page.send_message("this is a test message")
+
           expect(thread_page).to have_message(thread_id: thread.id, text: "this is a test message")
-          session.quit
         end
 
-        using_session(:tab_2) do |session|
-          expect(thread_page).to have_message(thread_id: thread.id, text: "this is a test message")
-          session.quit
-        end
+        expect(thread_page).to have_message(thread_id: thread.id, text: "this is a test message")
       end
 
       it "does not mark the channel unread if another user sends a message in the thread" do


### PR DESCRIPTION
Why this change?

The test being changed in question has been flaky on our CI. However, we
are unable to view the screenshot of why it failed because
ActionDispatch will only take a screenshot of the default session upon
failure. At the same time, taking screenshot of all sessions
automatically upon failure is not possible via the official Capybara or
Rails APIs at the moment. Therefore, we're changing this system test to
avoid using two custom session and instead have the main assertion use
the default session such that any failures will provide us with a
screenshot.