### PR TITLE
DEV: Add @model support in d-navigation-item

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation-item.hbs
@@ -4,7 +4,13 @@
   class={{@class}}
   ...attributes
 >
-  <LinkTo @route={{@route}}>
-    {{yield}}
-  </LinkTo>
+  {{#if @model}}
+    <LinkTo @route={{@route}} @model={{@model}}>
+      {{yield}}
+    </LinkTo>
+  {{else}}
+    <LinkTo @route={{@route}}>
+      {{yield}}
+    </LinkTo>
+  {{/if}}
 </li>

--- a/app/assets/javascripts/discourse/app/components/d-navigation-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation-item.hbs
@@ -4,8 +4,8 @@
   class={{@class}}
   ...attributes
 >
-  {{#if @model}}
-    <LinkTo @route={{@route}} @model={{@model}}>
+  {{#if this.models}}
+    <LinkTo @route={{@route}} @models={{this.models}}>
       {{yield}}
     </LinkTo>
   {{else}}

--- a/app/assets/javascripts/discourse/app/components/d-navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation-item.js
@@ -26,4 +26,8 @@ export default class DNavigationItem extends Component {
       return "page";
     }
   }
+
+  get models() {
+    return this.args.models || (this.args.model ? [this.args.model] : null);
+  }
 }

--- a/app/assets/javascripts/discourse/app/components/d-navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation-item.js
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+import { makeArray } from "discourse-common/lib/helpers";
 
 export default class DNavigationItem extends Component {
   @service router;
@@ -28,6 +29,6 @@ export default class DNavigationItem extends Component {
   }
 
   get models() {
-    return this.args.models || (this.args.model ? [this.args.model] : null);
+    return makeArray(this.args.models || this.args.model);
   }
 }


### PR DESCRIPTION
Some routes require and additional model to be linked properly.

It is necessary to add the if-confition to check the presence of the `@model` parameter
because `<LinkTo />` renders and additional  `#` in the anchor's href if we pass null in the
parameter `@model`.