### PR TITLE
DEV: skip flaky spec

### DIFF
--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -54,7 +54,7 @@ describe "Thread tracking state | drawer", type: :system do
       expect(thread_list_page).to have_no_unread_item(thread.id)
     end
 
-    it "shows unread indicators for the header icon and the list when a new unread arrives" do
+    xit "shows unread indicators for the header icon and the list when a new unread arrives" do
       thread.membership_for(current_user).update!(last_read_message_id: message_2.id)
       visit("/")
       chat_page.open_from_header


### PR DESCRIPTION
An attempt to make this spec more stable has been made in https://github.com/discourse/discourse/commit/f76a9aab220a6d457bce0ee45ddd091525d0cf3a which doesn’t seem to workout: https://github.com/discourse/discourse/actions/runs/5679336462/job/15391318065#step:31:1128

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
