### PR TITLE
UX: ensures user-status-picker’s input is autofocused

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-status-picker.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-status-picker.hbs
@@ -24,7 +24,6 @@
       {{on "input" this.setDefaultEmoji}}
       {{on "focus" this.focus}}
       {{on "blur" this.blur}}
-      autofocus="true"
     />
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/components/user-status-picker.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-status-picker.hbs
@@ -24,6 +24,7 @@
       {{on "input" this.setDefaultEmoji}}
       {{on "focus" this.focus}}
       {{on "blur" this.blur}}
+      autofocus="true"
     />
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/components/user-status-picker.js
+++ b/app/assets/javascripts/discourse/app/components/user-status-picker.js
@@ -15,6 +15,8 @@ export default class UserStatusPicker extends Component {
     if (!this.status) {
       this.set("status", {});
     }
+
+    document.querySelector(".user-status-description")?.focus();
   }
 
   @computed("status.emoji")

--- a/app/assets/javascripts/discourse/tests/integration/components/user-status-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-status-picker-test.js
@@ -26,6 +26,12 @@ module("Integration | Component | user-status-picker", function (hooks) {
     );
   });
 
+  test("it focuses the input on insert", async function (assert) {
+    await render(hbs`<UserStatusPicker />`);
+
+    assert.dom(".user-status-description").isFocused();
+  });
+
   test("it picks emoji", async function (assert) {
     const status = {
       emoji: "tooth",


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
