### PR TITLE
Revert "DEV: Skip flaky QUnit tests (#22847)"

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/admin-theme-settings-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-theme-settings-editor-test.js
@@ -1,4 +1,4 @@
-import { module, skip, test } from "qunit";
+import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
@@ -43,7 +43,7 @@ module(
 
     let model;
 
-    skip("renders passed json model object into string in the ace editor", async function (assert) {
+    test("renders passed json model object into string in the ace editor", async function (assert) {
       await render(hbs`<ThemeSettingsEditor @model={{hash
         model=(hash
          settings=(array


### PR DESCRIPTION
This reverts commit 26fc5d2d1f218edca5a3d0d8793f07620e4acd27.

Flaky test has been fixed in e7208ab4c6454613eb7af1e9a117b9f72b154cbf