### PR TITLE
UX: fix bookmark modal footer layout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/bookmark.hbs
@@ -77,24 +77,22 @@
   </:body>
 
   <:footer>
-    <div class="control-group">
+    <DButton
+      id="save-bookmark"
+      @label="bookmarks.save"
+      class="btn-primary"
+      @action={{this.saveAndClose}}
+    />
+    <DModalCancel @close={{action "closeWithoutSavingBookmark"}} />
+    {{#if this.showDelete}}
       <DButton
-        id="save-bookmark"
-        @label="bookmarks.save"
-        class="btn-primary"
-        @action={{this.saveAndClose}}
+        id="delete-bookmark"
+        @icon="trash-alt"
+        class="delete-bookmark btn-danger"
+        @action={{this.delete}}
+        @ariaLabel="post.bookmarks.actions.delete_bookmark.name"
+        @title="post.bookmarks.actions.delete_bookmark.name"
       />
-      <DModalCancel @close={{action "closeWithoutSavingBookmark"}} />
-      {{#if this.showDelete}}
-        <DButton
-          id="delete-bookmark"
-          @icon="trash-alt"
-          class="delete-bookmark btn-danger"
-          @action={{this.delete}}
-          @ariaLabel="post.bookmarks.actions.delete_bookmark.name"
-          @title="post.bookmarks.actions.delete_bookmark.name"
-        />
-      {{/if}}
-    </div>
+    {{/if}}
   </:footer>
 </DModal>

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -135,7 +135,9 @@
     }
   }
 
-  &:not(.history-modal):not(.sidebar__edit-navigation-menu__modal) {
+  &:not(.bookmark-reminder-modal):not(.history-modal):not(
+      .sidebar__edit-navigation-menu__modal
+    ) {
     .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(
         .poll-breakdown
       ) {
@@ -157,16 +159,12 @@
   align-items: center;
   padding: 14px 15px 10px;
   border-top: 1px solid var(--primary-low);
-  --btn-bottom-margin: 0.3em;
+  gap: 0.3em 0;
   .btn {
-    margin: 0 0.75em var(--btn-bottom-margin) 0;
+    margin: 0 0.75em 0 0;
     &[href] {
       min-height: unset;
     }
-  }
-
-  a {
-    margin-bottom: var(--btn-bottom-margin);
   }
 }
 

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -6,8 +6,6 @@
 
   .modal-footer {
     margin: 0;
-    border-top: 0;
-    padding: 0 1em 1em 1em;
 
     .delete-bookmark {
       margin-left: auto;
@@ -22,6 +20,7 @@
   .modal-body {
     width: 375px;
     box-sizing: border-box;
+    max-height: 70dvh;
 
     @media (max-width: 600px) {
       width: 100%;


### PR DESCRIPTION
Before:
![Screenshot 2023-07-24 at 6 18 43 PM](https://github.com/discourse/discourse/assets/1681963/809b105c-dfaf-4995-b7e5-643bce11dcbd)

After:
![Screenshot 2023-07-24 at 6 17 16 PM](https://github.com/discourse/discourse/assets/1681963/9cb99375-69e7-4ed5-81a1-12ce58b56dd6)

Really hate the massive `:not()` chain I added to here, but it proved too much of a yak shaving exercise for this PR