### PR TITLE
DEV: Don't fetch tagNotifications when additional tags are present

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -59,7 +59,7 @@ export default DiscourseRoute.extend({
     const filterType = this.navMode.split("/")[0];
 
     let tagNotification;
-    if (tag && tag.id !== NONE && this.currentUser) {
+    if (tag && tag.id !== NONE && this.currentUser && !additionalTags) {
       // If logged in, we should get the tag's user settings
       tagNotification = await this.store.find(
         "tagNotification",

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -12,11 +12,6 @@ acceptance("Tags intersection", function (needs) {
   needs.settings({ tagging_enabled: true });
 
   needs.pretender((server, helper) => {
-    server.get("/tag/first/notifications", () => {
-      return helper.response({
-        tag_notification: { id: "first", notification_level: 1 },
-      });
-    });
     server.get("/tags/intersection/first/second.json", () => {
       return helper.response({
         users: [],


### PR DESCRIPTION
We don't display them, see: https://github.com/discourse/discourse/blob/006a5166e571861d088658d9e0f07c6967a59161/app/assets/javascripts/discourse/app/components/d-navigation.js#L55-L55

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
