### PR TITLE
FEATURE: Add a shortcut to archive PM

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -589,7 +589,7 @@ export default Controller.extend(bufferedProperty("model"), {
     toggleArchiveMessage() {
       const topic = this.model;
 
-      if (topic.get("archiving")) {
+      if (!topic || topic.get("archiving") || !topic.isPrivateMessage) {
         return;
       }
 

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -47,6 +47,7 @@ const DEFAULT_BINDINGS = {
   "=": { handler: "toggleHamburgerMenu", anonymous: true },
   "?": { handler: "showHelpModal", anonymous: true },
   ".": { click: ".alert.alert-info.clickable", anonymous: true }, // show incoming/updated topics
+  a: { handler: "toggleArchivePM" },
   b: { handler: "toggleBookmark" },
   c: { handler: "createTopic" },
   "shift+c": { handler: "focusComposer" },
@@ -887,6 +888,10 @@ export default {
 
   toggleAdminActions() {
     this.appEvents.trigger("topic:toggle-actions");
+  },
+
+  toggleArchivePM() {
+    getOwner(this).lookup("controller:topic").send("toggleArchiveMessage");
   },
 
   webviewKeyboardBack() {

--- a/spec/system/keyboard_shortcuts_spec.rb
+++ b/spec/system/keyboard_shortcuts_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "Keyboard shortcuts", type: :system do
+  describe "<a>" do
+    let(:current_user) { topic.user }
+    let(:topic_page) { PageObjects::Pages::Topic.new }
+
+    before { sign_in(current_user) }
+
+    context "when on a private message page" do
+      fab!(:topic) { Fabricate(:private_message_topic) }
+
+      context "when the message is not archived" do
+        it "archives the message" do
+          topic_page.visit_topic(topic)
+          send_keys("a")
+          expect(page).to have_current_path("/u/#{current_user.username}/messages")
+          expect(UserArchivedMessage.exists?(topic: topic)).to be true
+        end
+      end
+
+      context "when the message is already archived" do
+        before { UserArchivedMessage.create!(topic: topic, user: current_user) }
+
+        it "moves back the message to inbox" do
+          topic_page.visit_topic(topic)
+          send_keys("a")
+          expect(page).to have_current_path("/u/#{current_user.username}/messages")
+          expect(UserArchivedMessage.exists?(topic: topic)).to be false
+        end
+      end
+    end
+
+    context "when on a public topic page" do
+      fab!(:topic) { Fabricate(:topic) }
+
+      it "doesn't archive the topic" do
+        topic_page.visit_topic(topic)
+        send_keys("a")
+        expect(page).to have_current_path("/t/#{topic.slug}/#{topic.id}")
+        expect(UserArchivedMessage.exists?(topic: topic)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new shortcut to allow archiving private messages. When on a private message page, just type `a` to archive it. Typing `a` on an already archived message will move it back to inbox.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
