### PR TITLE
DEV: Refactor chat specs related to message creation

### DIFF
--- a/plugins/chat/spec/components/chat/message_updater_spec.rb
+++ b/plugins/chat/spec/components/chat/message_updater_spec.rb
@@ -33,15 +33,13 @@ describe Chat::MessageUpdater do
   end
 
   def create_chat_message(user, message, channel, upload_ids: nil)
-    creator =
-      Chat::MessageCreator.create(
-        chat_channel: channel,
-        user: user,
-        in_reply_to_id: nil,
-        content: message,
-        upload_ids: upload_ids,
-      )
-    creator.chat_message
+    Fabricate(
+      :chat_message,
+      chat_channel: channel,
+      user: user,
+      message: message,
+      upload_ids: upload_ids,
+    )
   end
 
   it "errors when length is less than `chat_minimum_message_length`" do
@@ -643,14 +641,14 @@ describe Chat::MessageUpdater do
 
     it "errors when a blocked word is present" do
       chat_message = create_chat_message(user1, "something", public_chat_channel)
-      creator =
-        Chat::MessageCreator.create(
-          chat_channel: public_chat_channel,
-          user: user1,
-          content: "bad word - #{watched_word.word}",
+      updater =
+        Chat::MessageUpdater.update(
+          guardian: guardian,
+          chat_message: chat_message,
+          new_content: "bad word - #{watched_word.word}",
         )
-      expect(creator.failed?).to eq(true)
-      expect(creator.error.message).to match(
+      expect(updater.failed?).to eq(true)
+      expect(updater.error.message).to match(
         I18n.t("contains_blocked_word", { word: watched_word.word }),
       )
     end

--- a/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
+++ b/plugins/chat/spec/jobs/regular/mark_all_channel_threads_read_spec.rb
@@ -6,17 +6,19 @@ RSpec.describe Jobs::Chat::MarkAllChannelThreadsRead do
   fab!(:thread_2) { Fabricate(:chat_thread, channel: channel) }
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
-  fab!(:thread_1_message_1) { Fabricate(:chat_message, thread: thread_1) }
-  fab!(:thread_1_message_2) { Fabricate(:chat_message, thread: thread_1) }
-  fab!(:thread_1_message_3) { Fabricate(:chat_message, thread: thread_1) }
-  fab!(:thread_2_message_1) { Fabricate(:chat_message, thread: thread_2) }
-  fab!(:thread_2_message_2) { Fabricate(:chat_message, thread: thread_2) }
+  fab!(:thread_1_message_1) { Fabricate(:chat_message, thread: thread_1, chat_channel: channel) }
+  fab!(:thread_1_message_2) { Fabricate(:chat_message, thread: thread_1, chat_channel: channel) }
+  fab!(:thread_1_message_3) { Fabricate(:chat_message, thread: thread_1, chat_channel: channel) }
+  fab!(:thread_2_message_1) { Fabricate(:chat_message, thread: thread_2, chat_channel: channel) }
+  fab!(:thread_2_message_2) { Fabricate(:chat_message, thread: thread_2, chat_channel: channel) }
 
   before do
     channel.add(user_1)
     channel.add(user_2)
     thread_1.add(user_1)
+    thread_1.update!(last_message: thread_1_message_3)
     thread_2.add(user_2)
+    thread_2.update!(last_message: thread_2_message_2)
   end
 
   def unread_count(user)

--- a/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
@@ -359,10 +359,12 @@ describe Chat::ChannelFetcher do
       Chat::DirectMessageUser.create!(direct_message: dm_channel2, user: user1)
       Chat::DirectMessageUser.create!(direct_message: dm_channel2, user: user2)
 
-      Fabricate(:chat_message, user: user1, chat_channel: direct_message_channel1)
-      Fabricate(:chat_message, user: user1, chat_channel: direct_message_channel2)
+      dm_1 = Fabricate(:chat_message, user: user1, chat_channel: direct_message_channel1)
+      dm_2 = Fabricate(:chat_message, user: user1, chat_channel: direct_message_channel2)
 
+      direct_message_channel1.update!(last_message: dm_1)
       direct_message_channel1.last_message.update!(created_at: 1.day.ago)
+      direct_message_channel2.update!(last_message: dm_2)
       direct_message_channel2.last_message.update!(created_at: 1.hour.ago)
 
       expect(described_class.secured_direct_message_channels(user1.id, guardian).map(&:id)).to eq(

--- a/plugins/chat/spec/lib/chat/message_mover_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_mover_spec.rb
@@ -34,7 +34,10 @@ describe Chat::MessageMover do
   fab!(:message4) { Fabricate(:chat_message, chat_channel: destination_channel) }
   fab!(:message5) { Fabricate(:chat_message, chat_channel: destination_channel) }
   fab!(:message6) { Fabricate(:chat_message, chat_channel: destination_channel) }
+
   let(:move_message_ids) { [message1.id, message2.id, message3.id] }
+
+  before { source_channel.update!(last_message: message3) }
 
   describe "#move_to_channel" do
     def move!(move_message_ids = [message1.id, message2.id, message3.id])

--- a/plugins/chat/spec/lib/chat/parsed_mentions_spec.rb
+++ b/plugins/chat/spec/lib/chat/parsed_mentions_spec.rb
@@ -96,13 +96,7 @@ RSpec.describe Chat::ParsedMentions do
     end
 
     it "returns a user when self-mentioning" do
-      message =
-        Fabricate(
-          :chat_message,
-          chat_channel: chat_channel,
-          message: "Hey @#{channel_member_1.username}",
-          user: channel_member_1,
-        )
+      message = create_message("Hey @#{channel_member_1.username}", user: channel_member_1)
 
       mentions = described_class.new(message)
 
@@ -174,7 +168,7 @@ RSpec.describe Chat::ParsedMentions do
     end
   end
 
-  def create_message(text)
-    Fabricate(:chat_message, chat_channel: chat_channel, message: text)
+  def create_message(text, **extra_args)
+    Fabricate(:chat_message, chat_channel: chat_channel, message: text, **extra_args)
   end
 end

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -152,6 +152,11 @@ describe UserNotifications do
         )
       end
 
+      before do
+        channel.add(sender)
+        channel.update!(last_message: chat_message)
+      end
+
       it "doesn't return an email if there are no unread mentions" do
         email = described_class.chat_summary(user, {})
 
@@ -272,6 +277,7 @@ describe UserNotifications do
               chat_message: another_chat_message,
               notification: notification,
             )
+            another_chat_channel.update!(last_message: another_chat_message)
 
             email = described_class.chat_summary(user, {})
 
@@ -311,6 +317,7 @@ describe UserNotifications do
                 chat_message: another_chat_message,
                 notification: notification,
               )
+              another_chat_channel.update!(last_message: another_chat_message)
             end
 
             expected_subject =

--- a/plugins/chat/spec/plugin_helper.rb
+++ b/plugins/chat/spec/plugin_helper.rb
@@ -24,17 +24,18 @@ module ChatSystemHelpers
     user.activate
     user.user_option.update!(chat_enabled: true)
     Group.refresh_automatic_group!("trust_level_#{user.trust_level}".to_sym)
-    Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user)
+    channel.add(user)
   end
 
   def chat_thread_chain_bootstrap(channel:, users:, messages_count: 4, thread_attrs: {})
     last_user = nil
     last_message = nil
 
+    users.each { |user| chat_system_user_bootstrap(user: user, channel: channel) }
     messages_count.times do |i|
       in_reply_to = i.zero? ? nil : last_message.id
       thread_id = i.zero? ? nil : last_message.thread_id
-      last_user = last_user.present? ? (users - [last_user]).sample : users.sample
+      last_user = ((users - [last_user]).presence || users).sample
       creator =
         Chat::MessageCreator.new(
           chat_channel: channel,

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -17,12 +17,12 @@ describe Chat do
     fab!(:unused_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
 
     let!(:chat_message) do
-      Chat::MessageCreator.create(
+      Fabricate(
+        :chat_message,
         chat_channel: chat_channel,
         user: user,
-        in_reply_to_id: nil,
-        content: "Hello world!",
-        upload_ids: [upload.id],
+        message: "Hello world!",
+        uploads: [upload],
       )
     end
 
@@ -43,15 +43,13 @@ describe Chat do
     fab!(:unused_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
 
     let!(:chat_message) do
-      Chat::MessageCreator.create(
+      Fabricate(
+        :chat_message,
         chat_channel: chat_channel,
         user: user,
-        in_reply_to_id: nil,
-        content: "Hello world! #{message_upload.sha1}",
-        upload_ids: [],
+        message: "Hello world! #{message_upload.sha1}",
       )
     end
-
     let!(:draft_message) do
       Chat::Draft.create!(
         user: user,
@@ -135,16 +133,15 @@ describe Chat do
     fab!(:user_4) { Fabricate(:user, suspended_till: 3.weeks.from_now) }
 
     let!(:chat_message) do
-      Chat::MessageCreator.create(
-        chat_channel: chat_channel,
-        user: user,
-        in_reply_to_id: nil,
-        content: "Hello world!",
-        upload_ids: [],
-      ).chat_message
+      Fabricate(:chat_message, chat_channel: chat_channel, user: user, message: "Hello world!")
     end
 
     let(:chat_url) { "#{Discourse.base_url}/chat/c/-/#{chat_channel.id}" }
+
+    before do
+      chat_channel.update!(last_message: chat_message)
+      chat_channel.add(user)
+    end
 
     context "when inline" do
       it "renders channel" do
@@ -166,7 +163,6 @@ describe Chat do
 
     context "when regular" do
       it "renders channel, excluding inactive, staged, and suspended users" do
-        user.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
         user_2.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
         user_3.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
         user_4.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)

--- a/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Chat::Admin::IncomingWebhooksController do
 
   describe "#delete" do
     fab!(:existing) { Fabricate(:incoming_chat_webhook, chat_channel: chat_channel1) }
+    fab!(:webhook_event) { Fabricate(:chat_webhook_event, incoming_chat_webhook: existing) }
 
     it "errors for non-staff" do
       sign_in(user)
@@ -135,13 +136,6 @@ RSpec.describe Chat::Admin::IncomingWebhooksController do
 
     it "destroys webhook events records" do
       sign_in(admin)
-
-      Chat::MessageCreator.create(
-        chat_channel: existing.chat_channel,
-        user: Discourse.system_user,
-        content: "foo",
-        incoming_chat_webhook: existing,
-      )
 
       expect { delete "/admin/plugins/chat/hooks/#{existing.id}.json" }.to change {
         Chat::WebhookEvent.count

--- a/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Chat::Api::ChannelThreadMessagesController do
 
   describe "index" do
     describe "success" do
-      fab!(:message_1) { Fabricate(:chat_message, thread: thread) }
-      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:message_1) { Fabricate(:chat_message, thread: thread, chat_channel: thread.channel) }
+      fab!(:message_2) { Fabricate(:chat_message, chat_channel: thread.channel) }
 
       it "works" do
         get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages"

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -106,6 +106,11 @@ RSpec.describe Chat::Api::ChannelThreadsController do
       )
     end
 
+    before do
+      thread_1.add(current_user)
+      thread_3.add(current_user)
+    end
+
     it "returns the threads the user has sent messages in for the channel" do
       get "/chat/api/channels/#{public_channel.id}/threads"
       expect(response.status).to eq(200)

--- a/plugins/chat/spec/requests/chat/api/channel_threads_current_user_notification_settings_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_current_user_notification_settings_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Chat::Api::ChannelThreadsCurrentUserNotificationsSettingsControll
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
     sign_in(current_user)
+    thread.update!(last_message: last_reply)
   end
 
   describe "#update" do

--- a/plugins/chat/spec/requests/chat/api/reads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/reads_controller_spec.rb
@@ -133,6 +133,12 @@ RSpec.describe Chat::Api::ReadsController do
         )
       end
 
+      before do
+        chat_channel_1.update!(last_message: message_2)
+        chat_channel_2.update!(last_message: message_4)
+        chat_channel_3.update!(last_message: message_6)
+      end
+
       it "marks all messages as read across the user's channel memberships with the correct last_read_message_id" do
         put "/chat/api/channels/read.json"
 

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -126,13 +126,15 @@ RSpec.describe ::Chat::LookupChannelThreads do
           [thread_2, 1.day.ago],
           [thread_3, 2.seconds.ago],
         ].each do |thread, created_at|
-          Fabricate(
-            :chat_message,
-            user: current_user,
-            chat_channel: channel_1,
-            thread: thread,
-            created_at: created_at,
-          )
+          message =
+            Fabricate(
+              :chat_message,
+              user: current_user,
+              chat_channel: channel_1,
+              thread: thread,
+              created_at: created_at,
+            )
+          thread.update!(last_message: message)
         end
 
         expect(result.threads.map(&:id)).to eq([thread_3.id, thread_1.id, thread_2.id])
@@ -141,6 +143,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
       it "sorts by unread over recency" do
         unread_message = Fabricate(:chat_message, chat_channel: channel_1, thread: thread_2)
         unread_message.update!(created_at: 2.days.ago)
+        thread_2.update!(last_message: unread_message)
 
         expect(result.threads.map(&:id)).to eq([thread_2.id, thread_1.id, thread_3.id])
       end

--- a/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
+++ b/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
       )
     end
 
+    before do
+      channel_1.update!(last_message: message_2)
+      channel_2.update!(last_message: message_4)
+      channel_3.update!(last_message: message_6)
+    end
+
     context "when the user has no memberships" do
       let(:guardian) { Guardian.new(Fabricate(:user)) }
 
@@ -170,6 +176,7 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
 
         it "does use thread original messages for last_read_message_id" do
           new_om = Fabricate(:chat_message, chat_channel: channel_1, user: other_user)
+          channel_1.update!(last_message: new_om)
           thread.update!(original_message: new_om, original_message_user: other_user)
           result
           expect(membership_1.reload.last_read_message_id).to eq(new_om.id)

--- a/plugins/chat/spec/services/chat/message_destroyer_spec.rb
+++ b/plugins/chat/spec/services/chat/message_destroyer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Chat::MessageDestroyer do
       message_2 = Fabricate(:chat_message, chat_channel: message_1.chat_channel)
       message_3 = Fabricate(:chat_message, chat_channel: message_1.chat_channel)
       message_4 = Fabricate(:chat_message, chat_channel: message_1.chat_channel)
+      message_1.chat_channel.update(last_message: message_4)
       message_3.trash!
       membership =
         Chat::UserChatChannelMembership.create!(
@@ -64,7 +65,7 @@ RSpec.describe Chat::MessageDestroyer do
     end
 
     it "sets the last_message_id for the channel if that message is deleted" do
-      expect(message_1.chat_channel.last_message_id).to eq(message_1.id)
+      message_1.chat_channel.update!(last_message: message_1)
       described_class.new.destroy_in_batches(Chat::Message.where(id: message_1.id))
       expect(message_1.chat_channel.reload.last_message_id).to eq(nil)
     end

--- a/plugins/chat/spec/services/chat/restore_message_spec.rb
+++ b/plugins/chat/spec/services/chat/restore_message_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Chat::RestoreMessage do
 
         it "does not update the channel last_message_id if the message is not the last one in the channel" do
           next_message = Fabricate(:chat_message, chat_channel: message.chat_channel)
-          expect(message.chat_channel.reload.last_message_id).to eq(next_message.id)
+          message.chat_channel.update!(last_message: next_message)
           result
           expect(message.chat_channel.reload.last_message_id).to eq(next_message.id)
         end
@@ -97,10 +97,10 @@ RSpec.describe Chat::RestoreMessage do
           end
 
           it "does not update the thread last_message_id if the message is not the last one in the channel" do
-            next_message = Fabricate(:chat_message, thread: message.thread)
-            expect(message.thread.reload.last_message_id).to eq(next_message.id)
-            result
-            expect(message.thread.reload.last_message_id).to eq(next_message.id)
+            next_message =
+              Fabricate(:chat_message, thread: message.thread, chat_channel: message.chat_channel)
+            message.thread.update!(last_message: next_message)
+            expect { result }.not_to change { message.thread.reload.last_message }
           end
         end
       end

--- a/plugins/chat/spec/services/chat/trash_message_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_message_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Chat::TrashMessage do
           next_message =
             Fabricate(:chat_message, chat_channel: message.chat_channel, user: current_user)
           params[:message_id] = next_message.id
-          expect(message.chat_channel.reload.last_message).to eq(next_message)
+          message.chat_channel.update!(last_message: next_message)
           result
           expect(message.chat_channel.reload.last_message).to eq(message)
         end
@@ -174,9 +174,15 @@ RSpec.describe Chat::TrashMessage do
           end
 
           it "updates the thread last_message_id to the previous message in the thread" do
-            next_message = Fabricate(:chat_message, thread: thread, user: current_user)
+            next_message =
+              Fabricate(
+                :chat_message,
+                thread: thread,
+                user: current_user,
+                chat_channel: message.chat_channel,
+              )
             params[:message_id] = next_message.id
-            expect(thread.reload.last_message).to eq(next_message)
+            thread.update!(last_message: next_message)
             result
             expect(thread.reload.last_message).to eq(message)
           end

--- a/plugins/chat/spec/services/chat/update_thread_notification_settings_spec.rb
+++ b/plugins/chat/spec/services/chat/update_thread_notification_settings_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Chat::UpdateThreadNotificationSettings do
       }
     end
 
+    before { thread.update!(last_message: last_reply) }
+
     context "when all steps pass" do
       it "sets the service result as successful" do
         expect(result).to be_a_success

--- a/plugins/chat/spec/system/archive_channel_spec.rb
+++ b/plugins/chat/spec/system/archive_channel_spec.rb
@@ -65,19 +65,21 @@ RSpec.describe "Archive channel", type: :system do
         end
 
         context "when archived channels had unreads" do
-          before { channel_1.add(current_user) }
+          let(:other_user) { Fabricate(:user) }
 
-          it "clears unread indicators" do
+          before do
             Jobs.run_immediately!
-
-            other_user = Fabricate(:user)
-            channel_1.add(other_user)
-            Chat::MessageCreator.create(
+            channel_1.add(current_user)
+            Fabricate(
+              :chat_message,
               chat_channel: channel_1,
               user: other_user,
-              content: "this is fine @#{current_user.username}",
+              message: "this is fine @#{current_user.username}",
+              use_service: true,
             )
+          end
 
+          it "clears unread indicators" do
             visit("/")
             expect(page.find(".chat-channel-unread-indicator")).to have_content(1)
 

--- a/plugins/chat/spec/system/chat/composer/shortcuts/channel_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/channel_spec.rb
@@ -75,8 +75,10 @@ RSpec.describe "Chat | composer | shortcuts | channel", type: :system do
   end
 
   context "when using ArrowUp" do
-    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, user: current_user) }
-    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel_1) }
+    fab!(:message_1) do
+      Fabricate(:chat_message, chat_channel: channel_1, user: current_user, use_service: true)
+    end
+    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel_1, use_service: true) }
 
     it "edits last editable message" do
       chat.visit_channel(channel_1)

--- a/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
@@ -3,8 +3,10 @@
 RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:current_user) { Fabricate(:admin) }
-  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
-  fab!(:thread_1) { Fabricate(:chat_message, user: current_user, in_reply_to: message_1).thread }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, use_service: true) }
+  fab!(:thread_1) do
+    Fabricate(:chat_message, user: current_user, in_reply_to: message_1, use_service: true).thread
+  end
 
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }
@@ -32,7 +34,7 @@ RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
     let(:last_thread_message) { thread_1.replies.last }
 
     context "when there are editable messages" do
-      before { Fabricate(:chat_message, user: current_user, thread: thread_1) }
+      before { Fabricate(:chat_message, user: current_user, thread: thread_1, use_service: true) }
 
       it "starts editing the last editable message" do
         chat_page.visit_thread(thread_1)

--- a/plugins/chat/spec/system/chat/composer/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/thread_spec.rb
@@ -3,9 +3,11 @@
 RSpec.describe "Chat | composer | thread", type: :system, js: true do
   fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:current_user) { Fabricate(:admin) }
-  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, user: current_user) }
+  fab!(:message_1) do
+    Fabricate(:chat_message, chat_channel: channel_1, user: current_user, use_service: true)
+  end
   fab!(:message_2) do
-    Fabricate(:chat_message, chat_channel: channel_1, user: current_user, in_reply_to: message_1)
+    Fabricate(:chat_message, user: current_user, in_reply_to: message_1, use_service: true)
   end
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "Chat message - thread", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:thread_message_1) do
-    message_1 = Fabricate(:chat_message, chat_channel: channel_1)
-    Fabricate(:chat_message, chat_channel: channel_1, in_reply_to: message_1)
+    message_1 = Fabricate(:chat_message, chat_channel: channel_1, use_service: true)
+    Fabricate(:chat_message, in_reply_to: message_1, use_service: true)
   end
 
   let(:chat_page) { PageObjects::Pages::Chat.new }

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -59,9 +59,8 @@ describe "Thread indicator for chat messages", type: :system do
 
     it "it shows the reply count but no participant avatars when there is only one participant" do
       single_user_thread =
-        Fabricate(:chat_thread, channel: channel, original_message_user: current_user)
-      Fabricate(:chat_message, thread: single_user_thread, user: current_user)
-      Fabricate(:chat_message, thread: single_user_thread, user: current_user)
+        chat_thread_chain_bootstrap(channel: channel, users: [current_user], messages_count: 3)
+
       chat_page.visit_channel(channel)
       expect(
         channel_page.message_thread_indicator(single_user_thread.original_message),

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe "Navigation", type: :system do
   end
 
   context "when opening a thread" do
-    fab!(:thread) { Fabricate(:chat_thread, channel: category_channel) }
+    fab!(:thread) { Fabricate(:chat_thread, channel: category_channel, use_service: true) }
 
     before do
       category_channel.update!(threading_enabled: true)
-      Fabricate(:chat_message, thread: thread, chat_channel: thread.channel)
+      Fabricate(:chat_message, thread: thread, use_service: true)
       thread.add(current_user)
     end
 
@@ -335,7 +335,7 @@ RSpec.describe "Navigation", type: :system do
       it "activates the channel in the sidebar" do
         visit("/")
         chat_page.open_from_header
-        sidebar_component.click_link(category_channel.name)
+        sidebar_component.click_section_link(category_channel.name)
 
         expect(sidebar_component).to have_section_link(category_channel.name, active: true)
       end
@@ -346,7 +346,7 @@ RSpec.describe "Navigation", type: :system do
         visit("/")
         chat_page.open_from_header
 
-        sidebar_component.click_link(category_channel.name)
+        sidebar_component.click_section_link(category_channel.name)
         chat_drawer_page.close
 
         expect(sidebar_component).to have_no_section_link(category_channel.name, active: true)

--- a/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/drawer_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Reply to message - channel - drawer", type: :system do
     Fabricate(
       :chat_message,
       chat_channel: channel_1,
-      user: Fabricate(:user),
       message: "This is a message to reply to!",
+      use_service: true,
     )
   end
 
@@ -44,17 +44,7 @@ RSpec.describe "Reply to message - channel - drawer", type: :system do
   end
 
   context "when the message has an existing thread" do
-    fab!(:message_1) do
-      creator =
-        Chat::MessageCreator.new(
-          chat_channel: channel_1,
-          in_reply_to_id: original_message.id,
-          user: Fabricate(:user),
-          content: Faker::Lorem.paragraph,
-        )
-      creator.create
-      creator.chat_message
-    end
+    fab!(:message_1) { Fabricate(:chat_message, in_reply_to: original_message, use_service: true) }
 
     it "replies to the existing thread" do
       visit("/")

--- a/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/full_page_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
     Fabricate(
       :chat_message,
       chat_channel: channel_1,
-      user: Fabricate(:user),
       message: "This is a message to reply to!",
+      use_service: true,
     )
   end
 
@@ -56,9 +56,7 @@ RSpec.describe "Reply to message - channel - full page", type: :system do
   end
 
   context "when the message has an existing thread" do
-    fab!(:message_1) do
-      Fabricate(:chat_message, chat_channel: channel_1, in_reply_to: original_message)
-    end
+    fab!(:message_1) { Fabricate(:chat_message, in_reply_to: original_message, use_service: true) }
 
     before { original_message.thread.add(current_user) }
 

--- a/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/mobile_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: tru
     Fabricate(
       :chat_message,
       chat_channel: channel_1,
-      user: Fabricate(:user),
       message: "This is a message to reply to!",
+      use_service: true,
     )
   end
 
@@ -56,9 +56,7 @@ RSpec.describe "Reply to message - channel - mobile", type: :system, mobile: tru
   end
 
   context "when the message has an existing thread" do
-    fab!(:message_1) do
-      Fabricate(:chat_message, chat_channel: channel_1, in_reply_to: original_message)
-    end
+    fab!(:message_1) { Fabricate(:chat_message, in_reply_to: original_message, use_service: true) }
 
     it "replies to the existing thread" do
       chat_page.visit_channel(channel_1)

--- a/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
@@ -14,10 +14,15 @@ RSpec.describe "Shortcuts | mark all read", type: :system do
     SiteSetting.navigation_menu = "sidebar"
     chat_system_bootstrap(user_1, [channel_1, channel_2, channel_3])
     sign_in(user_1)
-    Fabricate(:chat_message, chat_channel: channel_1)
-    Fabricate(:chat_message, chat_channel: channel_1)
+    Fabricate(:chat_message, chat_channel: channel_1, use_service: true)
+    Fabricate(:chat_message, chat_channel: channel_1, use_service: true)
     10.times do |i|
-      Fabricate(:chat_message, chat_channel: channel_2, message: "all read message #{i}")
+      Fabricate(
+        :chat_message,
+        chat_channel: channel_2,
+        message: "all read message #{i}",
+        use_service: true,
+      )
     end
   end
 

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -17,6 +17,7 @@ describe "Single thread in side panel", type: :system do
 
   context "when threading_enabled is false for the channel" do
     fab!(:channel) { Fabricate(:chat_channel) }
+
     before { channel.update!(threading_enabled: false) }
 
     it "does not open the side panel for a single thread" do
@@ -116,7 +117,7 @@ describe "Single thread in side panel", type: :system do
       end
 
       it "changes the tracking bell to be Tracking level in the thread panel" do
-        new_thread = Fabricate(:chat_thread, channel: channel, with_replies: 1)
+        new_thread = Fabricate(:chat_thread, channel: channel, with_replies: 1, use_service: true)
         chat_page.visit_channel(channel)
         channel_page.message_thread_indicator(new_thread.original_message).click
         expect(side_panel).to have_open_thread(new_thread)
@@ -171,11 +172,12 @@ describe "Single thread in side panel", type: :system do
       it "does not mark the channel unread if another user sends a message in the thread" do
         other_user = Fabricate(:user)
         chat_system_user_bootstrap(user: other_user, channel: channel)
-        Chat::MessageCreator.create(
-          chat_channel: channel,
+        Fabricate(
+          :chat_message,
+          thread: thread,
           user: other_user,
-          content: "Hello world!",
-          thread_id: thread.id,
+          message: "Hello world!",
+          use_service: true,
         )
         sign_in(current_user)
         chat_page.visit_channel(channel)

--- a/plugins/chat/spec/system/thread_list/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_list/full_page_spec.rb
@@ -26,12 +26,12 @@ describe "Thread list in side panel | full page", type: :system do
   end
 
   context "for threads the user is not a participant in" do
-    fab!(:thread_om) { Fabricate(:chat_message, chat_channel: channel) }
+    fab!(:thread_om) { Fabricate(:chat_message, chat_channel: channel, use_service: true) }
 
     before { chat_system_user_bootstrap(user: other_user, channel: channel) }
 
     it "does not show existing threads in the channel if the user is not tracking them" do
-      Fabricate(:chat_thread, original_message: thread_om, channel: channel)
+      Fabricate(:chat_thread, original_message: thread_om, channel: channel, use_service: true)
       chat_page.visit_channel(channel)
       channel_page.open_thread_list
       expect(page).to have_content(I18n.t("js.chat.threads.none"))
@@ -118,7 +118,7 @@ describe "Thread list in side panel | full page", type: :system do
 
     it "shows the last reply date of the thread" do
       freeze_time
-      last_reply = Fabricate(:chat_message, chat_channel: thread_1.channel, thread: thread_1)
+      last_reply = Fabricate(:chat_message, thread: thread_1, use_service: true)
       chat_page.visit_channel(channel)
       channel_page.open_thread_list
       expect(thread_list_page.item_by_id(thread_1.id)).to have_css(

--- a/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/drawer_spec.rb
@@ -23,9 +23,9 @@ describe "Thread tracking state | drawer", type: :system do
 
   context "when the user has unread messages for a thread" do
     fab!(:message_1) do
-      Fabricate(:chat_message, chat_channel: channel, thread: thread, user: current_user)
+      Fabricate(:chat_message, thread: thread, user: current_user, use_service: true)
     end
-    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
+    fab!(:message_2) { Fabricate(:chat_message, thread: thread, use_service: true) }
 
     it "shows the count of threads with unread messages on the thread list button" do
       visit("/")
@@ -63,7 +63,7 @@ describe "Thread tracking state | drawer", type: :system do
       expect(drawer_page).to have_no_unread_thread_indicator
       expect(thread_list_page).to have_no_unread_item(thread.id)
       travel_to(1.minute.from_now)
-      Fabricate(:chat_message, chat_channel: channel, thread: thread, user: other_user)
+      Fabricate(:chat_message, thread: thread, user: other_user, use_service: true)
       expect(drawer_page).to have_unread_thread_indicator(count: 1)
       expect(thread_list_page).to have_unread_item(thread.id)
     end
@@ -100,7 +100,7 @@ describe "Thread tracking state | drawer", type: :system do
         chat_page.open_from_header
         expect(drawer_page).to have_unread_channel(channel)
         drawer_page.open_channel(channel)
-        Fabricate(:chat_message, thread: thread, user: other_user)
+        Fabricate(:chat_message, thread: thread, user: other_user, use_service: true)
         drawer_page.back
         expect(drawer_page).to have_no_unread_channel(channel)
       end
@@ -112,7 +112,7 @@ describe "Thread tracking state | drawer", type: :system do
         drawer_page.back
         expect(drawer_page).to have_no_unread_channel(channel)
         travel_to(1.minute.from_now)
-        Fabricate(:chat_message, thread: thread, user: other_user)
+        Fabricate(:chat_message, thread: thread, user: other_user, use_service: true)
         expect(drawer_page).to have_unread_channel(channel)
       end
     end

--- a/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
@@ -20,9 +20,9 @@ describe "Thread tracking state | full page", type: :system do
 
   context "when the user has unread messages for a thread" do
     fab!(:message_1) do
-      Fabricate(:chat_message, chat_channel: channel, thread: thread, user: current_user)
+      Fabricate(:chat_message, thread: thread, user: current_user, use_service: true)
     end
-    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
+    fab!(:message_2) { Fabricate(:chat_message, thread: thread, use_service: true) }
 
     it "shows the count of threads with unread messages on the thread list button" do
       chat_page.visit_channel(channel)
@@ -55,7 +55,7 @@ describe "Thread tracking state | full page", type: :system do
       chat_page.visit_channel(channel)
       channel_page.open_thread_list
       expect(thread_list_page).to have_no_unread_item(thread.id)
-      Fabricate(:chat_message, chat_channel: channel, thread: thread)
+      Fabricate(:chat_message, thread: thread, use_service: true)
       expect(thread_list_page).to have_unread_item(thread.id)
     end
 
@@ -63,7 +63,7 @@ describe "Thread tracking state | full page", type: :system do
       thread.remove(current_user)
       chat_page.visit_channel(channel)
       expect(channel_page).to have_no_unread_thread_indicator
-      Fabricate(:chat_message, chat_channel: channel, thread: thread)
+      Fabricate(:chat_message, thread: thread, use_service: true)
       expect(channel_page).to have_no_unread_thread_indicator
       channel_page.open_thread_list
       expect(thread_list_page).to have_no_unread_item(thread.id)
@@ -76,8 +76,8 @@ describe "Thread tracking state | full page", type: :system do
     end
 
     it "allows the user to start tracking a thread they have not replied to" do
-      new_thread = Fabricate(:chat_thread, channel: channel)
-      Fabricate(:chat_message, chat_channel: channel, thread: new_thread)
+      new_thread = Fabricate(:chat_thread, channel: channel, use_service: true)
+      Fabricate(:chat_message, thread: new_thread, use_service: true)
       chat_page.visit_thread(new_thread)
       thread_page.notification_level = :tracking
       expect(thread_page).to have_notification_level("tracking")
@@ -114,7 +114,7 @@ describe "Thread tracking state | full page", type: :system do
       it "does not show an unread indicator for the channel sidebar if a new thread message arrives while the user is looking at the channel" do
         chat_page.visit_channel(channel)
         expect(sidebar_page).to have_no_unread_channel(channel)
-        Fabricate(:chat_message, thread: thread)
+        Fabricate(:chat_message, thread: thread, use_service: true)
         expect(sidebar_page).to have_no_unread_channel(channel)
       end
 
@@ -122,7 +122,7 @@ describe "Thread tracking state | full page", type: :system do
         chat_page.visit_channel(channel)
         expect(sidebar_page).to have_no_unread_channel(channel)
         chat_page.visit_channel(other_channel)
-        Fabricate(:chat_message, thread: thread)
+        Fabricate(:chat_message, thread: thread, use_service: true)
         expect(sidebar_page).to have_unread_channel(channel)
       end
     end


### PR DESCRIPTION
This is extracted from #22390.

This PR aims to ease the transition to the new message creation service. (in progress in #22390) Indeed, the new service PR is breaking some specs from `discourse-ai` and `discourse-templates` because these plugins are using either `Chat::MessageCreator` or the `chat_message` fabricator.

This PR addresses these issues by normalizing how we create a chat message in specs. To do so, the preferred way is to use `Fabricate(:chat_message)` with a new `:use_service` option allowing to call the service under the hood. While this PR will obviously call `Chat::MessageCreator`, the new service PR will now be able to simply change the call to `Chat::CreateMessage` without breaking any specs from other plugins.

Another thing this PR does is to not create chat messages using the service for specs that aren’t system ones, thus speeding the execution time a bit in the process.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
