### PR TITLE
DEV: Correct typo in d-modal-body

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -29,7 +29,7 @@ export default class DModalBody extends Component {
 
   @action
   didInsert(element) {
-    if (element.closest(".d-modal:not(.d-modal-legacy")) {
+    if (element.closest(".d-modal:not(.d-modal-legacy)")) {
       // eslint-disable-next-line no-console
       console.error(LEGACY_ERROR);
       if (DEBUG) {


### PR DESCRIPTION
Interestingly, this missing parenthesis was silently repaired under Chrome/Firefox, but seems to have caused some issues on other browsers.

https://meta.discourse.org/t/272496

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
