### PR TITLE
UX: prevent overscroll behaviour in composer

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -64,6 +64,7 @@
   overflow: auto;
   cursor: default;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 
 .d-editor-input,
@@ -83,6 +84,7 @@
   padding: 10px;
   height: 100%;
   overflow-x: hidden;
+  overscroll-behavior: contain;
   resize: none;
 }
 


### PR DESCRIPTION
When the composer is open and being scrolled in either the input area or the preview area, this will prevent the scrolling from spilling over into the main page.
