### PR TITLE
DEV: Fix flakyness of keyboard navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -733,11 +733,13 @@ export default {
       newIndex += direction;
       article = articles[newIndex];
 
+      // Element doesn't exist
       if (!article) {
-        // Element doesn't exist
         return;
-      } else if (article.offsetParent !== null) {
-        // Element is not hidden
+      }
+
+      // Element is visible
+      if (article.getBoundingClientRect().height > 0) {
         break;
       }
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -72,8 +72,12 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
 
   test("j/k navigation skips hidden elements", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    query("#post_2").parentElement.style = "display: none";
-    query("#post_3").parentElement.style = "display: none";
+
+    document.querySelector("#qunit-fixture").innerHTML = `
+      <style>
+        #post_2, #post_3 { display: none; }
+      </style>
+    `;
 
     await triggerKeyEvent(document, "keypress", "J");
     assert


### PR DESCRIPTION
1. in the test, hiding is now done with css so if element gets rerendered it won't lose the styling
2. the skipping now allows for the `<article>` element itself being hidden

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
