### PR TITLE
FIX: attempt to fix multi sessions reaction spec

### DIFF
--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -71,26 +71,27 @@ RSpec.describe "React to message", type: :system do
 
         context "when current user has multiple sessions" do
           it "adds reaction on each session" do
-            reaction = OpenStruct.new(emoji: "grimacing")
+            reaction = "grimacing"
+
+            sign_in(current_user)
+            chat.visit_channel(category_channel_1)
 
             using_session(:tab_1) do
               sign_in(current_user)
               chat.visit_channel(category_channel_1)
             end
 
-            sign_in(current_user)
-            chat.visit_channel(category_channel_1)
-
             using_session(:tab_1) do |session|
               channel.hover_message(message_1)
               find(".chat-message-react-btn").click
-              find(".chat-emoji-picker [data-emoji=\"#{reaction.emoji}\"]").click
+              find(".chat-emoji-picker [data-emoji=\"#{reaction}\"]").click
 
-              expect(channel).to have_reaction(message_1, reaction.emoji)
+              expect(channel).to have_reaction(message_1, reaction)
+
               session.quit
             end
 
-            expect(channel).to have_reaction(message_1, reaction.emoji)
+            expect(channel).to have_reaction(message_1, "grimacing")
           end
         end
       end


### PR DESCRIPTION
I was only able to get one failure out of 100 tries, this failure didn't get me more info. My best guess  ATM is  that sometimes, the first session was still loading while receiving the reaction and created some unexpected situation.

The commit attempts to start the "check" session before the session making the reaction hoping that will be enough to prevent this case, if this is the issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
