### PR TITLE
DEV: Don't print warning about attempt to track status of a user without id in tests

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1381,7 +1381,7 @@ User.reopen(Evented, {
 
   // always call stopTrackingStatus() when done with a user
   trackStatus() {
-    if (!this.id) {
+    if (!this.id && !isTesting()) {
       // eslint-disable-next-line no-console
       console.warn(
         "It's impossible to track user status on a user model that doesn't have id. This user model won't be receiving live user status updates."


### PR DESCRIPTION
It is hard to catch and debug potential bugs related to live updates of user status (though, we haven't seen many such bugs so far). We have this `console.warn` statement that should help us to catch one class of such bugs:

https://github.com/discourse/discourse/blob/70f1cc55529d6446a1751989a1d9663db26c00df/app/assets/javascripts/discourse/app/models/user.js#L1384-L1389

But in tests, we quite often operate with stubs of users that don't have ID, and this warning create unnecessary noise. This PR disable the warning in the testing environment.
