### PR TITLE
UX: Hide header in dismiss modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/discard-draft.hbs
@@ -1,4 +1,8 @@
-<DModal @closeModal={{@closeModal}} class="discard-draft-modal">
+<DModal
+  @closeModal={{@closeModal}}
+  class="discard-draft-modal"
+  @dismissable={{false}}
+>
   <:body>
     <div class="instructions">
       {{i18n "post.cancel_composer.confirm"}}


### PR DESCRIPTION
The header was accidentally introduced during the refactoring in d8a87792af9afabc90e16f496205c02cfc7941b6




<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
<img width="422" alt="SCR-20230725-mhvs" src="https://github.com/discourse/discourse/assets/6270921/c3ded1b8-ed6c-42ca-be49-6bd4601fda9d">

⏬ 

<img width="430" alt="SCR-20230725-mhsw" src="https://github.com/discourse/discourse/assets/6270921/3fd14878-7b7c-468c-b66e-54f391f82222">


