### PR TITLE
FIX: keep first post edit history when moving/merging

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -260,7 +260,13 @@ class PostMover
 
     PostAction.copy(post, new_post)
 
-    attrs_to_update = { reply_count: @reply_count[1] || 0 }
+    PostRevision.copy(post, new_post)
+
+    attrs_to_update = {
+      reply_count: @reply_count[1] || 0,
+      version: post.version,
+      public_version: post.public_version,
+    }
 
     if new_post.post_number != @move_map[post.post_number]
       attrs_to_update[:post_number] = @move_map[post.post_number]

--- a/app/models/post_revision.rb
+++ b/app/models/post_revision.rb
@@ -39,6 +39,17 @@ class PostRevision < ActiveRecord::Base
   def create_notification
     PostActionNotifier.after_create_post_revision(self)
   end
+
+  def self.copy(original_post, target_post)
+    cols_to_copy = (column_names - %w[id post_id]).join(", ")
+
+    DB.exec <<~SQL
+    INSERT INTO post_revisions(post_id, #{cols_to_copy})
+    SELECT #{target_post.id}, #{cols_to_copy}
+    FROM post_revisions
+    WHERE post_id = #{original_post.id}
+    SQL
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
When moving or merging the OP from one topic to another, we create a duplicate and keep the original post and topic, but the post revisions (edit history) were missing from this duplication.

This PR copies `version`, `public_version`, and the edit history from the moved OP to the destination post.