### PR TITLE
DEV: Create wrapper API for `getCaretPosition()` jQuery

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -596,3 +596,19 @@ export function mergeSortedLists(list1, list2, comparator) {
   }
   return merged;
 }
+
+export function getCaretPosition(element, options) {
+  const jqueryElement = $(element);
+  const position = jqueryElement.caretPosition(options);
+
+  // Get the position of the textarea on the page
+  const textareaRect = element.getBoundingClientRect();
+
+  // Calculate the x and y coordinates by adding the element's position
+  const adjustedPosition = {
+    x: position.left + textareaRect.left,
+    y: position.top + textareaRect.top,
+  };
+
+  return adjustedPosition;
+}

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -6,7 +6,6 @@ import {
   escapeExpression,
   extractDomainFromUrl,
   fillMissingDates,
-  getCaretPosition,
   inCodeBlock,
   initializeDefaultHomepage,
   mergeSortedLists,
@@ -280,22 +279,6 @@ module("Unit | Utilities", function (hooks) {
       [6, 5, 4, 3, 2, 2, 1, 1],
       "it correctly merges lists that share common items"
     );
-  });
-
-  test("getCaretPosition", function (assert) {
-    const textarea = document.createElement("textarea");
-    const content = document.createTextNode("01234\n56789\n012345");
-    textarea.appendChild(content);
-    document.body.appendChild(textarea);
-
-    const adjustedPosition = getCaretPosition(textarea, {
-      pos: 0,
-    });
-    const expectedX = 0;
-    const expectedY = 2;
-
-    assert.equal(adjustedPosition.x, expectedX, "x coordinate is correct");
-    assert.equal(adjustedPosition.y, expectedY, "y coordinate is correct");
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -6,6 +6,7 @@ import {
   escapeExpression,
   extractDomainFromUrl,
   fillMissingDates,
+  getCaretPosition,
   inCodeBlock,
   initializeDefaultHomepage,
   mergeSortedLists,
@@ -279,6 +280,22 @@ module("Unit | Utilities", function (hooks) {
       [6, 5, 4, 3, 2, 2, 1, 1],
       "it correctly merges lists that share common items"
     );
+  });
+
+  test("getCaretPosition", function (assert) {
+    const textarea = document.createElement("textarea");
+    const content = document.createTextNode("01234\n56789\n012345");
+    textarea.appendChild(content);
+    document.body.appendChild(textarea);
+
+    const adjustedPosition = getCaretPosition(textarea, {
+      pos: 0,
+    });
+    const expectedX = 0;
+    const expectedY = 2;
+
+    assert.equal(adjustedPosition.x, expectedX, "x coordinate is correct");
+    assert.equal(adjustedPosition.y, expectedY, "y coordinate is correct");
   });
 });
 


### PR DESCRIPTION
This PR creates a wrapper utility for the jQuery plugin for `getCaretPosition()` so that it can be easily used to get a caret's coordinates when inside a `<textarea>`. This is necessary for being used in the Discourse AI plugin and its composer AI helper feature.

Test is omitted because its difficult to test without it being flaky (i.e. carePosition always slightly different in local/CI)