### PR TITLE
UX: removes a duplicate modal footer.

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/components/modal/install-theme.hbs
@@ -167,32 +167,30 @@
   </:body>
   <:footer>
     {{#unless this.popular}}
-      <div class="modal-footer">
-        {{#if this.duplicateRemoteThemeWarning}}
-          <div class="install-theme-warning">
-            ⚠️
-            {{this.duplicateRemoteThemeWarning}}
-          </div>
-        {{/if}}
-        {{#if this.themeCannotBeInstalled}}
-          <div class="install-theme-warning">
-            ⚠️
-            {{this.themeCannotBeInstalled}}
-          </div>
-        {{/if}}
-        <DButton
-          @action={{this.installTheme}}
-          @disabled={{this.installDisabled}}
-          class="btn
-            {{if this.themeCannotBeInstalled 'btn-danger' 'btn-primary'}}"
-          @label={{this.submitLabel}}
-        />
-        <DButton
-          class="btn-flat d-modal-cancel"
-          @action={{@closeModal}}
-          @label="cancel"
-        />
-      </div>
+      {{#if this.duplicateRemoteThemeWarning}}
+        <div class="install-theme-warning">
+          ⚠️
+          {{this.duplicateRemoteThemeWarning}}
+        </div>
+      {{/if}}
+      {{#if this.themeCannotBeInstalled}}
+        <div class="install-theme-warning">
+          ⚠️
+          {{this.themeCannotBeInstalled}}
+        </div>
+      {{/if}}
+      <DButton
+        @action={{this.installTheme}}
+        @disabled={{this.installDisabled}}
+        class="btn
+          {{if this.themeCannotBeInstalled 'btn-danger' 'btn-primary'}}"
+        @label={{this.submitLabel}}
+      />
+      <DButton
+        class="btn-flat d-modal-cancel"
+        @action={{@closeModal}}
+        @label="cancel"
+      />
     {{/unless}}
   </:footer>
 </DModal>


### PR DESCRIPTION
The theme install modal has duplicate footer HTML code. The commit fixes this.

Before:
![duplicate footer](https://github.com/discourse/discourse/assets/5654300/ff9d5836-5d60-4230-ac4b-b0dc2c8a8fd8)

After:
![fixed footer](https://github.com/discourse/discourse/assets/5654300/4c8e01f9-d791-457a-be83-9b0b2fc3346d)
