### PR TITLE
DEV: Remove deprecated arguments to Plugin::Instance#add_api_parameter_route

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -971,36 +971,7 @@ class Plugin::Instance
   #
   # See Auth::DefaultCurrentUserProvider::PARAMETER_API_PATTERNS for more examples
   # and Auth::DefaultCurrentUserProvider#api_parameter_allowed? for implementation
-  def add_api_parameter_route(
-    method: nil,
-    methods: nil,
-    route: nil,
-    actions: nil,
-    format: nil,
-    formats: nil
-  )
-    if Array(format).include?("*")
-      Discourse.deprecate(
-        "* is no longer a valid api_parameter_route format matcher. Use `nil` instead",
-        drop_from: "2.7",
-        raise_error: true,
-      )
-      # Old API used * as wildcard. New api uses `nil`
-      format = nil
-    end
-
-    # Backwards compatibility with old parameter names:
-    if method || route || format
-      Discourse.deprecate(
-        "method, route and format parameters for api_parameter_routes are deprecated. Use methods, actions and formats instead.",
-        drop_from: "2.7",
-        raise_error: true,
-      )
-      methods ||= method
-      actions ||= route
-      formats ||= format
-    end
-
+  def add_api_parameter_route(methods: nil, actions: nil, formats: nil)
     DiscoursePluginRegistry.register_api_parameter_route(
       RouteMatcher.new(methods: methods, actions: actions, formats: formats),
       self,


### PR DESCRIPTION
### What is this change?

We deprecated the keywords `method`, `route`, and `format` (replaced with `methods`, `actions`, and `formats` respectively) as parameters to `Plugin::Instance#add_api_parameter_route`, marked for removal in 2.7. This PR deletes them.

### Verification

- [x] These deprecations use `raise_error`, so the fallbacks are unreachable anyway and any usage would result in a runtime error.
- [x] Searched our logs for all hosting. No errors or warnings related to this found.
- [x] Searched our public and private repos. No usages found.