### PR TITLE
DEV: Remove webrick dependency which we no longer need

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -272,9 +272,6 @@ gem "faraday-retry"
 # https://github.com/ruby/net-imap/issues/16#issuecomment-803086765
 gem "net-http"
 
-# workaround for prometheus-client
-gem "webrick", require: false
-
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket (1.2.9)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -670,7 +669,6 @@ DEPENDENCIES
   web-push
   webdrivers
   webmock
-  webrick
   yaml-lint
   yard
 


### PR DESCRIPTION
The `discourse-prometheus` plugin has since specified the dependency on
webrick in the plugin so we no longer need to carry this in core.

See https://github.com/discourse/discourse-prometheus/commit/c4b675f0feaa8a08ddca964a63e62d2e4a7fa583