### PR TITLE
FIX: banners not removing when unset

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/banner.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/banner.js
@@ -21,6 +21,10 @@ export default {
 
   @bind
   onMessage(data = {}) {
-    this.site.set("banner", EmberObject.create(data));
+    if (data) {
+      this.site.set("banner", EmberObject.create(data));
+    } else {
+      this.site.set("banner", null);
+    }
   },
 };


### PR DESCRIPTION
Due to internal ember changes setting it to a blank ember object would result
in old banner still showing up. Perhaps exception related.
