### PR TITLE
FIX: `created:@` search keyword for uppercase usernames

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -491,7 +491,7 @@ class Search
   end
 
   advanced_filter(/\Acreated:@(.*)\z/i) do |posts, match|
-    user_id = User.where(username: match.downcase).pick(:id)
+    user_id = User.where(username_lower: match.downcase).pick(:id)
     posts.where(user_id: user_id, post_number: 1)
   end
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1980,6 +1980,18 @@ RSpec.describe Search do
       expect(
         Search.execute("test in:tracking", guardian: Guardian.new(topic.user)).posts.length,
       ).to eq(1)
+
+      another_user = Fabricate(:user, username: "AnotherUser")
+      post4 = Fabricate(:post, raw: "test by uppercase username", user: another_user)
+      topic4 = post4.topic
+      topic4.update(category: public_category)
+
+      expect(
+        Search
+          .execute("test created:@#{another_user.username}", guardian: Guardian.new())
+          .posts
+          .length,
+      ).to eq(1)
     end
 
     it "can find posts with images" do


### PR DESCRIPTION
The filter wasn't working if the username had uppercase letters. This commit fixes it.