### PR TITLE
UX: Use same color as reply button for active recommendation tab

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -253,6 +253,15 @@ a.reply-to-tab {
 }
 
 .more-content-wrapper {
+  margin-top: 2em;
+
+  .nav {
+    button.active {
+      color: var(--secondary);
+      background-color: var(--tertiary);
+    }
+  }
+
   &:not(.single-list) {
     .more-topics-title {
       display: none;
@@ -266,7 +275,7 @@ a.reply-to-tab {
 
 .more-content-topics {
   clear: left;
-  padding: 20px 0 15px 0;
+  padding-bottom: 15px;
 
   a.badge-category,
   a.badge-category-parent {


### PR DESCRIPTION
Also move the nav closer to the list and increase margin with topic-footer buttons.

<img width="533" alt="Screenshot 2023-08-02 at 17 30 20" src="https://github.com/discourse/discourse/assets/5025816/d92bad25-b97f-42be-9e86-e0c802cb3844">
