### PR TITLE
FIX: ensures we update cached model last message bus id

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
@@ -11,12 +11,13 @@ export default class ChatChannelPaneSubscriptionsManager extends ChatPaneBaseSub
 
   @tracked notices = new TrackedArray();
 
-  get messageBusChannel() {
-    return `/chat/${this.model.id}`;
+  beforeSubscribe(model) {
+    this.messageBusChannel = `/chat/${model.id}`;
+    this.messageBusLastId = model.channelMessageBusLastId;
   }
 
-  get messageBusLastId() {
-    return this.model.channelMessageBusLastId;
+  afterMessage(model, _, __, lastMessageBusId) {
+    model.channelMessageBusLastId = lastMessageBusId;
   }
 
   handleSentMessage() {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
@@ -50,11 +50,11 @@ export default class ChatPaneBaseSubscriptionsManager extends Service {
   afterMessage() {}
 
   subscribe(model) {
-    this.beforeSubscribe(model);
     this.unsubscribe();
+    this.beforeSubscribe(model);
     this.model = model;
 
-    if (!this.messageBusChannel || !this.messageBusLastId) {
+    if (!this.messageBusChannel) {
       return;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
@@ -39,21 +39,25 @@ export default class ChatPaneBaseSubscriptionsManager extends Service {
   @service currentUser;
   @service chatStagedThreadMapping;
 
-  get messageBusChannel() {
-    throw "not implemented";
-  }
-
-  get messageBusLastId() {
-    throw "not implemented";
-  }
+  messageBusChannel = null;
+  messageBusLastId = null;
 
   get messagesManager() {
     return this.model.messagesManager;
   }
 
+  beforeSubscribe() {}
+  afterMessage() {}
+
   subscribe(model) {
+    this.beforeSubscribe(model);
     this.unsubscribe();
     this.model = model;
+
+    if (!this.messageBusChannel || !this.messageBusLastId) {
+      return;
+    }
+
     this.messageBus.subscribe(
       this.messageBusChannel,
       this.onMessage,
@@ -120,6 +124,8 @@ export default class ChatPaneBaseSubscriptionsManager extends Service {
         this.handleNotice(busData);
         break;
     }
+
+    this.afterMessage(this.model, ...arguments);
   }
 
   handleSentMessage() {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane-subscriptions-manager.js
@@ -2,12 +2,13 @@ import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 import ChatPaneBaseSubscriptionsManager from "./chat-pane-base-subscriptions-manager";
 
 export default class ChatThreadPaneSubscriptionsManager extends ChatPaneBaseSubscriptionsManager {
-  get messageBusChannel() {
-    return `/chat/${this.model.channel.id}/thread/${this.model.id}`;
+  beforeSubscribe(model) {
+    this.messageBusChannel = `/chat/${model.channel.id}/thread/${model.id}`;
+    this.messageBusLastId = model.threadMessageBusLastId;
   }
 
-  get messageBusLastId() {
-    return this.model.threadMessageBusLastId;
+  afterMessage(model, _, __, lastMessageBusId) {
+    model.threadMessageBusLastId = lastMessageBusId;
   }
 
   handleSentMessage(data) {


### PR DESCRIPTION
Channels and threads are cached as much as possible, as a result the `last_message_bus_id` can become stalled.

It was for example exhibited with the following actions:
- open a channel (A)
- send a message
- navigate to another channel (B)
- come back to channel (A), and you would actually get all the messages replayed since you opened (A) for the first time as the `last_message_bus_id` would only refresh on a full page reload

This was technically not causing known bugs ATM, but was probably the source of few hard to repro bugs and would for sure cause issues in the future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
