### PR TITLE
FIX: correctly applies aria-expanded/aria-controls

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.hbs
@@ -9,11 +9,13 @@
       "chat-composer-dropdown__trigger-btn"
       (if @hasActivePanel "has-active-panel")
     }}
+    aria-expanded={{if this.isExpanded "true" "false"}}
+    aria-controls={{this.ariaControls}}
     ...attributes
   />
-
   {{#if this.isExpanded}}
     <ul
+      id="chat-composer-dropdown__list"
       class="chat-composer-dropdown__list"
       {{did-insert this.setupPanel}}
       {{will-destroy this.teardownPanel}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.js
@@ -7,12 +7,17 @@ import { tracked } from "@glimmer/tracking";
 
 export default class ChatComposerDropdown extends Component {
   @tracked isExpanded = false;
+  @tracked tippyInstance = null;
 
   trigger = null;
 
   @action
   setupTrigger(element) {
     this.trigger = element;
+  }
+
+  get ariaControls() {
+    return this.tippyInstance?.popper?.id;
   }
 
   @action
@@ -26,13 +31,13 @@ export default class ChatComposerDropdown extends Component {
 
   @action
   onButtonClick(button) {
-    this._tippyInstance.hide();
+    this.tippyInstance.hide();
     button.action();
   }
 
   @action
   setupPanel(element) {
-    this._tippyInstance = tippy(this.trigger, {
+    this.tippyInstance = tippy(this.trigger, {
       theme: "chat-composer-dropdown",
       trigger: "click",
       zIndex: 1400,
@@ -53,11 +58,11 @@ export default class ChatComposerDropdown extends Component {
       },
     });
 
-    this._tippyInstance.show();
+    this.tippyInstance.show();
   }
 
   @action
   teardownPanel() {
-    this._tippyInstance?.destroy();
+    this.tippyInstance?.destroy();
   }
 }


### PR DESCRIPTION
Prior to this fix `aria-expanded` would only be set to true on first open and not set to false after. Also  `aria-controls` was not defined which is a mandatory aspect of using `aria-expanded`.