### PR TITLE
DEV: Move PluginOutlet at bottom of TopicNavigation

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -299,13 +299,13 @@
             />
           </TopicProgress>
         {{/if}}
-      </TopicNavigation>
 
-      <PluginOutlet
-        @name="after-topic-navigation"
-        @connectorTagName="div"
-        @outletArgs={{hash model=this.model}}
-      />
+        <PluginOutlet
+          @name="topic-navigation-bottom"
+          @connectorTagName="div"
+          @outletArgs={{hash model=this.model}}
+        />
+      </TopicNavigation>
 
       <div class="row">
         <section class="topic-area" id="topic" data-topic-id={{this.model.id}}>


### PR DESCRIPTION
I recently added this outlet [in this commit](https://github.com/discourse/discourse/commit/ab3a9b46909954088ad5e61ae25d95a2d7e602cb), but it wasn't quite in the right spot. Only one usage and I've corrected the name.