### PR TITLE
A11Y: fix setting focus to a post

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -750,8 +750,11 @@ export default {
 
     for (const a of articles) {
       a.classList.remove("selected");
+      a.removeAttribute("tabindex");
     }
     article.classList.add("selected");
+    article.setAttribute("tabindex", "0");
+    article.focus();
 
     this.appEvents.trigger("keyboard:move-selection", {
       articles,
@@ -768,8 +771,7 @@ export default {
       );
     } else if (article.classList.contains("topic-post")) {
       return this._scrollTo(
-        article.querySelector("#post_1") ? 0 : articleTopPosition,
-        { focusTabLoc: true }
+        article.querySelector("#post_1") ? 0 : articleTopPosition
       );
     }
 
@@ -786,27 +788,11 @@ export default {
     this._scrollTo(articleTopPosition - window.innerHeight * scrollRatio);
   },
 
-  _scrollTo(scrollTop, opts = {}) {
+  _scrollTo(scrollTop) {
     window.scrollTo({
       top: scrollTop,
       behavior: "smooth",
     });
-
-    if (opts.focusTabLoc) {
-      window.addEventListener("scroll", this._onScrollEnds, { passive: true });
-    }
-  },
-
-  @bind
-  _onScrollEnds() {
-    window.removeEventListener("scroll", this._onScrollEnds, { passive: true });
-    discourseDebounce(this, this._onScrollEndsCallback, animationDuration);
-  },
-
-  _onScrollEndsCallback() {
-    document
-      .querySelector(".topic-post.selected a:not([tabindex='-1'])")
-      ?.focus();
   },
 
   categoriesTopicsList() {

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -10,9 +10,7 @@ import DiscourseURL from "discourse/lib/url";
 import Composer from "discourse/models/composer";
 import { capabilities } from "discourse/services/capabilities";
 import { INPUT_DELAY } from "discourse-common/config/environment";
-import discourseDebounce from "discourse-common/lib/debounce";
 import discourseLater from "discourse-common/lib/later";
-import { bind } from "discourse-common/utils/decorators";
 import domUtils from "discourse-common/utils/dom-utils";
 
 let extraKeyboardShortcutsHelp = {};

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -804,7 +804,9 @@ export default {
   },
 
   _onScrollEndsCallback() {
-    document.querySelector(".topic-post.selected span.tabLoc")?.focus();
+    document
+      .querySelector(".topic-post.selected a:not([tabindex='-1'])")
+      ?.focus();
   },
 
   categoriesTopicsList() {

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -78,18 +78,18 @@ export function highlightPost(postNumber) {
     return;
   }
 
-  // sets focus to the first focusable anchor in the post
-  container.querySelector("a:not([tabindex='-1'])")?.focus();
-
-  const element = container.querySelector(".topic-body");
+  const element = container.querySelector(".topic-body, .small-action-desc");
   if (!element || element.classList.contains("highlighted")) {
     return;
   }
 
   element.classList.add("highlighted");
+  element.setAttribute("tabindex", "0");
+  element.focus();
 
   const removeHighlighted = function () {
     element.classList.remove("highlighted");
+    element.removeAttribute("tabindex");
     element.removeEventListener("animationend", removeHighlighted);
   };
   element.addEventListener("animationend", removeHighlighted);

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -78,7 +78,8 @@ export function highlightPost(postNumber) {
     return;
   }
 
-  container.querySelector(".tabLoc")?.focus();
+  // sets focus to the first focusable anchor in the post
+  container.querySelector("a:not([tabindex='-1'])")?.focus();
 
   const element = container.querySelector(".topic-body");
   if (!element || element.classList.contains("highlighted")) {

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -190,9 +190,6 @@ export default createWidget("post-small-action", {
     }
 
     return [
-      h("span.tabLoc", {
-        attributes: { "aria-hidden": true, tabindex: -1 },
-      }),
       h("div.topic-avatar", iconNode(icons[attrs.actionCode] || "exclamation")),
       h("div.small-action-desc", [
         h("div.small-action-contents", contents),

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -758,11 +758,7 @@ createWidget("post-article", {
   },
 
   html(attrs, state) {
-    const rows = [
-      h("span.tabLoc", {
-        attributes: { "aria-hidden": true, tabindex: -1 },
-      }),
-    ];
+    const rows = [];
     if (state.repliesAbove.length) {
       const replies = state.repliesAbove.map((p) => {
         return this.attach("embedded-post", p, {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -11,6 +11,7 @@ import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import {
   acceptance,
+  chromeTest,
   count,
   exists,
   publishToMessageBus,
@@ -412,18 +413,22 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("Quoting a quote with replyAsNewTopic keeps the original poster name", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    await selectText("#post_5 blockquote");
-    await triggerKeyEvent(document, "keypress", "J");
-    await triggerKeyEvent(document, "keypress", "T");
+  // Using J/K on Firefox clean the text selection, so this won't work there
+  chromeTest(
+    "Quoting a quote with replyAsNewTopic keeps the original poster name",
+    async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      await selectText("#post_5 blockquote");
+      await triggerKeyEvent(document, "keypress", "J");
+      await triggerKeyEvent(document, "keypress", "T");
 
-    assert.ok(
-      query(".d-editor-input").value.includes(
-        'quote="codinghorror said, post:3, topic:280"'
-      )
-    );
-  });
+      assert.ok(
+        query(".d-editor-input").value.includes(
+          'quote="codinghorror said, post:3, topic:280"'
+        )
+      );
+    }
+  );
 
   test("Quoting by selecting text can mark the quote as full", async function (assert) {
     await visit("/t/internationalization-localization/280");

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -67,6 +67,7 @@
     vertical-align: middle;
     a {
       color: var(--primary-high-or-secondary-low);
+      outline-offset: -1px;
     }
   }
   .fa {
@@ -941,10 +942,23 @@ aside.quote {
     border-top: 1px solid var(--primary-low);
     padding-top: 0.5em;
   }
+
   @media (prefers-reduced-motion: no-preference) {
     &.highlighted {
       animation: background-fade-highlight 2.5s ease-out;
     }
+  }
+}
+
+.topic-body:not(.deleted),
+.small-action-desc {
+  @media (prefers-reduced-motion: no-preference) {
+    &.highlighted {
+      animation: background-fade-highlight 2.5s ease-out;
+    }
+  }
+  &.highlighted:focus-visible {
+    outline: none;
   }
   .deleted & {
     // Disable so the deleted background is visible immediately
@@ -1140,6 +1154,10 @@ blockquote > *:last-child {
   display: flex;
   align-items: center;
 
+  &:focus-visible {
+    outline: none;
+  }
+
   &.deleted {
     background-color: var(--danger-low-mid);
   }
@@ -1175,6 +1193,11 @@ blockquote > *:last-child {
     );
     min-width: 0; // Allows flex container to shrink
 
+    .avatar {
+      margin-right: 0.5em;
+      float: left;
+    }
+
     p {
       margin: 0;
       padding: 0.15em 0.5em 0 0;
@@ -1183,13 +1206,6 @@ blockquote > *:last-child {
 
   .small-action-contents {
     flex: 1 1 auto;
-    display: flex;
-    a.trigger-user-card {
-      display: inline-flex;
-      align-items: center;
-      margin-right: 0.5em;
-      border-radius: 1em;
-    }
   }
 
   .small-action-buttons {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1175,11 +1175,6 @@ blockquote > *:last-child {
     );
     min-width: 0; // Allows flex container to shrink
 
-    .avatar {
-      margin-right: 0.5em;
-      float: left;
-    }
-
     p {
       margin: 0;
       padding: 0.15em 0.5em 0 0;
@@ -1188,6 +1183,13 @@ blockquote > *:last-child {
 
   .small-action-contents {
     flex: 1 1 auto;
+    display: flex;
+    a.trigger-user-card {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 0.5em;
+      border-radius: 1em;
+    }
   }
 
   .small-action-buttons {

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -15,10 +15,6 @@
   box-shadow: -3px 0 0 var(--danger);
 }
 
-.tabLoc:focus {
-  outline: none;
-}
-
 .latest .featured-topic {
   padding-left: 4px;
 }

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -3,16 +3,22 @@
   border-left: 1px solid transparent;
 }
 
-.topic-list tr.selected td:first-child,
-.topic-list-item.selected td:first-child,
+.topic-list tr.selected,
+.topic-list-item.selected,
 .latest-topic-list-item.selected,
 .search-results .fps-result.selected {
   box-shadow: inset 3px 0 0 var(--danger); // needs to be inset for Edge
+  &:focus-visible {
+    outline: none;
+  }
 }
 
 .featured-topic.selected,
 .topic-post.selected {
   box-shadow: -3px 0 0 var(--danger);
+  &:focus-visible {
+    outline: none;
+  }
 }
 
 .latest .featured-topic {


### PR DESCRIPTION
This is a second attempt to fix this issue. (First fix at https://github.com/discourse/discourse/pull/23243)

See also https://meta.discourse.org/t/discourse-with-a-screen-reader/178105/144?u=pmusaraj (for the original report). 

In this PR, we're doing a couple of things: 

- when highlighting a post, we're now also setting focus to its container
- however, the container will have no focused state styling, it is already highlighted
- once the highlighting effect is removed, we're removing the `tabindex` property from the element so that screen readers stop considering that element as a focusable element
- J/K keyboard navigation has been refactored to use the same technique (instead of using a scroll listener)
- small posts will now be highlighted as well, previously we were selecting the small post but not highlighting it

The last change (small posts one) has a visible difference. In both videos below, I am loading the `http://localhost:4200/t/testing-something/848/2` URL (i.e. the small post URL)

Before

https://github.com/discourse/discourse/assets/368961/cd3418ff-40ac-46d0-90e5-3ac08d2525af

After

https://github.com/discourse/discourse/assets/368961/7a3daefd-9a8e-4ad5-9130-7cfa249ef488

