### PR TITLE
Add above-sidebar-sections plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -4,6 +4,7 @@
   {{/if}}
 
   {{#if this.sidebarState.showMainPanel}}
+    <PluginOutlet @name="above-sidebar-sections" />
     <Sidebar::Sections
       @currentUser={{this.currentUser}}
       @collapsableSections={{true}}


### PR DESCRIPTION
Add above-sidebar-sections plugin outlet to allow users to add things like custom buttons above the sidebar sections.