### PR TITLE
FIX: Display summaries for anonymous users.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/summary-box.js
+++ b/app/assets/javascripts/discourse/app/components/summary-box.js
@@ -14,6 +14,7 @@ const MIN_POST_READ_TIME = 4;
 export default class SummaryBox extends Component {
   @service siteSettings;
   @service messageBus;
+  @service currentUser;
 
   @tracked summary = "";
   @tracked summarizedOn = null;
@@ -166,12 +167,27 @@ export default class SummaryBox extends Component {
       this.loadingSummary = true;
     }
 
-    let fetchURL = `/t/${this.args.postAttrs.topicId}/strategy-summary?stream=true`;
+    let fetchURL = `/t/${this.args.postAttrs.topicId}/strategy-summary`;
 
-    if (this.canRegenerate) {
-      fetchURL += "&skip_age_check=true";
+    if (this.currentUser) {
+      fetchURL += `stream=true`;
     }
 
-    ajax(fetchURL).catch(popupAjaxError);
+    if (this.canRegenerate) {
+      if (this.currentUser) {
+        fetchURL += "&";
+      }
+
+      fetchURL += "skip_age_check=true";
+    }
+
+    ajax(fetchURL)
+      .then((data) => {
+        if (!this.currentUser) {
+          data.done = true;
+          this._updateSummary(data);
+        }
+      })
+      .catch(popupAjaxError);
   }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-summary-test.js
@@ -71,3 +71,44 @@ acceptance("Topic - Summary", function (needs) {
     assert.ok(exists(".summary-box .summarized-on"), "summary metadata exists");
   });
 });
+
+acceptance("Topic - Summary - Anon", function (needs) {
+  const finalSummary = "This is a completed summary";
+
+  needs.pretender((server, helper) => {
+    server.get("/t/1.json", () => {
+      const json = cloneJSON(topicFixtures["/t/280/1.json"]);
+      json.id = 1;
+      json.summarizable = true;
+
+      return helper.response(json);
+    });
+
+    server.get("/t/1/strategy-summary", () => {
+      return helper.response({
+        topic_summary: {
+          summarized_text: finalSummary,
+          summarized_on: "2023-01-01T04:00:00.000Z",
+          algorithm: "OpenAI GPT-4",
+          outdated: false,
+          new_posts_since_summary: false,
+          can_regenerate: false,
+        },
+      });
+    });
+  });
+
+  test("displays cached summary inmediately", async function (assert) {
+    await visit("/t/-/1");
+
+    await click(".topic-strategy-summarization");
+
+    assert.strictEqual(
+      query(".summary-box .generated-summary p").innerText,
+      finalSummary,
+      "Updates the summary with the result"
+    );
+
+    assert.ok(exists(".summary-box .summarized-on"), "summary metadata exists");
+  });
+});

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1185,7 +1185,7 @@ class TopicsController < ApplicationController
 
     opts = params.permit(:skip_age_check)
 
-    if params[:stream]
+    if params[:stream] && current_user
       Jobs.enqueue(
         :stream_topic_summary,
         topic_id: topic.id,


### PR DESCRIPTION
Streaming doesn't work for anonymous users because we scope updates to the current user. Since they can only see cached summaries, we can skip the streaming parameter and update it directly with the ajax response.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
