### PR TITLE
FIX: wrap tag description in a span tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.hbs
@@ -49,7 +49,7 @@
           {{/if}}
         </div>
         <div class="tag-description-wrapper">
-          {{html-safe this.tagInfo.description}}
+          <span>{{html-safe this.tagInfo.description}}</span>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
issue: if there is a space before an html tag in the tag description, then on the tag-info page this will be elided - causing the last character before the html tag to be flush up against it. 

this seems to be because the tag description on this page is wrapped in a class that specifies `display:flex`, and `flex` treats different blocks of contained freetext as the elements it operates on. explanation here:
https://stackoverflow.com/questions/39325039/css-flex-box-last-space-removed

applied the solution stack overflow suggested, to wrap description in a `span` tag, which forces flex to see the whole block as a single element.