### PR TITLE
FIX: Delete fast typer reviewable when deleting user

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -137,6 +137,14 @@ class UserDestroyer
           reviewable.perform(@actor, :agree_and_keep)
         end
       end
+
+    ReviewablePost
+      .where(target_created_by: user)
+      .find_each do |reviewable|
+        if reviewable.actions_for(@guardian).has?(:reject_and_delete)
+          reviewable.perform(@actor, :reject_and_delete)
+        end
+      end
   end
 
   def delete_posts(user, category_topic_ids, opts)

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -203,6 +203,26 @@ RSpec.describe UserDestroyer do
               reviewable.reload
               expect(reviewable).to be_approved
             end
+
+            it "rejects pending posts" do
+              post = Fabricate(:post, user: user)
+              reviewable =
+                Fabricate(
+                  :reviewable,
+                  type: "ReviewablePost",
+                  target_type: "Post",
+                  target_id: post.id,
+                  created_by: Discourse.system_user,
+                  target_created_by: user,
+                )
+
+              expect(reviewable).to be_pending
+
+              destroy
+
+              reviewable.reload
+              expect(reviewable).to be_rejected
+            end
           end
         end
 


### PR DESCRIPTION
### What was the problem?

In most cases, deleting a user from outside the review UI will also delete any pending reviewables for that user. This was not working in some cases, e.g. for reviewables created due to "fast typer" violations.

~~This was happening because `UserDestroyer` was looking for reviewables with a `created_by_id` equal to the deleted user's ID. But this column represents "reviewable was created by", and not "target of reviewable was created by".~~

This was happening because `UserDestroyer` only automatically resolves flagged posts.

### How does this fix it?

~~In addition to looking for reviewables with the condition `created_by_id: user.id` we also look for `target_created_by: user.id`. (The old condition is kept to prevent any regressions.)~~

After this change, in addition to existing checks, look for `ReviewablePost` where the post was created by the user and reject them if present.