### PR TITLE
FIX: Add missing props to move-to-topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
@@ -79,6 +79,14 @@ export default class MoveToTopic extends Component {
     return this.canSplitTopic && this.currentUser?.admin;
   }
 
+  get canAddTags() {
+    return this.site.can_create_tag;
+  }
+
+  get canTagMessages() {
+    return this.site.can_tag_pms;
+  }
+
   @action
   performMove() {
     if (this.newTopic) {


### PR DESCRIPTION
Fixes tagging topics in that modal. (regressed in 6650aa1)