### PR TITLE
UX: fix form template error label position

### DIFF
--- a/app/assets/stylesheets/common/components/form-template-field.scss
+++ b/app/assets/stylesheets/common/components/form-template-field.scss
@@ -1,4 +1,6 @@
 .form-template-field {
+  position: relative;
+
   input,
   textarea,
   select {


### PR DESCRIPTION
Sets `.form-template-field`'s position as `relative` to be the anchor for the `absolute` error labels.

### Before
![before](https://github.com/discourse/discourse/assets/3530/71d80611-3ed6-45e7-aacc-f69af093c2eb)


### After
![after](https://github.com/discourse/discourse/assets/3530/3034eaf8-6451-48e2-8640-ba7dfbd54116)
