### PR TITLE
FIX: Topic summary UI fixes.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/summary-box.hbs
+++ b/app/assets/javascripts/discourse/app/components/summary-box.hbs
@@ -11,7 +11,7 @@
       {{#if this.canCollapseSummary}}
         <DButton
           @class="btn-primary topic-strategy-summarization"
-          @action={{this.toggleSummary}}
+          @action={{this.collapseSummary}}
           @title="summary.buttons.hide"
           @label="summary.buttons.hide"
           @icon="chevron-up"
@@ -41,7 +41,7 @@
 
   {{#if this.showSummaryBox}}
     <article class="summary-box">
-      {{#if this.loadingSummary}}
+      {{#if (and this.loadingSummary (not this.summary))}}
         <AiSummarySkeleton />
       {{else}}
         <div class="generated-summary">{{this.summary}}</div>

--- a/app/assets/javascripts/discourse/app/components/summary-box.js
+++ b/app/assets/javascripts/discourse/app/components/summary-box.js
@@ -45,7 +45,6 @@ export default class SummaryBox extends Component {
     if (topicSummary.summarized_text) {
       cookAsync(topicSummary.summarized_text).then((cooked) => {
         this.summary = cooked;
-        this.loadingSummary = false;
       });
     }
 
@@ -58,6 +57,7 @@ export default class SummaryBox extends Component {
       this.canRegenerate = topicSummary.outdated && topicSummary.can_regenerate;
 
       this.canCollapseSummary = !this.canRegenerate;
+      this.loadingSummary = false;
     }
   }
 


### PR DESCRIPTION
Hide summary wasn't working because it called the wrong action, and we must disabled the summarize button until streaming finishes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
