### PR TITLE
DEV: Delete unused site settings

### DIFF
--- a/db/migrate/20230831153649_delete_unused_site_settings.rb
+++ b/db/migrate/20230831153649_delete_unused_site_settings.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DeleteUnusedSiteSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      DELETE
+      FROM
+        "site_settings"
+      WHERE
+        "name" IN (
+          'rate_limit_new_user_create_topic',
+          'enable_system_avatars',
+          'check_for_new_features',
+          'allow_user_api_keys'
+        )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
In a previous commit these site settings were removed from the codebase
because they were identified as unused settings. This commit removes
these settings from the db in case they existed in the site settings
table.

Follow up to: da389d7844f8895ea3531c61996a988e4d7b70e5
