### PR TITLE
DEV: Add missing keyboard shortcut on cheatsheet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.js
@@ -150,6 +150,12 @@ export default class KeyboardShortcutsHelp extends Component {
             keys1: [SHIFT, "a"],
             keysDelimiter: PLUS,
           }),
+          archive_private_message: buildShortcut(
+            "actions.archive_private_message",
+            {
+              keys1: ["a"],
+            }
+          ),
         },
       },
       navigation: {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4163,6 +4163,7 @@ en:
         print: "%{shortcut} Print topic"
         defer: "%{shortcut} Defer topic"
         topic_admin_actions: "%{shortcut} Open topic admin actions"
+        archive_private_message: "%{shortcut} Toggle archive private message"
       search_menu:
         title: "Search Menu"
         prev_next: "%{shortcut} Move selection up and down"


### PR DESCRIPTION
PR #23387 introduced a new keyboard shortcut to archive private messages, but the new shortcut wasn’t added to the keyboard shortcuts cheatsheet.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
