### PR TITLE
DEV: makes every spec use new messages helper

### DIFF
--- a/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
+++ b/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
@@ -7,7 +7,7 @@ describe "Channel thread message echoing", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:side_panel) { PageObjects::Pages::ChatSidePanel.new }
-  let(:open_thread) { PageObjects::Pages::ChatThread.new }
+  let(:thread_page) { PageObjects::Pages::ChatThread.new }
   let(:chat_drawer_page) { PageObjects::Pages::ChatDrawer.new }
 
   before do
@@ -49,9 +49,9 @@ describe "Channel thread message echoing", type: :system do
     it "does not echo new thread messages into the channel stream" do
       chat_page.visit_channel(channel)
       channel_page.message_thread_indicator(thread.original_message).click
-      expect(side_panel).to have_open_thread(thread)
-      open_thread.send_message("new thread message")
-      expect(open_thread).to have_message(thread_id: thread.id, text: "new thread message")
+      expect(side_panel).to have_thread_page(thread)
+      thread_page.send_message("new thread message")
+      expect(thread_page.messages).to have_message(thread_id: thread.id, text: "new thread message")
       new_message = thread.reload.replies.last
       expect(channel_page).not_to have_css(channel_page.message_by_id_selector(new_message.id))
     end

--- a/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
+++ b/plugins/chat/spec/system/channel_thread_message_echoing_spec.rb
@@ -49,7 +49,7 @@ describe "Channel thread message echoing", type: :system do
     it "does not echo new thread messages into the channel stream" do
       chat_page.visit_channel(channel)
       channel_page.message_thread_indicator(thread.original_message).click
-      expect(side_panel).to have_thread_page(thread)
+      expect(side_panel).to have_open_thread(thread)
       thread_page.send_message("new thread message")
       expect(thread_page.messages).to have_message(thread_id: thread.id, text: "new thread message")
       new_message = thread.reload.replies.last

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Chat channel", type: :system do
         end
 
         using_session(:tab_2) do |session|
-          expect(channel_page).to have_message(text: "test_message")
+          expect(channel_page.messages).to have_message(text: "test_message")
           session.quit
         end
       end

--- a/plugins/chat/spec/system/message_notifications_mobile_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_mobile_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Message notifications - mobile", type: :system, mobile: true do
     sign_in(creator)
     chat_page.visit_channel(channel)
     chat_channel_page.send_message(text)
-    expect(chat_channel_page).to have_message(text: text)
+    expect(chat_channel_page.messages).to have_message(text: text)
   end
 
   context "as a user" do

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -86,12 +86,6 @@ module PageObjects
         find(".open-drawer-btn").click
       end
 
-      def has_message?(message)
-        container = find(".chat-message-container[data-id=\"#{message.id}\"]")
-        container.has_content?(message.message)
-        container.has_content?(message.user.username)
-      end
-
       NEW_CHANNEL_BUTTON_SELECTOR = ".new-channel-btn"
 
       def new_channel_button

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -192,27 +192,6 @@ module PageObjects
         find(".chat-composer-dropdown__action-btn.#{action_button_class}").click
       end
 
-      def has_message?(text: nil, id: nil)
-        check_message_presence(exists: true, text: text, id: id)
-      end
-
-      def has_no_message?(text: nil, id: nil)
-        check_message_presence(exists: false, text: text, id: id)
-      end
-
-      def check_message_presence(exists: true, text: nil, id: nil)
-        css_method = exists ? :has_css? : :has_no_css?
-        if text
-          find(".chat-channel").send(css_method, ".chat-message-text", text: text, wait: 5)
-        elsif id
-          find(".chat-channel").send(
-            css_method,
-            ".chat-message-container[data-id=\"#{id}\"]",
-            wait: 10,
-          )
-        end
-      end
-
       def has_thread_indicator?(message)
         message_thread_indicator(message).exists?
       end

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -114,24 +114,6 @@ module PageObjects
         find(".chat-thread .chat-composer.is-send-enabled .chat-composer-button.-send").click
       end
 
-      def has_message?(text: nil, id: nil, thread_id: nil)
-        check_message_presence(exists: true, text: text, id: id, thread_id: thread_id)
-      end
-
-      def has_no_message?(text: nil, id: nil, thread_id: nil)
-        check_message_presence(exists: false, text: text, id: id, thread_id: thread_id)
-      end
-
-      def check_message_presence(exists: true, text: nil, id: nil, thread_id: nil)
-        css_method = exists ? :has_css? : :has_no_css?
-        selector = thread_id ? ".chat-thread[data-id=\"#{thread_id}\"]" : ".chat-thread"
-        if text
-          find(selector).send(css_method, ".chat-message-text", text: text, wait: 5)
-        elsif id
-          find(selector).send(css_method, ".chat-message-container[data-id=\"#{id}\"]", wait: 10)
-        end
-      end
-
       def expand_deleted_message(message)
         message_by_id(message.id).find(".chat-message-expand").click
       end

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
       thread_page.fill_composer("reply to message")
       thread_page.click_send_message
 
-      expect(thread_page).to have_message(text: "reply to message")
+      expect(thread_page.messages).to have_message(text: "reply to message")
       expect(channel_page).to have_thread_indicator(original_message)
     end
 
@@ -45,12 +45,12 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
         thread_page.fill_composer("reply to message")
         thread_page.click_send_message
 
-        expect(thread_page).to have_message(text: "reply to message")
+        expect(thread_page.messages).to have_message(text: "reply to message")
         expect(channel_page).to have_thread_indicator(original_message)
 
         refresh
 
-        expect(thread_page).to have_message(text: "reply to message")
+        expect(thread_page.messages).to have_message(text: "reply to message")
       end
     end
   end
@@ -95,7 +95,7 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
       channel_page.fill_composer("reply to message")
       channel_page.click_send_message
 
-      expect(channel_page).to have_message(text: "reply to message")
+      expect(channel_page.messages).to have_message(text: "reply to message")
     end
 
     it "renders safe HTML from the original message excerpt" do
@@ -112,7 +112,7 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
       channel_page.fill_composer("reply to message")
       channel_page.click_send_message
 
-      expect(channel_page).to have_message(text: "reply to message")
+      expect(channel_page.messages).to have_message(text: "reply to message")
     end
   end
 end

--- a/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
@@ -37,36 +37,36 @@ RSpec.describe "Reply to message - smoke", type: :system do
 
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(1)
 
-        expect(thread_page).to have_message(text: "user1reply")
+        expect(thread_page.messages).to have_message(text: "user1reply")
       end
 
       using_session(:user_2) do |session|
-        expect(thread_page).to have_message(text: "user1reply")
+        expect(thread_page.messages).to have_message(text: "user1reply")
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(1)
 
         thread_page.fill_composer("user2reply")
         thread_page.click_send_message
 
-        expect(thread_page).to have_message(text: "user2reply")
+        expect(thread_page.messages).to have_message(text: "user2reply")
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(2)
 
         refresh
 
-        expect(thread_page).to have_message(text: "user1reply")
-        expect(thread_page).to have_message(text: "user2reply")
+        expect(thread_page.messages).to have_message(text: "user1reply")
+        expect(thread_page.messages).to have_message(text: "user2reply")
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(2)
 
         session.quit
       end
 
       using_session(:user_1) do |session|
-        expect(thread_page).to have_message(text: "user2reply")
+        expect(thread_page.messages).to have_message(text: "user2reply")
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(2)
 
         refresh
 
-        expect(thread_page).to have_message(text: "user1reply")
-        expect(thread_page).to have_message(text: "user2reply")
+        expect(thread_page.messages).to have_message(text: "user1reply")
+        expect(thread_page.messages).to have_message(text: "user2reply")
         expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(2)
 
         session.quit

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -93,7 +93,10 @@ describe "Single thread in side panel", type: :system do
         channel_page.message_thread_indicator(thread.original_message).click
         expect(side_panel).to have_open_thread(thread)
         thread_page.send_message("new thread message")
-        expect(thread_page).to have_message(thread_id: thread.id, text: "new thread message")
+        expect(thread_page.messages).to have_message(
+          thread_id: thread.id,
+          text: "new thread message",
+        )
         thread_message = thread.last_message
         expect(thread_message.chat_channel_id).to eq(channel.id)
         expect(thread_message.thread.channel_id).to eq(channel.id)
@@ -104,7 +107,10 @@ describe "Single thread in side panel", type: :system do
         channel_page.message_thread_indicator(thread.original_message).click
         expect(side_panel).to have_open_thread(thread)
         thread_page.send_message("new thread message")
-        expect(thread_page).to have_message(thread_id: thread.id, text: "new thread message")
+        expect(thread_page.messages).to have_message(
+          thread_id: thread.id,
+          text: "new thread message",
+        )
         thread_message = thread.reload.replies.last
         expect(channel_page).not_to have_css(channel_page.message_by_id_selector(thread_message.id))
       end
@@ -136,18 +142,30 @@ describe "Single thread in side panel", type: :system do
 
         thread_page.send_message("the other user message")
 
-        expect(thread_page).to have_message(thread_id: thread.id, text: "the other user message")
+        expect(thread_page.messages).to have_message(
+          thread_id: thread.id,
+          text: "the other user message",
+        )
 
         using_session(:tab_1) do
           expect(side_panel).to have_open_thread(thread)
-          expect(thread_page).to have_message(thread_id: thread.id, text: "the other user message")
+          expect(thread_page.messages).to have_message(
+            thread_id: thread.id,
+            text: "the other user message",
+          )
 
           thread_page.send_message("this is a test message")
 
-          expect(thread_page).to have_message(thread_id: thread.id, text: "this is a test message")
+          expect(thread_page.messages).to have_message(
+            thread_id: thread.id,
+            text: "this is a test message",
+          )
         end
 
-        expect(thread_page).to have_message(thread_id: thread.id, text: "this is a test message")
+        expect(thread_page.messages).to have_message(
+          thread_id: thread.id,
+          text: "this is a test message",
+        )
       end
 
       it "does not mark the channel unread if another user sends a message in the thread" do

--- a/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
+++ b/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Unfollow dm channel", type: :system do
         sign_in(other_user)
         chat_page.visit_channel(dm_channel_1)
         channel_page.send_message(text)
-        expect(channel_page).to have_message(text: text)
+        expect(channel_page.messages).to have_message(text: text)
         session.quit
       end
 

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Visit channel", type: :system do
             chat.visit_channel(category_channel_1)
 
             expect(page).to have_content(category_channel_1.name)
-            expect(chat).to have_message(message_1)
+            expect(channel_page.messages).to have_message(message_1)
           end
         end
 
@@ -167,7 +167,7 @@ RSpec.describe "Visit channel", type: :system do
             chat.visit_channel(category_channel_1)
 
             expect(page).to have_content(category_channel_1.name)
-            expect(chat).to have_message(message_1)
+            expect(channel_page.messages).to have_message(message_1)
           end
 
           context "when URL doesn’t contain slug" do
@@ -217,7 +217,7 @@ RSpec.describe "Visit channel", type: :system do
           it "shows a preview of the channel" do
             chat.visit_channel(dm_channel_1)
 
-            expect(chat).to have_message(message_1)
+            expect(channel_page.messages).to have_message(message_1)
           end
 
           context "when URL doesn’t contain slug" do

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -195,10 +195,10 @@ RSpec.describe "Visit channel", type: :system do
             it "does not error" do
               visit(early_message.url)
               expect(channel_page).to have_no_loading_skeleton
-              expect(channel_page).to have_message(id: early_message.id)
+              expect(channel_page.messages).to have_message(id: early_message.id)
               sidebar_page.open_channel(other_channel)
               expect(dialog).to be_closed
-              expect(channel_page).to have_message(id: other_channel_message.id)
+              expect(channel_page.messages).to have_message(id: other_channel_message.id)
             end
           end
         end

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Visit channel", type: :system do
             chat.visit_channel(category_channel_1)
 
             expect(page).to have_content(category_channel_1.name)
-            expect(channel_page.messages).to have_message(message_1)
+            expect(channel_page.messages).to have_message(id: message_1.id)
           end
         end
 
@@ -167,7 +167,7 @@ RSpec.describe "Visit channel", type: :system do
             chat.visit_channel(category_channel_1)
 
             expect(page).to have_content(category_channel_1.name)
-            expect(channel_page.messages).to have_message(message_1)
+            expect(channel_page.messages).to have_message(id: message_1.id)
           end
 
           context "when URL doesn’t contain slug" do
@@ -217,7 +217,7 @@ RSpec.describe "Visit channel", type: :system do
           it "shows a preview of the channel" do
             chat.visit_channel(dm_channel_1)
 
-            expect(channel_page.messages).to have_message(message_1)
+            expect(channel_page.messages).to have_message(id: message_1.id)
           end
 
           context "when URL doesn’t contain slug" do


### PR DESCRIPTION
It's been introduced months ago, but not everything was transitioned to it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
