### PR TITLE
DEV: Instrument why a major GC was triggered

### DIFF
--- a/lib/gc_stat_instrumenter.rb
+++ b/lib/gc_stat_instrumenter.rb
@@ -11,6 +11,7 @@ class GCStatInstrumenter
         time: (end_gc_stat[:time] - start_gc_stat[:time]) / 1000.0,
         major_count: end_gc_stat[:major_gc_count] - start_gc_stat[:major_gc_count],
         minor_count: end_gc_stat[:minor_gc_count] - start_gc_stat[:minor_gc_count],
+        major_by: GC.latest_gc_info[:major_by],
       },
     }
   end

--- a/spec/lib/gc_stat_instrumenter_spec.rb
+++ b/spec/lib/gc_stat_instrumenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GCStatInstrumenter do
       expect(result[:gc][:time]).to be >= 0.0
       expect(result[:gc][:major_count]).to eq(1)
       expect(result[:gc][:minor_count]).to eq(1)
+      expect(result[:gc]).to have_key(:major_by)
     end
   end
 end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -778,6 +778,7 @@ RSpec.describe Middleware::RequestTracker do
       expect(@data[:timing][:gc][:time]).to be > 0.0
       expect(@data[:timing][:gc][:major_count]).to eq(1)
       expect(@data[:timing][:gc][:minor_count]).to eq(1)
+      expect(@data[:timing][:gc]).to have_key(:major_by)
     end
 
     it "can correctly log messagebus request types" do


### PR DESCRIPTION
Why this change?

In order to properly tune our GC, we need visibility on the reasons why
a major GC was triggered during a request. This visibility will allow us
to make a more informed choice on what variable to tune for our GC.