### PR TITLE
FIX: revert previously removed mentions transformation on the client

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
@@ -1,0 +1,43 @@
+import getURL from "discourse-common/lib/get-url";
+
+const domParser = new DOMParser();
+
+export default function transform(cooked, categories) {
+  let html = domParser.parseFromString(cooked, "text/html");
+  transformMentions(html);
+  transformCategoryTagHashes(html, categories);
+  return html.body.innerHTML;
+}
+
+function transformMentions(html) {
+  (html.querySelectorAll("span.mention") || []).forEach((mentionSpan) => {
+    let mentionLink = document.createElement("a");
+    let mentionText = document.createTextNode(mentionSpan.innerText);
+    mentionLink.classList.add("mention");
+    mentionLink.appendChild(mentionText);
+    mentionLink.href = getURL(`/u/${mentionSpan.innerText.substring(1)}`);
+    mentionSpan.parentNode.replaceChild(mentionLink, mentionSpan);
+  });
+}
+
+function transformCategoryTagHashes(html, categories) {
+  (html.querySelectorAll("span.hashtag") || []).forEach((hashSpan) => {
+    const categoryTagName = hashSpan.innerText.substring(1);
+    const matchingCategory = categories.find(
+      (category) =>
+        category.name.toLowerCase() === categoryTagName.toLowerCase()
+    );
+    const href = getURL(
+      matchingCategory
+        ? `/c/${matchingCategory.name}/${matchingCategory.id}`
+        : `/tag/${categoryTagName}`
+    );
+
+    let hashLink = document.createElement("a");
+    let hashText = document.createTextNode(hashSpan.innerText);
+    hashLink.classList.add("hashtag");
+    hashLink.appendChild(hashText);
+    hashLink.href = href;
+    hashSpan.parentNode.replaceChild(hashLink, hashSpan);
+  });
+}

--- a/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
@@ -5,7 +5,6 @@ const domParser = new DOMParser();
 export default function transform(cooked, categories) {
   let html = domParser.parseFromString(cooked, "text/html");
   transformMentions(html);
-  transformCategoryTagHashes(html, categories);
   return html.body.innerHTML;
 }
 
@@ -17,27 +16,5 @@ function transformMentions(html) {
     mentionLink.appendChild(mentionText);
     mentionLink.href = getURL(`/u/${mentionSpan.innerText.substring(1)}`);
     mentionSpan.parentNode.replaceChild(mentionLink, mentionSpan);
-  });
-}
-
-function transformCategoryTagHashes(html, categories) {
-  (html.querySelectorAll("span.hashtag") || []).forEach((hashSpan) => {
-    const categoryTagName = hashSpan.innerText.substring(1);
-    const matchingCategory = categories.find(
-      (category) =>
-        category.name.toLowerCase() === categoryTagName.toLowerCase()
-    );
-    const href = getURL(
-      matchingCategory
-        ? `/c/${matchingCategory.name}/${matchingCategory.id}`
-        : `/tag/${categoryTagName}`
-    );
-
-    let hashLink = document.createElement("a");
-    let hashText = document.createTextNode(hashSpan.innerText);
-    hashLink.classList.add("hashtag");
-    hashLink.appendChild(hashText);
-    hashLink.href = href;
-    hashSpan.parentNode.replaceChild(hashLink, hashSpan);
   });
 }

--- a/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
@@ -3,7 +3,7 @@ import getURL from "discourse-common/lib/get-url";
 const domParser = new DOMParser();
 
 export default function transform(cooked, categories) {
-  let html = domParser.parseFromString(cooked, "text/html");
+  const html = domParser.parseFromString(cooked, "text/html");
   transformMentions(html);
   return html.body.innerHTML;
 }

--- a/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/simple-category-hash-mention-transform.js
@@ -2,7 +2,7 @@ import getURL from "discourse-common/lib/get-url";
 
 const domParser = new DOMParser();
 
-export default function transform(cooked, categories) {
+export default function transform(cooked) {
   const html = domParser.parseFromString(cooked, "text/html");
   transformMentions(html);
   return html.body.innerHTML;

--- a/plugins/chat/assets/javascripts/discourse/lib/transform-mentions.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/transform-mentions.js
@@ -2,13 +2,13 @@ import getURL from "discourse-common/lib/get-url";
 
 const domParser = new DOMParser();
 
-export default function transform(cooked) {
+export default function transformMentions(cooked) {
   const html = domParser.parseFromString(cooked, "text/html");
-  transformMentions(html);
+  transform(html);
   return html.body.innerHTML;
 }
 
-function transformMentions(html) {
+function transform(html) {
   (html.querySelectorAll("span.mention") || []).forEach((mentionSpan) => {
     let mentionLink = document.createElement("a");
     let mentionText = document.createTextNode(mentionSpan.innerText);

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -192,10 +192,7 @@ export default class ChatMessage {
     } else {
       const cookFunction = await generateCookFunction(markdownOptions);
       ChatMessage.cookFunction = (raw) => {
-        return simpleCategoryHashMentionTransform(
-          cookFunction(raw),
-          site.categories
-        );
+        return simpleCategoryHashMentionTransform(cookFunction(raw));
       };
 
       this.cooked = ChatMessage.cookFunction(this.message);

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -5,6 +5,7 @@ import ChatMessageReaction from "discourse/plugins/chat/discourse/models/chat-me
 import Bookmark from "discourse/models/bookmark";
 import I18n from "I18n";
 import { generateCookFunction } from "discourse/lib/text";
+import simpleCategoryHashMentionTransform from "discourse/plugins/chat/discourse/lib/simple-category-hash-mention-transform";
 import { getOwner } from "discourse-common/lib/get-owner";
 import discourseLater from "discourse-common/lib/later";
 
@@ -191,7 +192,10 @@ export default class ChatMessage {
     } else {
       const cookFunction = await generateCookFunction(markdownOptions);
       ChatMessage.cookFunction = (raw) => {
-        return cookFunction(raw);
+        return simpleCategoryHashMentionTransform(
+          cookFunction(raw),
+          site.categories
+        );
       };
 
       this.cooked = ChatMessage.cookFunction(this.message);

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -5,7 +5,7 @@ import ChatMessageReaction from "discourse/plugins/chat/discourse/models/chat-me
 import Bookmark from "discourse/models/bookmark";
 import I18n from "I18n";
 import { generateCookFunction } from "discourse/lib/text";
-import simpleCategoryHashMentionTransform from "discourse/plugins/chat/discourse/lib/simple-category-hash-mention-transform";
+import transformMentions from "discourse/plugins/chat/discourse/lib/transform-mentions";
 import { getOwner } from "discourse-common/lib/get-owner";
 import discourseLater from "discourse-common/lib/later";
 
@@ -192,7 +192,7 @@ export default class ChatMessage {
     } else {
       const cookFunction = await generateCookFunction(markdownOptions);
       ChatMessage.cookFunction = (raw) => {
-        return simpleCategoryHashMentionTransform(cookFunction(raw));
+        return transformMentions(cookFunction(raw));
       };
 
       this.cooked = ChatMessage.cookFunction(this.message);


### PR DESCRIPTION
This partially reverts 2ecc829.

The problem is that if we don't transform mentions right away, there is a noticeable lag before a mention gets fully rendered:

https://github.com/discourse/discourse/assets/1274517/63817b5c-2ff1-4479-8927-9d62ff9a9e48

even when running locally:

https://github.com/discourse/discourse/assets/1274517/61610eae-1894-4c9f-9223-f26c2338a2bb

While with this transformation, everything is super smooth:

https://github.com/discourse/discourse/assets/1274517/f1c6cef7-b5e8-4811-a485-6c4b6c5f9df1

I'm reverting that change only for mentions. Another part was about category hashtags, but unfortunately they lag both with and without this transformation. We need to address them separately.

cc @martin-brennan




