### PR TITLE
DEV: Raise exception when capybara waiter times out

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -50,8 +50,7 @@ module PageObjects
 
       def visit_thread(thread)
         visit(thread.url)
-        has_css?(".chat-skeleton")
-        has_no_css?(".chat-skeleton")
+        has_css?(".chat-thread:not(.loading)[data-id=\"#{thread.id}\"]")
       end
 
       def visit_channel_settings(channel)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -283,10 +283,10 @@ RSpec.configure do |config|
 
     Capybara::Session.class_eval { prepend IgnoreUnicornCapturedErrors }
 
-    module MatcherTimeoutExtension
-      class MatcherTimedOut < StandardError
+    module CapybaraTimeoutExtension
+      class CapybaraTimedOut < StandardError
         def initialize(wait_time)
-          super "Matcher waited for the full wait duration (#{wait_time}s). " +
+          super "Capybara waited for the full wait duration (#{wait_time}s). " +
                   "This will slow down the test suite. " +
                   "Beware of negating the result of selenium's RSpec matchers."
         end
@@ -300,7 +300,7 @@ RSpec.configure do |config|
           seconds = session_options.default_max_wait_time if [nil, true].include? seconds
           if catch_error?(e, errors) && seconds != 0
             # This error will only have been raised if the timer expired. Raise our own error instead.
-            raise MatcherTimedOut.new(seconds)
+            raise CapybaraTimedOut.new(seconds)
           else
             raise
           end
@@ -308,7 +308,7 @@ RSpec.configure do |config|
       end
     end
 
-    Capybara::Node::Base.prepend(MatcherTimeoutExtension)
+    Capybara::Node::Base.prepend(CapybaraTimeoutExtension)
 
     # possible values: OFF, SEVERE, WARNING, INFO, DEBUG, ALL
     browser_log_level = ENV["SELENIUM_BROWSER_LOG_LEVEL"] || "SEVERE"


### PR DESCRIPTION
If a matcher takes the full wait duration to resolve, that means it has been written inefficiently. Most likely a matcher has been negated incorrectly.

This commit introduces a patch which will raise an error in this situation so that we can catch the issues while developing specs.

For example, if we revert the fix in from d753e00eb5b150cb109b41b928e8d072e4546847, this new logic detects the issue correctly:

```
1) Reviewables when performing a review action from the show route with a ReviewableQueuedPost delete_user does not delete reviewable
     Failure/Error: raise MatcherTimedOut.new(seconds)
     
     MatcherTimeoutExtension::MatcherTimedOut:
       Matcher waited for the full wait duration (2s). This will slow down the test suite. Beware of negating the result of selenium's RSpec matchers.
     
     [Screenshot Image]: /Users/david/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_reviewables_when_performing_a_review_action_from_the_show_route_with_a_reviewable_queued_post_delete_user_does_not_delete_reviewable_680.png

     ~~~~~~~ JS LOGS ~~~~~~~
     ~~~~~ END JS LOGS ~~~~~
     
     # ./spec/rails_helper.rb:300:in `rescue in synchronize'
     # ./spec/rails_helper.rb:294:in `synchronize'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:843:in `_verify_selector_result'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:110:in `assert_selector'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:39:in `block in has_selector?'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:877:in `make_predicate'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:39:in `has_selector?'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:310:in `has_css?'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/session.rb:773:in `has_css?'
     # ./spec/system/page_objects/pages/review.rb:58:in `has_error_dialog_visible?'
     # ./spec/system/page_objects/pages/review.rb:62:in `has_no_error_dialog_visible?'
     # ./spec/system/reviewables_spec.rb:49:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:390:in `block (2 levels) in <top (required)>'
     # /Users/david/.rvm/gems/ruby-3.2.1/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Capybara::ExpectationNotMet:
     #   expected to find css ".dialog-container .dialog-content" but there were no matches
     #   /Users/david/.rvm/gems/ruby-3.2.1/gems/capybara-3.39.2/lib/capybara/node/matchers.rb:112:in `block in assert_selector'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
