### PR TITLE
FIX: removes useless model reload

### DIFF
--- a/plugins/chat/app/services/chat/auto_join_channel_batch.rb
+++ b/plugins/chat/app/services/chat/auto_join_channel_batch.rb
@@ -62,7 +62,7 @@ module Chat
     end
 
     def publish_new_channel(channel:, added_user_ids:, **)
-      ::Chat::Publisher.publish_new_channel(channel.reload, User.where(id: added_user_ids))
+      ::Chat::Publisher.publish_new_channel(channel, User.where(id: added_user_ids))
     end
   end
 end


### PR DESCRIPTION
I suspect it was moreover possibly related to a flaky spec:

```
  1) Chat::AutoJoinChannelBatch.call when arguments are valid when channel is found when more than one membership is created publishes an event
     Failure/Error: subject(:result) { described_class.call(params) }

     Mocha::ExpectationError:
       unexpected invocation: Chat::Publisher.publish_new_channel(#<Chat::CategoryChannel:0x401f28>, #<User::ActiveRecord_Relation:0x401f50>)
       unsatisfied expectations:
       - expected exactly once, invoked never: Chat::Publisher.publish_new_channel(#<Chat::CategoryChannel:0x401f78>, [#<User:0x401fa0>, #<User:0x401fc8>])
       satisfied expectations:
       - allowed any number of times, invoked once: Chat::Action::CreateMembershipsForAutoJoin.call(has_entries({:channel => #<Chat::CategoryChannel:0x401f78>, :contract => instance_of(Chat::AutoJoinChannelBatch::Contract)}))
       - allowed any number of times, invoked never: Chat::ChannelMembershipManager.new(#<Chat::CategoryChannel:0x401f78>)
       - allowed any number of times, invoked never: #<Mock:0x402018>.recalculate_user_count(any_parameters)
     # ./plugins/chat/app/services/chat/auto_join_channel_batch.rb:65:in `publish_new_channel'
     # ./plugins/chat/app/services/service/base.rb:118:in `instance_exec'
     # ./plugins/chat/app/services/service/base.rb:118:in `call'
     # ./plugins/chat/app/services/service/base.rb:368:in `block in run!'
     # ./plugins/chat/app/services/service/base.rb:368:in `each'
     # ./plugins/chat/app/services/service/base.rb:368:in `run!'
     # ./plugins/chat/app/services/service/base.rb:361:in `run'
     # ./plugins/chat/app/services/service/base.rb:229:in `call'
     # ./plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb:50:in `block (3 levels) in <main>'
     # ./plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb:110:in `block (6 levels) in <main>'
     # ./spec/rails_helper.rb:393:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
