### PR TITLE
FIX: Display 'shown on X' user field flags

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -109,6 +109,6 @@
         />
       </div>
     </div>
-    <div class="row">{{this.flags}}</div>
+    <div class="row user-field-flags">{{this.flags}}</div>
   {{/if}}
 </div>

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
@@ -51,10 +51,10 @@ export default Component.extend(bufferedProperty("userField"), {
     if (userField.required) {
       ret.push(I18n.t("admin.user_fields.required.enabled"));
     }
-    if (userField.showOnProfile) {
+    if (userField.show_on_profile) {
       ret.push(I18n.t("admin.user_fields.show_on_profile.enabled"));
     }
-    if (userField.showOnUserCard) {
+    if (userField.show_on_user_card) {
       ret.push(I18n.t("admin.user_fields.show_on_user_card.enabled"));
     }
     if (userField.searchable) {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -37,12 +37,15 @@ module("Integration | Component | admin-user-field-item", function (hooks) {
     assert.ok(exists(".save"));
   });
 
-  test("user field with an id", async function (assert) {
+  test("field attributes are rendered correctly", async function (assert) {
     this.set("userField", {
       id: 1,
       field_type: "text",
       name: "foo",
       description: "what is foo",
+      show_on_profile: true,
+      show_on_user_card: true,
+      searchable: true,
     });
 
     await render(hbs`<AdminUserFieldItem @userField={{this.userField}} />`);
@@ -55,6 +58,13 @@ module("Integration | Component | admin-user-field-item", function (hooks) {
     assert.strictEqual(
       query(".field-type").innerText,
       I18n.t("admin.user_fields.field_types.text")
+    );
+
+    assert.strictEqual(
+      query(".user-field-flags").innerText,
+      `${I18n.t("admin.user_fields.show_on_profile.enabled")}, ${I18n.t(
+        "admin.user_fields.show_on_user_card.enabled"
+      )}, ${I18n.t("admin.user_fields.searchable.enabled")}`
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -60,11 +60,12 @@ module("Integration | Component | admin-user-field-item", function (hooks) {
       I18n.t("admin.user_fields.field_types.text")
     );
 
-    assert.strictEqual(
-      query(".user-field-flags").innerText,
-      `${I18n.t("admin.user_fields.show_on_profile.enabled")}, ${I18n.t(
-        "admin.user_fields.show_on_user_card.enabled"
-      )}, ${I18n.t("admin.user_fields.searchable.enabled")}`
-    );
+    assert
+      .dom(".user-field-flags")
+      .hasText(
+        `${I18n.t("admin.user_fields.show_on_profile.enabled")}, ${I18n.t(
+          "admin.user_fields.show_on_user_card.enabled"
+        )}, ${I18n.t("admin.user_fields.searchable.enabled")}`
+      );
   });
 });


### PR DESCRIPTION
In this commit 2.5 years ago, variables for `showOnUserCard` and `showOnProfile` were removed, but we still used them in the component. https://github.com/discourse/discourse/commit/e29605b79f25afac2d506c6371e1b528f120b670

This corrects the variable names and adds a test to confirm the text is now shown.

Example of bug of Meta:
![Screenshot 2023-08-15 at 2 40 18 PM](https://github.com/discourse/discourse/assets/16214023/1255efb4-308b-4086-be86-2ba8a1704139)

![Screenshot 2023-08-15 at 2 40 22 PM](https://github.com/discourse/discourse/assets/16214023/b688c35e-5266-4b8a-bd9b-137e0ec1262b)

