### PR TITLE
DEV: Fix group of tests that is leaking state

### DIFF
--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1366,11 +1366,11 @@ RSpec.describe TopicQuery do
   end
 
   describe "#list_suggested_for" do
+    use_redis_snapshotting
+
     def clear_cache!
       Discourse.redis.keys("random_topic_cache*").each { |k| Discourse.redis.del k }
     end
-
-    before { clear_cache! }
 
     context "when anonymous" do
       let(:topic) { Fabricate(:topic) }


### PR DESCRIPTION
The test group was only clearing the cache in a `before` block which
means it still leaks the state at the end of each test.