### PR TITLE
FIX: Loading more tags in edit nav menu tags modal not working

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.js
@@ -61,6 +61,11 @@ export default class extends Component {
       if (this.observer) {
         this.observer.disconnect();
       } else {
+        const root = document.querySelector(".modal-body");
+        const style = window.getComputedStyle(root);
+        const marginTop = parseFloat(style.marginTop);
+        const paddingTop = parseFloat(style.paddingTop);
+
         this.observer = new IntersectionObserver(
           (entries) => {
             entries.forEach((entry) => {
@@ -71,6 +76,7 @@ export default class extends Component {
           },
           {
             root: document.querySelector(".modal-body"),
+            rootMargin: `0px 0px ${marginTop + paddingTop}px 0px`,
             threshold: 1.0,
           }
         );

--- a/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/tags-modal.scss
+++ b/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/tags-modal.scss
@@ -1,4 +1,5 @@
 .sidebar-tags-form {
+  height: 100%;
   display: grid;
   gap: 0 0.5em;
   margin: 0;

--- a/spec/system/page_objects/modals/sidebar_edit_tags.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_tags.rb
@@ -6,8 +6,9 @@ module PageObjects
   module Modals
     class SidebarEditTags < SidebarEditNavigationModal
       def has_tag_checkboxes?(tags)
-        find(".sidebar-tags-form").has_content?(
+        expect(form).to have_content(
           tags.map { |tag| "#{tag.name} (#{tag.public_topic_count})" }.join("\n"),
+          exact: true,
         )
       end
 
@@ -25,6 +26,18 @@ module PageObjects
         ).click
 
         self
+      end
+
+      def scroll_to_tag(tag)
+        page.execute_script(
+          "document.querySelector('.sidebar-tags-form__tag[data-tag-name=\"#{tag.name}\"]').scrollIntoView()",
+        )
+      end
+
+      private
+
+      def form
+        find(".sidebar-tags-form")
       end
     end
   end


### PR DESCRIPTION
Why this change?

When setting up the `IntersectionObserver`, we did not account for the
top margin and padding causing no intersection event to fire when the
last tag is load into view. This commits fixes the problem by setting a
bottom margin using the `rootMargin` option when setting up the
`IntersectionObserver`.

This commit also improves the test coverage surrounding the loading of
more tags.