### PR TITLE
DEV: Remove unread_private_messages and deprecation

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -7,7 +7,6 @@ export default {
       avatar_template: "/user_avatar/localhost/eviltrout/{size}/5275.png",
       name: "Robin Ward",
       unread_notifications: 0,
-      unread_private_messages: 0,
       unread_high_priority_notifications: 0,
       admin: true,
       notification_channel_position: null,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -662,14 +662,6 @@ class User < ActiveRecord::Base
     results.to_h
   end
 
-  def unread_private_messages
-    Discourse.deprecate(
-      "#unread_private_messages is deprecated, use #unread_high_priority_notifications instead.",
-      drop_from: "2.5.0",
-    )
-    @unread_pms ||= unread_high_priority_notifications
-  end
-
   def unread_high_priority_notifications
     @unread_high_prios ||= unread_notifications_of_priority(high_priority: true)
   end
@@ -852,7 +844,6 @@ class User < ActiveRecord::Base
 
     payload = {
       unread_notifications: unread_notifications,
-      unread_private_messages: unread_private_messages,
       unread_high_priority_notifications: unread_high_priority_notifications,
       read_first_notification: read_first_notification?,
       last_notification: json,

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -6,7 +6,6 @@ class CurrentUserSerializer < BasicUserSerializer
 
   attributes :name,
              :unread_notifications,
-             :unread_private_messages,
              :unread_high_priority_notifications,
              :all_unread_notifications_count,
              :read_first_notification?,

--- a/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js
+++ b/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js
@@ -258,7 +258,7 @@ export function createData(store) {
 
     userWithUnread: createUser({
       unread_notifications: 3,
-      unread_private_messages: 7,
+      unread_high_priority_notifications: 7,
     }),
 
     lorem: cooked,

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Notification do
         }.to change(user, :total_unread_notifications)
       end
 
-      it "doesn't increase unread_private_messages" do
+      it "doesn't increase unread_high_priority_notifications" do
         expect {
           Fabricate(:notification, user: user)
           user.reload
-        }.not_to change(user, :unread_private_messages)
+        }.not_to change(user, :unread_high_priority_notifications)
       end
     end
 
@@ -180,13 +180,6 @@ RSpec.describe Notification do
           Fabricate(:notification, user: user)
           user.reload
         }.to change(user, :total_unread_notifications)
-      end
-
-      it "increases unread_private_messages" do
-        expect {
-          Fabricate(:private_message_notification, user: user)
-          user.reload
-        }.to change(user, :unread_private_messages)
       end
 
       it "increases unread_high_priority_notifications" do
@@ -283,11 +276,11 @@ RSpec.describe Notification do
       )
       expect(@post.user.unread_notifications).to eq(0)
       expect(@post.user.total_unread_notifications).to eq(0)
-      expect(@target.unread_private_messages).to eq(1)
+      expect(@target.unread_high_priority_notifications).to eq(1)
 
       Fabricate(:post, topic: @topic, user: @topic.user)
       @target.reload
-      expect(@target.unread_private_messages).to eq(1)
+      expect(@target.unread_high_priority_notifications).to eq(1)
     end
   end
 
@@ -351,9 +344,6 @@ RSpec.describe Notification do
 
       expect(user.unread_notifications).to eq(0)
       expect(user.total_unread_notifications).to eq(3)
-      # NOTE: because of deprecation this will be equal to unread_high_priority_notifications,
-      #       to be removed in 2.5
-      expect(user.unread_private_messages).to eq(2)
       expect(user.unread_high_priority_notifications).to eq(2)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2341,9 +2341,6 @@ RSpec.describe User do
           .first
 
       expect(message.data[:unread_notifications]).to eq(1)
-      # NOTE: because of deprecation this will be equal to unread_high_priority_notifications,
-      #       to be removed in 2.5
-      expect(message.data[:unread_private_messages]).to eq(2)
       expect(message.data[:unread_high_priority_notifications]).to eq(2)
     end
 


### PR DESCRIPTION
This was added all the way back in 2020 in b79ea986ac44c1ced0b332722c1bb16b4239b565,
enough time has passed, we can delete this now.

See also:

https://github.com/discourse/DiscourseMobile/pull/193
https://github.com/discourse/discourse-amazon-sns/pull/7