### PR TITLE
FIX: avoid eager rewrite of /my* routes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -227,14 +227,14 @@ const DiscourseURL = EmberObject.extend({
     path = path.replace(/(https?\:)?\/\/[^\/]+/, "");
 
     // Rewrite /my/* urls
-    let myPath = getURL("/my");
+    let myPath = getURL("/my/");
     const fullPath = getURL(path);
     if (fullPath.startsWith(myPath)) {
       const currentUser = User.current();
       if (currentUser) {
         path = fullPath.replace(
           myPath,
-          userPath(currentUser.get("username_lower"))
+          `${userPath(currentUser.get("username_lower"))}/`
         );
       } else {
         return this.redirectTo("/login-preferences");

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -90,6 +90,19 @@ module("Unit | Utility | url", function () {
     );
   });
 
+  test("routeTo does not rewrite routes started with /my", async function (assert) {
+    logIn();
+    sinon.stub(DiscourseURL, "router").get(() => {
+      return { currentURL: "/" };
+    });
+    sinon.stub(DiscourseURL, "handleURL");
+    DiscourseURL.routeTo("/myfeed");
+    assert.ok(
+      DiscourseURL.handleURL.calledWith(`/myfeed`),
+      "it should navigate to the unmodified route"
+    );
+  });
+
   test("prefixProtocol", async function (assert) {
     assert.strictEqual(
       prefixProtocol("mailto:mr-beaver@aol.com"),


### PR DESCRIPTION
Our `routeTo` implementation has a hard-coded rewrite of personal routes, but it was rewriting all `/my*` routes, affecting more routes than expected.

This PR changes the logic to only act on routes started with `/my/`.