### PR TITLE
FIX: Replying to OP is a reply to the topic, not the post

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -657,7 +657,8 @@ export default Controller.extend(bufferedProperty("model"), {
 
       if (
         composerController.get("model.topic.id") === topic.get("id") &&
-        composerController.get("model.action") === Composer.REPLY
+        composerController.get("model.action") === Composer.REPLY &&
+        post?.get("post_number") !== 1
       ) {
         composerController.set("model.post", post);
         composerController.set("model.composeState", Composer.OPEN);

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -334,6 +334,22 @@ acceptance("Composer", function (needs) {
     );
   });
 
+  test("Replying to the first post in a topic is a topic reply", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click("#post_1 .reply.create");
+    assert.strictEqual(
+      query(".reply-details a.topic-link").innerText,
+      "Internationalization / localization"
+    );
+
+    await click("#post_1 .reply.create");
+    assert.strictEqual(
+      query(".reply-details a.topic-link").innerText,
+      "Internationalization / localization"
+    );
+  });
+
   test("Can edit a post after starting a reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
 


### PR DESCRIPTION
There's been an age old bug (2014, due to keyboard shortcuts) when clicking on the OP's Reply button twice results in the post being a reply to post number 1.

This was highlighted in a discourse-post-voting bug (https://meta.discourse.org/t/some-posts-land-as-embedded-replies-not-answers/248356/15) when the user attempted to do the same when they should not be allowed to. So fixing this in core will help. 

Here is a video of the bug:

https://github.com/discourse/discourse/assets/1555215/c8ab2b29-7f48-4c4a-b84e-18ae25aa5cb6

Here is the video of the fix (also in tests):

https://github.com/discourse/discourse/assets/1555215/8ad842b3-3f90-4536-845c-62a7958b3396


I've also tested that the keyboard shortcut (`r`) still works.

https://github.com/discourse/discourse/assets/1555215/4b0ac72b-6b46-4878-a6a2-a98858743e4f

