### PR TITLE
DEV: Avoid constant redefinition warnings in specs

### DIFF
--- a/lib/tasks/maxminddb.rake
+++ b/lib/tasks/maxminddb.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-GEOLITE_DBS = %w[GeoLite2-City GeoLite2-ASN]
+GEOLITE_DBS ||= %w[GeoLite2-City GeoLite2-ASN]
 
 desc "downloads MaxMind's GeoLite2-City databases"
 task "maxminddb:get" => "environment" do


### PR DESCRIPTION
Specs sometimes do `Discourse::Application.load_tasks` which re-loads rake task files, causing constant redefinition.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
