### PR TITLE
DEV: Add a HasDeprecatedColumns concern for better deprecation messages

### DIFF
--- a/app/models/concerns/has_deprecated_columns.rb
+++ b/app/models/concerns/has_deprecated_columns.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HasDeprecatedColumns
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def deprecate_column(column_name, drop_from:, raise_error: false, message: nil)
+      if Gem::Version.new(Discourse::VERSION::STRING) >= Gem::Version.new(drop_from)
+        self.ignored_columns = self.ignored_columns.dup << column_name.to_s
+      else
+        message = message.presence || "column `#{column_name}` is deprecated"
+
+        define_method(column_name) do
+          Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
+          super()
+        end
+
+        define_method("#{column_name}=") do |value|
+          Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
+          super(value)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

Currently when we decide we're going to drop a column in the future we just mark it with a TODO comment and add it to `ignored_columns`. This makes it instantly unavailable, and we mostly forget about the TODO in the end. 😬 

This change adds a `HasDeprecatedColumns` concern which offers a little bit more flexibility. We can still simulate the old behaviour by setting `drop_from` to the current version, but we can also set it to a future version, causing it to raise a deprecation warning until then if used.

**Usage:**

```ruby
class MyModel < ActiveRecord::Base
  include HasDeprecatedColumns

  deprecate_column :foo, drop_from: "3.2"
  deprecate_column :bar, drop_from: "3.0"
end

MyModel.new.foo
#=> Deprecation warning

MyModel.new.bar
#=> NoMethod error
```