### PR TITLE
UX: Differentiate focus state from hover state

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -68,6 +68,10 @@
         color: Highlight;
       }
     }
+
+    &:focus-visible {
+      @include darken-background($hover-bg-color, 0.1);
+    }
   }
   &[href] {
     color: $text-color;

--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -84,7 +84,8 @@ html {
     }
   }
 
-  .menu-panel .panel-body-bottom .btn:hover {
+  .menu-panel .panel-body-bottom .btn:hover,
+  .menu-panel .panel-body-bottom .btn:focus {
     .d-icon {
       color: var(--primary);
     }


### PR DESCRIPTION
![image](https://github.com/discourse/discourse/assets/368961/85837770-ee17-476f-89bc-c36e7b8acd18)

This only applies to buttons. The main change is that when a button gets a focused state via keyboard, it is highlighted a bit more than the hover (or sometimes selected) state of the button. This helps differentiate the button, especially when navigation via keyboard. 