### PR TITLE
DEV: Remove unused user update params

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -192,10 +192,10 @@ class UsersController < ApplicationController
   def update
     user = fetch_user_from_params
     guardian.ensure_can_edit!(user)
-    attributes = user_params
 
-    # We can't update the username via this route. Use the username route
-    attributes.delete(:username)
+    # Exclude some attributes that are only for user creation because they have
+    # dedicated update routes.
+    attributes = user_params.except(:username, :email, :password)
 
     if params[:user_fields].present?
       attributes[:custom_fields] ||= {}

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2272,6 +2272,23 @@ RSpec.describe UsersController do
           expect(user.card_background_upload).to eq(upload)
         end
 
+        it "does not allow updating attributes specific to user creation" do
+          put "/u/#{user.username}.json",
+              params: {
+                username: "jimtom2",
+                email: "newemail@example.com",
+                password: "123456789",
+              }
+
+          expect(response.status).to eq(200)
+
+          user.reload
+
+          expect(user.username).not_to eq "jimtop2"
+          expect(user.password).not_to eq "123456789"
+          expect(user.email).not_to eq "newemail@example.com"
+        end
+
         it "updates watched tags in everyone tag group" do
           SiteSetting.tagging_enabled = true
           tags = [Fabricate(:tag), Fabricate(:tag)]


### PR DESCRIPTION
There is some shared logic in the `user_params` method we need to keep
for user create and update, but some attributes are only for user
  create, so removing them from user update.

Added a test just to be sure we don't regress in the user_updater
somehow with a call like user.update(attributes).
