### PR TITLE
FIX: TopicSummarization workaround for Postgres' discrete range types

### DIFF
--- a/app/serializers/topic_summary_serializer.rb
+++ b/app/serializers/topic_summary_serializer.rb
@@ -8,6 +8,11 @@ class TopicSummarySerializer < ApplicationSerializer
   end
 
   def new_posts_since_summary
-    object.target.highest_post_number.to_i - object.content_range&.end.to_i
+    # Postgres uses discrete range types for int4range, which means
+    # an inclusive [1,2] ranges is stored as [1,3). To work around this
+    # an provide an accurate count, we do the following:
+    range_end = [object.content_range&.end.to_i - 1, 0].max
+
+    object.target.highest_post_number.to_i - range_end
   end
 end

--- a/app/services/topic_summarization.rb
+++ b/app/services/topic_summarization.rb
@@ -116,7 +116,10 @@ class TopicSummarization
       )
     end
 
-    main_summary
+    # Calling reload here ensures Postgres' discrete range type is applied.
+    # an inclusive [1,2] ranges is stored as [1,3).
+    # Read more about this here: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-DISCRETE
+    main_summary.reload
   end
 
   def build_sha(ids)

--- a/plugins/chat/spec/requests/chat/api/summaries_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/summaries_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Chat::Api::SummariesController do
   before do
     group.add(current_user)
 
-    strategy = DummyCustomSummarization.new("dummy")
+    strategy = DummyCustomSummarization.new({ summary: "dummy", chunks: [] })
     plugin.register_summarization_strategy(strategy)
     SiteSetting.summarization_strategy = strategy.model
     SiteSetting.custom_summarization_allowed_groups = group.id
@@ -17,6 +17,8 @@ RSpec.describe Chat::Api::SummariesController do
     SiteSetting.chat_allowed_groups = group.id
     sign_in(current_user)
   end
+
+  after { DiscoursePluginRegistry.reset_register!(:summarization_strategies) }
 
   describe "#get_summary" do
     context "when the user is not allowed to join the channel" do

--- a/spec/jobs/regular/stream_topic_summary_spec.rb
+++ b/spec/jobs/regular/stream_topic_summary_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Jobs::StreamTopicSummary do
   subject(:job) { described_class.new }
 
   describe "#execute" do
-    fab!(:topic) { Fabricate(:topic) }
+    fab!(:topic) { Fabricate(:topic, highest_post_number: 2) }
+    fab!(:post_1) { Fabricate(:post, topic: topic, post_number: 1) }
+    fab!(:post_2) { Fabricate(:post, topic: topic, post_number: 2) }
     let(:plugin) { Plugin::Instance.new }
     let(:strategy) { DummyCustomSummarization.new({ summary: "dummy", chunks: [] }) }
     fab!(:user) { Fabricate(:leader) }
@@ -15,6 +17,8 @@ RSpec.describe Jobs::StreamTopicSummary do
       plugin.register_summarization_strategy(strategy)
       SiteSetting.summarization_strategy = strategy.model
     end
+
+    after { DiscoursePluginRegistry.reset_register!(:summarization_strategies) }
 
     describe "validates params" do
       it "does nothing if there is no topic" do

--- a/spec/lib/summarization/base_spec.rb
+++ b/spec/lib/summarization/base_spec.rb
@@ -10,10 +10,12 @@ describe Summarization::Base do
   before do
     group.add(user)
 
-    strategy = DummyCustomSummarization.new("dummy")
+    strategy = DummyCustomSummarization.new({ summary: "dummy", chunks: [] })
     plugin.register_summarization_strategy(strategy)
     SiteSetting.summarization_strategy = strategy.model
   end
+
+  after { DiscoursePluginRegistry.reset_register!(:summarization_strategies) }
 
   describe "#can_see_summary?" do
     context "when the user cannot generate a summary" do

--- a/spec/services/topic_summarization_spec.rb
+++ b/spec/services/topic_summarization_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 describe TopicSummarization do
-  fab!(:topic) { Fabricate(:topic) }
   fab!(:user) { Fabricate(:admin) }
-  fab!(:post_1) { Fabricate(:post, topic: topic) }
-  fab!(:post_2) { Fabricate(:post, topic: topic) }
+  fab!(:topic) { Fabricate(:topic, highest_post_number: 2) }
+  fab!(:post_1) { Fabricate(:post, topic: topic, post_number: 1) }
+  fab!(:post_2) { Fabricate(:post, topic: topic, post_number: 2) }
 
   shared_examples "includes only public-visible topics" do
     subject { described_class.new(DummyCustomSummarization.new({})) }


### PR DESCRIPTION
Our code assumed the content_range interval was inclusive, but they are open-ended due to Postgres' [discrete range types](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-DISCRETE), meaning [1,2] will be represented as [1,3).

It also fixes some flaky tests due to test data not being correctly setup and the registry not being resetted after each test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
