### PR TITLE
DEV: Remove deprecated whitelist methods

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -261,47 +261,6 @@ class SiteSetting < ActiveRecord::Base
     SiteSetting.navigation_menu == "legacy"
   end
 
-  ALLOWLIST_DEPRECATED_SITE_SETTINGS = {
-    email_domains_blacklist: "blocked_email_domains",
-    email_domains_whitelist: "allowed_email_domains",
-    unicode_username_character_whitelist: "allowed_unicode_username_characters",
-    user_website_domains_whitelist: "allowed_user_website_domains",
-    whitelisted_link_domains: "allowed_link_domains",
-    embed_whitelist_selector: "allowed_embed_selectors",
-    auto_generated_whitelist: "auto_generated_allowlist",
-    attachment_content_type_blacklist: "blocked_attachment_content_types",
-    attachment_filename_blacklist: "blocked_attachment_filenames",
-    use_admin_ip_whitelist: "use_admin_ip_allowlist",
-    blacklist_ip_blocks: "blocked_ip_blocks",
-    whitelist_internal_hosts: "allowed_internal_hosts",
-    whitelisted_crawler_user_agents: "allowed_crawler_user_agents",
-    blacklisted_crawler_user_agents: "blocked_crawler_user_agents",
-    onebox_domains_blacklist: "blocked_onebox_domains",
-    inline_onebox_domains_whitelist: "allowed_inline_onebox_domains",
-    white_listed_spam_host_domains: "allowed_spam_host_domains",
-    embed_blacklist_selector: "blocked_embed_selectors",
-    embed_classname_whitelist: "allowed_embed_classnames",
-  }
-
-  ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair do |old_method, new_method|
-    self.define_singleton_method(old_method) do
-      Discourse.deprecate(
-        "#{old_method.to_s} is deprecated, use the #{new_method.to_s}.",
-        drop_from: "2.6",
-        raise_error: true,
-      )
-      send(new_method)
-    end
-    self.define_singleton_method("#{old_method}=") do |args|
-      Discourse.deprecate(
-        "#{old_method.to_s} is deprecated, use the #{new_method.to_s}.",
-        drop_from: "2.6",
-        raise_error: true,
-      )
-      send("#{new_method}=", args)
-    end
-  end
-
   protected
 
   def self.clear_cache!

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -189,26 +189,8 @@ class Plugin::Instance
     end
   end
 
-  def whitelist_staff_user_custom_field(field)
-    Discourse.deprecate(
-      "whitelist_staff_user_custom_field is deprecated, use the allow_staff_user_custom_field.",
-      drop_from: "2.6",
-      raise_error: true,
-    )
-    allow_staff_user_custom_field(field)
-  end
-
   def allow_staff_user_custom_field(field)
     DiscoursePluginRegistry.register_staff_user_custom_field(field, self)
-  end
-
-  def whitelist_public_user_custom_field(field)
-    Discourse.deprecate(
-      "whitelist_public_user_custom_field is deprecated, use the allow_public_user_custom_field.",
-      drop_from: "2.6",
-      raise_error: true,
-    )
-    allow_public_user_custom_field(field)
   end
 
   def allow_public_user_custom_field(field)
@@ -376,15 +358,6 @@ class Plugin::Instance
 
       hidden_method_name
     end
-  end
-
-  def topic_view_post_custom_fields_whitelister(&block)
-    Discourse.deprecate(
-      "topic_view_post_custom_fields_whitelister is deprecated, use the topic_view_post_custom_fields_allowlister.",
-      drop_from: "2.6",
-      raise_error: true,
-    )
-    topic_view_post_custom_fields_allowlister(&block)
   end
 
   # Add a post_custom_fields_allowlister block to the TopicView, respecting if the plugin is enabled


### PR DESCRIPTION
### What is this change?

These methods were deprecated and marked for removal in 2.6. This change deletes them.

### Verification

These deprecations use `raise_error: true`, so the fallbacks are at this point unreachable and can't be used anyway.