### PR TITLE
DEV: Fix a flaky quote post spec

### DIFF
--- a/spec/models/quoted_post_spec.rb
+++ b/spec/models/quoted_post_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe QuotedPost do
       </aside>
     HTML
 
-    QuotedPost.create!(post_id: post2.id, quoted_post_id: 999)
     quote = QuotedPost.create!(post_id: post2.id, quoted_post_id: post1.id)
     original_date = quote.created_at
 


### PR DESCRIPTION
```
  1) QuotedPost correctly handles deltas
     Failure/Error: quote = QuotedPost.create!(post_id: post2.id, quoted_post_id: post1.id)
     
     ActiveRecord::RecordNotUnique:
       PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_quoted_posts_on_post_id_and_quoted_post_id"
       DETAIL:  Key (post_id, quoted_post_id)=(1000, 999) already exists.
```