### PR TITLE
UX: update styling for related/suggested topics buttons

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -1,17 +1,45 @@
 .more-topics__container {
+  position: relative;
   padding-bottom: max(env(safe-area-inset-bottom), 1em);
   max-width: calc(var(--d-max-width) * 0.87);
 
   .nav {
-    margin: 0 0 1em 0;
-
+    margin-block: 0;
     li {
       .btn {
-        padding: 0.5em 0.65em;
+        color: var(--primary);
+        background-color: transparent;
+        border-bottom: 2px solid transparent;
+        padding: 0.5em 5px;
+        &:hover {
+          border-bottom: 2px solid rgba(var(--tertiary-rgb), 0.5);
+        }
+        &.active {
+          border-bottom: 2px solid var(--tertiary);
+          .d-icon {
+            color: var(--primary-low);
+          }
+        }
       }
+    }
+  }
 
-      .btn.active .d-icon {
-        color: var(--primary-low);
+  @media screen and (min-width: 550px) {
+    .nav {
+      position: absolute;
+      top: 0;
+      li {
+        margin-right: 0;
+        .btn {
+          font-size: var(--font-0);
+          line-height: var(--line-height-large);
+          padding: 1em 0.65em;
+        }
+      }
+    }
+    .more-topics__lists:not(.single-list) {
+      .topic-list-header .default {
+        visibility: hidden;
       }
     }
   }


### PR DESCRIPTION
This PR updates the styling for the related & suggested topics to distract less from the Reply buttons and clearly indicate its usage as tabs, also referred to as pills.

See screenshots for reference before & after.

Desktop -- Same for mobile (Before)
<img width="1007" alt="CleanShot 2023-08-23 at 17 53 57@2x" src="https://github.com/discourse/discourse/assets/69276978/9fbe294f-4e1c-4c26-9fff-4330ccabf2a9">

Desktop (After)
![CleanShot 2023-08-23 at 17 05 29@2x](https://github.com/discourse/discourse/assets/69276978/a1b05e37-cd94-4ebc-947f-e67139949cf0)

Mobile (After)
![CleanShot 2023-08-23 at 17 21 01@2x](https://github.com/discourse/discourse/assets/69276978/08f87c39-d269-4a84-830a-44dc33f47047)

