### PR TITLE
FEATURE: Onebox and Download for WEBP and AVIF

### DIFF
--- a/lib/onebox/engine/image_onebox.rb
+++ b/lib/onebox/engine/image_onebox.rb
@@ -5,8 +5,8 @@ module Onebox
     class ImageOnebox
       include Engine
 
-      matches_content_type(%r{^image/(png|jpg|jpeg|gif|bmp|tif|tiff)$})
-      matches_regexp(%r{^(https?:)?//.+\.(png|jpg|jpeg|gif|bmp|tif|tiff)(\?.*)?$}i)
+      matches_content_type(%r{^image/(png|jpg|jpeg|gif|bmp|tif|tiff|webp|avif)$})
+      matches_regexp(%r{^(https?:)?//.+\.(png|jpg|jpeg|gif|bmp|tif|tiff|webp|avif)(\?.*)?$}i)
 
       def always_https?
         AllowlistedGenericOnebox.host_matches(uri, AllowlistedGenericOnebox.https_hosts)

--- a/spec/lib/onebox/engine/image_onebox_spec.rb
+++ b/spec/lib/onebox/engine/image_onebox_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Onebox::Engine::ImageOnebox do
     ).to match(/<img/)
   end
 
+  it "supports webp" do
+    expect(Onebox.preview("https://www.gstatic.com/webp/gallery/1.sm.webp").to_s).to match(/<img/)
+  end
+
+  it "supports avif" do
+    expect(
+      Onebox.preview(
+        "https://raw.githubusercontent.com/AOMediaCodec/av1-avif/master/testFiles/Xiph/abandoned_filmgrain.avif",
+      ).to_s,
+    ).to match(/<img/)
+  end
+
   it "supports image URLs with query parameters" do
     expect(
       Onebox.preview(


### PR DESCRIPTION
This adds support for oneboxing WEBP and AVIF images in posts and fixing oneboxing fixes download remote images for those formats too.

Reported in https://meta.discourse.org/t/-/276433?u=falco
