### PR TITLE
DEV: move xss dependency into core

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const EmberApp = require("ember-cli/lib/broccoli/ember-app");
-const { resolve, join } = require("path");
+const path = require("path");
 const mergeTrees = require("broccoli-merge-trees");
 const concat = require("broccoli-concat");
 const { createI18nTree } = require("./lib/translation-plugin");
@@ -15,7 +15,7 @@ const generateWorkboxTree = require("./lib/workbox-tree-builder");
 process.env.BROCCOLI_ENABLED_MEMOIZE = true;
 
 module.exports = function (defaults) {
-  const discourseRoot = resolve("../../../..");
+  const discourseRoot = path.resolve("../../../..");
   const vendorJs = discourseRoot + "/vendor/assets/javascripts/";
 
   // Silence deprecations which we are aware of - see `lib/deprecation-silencer.js`
@@ -179,10 +179,6 @@ module.exports = function (defaults) {
       "/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js"
   );
 
-  // See: https://github.com/embroider-build/embroider/issues/1574
-  // Specifically, markdownItBundleTree is triggering the MacrosConfig error
-  finalizeEmbroiderMacrosConfigs(app, resolve("."), app.project);
-
   const discoursePluginsTree = app.project
     .findAddonByName("discourse-plugins")
     .generatePluginsTree();
@@ -220,21 +216,3 @@ module.exports = function (defaults) {
     discoursePluginsTree,
   ]);
 };
-
-// See: https://github.com/embroider-build/embroider/issues/1574
-function finalizeEmbroiderMacrosConfigs(appInstance, appRoot, parent) {
-  parent.initializeAddons?.();
-
-  for (let addon of parent.addons) {
-    if (addon.name === "@embroider/macros") {
-      const MacrosConfig = require(join(
-        addon.packageRoot,
-        "src",
-        "macros-config"
-      )).default;
-      MacrosConfig.for(appInstance, appRoot).finalize();
-    } else {
-      finalizeEmbroiderMacrosConfigs(appInstance, appRoot, addon);
-    }
-  }
-}

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -108,7 +108,8 @@
     "workbox-expiration": "^7.0.0",
     "workbox-routing": "^7.0.0",
     "workbox-strategies": "^7.0.0",
-    "workbox-sw": "^7.0.0"
+    "workbox-sw": "^7.0.0",
+    "xss": "^1.0.14"
   },
   "engines": {
     "node": "16.* || >= 18",

--- a/app/assets/javascripts/pretty-text/addon/loader-shims.js
+++ b/app/assets/javascripts/pretty-text/addon/loader-shims.js
@@ -1,7 +1,0 @@
-import { importSync } from "@embroider/macros";
-import loaderShim from "discourse-common/lib/loader-shim";
-
-// AMD shims for the addon, see the comment in loader-shim.js
-// These effectively become public APIs for plugins, so add/remove them carefully
-// Note that this is included into the main app bundle for core
-loaderShim("xss", () => importSync("xss"));

--- a/app/assets/javascripts/pretty-text/addon/pretty-text.js
+++ b/app/assets/javascripts/pretty-text/addon/pretty-text.js
@@ -1,4 +1,3 @@
-import "./loader-shims";
 import {
   cook as cookIt,
   setup as setupIt,

--- a/app/assets/javascripts/pretty-text/package.json
+++ b/app/assets/javascripts/pretty-text/package.json
@@ -14,12 +14,10 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@embroider/macros": "^1.13.1",
     "discourse-common": "1.0.0",
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.3.0",
-    "xss": "^1.0.14"
+    "ember-cli-htmlbars": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.10",


### PR DESCRIPTION
This resolves the issue in #23064.

This issue arises because we need to produce the trees for the auxilary bundles in `ember-cli-build.js` to pass these trees as argument to `app.toTree()`. In order to produce these trees, the code internally need to set up babel, which deep-clones the addons' babel configs.

When using `@embroider/macros`, the addon's babel config includes a `MacrosConfig` object which is not supposed to be touched until the configs are "finalized". In a classic build, the finalization step happens when `app.toTree()` is called. In Embroider, this happens somewhere deeper inside `CompatApp`.

We need to produce these auxilary bundle trees before we call `app.toTree()` or before constructing `CompatApp` because they need to be passed as arguments to these functions. So this poses a tricky chicken-and-egg timing issue. It was difficult to find a workaround for this that works for both the classic and Embroider build pipeline.

Of all the internal addons that uses the auxilary bundle pattern, this only affets `pretty-text` as it is (for now, at least) the only addon that uses `@embroider/macros`.

Taking a step back, the only reason (for now, at least) it was introduced was for the loader shim for the `xss` package. This package is actually used inside the lazily loaded markdown-it bundle. However, we didn't have a better way to include the dep into the lazy bundle directly, so it ends up going into the main addon tree, and, inturns, the discourse core bundle.

In core's main loader shim manifest, we already have an entry for `xss`. This was perhaps a mistake at the time, but it doesn't make a difference – as mentioned above, `xss` needs to be included into the main bundle anyway.

So, for now, the simpliest solution is to avoid `@embroider/macros` in these internal addons for the time being. Ideally we would soon absorb these back into core as lazily loaded (`import()`-ed) code managed by Webpack when we fully switch over to Embroider.