### PR TITLE
UX: settings are misaligned when translations are too long

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -47,16 +47,7 @@
     </div>
 
     <div class="admin-controls">
-      {{#unless this.model.theme_id}}
-        <div class="pull-right">
-          <label>
-            <Input @type="checkbox" @checked={{this.onlyOverridden}} />
-            {{i18n "admin.settings.show_overriden"}}
-          </label>
-        </div>
-      {{/unless}}
-
-      <div>
+      <div class="pull-left">
         {{#if this.model.theme_id}}
           <InlineEditCheckbox
             @action={{action "applyUserSelectable"}}
@@ -71,6 +62,15 @@
           </label>
         {{/if}}
       </div>
+
+      {{#unless this.model.theme_id}}
+        <div class="pull-right">
+          <label>
+            <Input @type="checkbox" @checked={{this.onlyOverridden}} />
+            {{i18n "admin.settings.show_overriden"}}
+          </label>
+        </div>
+      {{/unless}}
     </div>
 
     {{#if this.colors.length}}

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -180,12 +180,19 @@
     }
 
     &.color-scheme .admin-controls {
+      display: flex;
       padding: 1em;
       label {
         margin-bottom: 0;
         input[type="checkbox"] {
           margin-top: 0;
         }
+      }
+      .pull-left {
+        width: 70%;
+      }
+      .pull-right {
+        width: 30%;
       }
     }
   }


### PR DESCRIPTION
Before:

<img width="730" alt="Screenshot 2023-08-29 at 5 50 02 PM" src="https://github.com/discourse/discourse/assets/11170663/77ddb6a7-80a5-4b4f-aed1-da0fab2a8d27">

After:

<img width="746" alt="Screenshot 2023-08-29 at 5 47 38 PM" src="https://github.com/discourse/discourse/assets/11170663/6bf87ba1-01cc-4f96-9df3-ef1c380ccd99">

