### PR TITLE
DEV: Add class when replies above exists

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -724,8 +724,11 @@ createWidget("post-article", {
     return `post_${attrs.post_number}`;
   },
 
-  buildClasses(attrs) {
+  buildClasses(attrs, state) {
     let classNames = [];
+    if (state.repliesAbove.length) {
+      classNames.push("replies-above");
+    }
     if (attrs.via_email) {
       classNames.push("via-email");
     }


### PR DESCRIPTION
Prep work for embedded replies style changes. This PR adds `replies-above` as a class to the post in order to have better CSS selection in styling.