### PR TITLE
UX: Remove .btn-primary from "Summarize with AI"

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
+++ b/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
@@ -100,7 +100,7 @@ export default createWidget("toggle-topic-summary", {
     const icon = canRegenerate ? "sync" : "magic";
 
     return this.attach("button", {
-      className: "btn btn-primary topic-strategy-summarization",
+      className: "btn topic-strategy-summarization",
       icon,
       title: I18n.t(title),
       translatedTitle: I18n.t(title),
@@ -112,7 +112,7 @@ export default createWidget("toggle-topic-summary", {
 
   hideSummaryButton() {
     return this.attach("button", {
-      className: "btn btn-primary topic-strategy-summarization",
+      className: "btn topic-strategy-summarization",
       icon: "chevron-up",
       title: "summary.buttons.hide",
       label: "summary.buttons.hide",


### PR DESCRIPTION
Leave "reply" as the most prominent button when viewing a topic.

Before|After
-|-
<img width="716" alt="image" src="https://github.com/discourse/discourse/assets/37538241/75e595f0-fdb8-4cb7-af23-64daf222353e">|<img width="734" alt="image" src="https://github.com/discourse/discourse/assets/37538241/6afae9e4-7a24-483c-a1c2-cf21be29d656">
