### PR TITLE
FIX: do not delete empty message with uploads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -126,8 +126,12 @@ export default class ChatComposer extends Component {
     const minLength = this.siteSettings.chat_minimum_message_length || 1;
     return (
       this.currentMessage?.message?.length >= minLength ||
-      (this.canAttachUploads && this.currentMessage?.uploads?.length > 0)
+      (this.canAttachUploads && this.hasUploads)
     );
+  }
+
+  get hasUploads() {
+    return this.currentMessage?.uploads?.length > 0;
   }
 
   get sendEnabled() {
@@ -229,14 +233,10 @@ export default class ChatComposer extends Component {
 
     if (
       this.currentMessage.editing &&
+      !this.hasUploads &&
       this.currentMessage.message.length === 0
     ) {
-      new ChatMessageInteractor(
-        getOwner(this),
-        this.currentMessage,
-        this.context
-      ).delete();
-      this.reset(this.args.channel, this.args.thread);
+      this.#deleteEmptyMessage();
       return;
     }
 
@@ -584,5 +584,14 @@ export default class ChatComposer extends Component {
 
   #isAutocompleteDisplayed() {
     return document.querySelector(".autocomplete");
+  }
+
+  #deleteEmptyMessage() {
+    new ChatMessageInteractor(
+      getOwner(this),
+      this.currentMessage,
+      this.context
+    ).delete();
+    this.reset(this.args.channel, this.args.thread);
   }
 }

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -104,6 +104,25 @@ RSpec.describe "Chat composer", type: :system do
 
       expect(channel_page.messages).to have_message(deleted: 1)
     end
+
+    context "with uploads" do
+      fab!(:upload_reference) do
+        Fabricate(
+          :upload_reference,
+          target: message_1,
+          upload: Fabricate(:upload, user: current_user),
+        )
+      end
+
+      it "doesnt delete the message" do
+        chat_page.visit_channel(channel_1)
+        channel_page.composer.edit_last_message_shortcut
+        channel_page.composer.fill_in(with: "")
+        channel_page.click_send_message
+
+        expect(channel_page.messages).to have_message(id: message_1.id)
+      end
+    end
   end
 
   context "when posting a message with length equal to minimum length" do

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -98,6 +98,7 @@ module PageObjects
           selector += ".-persisted" if args[:persisted]
           selector += ".-staged" if args[:staged]
           selector += ".-deleted" if args[:deleted]
+          selector += ":not(.-deleted)" if !args[:deleted]
           selector
         end
       end

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -98,7 +98,6 @@ module PageObjects
           selector += ".-persisted" if args[:persisted]
           selector += ".-staged" if args[:staged]
           selector += ".-deleted" if args[:deleted]
-          selector += ":not(.-deleted)" if !args[:deleted]
           selector
         end
       end


### PR DESCRIPTION
Prior to this fix when editing a message containing only upload, if we would save it, it would delete it by considering it empty.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
