### PR TITLE
DEV: Remove need for reloading cached summary thanks to Range#max

### DIFF
--- a/app/serializers/topic_summary_serializer.rb
+++ b/app/serializers/topic_summary_serializer.rb
@@ -9,10 +9,14 @@ class TopicSummarySerializer < ApplicationSerializer
 
   def new_posts_since_summary
     # Postgres uses discrete range types for int4range, which means
-    # an inclusive [1,2] ranges is stored as [1,3). To work around this
-    # an provide an accurate count, we do the following:
-    range_end = [object.content_range&.end.to_i - 1, 0].max
+    # (1..2) is stored as (1...3).
+    #
+    # We use Range#max to work around this, which in the case above always returns 2.
+    # Be careful with using Range#end here, it could lead to unexpected results as:
+    #
+    # (1..2).end => 2
+    # (1...3).end => 3
 
-    object.target.highest_post_number.to_i - range_end
+    object.target.highest_post_number.to_i - object.content_range&.max.to_i
   end
 end

--- a/app/services/topic_summarization.rb
+++ b/app/services/topic_summarization.rb
@@ -116,10 +116,7 @@ class TopicSummarization
       )
     end
 
-    # Calling reload here ensures Postgres' discrete range type is applied.
-    # an inclusive [1,2] ranges is stored as [1,3).
-    # Read more about this here: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-DISCRETE
-    main_summary.reload
+    main_summary
   end
 
   def build_sha(ids)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
