### PR TITLE
DEV: Add Custom emoji sanitization

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -684,6 +684,7 @@ class Plugin::Instance
   end
 
   def register_emoji(name, url, group = Emoji::DEFAULT_GROUP)
+    name = name.gsub(/[^a-z0-9]+/i, "_").gsub(/_{2,}/, "_").downcase
     Plugin::CustomEmoji.register(name, url, group)
     Emoji.clear_cache
   end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -589,6 +589,14 @@ RSpec.describe Plugin::Instance do
       expect(custom_emoji.url).to eq("/baz/bar.png")
       expect(custom_emoji.group).to eq("baz")
     end
+
+    it "sanitizes emojis' names" do
+      Plugin::Instance.new.register_emoji("?", "/baz/bar.png", "baz")
+      Plugin::Instance.new.register_emoji("?test?!!", "/foo/bar.png", "baz")
+
+      expect(Emoji.custom.first.name).to eq("_")
+      expect(Emoji.custom.second.name).to eq("_test_")
+    end
   end
 
   describe "#replace_flags" do


### PR DESCRIPTION
**Context** 
Discourse allows for the usage of custom emojis through UI or plugins

**Problem**
Adding emojis through plugins doesn't sanitize emojis' names. Having non-sanitized names on emojis causes issues where the next inserted emoji doesn't render properly

**Solution**
Properly sanitize emojis' names that are added through plugins
