### PR TITLE
DEV: Reduce theme-qunit smoke test timeout

### DIFF
--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -86,7 +86,7 @@ task "smoke:test" do
   query_params = { seed: Random.new.seed, theme_url: theme_url, hidepassed: 1, report_requests: 1 }
   url += "/" if !url.end_with?("/")
   full_url = "#{url}theme-qunit?#{query_params.to_query}"
-  timeout = 1000 * 60 * 10
+  timeout = 1000 * 20
 
   sh("node", "#{Rails.root}/test/run-qunit.js", full_url, timeout.to_s)
 


### PR DESCRIPTION
The theme tests we use for the smoke-test typically take 3-4 seconds to complete. This commit reduces the timeout from 10 minutes to 20 seconds, so that failures are detected more quickly

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
