### PR TITLE
FEATURE: add group filter for admin reports

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/dashboard.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.hbs
@@ -49,6 +49,8 @@
       </LinkTo>
     </li>
   {{/if}}
+
+  <PluginOutlet @name="admin-dashboard-tabs-after" />
 </ul>
 
 {{outlet}}

--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
@@ -199,6 +199,7 @@
     <PluginOutlet
       @name="admin-dashboard-general-bottom"
       @connectorTagName="div"
+      @outletArgs={{hash filters=this.filters}}
     />
   </span>
 </ConditionalLoadingSpinner>

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -868,7 +868,8 @@ class Post < ActiveRecord::Base
     start_date,
     end_date,
     category_id = nil,
-    include_subcategories = false
+    include_subcategories = false,
+    group_ids = nil
   )
     result =
       public_posts.where(
@@ -883,6 +884,13 @@ class Post < ActiveRecord::Base
       else
         result = result.where("topics.category_id = ?", category_id)
       end
+    end
+    if group_ids
+      result =
+        result
+          .joins("INNER JOIN users ON users.id = posts.user_id")
+          .joins("INNER JOIN group_users ON group_users.user_id = users.id")
+          .where("group_users.group_id IN (?)", group_ids)
     end
 
     result.group("date(posts.created_at)").order("date(posts.created_at)").count

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -82,6 +82,15 @@ class PostAction < ActiveRecord::Base
         result = result.joins(post: :topic).where("topics.category_id = ?", opts[:category_id])
       end
     end
+
+    if opts[:group_ids]
+      result =
+        result
+          .joins("INNER JOIN users ON users.id = post_actions.user_id")
+          .joins("INNER JOIN group_users ON group_users.user_id = users.id")
+          .where("group_users.group_id IN (?)", opts[:group_ids])
+    end
+
     result.group("date(post_actions.created_at)").order("date(post_actions.created_at)").count
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -652,7 +652,8 @@ class Topic < ActiveRecord::Base
     start_date,
     end_date,
     category_id = nil,
-    include_subcategories = false
+    include_subcategories = false,
+    group_ids = nil
   )
     result =
       listable_topics.where(
@@ -665,6 +666,15 @@ class Topic < ActiveRecord::Base
       result.where(
         category_id: include_subcategories ? Category.subcategory_ids(category_id) : category_id,
       ) if category_id
+
+    if group_ids
+      result =
+        result
+          .joins("INNER JOIN users ON users.id = topics.user_id")
+          .joins("INNER JOIN group_users ON group_users.user_id = users.id")
+          .where("group_users.group_id IN (?)", group_ids)
+    end
+
     result.count
   end
 

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -989,7 +989,7 @@ RSpec.describe PostAction do
   end
 
   describe "count_per_day_for_type" do
-    before { PostActionCreator.create(Fabricate(:user), post, :like) }
+    before { PostActionCreator.create(eviltrout, post, :like) }
 
     it "returns the correct count" do
       expect(PostAction.count_per_day_for_type(PostActionType.types[:like])).to eq(
@@ -1017,7 +1017,7 @@ RSpec.describe PostAction do
 
       PostActionCreator.create(codinghorror, post, :like)
       expect(
-        PostAction.count_per_day_for_type(PostActionType.types[:like], { group_ids: group.id }),
+        PostAction.count_per_day_for_type(PostActionType.types[:like], { group_ids: [group.id] }),
       ).to eq(Time.now.utc.to_date => 1)
     end
   end

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -987,4 +987,38 @@ RSpec.describe PostAction do
       end
     end
   end
+
+  describe "count_per_day_for_type" do
+    before { PostActionCreator.create(Fabricate(:user), post, :like) }
+
+    it "returns the correct count" do
+      expect(PostAction.count_per_day_for_type(PostActionType.types[:like])).to eq(
+        Time.now.utc.to_date => 1,
+      )
+    end
+
+    it "returns the correct count when there are multiple actions" do
+      PostActionCreator.create(codinghorror, post, :like)
+      expect(PostAction.count_per_day_for_type(PostActionType.types[:like])).to eq(
+        Time.now.utc.to_date => 2,
+      )
+    end
+
+    it "returns the correct count when there are multiple types" do
+      PostActionCreator.create(eviltrout, post, :spam)
+      expect(PostAction.count_per_day_for_type(PostActionType.types[:spam])).to eq(
+        Time.now.utc.to_date => 1,
+      )
+    end
+
+    it "returns the correct count with group filter" do
+      group = Fabricate(:group)
+      group.add(codinghorror)
+
+      PostActionCreator.create(codinghorror, post, :like)
+      expect(
+        PostAction.count_per_day_for_type(PostActionType.types[:like], { group_ids: group.id }),
+      ).to eq(Time.now.utc.to_date => 1)
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2109,4 +2109,52 @@ RSpec.describe Post do
       expect(post4.canonical_url).to eq("#{topic_url}?page=2#post_#{post4.post_number}")
     end
   end
+
+  describe "public_posts_count_per_day" do
+    before do
+      freeze_time DateTime.parse("2017-03-01 12:00")
+
+      Fabricate(:post)
+      Fabricate(:post, created_at: 1.day.ago)
+      Fabricate(:post, created_at: 1.day.ago)
+      Fabricate(:post, created_at: 2.days.ago)
+      Fabricate(:post, created_at: 4.days.ago)
+    end
+
+    let(:listable_topics_count_per_day) do
+      { 1.day.ago.to_date => 2, 2.days.ago.to_date => 1, Time.now.utc.to_date => 1 }
+    end
+
+    it "collect closed interval public post count" do
+      expect(Post.public_posts_count_per_day(2.days.ago, Time.now)).to include(
+        listable_topics_count_per_day,
+      )
+      expect(Post.public_posts_count_per_day(2.days.ago, Time.now)).not_to include(
+        4.days.ago.to_date => 1,
+      )
+    end
+
+    it "returns the correct number of public posts per day when there are no public posts" do
+      Fabricate(:post, post_type: Post.types[:whisper], created_at: 6.days.ago)
+      Fabricate(:post, post_type: Post.types[:whisper], created_at: 7.days.ago)
+
+      expect(Post.public_posts_count_per_day(10.days.ago, 5.days.ago)).to be_empty
+    end
+
+    it "returns the correct number of public posts per day with group filter" do
+      user = Fabricate(:user)
+      group_user = Fabricate(:user)
+      group = Fabricate(:group)
+      group.add(group_user)
+
+      Fabricate(:post, user: user, created_at: 6.days.ago)
+      Fabricate(:post, user: user, created_at: 7.days.ago)
+      Fabricate(:post, user: group_user, created_at: 6.days.ago)
+      Fabricate(:post, user: group_user, created_at: 7.days.ago)
+
+      expect(
+        Post.public_posts_count_per_day(10.days.ago, 5.days.ago, nil, false, [group.id]),
+      ).to eq(6.days.ago.to_date => 1, 7.days.ago.to_date => 1)
+    end
+  end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2573,6 +2573,16 @@ RSpec.describe Topic do
         4.days.ago.to_date => 1,
       )
     end
+
+    it "returns the correct count with group filter" do
+      group = Fabricate(:group)
+      group.add(user)
+      topic = Fabricate(:topic, user: user)
+
+      expect(Topic.listable_count_per_day(2.days.ago, Time.now, nil, false, [group.id])).to include(
+        Time.now.utc.to_date => 1,
+      )
+    end
   end
 
   describe "#secure_category?" do


### PR DESCRIPTION
DEV: add plugin outlet for admin dashboard tabs

This PR adds group filter for few admin reports (we already have category filter, but does not support group filtering).

This PR also adds a plugin outlet to support adding more tabs to admin dashboard.