### PR TITLE
FIX: correctly recognizes URL with subfolder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -3,6 +3,7 @@ import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 import { defaultHomepage } from "discourse/lib/utilities";
+import getURL from "discourse-common/lib/get-url";
 
 export default class SwitchPanelButtons extends Component {
   @service router;
@@ -15,7 +16,9 @@ export default class SwitchPanelButtons extends Component {
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
 
     const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
-    const destination = url === "/" ? `discovery.${defaultHomepage()}` : url;
+    const destination =
+      url === "/" ? `discovery.${defaultHomepage()}` : getURL(url);
+
     this.router
       .transitionTo(destination)
       .then(() => {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
@@ -6,6 +6,7 @@ import { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { escapeExpression } from "discourse/lib/utilities";
 import DiscourseURL from "discourse/lib/url";
+import getURL from "discourse-common/lib/get-url";
 
 export default Component.extend({
   tagName: "",
@@ -176,7 +177,7 @@ export default Component.extend({
   },
 
   _routeFromURL(url) {
-    let route = this.router.recognize(url || "/");
+    let route = this.router.recognize(getURL(url || "/"));
 
     // ember might recognize the index subroute
     if (route.localName === "index") {

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Drawer", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
-  let(:drawer) { PageObjects::Pages::ChatDrawer.new }
+  let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
 
   before do
     chat_system_bootstrap
@@ -21,7 +21,7 @@ RSpec.describe "Drawer", type: :system do
       it "opens channel info page" do
         visit("/")
         chat_page.open_from_header
-        drawer.open_channel(channel)
+        drawer_page.open_channel(channel)
         page.find(".chat-channel-title").click
 
         expect(page).to have_current_path("/chat/c/#{channel.slug}/#{channel.id}/info/about")
@@ -62,7 +62,7 @@ RSpec.describe "Drawer", type: :system do
 
       expect(page.find("body.chat-drawer-active")).to be_visible
 
-      drawer.close
+      drawer_page.close
 
       expect(page.find("body:not(.chat-drawer-active)")).to be_visible
     end
@@ -77,12 +77,12 @@ RSpec.describe "Drawer", type: :system do
     it "resets the active message" do
       visit("/")
       chat_page.open_from_header
-      drawer.open_channel(channel_1)
+      drawer_page.open_channel(channel_1)
       channel_page.hover_message(message_1)
 
       expect(page).to have_css(".chat-message-actions-container", visible: :all)
 
-      drawer.close
+      drawer_page.close
 
       expect(page).to have_no_css(".chat-message-actions-container")
     end
@@ -116,9 +116,9 @@ RSpec.describe "Drawer", type: :system do
       visit("/")
 
       chat_page.open_from_header
-      drawer.maximize
+      drawer_page.maximize
       chat_page.minimize_full_page
-      drawer.maximize
+      drawer_page.maximize
 
       using_session("user_1") do |session|
         sign_in(user_1)
@@ -132,6 +132,22 @@ RSpec.describe "Drawer", type: :system do
       chat_page.visit_channel(channel_2)
 
       expect(page).to have_content("onlyonce", count: 0, wait: 20)
+    end
+  end
+
+  context "when subfolder install" do
+    fab!(:channel) { Fabricate(:chat_channel) }
+
+    before do
+      channel.add(current_user)
+      set_subfolder "/discuss"
+    end
+
+    it "works to go from full page to drawer" do
+      visit("/discuss/chat")
+      chat_page.minimize_full_page
+
+      expect(drawer_page).to have_open_channel(channel)
     end
   end
 end


### PR DESCRIPTION
Prior to this fix minimizing a full page chat on a subfolder install would cause the drawer to not show.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
