### PR TITLE
DEV: Include context question for chat reviewables

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
@@ -66,12 +66,10 @@
     {{/if}}
   </div>
 
-  {{#if (eq this.reviewable.type "ReviewableFlaggedPost")}}
-    {{#if (eq this.reviewable.status 0)}}
-      <h3 class="reviewable-item__context-question">
-        {{this.reviewable.flaggedPostContextQuestion}}
-      </h3>
-    {{/if}}
+  {{#if this.displayContextQuestion}}
+    <h3 class="reviewable-item__context-question">
+      {{this.reviewable.flaggedReviewableContextQuestion}}
+    </h3>
   {{/if}}
 
   <div class="reviewable-actions">

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -58,6 +58,11 @@ export default Component.extend({
     return classes;
   },
 
+  @discourseComputed("reviewable.created_from_flag", "reviewable.status")
+  displayContextQuestion(createdFromFlag, status) {
+    return createdFromFlag && status === 0;
+  },
+
   @discourseComputed(
     "reviewable.topic",
     "reviewable.topic_id",

--- a/app/assets/javascripts/discourse/app/models/reviewable.js
+++ b/app/assets/javascripts/discourse/app/models/reviewable.js
@@ -35,14 +35,23 @@ const Reviewable = RestModel.extend({
     return "-" + dasherize(humanType);
   },
 
-  @discourseComputed
-  flaggedPostContextQuestion() {
+  @discourseComputed("resolvedType")
+  humanNoun(resolvedType) {
+    return I18n.t(`review.types.${underscore(resolvedType)}.noun`, {
+      defaultValue: "reviewable",
+    });
+  },
+
+  @discourseComputed("humanNoun")
+  flaggedReviewableContextQuestion(humanNoun) {
     const uniqueReviewableScores =
       this.reviewable_scores.uniqBy("score_type.type");
 
     if (uniqueReviewableScores.length === 1) {
       if (uniqueReviewableScores[0].score_type.type === "notify_moderators") {
-        return I18n.t("review.context_question.something_else_wrong");
+        return I18n.t("review.context_question.something_else_wrong", {
+          reviewable_type: humanNoun,
+        });
       }
     }
 
@@ -55,6 +64,7 @@ const Reviewable = RestModel.extend({
 
     return I18n.t("review.context_question.is_this_post", {
       reviewable_human_score_types: listOfQuestions,
+      reviewable_type: humanNoun,
     });
   },
 

--- a/app/serializers/reviewable_flagged_post_serializer.rb
+++ b/app/serializers/reviewable_flagged_post_serializer.rb
@@ -4,6 +4,10 @@ class ReviewableFlaggedPostSerializer < ReviewableSerializer
   target_attributes :cooked, :raw, :reply_count, :reply_to_post_number
   attributes :blank_post, :post_updated_at, :post_version
 
+  def created_from_flag?
+    true
+  end
+
   def post_version
     object.target&.version
   end

--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -16,6 +16,7 @@ class ReviewableSerializer < ApplicationSerializer
     :score,
     :version,
     :target_created_by_trust_level,
+    :created_from_flag?,
   )
 
   attribute :status_for_database, key: :status
@@ -94,6 +95,10 @@ class ReviewableSerializer < ApplicationSerializer
         data[:payload] = (object.payload || {}).slice(*self.class._payload_for_serialization)
       end
     end
+  end
+
+  def created_from_flag?
+    false
   end
 
   def topic_tags

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -618,24 +618,27 @@ en:
           title: "Everything"
 
       context_question:
-        is_this_post: "Is this post %{reviewable_human_score_types}?"
+        is_this_post: "Is this %{reviewable_type} %{reviewable_human_score_types}?"
         delimiter: "or"
-        something_else_wrong: "Is there something wrong with this post?"
+        something_else_wrong: "Is there something wrong with this %{reviewable_type}?"
 
       types:
         reviewable_flagged_post:
           title: "Flagged Post"
           flagged_by: "Flagged By"
+          noun: "post"
         reviewable_queued_topic:
           title: "Queued Topic"
+          noun: "topic"
         reviewable_queued_post:
           title: "Queued Post"
+          noun: "post"
         reviewable_user:
           title: "User"
+          noun: "user"
         reviewable_post:
           title: "Post"
-        reviewable_chat_message:
-          title: "Flagged chat message"
+          noun: "post"
       approval:
         title: "Post Needs Approval"
         description: "We've received your new post but it needs to be approved by a moderator before it will appear. Please be patient."

--- a/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
@@ -10,6 +10,10 @@ module Chat
 
     has_one :chat_channel, serializer: Chat::ChannelSerializer, root: false, embed: :objects
 
+    def created_from_flag?
+      true
+    end
+
     def chat_channel
       object.chat_message.chat_channel
     end

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -653,6 +653,9 @@ en:
       types:
         chat_reviewable_message:
           title: "Flagged Chat Message"
+        reviewable_chat_message:
+          title: "Flagged chat message"
+          noun: "chat message"
     keyboard_shortcuts_help:
       chat:
         title: "Chat"

--- a/spec/serializers/reviewable_flagged_post_serializer_spec.rb
+++ b/spec/serializers/reviewable_flagged_post_serializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ReviewableFlaggedPostSerializer do
     expect(json[:cooked]).to eq(p0.cooked)
     expect(json[:raw]).to eq(p0.raw)
     expect(json[:target_url]).to eq(Discourse.base_url + p0.url)
+    expect(json[:created_from_flag]).to eq(true)
   end
 
   it "works when the topic is deleted" do

--- a/spec/serializers/reviewable_serializer_spec.rb
+++ b/spec/serializers/reviewable_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ReviewableSerializer do
     expect(json[:can_edit]).to eq(true)
     expect(json[:version]).to eq(0)
     expect(json[:removed_topic_id]).to be_nil
+    expect(json[:created_from_flag]).to eq(false)
   end
 
   it "Includes the removed topic id when the topis was deleted" do


### PR DESCRIPTION
## What is this change?

Chat review queue flags were missing the context message above the actions, e.g.:

<img width="326" alt="Screenshot 2023-08-30 at 4 08 39 PM" src="https://github.com/discourse/discourse/assets/5259935/84483693-4735-4713-9317-15ea2703b5f5">

This is probably because the (reasonably complex) logic was somewhat hard-coded to posts. After some investigation I concluded we can reuse this logic with some small amendments.

## Future improvements

- We currently don't apply a fixed order to the flag types, resulting in sentences like: "is this something else or spam?" which would be nicer if it was: "is this spam or something else?" We can add explicit ordering to push "something else" to the back later.
- Currently the "disagree" option would read better if it was "no" I think. We can at least improve this in the English translation.

## Screenshots

### New behaviour

**Chat with single flag (something else):**

<img width="433" alt="chat-single-type" src="https://github.com/discourse/discourse/assets/5259935/512004d2-34e0-42fd-8c01-a876fb06f6d3">

**Chat with multiple flags:**

<img width="403" alt="chat-multi-type" src="https://github.com/discourse/discourse/assets/5259935/7ef47828-de6b-4a8e-946a-fecabd3300f8">

### Regression

**Post with single flag (something else):**

<img width="360" alt="post-single-type" src="https://github.com/discourse/discourse/assets/5259935/ba4b1bc5-e813-4427-90a8-f06ffdd491b2">

**Post with multiple flags:**

<img width="324" alt="post-multi-type" src="https://github.com/discourse/discourse/assets/5259935/440a7995-356e-47d6-ac97-5b52c052fe60">
