### PR TITLE
FIX: sets sidebar state on load

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -12,6 +12,7 @@ import { until } from "discourse/lib/formatter";
 import { inject as service } from "@ember/service";
 import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
 import getURL from "discourse-common/lib/get-url";
+import { initSidebarState } from "discourse/plugins/chat/discourse/lib/init-sidebar-state";
 
 export default {
   name: "chat-sidebar",
@@ -34,6 +35,8 @@ export default {
             switchButtonDefaultUrl = getURL("/chat");
           }
       );
+
+      initSidebarState(api, api.getCurrentUser());
     });
 
     withPluginApi("1.3.0", (api) => {

--- a/plugins/chat/assets/javascripts/discourse/lib/init-sidebar-state.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/init-sidebar-state.js
@@ -1,0 +1,16 @@
+import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";
+
+export function initSidebarState(api, user) {
+  api.setSidebarPanel("main");
+
+  const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(user);
+  if (chatSeparateSidebarMode.fullscreen) {
+    api.setCombinedSidebarMode();
+    api.showSidebarSwitchPanelButtons();
+  } else if (chatSeparateSidebarMode.always) {
+    api.setSeparatedSidebarMode();
+  } else {
+    api.setCombinedSidebarMode();
+    api.hideSidebarSwitchPanelButtons();
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -5,7 +5,9 @@ import { inject as service } from "@ember/service";
 import { scrollTop } from "discourse/mixins/scroll-top";
 import { schedule } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { initSidebarState } from "discourse/plugins/chat/discourse/lib/init-sidebar-state";
 import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";
+
 export default class ChatRoute extends DiscourseRoute {
   @service chat;
   @service router;
@@ -81,20 +83,7 @@ export default class ChatRoute extends DiscourseRoute {
 
   deactivate(transition) {
     withPluginApi("1.8.0", (api) => {
-      api.setSidebarPanel("main");
-
-      const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
-        this.currentUser
-      );
-      if (chatSeparateSidebarMode.fullscreen) {
-        api.setCombinedSidebarMode();
-        api.showSidebarSwitchPanelButtons();
-      } else if (chatSeparateSidebarMode.always) {
-        api.setSeparatedSidebarMode();
-      } else {
-        api.setCombinedSidebarMode();
-        api.hideSidebarSwitchPanelButtons();
-      }
+      initSidebarState(api, this.currentUser);
     });
 
     if (transition) {


### PR DESCRIPTION
This commit was incorrectly removed of https://github.com/discourse/discourse/pull/23078 and would set the state only on entering (or exiting) chat route. The tests were already present in the previous PR.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
