### PR TITLE
UX: increase experimental lightbox z-index

### DIFF
--- a/app/assets/stylesheets/common/components/d-lightbox.scss
+++ b/app/assets/stylesheets/common/components/d-lightbox.scss
@@ -233,7 +233,7 @@ html.has-lightbox {
     left: 0;
     height: 100%;
     width: 100%;
-    z-index: z("header");
+    z-index: z("max");
   }
 
   &__content {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/header-submenus/94584/151?u=awesomerobot

Currently the z-index is on the same level of the header, but sometimes a customization (or even a modal) will exist above the header. We should bump the lightbox to the top of the index to avoid any issues. 