### PR TITLE
DEV: Move 'ignore and delete' action under 'ignore' menu for chat flags

### DIFF
--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -73,10 +73,12 @@ module Chat
         )
       end
 
-      build_action(actions, :ignore, icon: "external-link-alt")
+      ignore_bundle = actions.add_bundle("#{id}-ignore", label: "reviewables.actions.ignore.title")
+
+      build_action(actions, :ignore, icon: "external-link-alt", bundle: ignore_bundle)
 
       unless chat_message.deleted_at?
-        build_action(actions, :delete_and_agree, icon: "far-trash-alt")
+        build_action(actions, :delete_and_agree, icon: "far-trash-alt", bundle: ignore_bundle)
       end
     end
 

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -113,14 +113,16 @@ en:
           title: "Delete Message"
           description: "Delete the message so that users cannot see it."
         delete_and_agree:
-          title: "Delete Message"
+          title: "Ignore Flag and Delete Message"
+          description: "Ignore the flag by removing it from the queue and delete the message."
         disagree_and_restore:
           title: "Disagree and Restore Message"
           description: "Restore the message so that all users can see it."
         disagree:
           title: "Disagree"
         ignore:
-          title: "Ignore"
+          title: "Do Nothing"
+          description: "Ignore the flag by removing it from the queue without taking any action."
       direct_messages:
         transcript_title: "Transcript of previous messages in %{channel_name}"
         transcript_body: "To give you more context, we included a transcript of the previous messages in this conversation (up to ten):\n\n%{transcript}"


### PR DESCRIPTION
### What is this change?

This moves the "delete message" action (if it is available) of a flagged chat message under the "ignore" menu. This puts it on par with the menu for flagged posts.

### Screenshots

**Before:**

<img width="402" alt="Screenshot 2023-08-29 at 3 48 18 PM" src="https://github.com/discourse/discourse/assets/5259935/dc5daace-5b3a-42d2-8a09-5efe23639d3d">

**After:**

<img width="635" alt="Screenshot 2023-08-29 at 3 47 00 PM" src="https://github.com/discourse/discourse/assets/5259935/280ed793-c71f-4211-a398-7335680a5ea6">
