### PR TITLE
FIX: Flashing history modal when changing versions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history.hbs
@@ -4,7 +4,7 @@
   class="history-modal"
 >
   <:body>
-    <ConditionalLoadingSpinner @condition={{this.loading}}>
+    <ConditionalLoadingSpinner @condition={{this.firstPaint}}>
       <Modal::History::Revision
         @model={{this.postRevision}}
         @mobileView={{this.site.mobileView}}

--- a/app/assets/javascripts/discourse/app/components/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history.hbs
@@ -4,7 +4,7 @@
   class="history-modal"
 >
   <:body>
-    <ConditionalLoadingSpinner @condition={{this.initialPaint}}>
+    <ConditionalLoadingSpinner @condition={{this.initialLoad}}>
       <Modal::History::Revision
         @model={{this.postRevision}}
         @mobileView={{this.site.mobileView}}

--- a/app/assets/javascripts/discourse/app/components/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history.hbs
@@ -4,7 +4,7 @@
   class="history-modal"
 >
   <:body>
-    <ConditionalLoadingSpinner @condition={{this.firstPaint}}>
+    <ConditionalLoadingSpinner @condition={{this.initialPaint}}>
       <Modal::History::Revision
         @model={{this.postRevision}}
         @mobileView={{this.site.mobileView}}

--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -167,10 +167,6 @@ export default class History extends Component {
     });
   }
 
-  get firstPaint() {
-    return this.loading && this.initialPaint;
-  }
-
   refresh(postId, postVersion) {
     this.loading = true;
     Post.loadRevision(postId, postVersion).then((result) => {

--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -29,7 +29,7 @@ export default class History extends Component {
   @tracked postRevision;
   @tracked viewMode = this.site?.mobileView ? "inline" : "side_by_side";
   @tracked bodyDiff;
-  @tracked initialPaint = true;
+  @tracked initialLoad = true;
 
   constructor() {
     super(...arguments);
@@ -172,9 +172,7 @@ export default class History extends Component {
     Post.loadRevision(postId, postVersion).then((result) => {
       this.postRevision = result;
       this.loading = false;
-      if (this.initialPaint) {
-        this.initialPaint = false;
-      }
+      this.initialLoad = false;
     });
   }
 

--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -29,6 +29,7 @@ export default class History extends Component {
   @tracked postRevision;
   @tracked viewMode = this.site?.mobileView ? "inline" : "side_by_side";
   @tracked bodyDiff;
+  @tracked initialPaint = true;
 
   constructor() {
     super(...arguments);
@@ -166,11 +167,18 @@ export default class History extends Component {
     });
   }
 
+  get firstPaint() {
+    return this.loading && this.initialPaint;
+  }
+
   refresh(postId, postVersion) {
     this.loading = true;
     Post.loadRevision(postId, postVersion).then((result) => {
       this.postRevision = result;
       this.loading = false;
+      if (this.initialPaint) {
+        this.initialPaint = false;
+      }
     });
   }
 


### PR DESCRIPTION
## Problem
History modal is flashing when changing revision versions

## Context
This was introduced in https://github.com/discourse/discourse/pull/22666

We need to have a conditional loading spinner for the initial paint of the history modal as we don't have the revision yet loaded, so this can cause some odd rendering issues. At the same time we don't want to display the loading spinner each time we toggle between the revision versions, because the loading spinner replaces the revision body causing the modal sizes to be drastically different resulting in _jumping_ or _flashing_.

## Fix
Render the loading spinner only on the first paint of the modal.

https://github.com/discourse/discourse/assets/50783505/8d19275e-86a5-4132-8a1f-af4b4f5301a6

