### PR TITLE
FIX: Ensure 'modern' modals are closed when opening legacy modal

### DIFF
--- a/app/assets/javascripts/discourse/app/services/modal.js
+++ b/app/assets/javascripts/discourse/app/services/modal.js
@@ -193,6 +193,8 @@ export default class ModalServiceWithLegacySupport extends ModalService {
       return super.show(modal, opts);
     }
 
+    this.close({ initiatedBy: CLOSE_INITIATED_BY_MODAL_SHOW });
+
     if (!KNOWN_LEGACY_MODALS.includes(modal)) {
       deprecated(
         `Defining modals using a controller is deprecated. Use the component-based API instead. (modal: ${modal})`,


### PR DESCRIPTION
e.g. the modernised share-topic modal will attempt to open the `create-invite` modal. Prior to this commit, this mixing of modern/legacy would fail silently, and the create-invite modal was never shown.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
