### PR TITLE
DEV: Add auto _map extensions for list site settings with no type

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -529,9 +529,14 @@ module SiteSettingExtension
 
     # Same logic as above for group_list settings, with the caveat that normal
     # list settings are not necessarily integers, so we just want to handle the splitting.
-    if type_supervisor.get_type(name) == :list &&
-         %w[simple compact].include?(type_supervisor.get_list_type(name))
-      define_singleton_method("#{clean_name}_map") { self.public_send(clean_name).to_s.split("|") }
+    if type_supervisor.get_type(name) == :list
+      list_type = type_supervisor.get_list_type(name)
+
+      if %w[simple compact].include?(list_type) || list_type.nil?
+        define_singleton_method("#{clean_name}_map") do
+          self.public_send(clean_name).to_s.split("|")
+        end
+      end
     end
 
     define_singleton_method "#{clean_name}?" do

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -870,6 +870,11 @@ RSpec.describe SiteSettingExtension do
       expect(SiteSetting.ga_universal_auto_link_domains_map).to eq(%w[test.com xy.com])
     end
 
+    it "handles splitting list settings with no type" do
+      SiteSetting.post_menu = "read|like"
+      expect(SiteSetting.post_menu_map).to eq(%w[read like])
+    end
+
     it "does not handle splitting secret list settings" do
       SiteSetting.discourse_connect_provider_secrets = "test|secret1\ntest2|secret2"
       expect(SiteSetting.respond_to?(:discourse_connect_provider_secrets_map)).to eq(false)


### PR DESCRIPTION
Followup to eea74e0e32f704f0756202c3f3ae801bcc8ac8bb. Site settings
which are a list without a list_type should also have the _map
extension added which returns an array based on split("|").

For example:

```
SiteSetting.post_menu_map
=> ["read", "like"]
```
