### PR TITLE
DEV: fixes flakey spec from auto-join-channel-batch

### DIFF
--- a/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
@@ -52,8 +52,9 @@ describe Chat::AutoJoinChannelBatch do
     fab!(:channel) { Fabricate(:chat_channel, auto_join_users: true) }
 
     let(:channel_id) { channel.id }
-    let(:start_user_id) { 0 }
-    let(:end_user_id) { 10 }
+    let(:user_ids) { [Fabricate(:user).id] }
+    let(:start_user_id) { user_ids.first }
+    let(:end_user_id) { user_ids.last }
     let(:params) do
       { channel_id: channel_id, start_user_id: start_user_id, end_user_id: end_user_id }
     end
@@ -84,44 +85,29 @@ describe Chat::AutoJoinChannelBatch do
       end
 
       context "when channel is found" do
-        fab!(:users) { Fabricate.times(2, :user) }
-
-        let(:manager) { mock.responds_like_instance_of(Chat::ChannelMembershipManager) }
-
-        before do
-          Chat::Action::CreateMembershipsForAutoJoin
-            .stubs(:call)
-            .with(has_entries(channel: channel, contract: instance_of(described_class::Contract)))
-            .returns(user_ids)
-          Chat::ChannelMembershipManager.stubs(:new).with(channel).returns(manager)
-          manager.stubs(:recalculate_user_count)
-        end
-
         context "when more than one membership is created" do
-          let(:user_ids) { users.map(&:id) }
+          let(:user_ids) { Fabricate.times(2, :user).map(&:id) }
 
           it "does not recalculate user count" do
-            manager.expects(:recalculate_user_count).never
+            ::Chat::ChannelMembershipManager.any_instance.expects(:recalculate_user_count).never
             result
           end
 
-          it "publishes an event" do
-            Chat::Publisher.expects(:publish_new_channel).with(channel, users)
-            result
+          it "publishes an event for each user" do
+            messages = MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) { result }
+            expect(messages.length).to eq(2)
           end
         end
 
         context "when only one membership is created" do
-          let(:user_ids) { [users.first.id] }
-
           it "recalculates user count" do
-            manager.expects(:recalculate_user_count)
+            ::Chat::ChannelMembershipManager.any_instance.expects(:recalculate_user_count).once
             result
           end
 
           it "publishes an event" do
-            Chat::Publisher.expects(:publish_new_channel).with(channel, [users.first])
-            result
+            messages = MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) { result }
+            expect(messages.length).to eq(1)
           end
         end
       end

--- a/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
@@ -94,7 +94,10 @@ describe Chat::AutoJoinChannelBatch do
           end
 
           it "publishes an event for each user" do
-            messages = MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) { result }
+            messages =
+              MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) do
+                result
+              end
             expect(messages.length).to eq(2)
           end
         end
@@ -106,7 +109,10 @@ describe Chat::AutoJoinChannelBatch do
           end
 
           it "publishes an event" do
-            messages = MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) { result }
+            messages =
+              MessageBus.track_publish(::Chat::Publisher::NEW_CHANNEL_MESSAGE_BUS_CHANNEL) do
+                result
+              end
             expect(messages.length).to eq(1)
           end
         end


### PR DESCRIPTION
The specs were relying a lot on mock and stubs. I suspect that under certain circumstances it didn't play well with fabricators and we ended up with the stub of another spec causing this kind of error:

```
  1) Chat::AutoJoinChannelBatch.call when arguments are valid when channel is found when more than one membership is created publishes an event
     Failure/Error: subject(:result) { described_class.call(params) }

     Mocha::ExpectationError:
       unexpected invocation: Chat::Publisher.publish_new_channel(#<Chat::CategoryChannel:0x39b840>, #<User::ActiveRecord_Relation:0x39b868>)
       unsatisfied expectations:
       - expected exactly once, invoked never: Chat::Publisher.publish_new_channel(#<Chat::CategoryChannel:0x39b890>, [#<User:0x39b8b8>, #<User:0x39b8e0>])
       satisfied expectations:
       - allowed any number of times, invoked once: Chat::Action::CreateMembershipsForAutoJoin.call(has_entries({:channel => #<Chat::CategoryChannel:0x39b890>, :contract => instance_of(Chat::AutoJoinChannelBatch::Contract)}))
       - allowed any number of times, invoked never: Chat::ChannelMembershipManager.new(#<Chat::CategoryChannel:0x39b890>)
       - allowed any number of times, invoked never: #<Mock:0x39b930>.recalculate_user_count(any_parameters)
     # ./plugins/chat/app/services/chat/auto_join_channel_batch.rb:65:in `publish_new_channel'
     # ./plugins/chat/app/services/service/base.rb:118:in `instance_exec'
     # ./plugins/chat/app/services/service/base.rb:118:in `call'
     # ./plugins/chat/app/services/service/base.rb:368:in `block in run!'
     # ./plugins/chat/app/services/service/base.rb:368:in `each'
     # ./plugins/chat/app/services/service/base.rb:368:in `run!'
     # ./plugins/chat/app/services/service/base.rb:361:in `run'
     # ./plugins/chat/app/services/service/base.rb:229:in `call'
     # ./plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb:50:in `block (3 levels) in <main>'
     # ./plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb:110:in `block (6 levels) in <main>'
     # ./spec/rails_helper.rb:412:in `block (2 levels) in <top (required)>'
```

The spec is now simplified and shouldn't have this issue anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
