### PR TITLE
FIX: distinguish between scroll and drag for sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -82,10 +82,24 @@ export default class SectionLink {
 
   @bind
   dragMove(event) {
-    this.startMouseY = this.#calcMouseY(event);
+    const moveMouseY = this.#calcMouseY(event);
 
-    event.stopPropagation();
-    event.preventDefault();
+    if (this.willDrag && moveMouseY !== this.startMouseY && !this.drag) {
+      /**
+       * If mouse position is different, it means that it is a scroll and not drag and drop action.
+       * In that case, we want to do nothing and keep original behaviour.
+       */
+      this.willDrag = false;
+      return;
+    } else {
+      /**
+       * Otherwise, event propagation should be stopped as we have our own handler for drag and drop.
+       */
+      event.stopPropagation();
+      event.preventDefault();
+    }
+
+    this.startMouseY = moveMouseY;
 
     if (!this.drag) {
       return;


### PR DESCRIPTION
Change to drag move event handling. When position of mouse changed, we can assume it is not drag and drop, and we should keep default behaviour.

Otherwise, we stop propagation of the event to handle drag and drop correctly. s

Demo from manual testing:

https://github.com/discourse/discourse/assets/72780/4b5346c6-8cfe-4d41-adf0-4d86d87818ca


https://github.com/discourse/discourse/assets/72780/fc77db18-11c4-4330-83e7-3292d318a4e1


