### PR TITLE
FIX: correctly delete webhook events with webhook

### DIFF
--- a/plugins/chat/app/models/chat/incoming_webhook.rb
+++ b/plugins/chat/app/models/chat/incoming_webhook.rb
@@ -5,7 +5,10 @@ module Chat
     self.table_name = "incoming_chat_webhooks"
 
     belongs_to :chat_channel, class_name: "Chat::Channel"
-    has_many :chat_webhook_events, class_name: "Chat::WebhookEvent"
+    has_many :chat_webhook_events,
+             foreign_key: "incoming_chat_webhook_id",
+             class_name: "Chat::WebhookEvent",
+             dependent: :delete_all
 
     before_create { self.key = SecureRandom.hex(12) }
 

--- a/plugins/chat/spec/models/chat/incoming_webhook_spec.rb
+++ b/plugins/chat/spec/models/chat/incoming_webhook_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::IncomingWebhook do
+  it do
+    is_expected.to have_many(:chat_webhook_events)
+      .with_foreign_key("incoming_chat_webhook_id")
+      .class_name("Chat::WebhookEvent")
+      .dependent(:delete_all)
+  end
+end

--- a/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
@@ -132,5 +132,20 @@ RSpec.describe Chat::Admin::IncomingWebhooksController do
         Chat::IncomingWebhook.count
       }.by(-1)
     end
+
+    it "destroys webhook events records" do
+      sign_in(admin)
+
+      Chat::MessageCreator.create(
+        chat_channel: existing.chat_channel,
+        user: Discourse.system_user,
+        content: "foo",
+        incoming_chat_webhook: existing,
+      )
+
+      expect { delete "/admin/plugins/chat/hooks/#{existing.id}.json" }.to change {
+        Chat::WebhookEvent.count
+      }.by(-1)
+    end
   end
 end


### PR DESCRIPTION
Each time a chat message is created through a webhook, we create a webhook event associated to this webhook.

When destroying a webhook, we were not destroying the webhook events which was causing orphans records and more importantly errors in the app expecting to find an associated webhook.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
