### PR TITLE
FIX: prevents setPanel to also set separated mode

### DIFF
--- a/app/assets/javascripts/discourse/app/services/sidebar-state.js
+++ b/app/assets/javascripts/discourse/app/services/sidebar-state.js
@@ -24,7 +24,6 @@ export default class SidebarState extends Service {
 
   setPanel(name) {
     this.currentPanelKey = name;
-    this.setSeparatedMode();
   }
 
   get currentPanel() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -1014,6 +1014,7 @@ acceptance("Sidebar - Plugin API", function (needs) {
         "new-panel"
       );
       api.setSidebarPanel("new-panel");
+      api.setSeparatedSidebarMode();
     });
 
     await visit("/");

--- a/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
+++ b/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
@@ -124,19 +124,27 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_switch_button("chat")
         expect(header_component).to have_open_chat_button
+        expect(sidebar_component).to have_section("Categories")
         expect(sidebar_component).to have_no_section("chat-channels")
 
         chat_page.open_from_header
 
         expect(sidebar_component).to have_no_switch_button
         expect(header_component).to have_open_chat_button
+        expect(sidebar_component).to have_section("Categories")
         expect(sidebar_component).to have_no_section("chat-channels")
 
         chat_drawer_page.close
 
         expect(sidebar_component).to have_switch_button("chat")
         expect(header_component).to have_open_chat_button
+        expect(sidebar_component).to have_section("Categories")
         expect(sidebar_component).to have_no_section("chat-channels")
+
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_no_section("chat-channels")
+        expect(sidebar_component).to have_section("Categories")
       end
     end
 
@@ -162,6 +170,16 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_switch_button("chat")
         expect(header_component).to have_open_chat_button
+        expect(sidebar_component).to have_no_section("chat-channels")
+        expect(sidebar_component).to have_section("Categories")
+
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section("chat-channels")
+        expect(sidebar_component).to have_no_section("Categories")
+
+        sidebar_component.switch_to_main
+
         expect(sidebar_component).to have_no_section("chat-channels")
         expect(sidebar_component).to have_section("Categories")
       end
@@ -199,6 +217,11 @@ RSpec.describe "Separate sidebar mode", type: :system do
         expect(header_component).to have_open_chat_button
         expect(sidebar_component).to have_section("Categories")
         expect(sidebar_component).to have_section("chat-channels")
+
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section("Categories")
+        expect(sidebar_component).to have_section("chat-channels")
       end
     end
 
@@ -224,6 +247,16 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_switch_button("chat")
         expect(header_component).to have_open_chat_button
+        expect(sidebar_component).to have_section("chat-channels")
+        expect(sidebar_component).to have_section("Categories")
+
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section("chat-channels")
+        expect(sidebar_component).to have_no_section("Categories")
+
+        sidebar_component.switch_to_main
+
         expect(sidebar_component).to have_section("chat-channels")
         expect(sidebar_component).to have_section("Categories")
       end

--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -34,6 +34,10 @@ module PageObjects
           find(".sidebar__panel-switch-button[data-key='chat']").click
         end
 
+        def switch_to_main
+          find(".sidebar__panel-switch-button[data-key='main']").click
+        end
+
         def has_no_section?(name)
           has_no_css?(".sidebar-sections [data-section-name='#{name.parameterize}']")
         end


### PR DESCRIPTION
This could happen after you had already change the separation mode and would cause unexpected bugs.

This PR also adds more tests around using switch buttons with chat.