### PR TITLE
FIX: topic summary flakey spec

### DIFF
--- a/app/serializers/topic_summary_serializer.rb
+++ b/app/serializers/topic_summary_serializer.rb
@@ -8,6 +8,9 @@ class TopicSummarySerializer < ApplicationSerializer
   end
 
   def new_posts_since_summary
-    object.target.highest_post_number.to_i - object.content_range&.end.to_i
+    range_end = object.content_range&.end || 0
+    range_end = 0 if range_end.infinite?
+
+    object.target.highest_post_number.to_i - range_end.to_i
   end
 end


### PR DESCRIPTION
Lately the following flakey spec appeared:

```
1) TopicsController#summary when the user is a member of an allowlisted group returns a summary
    Failure/Error: expect(response.status).to eq(200)

      expected: 200
          got: 500

      (compared using ==)
    # ./spec/requests/topics_controller_spec.rb:5570:in `block (4 levels) in <main>'
    # ./spec/rails_helper.rb:428:in `block (3 levels) in <top (required)>'
    # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.4.0/lib/timeout.rb:186:in `block in timeout'
    # ./vendor/bundle/ruby/3.2.0/gems/timeout-0.4.0/lib/timeout.rb:193:in `timeout'
    # ./spec/rails_helper.rb:423:in `block (2 levels) in <top (required)>'
    # ./spec/rails_helper.rb:412:in `block (2 levels) in <top (required)>'
    # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
    # ------------------
    # --- Caused by: ---
    #
    #   expected: 200
    #        got: 500
    #
    #   (compared using ==)
    #   ./spec/requests/topics_controller_spec.rb:5570:in `block (4 levels) in <main>'
```

I couldn't repro this failure locally but I did notice that the spec was failing for me locally if I was calling twice

```ruby
it "returns a summary" do
  get "/t/#{topic.id}/strategy-summary.json"
  get "/t/#{topic.id}/strategy-summary.json"

  expect(response.status).to eq(200)
end
```

With this error:

```
  expected: 200
      got: 500

  (compared using ==)
# ./spec/requests/topics_controller_spec.rb:5571:in `block (4 levels) in <main>'
# ./spec/rails_helper.rb:428:in `block (3 levels) in <top (required)>'
# ./spec/rails_helper.rb:423:in `block (2 levels) in <top (required)>'
# ./spec/rails_helper.rb:412:in `block (2 levels) in <top (required)>'
# ------------------
# --- Caused by: ---
# FloatDomainError:
#   Infinity
#   ./app/serializers/topic_summary_serializer.rb:11:in `to_i'
```

It appears that in this case the serialize would get -Infinity and Infinity values for `object.content_range`:

```ruby
def new_posts_since_summary
  object.target.highest_post_number.to_i - object.content_range&.end.to_i
end
```

My knowledge of the plugin is limited so Im not exactly clear how we could end up in this situation in this test, but that is my best guess so far.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
