### PR TITLE
DEV: Remove warning for discontinued site_setting_saved event

### DIFF
--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -13,15 +13,6 @@ class DiscourseEvent
   end
 
   def self.on(event_name, &block)
-    if event_name == :site_setting_saved
-      Discourse.deprecate(
-        "The :site_setting_saved event is deprecated. Please use :site_setting_changed instead",
-        since: "2.3.0beta8",
-        drop_from: "2.4",
-        raise_error: true,
-      )
-    end
-
     if event_name == :user_badge_removed
       Discourse.deprecate(
         "The :user_badge_removed event is deprecated. Please use :user_badge_revoked instead",


### PR DESCRIPTION
### What is this change?

We used to have a deprecation warning here for the now defunct `site_setting_saved` event, marked for removal in 2.4. This PR deletes it.

### Verification

- [x] The deprecation uses `raise_error`, so would result in runtime errors already for anyone using it.
- [x] Searched logs for all our hosting. No errors or warnings related to this.
- [x] Searched our public and private repos. No more usages.