### PR TITLE
FIX: Compact tag picker input not focused in iOS

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1004,6 +1004,10 @@ export default Component.extend(
           this.selectKit.options.filterable || this.selectKit.options.allowAny,
       });
 
+      if (this.selectKit.options.useHeaderFilter) {
+        this._focusFilterInput();
+      }
+
       this.triggerSearch();
 
       this._safeAfterRender(() => {
@@ -1044,19 +1048,33 @@ export default Component.extend(
         return;
       }
 
-      this._safeAfterRender(() => {
-        const input = this.getFilterInput();
-        if (!forceHeader && input) {
-          input.focus({ preventScroll: true });
+      // setting focus early is best for iOS
+      // because render/promise delays
+      // may cause the keyboard to not show
+      if (!forceHeader) {
+        this._focusFilterInput();
+      }
 
-          if (typeof input.selectionStart === "number") {
-            input.selectionStart = input.selectionEnd = input.value.length;
-          }
+      this._safeAfterRender(() => {
+        if (!forceHeader) {
+          this._focusFilterInput();
         } else if (!this.selectKit.options.preventHeaderFocus) {
           const headerContainer = this.getHeader();
           headerContainer && headerContainer.focus({ preventScroll: true });
         }
       });
+    },
+
+    _focusFilterInput() {
+      const input = this.getFilterInput();
+
+      if (input && document.activeElement !== input) {
+        input.focus({ preventScroll: true });
+
+        if (typeof input.selectionStart === "number") {
+          input.selectionStart = input.selectionEnd = input.value.length;
+        }
+      }
     },
 
     getFilterInput() {

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1048,15 +1048,15 @@ export default Component.extend(
         return;
       }
 
-      // setting focus early is best for iOS
-      // because render/promise delays
-      // may cause the keyboard to not show
+      // setting focus as early as possible is best for iOS
+      // because render/promise delays may cause keyboard not to show
       if (!forceHeader) {
         this._focusFilterInput();
       }
 
       this._safeAfterRender(() => {
-        if (!forceHeader) {
+        const input = this.getFilterInput();
+        if (!forceHeader && input) {
           this._focusFilterInput();
         } else if (!this.selectKit.options.preventHeaderFocus) {
           const headerContainer = this.getHeader();


### PR DESCRIPTION
Should fix an iOS regression in f5e8e73. iOS does not invoke the keyboard if the `.focus()` call is delayed by a rendering timeout or an asynchronous ajax call. 

Previously we were calling `.focus` on the filter multiple times for some dropdowns (for example, once on render and then again once `searchTrigger` completes). This PR only sets focus to the input if the element does not already have focus.  

Since the issue is only exhibited in iOS, it's not possible to add a specific test case, we don't run our test suite in iOS. 