### PR TITLE
Add plugin outlet for after-panel-body in user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
@@ -40,3 +40,7 @@
 {{else}}
   {{component this.emptyStateComponent}}
 {{/if}}
+<PluginOutlet
+  @name="after-panel-body"
+  @outletArgs={{hash closeUserMenu=@closeUserMenu}}
+/>


### PR DESCRIPTION
Similar to panel-body-bottom but shows up outside the div, and shows even during EmptyStateComponent is shown.