### PR TITLE
FEATURE: do not bump topics when retroactively closing

### DIFF
--- a/lib/tasks/topics.rake
+++ b/lib/tasks/topics.rake
@@ -20,7 +20,7 @@ def close_old_topics(category)
   end
 
   topics.find_each do |topic|
-    topic.update_status("closed", true, Discourse.system_user)
+    topic.update_status("closed", true, Discourse.system_user, { silent: true })
     RakeHelpers.print_status_with_label("    closing old topics: ", topics_closed += 1, total)
   end
 end

--- a/spec/tasks/topics_spec.rb
+++ b/spec/tasks/topics_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "Post rake tasks" do
+  fab!(:post) { Fabricate(:post, raw: "The quick brown fox jumps over the lazy dog") }
+  let(:topic) { post.topic }
+  let(:category) { topic.category }
+
+  before do
+    Rake::Task.clear if defined?(Rake::Task)
+    Discourse::Application.load_tasks
+    STDOUT.stubs(:write)
+  end
+
+  describe "topics:apply_autoclose" do
+    it "should close topics silently" do
+      category.auto_close_hours = 1
+      category.save!
+
+      original_bumped_at = topic.bumped_at
+
+      freeze_time 2.hours.from_now
+
+      Rake::Task["topics:apply_autoclose"].invoke
+
+      topic.reload
+
+      expect(topic.closed).to eq(true)
+      expect(topic.bumped_at).to eq_time(original_bumped_at)
+    end
+  end
+end


### PR DESCRIPTION
The category feature that automatically closes topics does it silently

This amends it so `rake topics:apply_autoclose` which does retroactive
closing will also do so silently.
