### PR TITLE
DEV: Don't stub an imported module

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -1,4 +1,3 @@
-import * as Utilities from "discourse/lib/utilities";
 import {
   allowsAttachments,
   allowsImages,
@@ -348,7 +347,8 @@ module("Unit | Utility | uploads", function (hooks) {
       "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
     );
 
-    sinon.stub(Utilities, "isAppleDevice").returns(true);
+    const capabilities = getOwner(this).lookup("service:capabilities");
+    sinon.stub(capabilities, "isIOS").get(() => true);
     assert.strictEqual(
       testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
       "![image|100x200](/uploads/123/abcdef.ext)"


### PR DESCRIPTION
Stub a service's getter instead (embroider compat issue)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
