### PR TITLE
FEATURE: Add flexible highlight plugin api

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -4,9 +4,16 @@ import mergeHTMLPlugin from "discourse/lib/highlight-syntax-merge-html-plugin";
 /*global hljs:true */
 let _moreLanguages = [];
 let _plugins = [];
+let _selectors = new Set();
+let _options = {};
 let _initialized = false;
 
-export default function highlightSyntax(elem, siteSettings, session) {
+export default function highlightSyntax(
+  elem,
+  siteSettings,
+  session,
+  customSelector
+) {
   if (!elem) {
     return;
   }
@@ -15,7 +22,10 @@ export default function highlightSyntax(elem, siteSettings, session) {
     ? "pre code"
     : "pre code[class]";
 
-  const codeblocks = elem.querySelectorAll(selector);
+  const finalSelector =
+    customSelector || Array.from(new Set([selector, ..._selectors])).join(",");
+
+  const codeblocks = elem.querySelectorAll(finalSelector);
 
   if (!codeblocks.length) {
     return;
@@ -50,6 +60,14 @@ export function registerHighlightJSPlugin(plugin) {
   _plugins.push(plugin);
 }
 
+export function registerHighlightJSSelector(selector) {
+  _selectors.add(selector);
+}
+
+export function registerHighlightJSConfigure(options) {
+  _options = { ..._options, ...options };
+}
+
 function customHighlightJSLanguages() {
   _moreLanguages.forEach((l) => {
     if (hljs.getLanguage(l.name) === undefined) {
@@ -70,6 +88,7 @@ function initializer() {
     customHighlightJSPlugins();
     hljs.addPlugin(mergeHTMLPlugin);
     hljs.configure({
+      ..._options,
       ignoreUnescapedHTML: true,
     });
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -83,8 +83,10 @@ import { on } from "@ember/object/evented";
 import { registerCustomAvatarHelper } from "discourse/helpers/user-avatar";
 import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/controllers/topic";
 import {
+  registerHighlightJSConfigure,
   registerHighlightJSLanguage,
   registerHighlightJSPlugin,
+  registerHighlightJSSelector,
 } from "discourse/lib/highlight-syntax";
 import { registerTopicFooterButton } from "discourse/lib/register-topic-footer-button";
 import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer-dropdown";
@@ -129,7 +131,7 @@ import { _addBulkButton } from "discourse/components/modal/topic-bulk-actions";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.8.0";
+export const PLUGIN_API_VERSION = "1.8.1";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -1481,6 +1483,40 @@ class PluginApi {
    **/
   registerHighlightJSPlugin(plugin) {
     registerHighlightJSPlugin(plugin);
+  }
+
+  /**
+   * Registers custom HighlightJS css selectors
+   *
+   * Apply highlight to selector
+   *
+   * See https://github.com/highlightjs/highlight.js#using-custom-html
+   * for the detail.
+   *
+   * Example:
+   *
+   * api.registerHighlightJSSelector('.foo, .bar');
+   * api.registerHighlightJSSelector('.foo');
+   * api.registerHighlightJSSelector('.bar');
+   *
+   */
+  registerHighlightJSSelector(selector) {
+    registerHighlightJSSelector(selector);
+  }
+
+  /**
+   * Registers global options to HighlightJS
+   *
+   * See https://highlightjs.readthedocs.io/en/latest/api.html#configure
+   * for instructions on how to define a options object
+   *
+   * Example:
+   *
+   * api.registerHighlightJSConfigure({ noHeighLightRe: /plain/ })
+   *
+   */
+  registerHighlightJSConfigure(options) {
+    registerHighlightJSConfigure(options);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -131,7 +131,7 @@ import { _addBulkButton } from "discourse/components/modal/topic-bulk-actions";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.8.1";
+export const PLUGIN_API_VERSION = "1.8.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/highlight-syntax-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/highlight-syntax-test.js
@@ -57,4 +57,58 @@ module("Unit | Utility | highlight-syntax", function () {
       3
     );
   });
+
+  test("highlighting custom HTML", async function (assert) {
+    fixture().innerHTML = `
+      <div class="language-ruby">
+        def code; puts 1 + 2 end
+      </div>
+    `;
+
+    await highlightSyntax(
+      fixture(),
+      siteSettings,
+      session,
+      "div.language-ruby"
+    );
+
+    assert.strictEqual(
+      document
+        .querySelector("div.language-ruby.hljs .hljs-keyword")
+        .innerText.trim(),
+      "def"
+    );
+  });
+
+  test("highlighting custom HTML with HTML intermingled", async function (assert) {
+    fixture().innerHTML = `
+      <div class="language-ruby">
+        <ol>
+        <li>def code</li>
+        <li>  puts 1 + 2</li>
+        <li>end</li>
+        </ol>
+      </div>
+    `;
+
+    await highlightSyntax(
+      fixture(),
+      siteSettings,
+      session,
+      "div.language-ruby"
+    );
+
+    assert.strictEqual(
+      document
+        .querySelector("div.language-ruby.hljs .hljs-keyword")
+        .innerText.trim(),
+      "def"
+    );
+
+    // Checks if HTML structure was preserved
+    assert.strictEqual(
+      document.querySelectorAll("div.language-ruby.hljs ol li").length,
+      3
+    );
+  });
 });

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,7 +7,7 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1] - 2023-07-26
+## [1.8.0] - 2023-07-26
 
 ### Added
 

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,16 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2023-07-26
+
+### Added
+
+- Adds `registerHighlightJSSelector` which allows to register custom HighlightJS cssSelectors.
+See https://github.com/highlightjs/highlight.js#using-custom-html for documentation.
+
+- Adds `registerHighlightJSConfigure` which allows to register HighlightJS global options
+See https://highlightjs.readthedocs.io/en/latest/api.html#configure for documentation.
+
 ## [1.7.1] - 2023-07-18
 
 ### Added


### PR DESCRIPTION
`customSelector` parameter of `highlightSyntax` allows to manually applying highlight to a custom selector.

`api.registerHighlightJSSelector` allows to apply highlight to custom selectors.

`api.registerHighlightJSConfigure` allows to extend the global highlight options.

ref https://meta.discourse.org/t/more-flexible-highlight-configuration-in-plugin-api/272879
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
