### PR TITLE
DEV: Fix chromedriver binary errors when running system tests in para…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,10 +204,6 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      - name: Setup Webdriver
-        if: matrix.build_type == 'system'
-        run: bin/rails runner "require 'webdrivers'; Webdrivers::Chromedriver.required_version='114.0.5735.90'; Webdrivers::Chromedriver.update"
-
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system

--- a/Gemfile
+++ b/Gemfile
@@ -141,9 +141,8 @@ group :test do
   gem "fakeweb", require: false
   gem "minitest", require: false
   gem "simplecov", require: false
-  gem "selenium-webdriver", require: false
+  gem "selenium-webdriver", "~> 4.11", require: false
   gem "test-prof"
-  gem "webdrivers", require: false
   gem "rails-dom-testing", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
       google-protobuf (~> 3.23)
     sass-embedded (1.64.1-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -515,10 +515,6 @@ GEM
       hkdf (~> 1.0)
       jwt (~> 2.0)
       openssl (~> 3.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -655,7 +651,7 @@ DEPENDENCIES
   ruby-readability
   rubyzip
   sanitize
-  selenium-webdriver
+  selenium-webdriver (~> 4.11)
   shoulda-matchers!
   sidekiq
   simplecov
@@ -672,7 +668,6 @@ DEPENDENCIES
   unf
   unicorn
   web-push
-  webdrivers
   webmock
   yaml-lint
   yard

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -230,6 +230,21 @@ RSpec.configure do |config|
       raise "There are pending migrations, run RAILS_ENV=test bin/rake db:migrate"
     end
 
+    # Use a file system lock to get `selenium-manager` to download the `chromedriver` binary that is requried for
+    # system tests to support running system tests in multiple processes. If we don't download the `chromedriver` binary
+    # before running system tests in multiple processes, each process will end up calling the `selenium-manager` binary
+    # to download the `chromedriver` binary at the same time but the problem is that the binary is being downloaded to
+    # the same location and this can interfere with the running tests in another process.
+    #
+    # The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each
+    # process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.
+    if !File.directory?("~/.cache/selenium")
+      File.open("#{Rails.root}/tmp/chrome_driver_flock", "w") do |file|
+        file.flock(File::LOCK_EX)
+        `#{Selenium::WebDriver::SeleniumManager.send(:binary)} --browser chrome`
+      end
+    end
+
     Sidekiq.error_handlers.clear
 
     # Ugly, but needed until we have a user creator

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,11 +59,8 @@ require "shoulda-matchers"
 require "sidekiq/testing"
 require "test_prof/recipes/rspec/let_it_be"
 require "test_prof/before_all/adapters/active_record"
-require "webdrivers"
 require "selenium-webdriver"
 require "capybara/rails"
-
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # The shoulda-matchers gem no longer detects the test framework
 # you're using or mixes itself into that framework automatically.
@@ -255,7 +252,7 @@ RSpec.configure do |config|
 
     SiteSetting.provider = TestLocalProcessProvider.new
 
-    WebMock.disable_net_connect!(allow_localhost: true, allow: [Webdrivers::Chromedriver.base_url])
+    WebMock.disable_net_connect!(allow_localhost: true)
 
     if ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].present?
       Capybara.default_max_wait_time = ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].to_i
@@ -310,6 +307,9 @@ RSpec.configure do |config|
         .new(logging_prefs: { "browser" => browser_log_level, "driver" => "ALL" })
         .tap do |options|
           options.add_emulation(device_name: "iPhone 12 Pro")
+          options.add_argument(
+            '--user-agent="--user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/36.0  Mobile/15E148 Safari/605.1.15"',
+          )
           apply_base_chrome_options(options)
         end
 


### PR DESCRIPTION
…llel (#23122)

What is the problem here?

The `selenium-webdriver` gem is responsible for downloading the right version of the `chromedriver` binary and it downloads it into the `~/.cache/selenium` folder. THe problem here is that when a user runs `bin/turbo_rspec spec/system` for the first time, all of the processes will try to download the `chromedriver` binary to the same path at the same time and will lead to concurrency errors.

What is the fix here?

Before running any RSpec suite, we first check if the `.cache/selenium` folder is present. If it is not present, we use a file system lock to download the `chromedriver` binary such that other processes that runs after will not need to install the `chromedriver` binary.

The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
