### PR TITLE
DEV: Auto `yarn install` root package in development

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -56,7 +56,8 @@ if !args.include?("test") && !args.include?("build") && !args.include?("--proxy"
   args << PROXY
 end
 
-exit 1 if !system "yarn -s install --cwd #{YARN_DIR}"
+# Running yarn install in the root directory will also run it for YARN_DIR via a post-install hook
+exit 1 if !system "yarn", "-s", "install", "--cwd", RAILS_ROOT
 
 yarn_env = {}
 if ARGV.include?("--forward-host")

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lttf:ignore": "lint-to-the-future ignore",
     "lttf:output": "lint-to-the-future output -o ./lint-progress/",
     "lint-progress": "yarn lttf:output && npx html-pages ./lint-progress --no-cache",
-    "postinstall": "yarn --cwd app/assets/javascripts $(node -e 'if(JSON.parse(process.env.npm_config_argv).original.includes(`--frozen-lockfile`)){console.log(`--frozen-lockfile`)}')"
+    "postinstall": "yarn --cwd app/assets/javascripts $(node -e 'const argv = JSON.parse(process.env.npm_config_argv).original; const passthrough = [`--frozen-lockfile`, `-s`].filter(arg => argv.includes(arg)); console.log(passthrough.join(` `));')"
   },
   "engines": {
     "node": "16.* || >= 18",


### PR DESCRIPTION
We were already running `yarn install` for the app directory before booting ember-cli via `bin/ember-cli`. This commit extends that so that it also runs `yarn install` for the root of the repository. In the long-term we hope to combine these packages, but for now they are separate.

The post-install hook for the root package is also updated to pass through the `-s` flag. Previously, we only passed through the `--frozen-lockfile` flag.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
