### PR TITLE
FIX: add mobile specific stylesheet for onebox

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -453,7 +453,6 @@ pre.onebox code {
   }
 
   .github-icon-container {
-    position: absolute;
     display: flex;
     align-items: center;
     margin-right: 10px;
@@ -474,9 +473,6 @@ pre.onebox code {
 
   .github-info-container {
     width: 100%;
-    h4 {
-      margin: 0 0 10px 50px;
-    }
   }
 
   .github-info {

--- a/app/assets/stylesheets/mobile/_index.scss
+++ b/app/assets/stylesheets/mobile/_index.scss
@@ -20,6 +20,7 @@
 @import "menu-panel";
 @import "modal";
 @import "new-user";
+@import "onebox";
 @import "personal-message";
 @import "push-notifications-mobile";
 @import "reviewables";

--- a/app/assets/stylesheets/mobile/onebox.scss
+++ b/app/assets/stylesheets/mobile/onebox.scss
@@ -1,0 +1,13 @@
+// Onebox - Github - PR, Commit & Issue
+.onebox.githubpullrequest,
+.onebox.githubcommit,
+.onebox.githubissue {
+  .github-icon-container {
+    position: absolute;
+  }
+  .github-info-container {
+    h4 {
+      margin: 0 0 10px 50px;
+    }
+  }
+}


### PR DESCRIPTION
Fixes the regression on desktop github onebox styling.

Before:

<img width="700" alt="Screenshot 2023-08-30 at 8 14 05 AM" src="https://github.com/discourse/discourse/assets/11170663/56ef424c-7a78-4d12-bb37-ef924342e8f8">

After:

<img width="702" alt="Screenshot 2023-08-30 at 8 13 49 AM" src="https://github.com/discourse/discourse/assets/11170663/84d10fc0-5a40-4777-93f1-507ef1f17e89">
