### PR TITLE
PERF: Avoid calling the same translation twice when rendering lists view

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -88,7 +88,8 @@
           <td class='posters'>
             <% t.posters.each do |poster| %>
               <a href="<%= Discourse.base_url %>/u/<%= poster.user.username %>" class="<%= poster.extras %>">
-                <img width="25" height="25" src="<%= poster.user.avatar_template.gsub('{size}', '25') %>" class="avatar" title='<%= h(poster.name_and_description) %>' aria-label='<%= h(poster.name_and_description) %>'>
+                <%- poster_name_and_description = h(poster.name_and_description) %>
+                <img width="25" height="25" src="<%= poster.user.avatar_template.gsub('{size}', '25') %>" class="avatar" title='<%= poster_name_and_description %>' aria-label='<%= poster_name_and_description %>'>
               </a>
             <% end %>
           </td>


### PR DESCRIPTION
Why this change?

In production, this appeared as a small hotspot as where we're calling
`poster.name_and_description` twice which in turns makes a method call
to `I18n.t`. When we're rendering a topic list with many topics and each
topic has many posters, this repeated and unnecessary method call
quickly adds up.

On meta.discourse.org, this is what we saw

![Screenshot from 2023-08-04 13-05-11](https://github.com/discourse/discourse/assets/4335742/d337f045-858e-4f3e-897e-61878048e312)
