### PR TITLE
DEV: Bump selenium-webdriver version to fix system spec running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,9 +204,9 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      - name: Setup Webdriver
-        if: matrix.build_type == 'system'
-        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
+      # - name: Setup Webdriver
+        # if: matrix.build_type == 'system'
+        # run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,10 +204,6 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      # - name: Setup Webdriver
-        # if: matrix.build_type == 'system'
-        # run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
-
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system

--- a/Gemfile
+++ b/Gemfile
@@ -141,9 +141,8 @@ group :test do
   gem "fakeweb", require: false
   gem "minitest", require: false
   gem "simplecov", require: false
-  gem "selenium-webdriver", require: false
+  gem "selenium-webdriver", "~> 4.11", require: false
   gem "test-prof"
-  gem "webdrivers", require: false
   gem "rails-dom-testing", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,7 +465,7 @@ GEM
       google-protobuf (~> 3.23)
     sass-embedded (1.64.2-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -517,10 +517,6 @@ GEM
       hkdf (~> 1.0)
       jwt (~> 2.0)
       openssl (~> 3.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -657,7 +653,7 @@ DEPENDENCIES
   ruby-readability
   rubyzip
   sanitize
-  selenium-webdriver
+  selenium-webdriver (~> 4.11)
   shoulda-matchers!
   sidekiq
   simplecov
@@ -674,7 +670,6 @@ DEPENDENCIES
   unf
   unicorn
   web-push
-  webdrivers
   webmock
   yaml-lint
   yard

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,11 +59,8 @@ require "shoulda-matchers"
 require "sidekiq/testing"
 require "test_prof/recipes/rspec/let_it_be"
 require "test_prof/before_all/adapters/active_record"
-require "webdrivers"
 require "selenium-webdriver"
 require "capybara/rails"
-
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # The shoulda-matchers gem no longer detects the test framework
 # you're using or mixes itself into that framework automatically.
@@ -255,7 +252,7 @@ RSpec.configure do |config|
 
     SiteSetting.provider = TestLocalProcessProvider.new
 
-    WebMock.disable_net_connect!(allow_localhost: true, allow: [Webdrivers::Chromedriver.base_url])
+    WebMock.disable_net_connect!(allow_localhost: true)
 
     if ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].present?
       Capybara.default_max_wait_time = ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].to_i

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -353,6 +353,9 @@ RSpec.configure do |config|
         .new(logging_prefs: { "browser" => browser_log_level, "driver" => "ALL" })
         .tap do |options|
           options.add_emulation(device_name: "iPhone 12 Pro")
+          options.add_argument(
+            '--user-agent="--user-agent="Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166"',
+          )
           apply_base_chrome_options(options)
         end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -354,7 +354,7 @@ RSpec.configure do |config|
         .tap do |options|
           options.add_emulation(device_name: "iPhone 12 Pro")
           options.add_argument(
-            '--user-agent="--user-agent="Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166"',
+            '--user-agent="--user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/36.0  Mobile/15E148 Safari/605.1.15"',
           )
           apply_base_chrome_options(options)
         end


### PR DESCRIPTION
We can no long user Webdriver - https://github.com/SeleniumHQ/selenium/issues/11066. Bumping selenium-webdriver did the trick, as well as manually setting the user_agent for mobile system specs. Unsure what changed to make this necessary, but it is necessary to get the app to boot in mobile view.