### PR TITLE
FIX: displays popup error for any error

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-messages-loader.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-messages-loader.js
@@ -55,7 +55,7 @@ export default class ChatMessagesLoader {
       this.canLoadMoreFuture = result.meta.can_load_more_future;
       this.canLoadMorePast = result.meta.can_load_more_past;
     } catch (error) {
-      this.#handleError(error);
+      popupAjaxError(error);
     } finally {
       this.loading = false;
     }
@@ -80,7 +80,7 @@ export default class ChatMessagesLoader {
       this.canLoadMorePast = result.meta.can_load_more_past;
       this.fetchedOnce = true;
     } catch (error) {
-      this.#handleError(error);
+      popupAjaxError(error);
     } finally {
       this.loading = false;
     }
@@ -110,18 +110,5 @@ export default class ChatMessagesLoader {
     return direction === PAST
       ? model.messagesManager.messages.find((message) => !message.staged)
       : model.messagesManager.messages.findLast((message) => !message.staged);
-  }
-
-  #handleError(error) {
-    switch (error?.jqXHR?.status) {
-      case 429:
-        popupAjaxError(error);
-        break;
-      case 404:
-        popupAjaxError(error);
-        break;
-      default:
-        throw error;
-    }
   }
 }


### PR DESCRIPTION
In the past we were only intercepting 429 and 404; it's probably better to surface any error.

There are already tests for the 404 and 429, I consider them enough for now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
