### PR TITLE
DEV: Remove the need to update chromedriver in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,10 +204,6 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      - name: Setup Webdriver
-        if: matrix.build_type == 'system'
-        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
-
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system


### PR DESCRIPTION
Getting the following error in CI now.

```
session not created: This version of ChromeDriver only supports Chrome version 114
Current browser version is 116.0.5845.96 with binary path /usr/bin/google-chrome
```

It is on our roadmap to remove the webdrivers gem that will remove this
problem entirely.