### PR TITLE
FIX: display customised community section button when no secondary links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.hbs
@@ -82,5 +82,11 @@
         @moreButtonIcon={{this.section.moreSectionButtonIcon}}
       />
     {{/if}}
+  {{else if this.section.moreSectionButtonAction}}
+    <Sidebar::SectionLinkButton
+      @action={{this.section.moreSectionButtonAction}}
+      @icon={{this.section.moreSectionButtonIcon}}
+      @text={{this.section.moreSectionButtonText}}
+    />
   {{/if}}
 </Sidebar::Section>

--- a/spec/system/editing_sidebar_community_section_spec.rb
+++ b/spec/system/editing_sidebar_community_section_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe "Editing Sidebar Community Section", type: :system do
     )
   end
 
+  it "allows admin to edit community section when no secondary section links" do
+    SidebarSection
+      .where(title: "Community")
+      .first
+      .sidebar_section_links
+      .where.not(position: 0)
+      .destroy_all
+
+    sign_in(admin)
+
+    visit("/latest")
+
+    modal = sidebar.click_customize_community_section_button
+
+    expect(modal).to be_visible
+  end
+
   it "should allow admins to open modal to edit the section when `navigation_menu` site setting is `header dropdown`" do
     SiteSetting.navigation_menu = "header dropdown"
 


### PR DESCRIPTION
Edit community section button is hidden in secondary/more section. 

However, when there are no secondary links, then more section is not shown. 

In that case, we should still display an edit button for admins, so they can edit the section.

Regular user view:
<img width="300" alt="Screenshot 2023-08-03 at 11 49 43 am" src="https://github.com/discourse/discourse/assets/72780/f2bf34cc-efe1-48db-8dfa-ef2b588e86d8">

Admin user view:
<img width="331" alt="Screenshot 2023-08-03 at 11 49 51 am" src="https://github.com/discourse/discourse/assets/72780/dfec8577-a48e-475b-b8b5-44795d2f2d5a">

Meta: https://meta.discourse.org/t/accidentily-deleted-the-main-sidebar-section/273624

