### PR TITLE
FIX: closes chat emoji picker on body scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
@@ -8,6 +8,7 @@ import { modifier } from "ember-modifier";
 
 export default class ChatChannelMessageEmojiPicker extends Component {
   <template>
+    {{! template-lint-disable modifier-name-case }}
     <ChatEmojiPicker
       @context="chat-channel-message"
       @didInsert={{this.didInsert}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
@@ -3,12 +3,37 @@ import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import { createPopper } from "@popperjs/core";
+import ChatEmojiPicker from "discourse/plugins/chat/discourse/components/chat-emoji-picker";
+import { modifier } from "ember-modifier";
 
 export default class ChatChannelMessageEmojiPicker extends Component {
+  <template>
+    <ChatEmojiPicker
+      @context="chat-channel-message"
+      @didInsert={{this.didInsert}}
+      @willDestroy={{this.willDestroy}}
+      @didSelectEmoji={{this.didSelectEmoji}}
+      @class="hidden"
+      {{this.listenToBodyScroll}}
+    />
+  </template>
+
   @service site;
   @service chatEmojiPickerManager;
 
   context = "chat-channel-message";
+
+  listenToBodyScroll = modifier(() => {
+    const handler = () => {
+      this.chatEmojiPickerManager.close();
+    };
+
+    document.addEventListener("scroll", handler);
+
+    return () => {
+      document.removeEventListener("scroll", handler);
+    };
+  });
 
   @action
   didSelectEmoji(emoji) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.hbs
@@ -1,7 +1,0 @@
-<ChatEmojiPicker
-  @context="chat-channel-message"
-  @didInsert={{this.didInsert}}
-  @willDestroy={{this.willDestroy}}
-  @didSelectEmoji={{this.didSelectEmoji}}
-  @class="hidden"
-/>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.hbs
@@ -15,6 +15,7 @@
     {{will-destroy (if @willDestroy @willDestroy (noop))}}
     {{will-destroy this.removeClickOutsideEventListener}}
     {{on "keydown" this.trapKeyDownEvents}}
+    ...attributes
   >
     <div class="chat-emoji-picker__filter-container">
       <DcFilterInput


### PR DESCRIPTION
Prior to this fix we would scroll the emoji picker with the body of the page in drawer mode.

With this fix scrolling inside the drawer or the emoji picker will scroll the drawer or the emoji picker, but, scrolling body will close the chat emoji picker.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
