### PR TITLE
FIX: correctly closes panel when exiting chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
@@ -30,7 +30,8 @@ export default class ChatChannelThread extends DiscourseRoute {
     if (
       transition.targetName === "chat.channel.index" ||
       transition.targetName === "chat.channel.near-message" ||
-      transition.targetName === "chat.index"
+      transition.targetName === "chat.index" ||
+      !transition.targetName.startsWith("chat")
     ) {
       this.chatStateManager.closeSidePanel();
     }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-threads.js
@@ -21,7 +21,12 @@ export default class ChatChannelThreads extends DiscourseRoute {
 
   @action
   willTransition(transition) {
-    if (transition.targetName === "chat.channel.index") {
+    if (
+      transition.targetName === "chat.channel.index" ||
+      transition.targetName === "chat.channel.near-message" ||
+      transition.targetName === "chat.index" ||
+      !transition.targetName.startsWith("chat")
+    ) {
       this.chatStateManager.closeSidePanel();
     }
   }

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -352,5 +352,29 @@ RSpec.describe "Navigation", type: :system do
         expect(sidebar_component).to have_no_section_link(category_channel.name, active: true)
       end
     end
+
+    context "when exiting a thread for homepage" do
+      fab!(:thread) { Fabricate(:chat_thread, channel: category_channel) }
+
+      before do
+        current_user.user_option.update(
+          chat_separate_sidebar_mode: UserOption.chat_separate_sidebar_modes[:always],
+        )
+        chat_page.prefers_full_page
+        category_channel.update!(threading_enabled: true)
+        thread.add(current_user)
+      end
+
+      it "correctly closes the panel" do
+        chat_page.visit_thread(thread)
+
+        expect(side_panel_page).to have_open_thread(thread)
+
+        find("#site-logo").click
+        sidebar_component.switch_to_chat
+
+        expect(page).to have_no_css(".chat-side-panel")
+      end
+    end
   end
 end

--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -30,6 +30,10 @@ module PageObjects
           has_css?(".sidebar-sections [data-section-name='#{name.parameterize}']")
         end
 
+        def switch_to_chat
+          find(".sidebar__panel-switch-button[data-key='chat']").click
+        end
+
         def has_no_section?(name)
           has_no_css?(".sidebar-sections [data-section-name='#{name.parameterize}']")
         end


### PR DESCRIPTION
We don't use activate/deactivate as it would cause: close/open in short succession when going from threads to thread for example.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
