### PR TITLE
DEV: Add rake command to help detect dead settings

### DIFF
--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -38,4 +38,35 @@ class SiteSettingsTask
     end
     [log, counts]
   end
+
+  def self.names
+    site_settings = SiteSetting.all_settings(include_hidden: true)
+    site_settings.map { |site_setting| site_setting[:setting].to_s }
+  end
+
+  def self.rg_installed?
+    !`which rg`.strip.empty?
+  end
+
+  def self.directory_path(directory_name)
+    File.expand_path(File.join(Dir.pwd, "..", directory_name))
+  end
+
+  def self.directories_to_check
+    %w[all-the-themes all-the-custom-themes all-the-plugins all-the-custom-plugins]
+  end
+
+  def self.directories
+    directories = [Dir.pwd]
+    SiteSettingsTask.directories_to_check.each do |d|
+      if Dir.exist? SiteSettingsTask.directory_path(d)
+        directories << SiteSettingsTask.directory_path(d)
+      end
+    end
+    directories
+  end
+
+  def self.rg_search_count(term, directory)
+    `rg -l --no-ignore "#{term}" "#{directory}" -g '!config' -g '!db/migrate' | wc -l`.strip.to_i
+  end
 end

--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -40,8 +40,9 @@ class SiteSettingsTask
   end
 
   def self.names
-    site_settings = SiteSetting.all_settings(include_hidden: true)
-    site_settings.map { |site_setting| site_setting[:setting].to_s }
+    SiteSetting
+      .all_settings(include_hidden: true)
+      .map { |site_setting| site_setting[:setting].to_s }
   end
 
   def self.rg_installed?
@@ -49,7 +50,12 @@ class SiteSettingsTask
   end
 
   def self.directory_path(directory_name)
-    File.expand_path(File.join(Dir.pwd, "..", directory_name))
+    all_the_parent_dir = ENV["ALL_THE_PARENT_DIR"]
+    if all_the_parent_dir
+      File.expand_path(File.join(all_the_parent_dir, directory_name))
+    else
+      File.expand_path(File.join(Dir.pwd, "..", directory_name))
+    end
   end
 
   def self.directories_to_check

--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -55,19 +55,25 @@ task "site_settings:find_dead" => :environment do
     exit 1
   end
 
+  if !ENV["ALL_THE_PARENT_DIR"]
+    puts "To specify a custom parent directory for all-the-themes & all-the-plugins"
+    puts "use the ALL_THE_PARENT_DIR ENV var."
+  end
   puts "Checking #{setting_names.count} settings in these directories:"
   puts directories
   puts
 
   setting_names.each do |setting_name|
-    count = 0
-    count = SiteSettingsTask.rg_search_count("SiteSetting.#{setting_name}", directories[0])
+    count = SiteSettingsTask.rg_search_count("SiteSetting.#{setting_name}", directories.first)
     count =
-      SiteSettingsTask.rg_search_count("siteSettings.#{setting_name}", directories[0]) if count == 0
+      SiteSettingsTask.rg_search_count(
+        "siteSettings.#{setting_name}",
+        directories.first,
+      ) if count.zero?
     directories.each do |directory|
-      count = SiteSettingsTask.rg_search_count(setting_name, directory) if count == 0
+      count = SiteSettingsTask.rg_search_count(setting_name, directory) if count.zero?
     end
-    if count == 0
+    if count.zero?
       print setting_name
       dead_settings << setting_name
     else

--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -34,3 +34,53 @@ task "site_settings:import" => :environment do
 
   exit 1 if counts[:not_found] + counts[:errors] > 0
 end
+
+# Outputs a list of Site Settings that may no longer be in use
+desc "Find dead site settings"
+task "site_settings:find_dead" => :environment do
+  setting_names = SiteSettingsTask.names
+
+  setting_names.each do |n|
+    if !SiteSetting.respond_to?(n)
+      # Likely won't hit here, but just in case
+      puts "Setting #{n} does not exist."
+    end
+  end
+
+  directories = SiteSettingsTask.directories
+  dead_settings = []
+
+  if !SiteSettingsTask.rg_installed?
+    puts "Please install ripgrep to use this command"
+    exit 1
+  end
+
+  puts "Checking #{setting_names.count} settings in these directories:"
+  puts directories
+  puts
+
+  setting_names.each do |setting_name|
+    count = 0
+    count = SiteSettingsTask.rg_search_count("SiteSetting.#{setting_name}", directories[0])
+    count =
+      SiteSettingsTask.rg_search_count("siteSettings.#{setting_name}", directories[0]) if count == 0
+    directories.each do |directory|
+      count = SiteSettingsTask.rg_search_count(setting_name, directory) if count == 0
+    end
+    if count == 0
+      print setting_name
+      dead_settings << setting_name
+    else
+      print "."
+    end
+  end
+
+  puts
+
+  if dead_settings.count > 0
+    puts "These settings may be unused:"
+    puts dead_settings
+  else
+    puts "No dead settings found."
+  end
+end


### PR DESCRIPTION
Some Site Settings may still exist but are no longer being used in the
core discourse code or in related plugins. This rake task will help
identify any unused (aka: dead) settings by using the `rg` command to
search for them.

You can execute the rake task by using this command:

`LOAD_PLUGINS=1 bin/rails "site_settings:find_dead"`
