### PR TITLE
DEV: Improve RestModel injections workaround

### DIFF
--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -103,15 +103,17 @@ RestModel.reopenClass({
   create(args) {
     args = args || {};
 
+    args.__munge = this.munge;
+    const createArgs = this.munge(args, args.store);
+
     // Some Discourse code calls `model.create()` directly without going through the
     // store. In that case the owner is not set, and injections will fail. This workaround ensures
     // the owner is always present. Eventually we should use the store for everything to fix this.
-    if (!getOwner(this)) {
-      setOwner(this, getOwnerWithFallback());
+    if (!getOwner(createArgs)) {
+      setOwner(createArgs, getOwnerWithFallback());
     }
 
-    args.__munge = this.munge;
-    return this._super(this.munge(args, args.store));
+    return this._super(createArgs);
   },
 });
 

--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -109,7 +109,8 @@ RestModel.reopenClass({
     // Some Discourse code calls `model.create()` directly without going through the
     // store. In that case the owner is not set, and injections will fail. This workaround ensures
     // the owner is always present. Eventually we should use the store for everything to fix this.
-    if (!getOwner(createArgs)) {
+    const receivedOwner = getOwner(createArgs);
+    if (!receivedOwner || receivedOwner.isDestroyed) {
       setOwner(createArgs, getOwnerWithFallback());
     }
 

--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -1,7 +1,8 @@
 import EmberObject from "@ember/object";
 import { Promise } from "rsvp";
 import { equal } from "@ember/object/computed";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner as getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner, setOwner } from "@ember/application";
 import { warn } from "@ember/debug";
 
 const RestModel = EmberObject.extend({
@@ -101,19 +102,12 @@ RestModel.reopenClass({
 
   create(args) {
     args = args || {};
-    let owner = getOwner(this);
 
     // Some Discourse code calls `model.create()` directly without going through the
-    // store. In that case the injections are not made, so we do them here. Eventually
-    // we should use the store for everything to fix this.
-    if (!args.store) {
-      args.store = owner.lookup("service:store");
-    }
-    if (!args.siteSettings) {
-      args.siteSettings = owner.lookup("service:site-settings");
-    }
-    if (!args.appEvents) {
-      args.appEvents = owner.lookup("service:app-events");
+    // store. In that case the owner is not set, and injections will fail. This workaround ensures
+    // the owner is always present. Eventually we should use the store for everything to fix this.
+    if (!getOwner(this)) {
+      setOwner(this, getOwnerWithFallback());
     }
 
     args.__munge = this.munge;


### PR DESCRIPTION
We have a workaround so that currentUser/siteSettings/appEvents work properly on RestModel instances which are created without an owner. This is not ideal, but updating all call sites to properly initialize models via the store will not be trivial. This commit improves the workaround to be more robust and support all service injections.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
