### PR TITLE
DEV: Fix `redis.sadd` warnings

### DIFF
--- a/lib/common_passwords.rb
+++ b/lib/common_passwords.rb
@@ -41,7 +41,7 @@ class CommonPasswords
 
   def self.load_passwords
     passwords = File.readlines(PASSWORD_FILE)
-    redis.sadd LIST_KEY, passwords.map!(&:chomp)
+    redis.sadd?(LIST_KEY, passwords.map!(&:chomp))
   rescue Errno::ENOENT
     # tolerate this so we don't block signups
     Rails.logger.error "Common passwords file #{PASSWORD_FILE} is not found! Common password checking is skipped."

--- a/spec/lib/backup_restore/system_interface_spec.rb
+++ b/spec/lib/backup_restore/system_interface_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe BackupRestore::SystemInterface do
           key = "#{hostname}:#{pid}"
           process = { pid: pid, hostname: hostname }
 
-          conn.sadd("processes", key)
+          conn.sadd?("processes", key)
           conn.hmset(key, "info", Sidekiq.dump_json(process))
 
           data =


### PR DESCRIPTION
```
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
