### PR TITLE
DEV: Fix theme error message

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/theme-errors-handler.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/theme-errors-handler.js
@@ -52,7 +52,7 @@ export default {
     reportToLogster(source.name, error);
 
     const message = I18n.t("themes.broken_theme_alert");
-    this.displayErrorNotice(this.currentUser, message, source);
+    this.displayErrorNotice(message, source);
   },
 
   reportGenericError(e) {


### PR DESCRIPTION
Since the refactoring in f822a933fa295c80a8b0408cf0f6c459918dfa08, the text of theme-related errors has been missing in the UI.

Before:
<img width="389" alt="SCR-20230803-nvwi" src="https://github.com/discourse/discourse/assets/6270921/bd20d54b-d6a9-40f2-ad75-f1e0de16753d">

After:
<img width="590" alt="SCR-20230803-nvut" src="https://github.com/discourse/discourse/assets/6270921/64e7b812-95cb-45fd-ab0b-bc5869125554">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
