### PR TITLE
Revert "FIX: Remove chat "enable chat plugin text" (#23327)"

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -1,8 +1,7 @@
 en:
   site_settings:
     chat_separate_sidebar_mode: "Show separate sidebar modes for forum and chat."
-    # intentionally left blank to avoid doubled-up text in the UI
-    chat_enabled: ""
+    chat_enabled: "Enable chat."
     enable_public_channels: "Enable public channels based on categories."
     chat_allowed_groups: "Users in these groups can chat. Note that staff can always access chat."
     chat_channel_retention_days: "Chat messages in regular channels will be retained for this many days. Set to '0' to retain messages forever."


### PR DESCRIPTION
This reverts commit 7f5c3d4e9ac9577bd768796886709222d68adaf4,
the setting text is not localized so we do need the label
even if it is redundant.
