### PR TITLE
DEV: Clean up more state in between system tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -463,6 +463,8 @@ RSpec.configure do |config|
     end
 
     page.execute_script("if (typeof MessageBus !== 'undefined') { MessageBus.stop(); }")
+    MessageBus.backend_instance.reset! # Clears all existing backlog from memory backend
+    Scheduler::Defer.do_all_work # Process everything that was added to the defer queue when running the test
     Capybara.reset_sessions!
     Capybara.use_default_driver
     Discourse.redis.flushdb


### PR DESCRIPTION
Why this change?

By default in the test environment, MessageBus uses the memory backend
which means all messages are stored in an in-memory data structure. However,
the in-memory data structure is not cleared after each system test so we
have the potential to be leaking stuff between system tests.

Similarly for the defer queue which process work in another thread, we
want to ensure that the defer queue processes everything it has to do
before the transaction is rolled back.