### PR TITLE
DEV: Add some description to help with understanding flakey test failures

### DIFF
--- a/spec/lib/validators/max_username_length_validator_spec.rb
+++ b/spec/lib/validators/max_username_length_validator_spec.rb
@@ -25,16 +25,19 @@ RSpec.describe MaxUsernameLengthValidator do
   end
 
   it "checks for users with short usernames" do
-    user = Fabricate(:user, username: "jackjackjack")
+    username = "jackjackjack"
+    Fabricate(:user, username: username)
 
     validator = described_class.new
-    expect(validator.valid_value?(12)).to eq(true)
+    expect(validator.valid_value?(12)).to eq(true),
+    "Valid as 12 >= #{SiteSetting.min_username_length}"
 
     validator = described_class.new
-    expect(validator.valid_value?(11)).to eq(false)
+    expect(validator.valid_value?(11)).to eq(false),
+    "Invalid as 11 < #{SiteSetting.min_username_length}"
 
     expect(validator.error_message).to eq(
-      I18n.t("site_settings.errors.max_username_length_exists", username: "jackjackjack"),
+      I18n.t("site_settings.errors.max_username_length_exists", username: username),
     )
   end
 end


### PR DESCRIPTION
We're seeing flakey test report /10298/944

```
./spec/lib/validators/max_username_length_validator_spec.rb:27
Total failures: 274
Failures since last report: 14
Last seen at: 2023-07-24 20:47:13 UTC

Seed: 14187
First seen: 2d6fdf86f
Last seen: e503a4fc3
Assertion: MaxUsernameLengthValidator checks for users with short usernames
Result:

  expected: true
       got: false
```

probably due to some contamination with `./spec/models/username_validator_spec.rb:49`. I want to confirm this by checking if the site setting is the wrong value.