### PR TITLE
FIX: Include 'notify staff' separator in chat message flag modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
@@ -31,10 +31,8 @@
       </div>
     </label>
   </div>
-  {{#if @includeSeparator}}
-    <hr />
-  {{/if}}
   {{#if this.staffFlagsAvailable}}
+    <hr />
     <h3>{{i18n "flagging.notify_staff"}}</h3>
   {{/if}}
 {{else}}

--- a/app/assets/javascripts/discourse/app/components/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.hbs
@@ -21,7 +21,6 @@
           @username={{@model.flagModel.username}}
           @staffFlagsAvailable={{this.staffFlagsAvailable}}
           @changePostActionType={{this.changePostActionType}}
-          @includeSeparator={{this.includeSeparator}}
         />
       </FlagSelection>
     </form>

--- a/app/assets/javascripts/discourse/app/components/modal/flag.js
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.js
@@ -7,7 +7,7 @@ import { MAX_MESSAGE_LENGTH } from "discourse/models/post-action-type";
 import User from "discourse/models/user";
 import { reload } from "discourse/helpers/page-reloader";
 
-const NOTIFY_MODERATORS_ID = 7;
+const NOTIFY_MODERATORS_KEY = "notify_moderators";
 
 export default class Flag extends Component {
   @service adminTools;
@@ -75,13 +75,6 @@ export default class Flag extends Component {
     return this.args.model.flagTarget.submitLabel();
   }
 
-  get includeSeparator() {
-    return (
-      this.staffFlagsAvailable ||
-      this.args.model.flagTarget.includeSeparator?.()
-    );
-  }
-
   get title() {
     return this.args.model.flagTarget.title();
   }
@@ -91,7 +84,7 @@ export default class Flag extends Component {
   }
 
   get staffFlagsAvailable() {
-    return this.args.model.flagModel.flagsAvailable?.length > 1;
+    return this.flagsAvailable.length > 1;
   }
 
   get submitEnabled() {
@@ -111,7 +104,7 @@ export default class Flag extends Component {
   }
 
   get notifyModeratorsFlag() {
-    return this.flagsAvailable.find((f) => f.id === NOTIFY_MODERATORS_ID);
+    return this.flagsAvailable.find((f) => f.id === NOTIFY_MODERATORS_KEY);
   }
 
   get canTakeAction() {

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-flag.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-flag.js
@@ -24,10 +24,6 @@ export default class ChatMessageFlag {
     return false;
   }
 
-  includeSeparator() {
-    return true;
-  }
-
   _rewriteFlagDescriptions(flags) {
     return flags.map((flag) => {
       flag.set(


### PR DESCRIPTION
### What is this fix?

When flagging a chat message, and options included both notifying user and notifying staff, the modal was missing the separating text. This was happening because the `#staffFlagsAvailable` method was based on post flags, and the model for chat flags is slightly different. This fixes that by delegating to the relevant flag target object.

### Room for improvement

We currently render this in a slightly awkward way, which relies on a hard-coded assumption that there will only ever be at most one "notify user" option. We also don't render the "notify moderators" text when there's no "notify user" option. We can improve this by hoisting the condition from the `FlagActionType` component into the parent and rendering notify user and notify moderators options separately. For later.

### Does it work now?

**Flagging post with both options:**

<img width="577" alt="Screenshot 2023-08-29 at 10 50 27 AM" src="https://github.com/discourse/discourse/assets/5259935/c68658a1-dd2d-435c-8cc7-d9eafba824ad">

**Flagging post with only "notify staff" options:**

<img width="579" alt="Screenshot 2023-08-29 at 10 50 45 AM" src="https://github.com/discourse/discourse/assets/5259935/b2d45fad-bc00-411b-b963-ffa705c40ce0">

**Flagging chat message with both options:**

<img width="572" alt="Screenshot 2023-08-29 at 10 59 53 AM" src="https://github.com/discourse/discourse/assets/5259935/a358f286-fc23-4901-beac-86d289e592f2">
