### PR TITLE
FEATURE: Digest suppression by tags

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -587,8 +587,8 @@ class Topic < ActiveRecord::Base
     end
     if SiteSetting.digest_suppress_tags.present?
       topics =
-        topics.joins("JOIN topic_tags tg ON topics.id = tg.topic_id").where(
-          "tg.tag_id NOT IN (?)",
+        topics.joins("LEFT JOIN topic_tags tg ON topics.id = tg.topic_id").where(
+          "tg.tag_id NOT IN (?) OR tg.tag_id IS NULL",
           SiteSetting.digest_suppress_tags.split("|").map(&:to_i),
         )
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -585,6 +585,13 @@ class Topic < ActiveRecord::Base
           SiteSetting.digest_suppress_categories.split("|").map(&:to_i),
         )
     end
+    if SiteSetting.digest_suppress_tags.present?
+      topics =
+        topics.joins("JOIN topic_tags tg ON topics.id = tg.topic_id").where(
+          "tg.tag_id NOT IN (?)",
+          SiteSetting.digest_suppress_tags.split("|").map(&:to_i),
+        )
+    end
     remove_category_ids << SiteSetting.shared_drafts_category if SiteSetting.shared_drafts_enabled?
     if remove_category_ids.present?
       remove_category_ids.uniq!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2149,6 +2149,7 @@ en:
     digest_min_excerpt_length: "Minimum post excerpt in the email summary, in characters."
     suppress_digest_email_after_days: "Suppress summary emails for users not seen on the site for more than (n) days."
     digest_suppress_categories: "Suppress these categories from summary emails."
+    digest_suppress_tags: "Suppress these tags from summary emails."
     disable_digest_emails: "Disable summary emails for all users."
     apply_custom_styles_to_digest: "Custom email template and css are applied to summary emails."
     email_accent_bg_color: "The accent color to be used as the background of some elements in HTML emails. Enter a color name ('red') or hex value ('#FF0000')."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1156,6 +1156,9 @@ email:
   digest_suppress_categories:
     type: category_list
     default: ""
+  digest_suppress_tags:
+    type: tag_list
+    default: ""
   disable_digest_emails:
     default: false
     client: true

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2363,6 +2363,26 @@ RSpec.describe Topic do
         expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
       end
 
+      it "doesn't return topics from suppressed tags" do
+        category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)
+        topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
+        tag = Fabricate(:tag)
+        Fabricate(:topic_tag, topic: topic, tag: tag)
+
+        SiteSetting.digest_suppress_tags = "#{tag.id}"
+        topics = Topic.for_digest(user, 1.year.ago, top_order: true)
+        expect(topics).to be_blank
+
+        Fabricate(
+          :topic_user,
+          user: user,
+          topic: topic,
+          notification_level: TopicUser.notification_levels[:regular],
+          )
+
+        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
+      end
+
       it "doesn't return topics from TL0 users" do
         new_user = Fabricate(:user, trust_level: 0)
         Fabricate(:topic, user: new_user, created_at: 1.minute.ago)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2378,7 +2378,7 @@ RSpec.describe Topic do
           user: user,
           topic: topic,
           notification_level: TopicUser.notification_levels[:regular],
-          )
+        )
 
         expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
       end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2366,12 +2366,13 @@ RSpec.describe Topic do
       it "doesn't return topics from suppressed tags" do
         category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)
         topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
+        topic2 = Fabricate(:topic, category: category, created_at: 1.minute.ago)
         tag = Fabricate(:tag)
         Fabricate(:topic_tag, topic: topic, tag: tag)
 
         SiteSetting.digest_suppress_tags = "#{tag.id}"
         topics = Topic.for_digest(user, 1.year.ago, top_order: true)
-        expect(topics).to be_blank
+        expect(topics).to eq([topic2])
 
         Fabricate(
           :topic_user,
@@ -2380,7 +2381,7 @@ RSpec.describe Topic do
           notification_level: TopicUser.notification_levels[:regular],
         )
 
-        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
+        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to eq([topic2])
       end
 
       it "doesn't return topics from TL0 users" do


### PR DESCRIPTION
**Context**
Discourse allows the distribution of emails with Digests. These Digests can be tailored using `SiteSettings`

**Problem**
The customer wants to be able to suppress Topics by `tags`

**Solution**
Add a `digest_suppress_tags` `SiteSetting` to allow customers to suppress Topics by `tags` and implement the correct logic in the `Topic` model 