### PR TITLE
FIX: Hashtag error in PrettyText when processing email

### DIFF
--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -125,6 +125,11 @@ module PrettyText
         cooking_user = User.find(cooking_user_id)
       end
 
+      types_in_priority_order =
+        types_in_priority_order.select do |type|
+          HashtagAutocompleteService.data_source_types.include?(type)
+        end
+
       result =
         HashtagAutocompleteService.new(Guardian.new(cooking_user)).lookup(
           [slug],

--- a/spec/lib/pretty_text/helpers_spec.rb
+++ b/spec/lib/pretty_text/helpers_spec.rb
@@ -163,6 +163,13 @@ RSpec.describe PrettyText::Helpers do
       )
     end
 
+    it "does not return any results for disabled types" do
+      SiteSetting.tagging_enabled = false
+      expect(
+        PrettyText::Helpers.hashtag_lookup("somecooltag::tag", user.id, %w[category tag]),
+      ).to eq(nil)
+    end
+
     it "returns nil when no tag or category that matches exists" do
       expect(PrettyText::Helpers.hashtag_lookup("blah", user.id, %w[category tag])).to eq(nil)
     end


### PR DESCRIPTION
Followup to b583872eed539eb510652291b136ffcf8abc4548
and 54001060eaca82196d9ce67531f3fdc319483b97

Another place where we need to filter hashtag types to
only enabled ones is PrettyText, though the latter PR
above should also already make it so the correct priority
types are passed.

This is causing errors in the email processing workflow
for some customers (presumably ones with tagging disabled).
