### PR TITLE
UX: different way of centering chat notice to accommodate longer texts

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-notices.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-notices.scss
@@ -21,9 +21,9 @@
     padding: 0.5em 0 0.5em 1em;
     color: var(--primary);
     padding: 0.5em 0 0.5em 1em;
-     min-width: 280px;
-     margin-left: auto;
-     margin-right: auto;
+    min-width: 280px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .btn-flat {

--- a/plugins/chat/assets/stylesheets/common/chat-notices.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-notices.scss
@@ -4,10 +4,13 @@
   gap: 0.5em;
   position: absolute;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
   z-index: 10;
-  min-width: 280px;
+  width: 100%;
+
+  .full-page-chat & {
+    padding-inline: 1rem;
+    box-sizing: border-box;
+  }
 
   &__notice,
   .chat-retention-reminder {
@@ -18,6 +21,9 @@
     padding: 0.5em 0 0.5em 1em;
     color: var(--primary);
     padding: 0.5em 0 0.5em 1em;
+     min-width: 280px;
+     margin-left: auto;
+     margin-right: auto;
   }
 
   .btn-flat {

--- a/plugins/chat/assets/stylesheets/common/chat-notices.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-notices.scss
@@ -26,9 +26,10 @@
     margin-right: auto;
   }
 
-  .btn-flat {
+  .dismiss-btn {
     margin: 0 0.25em;
     color: var(--primary-medium);
+    align-self: flex-start;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Making sure longer text goes full width when needed
<img width="854" alt="image" src="https://github.com/discourse/discourse/assets/101828855/55d10095-3e46-4ec3-8cf2-da90b41255a8">

instead of:
<img width="562" alt="image" src="https://github.com/discourse/discourse/assets/101828855/09449327-c5e0-43c7-b467-462188711aae">


While small ones stay narrow
<img width="846" alt="image" src="https://github.com/discourse/discourse/assets/101828855/377f5c98-eb02-4435-a9f0-55c0d740f6a2">


