### PR TITLE
UX: Fix composer category/tag column break on narrow screens

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -317,6 +317,7 @@ html.composer-open {
 
   .category-input + .mini-tag-chooser {
     margin-left: 8px;
+    width: unset;
   }
 
   .mini-tag-chooser {


### PR DESCRIPTION
(When the screen is below ~1073px the composer category/tag columns break)

Before|After
-|-
![image](https://github.com/discourse/discourse/assets/37538241/a6d91366-2545-4571-bf68-ccfd2797142d)|![image](https://github.com/discourse/discourse/assets/37538241/899f5dc5-0963-4b00-9aa9-38e1694e985f)
