### PR TITLE
DEV: Add basic bin/dev script for launching in development

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bin/ember-cli -u


### PR DESCRIPTION
### What is this change?

We have been discussing potentially adding a Procfile to help launch the application. As part of the discussions, @tgxworld also mentioned it'd be nice to have a command to launch the app in development.

This allows us to encode how to start the app in code and ship that in the repo, rather than having to rely on external documentation.

Newer installs of Rails come with a `bin/dev` script for exactly this purpose. This change adds one in retroactively for us.

The script currently runs `bin/ember-cli -u`, which is the canonical way of starting the app for development according to documentation. I know not everyone uses this, but the point of this PR is to add the script first, then we can iterate on the means of running the app. 🙂 