### PR TITLE
FIX: Display similar topics for anons on mobile.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/more-topics.js
+++ b/app/assets/javascripts/discourse/app/components/more-topics.js
@@ -34,18 +34,21 @@ export default class MoreTopics extends Component {
         };
       });
 
-      if (pills.length <= 1) {
-        this.singleList = true;
-      }
-
-      if (this.singleList || !this.site.mobileView) {
+      if (pills.length === 0) {
         return;
+      } else if (pills.length === 1) {
+        this.singleList = true;
       }
 
       let preference = this.moreTopicsPreferenceTracking.preference;
 
       if (!preference) {
-        this.moreTopicsPreferenceTracking.updatePreference(pills[0].id);
+        const rememberPref = this.site.mobileView && !this.singleList;
+
+        this.moreTopicsPreferenceTracking.updatePreference(
+          pills[0].id,
+          rememberPref
+        );
         preference = pills[0].id;
       }
 

--- a/app/assets/javascripts/discourse/app/services/more-topics-preference-tracking.js
+++ b/app/assets/javascripts/discourse/app/services/more-topics-preference-tracking.js
@@ -13,8 +13,11 @@ export default class MoreTopicsPreferenceTracking extends Service {
     this.preference = this.keyValueStore.get(TOPIC_LIST_PREFERENCE_KEY);
   }
 
-  updatePreference(value) {
-    this.keyValueStore.set({ key: TOPIC_LIST_PREFERENCE_KEY, value });
+  updatePreference(value, rememberPref = false) {
+    if (!rememberPref) {
+      this.keyValueStore.set({ key: TOPIC_LIST_PREFERENCE_KEY, value });
+    }
+
     this.preference = value;
   }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -764,12 +764,9 @@ acceptance(
 
       await publishUnreadToMessageBus({ userId: 5, topicId: 2 });
 
-      assert.ok(
-        query(".suggested-topics-message")
-          .innerText.trim()
-          .match(
-            /There is 1 unread\s+ and 1 new message remaining, or browse other personal messages/
-          ),
+      assert.strictEqual(
+        query(".suggested-topics-message").innerText.trim(),
+        "There is 1 unread and 1 new message remaining, or browse other personal messages",
         "displays the right browse more message"
       );
 
@@ -816,7 +813,7 @@ acceptance(
         query(".suggested-topics-message")
           .innerText.trim()
           .match(
-            /There is 1 unread\s+ and 1 new message remaining, or browse other messages in\s+awesome_group/
+            /There is 1 unread and 1 new message remaining, or browse other messages in\s+awesome_group/
           ),
         "displays the right browse more message"
       );


### PR DESCRIPTION
We never propagated the preference change because of the early return, meaning lists listening to it never got to decide if they had to remain hidden.

Also, we don't want to track the preference when there's a single list, as the user didn't choose to see it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
