### PR TITLE
FIX: Admins not able to convert topics if they aren't in personal_message_enabled_groups

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -201,11 +201,11 @@ module TopicGuardian
   alias can_create_unlisted_topic? can_toggle_topic_visibility?
 
   def can_convert_topic?(topic)
-    return false unless @user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
     return false if topic.blank?
     return false if topic.trashed?
     return false if topic.is_category_topic?
     return true if is_admin?
+    return false if !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
     is_moderator? && can_create_post?(topic)
   end
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1542,6 +1542,11 @@ RSpec.describe Guardian do
       SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
       expect(Guardian.new(user).can_convert_topic?(topic)).to be_falsey
     end
+
+    it "returns true if user is not in personal_message_enabled_groups but they are still admin" do
+      SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
+      expect(Guardian.new(admin).can_convert_topic?(topic)).to be_truthy
+    end
   end
 
   describe "can_edit?" do


### PR DESCRIPTION
Admins are always able to send PMs, so it doesn't make
sense that they shouldn't be able to convert topics just
because they aren't in personal_message_enabled_groups.
