### PR TITLE
 FIX: Use base 10 when gettings allowed group IDs from settings.

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -99,7 +99,7 @@ export default {
       const summarizationAllowedGroups =
         this.siteSettings.custom_summarization_allowed_groups
           .split("|")
-          .map(parseInt);
+          .map((id) => parseInt(id, 10));
 
       const canSummarize =
         this.siteSettings.summarization_strategy &&


### PR DESCRIPTION
Same as discourse/discourse-ai#113

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
