### PR TITLE
FIX: Adjust border-radius in multiple locations

### DIFF
--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -209,6 +209,16 @@
       width: 50%;
       box-sizing: border-box;
       text-align: center;
+      &.themes-tab {
+        border-top-right-radius: 0px;
+        border-bottom-left-radius: 0px;
+        border-bottom-right-radius: 0px;
+      }
+      &.components-tab {
+        border-top-left-radius: 0px;
+        border-bottom-left-radius: 0px;
+        border-bottom-right-radius: 0px;
+      }
 
       &.active {
         background-color: var(--quaternary);
@@ -228,6 +238,8 @@
     overflow-y: auto;
     box-sizing: border-box;
     max-height: 60vh;
+    border-bottom-right-radius: var(--d-border-radius);
+    border-bottom-left-radius: var(--d-border-radius);
     @media screen and (max-height: 1000px) {
       max-height: 50vh;
     }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -17,6 +17,7 @@
   top: 100%; // directly underneath .panel
   right: -10px; // 10px to the right of .panel - adjust as needed
   max-height: 80vh;
+  border-radius: var(--d-border-radius-large);
 }
 
 .menu-panel {
@@ -100,6 +101,7 @@
   right: 0;
   width: 320px;
   padding: 0;
+  border-top-right-radius: 0px;
 
   .panel-body-bottom {
     flex: 0;
@@ -122,6 +124,7 @@
       display: flex;
       padding: 0.857em;
       position: relative;
+      border-radius: 0px;
 
       .d-icon {
         color: var(--primary-medium);

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -25,6 +25,8 @@ $search-pad-horizontal: 0.5em;
     display: flex;
     align-items: center;
     border: 1px solid var(--primary-medium);
+    border-radius: var(--d-border-radius-large);
+    overflow: hidden;
     input#search-term {
       border-width: 0;
       margin-bottom: 0;

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -124,3 +124,8 @@
     line-height: var(--line-height-large);
   }
 }
+
+.user-navigation .nav-pills li a,
+button {
+  border-radius: 0px;
+}

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -125,7 +125,9 @@
   }
 }
 
-.user-navigation .nav-pills li a,
-button {
-  border-radius: 0px;
+.user-navigation .nav-pills > li {
+  a,
+  button {
+    border-radius: 0px;
+  }
 }


### PR DESCRIPTION
This PR adds the use of `var(--d-border-radius)` in these areas to respect that style if it is set by a theme. These before and after shots are screenshots of Core when border-radius was set.

|Component|Before|After|
|---|---|---|
|Theme/Component|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/b5ef8fb2-a7f3-434b-9f48-86a398711ecc">|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/35619468-f959-4bbd-b57f-9f81febc1727">|
|Menu Panel|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/1e033e3e-2b81-4e9d-b68d-9bd6fb7a8a46">|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/a039d714-5bf5-4213-9680-be6849cb4060">|
|Search Menu|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/97d9dc66-5041-4405-b35a-8c4f30a9ce2a">|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/1a84bb28-2b50-4af7-bb82-d47e95cea614">|
|User Nav|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/df4e8a79-7b31-42ae-8e33-2f1a3f13e170">|<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/5f7595d6-e623-4c8c-8596-36d6689efb3b">|