### PR TITLE
UX: allow composer title to shrink when needed

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -129,12 +129,13 @@ html.composer-open {
       align-items: center;
       width: auto;
       max-width: 100%;
-      min-width: 0;
+      min-width: 0; // allows shrinking when needed
 
       .action-title {
         display: flex;
         align-items: center;
         line-height: normal;
+        min-width: 0;
 
         .topic-link,
         .user-link,

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -129,18 +129,19 @@ html.composer-open {
       align-items: center;
       width: auto;
       max-width: 100%;
+      min-width: 0;
 
       .action-title {
         display: flex;
         align-items: center;
         line-height: normal;
-        @include ellipsis;
-      }
 
-      .topic-link,
-      .user-link,
-      .post-link {
-        margin-right: 8px;
+        .topic-link,
+        .user-link,
+        .post-link {
+          margin-right: 8px;
+          @include ellipsis;
+        }
       }
 
       .username {


### PR DESCRIPTION
this overflow usually isn't too noticeable and results in some title cropping, but it causes button overlap with the encrypt plugin: 

Before:

![Screenshot 2023-07-28 at 2 20 42 PM](https://github.com/discourse/discourse/assets/1681963/789522a5-cb11-4835-9e92-fc8c26c5146c)

After:

![Screenshot 2023-07-28 at 2 20 27 PM](https://github.com/discourse/discourse/assets/1681963/461e753c-b144-4498-a9ad-b6ed3eb3740a)

There are some button spacing improvements that can be made too, but those can be accomplished in the encrypt plugin. 