### PR TITLE
FIX: correctly check chat tab is present

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.js
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.js
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 
 export default class ChatPreferences extends Component {
-  static shouldRender(model, { siteSettings, currentUser }) {
+  static shouldRender({ model }, { siteSettings, currentUser }) {
     return siteSettings.chat_enabled && (model.can_chat || currentUser?.admin);
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
@@ -5,13 +5,19 @@ import { inject as service } from "@ember/service";
 export default class PreferencesChatRoute extends RestrictedUserRoute {
   @service chat;
   @service router;
+  @service siteSettings;
+  @service currentUser;
 
   showFooter = true;
 
   setupController(controller, user) {
-    if (!user?.can_chat && !this.currentUser.admin) {
+    if (
+      !this.siteSettings.chat_enabled ||
+      (!user.can_chat && !this.currentUser?.admin)
+    ) {
       return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
+
     controller.set("model", user);
   }
 }

--- a/plugins/chat/spec/system/user_chat_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_chat_preferences_spec.rb
@@ -17,20 +17,21 @@ RSpec.describe "User chat preferences", type: :system do
     end
 
     it "doesn’t show the tab" do
-      visit("/u/#{current_user.username}/preferences")
+      visit("/my/preferences")
 
       expect(page).to have_no_css(".user-nav__preferences-chat", visible: :all)
     end
 
     it "shows a not found page" do
-      visit("/u/#{current_user.username}/preferences/chat")
+      visit("/my/preferences/chat")
 
       expect(page).to have_content(I18n.t("page_not_found.title"))
     end
   end
 
   it "can select chat sound" do
-    visit("/u/#{current_user.username}/preferences/chat")
+    visit("/my/preferences")
+    find(".user-nav__preferences-chat", visible: :all).click
     select_kit = PageObjects::Components::SelectKit.new("#user_chat_sounds")
     select_kit.expand
     select_kit.select_row_by_value("bell")
@@ -40,7 +41,8 @@ RSpec.describe "User chat preferences", type: :system do
   end
 
   it "can select header_indicator_preference" do
-    visit("/u/#{current_user.username}/preferences/chat")
+    visit("/my/preferences")
+    find(".user-nav__preferences-chat", visible: :all).click
     select_kit = PageObjects::Components::SelectKit.new("#user_chat_header_indicator_preference")
     select_kit.expand
     select_kit.select_row_by_value("dm_and_mentions")
@@ -50,7 +52,8 @@ RSpec.describe "User chat preferences", type: :system do
   end
 
   it "can select separate sidebar mode" do
-    visit("/u/#{current_user.username}/preferences/chat")
+    visit("/my/preferences")
+    find(".user-nav__preferences-chat", visible: :all).click
     select_kit = PageObjects::Components::SelectKit.new("#user_chat_separate_sidebar_mode")
     select_kit.expand
     select_kit.select_row_by_value("fullscreen")
@@ -67,8 +70,7 @@ RSpec.describe "User chat preferences", type: :system do
 
     it "allows to change settings" do
       visit("/u/#{user_1.username}/preferences")
-
-      find(".user-nav__preferences-chat").click
+      find(".user-nav__preferences-chat", visible: :all).click
 
       expect(page).to have_current_path("/u/#{user_1.username}/preferences/chat")
     end


### PR DESCRIPTION
Priori to this fix we would test by visiting the tab which could create a false positive, as the tab could not be present but we could still access the tab, the implementation and tests have been changed to correctly ensure this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
