### PR TITLE
FIX: `user_id` arg override in Slack import

### DIFF
--- a/script/import_scripts/slack.rb
+++ b/script/import_scripts/slack.rb
@@ -252,9 +252,9 @@ class ImportScripts::Slack < ImportScripts::Base
 
     # Mentions
     text.gsub!(/<@(\w+)>/) do
-      user_id = $1
-      username = @lookup.find_username_by_import_id(user_id)
-      username ? "@#{username}" : "`@#{user_id}`"
+      mentioned_user_id = $1
+      username = @lookup.find_username_by_import_id(mentioned_user_id)
+      username ? "@#{username}" : "`@#{mentioned_user_id}`"
     end
 
     # Links


### PR DESCRIPTION
Fixes `user_id` arg override during mention parsing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
