### PR TITLE
FIX: Compact tag picker input not focused in iOS (#22922)

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1004,6 +1004,10 @@ export default Component.extend(
           this.selectKit.options.filterable || this.selectKit.options.allowAny,
       });
 
+      if (this.selectKit.options.useHeaderFilter) {
+        this._focusFilterInput();
+      }
+
       this.triggerSearch();
 
       this._safeAfterRender(() => {
@@ -1044,19 +1048,33 @@ export default Component.extend(
         return;
       }
 
+      // setting focus as early as possible is best for iOS
+      // because render/promise delays may cause keyboard not to show
+      if (!forceHeader) {
+        this._focusFilterInput();
+      }
+
       this._safeAfterRender(() => {
         const input = this.getFilterInput();
         if (!forceHeader && input) {
-          input.focus({ preventScroll: true });
-
-          if (typeof input.selectionStart === "number") {
-            input.selectionStart = input.selectionEnd = input.value.length;
-          }
+          this._focusFilterInput();
         } else if (!this.selectKit.options.preventHeaderFocus) {
           const headerContainer = this.getHeader();
           headerContainer && headerContainer.focus({ preventScroll: true });
         }
       });
+    },
+
+    _focusFilterInput() {
+      const input = this.getFilterInput();
+
+      if (input && document.activeElement !== input) {
+        input.focus({ preventScroll: true });
+
+        if (typeof input.selectionStart === "number") {
+          input.selectionStart = input.selectionEnd = input.value.length;
+        }
+      }
     },
 
     getFilterInput() {


### PR DESCRIPTION
Backporting to stable for commit 5dc3a27.

Should fix an iOS regression in f5e8e73. iOS does not pull up the keyboard if the `.focus()` call is delayed by a rendering timeout or an asynchronous ajax call. This PR adds earlier `.focus()` calls if the input element is present.
