### PR TITLE
FEATURE: add topic voting webhook event type

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -15,7 +15,7 @@ class WebHookEventType < ActiveRecord::Base
   GROUP_USER = 14
   LIKE = 15
   USER_PROMOTED = 16
-  TOPIC_UPVOTE = 17
+  TOPIC_VOTING = 17
 
   has_and_belongs_to_many :web_hooks
 
@@ -32,7 +32,7 @@ class WebHookEventType < ActiveRecord::Base
       ids_to_exclude << ASSIGN
     end
     unless defined?(SiteSetting.voting_enabled) && SiteSetting.voting_enabled
-      ids_to_exclude << TOPIC_UPVOTE
+      ids_to_exclude << TOPIC_VOTING
     end
 
     self.where.not(id: ids_to_exclude)

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -15,6 +15,7 @@ class WebHookEventType < ActiveRecord::Base
   GROUP_USER = 14
   LIKE = 15
   USER_PROMOTED = 16
+  TOPIC_UPVOTE = 17
 
   has_and_belongs_to_many :web_hooks
 
@@ -29,6 +30,9 @@ class WebHookEventType < ActiveRecord::Base
     end
     unless defined?(SiteSetting.assign_enabled) && SiteSetting.assign_enabled
       ids_to_exclude << ASSIGN
+    end
+    unless defined?(SiteSetting.voting_enabled) && SiteSetting.voting_enabled
+      ids_to_exclude << TOPIC_UPVOTE
     end
 
     self.where.not(id: ids_to_exclude)

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -69,3 +69,8 @@ WebHookEventType.seed do |b|
   b.id = WebHookEventType::USER_PROMOTED
   b.name = "user_promoted"
 end
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::TOPIC_UPVOTE
+  b.name = "topic_upvote"
+end

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -71,6 +71,6 @@ WebHookEventType.seed do |b|
 end
 
 WebHookEventType.seed do |b|
-  b.id = WebHookEventType::TOPIC_UPVOTE
-  b.name = "topic_upvote"
+  b.id = WebHookEventType::TOPIC_VOTING
+  b.name = "topic_voting"
 end

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WebHook do
       expect(assign_event_types.count).to eq(1)
 
       SiteSetting.stubs(:voting_enabled).returns(true)
-      voting_event_types = WebHookEventType.active.where(name: "topic_upvote")
+      voting_event_types = WebHookEventType.active.where(name: "topic_voting")
       expect(voting_event_types.count).to eq(1)
     end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -54,8 +54,16 @@ RSpec.describe WebHook do
 
     it "includes enabled plugin web_hooks" do
       SiteSetting.stubs(:solved_enabled).returns(true)
-      web_hook_event_types = WebHookEventType.active.where(name: "solved")
-      expect(web_hook_event_types.count).to eq(1)
+      solved_event_types = WebHookEventType.active.where(name: "solved")
+      expect(solved_event_types.count).to eq(1)
+
+      SiteSetting.stubs(:assign_enabled).returns(true)
+      assign_event_types = WebHookEventType.active.where(name: "assign")
+      expect(assign_event_types.count).to eq(1)
+
+      SiteSetting.stubs(:voting_enabled).returns(true)
+      voting_event_types = WebHookEventType.active.where(name: "topic_upvote")
+      expect(voting_event_types.count).to eq(1)
     end
 
     describe "#active_web_hooks" do


### PR DESCRIPTION
Adds a custom webhook event type for topic voting, which the `discourse-topic-voting` plugin will be responsible for.