### PR TITLE
DEV: Support version operators in .discourse-compatibility

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -60,7 +60,7 @@ module Discourse
         req_operator, req_version = parsed_requirement
         req_operator = "<=" if req_operator == "="
 
-        if !%w[= <= <].include?(req_operator)
+        if !%w[<= <].include?(req_operator)
           raise InvalidVersionListError,
                 "Invalid version specifier operator for '#{req_operator} #{req_version}'. Operator must be one of <= or <"
         end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -46,6 +46,8 @@ module Discourse
         .sort_by do |v, pin|
           op, v = Gem::Requirement.parse(v)
           v
+        rescue Gem::Requirement::BadRequirementError
+          raise InvalidVersionListError, "Invalid version specifier: #{v}"
         end
         .reverse
 

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -132,7 +132,13 @@ RSpec.describe Discourse::VERSION do
       end
 
       it "raises error for >= operator" do
-        expect { Discourse.find_compatible_resource(">= 3.1.0", "3.1.0") }.to raise_error(
+        expect { Discourse.find_compatible_resource(">= 3.1.0: test", "3.1.0") }.to raise_error(
+          Discourse::InvalidVersionListError,
+        )
+      end
+
+      it "raises error for invalid version" do
+        expect { Discourse.find_compatible_resource("1.1.: test", "3.1.0") }.to raise_error(
           Discourse::InvalidVersionListError,
         )
       end


### PR DESCRIPTION
This adds support for the `<=` and `<` version operators in `.discourse-compatibility` files. This allows for more flexibility (e.g. targeting the entire 3.1.x stable release via `< 3.2.0.beta1`), and should also make compatibility files to be more readable.

If an operator is not specified we default to `<=`, which matches the old behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
