### PR TITLE
Version bump for stable: v3.0.6

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -9,7 +9,7 @@ module Discourse
     module VERSION #:nodoc:
       MAJOR = 3
       MINOR = 0
-      TINY = 5
+      TINY = 6
       PRE = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
> :warning: This PR should not be merged via the GitHub web interface
> 
> It should only be merged (via fast-forward) using the associated `bin/rake version_bump:*` task.
