### PR TITLE
DEV: Display fuzzy site setting search results below direct matches

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -25,7 +25,7 @@ export default class AdminSiteSettingsController extends Controller {
   sortSettings(settings) {
     // Sort the site settings so that fuzzy results are at the bottom
     // and ordered by their gap count asc.
-    return settings.weight((a, b) => {
+    return settings.sort((a, b) => {
       const aWeight = a.weight === undefined ? 0 : a.weight;
       const bWeight = b.weight === undefined ? 0 : b.weight;
       return aWeight - bWeight;

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -25,12 +25,11 @@ export default class AdminSiteSettingsController extends Controller {
   sortSettings(settings) {
     // Sort the site settings so that fuzzy results are at the bottom
     // and ordered by their gap count asc.
-    settings.sort((a, b) => {
-      const aSort = a.sort === undefined ? 0 : a.sort;
-      const bSort = b.sort === undefined ? 0 : b.sort;
-      return aSort - bSort;
+    return settings.weight((a, b) => {
+      const aWeight = a.weight === undefined ? 0 : a.weight;
+      const bWeight = b.weight === undefined ? 0 : b.weight;
+      return aWeight - bWeight;
     });
-    return settings;
   }
 
   performSearch(filter, allSiteSettings, onlyOverridden) {
@@ -101,8 +100,7 @@ export default class AdminSiteSettingsController extends Controller {
             ) {
               const gapResult = strippedSetting.match(fuzzyRegexGaps);
               if (gapResult) {
-                const filteredGapResult = gapResult.filter((gap) => gap !== "");
-                item.sort = filteredGapResult.length;
+                item.weight = gapResult.filter((gap) => gap !== "").length;
               }
               fuzzyMatches.push(item);
             }

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -48,6 +48,13 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
     assert.deepEqual(results[0].siteSettings.length, 2);
     // ensures hello world shows up before fuzzy hpello world
     assert.deepEqual(results[0].siteSettings[0].setting, "hello world");
+
+    results = controller.performSearch("world", settings2);
+    assert.deepEqual(results[0].siteSettings.length, 2);
+    // ensures hello world shows up before fuzzy hpello world with "world" search
+    assert.deepEqual(results[0].siteSettings[0].setting, "hello world");
+
+    // ensures fuzzy search limiter is in place
     results = controller.performSearch("digest", settings2);
     assert.deepEqual(results[0].siteSettings.length, 1);
     assert.deepEqual(results[0].siteSettings[0].setting, "digest_logo");


### PR DESCRIPTION
When searching for site settings, in the results under the ALL category
all the fuzzy search results were showing first followed by any direct
matches. This change adjusts that so that fuzzy searches show below
direct matches.

Fuzzy results are now also sorted based on their gap calculation in
ascending order.
