### PR TITLE
UX: Fix checkbox slider

### DIFF
--- a/app/assets/stylesheets/common/components/d-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/d-toggle-switch.scss
@@ -54,7 +54,7 @@
     display: inline-block;
     cursor: pointer;
     background: var(--primary-low-mid);
-    border-radius: 16px;
+    border-radius: var(--toggle-switch-height);
     width: var(--toggle-switch-width);
     height: var(--toggle-switch-height);
     margin-right: 0.5em;
@@ -81,7 +81,7 @@
 
   &__checkbox-slider::before {
     background: var(--secondary);
-    border-radius: var(--toggle-switch-height);
+    border-radius: 50%;
     width: calc(var(--toggle-switch-height) * 0.75);
     height: calc(var(--toggle-switch-height) * 0.75);
     top: calc(var(--toggle-switch-height) * 0.125);

--- a/app/assets/stylesheets/common/components/d-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/d-toggle-switch.scss
@@ -81,11 +81,11 @@
 
   &__checkbox-slider::before {
     background: var(--secondary);
-    border-radius: 50%;
-    width: calc(var(--toggle-switch-width) / 2.5);
-    height: calc(var(--toggle-switch-width) / 2.5);
-    top: 3.5px;
-    left: 4px;
+    border-radius: var(--toggle-switch-height);
+    width: calc(var(--toggle-switch-height) * 0.75);
+    height: calc(var(--toggle-switch-height) * 0.75);
+    top: calc(var(--toggle-switch-height) * 0.125);
+    left: calc(var(--toggle-switch-height) * 0.125);
     transition: left 0.25s;
   }
 }


### PR DESCRIPTION
Before / After


normal (misaligned)
<img width="129" alt="Screenshot 2023-09-05 at 20 19 12" src="https://github.com/discourse/discourse/assets/66961/dba34264-2583-4597-9628-7632afc26012"> <img width="129" alt="Screenshot 2023-09-05 at 20 19 16" src="https://github.com/discourse/discourse/assets/66961/c4736300-7468-4c3c-ab84-73f8b9389d6a">

increased `--toggle-switch-width` (more misaligned 😉)
<img width="180" alt="Screenshot 2023-09-05 at 20 20 12" src="https://github.com/discourse/discourse/assets/66961/eb69127f-b0c4-43ac-bafd-2814a2be117a"> <img width="180" alt="Screenshot 2023-09-05 at 20 20 14" src="https://github.com/discourse/discourse/assets/66961/2ec1adb5-7877-4290-8058-c66aa8d02179">

increased `--toggle-switch-height` (ditto)
<img width="129" alt="Screenshot 2023-09-05 at 20 32 03" src="https://github.com/discourse/discourse/assets/66961/12586ba3-22a7-454b-a175-e8e3fa156d65"> <img width="129" alt="Screenshot 2023-09-05 at 20 31 52" src="https://github.com/discourse/discourse/assets/66961/f0d2f4eb-d945-4822-bcec-8054d1ebea8c">

cc: @discourse/designers 