### PR TITLE
FIX: Disable the previous revision button if it is the last revision

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -45,6 +45,7 @@ export default class History extends Component {
   get loadPreviousDisabled() {
     return (
       this.loading ||
+      !this.postRevision.previous_revision ||
       (!this.postRevision.previous_revision &&
         this.postRevision.current_revision <=
           this.postRevision.previous_revision)

--- a/app/assets/javascripts/discourse/tests/acceptance/history-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/history-test.js
@@ -47,7 +47,11 @@ acceptance("History Modal - authorized", function (needs) {
     });
 
     server.get("/posts/419/revisions/1.json", () => {
-      return helper.response({ ...revisionResponse, current_revision: 1 });
+      return helper.response({
+        ...revisionResponse,
+        current_revision: 1,
+        previous_revision: null,
+      });
     });
   });
 
@@ -68,6 +72,15 @@ acceptance("History Modal - authorized", function (needs) {
       .doesNotExist(
         "hides the edit post button when not on the latest revision"
       );
+  });
+
+  test("previous revision button", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("article[data-post-id='419'] .edits button");
+
+    await click(".history-modal .previous-revision");
+
+    assert.dom(".history-modal .previous-revision").isDisabled();
   });
 });
 


### PR DESCRIPTION
We introduced a tiny bug https://github.com/discourse/discourse/pull/22522.

When viewing the last revision of a post, we need to disable the ⏪ button. This fixes the issue.

<img width="1141" alt="Screenshot 2023-07-26 at 12 02 02 AM" src="https://github.com/discourse/discourse/assets/1555215/d188c9c3-fe10-4e65-af15-730ae7fe9b41">
