### PR TITLE
DEV: Add plugin outlets for after category/tag inputs in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -179,6 +179,10 @@
                           prioritizedCategoryId=this.composer.prioritizedCategoryId
                         }}
                       />
+                      <PluginOutlet
+                        @name="after-composer-category-input"
+                        @outletArgs={{hash composer=this.composer.model}}
+                      />
                       <PopupInputTip
                         @validation={{this.composer.categoryValidation}}
                       />
@@ -194,6 +198,10 @@
                         categoryId=this.composer.model.categoryId
                         minimum=this.composer.model.minimumRequiredTags
                       }}
+                    />
+                    <PluginOutlet
+                      @name="after-composer-tag-input"
+                      @outletArgs={{hash composer=this.composer.model}}
                     />
                     <PopupInputTip
                       @validation={{this.composer.tagValidation}}


### PR DESCRIPTION
This PR adds plugin outlets for after category and tag inputs for usage in Discourse AI