### PR TITLE
FIX: prevents user-tips to interfere with widget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -163,7 +163,7 @@ createWidget("header-notifications", {
       reference: document
         .querySelector(".d-header .badge-notification")
         ?.parentElement?.querySelector(".avatar"),
-      appendTo: document.querySelector(".d-header .panel"),
+      appendTo: document.querySelector(".d-header"),
 
       placement: "bottom-end",
     });


### PR DESCRIPTION
Prior to this fix the user tip was rendered with panels and interfering with widget code. I suspect it was causing the widget node  (revamped-hamburger-menu-wrapper) to not be removed, as a result clickOutside would be called two times, negating the effect of the click.

This fix is just rendering the tip in a different node, preventing the interference, it shouldn't impact behavior as the positioning is absolute.

Example of the problematic DOM, here the menu is closed, yet the node is still present with `[data-click-outside]`:

![Screenshot 2023-08-10 at 23 29 46](https://github.com/discourse/discourse/assets/339945/ce25fe8b-0c28-4ccd-b22f-ec023dc2a39b)



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
