### PR TITLE
FIX: Inline deprecated settings in migration file

### DIFF
--- a/db/migrate/20200709032247_allowlist_and_blocklist_site_settings.rb
+++ b/db/migrate/20200709032247_allowlist_and_blocklist_site_settings.rb
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
 class AllowlistAndBlocklistSiteSettings < ActiveRecord::Migration[6.0]
+  ALLOWLIST_DEPRECATED_SITE_SETTINGS = {
+    email_domains_blacklist: "blocked_email_domains",
+    email_domains_whitelist: "allowed_email_domains",
+    unicode_username_character_whitelist: "allowed_unicode_username_characters",
+    user_website_domains_whitelist: "allowed_user_website_domains",
+    whitelisted_link_domains: "allowed_link_domains",
+    embed_whitelist_selector: "allowed_embed_selectors",
+    auto_generated_whitelist: "auto_generated_allowlist",
+    attachment_content_type_blacklist: "blocked_attachment_content_types",
+    attachment_filename_blacklist: "blocked_attachment_filenames",
+    use_admin_ip_whitelist: "use_admin_ip_allowlist",
+    blacklist_ip_blocks: "blocked_ip_blocks",
+    whitelist_internal_hosts: "allowed_internal_hosts",
+    whitelisted_crawler_user_agents: "allowed_crawler_user_agents",
+    blacklisted_crawler_user_agents: "blocked_crawler_user_agents",
+    onebox_domains_blacklist: "blocked_onebox_domains",
+    inline_onebox_domains_whitelist: "allowed_inline_onebox_domains",
+    white_listed_spam_host_domains: "allowed_spam_host_domains",
+    embed_blacklist_selector: "blocked_embed_selectors",
+    embed_classname_whitelist: "allowed_embed_classnames",
+  }
+
   def up
-    SiteSetting::ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, new_key| DB.exec <<~SQL }
+    ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, new_key| DB.exec <<~SQL }
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         SELECT '#{new_key}', data_type, value, created_at, updated_At
         FROM site_settings
@@ -11,7 +33,7 @@ class AllowlistAndBlocklistSiteSettings < ActiveRecord::Migration[6.0]
   end
 
   def down
-    SiteSetting::ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |_old_key, new_key| DB.exec <<~SQL }
+    ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |_old_key, new_key| DB.exec <<~SQL }
         DELETE FROM site_settings
         WHERE name = '#{new_key}'
       SQL

--- a/db/migrate/20200724060632_remove_deprecated_allowlist_settings.rb
+++ b/db/migrate/20200724060632_remove_deprecated_allowlist_settings.rb
@@ -1,15 +1,37 @@
 # frozen_string_literal: true
 
 class RemoveDeprecatedAllowlistSettings < ActiveRecord::Migration[6.0]
+  ALLOWLIST_DEPRECATED_SITE_SETTINGS = {
+    email_domains_blacklist: "blocked_email_domains",
+    email_domains_whitelist: "allowed_email_domains",
+    unicode_username_character_whitelist: "allowed_unicode_username_characters",
+    user_website_domains_whitelist: "allowed_user_website_domains",
+    whitelisted_link_domains: "allowed_link_domains",
+    embed_whitelist_selector: "allowed_embed_selectors",
+    auto_generated_whitelist: "auto_generated_allowlist",
+    attachment_content_type_blacklist: "blocked_attachment_content_types",
+    attachment_filename_blacklist: "blocked_attachment_filenames",
+    use_admin_ip_whitelist: "use_admin_ip_allowlist",
+    blacklist_ip_blocks: "blocked_ip_blocks",
+    whitelist_internal_hosts: "allowed_internal_hosts",
+    whitelisted_crawler_user_agents: "allowed_crawler_user_agents",
+    blacklisted_crawler_user_agents: "blocked_crawler_user_agents",
+    onebox_domains_blacklist: "blocked_onebox_domains",
+    inline_onebox_domains_whitelist: "allowed_inline_onebox_domains",
+    white_listed_spam_host_domains: "allowed_spam_host_domains",
+    embed_blacklist_selector: "blocked_embed_selectors",
+    embed_classname_whitelist: "allowed_embed_classnames",
+  }
+
   def up
-    SiteSetting::ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, _new_key| DB.exec <<~SQL }
+    ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, _new_key| DB.exec <<~SQL }
         DELETE FROM site_settings
         WHERE name = '#{old_key}'
       SQL
   end
 
   def down
-    SiteSetting::ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, new_key| DB.exec <<~SQL }
+    ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair { |old_key, new_key| DB.exec <<~SQL }
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         SELECT '#{old_key}', data_type, value, created_at, updated_At
         FROM site_settings


### PR DESCRIPTION
### What is this change?

After deleting `SiteSetting::ALLOWLIST_DEPRECATED_SITE_SETTINGS`, we found out this was referenced in a migration file. This PR inlines the constant into the migration file to prevent it from erroring out.