### PR TITLE
DEV: Remove redundant line of code

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -310,7 +310,6 @@ class PostDestroyer
         .where.not(user_id: nil)
         .where.not(post_type: Post.types[:whisper])
         .order("created_at desc")
-        .limit(1)
         .first
 
     if last_post.present?


### PR DESCRIPTION
No need for `limit(1)` when we are already calling `first`