### PR TITLE
FEATURE: New topics vs replies toggle for the new new view

### DIFF
--- a/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.hbs
+++ b/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.hbs
@@ -1,0 +1,12 @@
+<div
+  class="topic-replies-toggle-wrapper"
+  {{on "click" (action this.click)}}
+  {{! template-lint-disable no-invalid-interactive  }}
+>
+  {{raw
+    "list/new-list-header-controls"
+    current=@current
+    newRepliesCount=@newRepliesCount
+    newTopicsCount=@newTopicsCount
+  }}
+</div>

--- a/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.hbs
+++ b/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.hbs
@@ -8,5 +8,6 @@
     current=@current
     newRepliesCount=@newRepliesCount
     newTopicsCount=@newTopicsCount
+    noStaticLabel=true
   }}
 </div>

--- a/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.js
+++ b/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.js
@@ -1,0 +1,14 @@
+import Component from "@glimmer/component";
+
+export default class NewListHeaderControlsWrapper extends Component {
+  click(e) {
+    const target = e.target;
+    if (target.closest("button.topics-replies-toggle.all")) {
+      this.args.changeNewListScope(null);
+    } else if (target.closest("button.topics-replies-toggle.topics")) {
+      this.args.changeNewListScope("topics");
+    } else if (target.closest("button.topics-replies-toggle.replies")) {
+      this.args.changeNewListScope("replies");
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.js
+++ b/app/assets/javascripts/discourse/app/components/new-list-header-controls-wrapper.js
@@ -4,11 +4,11 @@ export default class NewListHeaderControlsWrapper extends Component {
   click(e) {
     const target = e.target;
     if (target.closest("button.topics-replies-toggle.all")) {
-      this.args.changeNewListScope(null);
+      this.args.changeNewListSubset(null);
     } else if (target.closest("button.topics-replies-toggle.topics")) {
-      this.args.changeNewListScope("topics");
+      this.args.changeNewListSubset("topics");
     } else if (target.closest("button.topics-replies-toggle.replies")) {
-      this.args.changeNewListScope("replies");
+      this.args.changeNewListSubset("replies");
     }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-list.hbs
@@ -13,6 +13,10 @@
     listTitle=this.listTitle
     bulkSelectEnabled=this.bulkSelectEnabled
     canDoBulkActions=this.canDoBulkActions
+    showTopicsAndRepliesToggle=this.showTopicsAndRepliesToggle
+    newListScope=this.newListScope
+    newRepliesCount=this.newRepliesCount
+    newTopicsCount=this.newTopicsCount
   }}
 </thead>
 

--- a/app/assets/javascripts/discourse/app/components/topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-list.hbs
@@ -14,7 +14,7 @@
     bulkSelectEnabled=this.bulkSelectEnabled
     canDoBulkActions=this.canDoBulkActions
     showTopicsAndRepliesToggle=this.showTopicsAndRepliesToggle
-    newListScope=this.newListScope
+    newListSubset=this.newListSubset
     newRepliesCount=this.newRepliesCount
     newTopicsCount=this.newTopicsCount
   }}

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -184,6 +184,17 @@ export default Component.extend(LoadMore, {
         },
       });
     });
+
+    onClick("button.topics-replies-toggle", (element) => {
+      if (element.classList.contains("all")) {
+        this.changeNewListScope(null);
+      } else if (element.classList.contains("topics")) {
+        this.changeNewListScope("topics");
+      } else if (element.classList.contains("replies")) {
+        this.changeNewListScope("replies");
+      }
+      this.rerender();
+    });
   },
 
   keyDown(e) {

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -187,11 +187,11 @@ export default Component.extend(LoadMore, {
 
     onClick("button.topics-replies-toggle", (element) => {
       if (element.classList.contains("all")) {
-        this.changeNewListScope(null);
+        this.changeNewListSubset(null);
       } else if (element.classList.contains("topics")) {
-        this.changeNewListScope("topics");
+        this.changeNewListSubset("topics");
       } else if (element.classList.contains("replies")) {
-        this.changeNewListScope("replies");
+        this.changeNewListSubset("replies");
       }
       this.rerender();
     });

--- a/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
@@ -13,6 +13,7 @@ export const queryParams = {
   before: { replace: true, refreshModel: true },
   bumped_before: { replace: true, refreshModel: true },
   f: { replace: true, refreshModel: true },
+  s: { replace: true, refreshModel: true },
   period: { replace: true, refreshModel: true },
   topic_ids: { replace: true, refreshModel: true },
   group_name: { replace: true, refreshModel: true },
@@ -33,6 +34,13 @@ export function changeSort(sortBy) {
     this.controller.setProperties({ order: sortBy, ascending: false });
     model.updateSortParams(sortBy, false);
   }
+}
+
+export function changeNewListScope(newScope) {
+  this.controller.set("s", newScope);
+
+  let model = this.controllerFor("discovery.topics").model;
+  model.updateNewListScopeParam(newScope);
 }
 
 export function resetParams(skipParams = []) {

--- a/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
@@ -13,7 +13,7 @@ export const queryParams = {
   before: { replace: true, refreshModel: true },
   bumped_before: { replace: true, refreshModel: true },
   f: { replace: true, refreshModel: true },
-  s: { replace: true, refreshModel: true },
+  subset: { replace: true, refreshModel: true },
   period: { replace: true, refreshModel: true },
   topic_ids: { replace: true, refreshModel: true },
   group_name: { replace: true, refreshModel: true },
@@ -36,11 +36,11 @@ export function changeSort(sortBy) {
   }
 }
 
-export function changeNewListScope(newScope) {
-  this.controller.set("s", newScope);
+export function changeNewListSubset(subset) {
+  this.controller.set("subset", subset);
 
   let model = this.controllerFor("discovery.topics").model;
-  model.updateNewListScopeParam(newScope);
+  model.updateNewListSubsetParam(subset);
 }
 
 export function resetParams(skipParams = []) {

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -28,7 +28,6 @@ export default class TopicsController extends DiscoveryController.extend(
 
   @alias("currentUser.id") canStar;
   @alias("currentUser.user_option.redirected_to_top.reason") redirectedReason;
-  @alias("model.params.s") newListScope;
   @readOnly("model.params.order") order;
   @readOnly("model.params.ascending") ascending;
   @gt("model.topics.length", 0) hasTopics;

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -101,9 +101,45 @@ export default class TagShowController extends DiscoverySortableController.exten
     return this._isFilterPage(filter, "unread") && topicsLength > 0;
   }
 
-  @discourseComputed("list.filter", "list.topics.length")
-  showResetNew(filter, topicsLength) {
-    return this._isFilterPage(filter, "new") && topicsLength > 0;
+  @discourseComputed("list.filter")
+  new(filter) {
+    return this._isFilterPage(filter, "new");
+  }
+
+  @discourseComputed("new")
+  showTopicsAndRepliesToggle(isNew) {
+    return isNew && this.currentUser?.new_new_view_enabled;
+  }
+
+  @discourseComputed("topicTrackingState.messageCount")
+  newRepliesCount() {
+    if (this.currentUser?.new_new_view_enabled) {
+      return this.topicTrackingState.countUnread({
+        categoryId: this.category?.id,
+        noSubcategories: this.noSubcategories,
+        tagId: this.tag?.id,
+      });
+    } else {
+      return 0;
+    }
+  }
+
+  @discourseComputed("topicTrackingState.messageCount")
+  newTopicsCount() {
+    if (this.currentUser?.new_new_view_enabled) {
+      return this.topicTrackingState.countNew({
+        categoryId: this.category?.id,
+        noSubcategories: this.noSubcategories,
+        tagId: this.tag?.id,
+      });
+    } else {
+      return 0;
+    }
+  }
+
+  @discourseComputed("new", "list.topics.length")
+  showResetNew(isNew, topicsLength) {
+    return isNew && topicsLength > 0;
   }
 
   callResetNew(dismissPosts = false, dismissTopics = false, untrack = false) {

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -185,6 +185,11 @@ export default class TagShowController extends DiscoverySortableController.exten
   }
 
   @action
+  changeNewListSubset(subset) {
+    this.set("subset", subset);
+  }
+
+  @action
   changePeriod(p) {
     this.set("period", p);
   }

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -67,6 +67,18 @@ const TopicList = RestModel.extend({
     this.set("params", params);
   },
 
+  updateNewListScopeParam(newScope) {
+    let params = Object.assign({}, this.params || {});
+
+    if (params.q) {
+      params = { q: params.q };
+    } else {
+      params.s = newScope;
+    }
+
+    this.set("params", params);
+  },
+
   loadMore() {
     if (this.loadingMore) {
       return Promise.resolve();

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -67,13 +67,13 @@ const TopicList = RestModel.extend({
     this.set("params", params);
   },
 
-  updateNewListScopeParam(newScope) {
+  updateNewListSubsetParam(subset) {
     let params = Object.assign({}, this.params || {});
 
     if (params.q) {
       params = { q: params.q };
     } else {
-      params.s = newScope;
+      params.subset = subset;
     }
 
     this.set("params", params);

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -94,45 +94,45 @@ const TopicTrackingState = EmberObject.extend({
     this.messageBus.subscribe(
       "/latest",
       this._processChannelPayload,
-      meta["/latest"] || messageBusDefaultNewMessageId
+      meta["/latest"] ?? messageBusDefaultNewMessageId
     );
 
     if (this.currentUser) {
       this.messageBus.subscribe(
         "/new",
         this._processChannelPayload,
-        meta["/new"] || messageBusDefaultNewMessageId
+        meta["/new"] ?? messageBusDefaultNewMessageId
       );
 
       this.messageBus.subscribe(
         `/unread`,
         this._processChannelPayload,
-        meta["/unread"] || messageBusDefaultNewMessageId
+        meta["/unread"] ?? messageBusDefaultNewMessageId
       );
 
       this.messageBus.subscribe(
         `/unread/${this.currentUser.id}`,
         this._processChannelPayload,
-        meta[`/unread/${this.currentUser.id}`] || messageBusDefaultNewMessageId
+        meta[`/unread/${this.currentUser.id}`] ?? messageBusDefaultNewMessageId
       );
     }
 
     this.messageBus.subscribe(
       "/delete",
       this.onDeleteMessage,
-      meta["/delete"] || messageBusDefaultNewMessageId
+      meta["/delete"] ?? messageBusDefaultNewMessageId
     );
 
     this.messageBus.subscribe(
       "/recover",
       this.onRecoverMessage,
-      meta["/recover"] || messageBusDefaultNewMessageId
+      meta["/recover"] ?? messageBusDefaultNewMessageId
     );
 
     this.messageBus.subscribe(
       "/destroy",
       this.onDestroyMessage,
-      meta["/destroy"] || messageBusDefaultNewMessageId
+      meta["/destroy"] ?? messageBusDefaultNewMessageId
     );
   },
 

--- a/app/assets/javascripts/discourse/app/raw-templates/list/new-list-header-controls.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/list/new-list-header-controls.hbr
@@ -1,0 +1,9 @@
+<button class="topics-replies-toggle all{{#if view.allActive}} active{{/if}}">
+  {{view.allButtonLabel}}
+</button>
+<button class="topics-replies-toggle topics{{#if view.topicsActive}} active{{/if}}">
+  {{view.topicsButtonLabel}}
+</button>
+<button class="topics-replies-toggle replies{{#if view.repliesActive}} active{{/if}}">
+  {{view.repliesButtonLabel}}
+</button>

--- a/app/assets/javascripts/discourse/app/raw-templates/list/new-list-header-controls.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/list/new-list-header-controls.hbr
@@ -1,9 +1,13 @@
-<button class="topics-replies-toggle all{{#if view.allActive}} active{{/if}}">
-  {{view.allButtonLabel}}
-</button>
-<button class="topics-replies-toggle topics{{#if view.topicsActive}} active{{/if}}">
-  {{view.topicsButtonLabel}}
-</button>
-<button class="topics-replies-toggle replies{{#if view.repliesActive}} active{{/if}}">
-  {{view.repliesButtonLabel}}
-</button>
+{{#if view.staticLabel}}
+  <span class="static-label">{{view.staticLabel}}</span>
+{{else}}
+  <button class="topics-replies-toggle all{{#if view.allActive}} active{{/if}}">
+    {{view.allButtonLabel}}
+  </button>
+  <button class="topics-replies-toggle topics{{#if view.topicsActive}} active{{/if}}">
+    {{view.topicsButtonLabel}}
+  </button>
+  <button class="topics-replies-toggle replies{{#if view.repliesActive}} active{{/if}}">
+    {{view.repliesButtonLabel}}
+  </button>
+{{/if}}

--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
@@ -13,7 +13,13 @@
       </span>
     {{/if ~}}
   {{/if ~}}
-  <span>{{view.localizedName}}</span>
+  {{~#if view.showTopicsAndRepliesToggle}}
+    <span class="topic-replies-toggle-wrapper">
+      {{raw "list/new-list-header-controls" current=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
+    </span>
+  {{else}}
+    <span>{{view.localizedName}}</span>
+  {{/if ~}}
   {{~#if view.isSorting}}
     {{d-icon view.sortIcon}}
   {{/if ~}}

--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
@@ -14,7 +14,7 @@
     {{/if ~}}
   {{/if ~}}
   {{~#if view.showTopicsAndRepliesToggle}}
-    {{raw "list/new-list-header-controls" current=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
+    {{raw "list/new-list-header-controls" current=newListSubset newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
   {{else}}
     <span>{{view.localizedName}}</span>
   {{/if ~}}

--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
@@ -14,9 +14,7 @@
     {{/if ~}}
   {{/if ~}}
   {{~#if view.showTopicsAndRepliesToggle}}
-    <span class="topic-replies-toggle-wrapper">
-      {{raw "list/new-list-header-controls" current=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
-    </span>
+    {{raw "list/new-list-header-controls" current=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
   {{else}}
     <span>{{view.localizedName}}</span>
   {{/if ~}}

--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
@@ -6,7 +6,7 @@
     {{/if}}
   </th>
 {{/if}}
-{{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect canDoBulkActions=canDoBulkActions}}
+{{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect canDoBulkActions=canDoBulkActions showTopicsAndRepliesToggle=showTopicsAndRepliesToggle newListScope=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
 {{raw-plugin-outlet name="topic-list-header-after-main-link"}}
 {{#if showPosters}}
   {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters")}}

--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
@@ -6,7 +6,7 @@
     {{/if}}
   </th>
 {{/if}}
-{{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect canDoBulkActions=canDoBulkActions showTopicsAndRepliesToggle=showTopicsAndRepliesToggle newListScope=newListScope newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
+{{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect canDoBulkActions=canDoBulkActions showTopicsAndRepliesToggle=showTopicsAndRepliesToggle newListSubset=newListSubset newRepliesCount=newRepliesCount newTopicsCount=newTopicsCount}}
 {{raw-plugin-outlet name="topic-list-header-after-main-link"}}
 {{#if showPosters}}
   {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters")}}

--- a/app/assets/javascripts/discourse/app/raw-views/list/new-list-header-controls.js
+++ b/app/assets/javascripts/discourse/app/raw-views/list/new-list-header-controls.js
@@ -1,0 +1,52 @@
+import EmberObject from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
+import I18n from "I18n";
+
+export default EmberObject.extend({
+  @discourseComputed
+  topicsActive() {
+    return this.current === "topics";
+  },
+
+  @discourseComputed
+  repliesActive() {
+    return this.current === "replies";
+  },
+
+  @discourseComputed
+  allActive() {
+    return !this.topicsActive && !this.repliesActive;
+  },
+
+  @discourseComputed
+  allButtonLabel() {
+    const count = this.newRepliesCount + this.newTopicsCount;
+    if (count > 0) {
+      return I18n.t("filters.new.all_with_count", { count });
+    } else {
+      return I18n.t("filters.new.all");
+    }
+  },
+
+  @discourseComputed
+  repliesButtonLabel() {
+    if (this.newRepliesCount > 0) {
+      return I18n.t("filters.new.replies_with_count", {
+        count: this.newRepliesCount,
+      });
+    } else {
+      return I18n.t("filters.new.replies");
+    }
+  },
+
+  @discourseComputed
+  topicsButtonLabel() {
+    if (this.newTopicsCount > 0) {
+      return I18n.t("filters.new.topics_with_count", {
+        count: this.newTopicsCount,
+      });
+    } else {
+      return I18n.t("filters.new.topics");
+    }
+  },
+});

--- a/app/assets/javascripts/discourse/app/raw-views/list/new-list-header-controls.js
+++ b/app/assets/javascripts/discourse/app/raw-views/list/new-list-header-controls.js
@@ -49,4 +49,19 @@ export default EmberObject.extend({
       return I18n.t("filters.new.topics");
     }
   },
+
+  @discourseComputed
+  staticLabel() {
+    if (this.noStaticLabel) {
+      return null;
+    }
+    if (this.newTopicsCount > 0 && this.newRepliesCount > 0) {
+      return null;
+    }
+    if (this.newTopicsCount > 0) {
+      return this.topicsButtonLabel;
+    } else {
+      return this.repliesButtonLabel;
+    }
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -1,7 +1,7 @@
 import { inject as service } from "@ember/service";
 import { Promise, all } from "rsvp";
 import {
-  changeNewListScope,
+  changeNewListSubset,
   changeSort,
   queryParams,
   resetParams,
@@ -220,8 +220,8 @@ class AbstractCategoryRoute extends DiscourseRoute {
   }
 
   @action
-  changeNewListScope(newScope) {
-    changeNewListScope.call(this, newScope);
+  changeNewListSubset(newScope) {
+    changeNewListSubset.call(this, newScope);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -1,6 +1,7 @@
 import { inject as service } from "@ember/service";
 import { Promise, all } from "rsvp";
 import {
+  changeNewListScope,
   changeSort,
   queryParams,
   resetParams,
@@ -216,6 +217,11 @@ class AbstractCategoryRoute extends DiscourseRoute {
   @action
   changeSort(sortBy) {
     changeSort.call(this, sortBy);
+  }
+
+  @action
+  changeNewListScope(newScope) {
+    changeNewListScope.call(this, newScope);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -220,8 +220,8 @@ class AbstractCategoryRoute extends DiscourseRoute {
   }
 
   @action
-  changeNewListSubset(newScope) {
-    changeNewListSubset.call(this, newScope);
+  changeNewListSubset(subset) {
+    changeNewListSubset.call(this, subset);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -1,4 +1,5 @@
 import {
+  changeNewListScope,
   changeSort,
   queryParams,
   resetParams,
@@ -163,6 +164,11 @@ class AbstractTopicRoute extends DiscourseRoute {
   @action
   changeSort(sortBy) {
     changeSort.call(this, sortBy);
+  }
+
+  @action
+  changeNewListScope(newScope) {
+    changeNewListScope.call(this, newScope);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -1,5 +1,5 @@
 import {
-  changeNewListScope,
+  changeNewListSubset,
   changeSort,
   queryParams,
   resetParams,
@@ -167,8 +167,8 @@ class AbstractTopicRoute extends DiscourseRoute {
   }
 
   @action
-  changeNewListScope(newScope) {
-    changeNewListScope.call(this, newScope);
+  changeNewListSubset(subset) {
+    changeNewListSubset.call(this, subset);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -37,8 +37,11 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
     });
   }
 
-  // TODO(tgxworld): This action is required by the `discovery/topics` controller which is not necessary for this route.
+  // TODO(tgxworld): The following 2 actions are required by the `discovery/topics` controller which is not necessary for this route.
   // Figure out a way to remove this.
   @action
   changeSort() {}
+
+  @action
+  changeNewListScope() {}
 }

--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -43,5 +43,5 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
   changeSort() {}
 
   @action
-  changeNewListScope() {}
+  changeNewListSubset() {}
 }

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -94,9 +94,13 @@
       @topics={{this.model.topics}}
       @discoveryList={{true}}
       @focusLastVisitedTopic={{true}}
+      @showTopicsAndRepliesToggle={{this.showTopicsAndRepliesToggle}}
+      @newListScope={{this.model.params.s}}
+      @changeNewListScope={{route-action "changeNewListScope"}}
+      @newRepliesCount={{this.newRepliesCount}}
+      @newTopicsCount={{this.newTopicsCount}}
     />
   {{/if}}
-
   <span>
     <PluginOutlet
       @name="after-topic-list"

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -95,8 +95,8 @@
       @discoveryList={{true}}
       @focusLastVisitedTopic={{true}}
       @showTopicsAndRepliesToggle={{this.showTopicsAndRepliesToggle}}
-      @newListScope={{this.model.params.s}}
-      @changeNewListScope={{route-action "changeNewListScope"}}
+      @newListSubset={{this.model.params.subset}}
+      @changeNewListSubset={{route-action "changeNewListSubset"}}
       @newRepliesCount={{this.newRepliesCount}}
       @newTopicsCount={{this.newTopicsCount}}
     />

--- a/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
@@ -42,10 +42,10 @@
 
   {{#if this.showTopicsAndRepliesToggle}}
     <NewListHeaderControlsWrapper
-      @current={{this.newListScope}}
+      @current={{this.model.params.subset}}
       @newRepliesCount={{this.newRepliesCount}}
       @newTopicsCount={{this.newTopicsCount}}
-      @changeNewListScope={{route-action "changeNewListScope"}}
+      @changeNewListSubset={{route-action "changeNewListSubset"}}
     />
   {{/if}}
   {{#if this.hasTopics}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
@@ -40,6 +40,14 @@
     {{/if}}
   {{/if}}
 
+  {{#if this.showTopicsAndRepliesToggle}}
+    <NewListHeaderControlsWrapper
+      @current={{this.newListScope}}
+      @newRepliesCount={{this.newRepliesCount}}
+      @newTopicsCount={{this.newTopicsCount}}
+      @changeNewListScope={{route-action "changeNewListScope"}}
+    />
+  {{/if}}
   {{#if this.hasTopics}}
     <TopicList
       @ascending={{this.ascending}}

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -127,6 +127,14 @@
                 {{/if}}
               {{/if}}
 
+              {{#if (and this.showTopicsAndRepliesToggle this.site.mobileView)}}
+                <NewListHeaderControlsWrapper
+                  @current={{this.newListScope}}
+                  @newRepliesCount={{this.newRepliesCount}}
+                  @newTopicsCount={{this.newTopicsCount}}
+                  @changeNewListScope={{action "changeNewListScope"}}
+                />
+              {{/if}}
               {{#if this.list.topics}}
                 <TopicList
                   @topics={{this.list.topics}}
@@ -144,6 +152,11 @@
                   @ascending={{this.ascending}}
                   @changeSort={{action "changeSort"}}
                   @focusLastVisitedTopic={{true}}
+                  @showTopicsAndRepliesToggle={{this.showTopicsAndRepliesToggle}}
+                  @newListScope={{this.newListScope}}
+                  @changeNewListScope={{action "changeNewListScope"}}
+                  @newRepliesCount={{this.newRepliesCount}}
+                  @newTopicsCount={{this.newTopicsCount}}
                 />
               {{/if}}
             </DiscoveryTopicsList>

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -129,10 +129,10 @@
 
               {{#if (and this.showTopicsAndRepliesToggle this.site.mobileView)}}
                 <NewListHeaderControlsWrapper
-                  @current={{this.newListScope}}
+                  @current={{this.subset}}
                   @newRepliesCount={{this.newRepliesCount}}
                   @newTopicsCount={{this.newTopicsCount}}
-                  @changeNewListScope={{action "changeNewListScope"}}
+                  @changeNewListSubset={{action "changeNewListSubset"}}
                 />
               {{/if}}
               {{#if this.list.topics}}
@@ -153,8 +153,8 @@
                   @changeSort={{action "changeSort"}}
                   @focusLastVisitedTopic={{true}}
                   @showTopicsAndRepliesToggle={{this.showTopicsAndRepliesToggle}}
-                  @newListScope={{this.newListScope}}
-                  @changeNewListScope={{action "changeNewListScope"}}
+                  @newListSubset={{this.subset}}
+                  @changeNewListSubset={{action "changeNewListSubset"}}
                   @newRepliesCount={{this.newRepliesCount}}
                   @newTopicsCount={{this.newTopicsCount}}
                 />

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -32,6 +32,9 @@
     &:last-of-type {
       padding-right: 10px;
     }
+    th & {
+      border-bottom: 3px solid var(--primary-low);
+    }
   }
 
   button.bulk-select {
@@ -49,6 +52,22 @@
     }
     + .main-link {
       padding-left: 0;
+    }
+  }
+
+  .topic-replies-toggle-wrapper {
+    position: relative;
+    top: 0;
+    user-select: none;
+  }
+
+  .topics-replies-toggle {
+    background: none;
+    border: none;
+    line-height: var(--line-height-large);
+
+    &.active {
+      background: red;
     }
   }
 

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -55,19 +55,15 @@
     }
   }
 
-  .topic-replies-toggle-wrapper {
-    position: relative;
-    top: 0;
-    user-select: none;
-  }
-
   .topics-replies-toggle {
     background: none;
     border: none;
     line-height: var(--line-height-large);
+    min-height: 30px;
 
     &.active {
-      background: red;
+      background: var(--quaternary);
+      color: var(--secondary);
     }
   }
 

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -569,3 +569,22 @@ td .main-link {
     align-items: center;
   }
 }
+
+.topic-replies-toggle-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+
+  .topics-replies-toggle {
+    flex-grow: 1;
+    background: none;
+    border: none;
+    padding: 0.75em;
+    box-shadow: 0 3px 0 var(--primary-low);
+
+    &.active {
+      color: var(--quaternary);
+      box-shadow: 0 3px 0 var(--quaternary);
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3995,6 +3995,12 @@ en:
           one: "New (%{count})"
           other: "New (%{count})"
         help: "topics created in the last few days"
+        all: "All"
+        all_with_count: "All (%{count})"
+        topics: "Topics"
+        topics_with_count: "Topics (%{count})"
+        replies: "Replies"
+        replies_with_count: "Replies (%{count})"
       posted:
         title: "My Posts"
         help: "topics you have posted in"

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -53,6 +53,7 @@ class TopicQuery
       search
       q
       f
+      s
       group_name
       tags
       match_all_tags
@@ -304,7 +305,17 @@ class TopicQuery
 
   def list_new
     if @user&.new_new_view_enabled?
-      create_list(:new, { unordered: true }, new_and_unread_results)
+      new_list_scope = @options[:s]
+      list =
+        case new_list_scope
+        when "topics"
+          new_results
+        when "replies"
+          unread_results
+        else
+          new_and_unread_results
+        end
+      create_list(:new, { unordered: true }, list)
     else
       create_list(:new, { unordered: true }, new_results)
     end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -53,7 +53,7 @@ class TopicQuery
       search
       q
       f
-      s
+      subset
       group_name
       tags
       match_all_tags
@@ -305,9 +305,8 @@ class TopicQuery
 
   def list_new
     if @user&.new_new_view_enabled?
-      new_list_scope = @options[:s]
       list =
-        case new_list_scope
+        case @options[:subset]
         when "topics"
           new_results
         when "replies"

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1487,9 +1487,9 @@ RSpec.describe ListController do
         )
       end
 
-      context "when the s (scope) param is set to topics" do
+      context "when the subset param is set to topics" do
         it "returns only new topics" do
-          get "/new.json", params: { s: "topics" }
+          get "/new.json", params: { subset: "topics" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(
@@ -1500,9 +1500,9 @@ RSpec.describe ListController do
         end
       end
 
-      context "when the s (scope) param is set to replies" do
+      context "when the subset param is set to replies" do
         it "returns only topics with new replies" do
-          get "/new.json", params: { s: "replies" }
+          get "/new.json", params: { subset: "replies" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(
@@ -1521,13 +1521,13 @@ RSpec.describe ListController do
           expect(ids).to contain_exactly(new_topic_in_category.id, new_reply_in_category.id)
         end
 
-        it "respects the s (scope) param" do
-          get "/c/#{category.slug}/#{category.id}/l/new.json", params: { s: "topics" }
+        it "respects the subset param" do
+          get "/c/#{category.slug}/#{category.id}/l/new.json", params: { subset: "topics" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(new_topic_in_category.id)
 
-          get "/c/#{category.slug}/#{category.id}/l/new.json", params: { s: "replies" }
+          get "/c/#{category.slug}/#{category.id}/l/new.json", params: { subset: "replies" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(new_reply_in_category.id)
@@ -1542,13 +1542,13 @@ RSpec.describe ListController do
           expect(ids).to contain_exactly(new_topic_with_tag.id, new_reply_with_tag.id)
         end
 
-        it "respects the s (scope) param" do
-          get "/tag/#{tag.name}/l/new.json", params: { s: "topics" }
+        it "respects the subset param" do
+          get "/tag/#{tag.name}/l/new.json", params: { subset: "topics" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(new_topic_with_tag.id)
 
-          get "/tag/#{tag.name}/l/new.json", params: { s: "replies" }
+          get "/tag/#{tag.name}/l/new.json", params: { subset: "replies" }
 
           ids = extract_topic_ids(response)
           expect(ids).to contain_exactly(new_reply_with_tag.id)

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+describe "New topic list", type: :system do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group, users: [user]) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:tag) { Fabricate(:tag) }
+
+  fab!(:new_reply) { Fabricate(:post).topic }
+  fab!(:new_topic) { Fabricate(:post).topic }
+  fab!(:old_topic) { Fabricate(:post).topic }
+
+  fab!(:new_reply_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+  end
+  fab!(:new_topic_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+  end
+  fab!(:old_topic_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+  end
+
+  fab!(:new_reply_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
+  fab!(:new_topic_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
+  fab!(:old_topic_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
+
+  let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:tabs_toggle) { PageObjects::Components::NewTopicListToggle.new }
+
+  before do
+    sign_in(user)
+
+    [old_topic, old_topic_in_category, old_topic_with_tag].each do |topic|
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+    end
+
+    [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+      TopicUser.change(
+        user.id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[:tracking],
+      )
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+      Fabricate(:post, topic: topic)
+    end
+  end
+
+  [true, false].each do |mobile|
+    desc = mobile ? "when on mobile" : "when on desktop"
+    context desc, mobile: mobile do
+      context "when the new new view is enabled" do
+        before { SiteSetting.experimental_new_new_view_groups = group.name }
+
+        it "shows all new topics and replies by default" do
+          visit("/new")
+
+          expect(topic_list).to have_topics(count: 6)
+          [
+            new_reply,
+            new_topic,
+            new_reply_in_category,
+            new_topic_in_category,
+            new_reply_with_tag,
+            new_topic_with_tag,
+          ].each { |topic| expect(topic_list).to have_topic(topic) }
+
+          expect(tabs_toggle.all_tab).to have_count(6)
+          expect(tabs_toggle.replies_tab).to have_count(3)
+          expect(tabs_toggle.topics_tab).to have_count(3)
+        end
+
+        it "the All tab is the default is the default tab" do
+          visit("/new")
+
+          expect(tabs_toggle.all_tab).to be_active
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_inactive
+        end
+
+        it "respects the s (scope) query param and activates the appropriate tab" do
+          visit("/new?s=topics")
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_active
+
+          visit("/new?s=replies")
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          expect(tabs_toggle.topics_tab).to be_inactive
+        end
+
+        it "shows only new topics when the user switches to the Topics tab" do
+          visit("/new")
+          tabs_toggle.topics_tab.click
+
+          expect(topic_list).to have_topics(count: 3)
+          [new_topic, new_topic_in_category, new_topic_with_tag].each do |topic|
+            expect(topic_list).to have_topic(topic)
+          end
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_active
+
+          expect(tabs_toggle.all_tab).to have_count(6)
+          expect(tabs_toggle.replies_tab).to have_count(3)
+          expect(tabs_toggle.topics_tab).to have_count(3)
+
+          expect(current_url).to end_with("/new?s=topics")
+        end
+
+        it "shows only topics with new replies when the user switches to the Replies tab" do
+          visit("/new")
+          tabs_toggle.replies_tab.click
+
+          expect(topic_list).to have_topics(count: 3)
+          [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+            expect(topic_list).to have_topic(topic)
+          end
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          expect(tabs_toggle.topics_tab).to be_inactive
+
+          expect(tabs_toggle.all_tab).to have_count(6)
+          expect(tabs_toggle.replies_tab).to have_count(3)
+          expect(tabs_toggle.topics_tab).to have_count(3)
+
+          expect(current_url).to end_with("/new?s=replies")
+        end
+
+        it "strips out the s (scope) query params when switching back to the All tab from any of the other tabs" do
+          visit("/new")
+          tabs_toggle.replies_tab.click
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          try_until_success { expect(current_url).to end_with("/new?s=replies") }
+
+          tabs_toggle.all_tab.click
+
+          expect(tabs_toggle.all_tab).to be_active
+          expect(tabs_toggle.replies_tab).to be_inactive
+          try_until_success { expect(current_url).to end_with("/new") }
+        end
+
+        it "live-updates the counts shown on the tabs" do
+          visit("/new")
+
+          expect(tabs_toggle.all_tab).to have_count(6)
+          expect(tabs_toggle.replies_tab).to have_count(3)
+          expect(tabs_toggle.topics_tab).to have_count(3)
+
+          TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
+
+          try_until_success do
+            expect(tabs_toggle.all_tab).to have_count(5)
+            expect(tabs_toggle.replies_tab).to have_count(2)
+            expect(tabs_toggle.topics_tab).to have_count(3)
+          end
+
+          TopicUser.update_last_read(user, new_topic.id, 1, 1, 1)
+
+          try_until_success do
+            expect(tabs_toggle.all_tab).to have_count(4)
+            expect(tabs_toggle.replies_tab).to have_count(2)
+            expect(tabs_toggle.topics_tab).to have_count(2)
+          end
+        end
+
+        context "when the /new topic list is scoped to a category" do
+          it "shows new topics and replies in the category" do
+            visit("/c/#{category.slug}/#{category.id}/l/new")
+            expect(topic_list).to have_topics(count: 2)
+            [new_reply_in_category, new_topic_in_category].each do |topic|
+              expect(topic_list).to have_topic(topic)
+            end
+
+            expect(tabs_toggle.all_tab).to be_active
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_inactive
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+          end
+
+          it "shows only new topics in the category when the user switches to the Topics tab" do
+            visit("/c/#{category.slug}/#{category.id}/l/new")
+            tabs_toggle.topics_tab.click
+
+            expect(topic_list).to have_topics(count: 1)
+            expect(topic_list).to have_topic(new_topic_in_category)
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_active
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=topics")
+          end
+
+          it "shows only topics with new replies in the category when the user switches to the Replies tab" do
+            visit("/c/#{category.slug}/#{category.id}/l/new")
+            tabs_toggle.replies_tab.click
+
+            expect(topic_list).to have_topics(count: 1)
+            expect(topic_list).to have_topic(new_reply_in_category)
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_active
+            expect(tabs_toggle.topics_tab).to be_inactive
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=replies")
+          end
+
+          it "respects the s (scope) query param and activates the appropriate tab" do
+            visit("/c/#{category.slug}/#{category.id}/l/new?s=topics")
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_active
+
+            visit("/c/#{category.slug}/#{category.id}/l/new?s=replies")
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_active
+            expect(tabs_toggle.topics_tab).to be_inactive
+          end
+
+          it "live-updates the counts shown on the tabs" do
+            visit("/c/#{category.slug}/#{category.id}/l/new")
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
+
+            try_until_success do
+              expect(tabs_toggle.all_tab).to have_count(1)
+              expect(tabs_toggle.replies_tab).to have_count(0)
+              expect(tabs_toggle.topics_tab).to have_count(1)
+            end
+
+            TopicUser.update_last_read(user, new_topic_in_category.id, 1, 1, 1)
+
+            try_until_success do
+              expect(tabs_toggle.all_tab).to have_count(0)
+              expect(tabs_toggle.replies_tab).to have_count(0)
+              expect(tabs_toggle.topics_tab).to have_count(0)
+            end
+          end
+        end
+
+        context "when the /new topic list is scoped to a tag" do
+          it "shows new topics and replies with the tag" do
+            visit("/tag/#{tag.name}/l/new")
+            expect(topic_list).to have_topics(count: 2)
+            [new_reply_with_tag, new_topic_with_tag].each do |topic|
+              expect(topic_list).to have_topic(topic)
+            end
+
+            expect(tabs_toggle.all_tab).to be_active
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_inactive
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+          end
+
+          it "shows only new topics with the tag when the user switches to the Topics tab" do
+            visit("/tag/#{tag.name}/l/new")
+            tabs_toggle.topics_tab.click
+
+            expect(topic_list).to have_topics(count: 1)
+            expect(topic_list).to have_topic(new_topic_with_tag)
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_active
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=topics")
+          end
+
+          it "shows only topics with new replies with the tag when the user switches to the Replies tab" do
+            visit("/tag/#{tag.name}/l/new")
+
+            tabs_toggle.replies_tab.click
+
+            expect(topic_list).to have_topics(count: 1)
+            expect(topic_list).to have_topic(new_reply_with_tag)
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_active
+            expect(tabs_toggle.topics_tab).to be_inactive
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=replies")
+          end
+
+          it "respects the s (scope) query param and activates the appropriate tab" do
+            visit("/tag/#{tag.name}/l/new?s=topics")
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_inactive
+            expect(tabs_toggle.topics_tab).to be_active
+
+            visit("/tag/#{tag.name}/l/new?s=replies")
+
+            expect(tabs_toggle.all_tab).to be_inactive
+            expect(tabs_toggle.replies_tab).to be_active
+            expect(tabs_toggle.topics_tab).to be_inactive
+          end
+
+          it "live-updates the counts shown on the tabs" do
+            visit("/tag/#{tag.name}/l/new")
+
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
+
+            TopicUser.update_last_read(user, new_reply_with_tag.id, 2, 1, 1)
+
+            try_until_success do
+              expect(tabs_toggle.all_tab).to have_count(1)
+              expect(tabs_toggle.replies_tab).to have_count(0)
+              expect(tabs_toggle.topics_tab).to have_count(1)
+            end
+
+            TopicUser.update_last_read(user, new_topic_with_tag.id, 1, 1, 1)
+
+            try_until_success do
+              expect(tabs_toggle.all_tab).to have_count(0)
+              expect(tabs_toggle.replies_tab).to have_count(0)
+              expect(tabs_toggle.topics_tab).to have_count(0)
+            end
+          end
+        end
+      end
+    end
+
+    context "when the new new view is not enabled" do
+      before { SiteSetting.experimental_new_new_view_groups = "" }
+
+      it "doesn't show the tabs toggle" do
+        visit("/new")
+        expect(tabs_toggle).to be_not_rendered
+      end
+    end
+  end
+end

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -65,10 +65,6 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.all_tab).to have_count(6)
         expect(tabs_toggle.replies_tab).to have_count(3)
         expect(tabs_toggle.topics_tab).to have_count(3)
-      end
-
-      it "the All tab is the default is the default tab" do
-        visit("/new")
 
         expect(tabs_toggle.all_tab).to be_active
         expect(tabs_toggle.replies_tab).to be_inactive
@@ -172,9 +168,8 @@ describe "New topic list", type: :system do
         it "shows new topics and replies in the category" do
           visit("/c/#{category.slug}/#{category.id}/l/new")
           expect(topic_list).to have_topics(count: 2)
-          [new_reply_in_category, new_topic_in_category].each do |topic|
-            expect(topic_list).to have_topic(topic)
-          end
+          expect(topic_list).to have_topic(new_reply_in_category)
+          expect(topic_list).to have_topic(new_topic_in_category)
 
           expect(tabs_toggle.all_tab).to be_active
           expect(tabs_toggle.replies_tab).to be_inactive

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -45,313 +45,298 @@ describe "New topic list", type: :system do
     end
   end
 
-  [true, false].each do |mobile|
-    desc = mobile ? "when on mobile" : "when on desktop"
-    context desc, mobile: mobile do
-      context "when the new new view is enabled" do
-        before { SiteSetting.experimental_new_new_view_groups = group.name }
+  shared_examples "new list new topics and replies toggle" do
+    context "when the new new view is enabled" do
+      before { SiteSetting.experimental_new_new_view_groups = group.name }
 
-        it "shows all new topics and replies by default" do
-          visit("/new")
+      it "shows all new topics and replies by default" do
+        visit("/new")
 
-          expect(topic_list).to have_topics(count: 6)
-          [
-            new_reply,
-            new_topic,
-            new_reply_in_category,
-            new_topic_in_category,
-            new_reply_with_tag,
-            new_topic_with_tag,
-          ].each { |topic| expect(topic_list).to have_topic(topic) }
+        expect(topic_list).to have_topics(count: 6)
+        [
+          new_reply,
+          new_topic,
+          new_reply_in_category,
+          new_topic_in_category,
+          new_reply_with_tag,
+          new_topic_with_tag,
+        ].each { |topic| expect(topic_list).to have_topic(topic) }
 
-          expect(tabs_toggle.all_tab).to have_count(6)
-          expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.all_tab).to have_count(6)
+        expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.topics_tab).to have_count(3)
+      end
+
+      it "the All tab is the default is the default tab" do
+        visit("/new")
+
+        expect(tabs_toggle.all_tab).to be_active
+        expect(tabs_toggle.replies_tab).to be_inactive
+        expect(tabs_toggle.topics_tab).to be_inactive
+      end
+
+      it "respects the s (scope) query param and activates the appropriate tab" do
+        visit("/new?s=topics")
+
+        expect(tabs_toggle.all_tab).to be_inactive
+        expect(tabs_toggle.replies_tab).to be_inactive
+        expect(tabs_toggle.topics_tab).to be_active
+
+        visit("/new?s=replies")
+
+        expect(tabs_toggle.all_tab).to be_inactive
+        expect(tabs_toggle.replies_tab).to be_active
+        expect(tabs_toggle.topics_tab).to be_inactive
+      end
+
+      it "shows only new topics when the user switches to the Topics tab" do
+        visit("/new")
+        tabs_toggle.topics_tab.click
+
+        expect(topic_list).to have_topics(count: 3)
+        [new_topic, new_topic_in_category, new_topic_with_tag].each do |topic|
+          expect(topic_list).to have_topic(topic)
+        end
+
+        expect(tabs_toggle.all_tab).to be_inactive
+        expect(tabs_toggle.replies_tab).to be_inactive
+        expect(tabs_toggle.topics_tab).to be_active
+
+        expect(tabs_toggle.all_tab).to have_count(6)
+        expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.topics_tab).to have_count(3)
+
+        expect(current_url).to end_with("/new?s=topics")
+      end
+
+      it "shows only topics with new replies when the user switches to the Replies tab" do
+        visit("/new")
+        tabs_toggle.replies_tab.click
+
+        expect(topic_list).to have_topics(count: 3)
+        [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+          expect(topic_list).to have_topic(topic)
+        end
+
+        expect(tabs_toggle.all_tab).to be_inactive
+        expect(tabs_toggle.replies_tab).to be_active
+        expect(tabs_toggle.topics_tab).to be_inactive
+
+        expect(tabs_toggle.all_tab).to have_count(6)
+        expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.topics_tab).to have_count(3)
+
+        expect(current_url).to end_with("/new?s=replies")
+      end
+
+      it "strips out the s (scope) query params when switching back to the All tab from any of the other tabs" do
+        visit("/new")
+        tabs_toggle.replies_tab.click
+
+        expect(tabs_toggle.all_tab).to be_inactive
+        expect(tabs_toggle.replies_tab).to be_active
+        try_until_success { expect(current_url).to end_with("/new?s=replies") }
+
+        tabs_toggle.all_tab.click
+
+        expect(tabs_toggle.all_tab).to be_active
+        expect(tabs_toggle.replies_tab).to be_inactive
+        try_until_success { expect(current_url).to end_with("/new") }
+      end
+
+      it "live-updates the counts shown on the tabs" do
+        visit("/new")
+
+        expect(tabs_toggle.all_tab).to have_count(6)
+        expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.topics_tab).to have_count(3)
+
+        TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
+
+        try_until_success do
+          expect(tabs_toggle.all_tab).to have_count(5)
+          expect(tabs_toggle.replies_tab).to have_count(2)
           expect(tabs_toggle.topics_tab).to have_count(3)
         end
 
-        it "the All tab is the default is the default tab" do
-          visit("/new")
+        TopicUser.update_last_read(user, new_topic.id, 1, 1, 1)
+
+        try_until_success do
+          expect(tabs_toggle.all_tab).to have_count(4)
+          expect(tabs_toggle.replies_tab).to have_count(2)
+          expect(tabs_toggle.topics_tab).to have_count(2)
+        end
+      end
+
+      context "when the /new topic list is scoped to a category" do
+        it "shows new topics and replies in the category" do
+          visit("/c/#{category.slug}/#{category.id}/l/new")
+          expect(topic_list).to have_topics(count: 2)
+          [new_reply_in_category, new_topic_in_category].each do |topic|
+            expect(topic_list).to have_topic(topic)
+          end
 
           expect(tabs_toggle.all_tab).to be_active
           expect(tabs_toggle.replies_tab).to be_inactive
           expect(tabs_toggle.topics_tab).to be_inactive
+
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
+        end
+
+        it "shows only new topics in the category when the user switches to the Topics tab" do
+          visit("/c/#{category.slug}/#{category.id}/l/new")
+          tabs_toggle.topics_tab.click
+
+          expect(topic_list).to have_topics(count: 1)
+          expect(topic_list).to have_topic(new_topic_in_category)
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_active
+
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
+
+          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=topics")
+        end
+
+        it "shows only topics with new replies in the category when the user switches to the Replies tab" do
+          visit("/c/#{category.slug}/#{category.id}/l/new")
+          tabs_toggle.replies_tab.click
+
+          expect(topic_list).to have_topics(count: 1)
+          expect(topic_list).to have_topic(new_reply_in_category)
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          expect(tabs_toggle.topics_tab).to be_inactive
+
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
+
+          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=replies")
         end
 
         it "respects the s (scope) query param and activates the appropriate tab" do
-          visit("/new?s=topics")
+          visit("/c/#{category.slug}/#{category.id}/l/new?s=topics")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_inactive
           expect(tabs_toggle.topics_tab).to be_active
 
-          visit("/new?s=replies")
+          visit("/c/#{category.slug}/#{category.id}/l/new?s=replies")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_active
           expect(tabs_toggle.topics_tab).to be_inactive
-        end
-
-        it "shows only new topics when the user switches to the Topics tab" do
-          visit("/new")
-          tabs_toggle.topics_tab.click
-
-          expect(topic_list).to have_topics(count: 3)
-          [new_topic, new_topic_in_category, new_topic_with_tag].each do |topic|
-            expect(topic_list).to have_topic(topic)
-          end
-
-          expect(tabs_toggle.all_tab).to be_inactive
-          expect(tabs_toggle.replies_tab).to be_inactive
-          expect(tabs_toggle.topics_tab).to be_active
-
-          expect(tabs_toggle.all_tab).to have_count(6)
-          expect(tabs_toggle.replies_tab).to have_count(3)
-          expect(tabs_toggle.topics_tab).to have_count(3)
-
-          expect(current_url).to end_with("/new?s=topics")
-        end
-
-        it "shows only topics with new replies when the user switches to the Replies tab" do
-          visit("/new")
-          tabs_toggle.replies_tab.click
-
-          expect(topic_list).to have_topics(count: 3)
-          [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
-            expect(topic_list).to have_topic(topic)
-          end
-
-          expect(tabs_toggle.all_tab).to be_inactive
-          expect(tabs_toggle.replies_tab).to be_active
-          expect(tabs_toggle.topics_tab).to be_inactive
-
-          expect(tabs_toggle.all_tab).to have_count(6)
-          expect(tabs_toggle.replies_tab).to have_count(3)
-          expect(tabs_toggle.topics_tab).to have_count(3)
-
-          expect(current_url).to end_with("/new?s=replies")
-        end
-
-        it "strips out the s (scope) query params when switching back to the All tab from any of the other tabs" do
-          visit("/new")
-          tabs_toggle.replies_tab.click
-
-          expect(tabs_toggle.all_tab).to be_inactive
-          expect(tabs_toggle.replies_tab).to be_active
-          try_until_success { expect(current_url).to end_with("/new?s=replies") }
-
-          tabs_toggle.all_tab.click
-
-          expect(tabs_toggle.all_tab).to be_active
-          expect(tabs_toggle.replies_tab).to be_inactive
-          try_until_success { expect(current_url).to end_with("/new") }
         end
 
         it "live-updates the counts shown on the tabs" do
-          visit("/new")
+          Fabricate(:post, topic: Fabricate(:topic, category: category))
 
-          expect(tabs_toggle.all_tab).to have_count(6)
-          expect(tabs_toggle.replies_tab).to have_count(3)
-          expect(tabs_toggle.topics_tab).to have_count(3)
+          visit("/c/#{category.slug}/#{category.id}/l/new")
 
-          TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
+          expect(tabs_toggle.all_tab).to have_count(3)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(2)
 
-          try_until_success do
-            expect(tabs_toggle.all_tab).to have_count(5)
-            expect(tabs_toggle.replies_tab).to have_count(2)
-            expect(tabs_toggle.topics_tab).to have_count(3)
-          end
-
-          TopicUser.update_last_read(user, new_topic.id, 1, 1, 1)
+          TopicUser.update_last_read(user, new_topic_in_category.id, 1, 1, 1)
 
           try_until_success do
-            expect(tabs_toggle.all_tab).to have_count(4)
-            expect(tabs_toggle.replies_tab).to have_count(2)
-            expect(tabs_toggle.topics_tab).to have_count(2)
+            expect(tabs_toggle.all_tab).to have_count(2)
+            expect(tabs_toggle.replies_tab).to have_count(1)
+            expect(tabs_toggle.topics_tab).to have_count(1)
           end
         end
+      end
 
-        context "when the /new topic list is scoped to a category" do
-          it "shows new topics and replies in the category" do
-            visit("/c/#{category.slug}/#{category.id}/l/new")
-            expect(topic_list).to have_topics(count: 2)
-            [new_reply_in_category, new_topic_in_category].each do |topic|
-              expect(topic_list).to have_topic(topic)
-            end
-
-            expect(tabs_toggle.all_tab).to be_active
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_inactive
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
+      context "when the /new topic list is scoped to a tag" do
+        it "shows new topics and replies with the tag" do
+          visit("/tag/#{tag.name}/l/new")
+          expect(topic_list).to have_topics(count: 2)
+          [new_reply_with_tag, new_topic_with_tag].each do |topic|
+            expect(topic_list).to have_topic(topic)
           end
 
-          it "shows only new topics in the category when the user switches to the Topics tab" do
-            visit("/c/#{category.slug}/#{category.id}/l/new")
-            tabs_toggle.topics_tab.click
+          expect(tabs_toggle.all_tab).to be_active
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_inactive
 
-            expect(topic_list).to have_topics(count: 1)
-            expect(topic_list).to have_topic(new_topic_in_category)
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_active
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=topics")
-          end
-
-          it "shows only topics with new replies in the category when the user switches to the Replies tab" do
-            visit("/c/#{category.slug}/#{category.id}/l/new")
-            tabs_toggle.replies_tab.click
-
-            expect(topic_list).to have_topics(count: 1)
-            expect(topic_list).to have_topic(new_reply_in_category)
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_active
-            expect(tabs_toggle.topics_tab).to be_inactive
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=replies")
-          end
-
-          it "respects the s (scope) query param and activates the appropriate tab" do
-            visit("/c/#{category.slug}/#{category.id}/l/new?s=topics")
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_active
-
-            visit("/c/#{category.slug}/#{category.id}/l/new?s=replies")
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_active
-            expect(tabs_toggle.topics_tab).to be_inactive
-          end
-
-          it "live-updates the counts shown on the tabs" do
-            visit("/c/#{category.slug}/#{category.id}/l/new")
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
-
-            try_until_success do
-              expect(tabs_toggle.all_tab).to have_count(1)
-              expect(tabs_toggle.replies_tab).to have_count(0)
-              expect(tabs_toggle.topics_tab).to have_count(1)
-            end
-
-            TopicUser.update_last_read(user, new_topic_in_category.id, 1, 1, 1)
-
-            try_until_success do
-              expect(tabs_toggle.all_tab).to have_count(0)
-              expect(tabs_toggle.replies_tab).to have_count(0)
-              expect(tabs_toggle.topics_tab).to have_count(0)
-            end
-          end
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
         end
 
-        context "when the /new topic list is scoped to a tag" do
-          it "shows new topics and replies with the tag" do
-            visit("/tag/#{tag.name}/l/new")
-            expect(topic_list).to have_topics(count: 2)
-            [new_reply_with_tag, new_topic_with_tag].each do |topic|
-              expect(topic_list).to have_topic(topic)
-            end
+        it "shows only new topics with the tag when the user switches to the Topics tab" do
+          visit("/tag/#{tag.name}/l/new")
+          tabs_toggle.topics_tab.click
 
-            expect(tabs_toggle.all_tab).to be_active
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_inactive
+          expect(topic_list).to have_topics(count: 1)
+          expect(topic_list).to have_topic(new_topic_with_tag)
 
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_active
+
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
+
+          expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=topics")
+        end
+
+        it "shows only topics with new replies with the tag when the user switches to the Replies tab" do
+          visit("/tag/#{tag.name}/l/new")
+
+          tabs_toggle.replies_tab.click
+
+          expect(topic_list).to have_topics(count: 1)
+          expect(topic_list).to have_topic(new_reply_with_tag)
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          expect(tabs_toggle.topics_tab).to be_inactive
+
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
+
+          expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=replies")
+        end
+
+        it "respects the s (scope) query param and activates the appropriate tab" do
+          visit("/tag/#{tag.name}/l/new?s=topics")
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_inactive
+          expect(tabs_toggle.topics_tab).to be_active
+
+          visit("/tag/#{tag.name}/l/new?s=replies")
+
+          expect(tabs_toggle.all_tab).to be_inactive
+          expect(tabs_toggle.replies_tab).to be_active
+          expect(tabs_toggle.topics_tab).to be_inactive
+        end
+
+        it "live-updates the counts shown on the tabs" do
+          Fabricate(:post, topic: Fabricate(:topic, tags: [tag]))
+
+          visit("/tag/#{tag.name}/l/new")
+
+          expect(tabs_toggle.all_tab).to have_count(3)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(2)
+
+          TopicUser.update_last_read(user, new_topic_with_tag.id, 1, 1, 1)
+
+          try_until_success do
             expect(tabs_toggle.all_tab).to have_count(2)
             expect(tabs_toggle.replies_tab).to have_count(1)
             expect(tabs_toggle.topics_tab).to have_count(1)
-          end
-
-          it "shows only new topics with the tag when the user switches to the Topics tab" do
-            visit("/tag/#{tag.name}/l/new")
-            tabs_toggle.topics_tab.click
-
-            expect(topic_list).to have_topics(count: 1)
-            expect(topic_list).to have_topic(new_topic_with_tag)
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_active
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=topics")
-          end
-
-          it "shows only topics with new replies with the tag when the user switches to the Replies tab" do
-            visit("/tag/#{tag.name}/l/new")
-
-            tabs_toggle.replies_tab.click
-
-            expect(topic_list).to have_topics(count: 1)
-            expect(topic_list).to have_topic(new_reply_with_tag)
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_active
-            expect(tabs_toggle.topics_tab).to be_inactive
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=replies")
-          end
-
-          it "respects the s (scope) query param and activates the appropriate tab" do
-            visit("/tag/#{tag.name}/l/new?s=topics")
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_inactive
-            expect(tabs_toggle.topics_tab).to be_active
-
-            visit("/tag/#{tag.name}/l/new?s=replies")
-
-            expect(tabs_toggle.all_tab).to be_inactive
-            expect(tabs_toggle.replies_tab).to be_active
-            expect(tabs_toggle.topics_tab).to be_inactive
-          end
-
-          it "live-updates the counts shown on the tabs" do
-            visit("/tag/#{tag.name}/l/new")
-
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-
-            TopicUser.update_last_read(user, new_reply_with_tag.id, 2, 1, 1)
-
-            try_until_success do
-              expect(tabs_toggle.all_tab).to have_count(1)
-              expect(tabs_toggle.replies_tab).to have_count(0)
-              expect(tabs_toggle.topics_tab).to have_count(1)
-            end
-
-            TopicUser.update_last_read(user, new_topic_with_tag.id, 1, 1, 1)
-
-            try_until_success do
-              expect(tabs_toggle.all_tab).to have_count(0)
-              expect(tabs_toggle.replies_tab).to have_count(0)
-              expect(tabs_toggle.topics_tab).to have_count(0)
-            end
           end
         end
       end
@@ -363,6 +348,96 @@ describe "New topic list", type: :system do
       it "doesn't show the tabs toggle" do
         visit("/new")
         expect(tabs_toggle).to be_not_rendered
+      end
+    end
+  end
+
+  context "when on mobile", mobile: true do
+    include_examples "new list new topics and replies toggle"
+
+    context "when there are no new topics" do
+      before do
+        SiteSetting.experimental_new_new_view_groups = group.name
+
+        [new_topic, new_topic_in_category, new_topic_with_tag].each do |topic|
+          TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+        end
+      end
+
+      it "keeps the Topics tab even when there are no new topics" do
+        visit("/new")
+
+        expect(tabs_toggle.all_tab).to be_visible
+        expect(tabs_toggle.replies_tab).to be_visible
+        expect(tabs_toggle.topics_tab).to be_visible
+
+        expect(tabs_toggle.all_tab).to have_count(3)
+        expect(tabs_toggle.replies_tab).to have_count(3)
+        expect(tabs_toggle.topics_tab).to have_count(0)
+      end
+    end
+
+    context "when there are no new replies" do
+      before do
+        SiteSetting.experimental_new_new_view_groups = group.name
+
+        [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+          TopicUser.update_last_read(user, topic.id, 2, 1, 1)
+        end
+      end
+
+      it "keeps the Replies tab even when there are no new replies" do
+        visit("/new")
+
+        expect(tabs_toggle.all_tab).to be_visible
+        expect(tabs_toggle.replies_tab).to be_visible
+        expect(tabs_toggle.topics_tab).to be_visible
+
+        expect(tabs_toggle.all_tab).to have_count(3)
+        expect(tabs_toggle.replies_tab).to have_count(0)
+        expect(tabs_toggle.topics_tab).to have_count(3)
+      end
+    end
+  end
+
+  context "when on desktop" do
+    include_examples "new list new topics and replies toggle"
+
+    context "when there's only new topics" do
+      before do
+        SiteSetting.experimental_new_new_view_groups = group.name
+
+        [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+          TopicUser.update_last_read(user, topic.id, 2, 1, 1)
+        end
+      end
+
+      it "doesn't render the toggle and only shows a static label for new topics" do
+        visit("/new")
+
+        expect(tabs_toggle).to be_not_rendered
+        expect(find(".topic-list-header .static-label").text).to eq(
+          I18n.t("js.filters.new.topics_with_count", count: 3),
+        )
+      end
+    end
+
+    context "when there's only new replies" do
+      before do
+        SiteSetting.experimental_new_new_view_groups = group.name
+
+        [new_topic, new_topic_in_category, new_topic_with_tag].each do |topic|
+          TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+        end
+      end
+
+      it "doesn't render the toggle and only shows a static label for new replies" do
+        visit("/new")
+
+        expect(tabs_toggle).to be_not_rendered
+        expect(find(".topic-list-header .static-label").text).to eq(
+          I18n.t("js.filters.new.replies_with_count", count: 3),
+        )
       end
     end
   end

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -13,9 +13,11 @@ describe "New topic list", type: :system do
   fab!(:new_reply_in_category) do
     Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
   end
+
   fab!(:new_topic_in_category) do
     Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
   end
+
   fab!(:old_topic_in_category) do
     Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
   end
@@ -102,7 +104,7 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.replies_tab).to have_count(3)
         expect(tabs_toggle.topics_tab).to have_count(3)
 
-        expect(current_url).to end_with("/new?subset=topics")
+        expect(page).to have_current_path("/new?subset=topics")
       end
 
       it "shows only topics with new replies when the user switches to the Replies tab" do
@@ -122,7 +124,7 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.replies_tab).to have_count(3)
         expect(tabs_toggle.topics_tab).to have_count(3)
 
-        expect(current_url).to end_with("/new?subset=replies")
+        expect(page).to have_current_path("/new?subset=replies")
       end
 
       it "strips out the subset query params when switching back to the All tab from any of the other tabs" do
@@ -131,13 +133,14 @@ describe "New topic list", type: :system do
 
         expect(tabs_toggle.all_tab).to be_inactive
         expect(tabs_toggle.replies_tab).to be_active
-        expect(current_url).to end_with("/new?subset=replies")
+
+        expect(page).to have_current_path("/new?subset=replies")
 
         tabs_toggle.all_tab.click
 
         expect(tabs_toggle.all_tab).to be_active
         expect(tabs_toggle.replies_tab).to be_inactive
-        expect(current_url).to end_with("/new")
+        expect(page).to have_current_path("/new")
       end
 
       it "live-updates the counts shown on the tabs" do
@@ -149,19 +152,15 @@ describe "New topic list", type: :system do
 
         TopicUser.update_last_read(user, new_reply_in_category.id, 2, 1, 1)
 
-        try_until_success do
-          expect(tabs_toggle.all_tab).to have_count(5)
-          expect(tabs_toggle.replies_tab).to have_count(2)
-          expect(tabs_toggle.topics_tab).to have_count(3)
-        end
+        expect(tabs_toggle.all_tab).to have_count(5)
+        expect(tabs_toggle.replies_tab).to have_count(2)
+        expect(tabs_toggle.topics_tab).to have_count(3)
 
         TopicUser.update_last_read(user, new_topic.id, 1, 1, 1)
 
-        try_until_success do
-          expect(tabs_toggle.all_tab).to have_count(4)
-          expect(tabs_toggle.replies_tab).to have_count(2)
-          expect(tabs_toggle.topics_tab).to have_count(2)
-        end
+        expect(tabs_toggle.all_tab).to have_count(4)
+        expect(tabs_toggle.replies_tab).to have_count(2)
+        expect(tabs_toggle.topics_tab).to have_count(2)
       end
 
       context "when the /new topic list is scoped to a category" do
@@ -195,7 +194,9 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?subset=topics")
+          expect(page).to have_current_path(
+            "/c/#{category.slug}/#{category.id}/l/new?subset=topics",
+          )
         end
 
         it "shows only topics with new replies in the category when the user switches to the Replies tab" do
@@ -213,7 +214,9 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?subset=replies")
+          expect(page).to have_current_path(
+            "/c/#{category.slug}/#{category.id}/l/new?subset=replies",
+          )
         end
 
         it "respects the subset query param and activates the appropriate tab" do
@@ -241,11 +244,9 @@ describe "New topic list", type: :system do
 
           TopicUser.update_last_read(user, new_topic_in_category.id, 1, 1, 1)
 
-          try_until_success do
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-          end
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
         end
       end
 
@@ -281,7 +282,7 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/tag/#{tag.name}/l/new?subset=topics")
+          expect(page).to have_current_path("/tag/#{tag.name}/l/new?subset=topics")
         end
 
         it "shows only topics with new replies with the tag when the user switches to the Replies tab" do
@@ -300,7 +301,7 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/tag/#{tag.name}/l/new?subset=replies")
+          expect(page).to have_current_path("/tag/#{tag.name}/l/new?subset=replies")
         end
 
         it "respects the subset query param and activates the appropriate tab" do
@@ -328,11 +329,9 @@ describe "New topic list", type: :system do
 
           TopicUser.update_last_read(user, new_topic_with_tag.id, 1, 1, 1)
 
-          try_until_success do
-            expect(tabs_toggle.all_tab).to have_count(2)
-            expect(tabs_toggle.replies_tab).to have_count(1)
-            expect(tabs_toggle.topics_tab).to have_count(1)
-          end
+          expect(tabs_toggle.all_tab).to have_count(2)
+          expect(tabs_toggle.replies_tab).to have_count(1)
+          expect(tabs_toggle.topics_tab).to have_count(1)
         end
       end
     end

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -131,13 +131,13 @@ describe "New topic list", type: :system do
 
         expect(tabs_toggle.all_tab).to be_inactive
         expect(tabs_toggle.replies_tab).to be_active
-        try_until_success { expect(current_url).to end_with("/new?subset=replies") }
+        expect(current_url).to end_with("/new?subset=replies")
 
         tabs_toggle.all_tab.click
 
         expect(tabs_toggle.all_tab).to be_active
         expect(tabs_toggle.replies_tab).to be_inactive
-        try_until_success { expect(current_url).to end_with("/new") }
+        expect(current_url).to end_with("/new")
       end
 
       it "live-updates the counts shown on the tabs" do

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -6,37 +6,8 @@ describe "New topic list", type: :system do
   fab!(:category) { Fabricate(:category) }
   fab!(:tag) { Fabricate(:tag) }
 
-  fab!(:new_reply) { Fabricate(:post).topic }
-  fab!(:new_topic) { Fabricate(:post).topic }
-  fab!(:old_topic) { Fabricate(:post).topic }
-
-  fab!(:new_reply_in_category) do
-    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
-  end
-
-  fab!(:new_topic_in_category) do
-    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
-  end
-
-  fab!(:old_topic_in_category) do
-    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
-  end
-
-  fab!(:new_reply_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
-  fab!(:new_topic_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
-  fab!(:old_topic_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
-
-  let(:topic_list) { PageObjects::Components::TopicList.new }
-  let(:tabs_toggle) { PageObjects::Components::NewTopicListToggle.new }
-
-  before do
-    sign_in(user)
-
-    [old_topic, old_topic_in_category, old_topic_with_tag].each do |topic|
-      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
-    end
-
-    [new_reply, new_reply_in_category, new_reply_with_tag].each do |topic|
+  fab!(:new_reply) do
+    Fabricate(:post).topic.tap do |topic|
       TopicUser.change(
         user.id,
         topic.id,
@@ -46,6 +17,59 @@ describe "New topic list", type: :system do
       Fabricate(:post, topic: topic)
     end
   end
+
+  fab!(:new_topic) { Fabricate(:post).topic }
+
+  fab!(:old_topic) do
+    Fabricate(:post).topic.tap { |topic| TopicUser.update_last_read(user, topic.id, 1, 1, 1) }
+  end
+
+  fab!(:new_reply_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic.tap do |topic|
+      TopicUser.change(
+        user.id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[:tracking],
+      )
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+      Fabricate(:post, topic: topic)
+    end
+  end
+
+  fab!(:new_topic_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+  end
+
+  fab!(:old_topic_in_category) do
+    Fabricate(:post, topic: Fabricate(:topic, category: category)).topic.tap do |topic|
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+    end
+  end
+
+  fab!(:new_reply_with_tag) do
+    Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic.tap do |topic|
+      TopicUser.change(
+        user.id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[:tracking],
+      )
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+      Fabricate(:post, topic: topic)
+    end
+  end
+
+  fab!(:new_topic_with_tag) { Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic }
+
+  fab!(:old_topic_with_tag) do
+    Fabricate(:post, topic: Fabricate(:topic, tags: [tag])).topic.tap do |topic|
+      TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+    end
+  end
+
+  let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:tabs_toggle) { PageObjects::Components::NewTopicListToggle.new }
+
+  before { sign_in(user) }
 
   shared_examples "new list new topics and replies toggle" do
     context "when the new new view is enabled" do

--- a/spec/system/new_topic_list_spec.rb
+++ b/spec/system/new_topic_list_spec.rb
@@ -71,14 +71,14 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.topics_tab).to be_inactive
       end
 
-      it "respects the s (scope) query param and activates the appropriate tab" do
-        visit("/new?s=topics")
+      it "respects the subset query param and activates the appropriate tab" do
+        visit("/new?subset=topics")
 
         expect(tabs_toggle.all_tab).to be_inactive
         expect(tabs_toggle.replies_tab).to be_inactive
         expect(tabs_toggle.topics_tab).to be_active
 
-        visit("/new?s=replies")
+        visit("/new?subset=replies")
 
         expect(tabs_toggle.all_tab).to be_inactive
         expect(tabs_toggle.replies_tab).to be_active
@@ -102,7 +102,7 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.replies_tab).to have_count(3)
         expect(tabs_toggle.topics_tab).to have_count(3)
 
-        expect(current_url).to end_with("/new?s=topics")
+        expect(current_url).to end_with("/new?subset=topics")
       end
 
       it "shows only topics with new replies when the user switches to the Replies tab" do
@@ -122,16 +122,16 @@ describe "New topic list", type: :system do
         expect(tabs_toggle.replies_tab).to have_count(3)
         expect(tabs_toggle.topics_tab).to have_count(3)
 
-        expect(current_url).to end_with("/new?s=replies")
+        expect(current_url).to end_with("/new?subset=replies")
       end
 
-      it "strips out the s (scope) query params when switching back to the All tab from any of the other tabs" do
+      it "strips out the subset query params when switching back to the All tab from any of the other tabs" do
         visit("/new")
         tabs_toggle.replies_tab.click
 
         expect(tabs_toggle.all_tab).to be_inactive
         expect(tabs_toggle.replies_tab).to be_active
-        try_until_success { expect(current_url).to end_with("/new?s=replies") }
+        try_until_success { expect(current_url).to end_with("/new?subset=replies") }
 
         tabs_toggle.all_tab.click
 
@@ -195,7 +195,7 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=topics")
+          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?subset=topics")
         end
 
         it "shows only topics with new replies in the category when the user switches to the Replies tab" do
@@ -213,17 +213,17 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?s=replies")
+          expect(current_url).to end_with("/c/#{category.slug}/#{category.id}/l/new?subset=replies")
         end
 
-        it "respects the s (scope) query param and activates the appropriate tab" do
-          visit("/c/#{category.slug}/#{category.id}/l/new?s=topics")
+        it "respects the subset query param and activates the appropriate tab" do
+          visit("/c/#{category.slug}/#{category.id}/l/new?subset=topics")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_inactive
           expect(tabs_toggle.topics_tab).to be_active
 
-          visit("/c/#{category.slug}/#{category.id}/l/new?s=replies")
+          visit("/c/#{category.slug}/#{category.id}/l/new?subset=replies")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_active
@@ -281,7 +281,7 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=topics")
+          expect(current_url).to end_with("/tag/#{tag.name}/l/new?subset=topics")
         end
 
         it "shows only topics with new replies with the tag when the user switches to the Replies tab" do
@@ -300,17 +300,17 @@ describe "New topic list", type: :system do
           expect(tabs_toggle.replies_tab).to have_count(1)
           expect(tabs_toggle.topics_tab).to have_count(1)
 
-          expect(current_url).to end_with("/tag/#{tag.name}/l/new?s=replies")
+          expect(current_url).to end_with("/tag/#{tag.name}/l/new?subset=replies")
         end
 
-        it "respects the s (scope) query param and activates the appropriate tab" do
-          visit("/tag/#{tag.name}/l/new?s=topics")
+        it "respects the subset query param and activates the appropriate tab" do
+          visit("/tag/#{tag.name}/l/new?subset=topics")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_inactive
           expect(tabs_toggle.topics_tab).to be_active
 
-          visit("/tag/#{tag.name}/l/new?s=replies")
+          visit("/tag/#{tag.name}/l/new?subset=replies")
 
           expect(tabs_toggle.all_tab).to be_inactive
           expect(tabs_toggle.replies_tab).to be_active

--- a/spec/system/page_objects/components/new_topic_list_toggle.rb
+++ b/spec/system/page_objects/components/new_topic_list_toggle.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class NewTopicListToggle < PageObjects::Components::Base
+      COMMON_SELECTOR = ".topics-replies-toggle"
+
+      ALL_SELECTOR = "#{COMMON_SELECTOR}.all"
+      REPLIES_SELECTOR = "#{COMMON_SELECTOR}.replies"
+      TOPICS_SELECTOR = "#{COMMON_SELECTOR}.topics"
+
+      def not_rendered?
+        has_no_css?(COMMON_SELECTOR)
+      end
+
+      def all_tab
+        @all_tab ||= PageObjects::Components::NewTopicListToggleTab.new("all", ALL_SELECTOR)
+      end
+
+      def replies_tab
+        @replies_tab ||=
+          PageObjects::Components::NewTopicListToggleTab.new("replies", REPLIES_SELECTOR)
+      end
+
+      def topics_tab
+        @topics_tab ||=
+          PageObjects::Components::NewTopicListToggleTab.new("topics", TOPICS_SELECTOR)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
+++ b/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class NewTopicListToggleTab < PageObjects::Components::Base
+      def initialize(name, selector)
+        super()
+        @name = name
+        @selector = selector
+      end
+
+      def active?
+        has_css?("#{@selector}.active")
+      end
+
+      def inactive?
+        has_no_css?("#{@selector}.active") && has_css?(@selector)
+      end
+
+      def has_count?(count)
+        expected_label =
+          (
+            if count > 0
+              I18n.t("js.filters.new.#{@name}_with_count", count: count)
+            else
+              I18n.t("js.filters.new.#{@name}")
+            end
+          )
+        find(@selector).text == expected_label
+      end
+
+      def click
+        find(@selector).click
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
+++ b/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
@@ -17,6 +17,10 @@ module PageObjects
         has_no_css?("#{@selector}.active") && has_css?(@selector)
       end
 
+      def visible?
+        has_css?(@selector)
+      end
+
       def has_count?(count)
         expected_label =
           (

--- a/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
+++ b/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
@@ -30,7 +30,8 @@ module PageObjects
               I18n.t("js.filters.new.#{@name}")
             end
           )
-        find(@selector).text == expected_label
+
+        find(@selector, text: expected_label)
       end
 
       def click

--- a/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
+++ b/spec/system/page_objects/components/new_topic_list_toggle_tab.rb
@@ -31,7 +31,7 @@ module PageObjects
             end
           )
 
-        find(@selector, text: expected_label)
+        has_selector?(@selector, text: expected_label)
       end
 
       def click


### PR DESCRIPTION
This PR adds a new toggle to switch the (new) /new list between showing topics with new replies (a.k.a unread topics), new topics, or everything mixed together.

No screenshots of the new toggle as this PR isn't quite done yet; the styling and HTML structure of the new toggle of isn't finalized but I'm creating this PR to get the rest of the PR reviewed until the styling/design of the new toggle is done. I'll add screenshots when we get there.

Internal topic: t/103411.