### PR TITLE
DEV: Outlet for unobtrusive secondary full-page search.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -55,6 +55,7 @@ export default Controller.extend({
   application: controller(),
   composer: service(),
   modal: service(),
+  appEvents: service(),
 
   bulkSelectEnabled: null,
   loading: false,
@@ -510,6 +511,9 @@ export default Controller.extend({
           ?.removeAttribute("open");
       }
       this.set("page", 1);
+
+      this.appEvents.trigger("full-page-search:trigger-search");
+
       this._search();
     },
 

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -81,6 +81,12 @@
   </div>
 
   <div class="search-advanced">
+    <PluginOutlet
+      @name="full-page-search-below-search-header"
+      @connectorTagName="div"
+      @outletArgs={{hash search=this.searchTerm type=this.search_type}}
+    />
+
     {{#if this.hasResults}}
       {{#if this.usingDefaultSearchType}}
         <div


### PR DESCRIPTION
`discourse-ai` will use the outlet to perform a parallel semantic search.

