### PR TITLE
DEV: Unskip chat delete message spec

### DIFF
--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Deleted message", type: :system do
       thread_1.add(current_user)
     end
 
-    xit "hides the deleted messages" do
+    it "hides the deleted messages" do
       chat_page.visit_channel(channel_1)
 
       channel_page.message_thread_indicator(message_3).click


### PR DESCRIPTION
Skipped in https://github.com/discourse/discourse/pull/22862 but
it seems like that may have been a sidebar error, unskipping to
see if it's ok now
