### PR TITLE
DEV: New JS plugin api to render components into plugin outlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.hbs
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.hbs
@@ -42,3 +42,9 @@
     {{/if}}
   {{/each}}
 {{/if}}
+
+{{#each this.components as |c|}}
+  {{#let (component c) as |Component|}}
+    <Component @outletArgs={{this.outletArgsWithDeprecations}} />
+  {{/let}}
+{{/each}}

--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -10,6 +10,7 @@ import { helperContext } from "discourse-common/lib/helpers";
 import deprecated from "discourse-common/lib/deprecated";
 import { get } from "@ember/object";
 import { cached } from "@glimmer/tracking";
+import { registeredPluginOutletComponents } from "discourse/lib/registered-plugin-outlet-components";
 
 const PARENT_VIEW_DEPRECATION_MSG =
   "parentView should not be used within plugin outlets. Use the available outlet arguments, or inject a service which can provide the context you need.";
@@ -77,6 +78,10 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
     }
 
     return result;
+  }
+
+  get components() {
+    return registeredPluginOutletComponents[this.args.name] || [];
   }
 
   get connectors() {

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -125,6 +125,7 @@ import { registerCustomUserNavMessagesDropdownRow } from "discourse/controllers/
 import { registerFullPageSearchType } from "discourse/controllers/full-page-search";
 import { registerHashtagType } from "discourse/lib/hashtag-autocomplete";
 import { _addBulkButton } from "discourse/components/modal/topic-bulk-actions";
+import { registerPluginOutletComponents } from "discourse/lib/registered-plugin-outlet-components";
 
 // If you add any methods to the API ensure you bump up the version number
 // based on Semantic Versioning 2.0.0. Please update the changelog at
@@ -2416,6 +2417,22 @@ class PluginApi {
    */
   addBulkActionButton(opts) {
     _addBulkButton(opts);
+  }
+
+  /**
+   * EXPERIMENTAL: Do not use.
+   *
+   * Renders a component in a plugin outlet.
+   *
+   * ```
+   * import MyComponent from "theme-name/components/my-component";
+   *
+   * api.renderInPluginOutlet("above-discovery-categories", MyComponent);
+   * ```
+   *
+   */
+  renderInPluginOutlet(outletName, component) {
+    registerPluginOutletComponents(outletName, component);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/registered-plugin-outlet-components.js
+++ b/app/assets/javascripts/discourse/app/lib/registered-plugin-outlet-components.js
@@ -1,0 +1,10 @@
+export const registeredPluginOutletComponents = {};
+
+export function registerPluginOutletComponents(outletName, component) {
+  registeredPluginOutletComponents[outletName] ||= [];
+  registeredPluginOutletComponents[outletName].push(component);
+}
+
+export function clearRegisteredPluginOutletComponents() {
+  registeredPluginOutletComponents = {};
+}


### PR DESCRIPTION
Why this change?

Currently to render into a plugin outlet in core, plugin/theme authors have to follow a certain directory convention in order for the connector template file to be discovered. For example, plugins have to put the connector template file in the following path: `plugins/<plugin name>/assets/javascripts/discourse/templates/connectors/<outletn name>/`.

I feel that this directory convention is unneccessary and hard to explain. While this was the only way in the pre-Glimmer ember world, this is no longer the best way to do things. Instead, we can just expose a client side plugin API that allows plugin/theme authors to render into plugin outlets.

In this commit, the following API is introduced:

```
import "MyComponent from "../components/my-component";"

api.renderInPluginOutlet(outletName, MyComponent);
```

This removes the need for a directory convention and removes the need for a connector template file as well.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
