### PR TITLE
FIX: when using arrow to bottom fetch from newest

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -427,9 +427,8 @@ export default class ChatChannel extends Component {
   @action
   scrollToLatestMessage() {
     if (this.messagesLoader.canLoadMoreFuture) {
-      this.fetchMessages({ fetch_from_last_read: true });
+      this.fetchMessages();
     } else if (this.messagesManager.messages.length > 0) {
-      this._ignoreNextScroll = true;
       this.scrollToBottom(this.scrollable);
     }
   }


### PR DESCRIPTION
We were attempting to fetch from last read but this is actually complicated to get right when you have a lot unread, as we might still have more to load after this but the last unread id is still the same and would make the user end up in a loop.

We have already a test for this, but the previous state changed in this commit was not correctly tested.
