### PR TITLE
FIX: increase sidebar URL limit to 1000

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/constants.js
+++ b/app/assets/javascripts/discourse/app/lib/constants.js
@@ -15,7 +15,7 @@ export const SEARCH_PHRASE_REGEXP = '"([^"]+)"';
 export const SIDEBAR_URL = {
   max_icon_length: 40,
   max_name_length: 80,
-  max_value_length: 200,
+  max_value_length: 1000,
 };
 
 export const SIDEBAR_SECTION = {

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -6,7 +6,7 @@ class SidebarUrl < ActiveRecord::Base
   FULL_RELOAD_LINKS_REGEX = [%r{\A/my/[a-z_\-/]+\z}, %r{\A/pub/[a-z_\-/]+\z}, %r{\A/safe-mode\z}]
   MAX_ICON_LENGTH = 40
   MAX_NAME_LENGTH = 80
-  MAX_VALUE_LENGTH = 200
+  MAX_VALUE_LENGTH = 1000
   COMMUNITY_SECTION_LINKS = [
     {
       name: "Topics",
@@ -81,7 +81,7 @@ end
 #
 #  id         :bigint           not null, primary key
 #  name       :string(80)       not null
-#  value      :string(200)      not null
+#  value      :string(1000)     not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  icon       :string(40)       not null

--- a/db/migrate/20230816211907_increase_size_of_sidebar_urls.rb
+++ b/db/migrate/20230816211907_increase_size_of_sidebar_urls.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class IncreaseSizeOfSidebarUrls < ActiveRecord::Migration[7.0]
+  def up
+    change_column :sidebar_urls, :value, :string, limit: 1000
+  end
+
+  def down
+    change_column :sidebar_urls, :value, :string, limit: 200
+  end
+end

--- a/spec/models/sidebar_url_spec.rb
+++ b/spec/models/sidebar_url_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe SidebarUrl do
         value: "http://#{Discourse.current_hostname}/pub/test",
       ).valid?,
     ).to eq(true)
+    expect(
+      SidebarUrl.new(
+        icon: "link",
+        name: "external",
+        value: "https://www.test.com/" + "a" * 979,
+      ).valid?,
+    ).to eq(true)
+    expect(
+      SidebarUrl.new(
+        icon: "link",
+        name: "external",
+        value: "https://www.test.com/" + "a" * 980,
+      ).valid?,
+    ).to eq(false)
   end
 
   it "sets external flag" do


### PR DESCRIPTION
Before this change, sidebar URL had a limit of 200 characters.
In some cases it is not enough, therefore it was increased to 1000.

