### PR TITLE
DEV: Enhance post action handler events

### DIFF
--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -279,9 +279,9 @@ class PostActionCreator
     if post_action
       case @post_action_type_id
       when *PostActionType.notify_flag_type_ids
-        DiscourseEvent.trigger(:flag_created, post_action)
+        DiscourseEvent.trigger(:flag_created, post_action, self)
       when PostActionType.types[:like]
-        DiscourseEvent.trigger(:like_created, post_action)
+        DiscourseEvent.trigger(:like_created, post_action, self)
       end
     end
 

--- a/lib/post_action_destroyer.rb
+++ b/lib/post_action_destroyer.rb
@@ -54,6 +54,13 @@ class PostActionDestroyer
       GivenDailyLike.decrement_for(@destroyed_by.id)
     end
 
+    case @post_action_type_id
+    when *PostActionType.notify_flag_type_ids
+      DiscourseEvent.trigger(:flag_destroyed, post_action, self)
+    when PostActionType.types[:like]
+      DiscourseEvent.trigger(:like_destroyed, post_action, self)
+    end
+
     UserActionManager.post_action_destroyed(post_action)
     PostActionNotifier.post_action_deleted(post_action)
     result.success = true

--- a/spec/lib/post_action_destroyer_spec.rb
+++ b/spec/lib/post_action_destroyer_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe PostActionDestroyer do
           expect(stats_message).to be_present
           expect(stats_message.data[:like_count]).to eq(0)
         end
+
+        it "triggers the right flag events" do
+          PostActionCreator.new(user, post, PostActionType.types[:inappropriate]).perform
+          events =
+            DiscourseEvent.track_events { PostActionDestroyer.destroy(user, post, :inappropriate) }
+          event_names = events.map { |event| event[:event_name] }
+          expect(event_names).to include(:flag_destroyed)
+          expect(event_names).not_to include(:like_destroyed)
+        end
+
+        it "triggers the right like events" do
+          events = DiscourseEvent.track_events { PostActionDestroyer.destroy(user, post, :like) }
+          event_names = events.map { |event| event[:event_name] }
+          expect(event_names).to include(:like_destroyed)
+          expect(event_names).not_to include(:flag_destroyed)
+        end
+
+        it "sends the right event arguments" do
+          events = DiscourseEvent.track_events { PostActionDestroyer.destroy(user, post, :like) }
+          event = events.find { |e| e[:event_name] == :like_destroyed }
+          expect(event.present?).to eq(true)
+          expect(event[:params].first).to be_instance_of(PostAction)
+          expect(event[:params].second).to be_instance_of(PostActionDestroyer)
+        end
       end
 
       context "when post action doesn’t exist" do


### PR DESCRIPTION
The ActivityPub plugin needs more, and richer, post action events to handle publishing and receiving ActivityPub equivalents to PostActions.

cc @pmusaraj 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
