### PR TITLE
PERF: Add exponential backoff for `/presence/update` errors

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -562,6 +562,11 @@ export default class PresenceService extends Service {
         const waitSeconds = e.jqXHR.responseJSON?.extras?.wait_seconds || 10;
         this._presenceDebounceMs = waitSeconds * 1000;
       } else {
+        // Other error, exponential backoff capped at 30 seconds
+        this._presenceDebounceMs = Math.min(
+          this._presenceDebounceMs * 2,
+          PRESENCE_INTERVAL_S * 1000
+        );
         throw e;
       }
     } finally {


### PR DESCRIPTION
We already handled 429 rate limit errors correctly. This commit adds backoff logic to other types of error to avoid requests being retried every second.

https://meta.discourse.org/t/268063

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
