### PR TITLE
DEV: Enable broccoli memoization for faster incremental rebuilds

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -12,6 +12,8 @@ const funnel = require("broccoli-funnel");
 const DeprecationSilencer = require("deprecation-silencer");
 const generateWorkboxTree = require("./lib/workbox-tree-builder");
 
+process.env.BROCCOLI_ENABLED_MEMOIZE = true;
+
 module.exports = function (defaults) {
   const discourseRoot = resolve("../../../..");
   const vendorJs = discourseRoot + "/vendor/assets/javascripts/";


### PR DESCRIPTION
This has been proposed as the new default, and is currently in-use on many large ember apps without issue. It is already the default under Embroider. Testing locally, incremental rebuilds when editing a single file are around 2x faster (2.3s -> 1.2s).

Upstream reference: https://github.com/ember-cli/ember-cli/issues/8681

(Thanks to @ijlee2 for calling out this flag at EmberConf 🙌 )

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
