### PR TITLE
FIX: correctly display max users message error

### DIFF
--- a/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
@@ -15,7 +15,7 @@ class Chat::Api::DirectMessagesController < Chat::ApiController
       end
       on_model_not_found(:target_users) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:satisfies_dms_max_users_limit) do |policy|
-        raise Discourse::InvalidParameters.new(:target_usernames, policy.reason)
+        render_json_dump({ error: policy.reason }, status: 400)
       end
       on_failed_policy(:actor_allows_dms) do
         render_json_error(I18n.t("chat.errors.actor_disallowed_dms"))

--- a/plugins/chat/app/policies/chat/direct_message_channel/max_users_excess_policy.rb
+++ b/plugins/chat/app/policies/chat/direct_message_channel/max_users_excess_policy.rb
@@ -12,7 +12,7 @@ class Chat::DirectMessageChannel::MaxUsersExcessPolicy < PolicyBase
     return I18n.t("chat.errors.over_chat_max_direct_message_users_allow_self") if no_dm?
     I18n.t(
       "chat.errors.over_chat_max_direct_message_users",
-      count: SiteSetting.chat_max_direct_message_users + 1, # +1 for the acting user
+      count: SiteSetting.chat_max_direct_message_users,
     )
   end
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/message-creator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message-creator.js
@@ -453,6 +453,10 @@ export default class ChatMessageCreator extends Component {
     this.chat
       .upsertDmChannelForUsernames(users.mapBy("username"))
       .then((channel) => {
+        if (!channel) {
+          return;
+        }
+
         this.router.transitionTo("chat.channel", ...channel.routeModels);
         this.args.onClose?.();
       });

--- a/plugins/chat/spec/system/new_message_spec.rb
+++ b/plugins/chat/spec/system/new_message_spec.rb
@@ -45,6 +45,31 @@ RSpec.describe "New message", type: :system do
     end
   end
 
+  context "when selecting more users than allowed" do
+    fab!(:current_user) { Fabricate(:trust_level_1) }
+    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_2) { Fabricate(:user) }
+
+    before { SiteSetting.chat_max_direct_message_users = 1 }
+
+    it "shows an error" do
+      visit("/")
+      chat_page.open_new_message
+      chat_page.message_creator.filter(user_1.username)
+      chat_page.message_creator.shift_click_row(user_1)
+      chat_page.message_creator.filter(user_2.username)
+      chat_page.message_creator.shift_click_row(user_2)
+      chat_page.message_creator.click_cta
+
+      expect(page).to have_content(
+        I18n.t(
+          "chat.errors.over_chat_max_direct_message_users",
+          count: SiteSetting.chat_max_direct_message_users + 1, # +1 for the acting user
+        ),
+      )
+    end
+  end
+
   context "when public channels are disabled and user can't create direct message" do
     fab!(:current_user) { Fabricate(:user) }
 
@@ -61,7 +86,7 @@ RSpec.describe "New message", type: :system do
     end
   end
 
-  context "when the the content is not filtered" do
+  context "when the content is not filtered" do
     fab!(:channel_1) { Fabricate(:chat_channel) }
     fab!(:channel_2) { Fabricate(:chat_channel) }
     fab!(:user_1) { Fabricate(:user) }

--- a/plugins/chat/spec/system/new_message_spec.rb
+++ b/plugins/chat/spec/system/new_message_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "New message", type: :system do
       expect(page).to have_content(
         I18n.t(
           "chat.errors.over_chat_max_direct_message_users",
-          count: SiteSetting.chat_max_direct_message_users + 1, # +1 for the acting user
+          count: SiteSetting.chat_max_direct_message_users,
         ),
       )
     end


### PR DESCRIPTION
Prior to this fix we wouldn't output a correctly formatted error and would show a generic error instead of the proper reason.