### PR TITLE
DEV: upgrades diff-html to 1.0.0-beta.30

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -459,9 +459,6 @@ export default Component.extend(TextareaTextManipulation, {
         previewPromise = loadScript("/javascripts/diffhtml.min.js").then(() => {
           const previewElement =
             this.element.querySelector(".d-editor-preview");
-          // This is a workaround for a known bug in diffHTML
-          // https://github.com/tbranyen/diffhtml/issues/217#issuecomment-1479956332
-          window.diff.release(previewElement);
           window.diff.innerHTML(previewElement, cookedElement.innerHTML);
         });
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chrome-launcher": "^0.15.1",
     "chrome-remote-interface": "^0.31.3",
     "concurrently": "^8.0.1",
-    "diffhtml": "1.0.0-beta.20",
+    "diffhtml": "1.0.0-beta.30",
     "ember-template-lint": "5.10.3",
     "eslint": "^8.37.0",
     "eslint-config-discourse": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,10 +1469,10 @@ devtools-protocol@0.0.981744:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
   integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
 
-diffhtml@1.0.0-beta.20:
-  version "1.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/diffhtml/-/diffhtml-1.0.0-beta.20.tgz#129b403fa152276c9b876188980ca0f9b2540351"
-  integrity sha512-xSSwGb2dkQsTc7Bl910iySH65PkzsCtowfVGMfrmc2fEwvYrhJUpIEIx+3mpZ1wMWVt+t/0ltVwrjQkMJotxLg==
+diffhtml@1.0.0-beta.30:
+  version "1.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/diffhtml/-/diffhtml-1.0.0-beta.30.tgz#725c0a5941bd825675f8a62b701a12a67e7516c7"
+  integrity sha512-yrBteaq309reltj+kAnGqsnpJyQSqmCkd5LAJNAcWNmlgvu+PbiUm9bNxdRYi21BQsQsljTxrjs+AWeeHHghWA==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This update seems to vastly improve performance on large posts and also remove the need for a workaround which has been fixed in this version.

More details in this github discussion:
https://github.com/tbranyen/diffhtml/issues/217

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
