### PR TITLE
UX: do not show user tab preference when disabled

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.hbs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.hbs
@@ -1,6 +1,6 @@
-{{#if (or this.model.can_chat this.currentUser.admin)}}
+<li class="user-nav__preferences-chat">
   <LinkTo @route="preferences.chat">
     {{d-icon "d-chat"}}
     <span>{{i18n "chat.title_capitalized"}}</span>
   </LinkTo>
-{{/if}}
+</li>

--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.js
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.js
@@ -1,0 +1,7 @@
+import Component from "@glimmer/component";
+
+export default class ChatPreferences extends Component {
+  static shouldRender(model, { siteSettings, currentUser }) {
+    return siteSettings.chat_enabled && (model.can_chat || currentUser?.admin);
+  }
+}

--- a/plugins/chat/spec/system/user_chat_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_chat_preferences_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "User chat preferences", type: :system do
       sign_in(current_user)
     end
 
+    it "doesn’t show the tab" do
+      visit("/u/#{current_user.username}/preferences")
+
+      expect(page).to have_no_css(".user-nav__preferences-chat", visible: :all)
+    end
+
     it "shows a not found page" do
       visit("/u/#{current_user.username}/preferences/chat")
 


### PR DESCRIPTION
Prior to this fix we would only check if the user is allowed to chat and not if chat is enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
