### PR TITLE
Fix reference to non-existent `groups#remove_members` in API key scope

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -174,7 +174,7 @@ class ApiKeyScope < ActiveRecord::Base
         },
         groups: {
           manage_groups: {
-            actions: %w[groups#members groups#add_members groups#remove_members],
+            actions: %w[groups#members groups#add_members groups#remove_member],
             params: %i[id],
           },
           administer_groups: {


### PR DESCRIPTION
In essence, consider this a bug report (along with a simple fix) for 403 errors when trying to use the `DELETE` verb on `/groups/{id}/members.json`.

I would have expected that this be caught by existing tests, but it appears that that was not the case. I realize it may be desirable to rename the group controller method to `remove_members` to better reflect what it does.