### PR TITLE
DEV: Remove dependency on webdrivers gem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,10 +204,6 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      - name: Setup Webdriver
-        if: matrix.build_type == 'system'
-        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
-
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system

--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,6 @@ group :test do
   gem "simplecov", require: false
   gem "selenium-webdriver", require: false
   gem "test-prof"
-  gem "webdrivers", require: false
   gem "rails-dom-testing", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
       google-protobuf (~> 3.23)
     sass-embedded (1.64.1-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -515,10 +515,6 @@ GEM
       hkdf (~> 1.0)
       jwt (~> 2.0)
       openssl (~> 3.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -672,7 +668,6 @@ DEPENDENCIES
   unf
   unicorn
   web-push
-  webdrivers
   webmock
   yaml-lint
   yard

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,11 +59,8 @@ require "shoulda-matchers"
 require "sidekiq/testing"
 require "test_prof/recipes/rspec/let_it_be"
 require "test_prof/before_all/adapters/active_record"
-require "webdrivers"
 require "selenium-webdriver"
 require "capybara/rails"
-
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # The shoulda-matchers gem no longer detects the test framework
 # you're using or mixes itself into that framework automatically.
@@ -255,7 +252,7 @@ RSpec.configure do |config|
 
     SiteSetting.provider = TestLocalProcessProvider.new
 
-    WebMock.disable_net_connect!(allow_localhost: true, allow: [Webdrivers::Chromedriver.base_url])
+    WebMock.disable_net_connect!(allow_localhost: true)
 
     if ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].present?
       Capybara.default_max_wait_time = ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].to_i


### PR DESCRIPTION
The webdrivers gem is no longer need if we're on the latest version of
selenium-webdriver according to https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1641139415