### PR TITLE
DEV: Add `after-composer-title-input` outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-title.hbs
@@ -8,4 +8,10 @@
   @autocomplete="off"
 />
 
+<PluginOutlet
+  @name="after-composer-title-input"
+  @connectorTagName="div"
+  @outletArgs={{hash composer=this.composer}}
+/>
+
 <PopupInputTip @validation={{this.validation}} />


### PR DESCRIPTION
This PR adds the plugin outlet `after-composer-title-input` for usage in Discourse AI https://github.com/discourse/discourse-ai/pull/171