### PR TITLE
DEV: Allow connectors to be located in `/connectors` with no subdir

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -51,7 +51,7 @@ function unColocateConnectors(tree) {
       if (
         match &&
         match.groups.extension === "js" &&
-        match.groups.prefix.split("/").pop() === "templates"
+        match.groups.prefix.endsWith("/templates")
       ) {
         // Some plugins are colocating connector JS under `/templates`
         const { prefix, connector } = match.groups;

--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -31,7 +31,7 @@ function fixLegacyExtensions(tree) {
 }
 
 const COLOCATED_CONNECTOR_REGEX =
-  /^(?<prefix>.*)\/connectors\/(?<outlet>[^\/]+)\/(?<name>[^\/\.]+)\.(?<extension>.+)$/;
+  /^(?<prefix>.*)\/connectors\/(?<connector>.+)\.(?<extension>.+)$/;
 
 // Having connector templates and js in the same directory causes a clash
 // when outputting es6 modules. This shim separates colocated connectors
@@ -45,8 +45,8 @@ function unColocateConnectors(tree) {
         match.groups.extension === "hbs" &&
         match.groups.prefix.split("/").pop() !== "templates"
       ) {
-        const { prefix, outlet, name } = match.groups;
-        return `${prefix}/templates/connectors/${outlet}/${name}.hbs`;
+        const { prefix, connector } = match.groups;
+        return `${prefix}/templates/connectors/${connector}.hbs`;
       }
       if (
         match &&
@@ -54,9 +54,9 @@ function unColocateConnectors(tree) {
         match.groups.prefix.split("/").pop() === "templates"
       ) {
         // Some plugins are colocating connector JS under `/templates`
-        const { prefix, outlet, name } = match.groups;
+        const { prefix, connector } = match.groups;
         const newPrefix = prefix.slice(0, -"/templates".length);
-        return `${newPrefix}/connectors/${outlet}/${name}.js`;
+        return `${newPrefix}/connectors/${connector}.js`;
       }
       return relativePath;
     },

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -22,7 +22,7 @@ export function extraConnectorClass(name, obj) {
 }
 
 const OUTLET_REGEX =
-  /^discourse(\/[^\/]+)*?(?<template>\/templates)?\/connectors\/(?<outlet>[^\/]+)\/(?<name>[^\/\.]+)$/;
+  /^discourse(\/[^\/]+)*?(?<template>\/templates)?\/connectors\/(?<outlet>[^\/]+)(?:\/(?<name>[^\/\.]+))?$/;
 
 function findOutlets(keys, callback) {
   return keys.forEach((res) => {

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
@@ -316,3 +316,23 @@ module(
     });
   }
 );
+
+module(
+  "Integration | Component | plugin-outlet | definitions without subdirectory",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      registerTemporaryModule(
+        `${TEMPLATE_PREFIX}/test-name`,
+        hbs`<span class='no-subdir-test'>Hello world</span>`
+      );
+    });
+
+    test("detects a connector in the root of the connectors directory", async function (assert) {
+      await render(hbs`<PluginOutlet @name="test-name" />`);
+
+      assert.dom(".no-subdir-test").hasText("Hello world");
+    });
+  }
+);

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class ThemeJavascriptCompiler
-  COLOCATED_CONNECTOR_REGEX =
-    %r{\A(?<prefix>.*/?)connectors/(?<outlet>[^/]+)/(?<name>[^/\.]+)\.(?<extension>.+)\z}
+  COLOCATED_CONNECTOR_REGEX = %r{\A(?<prefix>.*/?)connectors/(?<connector>.+)\.(?<extension>.+)\z}
 
   class CompileError < StandardError
   end
@@ -119,9 +118,9 @@ class ThemeJavascriptCompiler
       is_in_templates_directory = match[:prefix].split("/").last == "templates"
 
       if is_template && !is_in_templates_directory
-        "#{match[:prefix]}templates/connectors/#{match[:outlet]}/#{match[:name]}.#{match[:extension]}"
+        "#{match[:prefix]}templates/connectors/#{match[:connector]}.#{match[:extension]}"
       elsif !is_template && is_in_templates_directory
-        "#{match[:prefix].chomp("templates/")}connectors/#{match[:outlet]}/#{match[:name]}.#{match[:extension]}"
+        "#{match[:prefix].chomp("templates/")}connectors/#{match[:connector]}.#{match[:extension]}"
       else
         filename
       end


### PR DESCRIPTION
Most plugins/themes only define a single connector for each outlet. Previously this would be done using a file named `connectors/outlet-name/unique-connector-name.hbs`. This commit makes it possible to omit the unique connector name and define the connector directly in the root `connectors/outlet-name.hbs`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
