### PR TITLE
FIX: Chat emoji picker focus offset

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -379,11 +379,18 @@ export default class ChatEmojiPicker extends Component {
     }
 
     schedule("afterRender", () => {
-      document
-        .querySelector(
-          `.chat-emoji-picker__section[data-section="${section}"] .emoji:nth-child(1)`
-        )
-        .focus();
+      const firsEmoji = document.querySelector(
+        `.chat-emoji-picker__section[data-section="${section}"] .emoji:nth-child(1)`
+      );
+
+      const targetEmoji =
+        [
+          ...document.querySelectorAll(
+            `.chat-emoji-picker__section[data-section="${section}"] .emoji`
+          ),
+        ].find((emoji) => emoji.offsetTop > firsEmoji.offsetTop) || firsEmoji;
+
+      targetEmoji.focus();
 
       later(() => {
         // iOS hack to avoid blank div when requesting section during momentum


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/9b3408223bd4698b6ff5fd94a51676af00cb5197 we use `focus()` instead of `scrollIntoView()` to jump the selected emoji section. When using `focus()` on an element out of view, inside a scrollable container, the element will get vertically centered inside the container.

When focusing on the second row instead of the first one, the title of the previous section does not appear anymore

<div align="center">

<b>Before / After</b>

![2023-07-25_23-48](https://github.com/discourse/discourse/assets/66427541/f3bb13a9-63b4-4ea6-9623-85322207204d)
</div>
