### PR TITLE
DEV: Add site setting to allow collection of GC stats during requests

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2148,6 +2148,9 @@ developer:
   max_sidebar_section_links:
     default: 50
     hidden: true
+  track_gc_stat_per_request:
+    default: false
+    hidden: true
 
 navigation:
   navigation_menu:

--- a/spec/lib/method_profiler_spec.rb
+++ b/spec/lib/method_profiler_spec.rb
@@ -37,4 +37,24 @@ RSpec.describe MethodProfiler do
 
     expect(result[:at_beach][:calls]).to eq(2)
   end
+
+  it "profiles GC stat information when `track_gc_stat_per_request` site setting has been enabled" do
+    MethodProfiler.start
+    GC.start(full_mark: false) # Minor GC
+    result = MethodProfiler.stop
+
+    expect(result[:gc]).not_to be_present
+
+    SiteSetting.track_gc_stat_per_request = true
+
+    MethodProfiler.start
+    GC.start(full_mark: true) # Major GC
+    GC.start(full_mark: false) # Minor GC
+    result = MethodProfiler.stop
+
+    expect(result[:gc]).to be_present
+    expect(result[:gc][:time]).to be >= 0.0
+    expect(result[:gc][:major_count]).to eq(1)
+    expect(result[:gc][:minor_count]).to eq(1)
+  end
 end


### PR DESCRIPTION
What does this change do?

This change adds a hidden `track_gc_stat_per_request` site setting which
when enabled will track the time spent in GC, major GC count and minor
GC count during a request.

Why is this change needed?

We have plans to tune our GC in production but without any
instrumentation, we will not be able to know if our tuning is effective
or not. This commit takes the first step at instrumenting some basic GC
stats in core during a request which can then be consumed by the discourse-prometheus plugin.