### PR TITLE
FIX: Attribute pending post to author in `PendingPostSerialier`

### DIFF
--- a/app/serializers/pending_post_serializer.rb
+++ b/app/serializers/pending_post_serializer.rb
@@ -15,7 +15,11 @@ class PendingPostSerializer < ApplicationSerializer
 
   delegate :created_by, :payload, :topic, to: :object, private: true
   delegate :url, to: :topic, prefix: true, allow_nil: true
-  delegate :avatar_template, :name, :username, to: :created_by, allow_nil: true
+  delegate :avatar_template, :name, :username, to: :target_created_by, allow_nil: true
+
+  def created_by_id
+    object.target_created_by_id
+  end
 
   def raw_text
     payload["raw"]
@@ -23,5 +27,11 @@ class PendingPostSerializer < ApplicationSerializer
 
   def title
     payload["title"] || topic&.title
+  end
+
+  private
+
+  def target_created_by
+    object.target_created_by
   end
 end

--- a/spec/serializers/pending_post_serializer_spec.rb
+++ b/spec/serializers/pending_post_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PendingPostSerializer do
   subject(:serializer) { described_class.new(post, scope: guardian, root: false) }
 
   let(:guardian) { Guardian.new(author) }
-  let(:author) { post.created_by }
+  let(:author) { post.target_created_by }
 
   before { freeze_time }
 


### PR DESCRIPTION
This fixes a regression introduced by an earlier change which changed `ReviewableQueuedPost` record creation to use the more appropriate `target_created_by_id` for the  author of the post being queued instead of setting it to the creator(system user) of the `ReviewableQueuedPost` record.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
