### PR TITLE
FIX: Update asset precompile list following c7dce90f

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -29,7 +29,7 @@ Rails.application.config.assets.precompile += %w[
   admin.js
   wizard.js
   test-support.js
-  test-helpers.js
+  tests.js
   test-site-settings.js
   browser-detect.js
   browser-update.js


### PR DESCRIPTION
`test-helpers.js` no longer exists. We need `tests.js` instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
