### PR TITLE
FIX: Infinite loading broken on group members list

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -23,7 +23,7 @@ export default Controller.extend({
   bulkSelection: null,
 
   get canLoadMore() {
-    return this.get("model.members")?.length >= this.get("model.user_count");
+    return this.get("model.members")?.length < this.get("model.user_count");
   },
 
   @observes("filterInput")

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -230,14 +230,15 @@ class GroupsController < ApplicationController
     render "posts/latest", formats: [:rss]
   end
 
-  MEMBERS_LIMIT = 1_000
+  MEMBERS_MAX_PAGE_SIZE = 1_000
+  MEMBERS_DEFAULT_PAGE_SIZE = 50
 
   def members
     group = find_group(:group_id)
 
     guardian.ensure_can_see_group_members!(group)
 
-    limit = fetch_limit_from_params(default: 50, max: MEMBERS_LIMIT)
+    limit = fetch_limit_from_params(default: MEMBERS_DEFAULT_PAGE_SIZE, max: MEMBERS_MAX_PAGE_SIZE)
     offset = params[:offset].to_i
 
     raise Discourse::InvalidParameters.new(:offset) if offset < 0

--- a/spec/system/viewing_group_members_spec.rb
+++ b/spec/system/viewing_group_members_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe "Viewing group members", type: :system do
+  fab!(:group) { Fabricate(:group) }
+  fab!(:user_in_group_1) { Fabricate(:user).tap { |u| group.add(u) } }
+  fab!(:user_in_group_2) { Fabricate(:user).tap { |u| group.add(u) } }
+  fab!(:user_in_group_3) { Fabricate(:user).tap { |u| group.add(u) } }
+
+  it "loads more group members when a user scrolls to the bottom of the list" do
+    stub_const(GroupsController, "MEMBERS_DEFAULT_PAGE_SIZE", 2) do
+      visit("/g/#{group.name}/members")
+
+      expect(page).to have_selector(".group-member", count: 3)
+    end
+  end
+end


### PR DESCRIPTION
This regressed in 5a9924362906040e5511a72e66bf946c2554080e where
the condition to load more members into the list on the client side was
inverted.