### PR TITLE
DEV: Refactor `Discourse::VERSION` and add `-dev` support

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,12 +7,16 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      MAJOR = 3
-      MINOR = 1
-      TINY = 0
-      PRE = "beta6"
+      STRING = "3.1.0.beta6"
 
-      STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+      PARTS = STRING.split(".")
+      private_constant :PARTS
+
+      MAJOR = PARTS[0].to_i
+      MINOR = PARTS[1].to_i
+      TINY = PARTS[2].to_i
+      PRE = PARTS[3]&.split("-", 2)&.first
+      DEV = PARTS[3]&.split("-", 2)&.second
     end
   end
 


### PR DESCRIPTION
For the Discourse 3.2 beta series, we intend to use a `-dev` suffix while beta versions are being developed in `main`/`tests-passed`. When a beta version is ready, it will be 'released' without the `-dev` suffix.

This commit adds support for the `-dev` suffix, and also refactors `Discourse::VERSION` so that the canonical representation is a simple human-readable string. Constants for each segment are derived  from that, so the interface remains unchanged.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
