### PR TITLE
DEV: Introduce ember-router-service-refresh-polyfill

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -78,6 +78,7 @@
     "ember-on-resize-modifier": "^2.0.2",
     "ember-production-deprecations": "1.0.0",
     "ember-qunit": "^6.2.0",
+    "ember-router-service-refresh-polyfill": "^1.1.0",
     "ember-template-imports": "^3.4.2",
     "ember-test-selectors": "^6.0.0",
     "eslint": "^8.47.0",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -4340,6 +4340,14 @@ ember-router-generator@^2.0.0:
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
 
+ember-router-service-refresh-polyfill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-router-service-refresh-polyfill/-/ember-router-service-refresh-polyfill-1.1.0.tgz#cfed655c68040ad163a4d17225eae6d666da5454"
+  integrity sha512-MhrJnpyTTie+Uo9PWiEX4f0t5y70vBjjgcS56aLOvwlSwfInNCtOEgQ/zH89J2dnYUVidebm/1FTubQ2meSjbw==
+  dependencies:
+    "@embroider/macros" "^1.0.0"
+    ember-cli-babel "^7.26.11"
+
 ember-source-channel-url@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-source-channel-url/-/ember-source-channel-url-3.0.0.tgz#bcd5be72c63fa0b8c390b3121783b462063e2a1b"


### PR DESCRIPTION
This provides a `refresh()` function on Ember's public router service. The feature was added to Ember in v4.1.0, but this polyfill will allow us to start using it straight away under 3.28

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
