### PR TITLE
FIX: Prevent lightbox from loading site icons from chat embeds

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -72,7 +72,7 @@ export default {
         (element) => {
           lightboxService.setupLightboxes({
             container: element,
-            selector: "img:not(.emoji, .avatar)",
+            selector: "img:not(.emoji, .avatar, .site-icon)",
           });
         },
         {


### PR DESCRIPTION
Sharing a link in chat will create a onebox embed with a source that includes a site icon and title.

This change prevents loading the site icon into lightbox.