### PR TITLE
FIX: Chat message button radius

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -91,6 +91,8 @@
       padding: 0.5em 0;
       width: 2.5em;
       transition: background 0.2s, border-color 0.2s;
+      border-top-left-radius: 0px;
+      border-bottom-left-radius: 0px;
 
       &:focus {
         border-color: var(--primary-300);


### PR DESCRIPTION
To fix the right-most button in chat msg actions.

<img width="349" alt="image" src="https://github.com/discourse/discourse/assets/30537603/17cf5eb5-896e-4a19-baa1-87ebb949dedf">
