### PR TITLE
DEV: Fix chromedriver binary errors when running system tests in parallel

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -230,6 +230,21 @@ RSpec.configure do |config|
       raise "There are pending migrations, run RAILS_ENV=test bin/rake db:migrate"
     end
 
+    # Use a file system lock to get `selenium-manager` to download the `chromedriver` binary that is requried for
+    # system tests to support running system tests in multiple processes. If we don't download the `chromedriver` binary
+    # before running system tests in multiple processes, each process will end up calling the `selenium-manager` binary
+    # to download the `chromedriver` binary at the same time but the problem is that the binary is being downloaded to
+    # the same location and this can interfere with the running tests in another process.
+    #
+    # The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each
+    # process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.
+    if !File.directory?("~/.cache/selenium")
+      File.open("#{Rails.root}/tmp/chrome_driver_flock", "w") do |file|
+        file.flock(File::LOCK_EX)
+        `#{Selenium::WebDriver::SeleniumManager.send(:binary)} --browser chrome`
+      end
+    end
+
     Sidekiq.error_handlers.clear
 
     # Ugly, but needed until we have a user creator


### PR DESCRIPTION
What is the problem here?

The `selenium-webdriver` gem is responsible for downloading the
right version of the `chromedriver` binary and it downloads it into the
`~/.cache/selenium` folder. THe problem here is that when a user runs `bin/turbo_rspec spec/system`
for the first time, all of the processes will try to download the
`chromedriver` binary to the same path at the same time and will lead
to concurrency errors.

What is the fix here?

Before running any RSpec suite, we first check if the `.cache/selenium`
folder is present. If it is not present, we use a file system lock to
download the `chromedriver` binary such that other processes that runs
after will not need to install the `chromedriver` binary.

The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each
process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.