### PR TITLE
DEV: Update `replaceWith` on Route

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-colors-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-colors-show.js
@@ -1,10 +1,17 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeColorsShowRoute extends Route {
+  @service router;
+
   model(params) {
     const all = this.modelFor("adminCustomize.colors");
     const model = all.findBy("id", parseInt(params.scheme_id, 10));
-    return model ? model : this.replaceWith("adminCustomize.colors.index");
+    if (model) {
+      return model;
+    } else {
+      this.router.replaceWith("adminCustomize.colors.index");
+    }
   }
 
   serialize(model) {

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-email-style-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-email-style-index.js
@@ -1,7 +1,10 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AdminCustomizeEmailStyleIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.replaceWith("adminCustomizeEmailStyle.edit", "html");
+    this.router.replaceWith("adminCustomizeEmailStyle.edit", "html");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
@@ -10,13 +10,15 @@ export default class AdminCustomizeThemesEditRoute extends Route {
   model(params) {
     const all = this.modelFor("adminCustomizeThemes");
     const model = all.findBy("id", parseInt(params.theme_id, 10));
-    return model
-      ? {
-          model,
-          target: params.target,
-          field_name: params.field_name,
-        }
-      : this.replaceWith("adminCustomizeThemes.index");
+    if (model) {
+      return {
+        model,
+        target: params.target,
+        field_name: params.field_name,
+      };
+    } else {
+      this.router.replaceWith("adminCustomizeThemes.index");
+    }
   }
 
   serialize(wrapper) {

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
@@ -7,6 +7,7 @@ import { scrollTop } from "discourse/mixins/scroll-top";
 
 export default class AdminCustomizeThemesShowRoute extends Route {
   @service dialog;
+  @service router;
 
   serialize(model) {
     return { theme_id: model.get("id") };
@@ -15,7 +16,11 @@ export default class AdminCustomizeThemesShowRoute extends Route {
   model(params) {
     const all = this.modelFor("adminCustomizeThemes");
     const model = all.findBy("id", parseInt(params.theme_id, 10));
-    return model ? model : this.replaceWith("adminCustomizeThemes.index");
+    if (model) {
+      return model;
+    } else {
+      this.router.replaceWith("adminCustomizeThemes.index");
+    }
   }
 
   setupController(controller, model) {

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
@@ -3,10 +3,13 @@
   chosen a category. It will redirect to the first category.
 **/
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminSiteSettingsIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.replaceWith(
+    this.router.replaceWith(
       "adminSiteSettingsCategory",
       this.controllerFor("adminSiteSettings").get("visibleSiteSettings")[0]
         .nameKey

--- a/app/assets/javascripts/admin/addon/routes/admin-watched-words-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-watched-words-index.js
@@ -1,8 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class AdminWatchedWordsIndexRoute extends DiscourseRoute {
+  @service router;
+
   beforeModel() {
-    this.replaceWith(
+    this.router.replaceWith(
       "adminWatchedWords.action",
       this.modelFor("adminWatchedWords")[0].nameKey
     );

--- a/app/assets/javascripts/discourse/app/routes/associate-account.js
+++ b/app/assets/javascripts/discourse/app/routes/associate-account.js
@@ -1,23 +1,42 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { ajax } from "discourse/lib/ajax";
-import { next } from "@ember/runloop";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import showModal from "discourse/lib/show-modal";
 import cookie from "discourse/lib/cookie";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import { next } from "@ember/runloop";
 
 export default DiscourseRoute.extend({
+  router: service(),
+  currentUser: service(),
+
   beforeModel(transition) {
     if (!this.currentUser) {
       cookie("destination_url", transition.intent.url);
-      return this.replaceWith("login");
+      return this.router.replaceWith("login");
     }
     const params = this.paramsFor("associate-account");
-    this.replaceWith(`preferences.account`, this.currentUser).then(() =>
-      next(() =>
-        ajax(`/associate/${encodeURIComponent(params.token)}.json`)
-          .then((model) => showModal("associate-account-confirm", { model }))
-          .catch(popupAjaxError)
-      )
-    );
+    this.redirectToAccount(params);
+  },
+
+  @action
+  async redirectToAccount() {
+    await this.router
+      .replaceWith(`preferences.account`, this.currentUser)
+      .followRedirects();
+    next(() => this.showAssociateAccount());
+  },
+
+  @action
+  async showAssociateAccount() {
+    try {
+      const model = await ajax(
+        `/associate/${encodeURIComponent(params.token)}.json`
+      );
+      showModal("associate-account-confirm", { model });
+    } catch {
+      popupAjaxError;
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/associate-account.js
+++ b/app/assets/javascripts/discourse/app/routes/associate-account.js
@@ -21,15 +21,15 @@ export default DiscourseRoute.extend({
   },
 
   @action
-  async redirectToAccount() {
+  async redirectToAccount(params) {
     await this.router
       .replaceWith(`preferences.account`, this.currentUser)
       .followRedirects();
-    next(() => this.showAssociateAccount());
+    next(() => this.showAssociateAccount(params));
   },
 
   @action
-  async showAssociateAccount() {
+  async showAssociateAccount(params) {
     try {
       const model = await ajax(
         `/associate/${encodeURIComponent(params.token)}.json`

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -20,6 +20,7 @@ import PreloadStore from "discourse/lib/preload-store";
 
 class AbstractCategoryRoute extends DiscourseRoute {
   @service composer;
+  @service router;
 
   queryParams = queryParams;
 
@@ -49,7 +50,7 @@ class AbstractCategoryRoute extends DiscourseRoute {
 
   afterModel(model, transition) {
     if (!model) {
-      this.replaceWith("/404");
+      this.router.replaceWith("/404");
       return;
     }
 
@@ -63,10 +64,11 @@ class AbstractCategoryRoute extends DiscourseRoute {
     ) {
       // TODO: avoid throwing away preload data by redirecting on the server
       PreloadStore.getAndRemove("topic_list");
-      return this.replaceWith(
+      this.router.replaceWith(
         "discovery.categoryNone",
         modelParams.category_slug_path_with_id
       );
+      return;
     }
 
     this._setupNavigation(category);

--- a/app/assets/javascripts/discourse/app/routes/discourse.js
+++ b/app/assets/javascripts/discourse/app/routes/discourse.js
@@ -3,8 +3,11 @@ import { once } from "@ember/runloop";
 import { seenUser } from "discourse/lib/user-presence";
 import { getOwner } from "discourse-common/lib/get-owner";
 import deprecated from "discourse-common/lib/deprecated";
+import { inject as service } from "@ember/service";
 
 const DiscourseRoute = Route.extend({
+  router: service(),
+
   willTransition() {
     seenUser();
   },
@@ -39,7 +42,7 @@ const DiscourseRoute = Route.extend({
   redirectIfLoginRequired() {
     const app = this.controllerFor("application");
     if (app.get("loginRequired")) {
-      this.replaceWith("login");
+      this.router.replaceWith("login");
     }
   },
 

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -3,12 +3,15 @@ import User from "discourse/models/user";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
 import { action } from "@ember/object";
 import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
+import { inject as service } from "@ember/service";
 
 /**
   The parent route for all discovery routes.
   Handles the logic for showing the loading spinners.
 **/
 export default class DiscoveryRoute extends DiscourseRoute {
+  @service router;
+
   queryParams = {
     filter: { refreshModel: true },
   };
@@ -28,14 +31,14 @@ export default class DiscoveryRoute extends DiscourseRoute {
       User.currentProp("user_option.should_be_redirected_to_top", false);
       const period =
         User.currentProp("user_option.redirected_to_top.period") || "all";
-      this.replaceWith("discovery.top", {
+      this.router.replaceWith("discovery.top", {
         queryParams: {
           period,
         },
       });
     } else if (url && (matches = url.match(/top\/(.*)$/))) {
       if (this.site.periods.includes(matches[1])) {
-        this.replaceWith("discovery.top", {
+        this.router.replaceWith("discovery.top", {
           queryParams: {
             period: matches[1],
           },

--- a/app/assets/javascripts/discourse/app/routes/edit-category-index.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category-index.js
@@ -1,8 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   afterModel() {
     const params = this.paramsFor("editCategory");
-    this.replaceWith(`/c/${params.slug}/edit/general`);
+    this.router.replaceWith(`/c/${params.slug}/edit/general`);
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/edit-category.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category.js
@@ -1,8 +1,11 @@
 import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   model(params) {
     return Category.reloadCategoryWithPermissions(
       params,
@@ -13,7 +16,7 @@ export default DiscourseRoute.extend({
 
   afterModel(model) {
     if (!model.can_edit) {
-      this.replaceWith("/404");
+      this.router.replaceWith("/404");
       return;
     }
   },

--- a/app/assets/javascripts/discourse/app/routes/forgot-password.js
+++ b/app/assets/javascripts/discourse/app/routes/forgot-password.js
@@ -6,14 +6,14 @@ import ForgotPassword from "discourse/components/modal/forgot-password";
 
 export default class ForgotPasswordRoute extends DiscourseRoute {
   @service modal;
+  @service router;
 
   async beforeModel() {
     const { loginRequired } = this.controllerFor("application");
 
-    await this.replaceWith(
+    await this.router.replaceWith(
       loginRequired ? "login" : `discovery.${defaultHomepage()}`
     );
-
     next(() => this.modal.show(ForgotPassword));
   }
 }

--- a/app/assets/javascripts/discourse/app/routes/group-manage-membership.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-membership.js
@@ -1,14 +1,17 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   titleToken() {
     return I18n.t("groups.manage.membership.title");
   },
 
   afterModel(group) {
     if (group.get("automatic")) {
-      this.replaceWith("group.manage.interaction", group);
+      this.router.replaceWith("group.manage.interaction", group);
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -3,9 +3,11 @@ import { inject as service } from "@ember/service";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { next } from "@ember/runloop";
 import StaticPage from "discourse/models/static-page";
+import { action } from "@ember/object";
 
 export default class LoginRoute extends DiscourseRoute {
   @service siteSettings;
+  @service router;
 
   // `login-page` because `login` controller is the one for
   // the login modal
@@ -13,13 +15,19 @@ export default class LoginRoute extends DiscourseRoute {
 
   beforeModel() {
     if (!this.siteSettings.login_required) {
-      this.replaceWith(`/${defaultHomepage()}`).then((e) => {
-        next(() => e.send("showLogin"));
-      });
+      this.showLogin();
     }
   }
 
   model() {
     return StaticPage.find("login");
+  }
+
+  @action
+  async showLogin() {
+    const route = await this.router
+      .replaceWith(`/${defaultHomepage()}`)
+      .followRedirects();
+    next(() => route.send("showLogin"));
   }
 }

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -3,7 +3,6 @@ import { inject as service } from "@ember/service";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { next } from "@ember/runloop";
 import StaticPage from "discourse/models/static-page";
-import { action } from "@ember/object";
 
 export default class LoginRoute extends DiscourseRoute {
   @service siteSettings;

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -15,19 +15,14 @@ export default class LoginRoute extends DiscourseRoute {
 
   beforeModel() {
     if (!this.siteSettings.login_required) {
-      this.showLogin();
+      this.router
+        .replaceWith(`/${defaultHomepage()}`)
+        .followRedirects()
+        .then((e) => next(() => e.send("showLogin")));
     }
   }
 
   model() {
     return StaticPage.find("login");
-  }
-
-  @action
-  async showLogin() {
-    const route = await this.router
-      .replaceWith(`/${defaultHomepage()}`)
-      .followRedirects();
-    next(() => route.send("showLogin"));
   }
 }

--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -2,6 +2,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import { Promise } from "rsvp";
 import { SEARCH_PRIORITIES } from "discourse/lib/constants";
+import { inject as service } from "@ember/service";
 
 let _newCategoryColor = "0088CC";
 let _newCategoryTextColor = "FFFFFF";
@@ -12,12 +13,14 @@ export function setNewCategoryDefaultColors(backgroundColor, textColor) {
 }
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   controllerName: "edit-category-tabs",
   templateName: "edit-category-tabs",
 
   beforeModel() {
     if (!this.currentUser) {
-      this.replaceWith("/404");
+      this.router.replaceWith("/404");
       return;
     }
     if (!this.currentUser.admin) {
@@ -25,7 +28,7 @@ export default DiscourseRoute.extend({
         !this.currentUser.moderator ||
         this.siteSettings.moderators_manage_categories_and_groups === false
       ) {
-        this.replaceWith("/404");
+        this.router.replaceWith("/404");
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/routes/new-message.js
+++ b/app/assets/javascripts/discourse/app/routes/new-message.js
@@ -8,6 +8,7 @@ import { inject as service } from "@ember/service";
 export default DiscourseRoute.extend({
   dialog: service(),
   composer: service(),
+  router: service(),
 
   beforeModel(transition) {
     const params = transition.to.queryParams;
@@ -15,42 +16,45 @@ export default DiscourseRoute.extend({
     const groupName = params.groupname || params.group_name;
 
     if (this.currentUser) {
-      this.replaceWith("discovery.latest").then(() => {
-        if (params.username) {
-          this.composer.openNewMessage({
-            recipients: params.username,
-            title: params.title,
-            body: params.body,
-          });
-        } else if (groupName) {
-          // send a message to a group
-          Group.messageable(groupName)
-            .then((result) => {
-              if (result.messageable) {
-                next(() =>
-                  this.composer.openNewMessage({
-                    recipients: groupName,
-                    title: params.title,
-                    body: params.body,
-                  })
-                );
-              } else {
-                this.dialog.alert(
-                  I18n.t("composer.cant_send_pm", { username: groupName })
-                );
-              }
-            })
-            .catch(() => this.dialog.alert(I18n.t("generic_error")));
-        } else {
-          this.composer.openNewMessage({
-            title: params.title,
-            body: params.body,
-          });
-        }
-      });
+      this.router
+        .replaceWith("discovery.latest")
+        .followRedirects()
+        .then(() => {
+          if (params.username) {
+            this.composer.openNewMessage({
+              recipients: params.username,
+              title: params.title,
+              body: params.body,
+            });
+          } else if (groupName) {
+            // send a message to a group
+            Group.messageable(groupName)
+              .then((result) => {
+                if (result.messageable) {
+                  next(() =>
+                    this.composer.openNewMessage({
+                      recipients: groupName,
+                      title: params.title,
+                      body: params.body,
+                    })
+                  );
+                } else {
+                  this.dialog.alert(
+                    I18n.t("composer.cant_send_pm", { username: groupName })
+                  );
+                }
+              })
+              .catch(() => this.dialog.alert(I18n.t("generic_error")));
+          } else {
+            this.composer.openNewMessage({
+              title: params.title,
+              body: params.body,
+            });
+          }
+        });
     } else {
       cookie("destination_url", window.location.href);
-      this.replaceWith("login");
+      this.router.replaceWith("login");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/new-topic.js
+++ b/app/assets/javascripts/discourse/app/routes/new-topic.js
@@ -6,35 +6,44 @@ import { inject as service } from "@ember/service";
 
 export default class extends DiscourseRoute {
   @service composer;
+  @service router;
+  @service currentUser;
+  @service site;
 
   beforeModel(transition) {
     if (this.currentUser) {
       const category = this.parseCategoryFromTransition(transition);
 
       if (category) {
-        this.replaceWith("discovery.category", {
-          category,
-          id: category.id,
-        }).then(() => {
-          if (this.currentUser.can_create_topic) {
-            this.openComposer({ transition, category });
-          }
-        });
+        this.router
+          .replaceWith("discovery.category", {
+            category,
+            id: category.id,
+          })
+          .followRedirects()
+          .then(() => {
+            if (this.currentUser.can_create_topic) {
+              this.openComposer({ transition, category });
+            }
+          });
       } else if (transition.from) {
         // Navigation from another ember route
         transition.abort();
         this.openComposer({ transition });
       } else {
-        this.replaceWith("discovery.latest").then(() => {
-          if (this.currentUser.can_create_topic) {
-            this.openComposer({ transition });
-          }
-        });
+        this.router
+          .replaceWith("discovery.latest")
+          .followRedirects()
+          .then(() => {
+            if (this.currentUser.can_create_topic) {
+              this.openComposer({ transition });
+            }
+          });
       }
     } else {
       // User is not logged in
       cookie("destination_url", window.location.href);
-      this.replaceWith("login");
+      this.router.replaceWith("login");
     }
   }
 

--- a/app/assets/javascripts/discourse/app/routes/new-topic.js
+++ b/app/assets/javascripts/discourse/app/routes/new-topic.js
@@ -15,11 +15,10 @@ export default class extends DiscourseRoute {
       const category = this.parseCategoryFromTransition(transition);
 
       if (category) {
+        // Using URL-based transition to avoid bug with dynamic segments and refreshModel query params
+        // https://github.com/emberjs/ember.js/issues/16992
         this.router
-          .replaceWith("discovery.category", {
-            category,
-            id: category.id,
-          })
+          .replaceWith(`/c/${category.id}`)
           .followRedirects()
           .then(() => {
             if (this.currentUser.can_create_topic) {

--- a/app/assets/javascripts/discourse/app/routes/restricted-user.js
+++ b/app/assets/javascripts/discourse/app/routes/restricted-user.js
@@ -1,10 +1,13 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 // A base route that allows us to redirect when access is restricted
 export default DiscourseRoute.extend({
+  router: service(),
+
   afterModel() {
     if (!this.modelFor("user").get("can_edit")) {
-      this.replaceWith("userActivity");
+      this.router.replaceWith("userActivity");
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/signup.js
+++ b/app/assets/javascripts/discourse/app/routes/signup.js
@@ -1,22 +1,26 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { next } from "@ember/runloop";
+import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
 
 export default class SignupRoute extends DiscourseRoute {
-  beforeModel() {
-    const { canSignUp } = this.controllerFor("application");
+  @service router;
+  @service siteSettings;
 
-    if (this.siteSettings.login_required) {
-      this.replaceWith("login").then((e) => {
-        if (canSignUp) {
-          next(() => e.send("showCreateAccount"));
-        }
-      });
-    } else {
-      this.replaceWith("discovery.latest").then((e) => {
-        if (canSignUp) {
-          next(() => e.send("showCreateAccount"));
-        }
-      });
+  beforeModel() {
+    this.showCreateAccount();
+  }
+
+  @action
+  async showCreateAccount() {
+    const { canSignUp } = this.controllerFor("application");
+    const route = await this.router
+      .replaceWith(
+        this.siteSettings.login_required ? "login" : "discovery.latest"
+      )
+      .followRedirects();
+    if (canSignUp) {
+      next(() => route.send("showCreateAccount"));
     }
   }
 }

--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -24,6 +24,8 @@ const ALL = "all";
 
 export default DiscourseRoute.extend({
   composer: service(),
+  router: service(),
+  currentUser: service(),
   navMode: "latest",
 
   queryParams,
@@ -98,7 +100,7 @@ export default DiscourseRoute.extend({
     ) {
       // TODO: avoid throwing away preload data by redirecting on the server
       PreloadStore.getAndRemove("topic_list");
-      return this.replaceWith(
+      return this.router.replaceWith(
         "tags.showCategoryNone",
         params.category_slug_path_with_id,
         tagId

--- a/app/assets/javascripts/discourse/app/routes/user-activity.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity.js
@@ -1,11 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   model() {
     let user = this.modelFor("user");
     if (user.get("profile_hidden")) {
-      return this.replaceWith("user.profile-hidden");
+      return this.router.replaceWith("user.profile-hidden");
     }
 
     return user;

--- a/app/assets/javascripts/discourse/app/routes/user-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-index.js
@@ -3,19 +3,20 @@ import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
   router: service(),
+  site: service(),
+  currentUser: service(),
 
   beforeModel() {
-    const { currentUser } = this;
     const viewingMe =
-      currentUser &&
-      currentUser.get("username") === this.modelFor("user").get("username");
+      this.currentUser?.get("username") ===
+      this.modelFor("user").get("username");
     const destination = viewingMe ? "userActivity" : "user.summary";
 
     // HACK: Something with the way the user card intercepts clicks seems to break how the
     // transition into a user's activity works. This makes the back button work on mobile
     // where there is no user card as well as desktop where there is.
     if (this.site.mobileView) {
-      this.replaceWith(destination);
+      this.router.replaceWith(destination);
     } else {
       this.router.transitionTo(destination);
     }

--- a/app/assets/javascripts/discourse/app/routes/user-invited-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-index.js
@@ -1,5 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
-imort { inject as service } from "@ember/service";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
   router: service(),

--- a/app/assets/javascripts/discourse/app/routes/user-invited-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-index.js
@@ -1,7 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+imort { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   beforeModel() {
-    this.replaceWith("userInvited.show", "pending");
+    this.router.replaceWith("userInvited.show", "pending");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-show.js
@@ -2,8 +2,11 @@ import DiscourseRoute from "discourse/routes/discourse";
 import Invite from "discourse/models/invite";
 import { action } from "@ember/object";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   model(params) {
     this.inviteFilter = params.filter;
     return Invite.findInvitedBy(this.modelFor("user"), params.filter);
@@ -11,7 +14,7 @@ export default DiscourseRoute.extend({
 
   afterModel(model) {
     if (!model.can_see_invite_details) {
-      this.replaceWith("userInvited.show", "redeemed");
+      this.router.replaceWith("userInvited.show", "redeemed");
     }
     this.controllerFor("user.invited").setProperties({
       invitesCount: model.counts,

--- a/app/assets/javascripts/discourse/app/routes/user-summary.js
+++ b/app/assets/javascripts/discourse/app/routes/user-summary.js
@@ -1,11 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+
   model() {
     const user = this.modelFor("user");
     if (user.get("profile_hidden")) {
-      return this.replaceWith("user.profile-hidden");
+      return this.router.replaceWith("user.profile-hidden");
     }
 
     return user.summary();

--- a/app/assets/javascripts/discourse/app/routes/user.js
+++ b/app/assets/javascripts/discourse/app/routes/user.js
@@ -2,11 +2,17 @@ import DiscourseRoute from "discourse/routes/discourse";
 import User from "discourse/models/user";
 import { action } from "@ember/object";
 import { bind } from "discourse-common/utils/decorators";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+  searchService: service("search"),
+  appEvents: service("app-events"),
+  messageBus: service("message-bus"),
+
   beforeModel() {
     if (this.siteSettings.hide_user_profiles_from_public && !this.currentUser) {
-      this.replaceWith("discovery");
+      this.router.replaceWith("discovery");
     }
   },
 
@@ -31,7 +37,7 @@ export default DiscourseRoute.extend({
       .findDetails()
       .then(() => user.findStaffInfo())
       .then(() => user.trackStatus())
-      .catch(() => this.replaceWith("/404"));
+      .catch(() => this.router.replaceWith("/404"));
   },
 
   serialize(model) {

--- a/app/assets/javascripts/discourse/app/routes/users.js
+++ b/app/assets/javascripts/discourse/app/routes/users.js
@@ -3,8 +3,13 @@ import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { Promise } from "rsvp";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
+  siteSettings: service(),
+  currentUser: service(),
+
   queryParams: {
     period: { refreshModel: true },
     order: { refreshModel: true },
@@ -36,7 +41,7 @@ export default DiscourseRoute.extend({
 
   beforeModel() {
     if (this.siteSettings.hide_user_profiles_from_public && !this.currentUser) {
-      this.replaceWith("discovery");
+      this.router.replaceWith("discovery");
     }
   },
 

--- a/app/assets/javascripts/discourse/config/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/config/deprecation-workflow.js
@@ -5,7 +5,6 @@ globalThis.deprecationWorkflow.config = {
   workflow: [
     { handler: "silence", matchId: "route-render-template" },
     { handler: "silence", matchId: "route-disconnect-outlet" },
-    { handler: "silence", matchId: "routing.transition-methods" },
     { handler: "silence", matchId: "this-property-fallback" },
     { handler: "silence", matchId: "discourse.select-kit" },
   ],

--- a/app/assets/javascripts/wizard/addon/routes/wizard-index.js
+++ b/app/assets/javascripts/wizard/addon/routes/wizard-index.js
@@ -1,8 +1,10 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  router: service(),
   beforeModel() {
     const appModel = this.modelFor("wizard");
-    this.replaceWith("wizard.step", appModel.start);
+    this.router.replaceWith("wizard.step", appModel.start);
   },
 });

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-archived.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-archived.js
@@ -1,9 +1,13 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class ChatBrowseIndexRoute extends DiscourseRoute {
+  @service router;
+  @service siteSettings;
+
   afterModel() {
     if (!this.siteSettings.chat_allow_archiving_channels) {
-      this.replaceWith("chat.browse");
+      this.router.replaceWith("chat.browse");
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
@@ -18,6 +18,6 @@ export default class ChatBrowseIndexRoute extends DiscourseRoute {
   }
 
   afterModel() {
-    this.replaceWith("chat.browse.open");
+    this.router.replaceWith("chat.browse.open");
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-about.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-about.js
@@ -1,9 +1,12 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class ChatChannelInfoAboutRoute extends DiscourseRoute {
+  @service router;
+
   afterModel(model) {
     if (model.isDirectMessageChannel) {
-      this.replaceWith("chat.channel.info.index");
+      this.router.replaceWith("chat.channel.info.index");
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-index.js
@@ -1,15 +1,18 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class ChatChannelInfoIndexRoute extends DiscourseRoute {
+  @service router;
+
   afterModel(model) {
     if (model.isDirectMessageChannel) {
       if (model.isOpen && model.membershipsCount >= 1) {
-        this.replaceWith("chat.channel.info.members");
+        this.router.replaceWith("chat.channel.info.members");
       } else {
-        this.replaceWith("chat.channel.info.settings");
+        this.router.replaceWith("chat.channel.info.settings");
       }
     } else {
-      this.replaceWith("chat.channel.info.about");
+      this.router.replaceWith("chat.channel.info.about");
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-members.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-members.js
@@ -1,13 +1,16 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class ChatChannelInfoMembersRoute extends DiscourseRoute {
+  @service router;
+
   afterModel(model) {
     if (!model.isOpen) {
-      return this.replaceWith("chat.channel.info.settings");
+      return this.router.replaceWith("chat.channel.info.settings");
     }
 
     if (model.membershipsCount < 1) {
-      return this.replaceWith("chat.channel.info");
+      return this.router.replaceWith("chat.channel.info");
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-settings.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-info-settings.js
@@ -1,9 +1,13 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { inject as service } from "@ember/service";
 
 export default class ChatChannelInfoSettingsRoute extends DiscourseRoute {
+  @service router;
+  @service currentUser;
+
   afterModel(model) {
     if (!this.currentUser?.staff && !model.currentUserMembership?.following) {
-      this.replaceWith("chat.channel.info");
+      this.router.replaceWith("chat.channel.info");
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-message.js
@@ -17,7 +17,7 @@ export default class ChatMessageRoute extends DiscourseRoute {
           params.messageId
         );
       })
-      .catch(() => this.replaceWith("/404"));
+      .catch(() => this.router.replaceWith("/404"));
   }
 
   beforeModel() {


### PR DESCRIPTION
# Context
This PR was originally implemented in https://github.com/discourse/discourse/pull/22645 then reverted in https://github.com/discourse/discourse/pull/22693. We protect from aborted transition when _awaiting_ on `replaceWith` by utilizing [followRedirects()](https://api.emberjs.com/ember/5.1/classes/Transition/methods/followRedirects?anchor=followRedirects)

# Description
Per https://deprecations.emberjs.com/v3.x/#toc_routing-transition-methods

We are upgrading all `this.replaceWith` calls on routes to directly call the router service (`this.router.replaceWith`)

