### PR TITLE
UX: show only one username on multiple likes notification

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/liked.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/liked.js
@@ -12,8 +12,7 @@ export default class extends NotificationTypeBase {
     } else if (this.count > 2) {
       return I18n.t("notifications.liked_by_multiple_users", {
         username: this.username,
-        username2: this.#username2,
-        count: this.count - 2,
+        count: this.count - 1,
       });
     } else {
       return super.label;

--- a/app/assets/javascripts/discourse/app/widgets/liked-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/liked-notification-item.js
@@ -9,7 +9,7 @@ createWidgetFrom(DefaultNotificationItem, "liked-notification-item", {
     const description = this.description(data);
 
     if (data.count > 1) {
-      const count = data.count - 2;
+      const count = data.count - 1;
       const username2 = formatUsername(data.username2);
 
       if (count === 0) {
@@ -22,7 +22,6 @@ createWidgetFrom(DefaultNotificationItem, "liked-notification-item", {
         return I18n.t("notifications.liked_many", {
           description,
           username: `<span class="multi-username">${username}</span>`,
-          username2: `<span class="multi-username">${username2}</span>`,
           count,
         });
       }

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
@@ -58,8 +58,7 @@ module("Unit | Notification Types | liked", function (hooks) {
       director.label,
       I18n.t("notifications.liked_by_multiple_users", {
         username: "osama",
-        username2: "shrek",
-        count: 1,
+        count: 2,
       }),
       "concatenates 2 usernames with comma and displays the remaining count when count larger than 2"
     );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2540,12 +2540,12 @@ en:
       liked: "<span>%{username}</span> %{description}"
       liked_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
       liked_many:
-        one: "<span class='multi-user'>%{username}, %{username2} and %{count} other</span> %{description}"
-        other: "<span class='multi-user'>%{username}, %{username2} and %{count} others</span> %{description}"
+        one: "<span class='multi-user'>%{username} and %{count} other</span> %{description}"
+        other: "<span class='multi-user'>%{username} and %{count} others</span> %{description}"
       liked_by_2_users: "%{username}, %{username2}"
       liked_by_multiple_users:
-        one: "%{username}, %{username2} and %{count} other"
-        other: "%{username}, %{username2} and %{count} others"
+        one: "%{username} and %{count} other"
+        other: "%{username} and %{count} others"
       liked_consolidated_description:
         one: "liked %{count} of your posts"
         other: "liked %{count} of your posts"


### PR DESCRIPTION
To adjust for small width screen and multiple locales only show one username on multiple likes notification.

Before:

<img width="312" alt="Screenshot 2023-09-04 at 8 45 37 PM" src="https://github.com/discourse/discourse/assets/11170663/ff92ac83-c532-43f3-bceb-e11d4a3b12e8">

After:

<img width="313" alt="Screenshot 2023-09-04 at 9 40 21 PM" src="https://github.com/discourse/discourse/assets/11170663/cd644a93-d913-4921-aeab-2b5ad6a7c82e">

