### PR TITLE
FIX: make document overflow hidden on both axis when lightbox is open

### DIFF
--- a/app/assets/stylesheets/common/components/d-lightbox.scss
+++ b/app/assets/stylesheets/common/components/d-lightbox.scss
@@ -1,7 +1,7 @@
 /* Main document */
 
 html.has-lightbox {
-  overflow-y: hidden;
+  overflow: hidden;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Fixes issue with scrolling background when lightbox is opened on mobile.

Since we rely on swiping for navigating lightbox galleries on mobile, we want to disable document scrolling.