### PR TITLE
FIX: correctly handles mobile and default

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/header/icon.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/header/icon.js
@@ -27,7 +27,8 @@ export default class ChatHeaderIcon extends Component {
   get title() {
     if (
       this.chatStateManager.isFullPageActive &&
-      !this.chatSeparateSidebarMode.never
+      !this.chatSeparateSidebarMode.never &&
+      !this.site.mobileView
     ) {
       return "sidebar.panels.forum.label";
     }
@@ -38,7 +39,8 @@ export default class ChatHeaderIcon extends Component {
   get icon() {
     if (
       this.chatStateManager.isFullPageActive &&
-      !this.chatSeparateSidebarMode.never
+      !this.chatSeparateSidebarMode.never &&
+      !this.site.mobileView
     ) {
       return "random";
     }

--- a/plugins/chat/assets/javascripts/discourse/lib/get-user-chat-separate-sidebar-mode.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/get-user-chat-separate-sidebar-mode.js
@@ -1,5 +1,8 @@
 export function getUserChatSeparateSidebarMode(user) {
-  const mode = user?.get("user_option.chat_separate_sidebar_mode");
+  let mode = user?.get("user_option.chat_separate_sidebar_mode");
+  if (mode === "default") {
+    mode = user.siteSettings.chat_separate_sidebar_mode;
+  }
 
   return {
     never: "never" === mode,

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -63,7 +63,12 @@ export default class ChatRoute extends DiscourseRoute {
   activate() {
     withPluginApi("1.8.0", (api) => {
       api.setSidebarPanel("chat");
-      if (getUserChatSeparateSidebarMode(this.currentUser).never) {
+
+      const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
+        this.currentUser
+      );
+
+      if (chatSeparateSidebarMode.never) {
         api.setCombinedSidebarMode();
         api.hideSidebarSwitchPanelButtons();
       } else {

--- a/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
+++ b/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
@@ -17,6 +17,36 @@ RSpec.describe "Separate sidebar mode", type: :system do
     sign_in(current_user)
   end
 
+  describe "when separate sidebar mode is not set" do
+    before do
+      SiteSetting.chat_separate_sidebar_mode = "always"
+      chat_page.prefers_full_page
+    end
+
+    it "uses the site setting" do
+      visit("/")
+
+      expect(sidebar_component).to have_switch_button("chat")
+      expect(header_component).to have_open_chat_button
+      expect(sidebar_component).to have_no_section("chat-channels")
+      expect(sidebar_component).to have_section("Categories")
+
+      chat_page.open_from_header
+
+      expect(sidebar_component).to have_switch_button("main")
+      expect(header_component).to have_open_forum_button
+      expect(sidebar_component).to have_section("chat-channels")
+      expect(sidebar_component).to have_no_section("Categories")
+
+      find("#site-logo").click
+
+      expect(sidebar_component).to have_switch_button("chat")
+      expect(header_component).to have_open_chat_button
+      expect(sidebar_component).to have_no_section("chat-channels")
+      expect(sidebar_component).to have_section("Categories")
+    end
+  end
+
   describe "when separate sidebar mode is never" do
     before do
       current_user.user_option.update!(

--- a/plugins/chat/test/javascripts/components/chat-header-icon-test.js
+++ b/plugins/chat/test/javascripts/components/chat-header-icon-test.js
@@ -41,4 +41,17 @@ module("Discourse Chat | Component | chat-header-icon", function (hooks) {
 
     assert.dom(".d-icon-random").exists();
   });
+
+  test("mobile", async function (assert) {
+    this.site.mobileView = true;
+
+    await render(hbs`<Chat::Header::Icon />`);
+
+    assert
+      .dom(".icon.btn-flat")
+      .hasAttribute("title", I18n.t("chat.title_capitalized"))
+      .hasAttribute("href", "/chat");
+
+    assert.dom(".d-icon-d-chat").exists();
+  });
 });


### PR DESCRIPTION
This commit ensures we have correct icon and title on mobile for the chat header icon.

It also fixes a bug where the site setting was not correctly used when the user has not yet set the user option.

Both cases are now correctly tested.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
