### PR TITLE
FIX: allow lightbox cleanup on navigation changes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lightbox/constants.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox/constants.js
@@ -52,7 +52,6 @@ export const SELECTORS = {
 };
 
 export const LIGHTBOX_APP_EVENT_NAMES = {
-  // this cannot use dom:clean else #cleanupLightboxes will be called after #setupLightboxes
   CLEAN: "dom:clean",
   CLOSE: "lightbox:close",
   CLOSED: "lightbox:closed",


### PR DESCRIPTION
When the user navigates to a new page, we should clean up the lightbox.