### PR TITLE
UX: Remove Plugin Settings tab

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/plugins.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins.hbs
@@ -4,13 +4,6 @@
     {{#each this.adminRoutes as |route|}}
       <NavItem @route={{route.full_location}} @label={{route.label}} />
     {{/each}}
-    {{#if this.currentUser.admin}}
-      <NavItem
-        @route="adminSiteSettingsCategory"
-        @label="admin.plugins.change_settings"
-        @routeParam="plugins"
-      />
-    {{/if}}
   </HorizontalOverflowNav>
 </div>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4996,7 +4996,6 @@ en:
         enabled: "Enabled?"
         is_enabled: "Y"
         not_enabled: "N"
-        change_settings: "Plugin Settings"
         change_settings_short: "Settings"
         howto: "How do I install plugins?"
         official: "Official Plugin"


### PR DESCRIPTION
This tab doesn't really provide anything useful, and can be quite
confusing in some cases. Each plugin is already listed below, and
you can navigate to their settings from there. We want to move away
from the catch-all Plugins category for site settings. Core plugins are
not shown in this list as at 97a812f022f3e7baa51f354e8f632bec0683fb6d.

![image](https://github.com/discourse/discourse/assets/920448/d8e213b6-6ca4-4017-ac15-4dc4f70c685c)
