### PR TITLE
DEV: rotate the user auth token on client IP address change.

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -234,6 +234,7 @@ class Auth::DefaultCurrentUserProvider
             rotated_at < UserAuthToken::URGENT_ROTATE_TIME.ago
           end
         )
+      needs_rotation ||= @user_token.client_ip != @request.ip
 
       if needs_rotation
         if @user_token.rotate!(


### PR DESCRIPTION
Previously, when a user's IP address changed, it was not instantly updated in the `user_auth_tokens`. This PR will force the rotation of the user auth token on each IP address change.
