### PR TITLE
FIX: Render user profile trust level name for TL0

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -68,6 +68,8 @@ export default Controller.extend(CanCheckEmails, {
     };
   }),
 
+  isTrustLevelZero: equal("model.trust_level", 0),
+  hasTrustLevel: or("isTrustLevelZero", "model.trust_level"),
   showStaffCounters: or(
     "hasGivenFlags",
     "hasFlaggedPosts",

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -384,7 +384,7 @@
                       @model={{this.model.invited_by}}
                     >{{this.model.invited_by.username}}</LinkTo></dd></div>
               {{/if}}
-              {{#if this.model.trust_level}}
+              {{#if this.hasTrustLevel}}
                 <div><dt class="trust-level">{{i18n "user.trust_level"}}</dt><dd
                     class="trust-level"
                   >{{this.model.trustLevel.name}}</dd></div>

--- a/spec/system/page_objects/pages/user.rb
+++ b/spec/system/page_objects/pages/user.rb
@@ -29,6 +29,12 @@ module PageObjects
         staff_counters.find("a[href='/u/#{user.username}/messages/warnings']").click
         self
       end
+
+      def expand_info_panel
+        button = page.find("button[aria-controls='collapsed-info-panel']")
+        button.click if button["aria-expanded"] == "false"
+        self
+      end
     end
   end
 end

--- a/spec/system/user_page/user_profile_info_panel_spec.rb
+++ b/spec/system/user_page/user_profile_info_panel_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe "User Profile Info Panel", system: true do
+  let(:user_page) { PageObjects::Pages::User.new }
+
+  describe "trust level" do
+    TrustLevel.levels.values.each do |trust_level|
+      context "when user has trust level #{trust_level}" do
+        fab!(:user) { Fabricate(:user, trust_level: trust_level) }
+        before { sign_in(user) }
+
+        it "displays the correct trust level element" do
+          user_page.visit(user).expand_info_panel
+          expect(user_page).to have_css("dd.trust-level", text: TrustLevel.name(trust_level))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Why was this change necessary?
The current logic in the user.hbs template file does not render the trust level element for the user's info panel when the user is TL0, because 0 is treated as falsey in the `if` conditional block.

Ref: https://meta.discourse.org/t/tl0-not-displayed-on-users-profile-pages/271779/10

#### How does it address the problem?

This PR adds a predicate helper method local to the user controller that includes an additional check which returns true if the trust_level of the user is 0 on top of the existing logic. This allows TL0 users to have their trust level rendered correctly in their profile's info panel.

#### Verification
Before:
<img width="632" alt="Screenshot 2023-07-20 at 10 11 47 PM" src="https://github.com/discourse/discourse/assets/133760061/b2167f7b-29fd-47b0-8010-dafe3760dda8">

After:
<img width="632" alt="Screenshot 2023-07-20 at 10 12 09 PM" src="https://github.com/discourse/discourse/assets/133760061/4423214e-1b17-4d95-9bae-030e6ddd3a75">


#### Considerations
I'd thought of testing the negative path of the conditional (where `user.trust_level` would return `nil`) but using an actual User fills in that attribute by default (and at the DB level, `trust_level` is non-nilable anyway). Mocking it didn't work either as I think there's a check somewhere else for the presence of trust_level and triggers an internal error. The test which passes but in reality results in a 500 on the client:

```ruby
    it "when user has no trust level, profile does not display trust level" do
      user = Fabricate(:user)
      User.any_instance.stubs(:trust_level).returns nil
      user_page.visit(user)
      expect(user_page).not_to have_css("dd.trust-level")
    end
```
Perhaps we could reconsider if the conditional `if this.model.trust_level` is really necessary in the templating file (unless I've missed out a scenario where the user model is loaded and would be missing a trust_level entirely).