### PR TITLE
DEV: specify chrome version to get system specs working (webdrivers issue)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Setup Webdriver
         if: matrix.build_type == 'system'
-        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.update"
+        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,8 @@ require "webdrivers"
 require "selenium-webdriver"
 require "capybara/rails"
 
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
 # The shoulda-matchers gem no longer detects the test framework
 # you're using or mixes itself into that framework automatically.
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Available versions: https://chromedriver.storage.googleapis.com/index.html . Google has moved to
a new "Chrome for Testing" system after v115 https://developer.chrome.com/blog/chrome-for-testing/
that means new versions of chromedriver won't be published to the chromedriver.storage site.

We use the webdrivers gem to get the chromedriver automatically based on chrome version, there
is an issue about this here:

https://github.com/titusfortner/webdrivers/issues/247

We need to move to the new way of getting chrome/chromedriver, but for now let's just
get system specs working again by pinning a specific version.