### PR TITLE
DEV: Remove deprecated ascending param from AdminUserIndexQuery

### DIFF
--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -33,22 +33,11 @@ class AdminUserIndexQuery
     find_users_query.count
   end
 
-  def custom_direction
-    if params[:ascending]
-      Discourse.deprecate(
-        ":ascending is deprecated please use :asc instead",
-        output_in_test: true,
-        drop_from: "2.9.0",
-      )
-    end
-    asc = params[:asc] || params[:ascending]
-    asc.present? && asc ? "ASC" : "DESC"
-  end
-
   def initialize_query_with_order(klass)
     order = []
 
     custom_order = params[:order]
+    custom_direction = params[:asc].present? ? "ASC" : "DESC"
     if custom_order.present? &&
          without_dir = SORTABLE_MAPPING[custom_order.downcase.sub(/ (asc|desc)\z/, "")]
       order << "#{without_dir} #{custom_direction}"


### PR DESCRIPTION
### What is this change?

The parameter `ascending` was deprecated (replaced by `asc`) and marked for deletion in 2.9. This PR removes it. Since the resulting code was a simple one-liner, the method body was inlined instead.

### Verification

- [x] Searched through the logs for all our hosting. No warnings related to this.
- [x] Searched through our public and private repos. No usages found.