### PR TITLE
FIX: correct bulk invite expire time for DST

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -134,7 +134,7 @@ class Invite < ActiveRecord::Base
 
   def self.generate(invited_by, opts = nil)
     opts ||= {}
-    Time.zone = invited_by.user_option.timezone if invited_by&.user_option&.timezone
+    time_zone = Time.find_zone(invited_by&.user_option&.timezone) || Time.zone
     email = Email.downcase(opts[:email]) if opts[:email].present?
 
     raise UserExists.new(new.user_exists_error_msg(email)) if find_user_by_email(email)
@@ -170,7 +170,7 @@ class Invite < ActiveRecord::Base
       invite.update_columns(
         created_at: Time.zone.now,
         updated_at: Time.zone.now,
-        expires_at: opts[:expires_at] || Time.zone.now + SiteSetting.invite_expiry_days.days,
+        expires_at: opts[:expires_at] || time_zone.now + SiteSetting.invite_expiry_days.days,
         emailed_status: emailed_status,
       )
     else
@@ -180,7 +180,7 @@ class Invite < ActiveRecord::Base
       create_args[:email] = email
       create_args[:emailed_status] = emailed_status
       create_args[:expires_at] = opts[:expires_at] ||
-        Time.zone.now + SiteSetting.invite_expiry_days.days
+        time_zone.now + SiteSetting.invite_expiry_days.days
 
       invite = Invite.create!(create_args)
     end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -134,7 +134,7 @@ class Invite < ActiveRecord::Base
 
   def self.generate(invited_by, opts = nil)
     opts ||= {}
-
+    Time.zone = invited_by.user_option.timezone if invited_by&.user_option&.timezone
     email = Email.downcase(opts[:email]) if opts[:email].present?
 
     raise UserExists.new(new.user_exists_error_msg(email)) if find_user_by_email(email)
@@ -170,7 +170,7 @@ class Invite < ActiveRecord::Base
       invite.update_columns(
         created_at: Time.zone.now,
         updated_at: Time.zone.now,
-        expires_at: opts[:expires_at] || SiteSetting.invite_expiry_days.days.from_now,
+        expires_at: opts[:expires_at] || Time.zone.now + SiteSetting.invite_expiry_days.days,
         emailed_status: emailed_status,
       )
     else
@@ -179,7 +179,8 @@ class Invite < ActiveRecord::Base
       create_args[:invited_by] = invited_by
       create_args[:email] = email
       create_args[:emailed_status] = emailed_status
-      create_args[:expires_at] = opts[:expires_at] || SiteSetting.invite_expiry_days.days.from_now
+      create_args[:expires_at] = opts[:expires_at] ||
+        Time.zone.now + SiteSetting.invite_expiry_days.days
 
       invite = Invite.create!(create_args)
     end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -134,3 +134,11 @@ Fabricator(:bot, from: :user) do
     [(min_id || 0) - 1, -10].min
   end
 end
+
+Fabricator(:east_coast_user, from: :user) do
+  email "eastcoast@tz.com"
+  after_create do |user|
+    user.user_option = UserOption.new(timezone: "Eastern Time (US & Canada)")
+    user.save
+  end
+end

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Jobs::BulkInvite do
         freeze_time DateTime.parse("2023-10-31 06:00:00 -0400")
         described_class.new.execute(current_user_id: east_coast_user.id, invites: invites)
         invite = Invite.first
-        expect(invite.expires_at.localtime.hour).to equal(6)
+        expect(invite.expires_at.hour).to equal(6)
       end
     end
 

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Jobs::BulkInvite do
   describe "#execute" do
     fab!(:user) { Fabricate(:user) }
     fab!(:admin) { Fabricate(:admin) }
+    fab!(:east_coast_user) { Fabricate(:east_coast_user) }
     fab!(:group1) { Fabricate(:group, name: "group1") }
     fab!(:group2) { Fabricate(:group, name: "group2") }
     fab!(:topic) { Fabricate(:topic) }
@@ -54,10 +55,13 @@ RSpec.describe Jobs::BulkInvite do
     it "handles daylight savings time correctly" do
       # EDT (-04:00) transitions to EST (-05:00) on the first Sunday in November.
       # Freeze time to the last Day of October, so that the creation and expiration date will be in different time zones.
-      freeze_time DateTime.parse("2023-10-31 6:00")
-      described_class.new.execute(current_user_id: admin.id, invites: invites)
-      invite = Invite.last
-      expect(invite.expires_at.hour).to equal(6)
+
+      Time.use_zone("Eastern Time (US & Canada)") do
+        freeze_time DateTime.parse("2023-10-31 06:00:00 -0400")
+        described_class.new.execute(current_user_id: east_coast_user.id, invites: invites)
+        invite = Invite.first
+        expect(invite.expires_at.localtime.hour).to equal(6)
+      end
     end
 
     it "does not create invited groups for automatic groups" do

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Jobs::BulkInvite do
       expect(post.raw).to include("1 error")
     end
 
+    it "handles daylight savings time correctly" do
+      # EDT (-04:00) transitions to EST (-05:00) on the first Sunday in November.
+      # Freeze time to the last Day of October, so that the creation and expiration date will be in different time zones.
+      freeze_time DateTime.parse("2023-10-31 6:00")
+      described_class.new.execute(current_user_id: admin.id, invites: invites)
+      invite = Invite.last
+      expect(invite.expires_at.hour).to equal(6)
+    end
+
     it "does not create invited groups for automatic groups" do
       group2.update!(automatic: true)
 


### PR DESCRIPTION
This is a bug that happens only when the current date is less than 90 days from a date on which the time zone transitions into or out of Daylight Savings Time.

In these conditions, bulk invites show the time of day of their expiration as being 1 hour later than the current time. 

Whereas it should match the time of day the invite was generated.

This is because the server has not been using the user's timezone in calculating the expiration time of day. This PR fixes issue by considering the user's timezone when doing the date math.

https://meta.discourse.org/t/bulk-invite-logic-to-generate-expire-date-bug/274689