### PR TITLE
UX: fix tag chooser width when there are multiple tags

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -317,7 +317,8 @@ html.composer-open {
 
   .category-input + .mini-tag-chooser {
     margin-left: 8px;
-    width: unset;
+    width: auto;
+    max-width: calc(50% - 4px);
   }
 
   .mini-tag-chooser {


### PR DESCRIPTION
Before:

<img width="836" alt="Screenshot 2023-09-06 at 3 44 31 PM" src="https://github.com/discourse/discourse/assets/11170663/ff0a200b-5824-4325-9aa3-cd6f7dd88943">

After:

<img width="559" alt="Screenshot 2023-09-06 at 3 42 50 PM" src="https://github.com/discourse/discourse/assets/11170663/6dcd7dd3-cf1a-4418-8c49-755d686786fc">
