### PR TITLE
FIX: sidebar URL full reload when anchor

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -22,6 +22,7 @@ export default class SectionLink {
     this.text = name;
     this.value = value;
     this.section = section;
+    this.withAnchor = value.match(/#\w+$/gi);
 
     if (!this.externalOrFullReload) {
       const routeInfoHelper = new RouteInfoHelper(router, value);
@@ -36,7 +37,7 @@ export default class SectionLink {
   }
 
   get externalOrFullReload() {
-    return this.external || this.fullReload;
+    return this.external || this.fullReload || this.withAnchor;
   }
 
   @bind

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -95,6 +95,24 @@ describe "Custom sidebar sections", type: :system do
     )
   end
 
+  it "allows the user to create custom section with anchor" do
+    sign_in user
+    visit("/latest")
+    sidebar.click_add_section_button
+
+    expect(section_modal).to be_visible
+    expect(section_modal).to have_disabled_save
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
+
+    section_modal.fill_name("My section")
+    section_modal.fill_link("Faq", "/faq#anchor")
+    section_modal.save
+
+    expect(sidebar).to have_section("My section")
+    take_screenshot
+    expect(sidebar).to have_section_link("Faq", target: "_blank")
+  end
+
   it "allows the user to edit custom section" do
     sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
     sidebar_url_1 = Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags")


### PR DESCRIPTION
Ember LinkTo is not accepting anchors.
In that case, we should treat those links as external, which will trigger full reload.


https://github.com/discourse/discourse/assets/72780/b3561cdb-7c26-45e4-bf5e-adff79bcb26e


