### PR TITLE
UX: Add tooltip about multiple emails to admin.groups.incoming_email field

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.hbs
@@ -106,8 +106,10 @@
     />
 
     <span>
-        {{d-icon "info-circle"}}
-        <DTooltip>{{i18n "admin.groups.manage.interaction.incoming_email_tooltip"}}</DTooltip>
+      {{d-icon "info-circle"}}
+      <DTooltip>{{i18n
+          "admin.groups.manage.interaction.incoming_email_tooltip"
+        }}</DTooltip>
     </span>
 
     <span>

--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.hbs
@@ -106,6 +106,11 @@
     />
 
     <span>
+        {{d-icon "info-circle"}}
+        <DTooltip>{{i18n "admin.groups.manage.interaction.incoming_email_tooltip"}}</DTooltip>
+    </span>
+
+    <span>
       <PluginOutlet
         @name="group-email-in"
         @connectorTagName="div"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4704,6 +4704,7 @@ en:
             email: Email
             incoming_email: "Custom incoming email address"
             incoming_email_placeholder: "enter email address"
+            incoming_email_tooltip: "You can separate multiple email addresses with the | character."
             visibility: Visibility
             visibility_levels:
               title: "Who can see this group?"


### PR DESCRIPTION
https://meta.discourse.org/t/multiple-email-addresses-for-a-group/38193/10

This PR adds a tooltip to the Custom incoming email address field for Admin > Groups > Manage > Interaction to show users how to add multiple email addresses. We already show the [same tooltip on the Edit Category Settings page](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/edit-category-settings.hbs#L336-L339). 

I've tested that the tooltip appears while creating a new group, or while managing an existing group as an admin. 

<img width="937" alt="Screenshot 2023-08-02 at 12 38 36 PM" src="https://github.com/discourse/discourse/assets/5862206/ac3beb33-4532-4725-99f5-2f9a9fb47abf">





