### PR TITLE
UX: Fix hover color for header icons in WCAG

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -94,11 +94,6 @@ html {
     color: var(--primary-low-mid);
   }
 
-  .d-header-icons .icon:hover .d-icon,
-  .d-header-icons .icon:focus .d-icon {
-    color: var(--primary-high);
-  }
-
   .d-header-icons .unread-notifications {
     background: var(--tertiary);
   }


### PR DESCRIPTION
Before: 

<img width="177" alt="image" src="https://github.com/discourse/discourse/assets/368961/6b2b3bc5-8039-4352-aae5-87200226a431">

After: 

<img width="169" alt="image" src="https://github.com/discourse/discourse/assets/368961/8f928989-f15e-44c2-9605-b962eed2ed20">

This only affected WCAG themes. 