### PR TITLE
DEV: Ensure plugin raw connectors are transpiled to `/raw-templates`

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -15,13 +15,18 @@ function fixLegacyExtensions(tree) {
     getDestinationPath: function (relativePath) {
       if (relativePath.endsWith(".es6")) {
         return relativePath.slice(0, -4);
-      } else if (relativePath.includes("/templates/")) {
-        if (relativePath.endsWith(".raw.hbs")) {
-          relativePath = relativePath.replace(".raw.hbs", ".hbr");
-        }
+      } else if (relativePath.endsWith(".raw.hbs")) {
+        relativePath = relativePath.replace(".raw.hbs", ".hbr");
+      }
 
-        if (relativePath.endsWith(".hbr")) {
-          return relativePath.replace("/templates/", "/raw-templates/");
+      if (relativePath.endsWith(".hbr")) {
+        if (relativePath.includes("/templates/")) {
+          relativePath = relativePath.replace("/templates/", "/raw-templates/");
+        } else if (relativePath.includes("/connectors/")) {
+          relativePath = relativePath.replace(
+            "/connectors/",
+            "/raw-templates/connectors/"
+          );
         }
       }
 


### PR DESCRIPTION
Transpiling to `/raw-templates` is important so that they are detected by the `eager-load-raw-templates` initializer. Prior to 16c6ab86 this wasn't a problem because all connector modules were being eager-loaded. Now that connectors are lazily loaded, it's critical that `eager-load-raw-templates` does the eager loading for raw connectors.

This problem doesn't affect themes because they compile raw templates into an iife instead of a `define()` module.

Unfortunately we don't have any way to introduce automated testing for this part of our compilation pipeline. However, discourse-calendar will begin depending on this functionality imminently, so its tests will warn us of future regressions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
