### PR TITLE
FIX: Attempt to connect with navigator.onLine is initially false

### DIFF
--- a/app/assets/javascripts/discourse/app/services/network-connectivity.js
+++ b/app/assets/javascripts/discourse/app/services/network-connectivity.js
@@ -13,8 +13,6 @@ export default class NetworkConnectivity extends Service {
   constructor() {
     super(...arguments);
 
-    this.setConnectivity(navigator.onLine);
-
     window.addEventListener("offline", () => {
       this.setConnectivity(false);
       this.startTimerToCheckNavigator();
@@ -23,6 +21,10 @@ export default class NetworkConnectivity extends Service {
     window.addEventListener("online", this.pingServerAndSetConnectivity);
 
     window.addEventListener("visibilitychange", this.onFocus);
+
+    if (!navigator.onLine) {
+      this.pingServerAndSetConnectivity();
+    }
   }
 
   @bind


### PR DESCRIPTION
There is a chromium issue where `navigator.onLine` is sometimes `false` when it should be true.

On app boot, instead of immediately marking connectivity as disconnected when `navigator.onLine` is false, we ping the server and start the `navigator.onLine` check loop. If it's false and we ping the server and get a response, then we set to true.