### PR TITLE
UX: update styling for related/suggested

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -9,18 +9,18 @@
       .btn {
         color: var(--primary);
         background-color: transparent;
-        border-bottom: 2px solid transparent;
         padding: 0.5em 5px;
         &:hover {
-          border-bottom: 2px solid rgba(var(--tertiary-rgb), 0.5);
+          box-shadow: inset 0px -3px 0px 0px rgba(var(--tertiary-rgb), 0.5);
+          .d-icon {
+            color: var(--primary-high);
+          }
         }
         &.active {
-          border-bottom: 2px solid var(--tertiary);
-        }
-        .d-icon,
-        &:hover .d-icon,
-        &:active .d-icon {
-          color: var(--primary-high);
+          box-shadow: inset 0px -3px 0px 0px var(--tertiary);
+          .d-icon {
+            color: var(--primary-high);
+          }
         }
       }
     }

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -17,26 +17,11 @@
         &.active {
           border-bottom: 2px solid var(--tertiary);
         }
-      }
-    }
-  }
-
-  @media screen and (min-width: 550px) {
-    .nav {
-      position: absolute;
-      top: 0;
-      li {
-        margin-right: 0;
-        .btn {
-          font-size: var(--font-0);
-          line-height: var(--line-height-large);
-          padding: 1em 0.65em;
+        .d-icon,
+        &:hover .d-icon,
+        &:active .d-icon {
+          color: var(--primary-high);
         }
-      }
-    }
-    .more-topics__lists:not(.single-list) {
-      .topic-list-header .default {
-        visibility: hidden;
       }
     }
   }
@@ -90,13 +75,5 @@
   .suggested-topics-message .badge-wrapper.bullet span.badge-category,
   .suggested-topics-message .badge-wrapper.bar span.badge-category {
     max-width: 150px;
-  }
-}
-
-#main-outlet .regular {
-  @media screen and (min-width: 550px) {
-    .more-topics__container .nav li .btn {
-      padding: 0.75em 0.65em;
-    }
   }
 }

--- a/app/assets/stylesheets/desktop/components/_index.scss
+++ b/app/assets/stylesheets/desktop/components/_index.scss
@@ -1,3 +1,4 @@
+@import "more-topics";
 @import "user-card";
 @import "user-info";
 @import "user-stream-item";

--- a/app/assets/stylesheets/desktop/components/more-topics.scss
+++ b/app/assets/stylesheets/desktop/components/more-topics.scss
@@ -1,7 +1,7 @@
 .more-topics__container {
   .nav {
     position: absolute;
-    top: 1em;
+    top: 2px;
     li {
       margin-right: 0;
       .btn {
@@ -20,7 +20,6 @@
 
 #main-outlet .regular {
   .more-topics__container .nav {
-    top: 0;
     li .btn {
       padding: 0.75em 0.65em;
     }

--- a/app/assets/stylesheets/desktop/components/more-topics.scss
+++ b/app/assets/stylesheets/desktop/components/more-topics.scss
@@ -1,0 +1,28 @@
+.more-topics__container {
+  .nav {
+    position: absolute;
+    top: 1em;
+    li {
+      margin-right: 0;
+      .btn {
+        font-size: var(--font-0);
+        line-height: var(--line-height-large);
+        padding: 1em 0.65em;
+      }
+    }
+  }
+  .more-topics__lists:not(.single-list) {
+    .topic-list-header .default {
+      visibility: hidden;
+    }
+  }
+}
+
+#main-outlet .regular {
+  .more-topics__container .nav {
+    top: 0;
+    li .btn {
+      padding: 0.75em 0.65em;
+    }
+  }
+}

--- a/app/assets/stylesheets/mobile/components/more-topics.scss
+++ b/app/assets/stylesheets/mobile/components/more-topics.scss
@@ -1,4 +1,8 @@
 .more-topics__container {
+  .nav {
+    margin-block: 0.5em 1em;
+  }
+
   .more-content-topics {
     padding: 15px 0 15px 0;
 


### PR DESCRIPTION
This PR follows the previous updated of related/suggested buttons and addresses a couple issues:
* Button states for icons
* Wide mobile devices -> moves styling to desktop.scss

Wide Mobile:
Before
![d5472e9a2c6a1c7105ba2fb13532efc0bfb13281](https://github.com/discourse/discourse/assets/69276978/6b2fdc54-ad68-4bd9-9b23-f87cb1e2674b)

After -- based on mobile.scss instead of media query, absolute positioning is used in desktop.scss instead
![CleanShot 2023-08-24 at 13 38 10@2x](https://github.com/discourse/discourse/assets/69276978/b18cfbf5-04c1-4ed1-b7d1-246fe476d895)

Narrow Mobile:
Before
<img width="598" alt="CleanShot 2023-08-24 at 13 35 17@2x" src="https://github.com/discourse/discourse/assets/69276978/13873869-b583-451a-926c-eff764dc69db">
<img width="438" alt="CleanShot 2023-08-24 at 13 46 00@2x" src="https://github.com/discourse/discourse/assets/69276978/0149f44a-7860-4995-850f-7642be3eab2b">


After
<img width="600" alt="CleanShot 2023-08-24 at 13 34 29@2x" src="https://github.com/discourse/discourse/assets/69276978/3a5ab037-17e6-417a-943e-08c718ef3629">
<img width="439" alt="CleanShot 2023-08-24 at 13 44 47@2x" src="https://github.com/discourse/discourse/assets/69276978/7feae53a-fd82-42a5-8920-b5f0a9c62018">


Button State Icons:

Before
![CleanShot 2023-08-24 at 13 42 21](https://github.com/discourse/discourse/assets/69276978/1d799579-73fe-4f2b-aff3-775acce365c4)

After
![CleanShot 2023-08-24 at 13 40 30]![CleanShot 2023-08-24 at 13 40 30](https://github.com/discourse/discourse/assets/69276978/6f5433df-2a41-425e-a717-bcb92145f725)



