### PR TITLE
FIX: Respect default category sort order when navigating within app

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -749,7 +749,7 @@ class TopicQuery
         # category default sort order
         sort_order, sort_ascending =
           Category.where(id: category_id).pick(:sort_order, :sort_ascending)
-        if sort_order && (filter.blank? || %i[latest unseen].include?(filter))
+        if sort_order && (filter.blank? || %w[latest unseen].include?(filter.to_s))
           options[:order] = sort_order
           options[:ascending] = !!sort_ascending ? "true" : "false"
         else

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -998,6 +998,13 @@ RSpec.describe TopicQuery do
         expect(topic_ids - [topic_category.id]).to eq([topic_in_cat1.id, topic_in_cat2.id])
       end
 
+      it "uses the category's default sort order when filter is passed as a string" do
+        category.update!(sort_order: "created", sort_ascending: true)
+        topic_ids =
+          TopicQuery.new(user, category: category.id, filter: "latest").list_latest.topics.map(&:id)
+        expect(topic_ids - [topic_category.id]).to eq([topic_in_cat1.id, topic_in_cat2.id])
+      end
+
       it "should apply default sort order to latest and unseen filters only" do
         category.update!(sort_order: "created", sort_ascending: true)
 


### PR DESCRIPTION
When navigating around, we make ajax requests with a parameter like `?filter=latest`. This results in the TopicQuery being set up with `filter: "latest"` as a string. The logic introduced in fd9a5bc0 checks for equality with `:latest` and `:unseen` symbols, which didn't work correctly in this situation

This commit makes the logic detect both strings and symbols, and adds a spec for the behaviour.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
