### PR TITLE
FIX: Do not scroll-top for aborted transitions

### DIFF
--- a/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
+++ b/app/assets/javascripts/discourse/app/services/route-scroll-manager.js
@@ -38,6 +38,10 @@ export default class RouteScrollManager extends Service {
 
   @bind
   routeDidChange(transition) {
+    if (transition.isAborted) {
+      return;
+    }
+
     const newUuid = this.router.location.getState?.().uuid;
 
     if (newUuid === this.uuid) {


### PR DESCRIPTION
We only want to scroll to the top for successful transitions. If a transition is aborted (e.g. when clicking a chat link when chat is in drawer mode) then we should maintain the existing scroll location.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
