### PR TITLE
FIX: Ensure PresenceChannel does not raise error during readonly

### DIFF
--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -314,7 +314,10 @@ class PresenceChannel
         else
           raise InvalidConfig.new "Expected PresenceChannel::Config or nil. Got a #{result.class.name}"
         end
-      PresenceChannel.redis.set(redis_key_config, to_cache, ex: CONFIG_CACHE_SECONDS)
+
+      DiscourseRedis.ignore_readonly do
+        PresenceChannel.redis.set(redis_key_config, to_cache, ex: CONFIG_CACHE_SECONDS)
+      end
 
       raise PresenceChannel::NotFound if result.nil?
       result

--- a/spec/lib/presence_channel_spec.rb
+++ b/spec/lib/presence_channel_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe PresenceChannel do
     expect(channel3.count).to eq(0)
   end
 
+  it "does not raise error when getting channel config under readonly" do
+    PresenceChannel.redis.stubs(:set).raises(Redis::CommandError.new("READONLY")).once
+    channel = PresenceChannel.new("/test/public1")
+    expect(channel.user_ids).to eq([])
+  end
+
   it "can automatically expire users" do
     channel = PresenceChannel.new("/test/public1")
 


### PR DESCRIPTION
PresenceChannel configuration is cached using redis. That cache is used, and sometimes repopulated, during normal GET requests. When the primary redis server was readonly, that `redis.set` call would raise an error and cause the entire request to fail. Instead, we should ignore the failure and continue without populating the cache.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
