### PR TITLE
FEATURE: Remove restrictions from the chat messages export

### DIFF
--- a/plugins/chat/lib/chat/messages_exporter.rb
+++ b/plugins/chat/lib/chat/messages_exporter.rb
@@ -2,8 +2,6 @@
 
 module Chat
   module MessagesExporter
-    LIMIT = 10_000
-
     def chat_message_export(&block)
       # perform 1 db query per month:
       now = Time.now
@@ -49,7 +47,6 @@ module Chat
         .includes(:chat_channel)
         .includes(:user)
         .includes(:last_editor)
-        .limit(LIMIT)
         .find_each do |chat_message|
           yield(
             [

--- a/plugins/chat/lib/chat/messages_exporter.rb
+++ b/plugins/chat/lib/chat/messages_exporter.rb
@@ -7,7 +7,7 @@ module Chat
     def chat_message_export(&block)
       # perform 1 db query per month:
       now = Time.now
-      from = 6.months.ago
+      from = oldest_message_date
       while from <= now
         export(from, from + 1.month, &block)
         from = from + 1.month
@@ -37,6 +37,10 @@ module Chat
     end
 
     private
+
+    def oldest_message_date
+      Chat::Message.order(:created_at).pick(:created_at)
+    end
 
     def export(from, to)
       Chat::Message


### PR DESCRIPTION
Now, when we took care of performance in fbe0e4c7 and ad05924b there is no need anymore to restrict the export to
- 6 months
- 10000 rows
