### PR TITLE
UX: lower z-index

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
@@ -3,7 +3,7 @@
   bottom: 0;
 
   position: absolute;
-  z-index: calc(z("header") - 1);
+  z-index: calc(z("composer", "content") - 1);
   transition: background-color 0.15s 0.15s;
   background-color: transparent;
 

--- a/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel-resizer.scss
@@ -3,7 +3,7 @@
   bottom: 0;
 
   position: absolute;
-  z-index: calc(z("composer", "content") - 1);
+  z-index: z("composer", "content") - 1;
   transition: background-color 0.15s 0.15s;
   background-color: transparent;
 


### PR DESCRIPTION
Preventing the line to cross composer on hover:
<img width="1418" alt="image" src="https://github.com/discourse/discourse/assets/101828855/ee684b34-3db8-4837-8629-bd8fbaffb805">
