### PR TITLE
FIX: Allow pending posts to have empty titles

### DIFF
--- a/app/serializers/pending_post_serializer.rb
+++ b/app/serializers/pending_post_serializer.rb
@@ -22,6 +22,6 @@ class PendingPostSerializer < ApplicationSerializer
   end
 
   def title
-    payload["title"] || topic.title
+    payload["title"] || topic&.title
   end
 end


### PR DESCRIPTION
It's possible for a pending post to have a nil title. The PendingPostSerializer should not throw an error when this is encountered.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
