### PR TITLE
UX: remove border radius on tippy

### DIFF
--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -6,7 +6,7 @@ $d-popover-border: var(--primary-low);
   background: $d-popover-background;
   border: 1px solid var(--primary-low);
   box-shadow: var(--shadow-menu-panel);
-  border-radius: 0;
+  border-radius: var(--d-border-radius);
 
   > .tippy-svg-arrow {
     color: $d-popover-background;

--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -6,6 +6,7 @@ $d-popover-border: var(--primary-low);
   background: $d-popover-background;
   border: 1px solid var(--primary-low);
   box-shadow: var(--shadow-menu-panel);
+  border-radius: 0;
 
   > .tippy-svg-arrow {
     color: $d-popover-background;


### PR DESCRIPTION
This PR overrides tippy's border-radius to align with standard Discourse.