### PR TITLE
FIX: Remove chat "enable chat plugin text"

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -1,7 +1,8 @@
 en:
   site_settings:
     chat_separate_sidebar_mode: "Show separate sidebar modes for forum and chat."
-    chat_enabled: "Enable the chat plugin."
+    # intentionally left blank to avoid doubled-up text in the UI
+    chat_enabled: ""
     enable_public_channels: "Enable public channels based on categories."
     chat_allowed_groups: "Users in these groups can chat. Note that staff can always access chat."
     chat_channel_retention_days: "Chat messages in regular channels will be retained for this many days. Set to '0' to retain messages forever."


### PR DESCRIPTION
This text is repetitive and also a little confusing
to end users, since it doesn't really matter that
chat is a plugin, since it is in core.
