### PR TITLE
FIX: Avoid scroll jumping for topics on slow connections

### DIFF
--- a/app/assets/javascripts/discourse/app/services/loading-slider.js
+++ b/app/assets/javascripts/discourse/app/services/loading-slider.js
@@ -108,13 +108,13 @@ export default class LoadingSlider extends Service.extend(Evented) {
     this.trigger("stateChanged", false);
 
     this.scheduleManager.cancelAll();
-    this.scheduleManager.schedule("afterRender", this.removeClasses);
+    this.scheduleManager.schedule("render", this.removeClasses);
   }
 
   @bind
   setStillLoading() {
     this.stillLoading = true;
-    this.scheduleManager.schedule("afterRender", this.addStillLoadingClass);
+    this.scheduleManager.schedule("render", this.addStillLoadingClass);
   }
 
   @bind


### PR DESCRIPTION
When the 'loading slider' navigation indicator is enabled, and a connection is very slow, we `display: none` most of the page and display a spinner. The `still-loading` body class for this was being added in the `afterRender` step in the Ember runloop. This meant that, depending on the order they were scheduled, other `afterRender` jobs may run before it. This caused an issue with topic scroll locations because we would attempt to scroll to an element which was `display: none` at the point its position was calculated.

This commit moves the `still-loading` class manipulations to the `render` step of the runloop, which is technically more correct, and means that anything scheduled in the `afterRender` step is guaranteed to run without the `display: none` CSS.

https://meta.discourse.org/t/276305/29

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
