### PR TITLE
UX: responsive oneboxing with images in chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -20,13 +20,20 @@ $max_image_height: 150px;
   .onebox {
     container-type: inline-size;
 
-    @container (width < 300px) {
+    .thumbnail {
+      max-width: 40%;
+      &.onebox-avatar {
+        max-height: 100px;
+      }
+    }
+
+    @container (width < 400px) {
       .onebox-body {
         display: flex;
         flex-direction: column;
 
         h3 {
-          margin-block: 0.75rem;
+          margin-block: 0.75rem 0;
         }
         p {
           margin-top: 0.5rem;
@@ -35,6 +42,10 @@ $max_image_height: 150px;
         .thumbnail {
           max-width: 100%;
           margin: 0;
+
+          &.onebox-avatar {
+            max-width: 20%;
+          }
         }
       }
     }

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -21,9 +21,11 @@ $max_image_height: 150px;
     container-type: inline-size;
 
     .thumbnail {
-      max-width: 40%;
+      max-width: 40% !important;
       &.onebox-avatar {
         max-height: 100px;
+        width: 20%;
+        max-width: 60px;
       }
     }
 
@@ -40,7 +42,7 @@ $max_image_height: 150px;
         }
 
         .thumbnail {
-          max-width: 100%;
+          max-width: 100% !important;
           margin: 0;
 
           &.onebox-avatar {

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -26,13 +26,16 @@ $max_image_height: 150px;
         max-height: 100px;
         width: 20%;
         max-width: 60px;
+        margin-right: 0.5rem;
       }
     }
 
     @container (width < 400px) {
       .onebox-body {
-        display: flex;
-        flex-direction: column;
+        &:not(:has(.thumbnail.onebox-avatar)) {
+          display: flex;
+          flex-direction: column;
+        }
 
         h3 {
           margin-block: 0.75rem 0;
@@ -47,6 +50,7 @@ $max_image_height: 150px;
 
           &.onebox-avatar {
             max-width: 20%;
+            margin-right: 0.5rem;
           }
         }
       }

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -3,12 +3,10 @@ $max_image_height: 150px;
 .chat-message {
   // append selectors to set images to a
   // max height of $max_image_height
-  .chat-message-collapser
-    .onebox
-    img:not(.ytp-thumbnail-image, .onebox-avatar-inline),
-  .chat-message-collapser img.onebox,
-  .chat-message-collapser .chat-uploads img,
-  .chat-message-collapser p img,
+  .onebox img:not(.ytp-thumbnail-image, .onebox-avatar-inline),
+  img.onebox,
+  .chat-uploads img,
+  p img,
   aside.onebox .onebox-body .aspect-image-full-size,
   aside.onebox .onebox-body .aspect-image-full-size img,
   .chat-message-text p img:not(.emoji) {
@@ -17,6 +15,29 @@ $max_image_height: 150px;
     max-width: 100%;
     width: unset;
     overflow: hidden;
+  }
+
+  .onebox {
+    container-type: inline-size;
+
+    @container (width < 300px) {
+      .onebox-body {
+        display: flex;
+        flex-direction: column;
+
+        h3 {
+          margin-block: 0.75rem;
+        }
+        p {
+          margin-top: 0.5rem;
+        }
+
+        .thumbnail {
+          max-width: 100%;
+          margin: 0;
+        }
+      }
+    }
   }
 
   .chat-message-collapser


### PR DESCRIPTION
Improving the responsive scaling of images in the oneboxes
* onebox image scaled differently based on presence of other image in chat-message
* onebox avatars were too big
* regular thumbnail was too small on narrow views
* added flex column on narrow views for regular thumbnails

**BEFORE**
<img width="679" alt="image" src="https://github.com/discourse/discourse/assets/101828855/cebaf88b-4c0d-417a-a894-87e10a544a45">


**AFTER**
<img width="819" alt="image" src="https://github.com/discourse/discourse/assets/101828855/488877c3-92c6-4148-9e41-5bba81a9b4db">


