### PR TITLE
FIX: Adjust badge overflow ellipsis

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -44,7 +44,6 @@
     span.badge-category {
       color: var(--primary-high);
       overflow: hidden;
-      text-overflow: ellipsis;
       .extra-info-wrapper & {
         color: var(--header-primary);
       }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -189,6 +189,7 @@
 
   .topic-item-stats__category-tags {
     margin-right: 0.5em;
+    max-width: 90%;
 
     .discourse-tags {
       display: inline;
@@ -205,6 +206,7 @@
     }
 
     .badge-wrapper {
+      max-width: 100%;
       vertical-align: bottom;
     }
 


### PR DESCRIPTION
This PR fixes a minor visual bug where long category names would increase with viewport width on mobile. It also removes an unnecessary line from scss.

### Before
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/00bce7d5-a2db-48c8-9835-01a6a8870fe7">


### After
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/33e3f8c9-3533-44b1-a191-be360ea70d57">
