### PR TITLE
UX: Edit placeholder summary text animation

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/summary-box.js
+++ b/app/assets/javascripts/discourse/app/widgets/summary-box.js
@@ -22,12 +22,16 @@ createWidget("summary-skeleton", {
 
     html.push(
       h("span", {}, [
-        iconNode("magic", { class: "rotate-center" }),
         h(
           "div.placeholder-generating-summary-text",
           {},
           I18n.t("summary.in_progress")
         ),
+        h("span.ai-summarizing-indicator__wave", {}, [
+          h("span.ai-summarizing-indicator__dot", "."),
+          h("span.ai-summarizing-indicator__dot", "."),
+          h("span.ai-summarizing-indicator__dot", "."),
+        ]),
       ])
     );
 

--- a/app/assets/stylesheets/common/base/topic-summary.scss
+++ b/app/assets/stylesheets/common/base/topic-summary.scss
@@ -15,16 +15,25 @@
       width: 100%;
     }
 
-    .rotate-center {
-      -webkit-animation: rotate-center 3s cubic-bezier(0.68, -0.55, 0.265, 1.55)
-        0.5s infinite both;
-      animation: rotate-center 3s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.5s
-        infinite both;
-    }
-
     .placeholder-generating-summary-text {
       display: inline-block;
       margin-left: 3px;
+    }
+
+    .ai-summarizing-indicator__wave {
+      flex: 0 0 auto;
+      display: inline-flex;
+    }
+
+    .ai-summarizing-indicator__dot {
+      display: inline-block;
+      animation: ai-summarizing-indicator__wave 1.8s linear infinite;
+      &:nth-child(2) {
+        animation-delay: -1.6s;
+      }
+      &:nth-child(3) {
+        animation-delay: -1.4s;
+      }
     }
 
     .summarized-on {
@@ -38,5 +47,16 @@
     .outdated-summary {
       color: var(--primary-medium);
     }
+  }
+}
+
+@keyframes ai-summarizing-indicator__wave {
+  0%,
+  60%,
+  100% {
+    transform: initial;
+  }
+  30% {
+    transform: translateY(-0.2em);
   }
 }


### PR DESCRIPTION
This commit removes the magic wand animation from the placeholder summary text and adds the animated ellipses that we also use in chat when "someone is typing...".

**Before**
![Kapture 2023-07-25 at 14 33 59](https://github.com/discourse/discourse/assets/30537603/667aed49-7a9d-4e55-8110-315df7ee055a)

**After**
![Kapture 2023-07-25 at 14 29 38](https://github.com/discourse/discourse/assets/30537603/135533db-b02c-4ccd-825b-5d717e643789)

