### PR TITLE
DEV: Add `above-topic-list-item` plugin outlet and pass topic in `above-latest-topic-list-item` args

### DIFF
--- a/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
@@ -1,4 +1,8 @@
-<PluginOutlet @name="above-latest-topic-list-item" @connectorTagName="div" />
+<PluginOutlet
+  @name="above-latest-topic-list-item"
+  @connectorTagName="div"
+  @outletArgs={{hash topic=this.topic}}
+/>
 <div class="topic-poster">
   <UserLink @user={{this.topic.lastPosterUser}}>
     {{avatar this.topic.lastPosterUser imageSize="large"}}

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.hbs
@@ -1,1 +1,5 @@
+<PluginOutlet
+  @name="above-topic-list-item"
+  @outletArgs={{hash topic=this.topic}}
+/>
 {{this.topicListItemContents}}


### PR DESCRIPTION
This PR does a couple of things:

1. Add a new plugin outlet, `above-topic-list-item`, to the `topic-list-item` component
2. Pass the topic in question as an outlet argument for the (existing) `above-latest-topic-list-item` outlet in the `latest-topic-list-item` component.