### PR TITLE
FIX: Fallback to development mode if not specify

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,29 @@
 {
   "name": "Discourse",
   "image": "discourse/discourse_dev:release",
-  "workspaceMount": "source=${localWorkspaceFolder}/../..,target=/var/www/discourse,type=bind",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/discourse,type=bind",
   "workspaceFolder": "/var/www/discourse",
+  "mounts": [
+    {
+      "source": "${localWorkspaceFolder}/../discourse-plugins/",
+      "target": "/var/www/discourse-plugins",
+      "type": "bind"
+    },
+    {
+      "source": "discourse-data",
+      "target": "/shared/postgres_data",
+      "type": "volume"
+    }
+  ],
   "settings": {
     "search.followSymlinks": false
   },
-  "postStartCommand": "sudo /sbin/boot",
-  "extensions": ["rebornix.Ruby"],
-  "forwardPorts": [9292],
+  "postStartCommand": "nohup bash -c 'sudo /sbin/boot &' > tmp/nohup.out",
+  "extensions": [
+	"rebornix.Ruby",
+	"esbenp.prettier-vscode",
+	"dbaeumer.vscode-eslint"
+],
   "remoteUser": "discourse",
   "remoteEnv": {
     "DISCOURSE_DEV_HOSTS": ".githubpreview.dev"

--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -64,7 +64,12 @@ if ARGV.include?("--forward-host")
 end
 
 if ARGV.include?("-u") || ARGV.include?("--unicorn")
-  unicorn_env = { "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200" }
+  unicorn_env = { 
+    "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200",
+    # fallback to development mode if not specify
+    # since RAILS_ENV is empty string by default in the discourse_dev docker container
+    "RAILS_ENV" => ENV["RAILS_ENV"].to_s.empty? ? 'development' : ENV["RAILS_ENV"]
+  }
   unicorn_pid = spawn(unicorn_env, __dir__ + "/unicorn")
   ember_cli_pid = nil
 


### PR DESCRIPTION
If not set to dev/test, `ember-cli -u` will not make unicorn listen on `PORT` unless the `UNICORN_PORT` environment variables is exported.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
