### PR TITLE
UX: hide replies/participants on low usage

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.hbs
@@ -24,10 +24,17 @@
       {{format-date @message.thread.preview.lastReplyCreatedAt leaveAgo="true"}}
     </span>
   </div>
-  <div class="chat-message-thread-indicator__replies-count">
-    {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
-  </div>
-  <Chat::Thread::Participants @thread={{@message.thread}} />
+
+  {{#if (gt @message.thread.replyCount 1)}}
+    <div class="chat-message-thread-indicator__replies-count">
+      {{i18n "chat.thread.replies" count=@message.thread.preview.replyCount}}
+    </div>
+  {{/if}}
+
+  {{#if (gt @message.thread.preview.participantCount 2)}}
+    <Chat::Thread::Participants @thread={{@message.thread}} />
+  {{/if}}
+
   <div class="chat-message-thread-indicator__last-reply-excerpt">
     {{replace-emoji (html-safe @message.thread.preview.lastReplyExcerpt)}}
   </div>

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -52,9 +52,9 @@ describe "Thread indicator for chat messages", type: :system do
       expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_reply_count(
         3,
       )
-      expect(channel_page.message_thread_indicator(thread_2.original_message)).to have_reply_count(
-        1,
-      )
+      expect(
+        channel_page.message_thread_indicator(thread_2.original_message),
+      ).to have_no_reply_count
     end
 
     it "it shows the reply count but no participant avatars when there is only one participant" do
@@ -114,13 +114,25 @@ describe "Thread indicator for chat messages", type: :system do
     end
 
     it "shows avatars for the participants of the thread" do
+      extra_user = Fabricate(:user)
+      thread_1.add(extra_user)
+      Fabricate(:chat_message, thread: thread_1, user: extra_user)
+
       chat_page.visit_channel(channel)
+
       expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_participant(
         current_user,
       )
       expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_participant(
         other_user,
       )
+      expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_participant(
+        extra_user,
+      )
+
+      expect(
+        channel_page.message_thread_indicator(thread_2.original_message),
+      ).to have_no_participants
     end
 
     it "shows an excerpt of the last reply in the thread" do

--- a/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
@@ -31,6 +31,10 @@ module PageObjects
           )
         end
 
+        def has_no_reply_count?
+          find(@context).has_no_css?("#{SELECTOR}__replies-count")
+        end
+
         def has_participant?(user)
           find(@context).has_css?(
             ".chat-thread-participants__avatar-group .chat-user-avatar .chat-user-avatar__container[data-user-card=\"#{user.username}\"] img",


### PR DESCRIPTION
Low usage being:
- only 1 reply
- <= 2 participants

The second thread indicator doesn't display any info following this change:
![Screenshot 2023-08-23 at 13 57 01](https://github.com/discourse/discourse/assets/339945/8445d0be-0a05-4180-9e7a-86d94572b0f8)

Prior to this change it would have displayed this:
![Screenshot 2023-08-23 at 13 57 55](https://github.com/discourse/discourse/assets/339945/5a9d977a-7703-4317-a7c4-b8eddf497f72)
