### PR TITLE
FIX: Create a reviewable when flagging a chat message for "something else"

### DIFF
--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -246,6 +246,13 @@ describe Chat::ReviewQueue do
         )
       end
 
+      it "creates a reviewable" do
+        queue.flag_message(message, guardian, ReviewableScore.types[:notify_moderators])
+
+        reviewable = Chat::ReviewableMessage.find_by(target: message)
+        expect(reviewable).to be_present
+      end
+
       it "ignores the is_warning flag when notifying moderators" do
         queue.flag_message(
           message,


### PR DESCRIPTION
### What is this change?

In #22914 we added a fix to stop creating reviewables in the review queue when flagging a chat message and choosing the "notify user" option. By mistake we also stopped creating it when selecting the "something else" option.

This change makes it so a "something else" flag once again creates a reviewable. (Same behaviour as posts.)