### PR TITLE
FIX: Managing sidebar custom sections not working on subfolder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
@@ -10,6 +10,7 @@ import { A } from "@ember/array";
 import { SIDEBAR_SECTION, SIDEBAR_URL } from "discourse/lib/constants";
 import { bind } from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
+import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 
 const FULL_RELOAD_LINKS_REGEX = [
   /^\/my\/[a-z_\-\/]+$/,
@@ -227,8 +228,10 @@ class SectionLink {
   }
 
   #validInternal() {
+    const routeInfoHelper = new RouteInfoHelper(this.router, this.path);
+
     return (
-      this.router.recognize(this.path).name !== "unknown" ||
+      routeInfoHelper.route !== "unknown" ||
       FULL_RELOAD_LINKS_REGEX.some((regex) => this.path.match(regex))
     );
   }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/route-info-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/route-info-helper.js
@@ -1,6 +1,6 @@
 export default class RouteInfoHelper {
   constructor(router, url) {
-    this.routeInfo = router.recognize(url);
+    this.routeInfo = router.recognize(router.rootURL.replace(/\/$/, "") + url);
   }
 
   get route() {

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -14,11 +14,14 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit "/session/#{user.encoded_username}/become.json?redirect=false"
+    visit File.join(
+            GlobalSetting.relative_url_root || "",
+            "/session/#{user.encoded_username}/become.json?redirect=false",
+          )
   end
 
   def sign_out
-    delete "/session"
+    delete File.join(GlobalSetting.relative_url_root || "", "/session")
   end
 
   def setup_system_test

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -8,28 +8,38 @@ describe "Custom sidebar sections", type: :system do
 
   before { user.user_option.update!(external_links_in_new_tab: true) }
 
-  it "allows the user to create custom section" do
-    visit("/latest")
+  shared_examples "creating custom sections" do |relative_root_url|
+    it "allows the user to create custom section" do
+      visit("#{relative_root_url}/latest")
 
-    expect(sidebar).to have_no_add_section_button
+      expect(sidebar).to have_no_add_section_button
 
-    sign_in user
-    visit("/latest")
-    sidebar.click_add_section_button
+      sign_in user
+      visit("#{relative_root_url}/latest")
+      sidebar.click_add_section_button
 
-    expect(section_modal).to be_visible
-    expect(section_modal).to have_disabled_save
-    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
+      expect(section_modal).to be_visible
+      expect(section_modal).to have_disabled_save
+      expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
 
-    section_modal.fill_name("My section")
+      section_modal.fill_name("My section")
 
-    section_modal.fill_link("Sidebar Tags", "/tags")
-    expect(section_modal).to have_enabled_save
+      section_modal.fill_link("Sidebar Tags", "/tags")
+      expect(section_modal).to have_enabled_save
 
-    section_modal.save
+      section_modal.save
 
-    expect(sidebar).to have_section("My section")
-    expect(sidebar).to have_section_link("Sidebar Tags")
+      expect(sidebar).to have_section("My section")
+      expect(sidebar).to have_section_link("Sidebar Tags")
+    end
+  end
+
+  include_examples "creating custom sections"
+
+  context "when subfolder install" do
+    before { set_subfolder "/community" }
+
+    include_examples "creating custom sections", "/community"
   end
 
   it "allows the user to create custom section with /my link" do


### PR DESCRIPTION
Why this change?

We were verifying that a url for a section link in a custom sidebar
section is valid by passing the url string to `Router#recognize`.
If a `rootURL` has been set on the router, the url string that is passed
to `Router#recognize` has to start with the `rootURL`.

This commit fixes the problem by ensuring that `RouteInfoHelper` adds
the application subfolder path before calling `Router#recognize` on the
url string.