### PR TITLE
UX: Use full width when displaying a single recommendations list.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/more-topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/more-topics.hbs
@@ -1,6 +1,5 @@
 <div
-  class="more-content-wrapper
-    {{if this.showTitleOnMobile 'mobile-single-list'}}"
+  class="more-content-wrapper {{if this.singleList 'single-list'}}"
   {{did-insert this.buildListPills}}
 >
   {{#if this.showTopicListsNav}}

--- a/app/assets/javascripts/discourse/app/components/more-topics.js
+++ b/app/assets/javascripts/discourse/app/components/more-topics.js
@@ -15,10 +15,6 @@ export default class MoreTopics extends Component {
     return this.site.mobileView && !this.singleList;
   }
 
-  get showTitleOnMobile() {
-    return this.site.mobileView && this.singleList;
-  }
-
   @action
   rememberTopicListPreference(value) {
     this.moreTopicsPreferenceTracking.updatePreference(value);
@@ -28,10 +24,6 @@ export default class MoreTopics extends Component {
 
   @action
   buildListPills() {
-    if (!this.site.mobileView) {
-      return;
-    }
-
     next(() => {
       const pills = Array.from(
         document.querySelectorAll(".more-content-topics")
@@ -44,6 +36,9 @@ export default class MoreTopics extends Component {
 
       if (pills.length <= 1) {
         this.singleList = true;
+      }
+
+      if (this.singleList || !this.site.mobileView) {
         return;
       }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -368,10 +368,6 @@ a.badge-category {
   max-width: 757px;
 }
 
-.more-content-wrapper .topic-list-body .topic-list-data:first-of-type {
-  padding-left: 0;
-}
-
 // Target the .badge-category text, the bullet icon needs to maintain `display: block`
 .more-content-topics h3 .badge-wrapper.bullet span.badge-category,
 .more-content-topics h3 .badge-wrapper.box span,

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -362,6 +362,12 @@ pre.codeblock-buttons:hover {
   }
 }
 
+.more-content-wrapper.single-list {
+  .more-content-topics {
+    width: 100%;
+  }
+}
+
 .more-content-topics {
   margin-top: 2em;
 

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -138,6 +138,7 @@
 
 .more-content-wrapper {
   display: flex;
+  justify-content: space-around;
 
   .topic-list-header,
   .posts-map,
@@ -147,6 +148,10 @@
 
   .topic-list-body {
     border-top: none;
+
+    .topic-list-item {
+      padding-left: 5px;
+    }
 
     .topic-list-item:last-of-type {
       border-bottom: none;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -253,10 +253,14 @@ a.reply-to-tab {
 }
 
 .more-content-wrapper {
-  &:not(.mobile-single-list) {
+  &:not(.single-list) {
     .more-topics-title {
       display: none;
     }
+  }
+
+  .topic-list-data {
+    padding-left: 5px;
   }
 }
 


### PR DESCRIPTION
#### Desktop - Single and multi lists.

<img width="1103" alt="Screenshot 2023-08-01 at 00 37 23" src="https://github.com/discourse/discourse/assets/5025816/133606c9-144f-45e2-b2b9-d05dd627dbe0">
<img width="1019" alt="Screenshot 2023-08-01 at 00 37 00" src="https://github.com/discourse/discourse/assets/5025816/11cde569-67e6-4e98-a96a-51a2f6d788d0">


#### Mobile - Single and multi lists.
<img width="1720" alt="Screenshot 2023-08-01 at 00 42 34" src="https://github.com/discourse/discourse/assets/5025816/9ceae264-dfe3-4b29-971c-21073fdc29e6">
<img width="1718" alt="Screenshot 2023-08-01 at 00 42 04" src="https://github.com/discourse/discourse/assets/5025816/445596f7-e618-4af3-a27b-2419c3c13ae4">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
