### PR TITLE
UX: update styling for related/suggested

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -16,9 +16,6 @@
         }
         &.active {
           border-bottom: 2px solid var(--tertiary);
-          .d-icon {
-            color: var(--primary-low);
-          }
         }
       }
     }
@@ -93,5 +90,14 @@
   .suggested-topics-message .badge-wrapper.bullet span.badge-category,
   .suggested-topics-message .badge-wrapper.bar span.badge-category {
     max-width: 150px;
+  }
+}
+
+
+#main-outlet .regular {
+  @media screen and (min-width: 550px) {
+    .more-topics__container .nav li .btn {
+      padding: 0.75em 0.65em;
+    }
   }
 }

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -93,7 +93,6 @@
   }
 }
 
-
 #main-outlet .regular {
   @media screen and (min-width: 550px) {
     .more-topics__container .nav li .btn {


### PR DESCRIPTION
This PR fixes styling for previous related/suggested changes' positioning, specifically for topics, and updates the active icon color to stay easily visible by removing a line that changed its active color.

Topic (Before)
<img width="1004" alt="CleanShot 2023-08-24 at 00 18 04@2x" src="https://github.com/discourse/discourse/assets/69276978/f71b444a-a033-4e0b-8f36-a3c373a277d8">

Topic (After)
<img width="1003" alt="CleanShot 2023-08-24 at 00 13 11@2x" src="https://github.com/discourse/discourse/assets/69276978/64c8b3ea-4a4a-4b93-9489-3a32765d1ed2">

Message (Unchanged)
<img width="1016" alt="CleanShot 2023-08-24 at 00 19 12@2x" src="https://github.com/discourse/discourse/assets/69276978/d9a67233-395d-4df9-8d1e-4884fe8c91cc">

