### PR TITLE
FIX: disable switch sidebar panel button after click

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
@@ -1,6 +1,6 @@
 {{#each @buttons as |button|}}
   <DButton
-    @action={{action "switchPanel" @currentPanel button}}
+    @action={{action "switchPanel" button}}
     @class="btn-default sidebar__panel-switch-button"
     @icon={{button.switchButtonIcon}}
     @translatedLabel={{button.switchButtonLabel}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
@@ -3,7 +3,7 @@
     @action={{action "switchPanel" button}}
     @class="btn-default sidebar__panel-switch-button"
     @icon={{button.switchButtonIcon}}
-    @disabled={{this.switching}}
+    @disabled={{this.isSwitching}}
     @translatedLabel={{button.switchButtonLabel}}
   />
 {{/each}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.hbs
@@ -3,6 +3,7 @@
     @action={{action "switchPanel" button}}
     @class="btn-default sidebar__panel-switch-button"
     @icon={{button.switchButtonIcon}}
+    @disabled={{this.switching}}
     @translatedLabel={{button.switchButtonLabel}}
   />
 {{/each}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -14,10 +14,10 @@ export default class SwitchPanelButtons extends Component {
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
 
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
-    const destination = url === "/" ? "discovery.latest" : url;
+    const destination = url === "/" ? "/latest" : url;
     this.router.transitionTo(destination).finally(() => {
-      this.sidebarState.setPanel(panel.key);
       this.isSwitching = false;
+      this.sidebarState.setPanel(panel.key);
     });
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -1,18 +1,20 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
 
 export default class SwitchPanelButtons extends Component {
   @service router;
   @service sidebarState;
+  @tracked switching = false;
 
   @action
   switchPanel(panel) {
+    this.switching = true;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
     const destination = url === "/" ? "discovery.latest" : url;
-    this.router
-      .transitionTo(destination)
-      .then(() => this.sidebarState.setPanel(panel.key));
+    this.router.transitionTo(destination).then(() => (this.switching = false));
+    this.sidebarState.setPanel(panel.key);
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -12,12 +12,12 @@ export default class SwitchPanelButtons extends Component {
   switchPanel(panel) {
     this.isSwitching = true;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
-    this.sidebarState.setPanel(panel.key);
 
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
     const destination = url === "/" ? "discovery.latest" : url;
-    this.router
-      .transitionTo(destination)
-      .finally(() => (this.isSwitching = false));
+    this.router.transitionTo(destination).finally(() => {
+      this.sidebarState.setPanel(panel.key);
+      this.isSwitching = false;
+    });
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -12,11 +12,12 @@ export default class SwitchPanelButtons extends Component {
   switchPanel(panel) {
     this.isSwitching = true;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
+    this.sidebarState.setPanel(panel.key);
+
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
     const destination = url === "/" ? "discovery.latest" : url;
     this.router
       .transitionTo(destination)
       .then(() => (this.isSwitching = false));
-    this.sidebarState.setPanel(panel.key);
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -18,6 +18,6 @@ export default class SwitchPanelButtons extends Component {
     const destination = url === "/" ? "discovery.latest" : url;
     this.router
       .transitionTo(destination)
-      .then(() => (this.isSwitching = false));
+      .finally(() => (this.isSwitching = false));
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -7,14 +7,12 @@ export default class SwitchPanelButtons extends Component {
   @service sidebarState;
 
   @action
-  switchPanel(currentPanel, panel) {
+  switchPanel(panel) {
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
-    this.sidebarState.setPanel(panel.key);
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
-    if (url === "/") {
-      this.router.transitionTo("discovery.latest");
-    } else {
-      this.router.transitionTo(url);
-    }
+    const destination = url === "/" ? "discovery.latest" : url;
+    this.router
+      .transitionTo(destination)
+      .then(() => this.sidebarState.setPanel(panel.key));
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -6,15 +6,17 @@ import { tracked } from "@glimmer/tracking";
 export default class SwitchPanelButtons extends Component {
   @service router;
   @service sidebarState;
-  @tracked switching = false;
+  @tracked isSwitching = false;
 
   @action
   switchPanel(panel) {
-    this.switching = true;
+    this.isSwitching = true;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
     const destination = url === "/" ? "discovery.latest" : url;
-    this.router.transitionTo(destination).then(() => (this.switching = false));
+    this.router
+      .transitionTo(destination)
+      .then(() => (this.isSwitching = false));
     this.sidebarState.setPanel(panel.key);
   }
 }


### PR DESCRIPTION
Bug when you click fast on the switch panel button. It is happening because we are not waiting for the transition to finish before update state. Button should be disabled until transition finishes.

In addition, unused `currentPanel` property was removed.


https://github.com/discourse/discourse/assets/72780/f0b42c28-c4c5-4661-a911-5983c8cf1ac0



