### PR TITLE
DEV: Move option to delete user under reviewable reject menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.hbs
@@ -1,6 +1,10 @@
 {{#if this.multiple}}
   <DropdownSelectBox
-    @class="reviewable-action-dropdown btn-icon-text"
+    @class={{concat-class
+      "reviewable-action-dropdown btn-icon-text"
+      (dasherize this.first.id)
+      this.first.button_class
+    }}
     @nameProperty="label"
     @content={{this.bundle.actions}}
     @onChange={{action "performById"}}

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -273,15 +273,17 @@
 
     button {
       white-space: nowrap;
+    }
 
-      &.approve-post {
-        background-color: var(--success);
-        color: var(--secondary);
-      }
-      &.reject-post {
-        background-color: var(--danger);
-        color: var(--secondary);
-      }
+    .approve-post,
+    .approve-post > summary {
+      background-color: var(--success);
+      color: var(--secondary);
+    }
+    .reject-post,
+    .reject-post > summary {
+      background-color: var(--danger);
+      color: var(--secondary);
     }
 
     .reviewable-action,

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -668,7 +668,6 @@ class Reviewable < ActiveRecord::Base
       a.icon = "user-times"
       a.label = "reviewables.actions.reject_user.delete.title"
       a.require_reject_reason = require_reject_reason
-      a.description = "reviewables.actions.reject_user.delete.description"
     end
 
     actions.add(:delete_user_block, bundle: bundle) do |a|

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -41,13 +41,23 @@ class ReviewableQueuedPost < Reviewable
     end
 
     if pending?
-      actions.add(:reject_post) do |a|
-        a.icon = "times"
-        a.label = "reviewables.actions.reject_post.title"
+      if guardian.can_delete_user?(target_created_by)
+        reject_bundle =
+          actions.add_bundle("#{id}-reject", label: "reviewables.actions.reject_post.title")
+
+        actions.add(:reject_post, bundle: reject_bundle) do |a|
+          a.icon = "times"
+          a.label = "reviewables.actions.discard_post.title"
+          a.button_class = "reject-post"
+        end
+        delete_user_actions(actions, reject_bundle)
+      else
+        actions.add(:reject_post) do |a|
+          a.icon = "times"
+          a.label = "reviewables.actions.reject_post.title"
+        end
       end
     end
-
-    delete_user_actions(actions) if pending? && guardian.can_delete_user?(target_created_by)
 
     actions.add(:delete) if guardian.can_delete?(self)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5206,6 +5206,8 @@ en:
         description: "Restore the post so that all users can see it."
       disagree:
         title: "No"
+      discard_post:
+        title: "Discard Post"
       ignore:
         title: "Ignore"
       ignore_and_do_nothing:


### PR DESCRIPTION
### What is this change?

Follow-up to #23199 in which we moved the "delete user" options under the relevant action menu for flagged post. This change does the same, but to queued posts.

### What does it look like?

**If the user can't be deleted:**

<img width="321" alt="Screenshot 2023-08-25 at 1 43 31 PM" src="https://github.com/discourse/discourse/assets/5259935/bf7331ee-ad4e-4614-9a20-d9523e7583ce">

(Same as existing UI.)

**If the user can be deleted:**

<img width="566" alt="Screenshot 2023-08-25 at 2 38 01 PM" src="https://github.com/discourse/discourse/assets/5259935/f5cab2de-6969-40fa-a38c-74a52ed67236">
