### PR TITLE
FIX: Internal oneboxes with github links

### DIFF
--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -114,7 +114,11 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
       @in_quote = !@keep_onebox_source if attributes.include?(%w[class source])
     when "div", "span"
       attributes = Hash[*attributes.flatten]
-      if attributes["class"]&.include?("excerpt")
+
+      # Only match "excerpt" class if it does specifically equal "excerpt
+      # hidden" in order to prevent internal links with GitHub oneboxes from
+      # being empty https://meta.discourse.org/t/269436
+      if attributes["class"]&.include?("excerpt") && !attributes["class"]&.match?("excerpt hidden")
         @excerpt = +""
         @current_length = 0
         @start_excerpt = true

--- a/spec/lib/excerpt_parser_spec.rb
+++ b/spec/lib/excerpt_parser_spec.rb
@@ -110,6 +110,57 @@ RSpec.describe ExcerptParser do
         The first paragraph of this pinned topic will be &hellip;
       HTML
     end
+
+    it "keeps the content for internal oneboxes that contain github oneboxes" do
+      html = <<~HTML.strip
+        <p>Another commit to test out.</p>
+        <p>This time this commit has a longer commit message.</p>
+        <aside class="onebox githubcommit" data-onebox-src="https://github.com/discourse/discourse/commit/90f395a11895e9cfb7edd182b0bf5ec3d51d7892">
+          <header class="source">
+              <a href="https://github.com/discourse/discourse/commit/90f395a11895e9cfb7edd182b0bf5ec3d51d7892" target="_blank" rel="noopener">github.com/discourse/discourse</a>
+          </header>
+          <article class="onebox-body">
+            <div class="github-row">
+          <div class="github-icon-container" title="Commit">
+            <svg width="60" height="60" class="github-icon" viewBox="0 0 14 16" aria-hidden="true"><path fill-rule="evenodd" d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"></path></svg>
+          </div>
+          <div class="github-info-container">
+            <h4>
+              <a href="https://github.com/discourse/discourse/commit/90f395a11895e9cfb7edd182b0bf5ec3d51d7892" target="_blank" rel="noopener">DEV: Skip srcset for onebox thumbnails (#22621)</a>
+            </h4>
+            <div class="github-info">
+              <div class="date">
+                committed <span class="discourse-local-date" data-format="ll" data-date="2023-07-19" data-time="18:21:34" data-timezone="UTC">06:21PM - 19 Jul 23 UTC (UTC)</span>
+              </div>
+              <div class="user">
+                <a href="https://github.com/oblakeerickson" target="_blank" rel="noopener">
+                  <img alt="oblakeerickson" src="//localhost:3000/uploads/default/original/1X/741ac99d6a66d71cdd46dd99fb5156506e13fdf2.jpeg" class="onebox-avatar-inline" width="20" height="20" data-dominant-color="3C3C3C">
+                  oblakeerickson
+                </a>
+              </div>
+              <div class="lines" title="changed 2 files with 24 additions and 15 deletions">
+                <a href="https://github.com/discourse/discourse/commit/90f395a11895e9cfb7edd182b0bf5ec3d51d7892" target="_blank" rel="noopener">
+                  <span class="added">+24</span>
+                  <span class="removed">-15</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+          <div class="github-row">
+            <p class="github-body-container">* DEV: Test commit message
+        This is a longer commit message <span class="show-more-container"><a href="https://github.com/discourse/discourse/commit/90f395a11895e9cfb7edd182b0bf5ec3d51d7892" target="_blank" rel="noopener" class="show-more">…</a></span><span class="excerpt hidden">that has the show-more class along with the exerpt hidden class</span></p>
+          </div>
+          </article>
+          <div class="onebox-metadata">
+          </div>
+          <div style="clear: both"></div>
+        </aside>
+      HTML
+      expect(ExcerptParser.get_excerpt(html, 100, keep_onebox_body: false)).to eq(<<~HTML.strip)
+        Another commit to test out. \nThis time this commit has a longer commit message.
+      HTML
+    end
   end
 
   describe "keep_quotes parameter" do


### PR DESCRIPTION
Internal oneboxes to posts that contained oneboxed github links to
commits or PRs with long enough commit messages to have the `show-more`
and the `excerpt hidden` classes in their html were being stripped of
their content resulting in empty internal oneboxes.

see: https://meta.discourse.org/t/269436

This fixes a regression introduced in:

0b3cf83e3c7d03c2dcd54f86de60efe32f385a44
