### PR TITLE
FIX: Update DIRECT_UPLOAD CORS ruleset to include new Amazon signing headers

### DIFF
--- a/lib/s3_cors_rulesets.rb
+++ b/lib/s3_cors_rulesets.rb
@@ -19,7 +19,7 @@ class S3CorsRulesets
   }.freeze
 
   DIRECT_UPLOAD = {
-    allowed_headers: %w[Authorization Content-Disposition Content-Type],
+    allowed_headers: %w[Authorization Content-Disposition Content-Type X-Amz-Acl X-Amz-Meta-Sha1-Checksum],
     expose_headers: ["ETag"],
     allowed_methods: %w[GET HEAD PUT],
     allowed_origins: ["*"],

--- a/lib/s3_cors_rulesets.rb
+++ b/lib/s3_cors_rulesets.rb
@@ -19,7 +19,13 @@ class S3CorsRulesets
   }.freeze
 
   DIRECT_UPLOAD = {
-    allowed_headers: %w[Authorization Content-Disposition Content-Type X-Amz-Acl X-Amz-Meta-Sha1-Checksum],
+    allowed_headers: %w[
+      Authorization
+      Content-Disposition
+      Content-Type
+      X-Amz-Acl
+      X-Amz-Meta-Sha1-Checksum
+    ],
     expose_headers: ["ETag"],
     allowed_methods: %w[GET HEAD PUT],
     allowed_origins: ["*"],


### PR DESCRIPTION
New headers were added to upload PUT requests as part of a MinIO update (cf42466). This change updates the asset bucket CORS ruleset to allow the new headers in the preflight request.

See https://dev.discourse.org/t/111136