### PR TITLE
FIX: Hide core plugins from the admin Plugins list

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -24,6 +24,7 @@ register_svg_icon "file-image"
 
 # route: /admin/plugins/chat
 add_admin_route "chat.admin.title", "chat"
+hide_plugin
 
 GlobalSetting.add_default(:allow_unsecure_chat_uploads, false)
 

--- a/plugins/checklist/plugin.rb
+++ b/plugins/checklist/plugin.rb
@@ -10,3 +10,4 @@ enabled_site_setting :checklist_enabled
 
 register_asset "stylesheets/checklist.scss"
 register_svg_icon "spinner"
+hide_plugin

--- a/plugins/discourse-details/plugin.rb
+++ b/plugins/discourse-details/plugin.rb
@@ -7,7 +7,7 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-details
 
 enabled_site_setting :details_enabled
-hide_plugin if self.respond_to?(:hide_plugin)
+hide_plugin
 
 register_asset "stylesheets/details.scss"
 

--- a/plugins/discourse-lazy-videos/plugin.rb
+++ b/plugins/discourse-lazy-videos/plugin.rb
@@ -6,7 +6,7 @@
 # authors: Jan Cernik
 # url: https://github.com/discourse/discourse-lazy-videos
 
-hide_plugin if self.respond_to?(:hide_plugin)
+hide_plugin
 enabled_site_setting :lazy_videos_enabled
 
 register_asset "stylesheets/lazy-videos.scss"

--- a/plugins/discourse-local-dates/plugin.rb
+++ b/plugins/discourse-local-dates/plugin.rb
@@ -5,7 +5,7 @@
 # version: 0.1
 # author: Joffrey Jaffeux
 
-hide_plugin if self.respond_to?(:hide_plugin)
+hide_plugin
 
 register_asset "stylesheets/common/discourse-local-dates.scss"
 register_asset "moment.js", :vendored_core_pretty_text

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -7,7 +7,7 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-narrative-bot
 
 enabled_site_setting :discourse_narrative_bot_enabled
-hide_plugin if self.respond_to?(:hide_plugin)
+hide_plugin
 
 if Rails.env == "development"
   # workaround, teach reloader to reload jobs

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -7,7 +7,7 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-presence
 
 enabled_site_setting :presence_enabled
-hide_plugin if self.respond_to?(:hide_plugin)
+hide_plugin
 
 register_asset "stylesheets/presence.scss"
 

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -7,6 +7,7 @@
 
 register_asset "stylesheets/styleguide.scss"
 enabled_site_setting :styleguide_enabled
+hide_plugin
 
 load File.expand_path("../lib/styleguide/engine.rb", __FILE__)
 


### PR DESCRIPTION
Most of the core plugins were already hidden, this hides
chat, styleguide, and checklist to avoid potential confusion
for end users.

Also removes respond_to? :hide_plugin, since that API has been
in place for a while now.
