### PR TITLE
DEV: Group babel updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,7 @@ updates:
       timezone: Australia/Sydney
     open-pull-requests-limit: 20
     versioning-strategy: increase
+    groups:
+      babel:
+        patterns:
+          - "@babel*"


### PR DESCRIPTION
Grouped Dependabot updates are now available (https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/) so we can finally make it create a single PR for both `@babel/core` and `@babel/standalone` 😌

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
