### PR TITLE
FIX: Confusing vague upload error

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -329,14 +329,14 @@ export function displayErrorForUpload(data, siteSettings, fileName) {
   }
 
   // otherwise, display a generic error message
-  dialog.alert(I18n.t("post.errors.upload"));
+  dialog.alert(I18n.t("post.errors.upload", { file_name: fileName }));
 }
 
 function displayErrorByResponseStatus(status, body, fileName, siteSettings) {
   switch (status) {
     // didn't get headers from server, or browser refuses to tell us
     case 0:
-      dialog.alert(I18n.t("post.errors.upload"));
+      dialog.alert(I18n.t("post.errors.upload", { file_name: fileName }));
       return true;
 
     // entity too large, usually returned from the web server

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -390,7 +390,9 @@ module("Unit | Utility | uploads", function (hooks) {
       "test.png"
     );
     assert.ok(
-      dialog.alert.calledWith(I18n.t("post.errors.upload")),
+      dialog.alert.calledWith(
+        I18n.t("post.errors.upload", { file_name: "test.png" })
+      ),
       "the alert is called"
     );
   });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3465,7 +3465,7 @@ en:
       errors:
         create: "Sorry, there was an error creating your post. Please try again."
         edit: "Sorry, there was an error editing your post. Please try again."
-        upload: "Sorry, there was an error uploading that file. Please try again."
+        upload: "Sorry, there was an error uploading %{file_name}. Please try again."
         file_too_large: "Sorry, that file is too big (maximum size is %{max_size_kb}kb). Why not upload your large file to a cloud sharing service, then paste the link?"
         file_size_zero: "Sorry, it looks like something has gone wrong, the file you are trying to upload is 0 bytes. Please try again."
         file_too_large_humanized: "Sorry, that file is too big (maximum size is %{max_size}). Why not upload your large file to a cloud sharing service, then paste the link?"


### PR DESCRIPTION
When an upload fails and we don't have a specific error, we
show a generic one. But it's a little too generic -- it doesn't
even include the file name.

This commit shows the file name so you at least know which of your
uploads failed.

Before:

![image](https://github.com/discourse/discourse/assets/920448/27c061c2-3ba5-45af-8893-a7d68f3b2d46)

After:

![image](https://github.com/discourse/discourse/assets/920448/347b0735-3642-46a0-808d-af9f4c6ff555)
