### PR TITLE
DEV: Move option to delete user under reviewable agree menu

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -656,22 +656,22 @@ class Reviewable < ActiveRecord::Base
     self.score
   end
 
-  def delete_user_actions(actions, require_reject_reason: false)
-    reject =
+  def delete_user_actions(actions, bundle = nil, require_reject_reason: false)
+    bundle ||=
       actions.add_bundle(
         "reject_user",
         icon: "user-times",
         label: "reviewables.actions.reject_user.title",
       )
 
-    actions.add(:delete_user, bundle: reject) do |a|
+    actions.add(:delete_user, bundle: bundle) do |a|
       a.icon = "user-times"
       a.label = "reviewables.actions.reject_user.delete.title"
       a.require_reject_reason = require_reject_reason
       a.description = "reviewables.actions.reject_user.delete.description"
     end
 
-    actions.add(:delete_user_block, bundle: reject) do |a|
+    actions.add(:delete_user_block, bundle: bundle) do |a|
       a.icon = "ban"
       a.label = "reviewables.actions.reject_user.block.title"
       a.require_reject_reason = require_reject_reason

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -44,28 +44,32 @@ class ReviewableFlaggedPost < Reviewable
     return unless pending?
     return if post.blank?
 
-    agree =
+    agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
+    if potential_spam? && guardian.can_delete_user?(target_created_by)
+      delete_user_actions(actions, agree_bundle)
+    end
+
     if !post.user_deleted? && !post.hidden?
-      build_action(actions, :agree_and_hide, icon: "far-eye-slash", bundle: agree)
+      build_action(actions, :agree_and_hide, icon: "far-eye-slash", bundle: agree_bundle)
     end
 
     if post.hidden?
-      build_action(actions, :agree_and_keep_hidden, icon: "thumbs-up", bundle: agree)
+      build_action(actions, :agree_and_keep_hidden, icon: "thumbs-up", bundle: agree_bundle)
     else
-      build_action(actions, :agree_and_keep, icon: "thumbs-up", bundle: agree)
+      build_action(actions, :agree_and_keep, icon: "thumbs-up", bundle: agree_bundle)
     end
 
     if guardian.can_delete_post_or_topic?(post)
-      build_action(actions, :delete_and_agree, icon: "far-trash-alt", bundle: agree)
+      build_action(actions, :delete_and_agree, icon: "far-trash-alt", bundle: agree_bundle)
 
       if post.reply_count > 0
         build_action(
           actions,
           :delete_and_agree_replies,
           icon: "far-trash-alt",
-          bundle: agree,
+          bundle: agree_bundle,
           confirm: true,
         )
       end
@@ -76,19 +80,21 @@ class ReviewableFlaggedPost < Reviewable
         actions,
         :agree_and_suspend,
         icon: "ban",
-        bundle: agree,
+        bundle: agree_bundle,
         client_action: "suspend",
       )
       build_action(
         actions,
         :agree_and_silence,
         icon: "microphone-slash",
-        bundle: agree,
+        bundle: agree_bundle,
         client_action: "silence",
       )
     end
 
-    build_action(actions, :agree_and_restore, icon: "far-eye", bundle: agree) if post.user_deleted?
+    if post.user_deleted?
+      build_action(actions, :agree_and_restore, icon: "far-eye", bundle: agree_bundle)
+    end
     if post.hidden?
       build_action(actions, :disagree_and_restore, icon: "thumbs-down")
     else
@@ -117,8 +123,6 @@ class ReviewableFlaggedPost < Reviewable
         )
       end
     end
-
-    delete_user_actions(actions) if potential_spam? && guardian.can_delete_user?(target_created_by)
   end
 
   def perform_ignore(performed_by, args)


### PR DESCRIPTION
### What is this change?

As per discussion, we want to move the options to delete the user under the "Yes" menu of the review queue, since these options are often the most recommended, but also frequently missed because they are tucked away under their own menu.

> We want to move the “delete user” options under the “Yes” option in the review queue for items that show up asking “Is this post spam?” because as it stands today, people often seem to miss these options, which should be the ones most recommended.

In addition to the move, I removed the title case of the options so that it matches the other options in the "Yes" menu.

### Before

<img width="440" alt="Screenshot 2023-08-23 at 2 08 19 PM" src="https://github.com/discourse/discourse/assets/5259935/8deee7c9-0bc7-4d8f-b6e3-c7e60ef1b37b">

### After

<img width="610" alt="Screenshot 2023-08-23 at 2 06 57 PM" src="https://github.com/discourse/discourse/assets/5259935/4c7a6eab-dda4-4959-b020-7c038ea8b664">

### What about tests?

We currently have tests that all appropriate actions are included based on the guardian, but not which "bundle" each action goes in. If we want to add this granularity to the test, I can do so. For now relying on the existing test for regression.