### PR TITLE
DEV: add note for DKIM record creation in cloud installation docs

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -44,6 +44,8 @@ walkthrough will go through these in detail:
 
 - To ensure mail deliverability, you must add valid [SPF and DKIM records](https://www.google.com/search?q=what+is+spf+dkim) in your DNS. You'll need SMTP credentials from your email provider, which include an SMTP username and password. Log in to your email provider's account, go to SMTP settings or Email API section, and locate/generate your unique SMTP credentials. Keep them secure, as you'll use them during the Discourse configuration. See your mail provider instructions for specifics.
 
+- When creating the DKIM record, some cloud hosting providers may append the domain name automatically to the input for public key. Do check that the created record has the expected public key value.
+
 - If you're having trouble getting emails to work, follow our [Email Troubleshooting Guide](https://meta.discourse.org/t/troubleshooting-email-on-a-new-discourse-install/16326)
 
 ## Installation


### PR DESCRIPTION
This tripped me up slightly when creating my SPF/DKIM records in DigitalOcean since DO has the behaviour of appending your domain name to the public key input, while in Mailjet, the DKIM details UI has a quick copy button for the public key that already includes that domain name as well. 

<img width="607" alt="Screenshot 2023-08-18 at 1 01 36 PM" src="https://github.com/discourse/discourse/assets/133760061/c5cda852-7d27-4f5a-88b7-fc79386452d3">

I'm unsure if other hosting providers / mail providers have these quirks in their config setup, so I'm placing it in the general cloud install instructions. 