### PR TITLE
DEV: Plugin API method to replace post-menu buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -8,6 +8,7 @@ import {
   addButton,
   apiExtraButtons,
   removeButton,
+  replaceButton,
 } from "discourse/widgets/post-menu";
 import {
   addExtraIconRenderer,
@@ -654,6 +655,26 @@ class PluginApi {
    **/
   removePostMenuButton(name, callback) {
     removeButton(name, callback);
+  }
+
+  /**
+   * Replace existing button with a passed in widget
+   *
+   * Example:
+   * ```
+   * api.replacePostMenuButton("like", {
+   *   name: "widget-name",
+   *   buildAttrs: (widget) => {
+   *     return { post: widget.findAncestorModel() };
+   *   },
+   *   shouldRender: (widget) => {
+   *     const post = widget.findAncestorModel();
+   *     return post.id === 1
+   *   }
+   * });
+   **/
+  replacePostMenuButton(name, widget) {
+    replaceButton(name, widget);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -130,7 +130,7 @@ import { _addBulkButton } from "discourse/components/modal/topic-bulk-actions";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.8.0";
+export const PLUGIN_API_VERSION = "1.8.1";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -658,7 +658,7 @@ class PluginApi {
   }
 
   /**
-   * Replace existing button with a passed in widget
+   * Replace an existing button with a widget
    *
    * Example:
    * ```

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -65,14 +65,12 @@ export function buildButton(name, widget) {
 
   // Look for a button replacement, build and return widget attrs if present
   let replacement = _buttonsToReplace[name];
-  if (replacement) {
-    if (replacement.shouldRender(widget)) {
-      return {
-        replaced: true,
-        name: replacement.name,
-        attrs: replacement.buildAttrs(widget),
-      };
-    }
+  if (replacement && replacement?.shouldRender(widget)) {
+    return {
+      replaced: true,
+      name: replacement.name,
+      attrs: replacement.buildAttrs(widget),
+    };
   }
 
   let builder = _builders[name];

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -20,6 +20,7 @@ const _builders = {};
 export let apiExtraButtons = {};
 let _extraButtons = {};
 let _buttonsToRemoveCallbacks = {};
+let _buttonsToReplace = {};
 
 export function addButton(name, builder) {
   _extraButtons[name] = builder;
@@ -32,12 +33,17 @@ export function resetPostMenuExtraButtons() {
 
   _extraButtons = {};
   _buttonsToRemoveCallbacks = {};
+  _buttonsToReplace = {};
 }
 
 export function removeButton(name, callback) {
   // 🏌️
   _buttonsToRemoveCallbacks[name] ??= [];
   _buttonsToRemoveCallbacks[name].push(callback || (() => true));
+}
+
+export function replaceButton(name, replaceWith) {
+  _buttonsToReplace[name] = replaceWith;
 }
 
 function registerButton(name, builder) {
@@ -47,17 +53,30 @@ function registerButton(name, builder) {
 export function buildButton(name, widget) {
   let { attrs, state, siteSettings, settings, currentUser } = widget;
 
-  let shouldAddButton = true;
-
-  if (_buttonsToRemoveCallbacks[name]) {
-    shouldAddButton = !_buttonsToRemoveCallbacks[name].some((c) =>
+  // Return early if the button is supposed to be removed via the plugin API
+  if (
+    _buttonsToRemoveCallbacks[name] &&
+    _buttonsToRemoveCallbacks[name].some((c) =>
       c(attrs, state, siteSettings, settings, currentUser)
-    );
+    )
+  ) {
+    return;
+  }
+
+  // Look for a button replacement, build and return widget attrs if present
+  let replacement = _buttonsToReplace[name];
+  if (replacement) {
+    if (replacement.shouldRender(widget)) {
+      return {
+        replaced: true,
+        name: replacement.name,
+        attrs: replacement.buildAttrs(widget),
+      };
+    }
   }
 
   let builder = _builders[name];
-
-  if (shouldAddButton && builder) {
+  if (builder) {
     let button = builder(attrs, state, siteSettings, settings, currentUser);
     if (button && !button.id) {
       button.id = name;
@@ -438,7 +457,7 @@ registerButton("delete", (attrs) => {
   }
 });
 
-function replaceButton(buttons, find, replace) {
+function _replaceButton(buttons, find, replace) {
   const idx = buttons.indexOf(find);
   if (idx !== -1) {
     buttons[idx] = replace;
@@ -468,6 +487,13 @@ export default createWidget("post-menu", {
 
   attachButton(name) {
     let buttonAtts = buildButton(name, this);
+
+    // If the button is replaced via the plugin API, we need to render the
+    // replacement rather than a button
+    if (buttonAtts?.replaced) {
+      return this.attach(buttonAtts.name, buttonAtts.attrs);
+    }
+
     if (buttonAtts) {
       let button = this.attach(this.settings.buttonType, buttonAtts);
       if (buttonAtts.before) {
@@ -509,8 +535,8 @@ export default createWidget("post-menu", {
 
     // If the post is a wiki, make Edit more prominent
     if (attrs.wiki && attrs.canEdit) {
-      replaceButton(orderedButtons, "edit", "reply-small");
-      replaceButton(orderedButtons, "reply", "wiki-edit");
+      _replaceButton(orderedButtons, "edit", "reply-small");
+      _replaceButton(orderedButtons, "reply", "wiki-edit");
     }
 
     orderedButtons.forEach((i) => {

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,20 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2023-08-08
+
+### Added
+
+- Adds `replacePostMenuButton` which allows plugins to replace a post menu button with a widget.
+
+## [1.8.0] - 2023-07-18
+
+### Added
+- Adds `addSidebarPanel` which is experimental, and adds a Sidebar panel by returning a class which extends from the 
+  BaseCustomSidebarPanel class.
+
+- Adds `setSidebarPanel` which is experimental, and sets the current sidebar panel.
+
 ## [1.7.1] - 2023-07-18
 
 ### Added


### PR DESCRIPTION
Reason described here: https://meta.discourse.org/t/post-voting-has-likes-enabled-but-they-wont-appear/248297/9?u=markvanlan