### PR TITLE
DEV: Allow chat services to have optional models

### DIFF
--- a/plugins/chat/spec/lib/service_runner_spec.rb
+++ b/plugins/chat/spec/lib/service_runner_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe ServiceRunner do
     end
   end
 
+  class FailureWithOptionalModelService
+    include Service::Base
+
+    model :fake_model, optional: true
+
+    private
+
+    def fetch_fake_model
+      nil
+    end
+  end
+
   class FailureWithModelErrorsService
     include Service::Base
 
@@ -284,6 +296,14 @@ RSpec.describe ServiceRunner do
         BLOCK
 
       context "when fetching a single model" do
+        context "when the service uses an optional model" do
+          let(:service) { FailureWithOptionalModelService }
+
+          it "does not run the provided block" do
+            expect(runner).not_to eq :no_model
+          end
+        end
+
         context "when the service fails without a model" do
           let(:service) { FailureWithModelService }
 


### PR DESCRIPTION
This is extracted from #22390.

This patch adds a new `optional` option to the `model` step. This means if an optional model returns something blank (`nil` or an empty collection) then the service won’t fail and will execute the next step. However if a model is properly returned, the step will try to check if it is valid or not (if it responds to `#invalid?`). If the model isn’t valid, then the step will fail (so no change here).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
