### PR TITLE
DEV: Add logging and rescue when user already exists and connecting via DiscourseConnect

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -267,7 +267,16 @@ class DiscourseConnect < DiscourseConnectBase
           ReviewableUser.set_approved_fields!(user, Discourse.system_user)
         end
 
-        user.save!
+        begin
+          user.save!
+        rescue ActiveRecord::RecordInvalid => e
+          if SiteSetting.verbose_discourse_connect_logging
+            Rails.logger.error(
+              "Verbose SSO log: User creation failed. External id: #{external_id}, New User (user_id: #{user.id}) Params: #{user_params} User Params: #{user.attributes} User Errors: #{user.errors.full_messages} Email: #{user.primary_email.attributes} Email Error: #{user.primary_email.errors.full_messages}",
+            )
+          end
+          raise e
+        end
 
         if SiteSetting.verbose_discourse_connect_logging
           Rails.logger.warn(


### PR DESCRIPTION
m/272282/26

Steps to repro:

1. Connect a DiscourseConnect provider to forum.
2. On the forum there already exists a steaky@cat.com user
3. On the provider, there is a steaky@cat.com user
4. They have never connected via SSO
5. Now when Steaky tries to connect he will hit an error in https://github.com/discourse/discourse/blob/291629834d2870f3c1ac71311e5e0a39340f9027/app/models/discourse_connect.rb#L270
  - https://github.com/discourse/discourse/blob/291629834d2870f3c1ac71311e5e0a39340f9027/app/models/discourse_connect.rb#L250
  - This is happening because despite the user already existing in the forum, the `SingleSignOnRecord` doesn't exist and "require_activation" is set on the provider, causing us to skip looking for the email, and resulting in us creating a new User then seeing `Validation failed: Primary email has already been taken` when DiscourseConnect is attempting to make a new account.
  
This is a plug to allow us to debug and get the external ID of the user via logs. We will need to think about how to handle this edge case properly.