### PR TITLE
UX: Add disabled styling to switch

### DIFF
--- a/app/assets/stylesheets/common/components/d-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/d-toggle-switch.scss
@@ -13,7 +13,7 @@
       background-color: var(--primary-high);
     }
 
-    .d-toggle-switch__checkbox[aria-checked="true"]
+    .d-toggle-switch__checkbox[aria-checked="true"]:not([disabled])
       + .d-toggle-switch__checkbox-slider {
       background-color: var(--tertiary-hover);
     }
@@ -39,6 +39,15 @@
 
   &__checkbox[aria-checked="true"] + .d-toggle-switch__checkbox-slider::before {
     left: calc(var(--toggle-switch-width) - 22px);
+  }
+
+  &__checkbox[disabled] + .d-toggle-switch__checkbox-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+
+    &::before {
+      cursor: not-allowed;
+    }
   }
 
   &__checkbox-slider {


### PR DESCRIPTION
**This PR adds styling to `<DToggleSwitch/>` when in a `disabled` state.** 

Previously the `disabled` attribute would be applied to the `<button>` portion, but since the switch styling is on `<span class="d-toggle-switch__checkbox-slider">` it isn't clear the switch is disabled. So this PR resolves that by ensuring the cursor is shown in a disabled state and the switch itself is dimmer, making it clear that it's disabled.

State|Before|After|
|---|---|---|
|Toggled Off<br><br>Disabled (toggled on)<br><br>Toggled On|<img width="151" alt="Screenshot 2023-08-04 at 15 05 32" src="https://github.com/discourse/discourse/assets/30090424/b2c3889e-8139-4018-94d0-02b39e5ee5df">|<img width="176" alt="Screenshot 2023-08-04 at 15 03 14" src="https://github.com/discourse/discourse/assets/30090424/ec1e597a-e131-4813-a308-e33abe6af374">|
