### PR TITLE
UX: update outdated description of chat messages export

### DIFF
--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -471,7 +471,7 @@ en:
         title: "Chat"
         export_messages:
           title: "Export chat messages"
-          description: "Export is currently limited to 10000 most recent messages in the last 6 months."
+          description: "This exports all messages from all channels."
           create_export: "Create export"
           export_has_started: "The export has started. You'll receive a PM when it's ready."
 


### PR DESCRIPTION
We removed all restrictions from the exporter of chat messages in cd45f334, but forgot to update the description on the page `/admin/plugins/chat`.

Before:
<img width="394" alt="Screenshot 2023-08-22 at 20 18 15" src="https://github.com/discourse/discourse/assets/1274517/8ba13a8d-d3fe-4878-96e7-d872922cf500">

After:
<img width="400" alt="Screenshot 2023-08-22 at 20 21 31" src="https://github.com/discourse/discourse/assets/1274517/db8adb2d-5390-4650-869a-ffa8b08d983b">


