### PR TITLE
DEV: Assert that user has been signed in successfully in system tests

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -18,6 +18,8 @@ module SystemHelpers
             GlobalSetting.relative_url_root || "",
             "/session/#{user.encoded_username}/become.json?redirect=false",
           )
+
+    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
   end
 
   def sign_out


### PR DESCRIPTION
We have seen instances where the user has not been signed in but we need
more debugging information to know why.

Exmaple where test fails due to user not being signed in https://github.com/discourse/discourse/actions/runs/5718655343/job/15494917165