### PR TITLE
DEV: Ensure don't feed the trolls feature considers active flags only

### DIFF
--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -238,7 +238,7 @@ class ComposerMessagesFinder
 
     return if post.blank?
 
-    flags = post.flags.group(:user_id).count
+    flags = post.flags.active.group(:user_id).count
     flagged_by_replier = flags[@user.id].to_i > 0
     flagged_by_others = flags.values.sum >= SiteSetting.dont_feed_the_trolls_threshold
 

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe ComposerMessagesFinder do
     fab!(:self_flagged_post) { Fabricate(:post, topic: topic, user: author) }
     fab!(:under_flagged_post) { Fabricate(:post, topic: topic, user: author) }
     fab!(:over_flagged_post) { Fabricate(:post, topic: topic, user: author) }
+    fab!(:resolved_flag_post) { Fabricate(:post, topic: topic, user: author) }
 
     before { SiteSetting.dont_feed_the_trolls_threshold = 2 }
 
@@ -379,6 +380,20 @@ RSpec.describe ComposerMessagesFinder do
           composer_action: "reply",
           topic_id: topic.id,
           post_id: under_flagged_post.id,
+        )
+      expect(finder.check_dont_feed_the_trolls).to be_blank
+    end
+
+    it "does not show a message when the flag has already been resolved" do
+      SiteSetting.dont_feed_the_trolls_threshold = 1
+
+      Fabricate(:flag, post: resolved_flag_post, user: other_user, disagreed_at: 1.hour.ago)
+      finder =
+        ComposerMessagesFinder.new(
+          user,
+          composer_action: "reply",
+          topic_id: topic.id,
+          post_id: resolved_flag_post.id,
         )
       expect(finder.check_dont_feed_the_trolls).to be_blank
     end


### PR DESCRIPTION
### What is the problem?

We recently added a "don't feed the trolls" feature which warns you about interacting with posts that have been flagged and are pending review. The problem is the warning persists even if an admin reviews the post and rejects the flag.

### How does this fix it?

Only consider active flags when deciding whether to show the warning or not.