### PR TITLE
DEV: Tighten up fuzzy search site setting results

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -79,7 +79,15 @@ export default class AdminSiteSettingsController extends Controller {
             item.get("description").toLowerCase().includes(filter) ||
             (item.get("value") || "").toString().toLowerCase().includes(filter);
           if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
-            fuzzyMatches.push(item);
+            // Tightens up fuzzy search results a bit.
+            const fuzzySearchLimiter = 15;
+            const strippedSetting = setting.replace(/[^a-z0-9]/gi, "");
+            if (
+              strippedSetting.length <=
+              strippedQuery.length + fuzzySearchLimiter
+            ) {
+              fuzzyMatches.push(item);
+            }
           }
           return filterResult;
         } else {

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -30,6 +30,16 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
             value: "",
             setting: "hello world",
           }),
+          SiteSetting.create({
+            description: "",
+            value: "",
+            setting: "digest_logo",
+          }),
+          SiteSetting.create({
+            description: "",
+            value: "",
+            setting: "pending_users_reminder_delay_minutes",
+          }),
         ],
       },
     ];
@@ -38,5 +48,8 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
     assert.deepEqual(results[0].siteSettings.length, 2);
     // ensures hello world shows up before fuzzy hpello world
     assert.deepEqual(results[0].siteSettings[0].setting, "hello world");
+    results = controller.performSearch("digest", settings2);
+    assert.deepEqual(results[0].siteSettings.length, 1);
+    assert.deepEqual(results[0].siteSettings[0].setting, "digest_logo");
   });
 });


### PR DESCRIPTION
Sometimes the fuzzy search would return too many site setting results
making it hard to find what you are searching for. This change still
allows for fuzzy searching but tightens up the criteria for being a
fuzzy match.

One example is searching for 'cheer', a term associated with a plugin,
previously returned ~55 search results. With this change it will return
~13 (Actual numbers depend on how many plugins your instance has).

Another example is searching for 'digest'. Previously returned ~37
results and now will return ~14.

Follow up to: e63e193a0aa65b26863d9ab0f301a9466b2a87f9

See also: https://meta.discourse.org/t/276013
