### PR TITLE
DEV: Avoid waiting full Capbyara default wait timeout in system tests

### DIFF
--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -46,6 +46,10 @@ module PageObjects
         page.has_css?(REVIEWABLE_ACTION_DROPDOWN)
       end
 
+      def has_no_reviewable_action_dropdown?
+        page.has_no_css?(REVIEWABLE_ACTION_DROPDOWN)
+      end
+
       def has_reviewable_with_pending_status?(reviewable)
         within(reviewable_by_id(reviewable.id)) { page.has_css?(".status .pending") }
       end
@@ -59,7 +63,7 @@ module PageObjects
       end
 
       def has_no_error_dialog_visible?
-        !has_error_dialog_visible?
+        page.has_no_css?("dialog-container .dialog-content")
       end
 
       private

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -48,7 +48,7 @@ describe "Reviewables", type: :system do
 
         expect(review_page).to have_no_error_dialog_visible
         expect(review_page).to have_reviewable_with_rejected_status(queued_post_reviewable)
-        expect(review_page).not_to have_reviewable_action_dropdown
+        expect(review_page).to have_no_reviewable_action_dropdown
         expect(queued_post_reviewable.reload).to be_rejected
         expect(queued_post_reviewable.target_created_by).to be_nil
       end


### PR DESCRIPTION
Avoid using negated matchers with custom RSpec matchers that rely on
`has_css?` as it'll result in Capybara waiting the full default wait
time.