### PR TITLE
FIX: prevent event propagation when pressing escape key on lightbox

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-lightbox.js
+++ b/app/assets/javascripts/discourse/app/components/d-lightbox.js
@@ -361,6 +361,7 @@ export default class DLightbox extends Component {
   onKeydown(event) {
     if (event.key === KEYBOARD_SHORTCUTS.CLOSE) {
       event.preventDefault();
+      event.stopPropagation();
       return this.close();
     }
   }


### PR DESCRIPTION
When we use the escape key to exit lightbox for images within a chat channel, it also closes the chat drawer due to event bubbling (since both lightbox and chat use an event listener on the escape key).

This change prevents event bubbling when using the escape key within lightbox, which means that it will close the lightbox but won't close the chat drawer.

/t/108968