### PR TITLE
FIX: Make poll breakdown modal closable again

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-breakdown.hbs
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-breakdown.hbs
@@ -1,5 +1,9 @@
 {{! template-lint-disable no-invalid-interactive }}
-<DModal @title={{i18n "poll.breakdown.title"}} class="has-tabs">
+<DModal
+  @title={{i18n "poll.breakdown.title"}}
+  @closeModal={{@closeModal}}
+  class="has-tabs"
+>
   <:headerBelowTitle>
     <ul class="modal-tabs">
       <li


### PR DESCRIPTION
Regressed in https://github.com/discourse/discourse/pull/22164

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
