### PR TITLE
DEV: Avoid site-header error when rendering fails

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -486,7 +486,7 @@ export default SiteHeaderComponent.extend({
       this._resizeObserver = new ResizeObserver((entries) => {
         for (let entry of entries) {
           if (entry.contentRect) {
-            const headerTop = this.header.offsetTop;
+            const headerTop = this.header?.offsetTop;
             document.documentElement.style.setProperty(
               "--header-top",
               `${headerTop}px`


### PR DESCRIPTION
When Ember rendering fails for some reason, `this.header` will be undefined. This causes site-header to raise an error, which often gets printed to the console more obviously than the actual root cause.

This commit makes site-header fail more gracefully in this situation, to avoid it being a red-herring during development/debugging.

e.g., the site-header error here is not relevant to the actual failure:
<img width="548" alt="SCR-20230807-oohx" src="https://github.com/discourse/discourse/assets/6270921/f649c56c-dde4-4fc8-a122-86ef6967c104">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
