### PR TITLE
DEV: Correctly strip sourcemap URL from splash-screen js

### DIFF
--- a/app/helpers/splash_screen_helper.rb
+++ b/app/helpers/splash_screen_helper.rb
@@ -19,7 +19,7 @@ module SplashScreenHelper
 
   def self.load_js
     File.read("#{Rails.root}/app/assets/javascripts/discourse/dist/assets/splash-screen.js").sub(
-      "//# sourceMappingURL=splash-screen.map\n",
+      "//# sourceMappingURL=splash-screen.map",
       "",
     )
   rescue Errno::ENOENT


### PR DESCRIPTION
In e1d27400f5d8be345383b52bd118e652724a517e we started running the splash-screen JS through terser, which removed the trailing newline from the `sourceMappingURL` line.

Adding a reliable end-to-end test for this isn't possible because our testing environment doesn't use terser.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
