### PR TITLE
PERF: Improve rendering performance of empty PluginOutlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.hbs
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.hbs
@@ -22,7 +22,7 @@
       {{/if}}
     {{/each}}
   </this.wrapperComponent>
-{{else}}
+{{else if this.connectorsExist}}
   {{! The modern path: no wrapper element = no classic component }}
   {{#each this.connectors as |c|}}
     {{#if c.componentClass}}

--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -3,6 +3,7 @@ import ClassicComponent from "@ember/component";
 
 import {
   buildArgsWithDeprecations,
+  connectorsExist,
   renderedConnectorsFor,
 } from "discourse/lib/plugin-connectors";
 import { helperContext } from "discourse-common/lib/helpers";
@@ -84,6 +85,10 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
       this.outletArgsWithDeprecations,
       this.context
     );
+  }
+
+  get connectorsExist() {
+    return connectorsExist(this.args.name);
   }
 
   // Traditionally, pluginOutlets had an argument named 'args'. However, that name is reserved

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -165,6 +165,13 @@ function buildConnectorCache() {
   }
 }
 
+export function connectorsExist(outletName) {
+  if (!_connectorCache) {
+    buildConnectorCache();
+  }
+  return Boolean(_connectorCache[outletName]);
+}
+
 export function connectorsFor(outletName) {
   if (!_connectorCache) {
     buildConnectorCache();


### PR DESCRIPTION
This commit introduces a 'shortcut' when rendering PluginOutlets which have no registered connectors. On my machine, this improves rendering performance of empty PluginOutlets by around 30-40% (tested by running tachometer on a `/latest` route with 600 plugin outlets).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
