### PR TITLE
FIX: Pending post deletion by creator

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -166,7 +166,11 @@ class ReviewablesController < ApplicationController
         current_user
       end
 
-    reviewable = Reviewable.find_by(id: params[:reviewable_id], created_by: user)
+    reviewable =
+      Reviewable.find_by_flagger_or_queued_post_creator(
+        id: params[:reviewable_id],
+        user_id: user.id,
+      )
     raise Discourse::NotFound.new if reviewable.blank?
 
     reviewable.perform(current_user, :delete, { guardian: @guardian })

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -717,6 +717,15 @@ class Reviewable < ActiveRecord::Base
     end
   end
 
+  def self.find_by_flagger_or_queued_post_creator(id:, user_id:)
+    Reviewable.find_by(
+      "id = :id AND (created_by_id = :user_id
+       OR (target_created_by_id = :user_id AND type = 'ReviewableQueuedPost'))",
+      id: id,
+      user_id: user_id,
+    )
+  end
+
   private
 
   def update_flag_stats(status:, user_ids:)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -236,7 +236,7 @@ class Guardian
     return false if !authenticated?
     return true if is_api? && is_admin?
 
-    reviewable.created_by_id == @user.id
+    reviewable.target_created_by_id == @user.id
   end
 
   def can_see_group?(group)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -4389,7 +4389,7 @@ RSpec.describe Guardian do
 
     context "when attempting to destroy your own reviewable" do
       it "returns true" do
-        queued_post = Fabricate(:reviewable_queued_post, created_by: user)
+        queued_post = Fabricate(:reviewable_queued_post, target_created_by: user)
         env =
           create_request_env(path: "/review/#{queued_post.id}.json").merge(
             { "REQUEST_METHOD" => "DELETE" },

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -805,7 +805,7 @@ RSpec.describe ReviewablesController do
 
       it "returns 200 if the user can delete the reviewable" do
         sign_in(user)
-        queued_post = Fabricate(:reviewable_queued_post, created_by: user)
+        queued_post = Fabricate(:reviewable_queued_post, target_created_by: user)
         delete "/review/#{queued_post.id}.json"
         expect(response.code).to eq("200")
         expect(queued_post.reload).to be_deleted
@@ -813,7 +813,7 @@ RSpec.describe ReviewablesController do
 
       it "denies attempts to destroy unowned reviewables" do
         sign_in(admin)
-        queued_post = Fabricate(:reviewable_queued_post, created_by: user)
+        queued_post = Fabricate(:reviewable_queued_post, target_created_by: user)
         delete "/review/#{queued_post.id}.json"
         expect(response.status).to eq(404)
         # Reviewable is not deleted because request is not via API
@@ -823,7 +823,7 @@ RSpec.describe ReviewablesController do
       shared_examples "for a passed user" do
         it "deletes reviewable" do
           api_key = Fabricate(:api_key).key
-          queued_post = Fabricate(:reviewable_queued_post, created_by: recipient)
+          queued_post = Fabricate(:reviewable_queued_post, target_created_by: recipient)
           delete "/review/#{queued_post.id}.json",
                  params: {
                    username: recipient.username,


### PR DESCRIPTION
`ReviewableQueuedPost` got refactored a while back to use the more appropriate `target_created_by` for the user of the post being queued instead of `created_by`. The change was not extended to the `DELETE /review/:id` endpoint leading to error responses for a user attempting to deleting their own queued post.

This fix extends the `Reviewable` lookup implementation in `ReviewablesController#destroy` and Guardian implementation to account for this change.

See https://github.com/discourse/discourse/commit/3d554aa10e8c0f7b5c8a35f956a3577751ba776c for more.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
