### PR TITLE
DEV: Don't run dev-only code in specs

### DIFF
--- a/lib/discourse_dev/config.rb
+++ b/lib/discourse_dev/config.rb
@@ -16,7 +16,7 @@ module DiscourseDev
       if File.exist?(file_path)
         user_config = YAML.load_file(file_path, permitted_classes: [Date])
       else
-        puts "I did no detect a custom `config/dev.yml` file, creating one for you where you can amend defaults."
+        puts "Did not detect `config/dev.yml`, creating one for you where you can amend defaults."
         FileUtils.cp(default_file_path, file_path)
         user_config = {}
       end

--- a/lib/faker/discourse_markdown.rb
+++ b/lib/faker/discourse_markdown.rb
@@ -86,7 +86,7 @@ module Faker
 
       def available_methods
         methods = super
-        methods << :image if ::DiscourseDev.config.post[:include_images]
+        methods << :image if Rails.env.dev? && ::DiscourseDev.config.post[:include_images]
         methods
       end
     end


### PR DESCRIPTION
This was causing the following notice to be printed out when running system specs:

```
I did no detect a custom `config/dev.yml` file, creating one for you where you can amend defaults.
```

(since 61571bee43eae88755b5e258e96d03c146f9d2cb)