### PR TITLE
UX: update styling for related/suggested

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -12,15 +12,14 @@
         padding: 0.5em 5px;
         &:hover {
           box-shadow: inset 0px -3px 0px 0px rgba(var(--tertiary-rgb), 0.5);
-          .d-icon {
-            color: var(--primary-high);
-          }
         }
         &.active {
           box-shadow: inset 0px -3px 0px 0px var(--tertiary);
-          .d-icon {
-            color: var(--primary-high);
-          }
+        }
+        .d-icon,
+        &:hover .d-icon,
+        &:active .d-icon {
+          color: var(--primary-high);
         }
       }
     }


### PR DESCRIPTION
This PR changes the icon color to always be the same color, even when not selected or active:

Before
![CleanShot 2023-08-24 at 16 06 05@2x](https://github.com/discourse/discourse/assets/69276978/408a1e71-9f2d-4e89-b5bb-e8f88142efbb)


After
<img width="855" alt="CleanShot 2023-08-24 at 16 03 00@2x" src="https://github.com/discourse/discourse/assets/69276978/2670b599-8a6b-44be-a48e-438d111d200f">
