### PR TITLE
FIX: Restore the unconditional yield in d-button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -64,12 +64,12 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             &hellip;
           {{~/if~}}
         </span>
-      {{~else if (has-block)~}}
-        {{yield}}
       {{~else~}}
         &#8203;
         {{! Zero-width space character, so icon-only button height = regular button height }}
       {{~/if~}}
+
+      {{yield}}
     </button>
   </template>
 


### PR DESCRIPTION
Fixes bootstrap button tooltips

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
