### PR TITLE
UX: Move topic notification description to a tooltip

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.hbs
@@ -1,28 +1,15 @@
-{{#if this.appendReason}}
-  <p class="reason">
-    <TopicNotificationsOptions
-      @value={{this.notificationLevel}}
-      @topic={{this.topic}}
-      @onChange={{action "changeTopicNotificationLevel"}}
-      @options={{hash
-        icon=this.icon
-        showFullTitle=this.showFullTitle
-        showCaret=this.showCaret
-        headerAriaLabel=(i18n "topic.notifications.title")
-      }}
-    />
-    <span class="text">{{html-safe this.notificationReasonText}}</span>
-  </p>
-{{else}}
-  <TopicNotificationsOptions
-    @value={{this.notificationLevel}}
-    @topic={{this.topic}}
-    @onChange={{action "changeTopicNotificationLevel"}}
-    @options={{hash
-      icon=this.icon
-      showFullTitle=this.showFullTitle
-      showCaret=this.showCaret
-      headerAriaLabel=(i18n "topic.notifications.title")
-    }}
-  />
-{{/if}}
+<TopicNotificationsOptions
+  @value={{this.notificationLevel}}
+  @topic={{this.topic}}
+  @onChange={{action "changeTopicNotificationLevel"}}
+  @options={{hash
+    icon=this.icon
+    showFullTitle=this.showFullTitle
+    showCaret=this.showCaret
+    headerAriaLabel=(i18n "topic.notifications.title")
+  }}
+/>
+
+<DTooltip @placement="right" @arrow={{true}}>
+  {{html-safe this.notificationReasonText}}
+</DTooltip>

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1511,8 +1511,22 @@ span.mention {
     margin-top: 0;
   }
 
-  .pinned-button,
   .topic-notifications-button {
+    display: inline-flex;
+    margin: 0.5em 0 1em;
+
+    .dropdown-select-box {
+      .select-kit-selected-name {
+        overflow: hidden;
+        width: 100%;
+      }
+      .name {
+        @include ellipsis;
+      }
+    }
+  }
+
+  .pinned-button {
     margin: 0.5em 0 1em;
 
     .reason {


### PR DESCRIPTION
<img width="618" alt="Screenshot 2023-08-28 at 02 03 41" src="https://github.com/discourse/discourse/assets/66961/625090ba-a007-4bc6-90d1-818e9245494d">
<img width="618" alt="Screenshot 2023-08-28 at 02 04 00" src="https://github.com/discourse/discourse/assets/66961/f49dc1d7-e801-48f6-8547-49cb8d29c7f5">
