### PR TITLE
DEV: Consistently use html5 loofah

### DIFF
--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -12,7 +12,7 @@ module Chat
       @opts = {}
 
       cooked = Chat::Message.cook(chat_message.message, user_id: chat_message.last_editor_id)
-      @doc = Loofah.fragment(cooked)
+      @doc = Loofah.html5_fragment(cooked)
     end
 
     def run!


### PR DESCRIPTION
Turns out making a html4 fragment and then operating on parts of it using html5 fragments is a bad idea. ;) This seems to fix the issue with occasionally missing GH icons in oneboxes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
