### PR TITLE
FIX: Respect default category sort when `filter=default`

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -749,7 +749,7 @@ class TopicQuery
         # category default sort order
         sort_order, sort_ascending =
           Category.where(id: category_id).pick(:sort_order, :sort_ascending)
-        if sort_order && (filter.blank? || %w[latest unseen].include?(filter.to_s))
+        if sort_order && (filter.blank? || %w[default latest unseen].include?(filter.to_s))
           options[:order] = sort_order
           options[:ascending] = !!sort_ascending ? "true" : "false"
         else

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1005,6 +1005,17 @@ RSpec.describe TopicQuery do
         expect(topic_ids - [topic_category.id]).to eq([topic_in_cat1.id, topic_in_cat2.id])
       end
 
+      it "uses the category's default sort order when filter=default is passed explicitely" do
+        category.update!(sort_order: "created", sort_ascending: true)
+        topic_ids =
+          TopicQuery
+            .new(user, category: category.id, filter: "default")
+            .list_latest
+            .topics
+            .map(&:id)
+        expect(topic_ids - [topic_category.id]).to eq([topic_in_cat1.id, topic_in_cat2.id])
+      end
+
       it "should apply default sort order to latest and unseen filters only" do
         category.update!(sort_order: "created", sort_ascending: true)
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1005,7 +1005,7 @@ RSpec.describe TopicQuery do
         expect(topic_ids - [topic_category.id]).to eq([topic_in_cat1.id, topic_in_cat2.id])
       end
 
-      it "uses the category's default sort order when filter=default is passed explicitely" do
+      it "uses the category's default sort order when filter=default is passed explicitly" do
         category.update!(sort_order: "created", sort_ascending: true)
         topic_ids =
           TopicQuery


### PR DESCRIPTION
Previously we would respect it if the filter was `nil`, but if `default` was explicitly passed then it would ignore the category order settings. This explicit passing of `filter=default` happens for some types of navigations in the JS app.

This extends the fix from 92bc61b4be9242dd0242ed60641a5129938a231a

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
