### PR TITLE
FIX: reset scrollbar position for mobile on lightbox images

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-lightbox.js
+++ b/app/assets/javascripts/discourse/app/components/d-lightbox.js
@@ -47,6 +47,7 @@ export default class DLightbox extends Component {
   elementId = LIGHTBOX_ELEMENT_ID;
   titleElementId = TITLE_ELEMENT_ID;
   animationDuration = ANIMATION_DURATION;
+  scrollPosition = 0;
 
   get layoutType() {
     return window.innerWidth > window.innerHeight
@@ -201,6 +202,7 @@ export default class DLightbox extends Component {
 
     this.isLoading = true;
     this.isVisible = true;
+    this.scrollPosition = window.scrollY;
 
     this.#setCurrentItem(this.currentIndex);
 
@@ -462,10 +464,22 @@ export default class DLightbox extends Component {
       this.isVisible = false;
       this.willClose = false;
 
+      this.resetScrollPosition();
+
       this.callbacks.onCleanup?.();
 
       this.callbacks = {};
       this.options = {};
+    }
+  }
+
+  resetScrollPosition() {
+    if (window.scrollY !== this.scrollPosition) {
+      window.scrollTo({
+        left: 0,
+        top: parseInt(this.scrollPosition, 10),
+        behavior: "instant",
+      });
     }
   }
 


### PR DESCRIPTION
Using pinch-zoom on mobile devices with lightbox images can lead to scrolling of background content.

We can't disable touch gestures entirely as they are needed for zooming images.

This change handles this by capturing the `window.scrollY` value when opening the lightbox, then when exiting we check if the scroll position has changed and reset it.

Note: I haven't included a test for this change as it's pretty difficult to track scrollbar changes within qunit. Within qunit we need to rely on `document.getElementById("ember-testing-container").scrollTop` to change the scroll position, however within our component we rely on `window.scrollTo` and `window.scrollY` to handle scrollbar position changes. Neither of these will work as expected within qunit.