### PR TITLE
FIX: Make ember-cli start unicorn server in development mode if not specify

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -64,7 +64,12 @@ if ARGV.include?("--forward-host")
 end
 
 if ARGV.include?("-u") || ARGV.include?("--unicorn")
-  unicorn_env = { "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200" }
+  unicorn_env = { 
+    "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200",
+    # fallback to development mode if not specify
+    # since RAILS_ENV is empty string by default in the discourse_dev docker container
+    "RAILS_ENV" => ENV["RAILS_ENV"].to_s.empty? ? 'development' : ENV["RAILS_ENV"]
+  }
   unicorn_pid = spawn(unicorn_env, __dir__ + "/unicorn")
   ember_cli_pid = nil
 


### PR DESCRIPTION
If not set to dev/test mode, `ember-cli -u` will not make unicorn listen on `PORT` unless the `UNICORN_PORT` environment variables is exported. And also enable benefit from dev_mode hackery.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
