### PR TITLE
DEV: Constrain category_slug_path_with_id route segments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1166,12 +1166,12 @@ Discourse::Application.routes.draw do
         }
     get "/new-category" => "categories#show", :constraints => { format: "html" }
 
-    get "c/*category_slug_path_with_id.rss" => "list#category_feed",
+    get "c/:category_slug_path_with_id.rss" => "list#category_feed",
         :constraints => {
           category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
         },
         :format => :rss
-    scope path: "c/*category_slug_path_with_id",
+    scope path: "c/:category_slug_path_with_id",
           constraints: {
             category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
           } do
@@ -1509,7 +1509,7 @@ Discourse::Application.routes.draw do
       delete "/unused" => "tags#destroy_unused"
 
       constraints(tag_id: %r{[^/]+?}, format: /json|rss/) do
-        scope path: "/c/*category_slug_path_with_id",
+        scope path: "/c/:category_slug_path_with_id",
               constraints: {
                 category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
               } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1166,8 +1166,15 @@ Discourse::Application.routes.draw do
         }
     get "/new-category" => "categories#show", :constraints => { format: "html" }
 
-    get "c/*category_slug_path_with_id.rss" => "list#category_feed", :format => :rss
-    scope path: "c/*category_slug_path_with_id" do
+    get "c/*category_slug_path_with_id.rss" => "list#category_feed",
+        :constraints => {
+          category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
+        },
+        :format => :rss
+    scope path: "c/*category_slug_path_with_id",
+          constraints: {
+            category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
+          } do
       get "/none" => "list#category_none_latest"
 
       TopTopic.periods.each do |period|
@@ -1502,7 +1509,10 @@ Discourse::Application.routes.draw do
       delete "/unused" => "tags#destroy_unused"
 
       constraints(tag_id: %r{[^/]+?}, format: /json|rss/) do
-        scope path: "/c/*category_slug_path_with_id" do
+        scope path: "/c/*category_slug_path_with_id",
+              constraints: {
+                category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
+              } do
           Discourse.filters.each do |filter|
             get "/none/:tag_id/l/#{filter}" => "tags#show_#{filter}",
                 :as => "tag_category_none_show_#{filter}",

--- a/lib/route_format.rb
+++ b/lib/route_format.rb
@@ -8,4 +8,8 @@ module RouteFormat
   def self.backup
     /.+\.(sql\.gz|tar\.gz|tgz)/i
   end
+
+  def self.category_slug_path_with_id
+    %r{[^/].+/\d+}
+  end
 end

--- a/spec/routing/category_routes_spec.rb
+++ b/spec/routing/category_routes_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe "Category routes" do
+  it "constrains category slug with id" do
+    with_routing do |set|
+      set.draw do
+        mount Discourse::Application => "/"
+
+        # an example of plugin-added routes
+        get "/c/:category_slug_path_with_id/extra/awesome/path" => "posts#show",
+            :constraints => {
+              category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
+            }
+        get "/c/*category_slug_path_with_id/bloop" => "posts#index",
+            :constraints => {
+              category_slug_path_with_id: RouteFormat.category_slug_path_with_id,
+            }
+      end
+
+      # core route still works
+      expect(get("/c/test-category/3/all")).to route_to(
+        {
+          controller: "list",
+          action: "category_default",
+          category_slug_path_with_id: "test-category/3",
+        },
+      )
+
+      # plugin routes work
+      expect(get("/c/test-category/3/bloop")).to route_to(
+        { controller: "posts", action: "index", category_slug_path_with_id: "test-category/3" },
+      )
+      expect(get("/c/test-category/3/extra/awesome/path")).to route_to(
+        { controller: "posts", action: "show", category_slug_path_with_id: "test-category/3" },
+      )
+
+      # non-existent routes still 404
+      expect(get("/c/test-category/3/does/not/exist")).to_not be_routable
+    end
+  end
+end


### PR DESCRIPTION
This allows to add new /c/:category_slug_path_with_id/ sub-routes in plugins.

Without the constraint, even if there are new sub routes, paths would still be matched like this:

```
Rails.application.routes.recognize_path "/c/test-category/7/whatever/else/here"

=> {:controller=>"list",
 :action=>"category_default",
 :category_slug_path_with_id=>"test-category/7/whatever/else/here"}
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
