### PR TITLE
FIX: Count all emojis from titles

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -296,6 +296,18 @@ module PrettyText
       JS
   end
 
+  def self.count_emoji(string)
+    return unless string
+
+    protect { v8.eval(<<~JS) }
+        __countEmoji(#{string.inspect}, {
+          enableEmojiShortcuts: #{SiteSetting.enable_emoji_shortcuts},
+          inlineEmoji: #{SiteSetting.enable_inline_emoji_translation},
+          customEmoji: new Set(#{Emoji.custom.map { |e| e.name }.to_json})
+        });
+      JS
+  end
+
   def self.cook(text, opts = {})
     options = opts.dup
     working_text = text.dup

--- a/lib/pretty_text/shims.js
+++ b/lib/pretty_text/shims.js
@@ -3,6 +3,7 @@ __buildOptions = require("pretty-text/pretty-text").buildOptions;
 __performEmojiUnescape = require("pretty-text/emoji").performEmojiUnescape;
 __emojiReplacementRegex = require("pretty-text/emoji").emojiReplacementRegex;
 __performEmojiEscape = require("pretty-text/emoji").performEmojiEscape;
+__countEmoji = require("pretty-text/emoji").countEmoji;
 __resetTranslationTree =
   require("pretty-text/engines/discourse-markdown/emoji").resetTranslationTree;
 

--- a/lib/validators/max_emojis_validator.rb
+++ b/lib/validators/max_emojis_validator.rb
@@ -2,10 +2,7 @@
 
 class MaxEmojisValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unescaped_title = PrettyText.unescape_emoji(Emoji.unicode_unescape(CGI.escapeHTML(value)))
-    if unescaped_title.present? &&
-         unescaped_title.scan(/<img.+?class\s*=\s*'(emoji|emoji emoji-custom)'/).size >
-           SiteSetting.max_emojis_in_title
+    if value.present? && PrettyText.count_emoji(value) > SiteSetting.max_emojis_in_title
       record.errors.add(
         attribute,
         SiteSetting.max_emojis_in_title > 0 ? :max_emojis : :emojis_disabled,

--- a/spec/lib/validators/max_emojis_validator_spec.rb
+++ b/spec/lib/validators/max_emojis_validator_spec.rb
@@ -9,19 +9,32 @@ RSpec.describe MaxEmojisValidator do
   end
 
   shared_examples "validating any topic title" do
-    it "adds an error when emoji count is greater than SiteSetting.max_emojis_in_title" do
+    before do
       SiteSetting.max_emojis_in_title = 3
       CustomEmoji.create!(name: "trout", upload: Fabricate(:upload))
       Emoji.clear_cache
+    end
+
+    it "adds an error when emoji count is greater than SiteSetting.max_emojis_in_title" do
       record.title = "🧐 Lots of emojis here 🎃 :trout: :)"
       validate
       expect(record.errors[:title][0]).to eq(
         I18n.t("errors.messages.max_emojis", max_emojis_count: 3),
       )
+    end
 
+    it "does not add an error when emoji count is exactly SiteSetting.max_emojis_in_title" do
       record.title = ":joy: :blush: :smile: is not only about emojis: Happiness::start()"
       validate
       expect(record.valid?).to be true
+    end
+
+    it "counts emojis with variation selectors" do
+      record.title = "Title with emojis ☠️☠️☠️☠️"
+      validate
+      expect(record.errors[:title][0]).to eq(
+        I18n.t("errors.messages.max_emojis", max_emojis_count: 3),
+      )
     end
   end
 


### PR DESCRIPTION
Previous code did not count emojis followed by variation characters and converted the input several times before determining the number of emojis. The new code scans for all emojis, text emojis or emoji shortcuts and counts them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
