### PR TITLE
FIX: do not mutate `this.attrs` and `this.actions`

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1127,14 +1127,13 @@ export default Component.extend(
     },
 
     _deprecateMutations() {
-      if (!this.attrs?.onChange && !this.actions?.onChange) {
+      this.actions ??= {};
+      this.attrs ??= {};
+
+      if (!this.attrs.onChange && !this.actions.onChange) {
         this._deprecated(
           "Implicit mutation has been deprecated, please use `onChange` handler"
         );
-
-        if (!this.actions) {
-          return;
-        }
 
         this.actions.onChange =
           this.attrs.onSelect ||

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1127,13 +1127,14 @@ export default Component.extend(
     },
 
     _deprecateMutations() {
-      this.actions = this.actions || {};
-      this.attrs = this.attrs || {};
-
-      if (!this.attrs.onChange && !this.actions.onChange) {
+      if (!this.attrs?.onChange && !this.actions?.onChange) {
         this._deprecated(
           "Implicit mutation has been deprecated, please use `onChange` handler"
         );
+
+        if (!this.actions) {
+          return;
+        }
 
         this.actions.onChange =
           this.attrs.onSelect ||


### PR DESCRIPTION
Prior to this fix we would always re-set `this.attrs` with `this.attrs` when defined, which is both wasteful but also dangerous as `this.attrs` can possibly error when mutated.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
