### PR TITLE
FIX: prevent event bubbling when closing modals with escape key

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -86,6 +86,7 @@ export default class DModal extends Component {
     }
 
     if (event.key === "Escape" && this.dismissable) {
+      event.stopPropagation();
       this.args.closeModal({ initiatedBy: CLOSE_INITIATED_BY_ESC });
     }
 


### PR DESCRIPTION
This change prevents event bubbling for the `Escape` key on all modals. Currently when we close the modal using the Escape key, all other event listeners attached will also be triggered (such as closing the chat drawer if it's open).

