### PR TITLE
FIX: Handle empty directory columns in /u route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/users.js
+++ b/app/assets/javascripts/discourse/app/routes/users.js
@@ -42,7 +42,10 @@ export default DiscourseRoute.extend({
   model(params) {
     return ajax("/directory-columns.json")
       .then((response) => {
-        params.order = params.order || response.directory_columns[0].name;
+        params.order =
+          params.order ||
+          response.directory_columns[0]?.name ||
+          "likes_received";
         return { params, columns: response.directory_columns };
       })
       .catch(popupAjaxError);


### PR DESCRIPTION
The `/u` route was broken when there were no directory columns because its order parameter relied on the first column's name. This commit adds a `likes_received` as the default order when there are no columns, which results in a list of users being output without any additional columns.

For this very edge case, that's better than a JS error.