### PR TITLE
FIX: Compile js-processor before db:migrate

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -216,8 +216,12 @@ task "multisite:migrate" => %w[db:load_config environment set_locale] do |_, arg
   end
 end
 
-# we need to run seed_fu every time we run rake db:migrate
-task "db:migrate" => %w[load_config environment set_locale] do |_, args|
+task "db:migrate" => %w[
+       load_config
+       environment
+       set_locale
+       assets:precompile:js_processor
+     ] do |_, args|
   DistributedMutex.synchronize(
     "db_migration",
     redis: Discourse.redis.without_namespace,


### PR DESCRIPTION
In production env it's possible to have migrations run before js-processor is available.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
