### PR TITLE
FEATURE: add silence reason dropdown to admin penalty reason

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-penalty-reason.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-penalty-reason.hbs
@@ -18,15 +18,24 @@
       />
     {{/if}}
   {{else if (eq @penaltyType "silence")}}
-    <label class="silence-reason-title">{{html-safe
-        (i18n "admin.user.silence_reason_label")
-      }}</label>
-    <TextField
-      @value={{this.customReason}}
+    <label class="silence-reason-title">
+      {{html-safe (i18n "admin.user.silence_reason_label")}}</label>
+
+    <ComboBox
+      @content={{this.reasons}}
+      @value={{this.selectedReason}}
       @class="silence-reason"
-      @onChange={{this.setCustomReason}}
-      @placeholderKey="admin.user.silence_reason_placeholder"
+      @onChange={{this.setSelectedReason}}
     />
+
+    {{#if this.isCustomReason}}
+      <TextField
+        @value={{this.customReason}}
+        @class="silence-reason"
+        @onChange={{this.setCustomReason}}
+        @placeholderKey="admin.user.silence_reason_placeholder"
+      />
+    {{/if}}
   {{/if}}
 </div>
 

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -123,7 +123,7 @@ acceptance("flagging", function (needs) {
     await silenceUntilCombobox.expand();
     await silenceUntilCombobox.selectRowByValue("tomorrow");
     assert.ok(exists(".modal-body"));
-    await fillIn(".silence-reason", "for breaking the rules");
+    await fillIn("input.silence-reason", "for breaking the rules");
 
     await click(".perform-penalize");
     assert.ok(!exists(".modal-body"));
@@ -139,7 +139,7 @@ acceptance("flagging", function (needs) {
     const silenceUntilCombobox = selectKit(".silence-until .combobox");
     await silenceUntilCombobox.expand();
     await silenceUntilCombobox.selectRowByValue("tomorrow");
-    await fillIn(".silence-reason", "for breaking the rules");
+    await fillIn("input.silence-reason", "for breaking the rules");
     await click(".d-modal-cancel");
     assert.ok(exists(".dialog-body"));
 


### PR DESCRIPTION
Adds dropdown list for pre-defined penalty options to silence to mirror options on suspension list.