### PR TITLE
FIX: correctly resets editing state when done

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -539,6 +539,7 @@ export default class ChatChannel extends Component {
     } catch (e) {
       popupAjaxError(e);
     } finally {
+      message.editing = false;
       this.chatDraftsManager.remove({ channelId: this.args.channel.id });
       this.pane.sending = false;
     }

--- a/plugins/chat/spec/system/edited_message_spec.rb
+++ b/plugins/chat/spec/system/edited_message_spec.rb
@@ -44,4 +44,16 @@ RSpec.describe "Edited message", type: :system do
       expect(page).to have_css(".cooked-date")
     end
   end
+
+  context "when replying to and edited message" do
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, user: current_user) }
+
+    it "shows the correct reply indicator" do
+      chat_page.visit_channel(channel_1)
+      channel_page.edit_message(message_1, message_1.message + "a")
+      channel_page.reply_to(message_1)
+
+      expect(channel_page.composer.message_details).to be_replying_to(message_1)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this fix, attempting to reply to a recently edited message would show the edit icon instead of the reply icon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
