### PR TITLE
FIX: Can't dismiss new topics that belong to a sub-sub category

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1062,13 +1062,17 @@ class TopicsController < ApplicationController
     if tag_name = params[:tag_id]
       tag_name = DiscourseTagging.visible_tags(guardian).where(name: tag_name).pluck(:name).first
     end
+
     topic_scope =
       if params[:category_id].present?
-        category_ids = [params[:category_id].to_i]
-        if ActiveModel::Type::Boolean.new.cast(params[:include_subcategories])
-          category_ids =
-            category_ids.concat(Category.where(parent_category_id: params[:category_id]).pluck(:id))
-        end
+        category_id = params[:category_id].to_i
+
+        category_ids =
+          if ActiveModel::Type::Boolean.new.cast(params[:include_subcategories])
+            Category.subcategory_ids(category_id)
+          else
+            [category_id]
+          end
 
         category_ids &= guardian.allowed_category_ids
         if category_ids.blank?

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3972,8 +3972,32 @@ RSpec.describe TopicsController do
 
           put "/topics/reset-new.json?category_id=#{category.id}&include_subcategories=true"
 
+          expect(response.status).to eq(200)
+
           expect(DismissedTopicUser.where(user_id: user.id).pluck(:topic_id).sort).to eq(
             [category_topic.id, subcategory_topic.id].sort,
+          )
+        end
+
+        it "dismisses topics for main category, subcategories and sub-subcategories" do
+          SiteSetting.max_category_nesting = 3
+
+          sub_subcategory = Fabricate(:category, parent_category_id: subcategory.id)
+          sub_subcategory_topic = Fabricate(:topic, category: sub_subcategory)
+
+          TopicTrackingState.expects(:publish_dismiss_new).with(
+            user.id,
+            topic_ids: [category_topic.id, subcategory_topic.id, sub_subcategory_topic.id],
+          )
+
+          put "/topics/reset-new.json?category_id=#{category.id}&include_subcategories=true"
+
+          expect(response.status).to eq(200)
+
+          expect(DismissedTopicUser.where(user_id: user.id).pluck(:topic_id)).to contain_exactly(
+            category_topic.id,
+            subcategory_topic.id,
+            sub_subcategory_topic.id,
           )
         end
 
@@ -3993,16 +4017,17 @@ RSpec.describe TopicsController do
 
           it "doesn't dismiss topics in private child categories that the user can't see" do
             messages =
-              MessageBus.track_publish do
+              MessageBus.track_publish(TopicTrackingState.unread_channel_key(user.id)) do
                 put "/topics/reset-new.json",
                     params: {
                       category_id: category.id,
                       include_subcategories: true,
                     }
+
+                expect(response.status).to eq(200)
               end
-            expect(response.status).to eq(200)
+
             expect(messages.size).to eq(1)
-            expect(messages[0].channel).to eq(TopicTrackingState.unread_channel_key(user.id))
             expect(messages[0].user_ids).to eq([user.id])
             expect(messages[0].data["message_type"]).to eq(
               TopicTrackingState::DISMISS_NEW_MESSAGE_TYPE,
@@ -4017,17 +4042,19 @@ RSpec.describe TopicsController do
 
           it "dismisses topics in private child categories that the user can see" do
             group.add(user)
+
             messages =
-              MessageBus.track_publish do
+              MessageBus.track_publish(TopicTrackingState.unread_channel_key(user.id)) do
                 put "/topics/reset-new.json",
                     params: {
                       category_id: category.id,
                       include_subcategories: true,
                     }
+
+                expect(response.status).to eq(200)
               end
-            expect(response.status).to eq(200)
+
             expect(messages.size).to eq(1)
-            expect(messages[0].channel).to eq(TopicTrackingState.unread_channel_key(user.id))
             expect(messages[0].user_ids).to eq([user.id])
             expect(messages[0].data["message_type"]).to eq(
               TopicTrackingState::DISMISS_NEW_MESSAGE_TYPE,


### PR DESCRIPTION
What is the context for this change?

Prior to this change, there is a bug in `TopicsController#reset_new`
where it does not dismiss new topics in sub-subcategories when the
`category_id` and `include_subcategories=true` params are present. This
is because the controller did not account for sub-subcategories when
fetching the category ids of the new topics that should be dismissed.

This commit fixes the problem by relying on the `Category.subcategory_ids` class
method which accounts for sub-subcategories.