### PR TITLE
DEV: update index.html files

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -19,6 +19,9 @@
     <bootstrap-content key="discourse-preload-stylesheets">
     {{content-for "discourse-preload-stylesheets"}}
 
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/discourse.css" />
+
     <script defer src="{{rootURL}}assets/vendor.js"></script>
     <script defer src="{{rootURL}}assets/discourse.js"></script>
 

--- a/app/assets/javascripts/discourse/app/styles/app.css
+++ b/app/assets/javascripts/discourse/app/styles/app.css
@@ -1,0 +1,4 @@
+/**
+ * 👋 Greetings Discourse Developer. This CSS file is unused. If you're looking
+ * for stylesheets managed by Rails, see app/assets/stylesheets at project root.
+ */

--- a/app/assets/javascripts/discourse/tests/index.html
+++ b/app/assets/javascripts/discourse/tests/index.html
@@ -18,6 +18,7 @@
     {{content-for "head"}} {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/discourse.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css" />
     <link rel="stylesheet" href="{{rootURL}}assets/qunit.css" />
     <link rel="stylesheet" href="{{rootURL}}assets/qunit-custom.css" />


### PR DESCRIPTION
This brings them more in line with an idiomatic ember app looks like, in particular, embroider really expects the CSS file to be there.

As far as I can tell this is fairly harmless, since in production the actual HTML is generated and served by Rails anyway.

Down the road, this may also be a good alternative to hacking the build pipeline to bring in styles for tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
