### PR TITLE
FIX: prevents readonly mode to crash channel_messages#index

### DIFF
--- a/plugins/chat/app/services/chat/list_channel_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_messages.rb
@@ -158,7 +158,9 @@ module Chat
     end
 
     def update_membership_last_viewed_at(guardian:, **)
-      context.membership&.update!(last_viewed_at: Time.zone.now)
+      Scheduler::Defer.later "Chat::ListChannelMessages - defer update_membership_last_viewed_at" do
+        context.membership&.update!(last_viewed_at: Time.zone.now)
+      end
     end
   end
 end

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Chat::Api::ChannelMessagesController do
       fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel) }
 
       before { Discourse.enable_readonly_mode }
+      after { Discourse.disable_readonly_mode }
 
       it "works" do
         get "/chat/api/channels/#{channel.id}/messages"

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Chat::Api::ChannelMessagesController do
       end
     end
 
+    context "when readonly mode" do
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel) }
+
+      before { Discourse.enable_readonly_mode }
+
+      it "works" do
+        get "/chat/api/channels/#{channel.id}/messages"
+
+        expect(response.status).to eq(200)
+      end
+    end
+
     context "when channnel doesn’t exist" do
       it "returns a 404" do
         get "/chat/api/channels/-999/messages"


### PR DESCRIPTION
Prior to this fix `context.membership&.update!(last_viewed_at: Time.zone.now)` would generate an update statement from a GET request which is not permitted by default when in readonly mode.

The usual fix in this case is to check for readonly or rescue an error, however, this common pattern of updating "last seen" or similar can be better handled in a `Schedule::Defer` block, which won't raise the `ActiveRecord::ReadOnlyError` when in readonly and will also prevent the controller to wait for this operation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
