### PR TITLE
FIX: form template cooked heading from label

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -126,6 +126,7 @@
           @disableTextarea={{this.composer.disableTextarea}}
           @formTemplateIds={{this.composer.formTemplateIds}}
           @formTemplateInitialValues={{this.composer.formTemplateInitialValues}}
+          @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
         >
           <div class="composer-fields">
             <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -18,6 +18,7 @@
   @popupMenuOptions={{this.popupMenuOptions}}
   @formTemplateIds={{this.formTemplateIds}}
   @formTemplateInitialValues={{@formTemplateInitialValues}}
+  @onSelectFormTemplate={{@onSelectFormTemplate}}
   @replyingToTopic={{this.composer.replyingToTopic}}
   @editingPost={{this.composer.editingPost}}
   @disabled={{this.disableTextarea}}

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -18,6 +18,7 @@
         <FormTemplateField::Wrapper
           @id={{this.selectedFormTemplateId}}
           @initialValues={{@formTemplateInitialValues}}
+          @onSelectFormTemplate={{@onSelectFormTemplate}}
         />
       </form>
     {{else}}

--- a/app/assets/javascripts/discourse/app/components/form-template-field/wrapper.js
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/wrapper.js
@@ -23,6 +23,8 @@ export default class FormTemplateFieldWrapper extends Component {
   _loadTemplate(templateContent) {
     try {
       this.parsedTemplate = Yaml.load(templateContent);
+
+      this.args.onSelectFormTemplate?.(this.parsedTemplate);
     } catch (e) {
       this.error = e;
     }

--- a/app/assets/javascripts/discourse/app/lib/form-template-validation.js
+++ b/app/assets/javascripts/discourse/app/lib/form-template-validation.js
@@ -1,6 +1,11 @@
 import I18n from "I18n";
 
-export default function prepareFormTemplateData(form) {
+export default function prepareFormTemplateData(form, formTemplate) {
+  const labelMap = formTemplate.reduce((acc, field) => {
+    acc[field.id] = field.attributes.label;
+    return acc;
+  }, {});
+
   const formData = new FormData(form);
 
   // Validate the form template
@@ -36,7 +41,7 @@ export default function prepareFormTemplateData(form) {
     const key = Object.keys(item)[0];
     const value = item[key];
     if (value) {
-      return `### ${key}\n${value}`;
+      return `### ${labelMap[key]}\n${value}`;
     }
   });
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -182,6 +182,11 @@ export default class ComposerService extends Service {
     return this.set("_formTemplateInitialValues", values);
   }
 
+  @action
+  onSelectFormTemplate(formTemplate) {
+    this.selectedFormTemplate = formTemplate;
+  }
+
   @discourseComputed("showPreview")
   toggleText(showPreview) {
     return showPreview
@@ -920,7 +925,8 @@ export default class ComposerService extends Service {
         !this.get("model.editingPost")
       ) {
         const formTemplateData = prepareFormTemplateData(
-          document.querySelector("#form-template-form")
+          document.querySelector("#form-template-form"),
+          this.selectedFormTemplate
         );
         if (formTemplateData) {
           this.model.set("reply", formTemplateData);

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -229,13 +229,13 @@ describe "Composer Form Templates", type: :system do
     composer.fill_title(topic_title)
     composer.fill_form_template_field("input", "Bruce Wayne")
     composer.create
-    topic = Topic.where(user: user, title: topic_title)
-    topic_id = Topic.where(user: user, title: topic_title).pluck(:id)
-    post = Post.where(topic_id: topic_id).first
 
     expect(topic_page).to have_topic_title(topic_title)
     expect(find("#{topic_page.post_by_number_selector(1)} .cooked p")).to have_content(
       "Bruce Wayne",
+    )
+    expect(find("#{topic_page.post_by_number_selector(1)} .cooked h3")).to have_content(
+      "What is your full name?",
     )
   end
 


### PR DESCRIPTION
When we added [the id attribute](https://github.com/discourse/discourse/pull/23313) to the experimental form templates fields' definition and changed the `input` `name`s from using the `label` value to use the value of this new `id` attribute, the generated raw content regressed to show ids as headings instead of the labels.

This PR keeps track of the last selected form template and uses it to capture the field labels when it's time to `prepareFormTemplateData`.