### PR TITLE
FIX: Staff action log could not be accessed via link

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
@@ -18,7 +18,7 @@ export default class AdminLogsStaffActionLogsRoute extends DiscourseRoute {
   }
 
   deserializeQueryParam(value, urlKey, defaultValueType) {
-    if (urlKey === "filters") {
+    if (urlKey === "filters" && value) {
       return EmberObject.create(JSON.parse(decodeURIComponent(value)));
     }
 


### PR DESCRIPTION
011ba5b9 slightly changed the way the staff-action-log route is activated. It's now possible for `deserializeQueryParam` to be called with a null value, so we need to deal with that case.

This route is currently untested - we'll follow-up with another commit to add some.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
