### PR TITLE
DEV: Change fast typer trust level setting to enum type

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1934,7 +1934,9 @@ spam:
   auto_respond_to_flag_actions: true
   min_first_post_typing_time: 3000
   auto_silence_fast_typers_on_first_post: true
-  auto_silence_fast_typers_max_trust_level: 0
+  auto_silence_fast_typers_max_trust_level:
+    default: 0
+    enum: "TrustLevelSetting"
   auto_silence_first_post_regex: ""
   high_trust_flaggers_auto_hide_posts: true
   cooldown_hours_until_reflag:

--- a/db/migrate/20230906030920_change_auto_silence_fast_typers_setting_to_enum_type.rb
+++ b/db/migrate/20230906030920_change_auto_silence_fast_typers_setting_to_enum_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ChangeAutoSilenceFastTypersSettingToEnumType < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE
+        "site_settings"
+      SET
+        "data_type" = 7
+      WHERE
+        "name" = 'auto_silence_fast_typers_max_trust_level' AND
+        "data_type" = 3
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE
+        "site_settings"
+      SET
+        "data_type" = 3
+      WHERE
+        "name" = 'auto_silence_fast_typers_max_trust_level' AND
+        "data_type" = 7
+    SQL
+  end
+end


### PR DESCRIPTION
### What is this change?

We have one site setting, `auto_silence_fast_typers_max_trust_level`, which expects a trust level. However, the type is set to integer, which makes it very hard for a layman to enter the correct thing.

This PR changes the type of the site setting to the `TrustLevelSetting` enum.

**Before:**

<img width="640" alt="Screenshot 2023-09-06 at 11 17 12 AM" src="https://github.com/discourse/discourse/assets/5259935/f78f7c69-f9ee-45f3-944d-148159ab0f67">

**After:**

<img width="641" alt="Screenshot 2023-09-06 at 11 18 45 AM" src="https://github.com/discourse/discourse/assets/5259935/69a3d347-45c8-4c76-ac18-93c2361de54a">

The use of these are interchangeable in the back-end, since `SiteSetting.auto_silence_fast_typers_max_trust_level` still returns the integer value with the enum.