### PR TITLE
FIX: Account for empty string site setting values when migrating category settings

### DIFF
--- a/db/migrate/20230727015254_change_category_setting_num_auto_bump_daily_default.rb
+++ b/db/migrate/20230727015254_change_category_setting_num_auto_bump_daily_default.rb
@@ -10,15 +10,15 @@ class ChangeCategorySettingNumAutoBumpDailyDefault < ActiveRecord::Migration[7.0
           category_id,
           MAX(
             CASE WHEN (name = 'require_topic_approval')
-            THEN value ELSE NULL END
+            THEN NULLIF(value, '') ELSE NULL END
           )::boolean AS require_topic_approval,
           MAX(
             CASE WHEN (name = 'require_reply_approval')
-            THEN value ELSE NULL END
+            THEN NULLIF(value, '') ELSE NULL END
           )::boolean AS require_reply_approval,
           MAX(
             CASE WHEN (name = 'num_auto_bump_daily')
-            THEN value ELSE NULL END
+            THEN NULLIF(value, '') ELSE NULL END
           )::integer AS num_auto_bump_daily,
           NOW() AS created_at,
           NOW() AS updated_at


### PR DESCRIPTION
### What was happening?

This migration that populates category setting data from custom fields did not account for the fact that custom fields that expect an integer can still be an empty string. An empty string can't be inserted into the new integer type column.

### How does this fix it?

If the setting is an empty string, cast it to NULL.