### PR TITLE
DEV: Resolve user_option deprecation

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/user-tips.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/user-tips.js
@@ -33,8 +33,6 @@ export default {
       return;
     }
 
-    this.currentUser.set("seen_popups", seenUserTips);
-
     if (!this.currentUser.user_option) {
       this.currentUser.set("user_option", {});
     }


### PR DESCRIPTION
Setting user_options directly on the user object is deprecated (see https://github.com/discourse/discourse/blob/0b56af6f58/app/assets/javascripts/discourse/app/models/user.js#L150-L165). We're already setting it in the correct way a few lines later, so this line can be removed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
