### PR TITLE
FIX: A select-kit+modal regression

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -988,10 +988,9 @@ export default Component.extend(
               enabled: !!(inModal && this.site.mobileView),
               phase: "afterWrite",
               fn: ({ state }) => {
-                const modalBody = inModal.querySelector(".modal-body");
-                modalBody.style = "";
-                modalBody.style.height =
-                  modalBody.clientHeight + state.rects.popper.height + "px";
+                inModal.style = "";
+                inModal.style.height =
+                  inModal.clientHeight + state.rects.popper.height + "px";
               },
             },
           ],


### PR DESCRIPTION
Regressed in https://github.com/discourse/discourse/pull/22642

`inModal` var is `.modal-body` itself now, so the changing the modal height failed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
