### PR TITLE
FIX: Use category hashtag instead of link in `discourse_welcome_topic.body`

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -697,7 +697,7 @@ en:
 
       :handshake: **Contribute** by commenting, sharing your own perspective, asking questions, or offering feedback in the discussion. Before replying or starting new topics, please review the [Community Guidelines](%{base_path}/faq).
 
-      > If you need help or have a suggestion, feel free to ask in [#feedback](%{base_path}/c/site-feedback) or [contact the admins](%{base_path}/about).
+      > If you need help or have a suggestion, feel free to ask in %{feedback_category} or [contact the admins](%{base_path}/about).
 
   admin_quick_start_title: "Admin Guide: Getting Started"
 

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -109,6 +109,10 @@ module SeedData
               ""
             end
 
+          feedback_category = Category.find_by(id: SiteSetting.meta_category_id)
+          feedback_category_hashtag =
+            feedback_category ? "##{feedback_category.slug}" : "#site-feedback"
+
           topics << {
             site_setting_name: "welcome_topic_id",
             title: I18n.t("discourse_welcome_topic.title", site_title: SiteSetting.title),
@@ -119,6 +123,7 @@ module SeedData
                 site_title: SiteSetting.title,
                 site_description: SiteSetting.site_description,
                 site_info_quote: site_info_quote,
+                feedback_category: feedback_category_hashtag,
               ),
             category: general_category,
             after_create: proc { |post| post.topic.update_pinned(true, true) },

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe SeedData::Topics do
 
   describe "#create" do
     it "creates a missing topic" do
+      staff_category = Fabricate(:category, name: "Feedback")
+      SiteSetting.meta_category_id = staff_category.id
+
       expect { create_topic }.to change { Topic.count }.by(1).and change { Post.count }.by(1)
 
       topic = Topic.last
@@ -29,6 +32,7 @@ RSpec.describe SeedData::Topics do
           site_title: SiteSetting.title,
           site_description: SiteSetting.site_description,
           site_info_quote: "",
+          feedback_category: "#feedback",
         ).rstrip,
       )
       expect(topic.category_id).to eq(SiteSetting.general_category_id)
@@ -133,6 +137,7 @@ RSpec.describe SeedData::Topics do
           site_title: SiteSetting.title,
           site_description: SiteSetting.site_description,
           site_info_quote: "",
+          feedback_category: "#site-feedback",
         ).rstrip,
       )
     end


### PR DESCRIPTION
Linking to the #feedback category can break if the category gets renamed or a different site locale is used. By using the correct hashtag (at the time of seeding) this issues can be avoided.