### PR TITLE
DEV: Remove unnecessary `assert.expect`s

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.js
@@ -9,8 +9,6 @@ module("Integration | Component | ComposerEditor", function (hooks) {
   setupRenderingTest(hooks);
 
   test("warns about users that will not see a mention", async function (assert) {
-    assert.expect(2);
-
     this.set("model", {});
     this.set("noop", () => {});
     this.set("expectation", (warning) => {

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
@@ -14,7 +14,6 @@ module("Integration | Component | themes-list-item", function (hooks) {
 
     await render(hbs`<ThemesListItem @theme={{this.theme}} />`);
 
-    assert.expect(1);
     assert.strictEqual(count(".d-icon-check"), 1, "shows default theme icon");
   });
 
@@ -26,7 +25,6 @@ module("Integration | Component | themes-list-item", function (hooks) {
 
     await render(hbs`<ThemesListItem @theme={{this.theme}} />`);
 
-    assert.expect(1);
     assert.strictEqual(count(".d-icon-sync"), 1, "shows pending update icon");
   });
 
@@ -41,7 +39,6 @@ module("Integration | Component | themes-list-item", function (hooks) {
 
     await render(hbs`<ThemesListItem @theme={{this.theme}} />`);
 
-    assert.expect(1);
     assert.strictEqual(
       count(".d-icon-exclamation-circle"),
       1,
@@ -65,7 +62,6 @@ module("Integration | Component | themes-list-item", function (hooks) {
 
     await render(hbs`<ThemesListItem @theme={{this.theme}} />`);
 
-    assert.expect(2);
     assert.deepEqual(
       query(".components")
         .innerText.trim()

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -57,7 +57,6 @@ module("Unit | Utility | click-track", function (hooks) {
   });
 
   skip("tracks internal URLs", async function (assert) {
-    assert.expect(2);
     sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
     const done = assert.async();
@@ -121,8 +120,6 @@ module("Unit | Utility | click-track", function (hooks) {
   });
 
   skip("tracks external URLs", async function (assert) {
-    assert.expect(2);
-
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
       assert.ok(
@@ -136,7 +133,6 @@ module("Unit | Utility | click-track", function (hooks) {
   });
 
   skip("tracks external URLs when opening in another window", async function (assert) {
-    assert.expect(3);
     User.currentProp("user_option.external_links_in_new_tab", true);
 
     const done = assert.async();

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -69,8 +69,6 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("findBySlug", function (assert) {
-    assert.expect(6);
-
     const store = getOwner(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {
@@ -134,8 +132,6 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("findSingleBySlug", function (assert) {
-    assert.expect(6);
-
     const store = getOwner(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -1,8 +1,6 @@
 import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import NavItem from "discourse/models/nav-item";
-import Site from "discourse/models/site";
-import { run } from "@ember/runloop";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
@@ -10,19 +8,16 @@ module("Unit | Model | nav-item", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    run(function () {
-      const store = getOwner(this).lookup("service:store");
-      const fooCategory = store.createRecord("category", {
-        slug: "foo",
-        id: 123,
-      });
-      Site.currentProp("categories").addObject(fooCategory);
+    const store = getOwner(this).lookup("service:store");
+    const fooCategory = store.createRecord("category", {
+      slug: "foo",
+      id: 123,
     });
+    const site = getOwner(this).lookup("service:site");
+    site.categories.addObject(fooCategory);
   });
 
   test("href", function (assert) {
-    assert.expect(4);
-
     function href(text, opts, expected, label) {
       assert.strictEqual(NavItem.fromText(text, opts).href, expected, label);
     }

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -45,21 +45,16 @@ module("Unit | Model | rest-model", function (hooks) {
   });
 
   test("updating simultaneously", async function (assert) {
-    assert.expect(2);
-
     const store = getOwner(this).lookup("service:store");
     const widget = await store.find("widget", 123);
 
     const firstPromise = widget.update({ name: "new name" });
     const secondPromise = widget.update({ name: "new name" });
 
-    firstPromise.then(function () {
-      assert.ok(true, "the first promise succeeds");
-    });
+    firstPromise.then(() => assert.true(true, "the first promise succeeds"));
+    secondPromise.catch(() => assert.true(true, "the second promise fails"));
 
-    secondPromise.catch(function () {
-      assert.ok(true, "the second promise fails");
-    });
+    await Promise.allSettled([firstPromise, secondPromise]);
   });
 
   test("save new", async function (assert) {
@@ -88,21 +83,17 @@ module("Unit | Model | rest-model", function (hooks) {
     assert.strictEqual(result.target.name, widget.name);
   });
 
-  test("creating simultaneously", function (assert) {
-    assert.expect(2);
-
+  test("creating simultaneously", async function (assert) {
     const store = getOwner(this).lookup("service:store");
     const widget = store.createRecord("widget");
 
     const firstPromise = widget.save({ name: "Evil Widget" });
     const secondPromise = widget.save({ name: "Evil Widget" });
-    firstPromise.then(function () {
-      assert.ok(true, "the first promise succeeds");
-    });
 
-    secondPromise.catch(function () {
-      assert.ok(true, "the second promise fails");
-    });
+    firstPromise.then(() => assert.true(true, "the first promise succeeds"));
+    secondPromise.catch(() => assert.true(true, "the second promise fails"));
+
+    await Promise.allSettled([firstPromise, secondPromise]);
   });
 
   test("destroyRecord", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -58,10 +58,10 @@ module("Unit | Model | user-badge", function (hooks) {
   });
 
   test("revoke", async function (assert) {
-    assert.expect(0);
     const store = getOwner(this).lookup("service:store");
     const userBadge = store.createRecord("user-badge", { id: 1 });
-    await userBadge.revoke();
+    const result = await userBadge.revoke();
+    assert.deepEqual(result, { success: true });
   });
 
   test("favorite", async function (assert) {


### PR DESCRIPTION
And one superfluous `run`. And add an assert to user-badge test. And replace `expect` with `step`/`verifySteps` in rest-model tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
