### PR TITLE
DEV: Remove unused chat translations

### DIFF
--- a/plugins/chat/config/locales/client.ar.yml
+++ b/plugins/chat/config/locales/client.ar.yml
@@ -283,8 +283,6 @@ ar:
         closed: "القناة مغلقة، ولا يمكنك إرسال رسائل جديدة الآن."
         read_only: "القناة للقراءة فقط، لا يمكنك إرسال رسائل جديدة الآن."
       placeholder_silenced: "لا يمكنك إرسال رسائل في الوقت الحالي."
-      placeholder_start_conversation: "ابدأ محادثة مع..."
-      placeholder_start_conversation_users: "ابدأ محادثة مع %{commaSeparatedUsernames}"
       remove_upload: "إزالة ملف"
       react: "التفاعل برمز تعبيري"
       reply: "رد"

--- a/plugins/chat/config/locales/client.de.yml
+++ b/plugins/chat/config/locales/client.de.yml
@@ -239,8 +239,6 @@ de:
         closed: "Der Kanal ist geschlossen, du kannst im Moment keine neuen Nachrichten senden."
         read_only: "Der Kanal ist schreibgeschützt, du kannst im Moment keine neuen Nachrichten senden."
       placeholder_silenced: "Du kannst derzeit keine Nachrichten senden."
-      placeholder_start_conversation: "Unterhaltung beginnen mit …"
-      placeholder_start_conversation_users: "Unterhaltung mit %{commaSeparatedUsernames} beginnen"
       remove_upload: "Datei löschen"
       react: "Mit Emoji reagieren"
       reply: "Antworten"

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -240,8 +240,6 @@ en:
         closed: "Channel is closed, you cannot send new messages right now."
         read_only: "Channel is read only, you cannot send new messages right now."
       placeholder_silenced: "You cannot send messages at this time."
-      placeholder_start_conversation: "Start a conversation with ..."
-      placeholder_start_conversation_users: "Start a conversation with %{commaSeparatedUsernames}"
       remove_upload: "Remove file"
       react: "React with emoji"
       reply: "Reply"

--- a/plugins/chat/config/locales/client.es.yml
+++ b/plugins/chat/config/locales/client.es.yml
@@ -239,8 +239,6 @@ es:
         closed: "El canal está cerrado, no puedes enviar nuevos mensajes en este momento."
         read_only: "El canal es de solo lectura, no puedes enviar nuevos mensajes en este momento."
       placeholder_silenced: "No puedes enviar mensajes en este momento."
-      placeholder_start_conversation: "Iniciar una conversación con ..."
-      placeholder_start_conversation_users: "Iniciar una conversación con %{commaSeparatedUsernames}"
       remove_upload: "Eliminar archivo"
       react: "Reaccionar con emojis"
       reply: "Responder"

--- a/plugins/chat/config/locales/client.fi.yml
+++ b/plugins/chat/config/locales/client.fi.yml
@@ -186,8 +186,6 @@ fi:
         closed: "Kanava on suljettu, et voi lähettää uusia viestejä juuri nyt."
         read_only: "Kanava on vain luettavissa, et voi lähettää uusia viestejä juuri nyt."
       placeholder_silenced: "Et voi lähettää viestejä tällä hetkellä."
-      placeholder_start_conversation: "Aloita keskustelu..."
-      placeholder_start_conversation_users: "Aloita keskustelu käyttäjän %{commaSeparatedUsernames} kanssa"
       remove_upload: "Poista tiedosto"
       react: "Reagoi emojilla"
       reply: "Vastaa"

--- a/plugins/chat/config/locales/client.fr.yml
+++ b/plugins/chat/config/locales/client.fr.yml
@@ -239,8 +239,6 @@ fr:
         closed: "Le canal est fermé, vous ne pouvez pas envoyer de nouveaux messages pour le moment."
         read_only: "Le canal est en lecture seule, vous ne pouvez pas envoyer de nouveaux messages pour le moment."
       placeholder_silenced: "Vous ne pouvez pas envoyer de messages pour le moment."
-      placeholder_start_conversation: "Démarrer une conversation avec ..."
-      placeholder_start_conversation_users: "Démarrer une conversation avec %{commaSeparatedUsernames}"
       remove_upload: "Supprimer le fichier"
       react: "Réagir avec un émoji"
       reply: "Répondre"

--- a/plugins/chat/config/locales/client.he.yml
+++ b/plugins/chat/config/locales/client.he.yml
@@ -261,8 +261,6 @@ he:
         closed: "הערוץ סגור, אי אפשר לשלוח אליו הודעות חדשות כעת."
         read_only: "הערוץ לקריאה בלבד, אי אפשר לשלוח אליו הודעות חדשות כעת."
       placeholder_silenced: "אין לך אפשרות לשלוח הודעות כרגע."
-      placeholder_start_conversation: "פציחה בשיחה עם…"
-      placeholder_start_conversation_users: "פציחה בשיחה עם %{commaSeparatedUsernames}"
       remove_upload: "הסרת קובץ"
       react: "להגיב עם אמוג׳י"
       reply: "להגיב"

--- a/plugins/chat/config/locales/client.hr.yml
+++ b/plugins/chat/config/locales/client.hr.yml
@@ -159,8 +159,6 @@ hr:
         archived: "Kanal je arhiviran, trenutno ne možete slati nove poruke."
         closed: "Kanal je zatvoren, trenutno ne možete slati nove poruke."
         read_only: "Kanal je samo za čitanje, trenutno ne možete slati nove poruke."
-      placeholder_start_conversation: "Započnite razgovor s..."
-      placeholder_start_conversation_users: "Započnite razgovor s %{commaSeparatedUsernames}"
       reply: "Odgovor"
       edit: "Uredi"
       rebake_message: "Popravi HTML"

--- a/plugins/chat/config/locales/client.it.yml
+++ b/plugins/chat/config/locales/client.it.yml
@@ -185,8 +185,6 @@ it:
         closed: "Il canale è chiuso, non puoi inviare nuovi messaggi in questo momento."
         read_only: "Il canale è in sola lettura, non è possibile inviare nuovi messaggi in questo momento."
       placeholder_silenced: "In questo momento non puoi inviare messaggi."
-      placeholder_start_conversation: "Inizia una conversazione con..."
-      placeholder_start_conversation_users: "Inizia una conversazione con %{commaSeparatedUsernames}"
       remove_upload: "Rimuovi file"
       react: "Reagisci con delle emoji"
       reply: "Rispondi"

--- a/plugins/chat/config/locales/client.ja.yml
+++ b/plugins/chat/config/locales/client.ja.yml
@@ -228,8 +228,6 @@ ja:
         closed: "チャンネルは閉鎖されているため、新しいメッセージを送信できません。"
         read_only: "チャンネルは読み取り専用であるため、新しいメッセージを送信できません。"
       placeholder_silenced: "現在、メッセージを送信できません。"
-      placeholder_start_conversation: "会話を始める..."
-      placeholder_start_conversation_users: "%{commaSeparatedUsernames} と会話を始める"
       remove_upload: "ファイルを削除する"
       react: "絵文字でリアクション"
       reply: "返信"

--- a/plugins/chat/config/locales/client.ko.yml
+++ b/plugins/chat/config/locales/client.ko.yml
@@ -123,8 +123,6 @@ ko:
       placeholder_new_message_disallowed:
         archived: "채널이 보관되어 메시지를 보낼 수 없습니다."
         read_only: "채널이 읽기 전용이므로 메시지를 보낼 수 없습니다."
-      placeholder_start_conversation: "대화 시작..."
-      placeholder_start_conversation_users: "%{commaSeparatedUsernames}과 대화 시작"
       remove_upload: "파일 제거"
       reply: "댓글쓰기"
       edit: "편집"

--- a/plugins/chat/config/locales/client.nl.yml
+++ b/plugins/chat/config/locales/client.nl.yml
@@ -239,8 +239,6 @@ nl:
         closed: "Kanaal is gesloten, je kunt momenteel geen nieuwe berichten sturen."
         read_only: "Kanaal is alleen-lezen, je kunt momenteel geen nieuwe berichten sturen."
       placeholder_silenced: "Je kunt op dit moment geen berichten sturen."
-      placeholder_start_conversation: "Begin een gesprek met ..."
-      placeholder_start_conversation_users: "Begin een gesprek met %{commaSeparatedUsernames}"
       remove_upload: "Bestand verwijderen"
       react: "Reageren met emoji"
       reply: "Antwoorden"

--- a/plugins/chat/config/locales/client.pl_PL.yml
+++ b/plugins/chat/config/locales/client.pl_PL.yml
@@ -207,8 +207,6 @@ pl_PL:
         closed: "Kanał jest zamknięty, nie możesz teraz wysyłać nowych wiadomości."
         read_only: "Kanał jest tylko do odczytu, nie możesz teraz wysyłać nowych wiadomości."
       placeholder_silenced: "W tej chwili nie możesz wysyłać wiadomości."
-      placeholder_start_conversation: "Rozpocznij rozmowę z..."
-      placeholder_start_conversation_users: "Rozpocznij rozmowę z %{commaSeparatedUsernames}"
       remove_upload: "Usuń plik"
       react: "Zareaguj z emoji"
       reply: "Odpowiedz"

--- a/plugins/chat/config/locales/client.pt_BR.yml
+++ b/plugins/chat/config/locales/client.pt_BR.yml
@@ -239,8 +239,6 @@ pt_BR:
         closed: "Canal fechado, não é possível enviar novas mensagens no momento."
         read_only: "Canal somente para leitura, não é possível enviar novas mensagens no momento."
       placeholder_silenced: "Você não pode enviar mensagens neste momento."
-      placeholder_start_conversation: "Iniciar uma conversa com ..."
-      placeholder_start_conversation_users: "Iniciar uma conversa com %{commaSeparatedUsernames}"
       remove_upload: "Remover arquivo"
       react: "Reagir com emoji"
       reply: "Responder"

--- a/plugins/chat/config/locales/client.ru.yml
+++ b/plugins/chat/config/locales/client.ru.yml
@@ -273,8 +273,6 @@ ru:
         closed: "Канал закрыт, вы не можете отправлять новые сообщения."
         read_only: "Канал в режиме «только для чтения», вы не можете отправлять новые сообщения."
       placeholder_silenced: "В настоящее время вы не можете отправлять сообщения."
-      placeholder_start_conversation: "Начать беседу с пользователем…"
-      placeholder_start_conversation_users: "Начать беседу с пользователем %{commaSeparatedUsernames}"
       remove_upload: "Удалить файл"
       react: "Реакция с помощью эмодзи"
       reply: "Ответить"

--- a/plugins/chat/config/locales/client.sk.yml
+++ b/plugins/chat/config/locales/client.sk.yml
@@ -54,8 +54,6 @@ sk:
         archived: "Kanál je archivovaný, nie je možné posielať nové správy."
         closed: "Kanál je zatvorený, nie je možné posielať nové správy."
         read_only: "Kanál je len na čítanie, nie je možné posielať nové správy."
-      placeholder_start_conversation: "Začnite konverzáciu s ..."
-      placeholder_start_conversation_users: "Začnite konverzáciu s %{commaSeparatedUsernames}"
       reply: "Odpoveď"
       edit: "Upraviť"
       rebake_message: "Pregenerovať HTML"

--- a/plugins/chat/config/locales/client.sv.yml
+++ b/plugins/chat/config/locales/client.sv.yml
@@ -239,8 +239,6 @@ sv:
         closed: "Kanalen är stängd, och du kan inte skicka nya meddelanden just nu."
         read_only: "Kanalen är lässkyddad, och du kan inte skicka nya meddelanden just nu."
       placeholder_silenced: "Du kan inte skicka meddelanden just nu."
-      placeholder_start_conversation: "Inled ett samtal med ..."
-      placeholder_start_conversation_users: "Inled ett samtal med %{commaSeparatedUsernames}"
       remove_upload: "Ta bort fil"
       react: "Reagera med emoji"
       reply: "Svara"

--- a/plugins/chat/config/locales/client.tr_TR.yml
+++ b/plugins/chat/config/locales/client.tr_TR.yml
@@ -239,8 +239,6 @@ tr_TR:
         closed: "Kanal kapalı, şu anda yeni mesaj gönderemezsiniz."
         read_only: "Kanal salt okunurdur, şu anda yeni mesaj gönderemezsiniz."
       placeholder_silenced: "Şu anda mesaj gönderemezsiniz."
-      placeholder_start_conversation: "Şu kişiyle konuşma başlatın:"
-      placeholder_start_conversation_users: "%{commaSeparatedUsernames} ile konuşma başlatın"
       remove_upload: "Dosyayı kaldır"
       react: "Emoji ile tepki ver"
       reply: "Yanıtla"

--- a/plugins/chat/config/locales/client.uk.yml
+++ b/plugins/chat/config/locales/client.uk.yml
@@ -202,8 +202,6 @@ uk:
         closed: "Канал закритий, зараз ви не можете надсилати нові повідомлення."
         read_only: "Канал доступний лише для читання, зараз ви не можете надсилати нові повідомлення."
       placeholder_silenced: "В даний момент ви не можете надсилати повідомлення."
-      placeholder_start_conversation: "Почніть розмову з..."
-      placeholder_start_conversation_users: "Почніть розмову з %{commaSeparatedUsernames}"
       remove_upload: "Видалити файл"
       react: "Реагувати з emoji"
       reply: "Відповідь"

--- a/plugins/chat/config/locales/client.zh_CN.yml
+++ b/plugins/chat/config/locales/client.zh_CN.yml
@@ -228,8 +228,6 @@ zh_CN:
         closed: "频道已关闭，您现在无法发送新消息。"
         read_only: "频道为只读，您现在无法发送新消息。"
       placeholder_silenced: "您目前无法发送消息。"
-      placeholder_start_conversation: "开始对话…"
-      placeholder_start_conversation_users: "开始与 %{commaSeparatedUsernames} 的对话"
       remove_upload: "移除文件"
       react: "使用表情符号回复"
       reply: "回复"

--- a/plugins/chat/config/locales/client.zh_TW.yml
+++ b/plugins/chat/config/locales/client.zh_TW.yml
@@ -83,7 +83,6 @@ zh_TW:
           other: "前 %{count} 小時"
       mention_warning:
         dismiss: "忽略"
-      placeholder_start_conversation_users: "與 %{commaSeparatedUsernames} 開始聊天"
       remove_upload: "移除檔案"
       react: "用表情符號反應"
       reply: "回覆"


### PR DESCRIPTION
Both placeholder_start_conversation and
placeholder_start_conversation_users are no
longer used.
