### PR TITLE
UX: Fix positioning of mobile show-more following 71ff3417

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -383,18 +383,6 @@
     font-size: var(--font-0);
     cursor: default;
   }
-
-  .show-more {
-    width: 100%;
-    z-index: z("base");
-    position: absolute;
-    top: 0;
-
-    .alert {
-      margin: 0;
-      padding: 1.1em 2em 1.1em 0.65em;
-    }
-  }
 }
 
 .topic-list {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -178,6 +178,18 @@
   h2 {
     margin: 20px 0 10px;
   }
+
+  .show-more {
+    width: 100%;
+    z-index: z("base");
+    position: absolute;
+    top: 0;
+
+    .alert {
+      margin: 0;
+      padding: 1.1em 2em 1.1em 0.65em;
+    }
+  }
 }
 
 .bulk-select-topics {


### PR DESCRIPTION
71ff3417 removed the mobile-specific template for discovery/topics. It was noted that this would introduce an additional `<div class='show-more'>` wrapper around the new topic indicator on mobile, but I didn't realise that it would cause positioning problems on mobile.

This commit moves the desktop-specific CSS into the desktop SCSS file so that it does not apply to mobile.

Mobile before:
<img width="364" alt="SCR-20230822-pcom" src="https://github.com/discourse/discourse/assets/6270921/8df82623-841d-4c68-8e17-3a69340ae431">

Mobile after:
<img width="447" alt="SCR-20230822-pcmo" src="https://github.com/discourse/discourse/assets/6270921/1983bd31-368b-49b5-870a-ae6c1979f84c">

Desktop is unaffected:

<img width="1114" alt="SCR-20230822-pcxj" src="https://github.com/discourse/discourse/assets/6270921/51f4ba7b-0fa5-4dfc-b418-14ee4be980ed">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
