### PR TITLE
FIX: no form template logic when editing posts

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -909,7 +909,8 @@ export default class ComposerService extends Service {
     if (this.siteSettings.experimental_form_templates) {
       if (
         this.formTemplateIds?.length > 0 &&
-        !this.get("model.replyingToTopic")
+        !this.get("model.replyingToTopic") &&
+        !this.get("model.editingPost")
       ) {
         const formTemplateData = prepareFormTemplateData(
           document.querySelector("#form-template-form")


### PR DESCRIPTION
The (experimental) form template is not currently rendered when editing posts, so this PR also ignores it while saving the post edition, otherwise the `prepareFormTemplateData` would fail as there's no form to prepare.

