### PR TITLE
UX: fix alignment extra buttons in post controls

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -374,6 +374,10 @@ nav.post-controls {
       margin-right: 0;
     }
   }
+
+  .extra-buttons .widget-button {
+    height: 100%;
+  }
 }
 
 .deleted {


### PR DESCRIPTION
Sudden misalignment for the extra-buttons

<img width="508" alt="image" src="https://github.com/discourse/discourse/assets/101828855/3c154fc4-3c5b-485b-9851-ff68a9065e60">


