### PR TITLE
FIX: correctly makes `this` accessible in the scope

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -203,7 +203,7 @@ export default class History extends Component {
         }
         this.args.closeModal();
       })
-      .catch(function (e) {
+      .catch((e) => {
         if (e.jqXHR.responseJSON?.errors?.[0]) {
           this.dialog.alert(e.jqXHR.responseJSON.errors[0]);
         }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
