### PR TITLE
DEV: Cachebust workbox assets

### DIFF
--- a/app/assets/javascripts/discourse/lib/workbox-tree-builder.js
+++ b/app/assets/javascripts/discourse/lib/workbox-tree-builder.js
@@ -2,6 +2,10 @@ const crypto = require("crypto");
 const mergeTrees = require("broccoli-merge-trees");
 const funnel = require("broccoli-funnel");
 
+// Bump to cache-bust if there are any changes to the workbox compilation logic
+// which are not caused by a simple workbox version bump
+const COMPILER_VERSION = 2;
+
 module.exports = function generateWorkboxTree() {
   const workboxDeps = [
     "workbox-sw",
@@ -25,7 +29,7 @@ module.exports = function generateWorkboxTree() {
   // Sprockets' default behaviour for these files is disabled via freedom_patches/sprockets.rb.
   const versionHash = crypto
     .createHash("md5")
-    .update(versions.join("|"))
+    .update(`${versions.join("|")}|${COMPILER_VERSION}`)
     .digest("hex");
 
   return funnel(mergeTrees(nodes), {


### PR DESCRIPTION
The changes in e1d27400f5d8be345383b52bd118e652724a517e slightly changed the sourcemap paths of our workbox assets. The sourcemaps now have the extension `.prod.map` instead of `prod.js.map`. However, since the version number of workbox didn't change, the directory digest remained the same, and so cached versions of the JS were pointing to the now-nonexistant map files.

This commit introduces a cachebusting constant which we can bump for these kinds of changes in future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
