### PR TITLE
A11Y: Set focus to post author when navigating

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -803,7 +803,9 @@ export default {
   },
 
   _onScrollEndsCallback() {
-    document.querySelector(".topic-post.selected span.tabLoc")?.focus();
+    document
+      .querySelector(".topic-post.selected a:not([tabindex='-1'])")
+      ?.focus();
   },
 
   categoriesTopicsList() {

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -77,7 +77,8 @@ export function highlightPost(postNumber) {
     return;
   }
 
-  container.querySelector(".tabLoc")?.focus();
+  // sets focus to the first focusable anchor in the post
+  container.querySelector("a:not([tabindex='-1'])")?.focus();
 
   const element = container.querySelector(".topic-body");
   if (!element || element.classList.contains("highlighted")) {

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -190,9 +190,6 @@ export default createWidget("post-small-action", {
     }
 
     return [
-      h("span.tabLoc", {
-        attributes: { "aria-hidden": true, tabindex: -1 },
-      }),
       h("div.topic-avatar", iconNode(icons[attrs.actionCode] || "exclamation")),
       h("div.small-action-desc", [
         h("div.small-action-contents", contents),

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -751,11 +751,7 @@ createWidget("post-article", {
   },
 
   html(attrs, state) {
-    const rows = [
-      h("span.tabLoc", {
-        attributes: { "aria-hidden": true, tabindex: -1 },
-      }),
-    ];
+    const rows = [];
     if (state.repliesAbove.length) {
       const replies = state.repliesAbove.map((p) => {
         return this.attach("embedded-post", p, {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1170,11 +1170,6 @@ blockquote > *:last-child {
     );
     min-width: 0; // Allows flex container to shrink
 
-    .avatar {
-      margin-right: 0.5em;
-      float: left;
-    }
-
     p {
       margin: 0;
       padding: 0.15em 0.5em 0 0;
@@ -1183,6 +1178,13 @@ blockquote > *:last-child {
 
   .small-action-contents {
     flex: 1 1 auto;
+    display: flex;
+    a.trigger-user-card {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 0.5em;
+      border-radius: 1em;
+    }
   }
 
   .small-action-buttons {

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -15,10 +15,6 @@
   box-shadow: -3px 0 0 var(--danger);
 }
 
-.tabLoc:focus {
-  outline: none;
-}
-
 .latest .featured-topic {
   padding-left: 4px;
 }


### PR DESCRIPTION
When navigating to a topic from the topic list using a screen reader, we need to set focus to the correct post. Before this commit, this was done using a `span.tabLoc` element with the `aria-hidden=true` and `tabindex=-1` attributes. This technique was used to avoid adding an extra element, however, it doesn't work well. See https://meta.discourse.org/t/discourse-with-a-screen-reader/178105/144?u=pmusaraj for reports of issues with it from screen reader users. 

The main problem with it is that the `tabLoc` element is invisible to screen readers. So even though focus is set by the browser to the element, the screen reader itself (NVDA) is not aware of the context. 

**Solution**

Set focus to the first focusable element of a post (and remove the `tabLoc` element). That is the username anchor for full posts or the avatar anchor for small posts. 

The PR also includes some styling changes for the "focused" state of small posts (note that the styling only applies when navigating via keyboard): 

<img width="854" alt="image" src="https://github.com/discourse/discourse/assets/368961/cd7b84dc-31ad-4738-b619-30687bbaf5b2">
