### PR TITLE
FIX: Use only first character when looking up emoji

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -39,7 +39,7 @@ Object.entries(aliases).forEach(([name, list]) => {
   list.forEach((alias) => aliasMap.set(alias, name));
 });
 
-function isReplacableInlineEmoji(string, index, inlineEmoji) {
+function isReplaceableInlineEmoji(string, index, inlineEmoji) {
   if (inlineEmoji) {
     return true;
   }
@@ -68,13 +68,13 @@ export function performEmojiUnescape(string, opts) {
 
   const replacementFunction = (m, index) => {
     const isEmoticon = opts.enableEmojiShortcuts && !!allTranslations[m];
-    const isUnicodeEmoticon = !!replacements[m];
+    const isUnicodeEmoticon = !!replacements[m] || !!replacements[m[0]];
     let emojiVal;
 
     if (isEmoticon) {
       emojiVal = allTranslations[m];
     } else if (isUnicodeEmoticon) {
-      emojiVal = replacements[m];
+      emojiVal = replacements[m] || replacements[m[0]];
     } else {
       emojiVal = m.slice(1, m.length - 1);
     }
@@ -95,7 +95,7 @@ export function performEmojiUnescape(string, opts) {
 
     const isReplacable =
       (isEmoticon || hasEndingColon || isUnicodeEmoticon) &&
-      isReplacableInlineEmoji(string, index, opts.inlineEmoji);
+      isReplaceableInlineEmoji(string, index, opts.inlineEmoji);
 
     const title = opts.title ?? emojiVal;
     const tabIndex = opts.tabIndex ? ` tabindex='${opts.tabIndex}'` : "";
@@ -121,11 +121,13 @@ export function performEmojiEscape(string, opts) {
   );
 
   const replacementFunction = (m, index) => {
-    if (isReplacableInlineEmoji(string, index, opts.inlineEmoji)) {
+    if (isReplaceableInlineEmoji(string, index, opts.inlineEmoji)) {
       if (!!allTranslations[m]) {
         return opts.emojiShortcuts ? `:${allTranslations[m]}:` : m;
       } else if (!!replacements[m]) {
         return `:${replacements[m]}:`;
+      } else if (!!replacements[m[0]]) {
+        return `:${replacements[m[0]]}:`;
       }
     }
 

--- a/spec/lib/validators/max_emojis_validator_spec.rb
+++ b/spec/lib/validators/max_emojis_validator_spec.rb
@@ -9,19 +9,32 @@ RSpec.describe MaxEmojisValidator do
   end
 
   shared_examples "validating any topic title" do
-    it "adds an error when emoji count is greater than SiteSetting.max_emojis_in_title" do
+    before do
       SiteSetting.max_emojis_in_title = 3
       CustomEmoji.create!(name: "trout", upload: Fabricate(:upload))
       Emoji.clear_cache
+    end
+
+    it "adds an error when emoji count is greater than SiteSetting.max_emojis_in_title" do
       record.title = "🧐 Lots of emojis here 🎃 :trout: :)"
       validate
       expect(record.errors[:title][0]).to eq(
         I18n.t("errors.messages.max_emojis", max_emojis_count: 3),
       )
+    end
 
+    it "does not add an error when emoji count is exactly SiteSetting.max_emojis_in_title" do
       record.title = ":joy: :blush: :smile: is not only about emojis: Happiness::start()"
       validate
       expect(record.valid?).to be true
+    end
+
+    it "counts emojis with variation selectors" do
+      record.title = "Title with emojis ☠️☠️☠️☠️"
+      validate
+      expect(record.errors[:title][0]).to eq(
+        I18n.t("errors.messages.max_emojis", max_emojis_count: 3),
+      )
     end
   end
 


### PR DESCRIPTION
The other characters may be variation selectors and lookup may result in a false-negative.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
