### PR TITLE
FIX: Missing pending queued posts from topic view

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -459,7 +459,7 @@ module Jobs
 
       # Most Reviewable fields staff-private, but post content needs to be exported.
       ReviewableQueuedPost
-        .where(created_by: @current_user.id)
+        .where(target_created_by_id: @current_user.id)
         .order(:created_at)
         .each do |rev|
           yield(

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -101,7 +101,8 @@ class Reviewable < ActiveRecord::Base
     created_by:,
     payload: nil,
     reviewable_by_moderator: false,
-    potential_spam: true
+    potential_spam: true,
+    target_created_by: nil
   )
     reviewable =
       new(
@@ -111,6 +112,7 @@ class Reviewable < ActiveRecord::Base
         reviewable_by_moderator: reviewable_by_moderator,
         payload: payload,
         potential_spam: potential_spam,
+        target_created_by: target_created_by,
       )
     reviewable.created_new!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1543,7 +1543,7 @@ class User < ActiveRecord::Base
   end
 
   def number_of_rejected_posts
-    ReviewableQueuedPost.rejected.where(created_by_id: self.id).count
+    ReviewableQueuedPost.rejected.where(target_created_by_id: self.id).count
   end
 
   def number_of_flags_given

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -575,7 +575,7 @@ class TopicView
 
   def pending_posts
     @pending_posts ||=
-      ReviewableQueuedPost.pending.where(created_by: @user, topic: @topic).order(:created_at)
+      ReviewableQueuedPost.pending.where(target_created_by: @user, topic: @topic).order(:created_at)
   end
 
   def actions_summary

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -522,9 +522,11 @@ RSpec.describe Jobs::ExportUserArchive do
 
   describe "queued posts" do
     let(:component) { "queued_posts" }
-    let(:reviewable_post) { Fabricate(:reviewable_queued_post, topic: topic, created_by: user) }
+    let(:reviewable_post) do
+      Fabricate(:reviewable_queued_post, topic: topic, target_created_by: user)
+    end
     let(:reviewable_topic) do
-      Fabricate(:reviewable_queued_post_topic, category: category, created_by: user)
+      Fabricate(:reviewable_queued_post_topic, category: category, target_created_by: user)
     end
 
     it "correctly exports queued posts" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -547,7 +547,7 @@ RSpec.describe User do
     fab!(:posts) { [post1, post2, post3] }
     fab!(:post_ids) { [post1.id, post2.id, post3.id] }
     let(:guardian) { Guardian.new(Fabricate(:admin)) }
-    fab!(:reviewable_queued_post) { Fabricate(:reviewable_queued_post, created_by: user) }
+    fab!(:reviewable_queued_post) { Fabricate(:reviewable_queued_post, target_created_by: user) }
 
     it "deletes only one batch of posts" do
       post2
@@ -1981,13 +1981,21 @@ RSpec.describe User do
 
     describe "#number_of_rejected_posts" do
       it "counts rejected posts" do
-        Fabricate(:reviewable_queued_post, created_by: user, status: Reviewable.statuses[:rejected])
+        Fabricate(
+          :reviewable_queued_post,
+          target_created_by: user,
+          status: Reviewable.statuses[:rejected],
+        )
 
         expect(user.number_of_rejected_posts).to eq(1)
       end
 
       it "ignore non-rejected posts" do
-        Fabricate(:reviewable_queued_post, created_by: user, status: Reviewable.statuses[:approved])
+        Fabricate(
+          :reviewable_queued_post,
+          target_created_by: user,
+          status: Reviewable.statuses[:approved],
+        )
 
         expect(user.number_of_rejected_posts).to eq(0)
       end

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -357,7 +357,8 @@ RSpec.describe TopicViewSerializer do
           payload: {
             raw: "hello my raw contents",
           },
-          created_by: user,
+          created_by: Discourse.system_user,
+          target_created_by: user,
         )
       end
 


### PR DESCRIPTION
A previous change updated `ReviewableQueuedPost`'s `created_by` to be consistent with other reviewable types. It assigns the the creator of the post content being queued to `target_created_by` and sets the `created_by` to the creator of the reviewable itself.

This fix updates some of the `created_by` references missed during the initial fix.

See https://github.com/discourse/discourse/commit/3d554aa10e8c0f7b5c8a35f956a3577751ba776c and https://meta.discourse.org/t/awaiting-approval-post-display-issue-following-update-to-discourse-version-3-1-0-beta6/272781

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
