### PR TITLE
FIX: Apply ember-this-fallback patches sequentially

### DIFF
--- a/app/assets/javascripts/patches/ember-this-fallback+0.3.1+001+initial.patch
+++ b/app/assets/javascripts/patches/ember-this-fallback+0.3.1+001+initial.patch
@@ -1,0 +1,40 @@
+diff --git a/node_modules/ember-this-fallback/index.js b/node_modules/ember-this-fallback/index.js
+index afa73eb..168bb16 100644
+--- a/node_modules/ember-this-fallback/index.js
++++ b/node_modules/ember-this-fallback/index.js
+@@ -8,7 +8,7 @@ module.exports = {
+ 
+   setupPreprocessorRegistry(type, registry) {
+     if (type === 'parent') {
+-      const options = getOptions(findHost(this));
++      const options = getOptions(this.parent); // findHost doesn't work for us - not sure why
+       registry.add('htmlbars-ast-plugin', this._buildPlugin(options));
+     }
+   },
+diff --git a/node_modules/ember-this-fallback/lib/helpers/deprecations.js b/node_modules/ember-this-fallback/lib/helpers/deprecations.js
+index 5a00c44..993e3cf 100644
+--- a/node_modules/ember-this-fallback/lib/helpers/deprecations.js
++++ b/node_modules/ember-this-fallback/lib/helpers/deprecations.js
+@@ -6,8 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.deprecationOptionsFor = void 0;
+ const assert_1 = __importDefault(require("../types/assert"));
+ const CURRENT_DEPRECATIONS = [
++  [
++    'this-property-fallback',
+     {
+-        id: 'this-property-fallback',
++        id: 'ember-this-fallback.this-property-fallback', // Updating deprecation id so we can distinguish it from Ember's
+         until: 'n/a',
+         for: 'ember-this-fallback',
+         url: 'https://deprecations.emberjs.com/v3.x#toc_this-property-fallback',
+@@ -15,8 +17,9 @@ const CURRENT_DEPRECATIONS = [
+             available: '0.2.0',
+         },
+     },
++  ]
+ ];
+-const DEPRECATION_OPTIONS_MAP = new Map(CURRENT_DEPRECATIONS.map((options) => [options.id, options]));
++const DEPRECATION_OPTIONS_MAP = new Map(CURRENT_DEPRECATIONS);
+ function deprecationOptionsFor(id) {
+     const options = DEPRECATION_OPTIONS_MAP.get(id);
+     (0, assert_1.default)(`expected to find DeprecationOptions for id=${id}`, options);

--- a/app/assets/javascripts/patches/ember-this-fallback+0.3.1+002+themes.patch
+++ b/app/assets/javascripts/patches/ember-this-fallback+0.3.1+002+themes.patch
@@ -2,15 +2,6 @@ diff --git a/node_modules/ember-this-fallback/index.js b/node_modules/ember-this
 index afa73eb..21e9411 100644
 --- a/node_modules/ember-this-fallback/index.js
 +++ b/node_modules/ember-this-fallback/index.js
-@@ -8,7 +8,7 @@ module.exports = {
- 
-   setupPreprocessorRegistry(type, registry) {
-     if (type === 'parent') {
--      const options = getOptions(findHost(this));
-+      const options = getOptions(this.parent); // findHost doesn't work for us - not sure why
-       registry.add('htmlbars-ast-plugin', this._buildPlugin(options));
-     }
-   },
 @@ -17,15 +17,20 @@ module.exports = {
      ThisFallbackPlugin.baseDir = () => __dirname;
      ThisFallbackPlugin.cacheKey = () => 'ember-this-fallback';
@@ -37,33 +28,6 @@ index afa73eb..21e9411 100644
    },
  };
  
-diff --git a/node_modules/ember-this-fallback/lib/helpers/deprecations.js b/node_modules/ember-this-fallback/lib/helpers/deprecations.js
-index 5a00c44..993e3cf 100644
---- a/node_modules/ember-this-fallback/lib/helpers/deprecations.js
-+++ b/node_modules/ember-this-fallback/lib/helpers/deprecations.js
-@@ -6,8 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
- exports.deprecationOptionsFor = void 0;
- const assert_1 = __importDefault(require("../types/assert"));
- const CURRENT_DEPRECATIONS = [
-+  [
-+    'this-property-fallback',
-     {
--        id: 'this-property-fallback',
-+        id: 'ember-this-fallback.this-property-fallback', // Updating deprecation id so we can distinguish it from Ember's
-         until: 'n/a',
-         for: 'ember-this-fallback',
-         url: 'https://deprecations.emberjs.com/v3.x#toc_this-property-fallback',
-@@ -15,8 +17,9 @@ const CURRENT_DEPRECATIONS = [
-             available: '0.2.0',
-         },
-     },
-+  ]
- ];
--const DEPRECATION_OPTIONS_MAP = new Map(CURRENT_DEPRECATIONS.map((options) => [options.id, options]));
-+const DEPRECATION_OPTIONS_MAP = new Map(CURRENT_DEPRECATIONS);
- function deprecationOptionsFor(id) {
-     const options = DEPRECATION_OPTIONS_MAP.get(id);
-     (0, assert_1.default)(`expected to find DeprecationOptions for id=${id}`, options);
 diff --git a/node_modules/ember-this-fallback/lib/helpers/logger.js b/node_modules/ember-this-fallback/lib/helpers/logger.js
 index b856edc..afb059a 100644
 --- a/node_modules/ember-this-fallback/lib/helpers/logger.js


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
