### PR TITLE
DEV: relative_url_root is used for subfolder installs add comment

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -190,7 +190,7 @@ connection_reaper_age = 30
 # run reap check every 30 seconds
 connection_reaper_interval = 30
 
-# set to relative URL (for subdirectory hosting)
+# set to relative URL (for subdirectory/subfolder hosting)
 # IMPORTANT: path must not include a trailing /
 # EG: /forum
 relative_url_root =


### PR DESCRIPTION
The word subfolder is used commonly to describe subdirectory installs
