### PR TITLE
DEV: Rename custom getOwner to getOwnerWithFallback

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-tools.js
+++ b/app/assets/javascripts/admin/addon/services/admin-tools.js
@@ -3,7 +3,7 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import Service, { inject as service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import { htmlSafe } from "@ember/template";
 import { action } from "@ember/object";
 import PenalizeUserModal from "admin/components/modal/penalize-user";

--- a/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
@@ -3,12 +3,30 @@ import deprecated from "discourse-common/lib/deprecated";
 
 let _default = {};
 
-export function getOwner(obj) {
+/**
+ * Works similarly to { getOwner } from `@ember/application`, but has a fallback
+ * when the passed object doesn't have an owner.
+ *
+ * This exists for historical reasons. Ideally, any uses of it should be updated to use
+ * the official `@ember/application` implementation.
+ */
+export function getOwnerWithFallback(obj) {
   if (emberGetOwner) {
     return emberGetOwner(obj || _default) || emberGetOwner(_default);
   }
 
   return obj.container;
+}
+
+/**
+ * @deprecated use `getOwnerWithFallback` instead
+ */
+export function getOwner(obj) {
+  deprecated(
+    "Importing getOwner from `discourse-common/lib/get-owner` is deprecated. Use `import { getOwner } from '@ember/application'`, or if you still need the fallback shim, use `import { getOwnerWithFallback } from 'discourse-common/lib/get-owner';`.",
+    { since: "3.2", id: "discourse.get-owner-with-fallback" }
+  );
+  return getOwnerWithFallback(obj);
 }
 
 export function setDefaultOwner(container) {
@@ -18,7 +36,7 @@ export function setDefaultOwner(container) {
 // `this.container` is deprecated, but we can still build a container-like
 // object for components to use
 export function getRegister(obj) {
-  const owner = getOwner(obj);
+  const owner = getOwnerWithFallback(obj);
   const register = {
     lookup: (...args) => owner.lookup(...args),
     lookupFactory: (...args) => {

--- a/app/assets/javascripts/discourse/app/components/bulk-select-toggle.js
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-toggle.js
@@ -1,11 +1,11 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 export default class BulkSelectToggle extends Component {
   @action
   toggleBulkSelect() {
-    const controller = getOwner(this).lookup(
+    const controller = getOwnerWithFallback(this).lookup(
       `controller:${this.args.parentController}`
     );
     const helper = controller.bulkSelectHelper;

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -42,7 +42,7 @@ import {
   initUserStatusHtml,
   renderUserStatusHtml,
 } from "discourse/lib/user-status-on-autocomplete";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 // original string `![image|foo=bar|690x220, 50%|bar=baz](upload://1TjaobgKObzpU7xRMw2HuUc87vO.png "image title")`
 // group 1 `image|foo=bar`
@@ -224,7 +224,7 @@ export default Component.extend(ComposerUploadUppy, {
             categoryId: this.topic?.category_id || this.composer?.categoryId,
             includeGroups: true,
           }).then((result) => {
-            initUserStatusHtml(getOwner(this), result.users);
+            initUserStatusHtml(getOwnerWithFallback(this), result.users);
             return result;
           });
         },

--- a/app/assets/javascripts/discourse/app/components/composer-message.js
+++ b/app/assets/javascripts/discourse/app/components/composer-message.js
@@ -1,14 +1,16 @@
 import Component from "@ember/component";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 export default Component.extend({
   classNameBindings: [":composer-popup", "message.extraClass"],
 
   @discourseComputed("message.templateName")
   layout(templateName) {
-    return getOwner(this).lookup(`template:composer/${templateName}`);
+    return getOwnerWithFallback(this).lookup(
+      `template:composer/${templateName}`
+    );
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/components/custom-html.js
+++ b/app/assets/javascripts/discourse/app/components/custom-html.js
@@ -1,6 +1,6 @@
 import Component from "@ember/component";
 import { getCustomHTML } from "discourse/helpers/custom-html";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { hbs } from "ember-cli-htmlbars";
 import deprecated from "discourse-common/lib/deprecated";
 
@@ -16,7 +16,7 @@ export default Component.extend({
       this.set("html", html);
       this.set("layout", hbs`{{this.html}}`);
     } else {
-      const template = getOwner(this).lookup(`template:${name}`);
+      const template = getOwnerWithFallback(this).lookup(`template:${name}`);
       if (template) {
         deprecated(
           "Defining an hbs template for CustomHTML rendering is deprecated. Use plugin outlets instead.",

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -3,7 +3,7 @@ import { filterTypeForMode } from "discourse/lib/filter-mode";
 import NavItem from "discourse/models/nav-item";
 import discourseComputed from "discourse-common/utils/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { htmlSafe } from "@ember/template";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
@@ -144,7 +144,9 @@ export default Component.extend({
 
   @discourseComputed()
   canBulk() {
-    const controller = getOwner(this).lookup("controller:discovery/topics");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:discovery/topics"
+    );
     return controller.canBulkSelect;
   },
 

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.js
@@ -11,7 +11,7 @@ import showModal from "discourse/lib/show-modal";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import I18n from "I18n";
 import Category from "discourse/models/category";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
   topic: readOnly("model.topic"),
@@ -108,7 +108,8 @@ const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
     const postStream = this.topic.postStream;
     const postId = this.post?.id || postStream.findPostIdForPostNumber(1);
     const post = postStream.findLoadedPost(postId);
-    const topicController = getOwner(this).lookup("controller:topic");
+    const topicController =
+      getOwnerWithFallback(this).lookup("controller:topic");
     topicController.actions.replyAsNewTopic.call(topicController, post);
     this.closeModal();
   },

--- a/app/assets/javascripts/discourse/app/components/modal/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/components/modal/topic-bulk-actions.js
@@ -9,7 +9,7 @@ import ChangeCategory from "../bulk-actions/change-category";
 import NotificationLevel from "../bulk-actions/notification-level";
 import ChangeTags from "../bulk-actions/change-tags";
 import AppendTags from "../bulk-actions/append-tags";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 const _customButtons = [];
 
@@ -72,7 +72,7 @@ export default class TopicBulkActions extends Component {
       class: "btn-default",
       visible: ({ topics }) => topics.some((t) => t.isPrivateMessage),
       action: ({ performAndRefresh }) => {
-        const userPrivateMessages = getOwner(this).lookup(
+        const userPrivateMessages = getOwnerWithFallback(this).lookup(
           "controller:user-private-messages"
         );
         let params = { type: "archive_messages" };
@@ -90,7 +90,7 @@ export default class TopicBulkActions extends Component {
       class: "btn-default",
       visible: ({ topics }) => topics.some((t) => t.isPrivateMessage),
       action: ({ performAndRefresh }) => {
-        const userPrivateMessages = getOwner(this).lookup(
+        const userPrivateMessages = getOwnerWithFallback(this).lookup(
           "controller:user-private-messages"
         );
         let params = { type: "move_messages_to_inbox" };

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -9,7 +9,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { action, set } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import ExplainReviewableModal from "discourse/components/modal/explain-reviewable";
 
 let _components = {};
@@ -121,7 +121,7 @@ export default Component.extend({
     }
 
     const dasherized = dasherize(type);
-    const owner = getOwner(this);
+    const owner = getOwnerWithFallback(this);
     const componentExists =
       owner.hasRegistration(`component:${dasherized}`) ||
       owner.hasRegistration(`template:components/${dasherized}`);

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
@@ -1,6 +1,6 @@
 import { cached } from "@glimmer/tracking";
 
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import Component from "@glimmer/component";
 import { bind } from "discourse-common/utils/decorators";
 import GroupMessageSectionLink from "discourse/lib/sidebar/user/messages-section/group-message-section-link";
@@ -85,7 +85,8 @@ export default class SidebarUserMessagesSection extends Component {
       };
 
       if (currentRouteParentName === "topic") {
-        const topicController = getOwner(this).lookup("controller:topic");
+        const topicController =
+          getOwnerWithFallback(this).lookup("controller:topic");
 
         if (topicController.model.isPrivateMessage) {
           attrs.privateMessageTopic = topicController.model;

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -15,7 +15,7 @@ import UserMenuReviewablesList from "./reviewables-list";
 import UserMenuProfileTabContent from "./profile-tab-content";
 import UserMenuOtherNotificationsList from "./other-notifications-list";
 import deprecated from "discourse-common/lib/deprecated";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 const DEFAULT_TAB_ID = "all-notifications";
 const DEFAULT_PANEL_COMPONENT = UserMenuNotificationsList;
@@ -281,7 +281,7 @@ export default class UserMenu extends Component {
 
     this.currentTabId = tab.id;
     this.currentPanelComponent = resolvePanelComponent(
-      getOwner(this),
+      getOwnerWithFallback(this),
       tab.panelComponent
     );
 

--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -3,7 +3,7 @@ import { inject as service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import UserTipContainer from "discourse/components/user-tip-container";
 import DTooltipInstance from "float-kit/lib/d-tooltip-instance";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import { schedule } from "@ember/runloop";
 import { escape } from "pretty-text/sanitizer";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/app/instance-initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/jquery-plugins.js
@@ -1,6 +1,6 @@
 import autocomplete from "discourse/lib/autocomplete";
 import bootbox from "bootbox";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import deprecated from "discourse-common/lib/deprecated";
 
 let jqueryPluginsConfigured = false;
@@ -19,7 +19,7 @@ export default {
     const originalAlert = bootbox.alert;
     bootbox.alert = function () {
       if (arguments.length === 1) {
-        const dialog = getOwner(this).lookup("service:dialog");
+        const dialog = getOwnerWithFallback(this).lookup("service:dialog");
         if (dialog) {
           deprecated(
             "`bootbox.alert` is deprecated, please use the dialog service instead.",

--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -1,5 +1,5 @@
 import I18n from "I18n";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { htmlSafe } from "@ember/template";
 
 function extractErrorInfo(error, defaultMessage) {
@@ -90,7 +90,7 @@ export function flashAjaxError(modal, defaultMessage) {
 }
 
 export function popupAjaxError(error) {
-  const dialog = getOwner(this).lookup("service:dialog");
+  const dialog = getOwnerWithFallback(this).lookup("service:dialog");
   const errorInfo = extractErrorInfo(error);
 
   if (errorInfo.html) {

--- a/app/assets/javascripts/discourse/app/lib/click-track.js
+++ b/app/assets/javascripts/discourse/app/lib/click-track.js
@@ -7,7 +7,7 @@ import getURL, { samePrefix } from "discourse-common/lib/get-url";
 import { isTesting } from "discourse-common/config/environment";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import deprecated from "discourse-common/lib/deprecated";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import jQuery from "jquery";
 
 export function isValidLink(link) {
@@ -102,7 +102,7 @@ export default {
         siteSettings?.prevent_anons_from_downloading_files &&
         !User.current()
       ) {
-        const dialog = getOwner(this).lookup("service:dialog");
+        const dialog = getOwnerWithFallback(this).lookup("service:dialog");
         dialog.alert(I18n.t("post.errors.attachment_download_requires_login"));
       } else if (wantsNewWindow(e)) {
         const newWindow = window.open(href, "_blank");

--- a/app/assets/javascripts/discourse/app/lib/codeblock-buttons.js
+++ b/app/assets/javascripts/discourse/app/lib/codeblock-buttons.js
@@ -6,7 +6,7 @@ import I18n from "I18n";
 import { guidFor } from "@ember/object/internals";
 import { clipboardCopy } from "discourse/lib/utilities";
 import { iconHTML } from "discourse-common/lib/icon-library";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import FullscreenCodeModal from "discourse/components/modal/fullscreen-code";
 
 // Use to attach copy/fullscreen buttons to a block of code, either
@@ -173,7 +173,7 @@ export default class CodeblockButtons {
           this._copyComplete(button);
         }
       } else if (action === "fullscreen") {
-        const modal = getOwner(this).lookup("service:modal");
+        const modal = getOwnerWithFallback(this).lookup("service:modal");
         modal.show(FullscreenCodeModal, {
           model: {
             code: text,

--- a/app/assets/javascripts/discourse/app/lib/download-calendar.js
+++ b/app/assets/javascripts/discourse/app/lib/download-calendar.js
@@ -1,6 +1,6 @@
 import User from "discourse/models/user";
 import getURL from "discourse-common/lib/get-url";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import downloadCalendarModal from "discourse/components/modal/download-calendar";
 
 export function downloadCalendar(title, dates) {
@@ -81,7 +81,7 @@ export function generateIcsData(title, dates) {
 }
 
 function _displayModal(title, dates) {
-  const modal = getOwner(this).lookup("service:modal");
+  const modal = getOwnerWithFallback(this).lookup("service:modal");
   modal.show(downloadCalendarModal, { model: { calendar: { title, dates } } });
 }
 

--- a/app/assets/javascripts/discourse/app/lib/export-csv.js
+++ b/app/assets/javascripts/discourse/app/lib/export-csv.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function exportEntityByType(type, entity, args) {
   return ajax("/export_csv/export_entity.json", {
@@ -11,7 +11,7 @@ function exportEntityByType(type, entity, args) {
 }
 
 export function exportUserArchive() {
-  const dialog = getOwner(this).lookup("service:dialog");
+  const dialog = getOwnerWithFallback(this).lookup("service:dialog");
   return exportEntityByType("user", "user_archive")
     .then(function () {
       dialog.alert(I18n.t("user.download_archive.success"));

--- a/app/assets/javascripts/discourse/app/lib/export-result.js
+++ b/app/assets/javascripts/discourse/app/lib/export-result.js
@@ -1,8 +1,8 @@
 import I18n from "I18n";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 export function outputExportResult(result) {
-  const dialog = getOwner(this).lookup("service:dialog");
+  const dialog = getOwnerWithFallback(this).lookup("service:dialog");
 
   if (result.success) {
     dialog.alert(I18n.t("admin.export_csv.success"));

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -3,7 +3,7 @@ import { postRNWebviewMessage } from "discourse/lib/utilities";
 import I18n from "I18n";
 import User from "discourse/models/user";
 import deprecated from "discourse-common/lib/deprecated";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { helperContext } from "discourse-common/lib/helpers";
 import { isTesting } from "discourse-common/config/environment";
 import loadScript from "discourse/lib/load-script";
@@ -12,12 +12,12 @@ import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { SELECTORS } from "discourse/lib/lightbox/constants";
 
 export async function setupLightboxes({ container, selector }) {
-  const lightboxService = getOwner(this).lookup("service:lightbox");
+  const lightboxService = getOwnerWithFallback(this).lookup("service:lightbox");
   lightboxService.setupLightboxes({ container, selector });
 }
 
 export function cleanupLightboxes() {
-  const lightboxService = getOwner(this).lookup("service:lightbox");
+  const lightboxService = getOwnerWithFallback(this).lookup("service:lightbox");
   return lightboxService.cleanupLightboxes();
 }
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -78,7 +78,7 @@ import { addWidgetCleanCallback } from "discourse/components/mount-widget";
 import deprecated from "discourse-common/lib/deprecated";
 import { disableNameSuppression } from "discourse/widgets/poster-name";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { h } from "virtual-dom";
 import { includeAttributes } from "discourse/lib/transform-post";
 import { modifySelectKit } from "select-kit/mixins/plugin-api";
@@ -2505,7 +2505,7 @@ function getPluginApi(version) {
   version = version.toString();
 
   if (cmpVersions(version, PLUGIN_API_VERSION) <= 0) {
-    const owner = getOwner(this);
+    const owner = getOwnerWithFallback(this);
     let pluginApi = owner.lookup("plugin-api:main");
 
     if (!pluginApi) {

--- a/app/assets/javascripts/discourse/app/lib/show-modal.js
+++ b/app/assets/javascripts/discourse/app/lib/show-modal.js
@@ -1,6 +1,6 @@
 // Remove when legacy modals are dropped (deprecation: discourse.modal-controllers)
 
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 /**
  * Render a modal
@@ -26,7 +26,7 @@ export default function showModal(name, opts) {
   }
   opts = opts || {};
 
-  let container = getOwner(this);
+  let container = getOwnerWithFallback(this);
   if (container.isDestroying || container.isDestroyed) {
     return;
   }

--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import deprecated from "discourse-common/lib/deprecated";
 import { isAppleDevice } from "discourse/lib/utilities";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function isGUID(value) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
@@ -12,7 +12,7 @@ function isGUID(value) {
 // This wrapper simplifies unit testing the dialog service
 export const dialog = {
   alert(msg) {
-    const dg = getOwner(this).lookup("service:dialog");
+    const dg = getOwnerWithFallback(this).lookup("service:dialog");
     dg.alert(msg);
   },
 };

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -6,7 +6,7 @@ import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
 import { get } from "@ember/object";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import getURL from "discourse-common/lib/get-url";
 
 const STAFF_GROUP_NAME = "staff";
@@ -383,7 +383,9 @@ Category.reopenClass({
   },
 
   slugEncoded() {
-    let siteSettings = getOwner(this).lookup("service:site-settings");
+    let siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     return siteSettings.slug_generation_method === "encoded";
   },
 

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -7,7 +7,7 @@ import { deepMerge } from "discourse-common/lib/object";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
 import { emojiUnescape } from "discourse/lib/text";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import {
   hasTrackedFilter,
   isTrackedTopic,
@@ -228,7 +228,7 @@ NavItem.reopenClass({
       deepMerge(args, cb.call(this, filterType, opts))
     );
 
-    let store = getOwner(this).lookup("service:store");
+    let store = getOwnerWithFallback(this).lookup("service:store");
     return store.createRecord("nav-item", args);
   },
 
@@ -245,11 +245,13 @@ NavItem.reopenClass({
         dropFrom: "2.7.0",
         id: "discourse.nav-item.built-list-site-settings",
       });
-      args.siteSettings = getOwner(this).lookup("service:site-settings");
+      args.siteSettings = getOwnerWithFallback(this).lookup(
+        "service:site-settings"
+      );
     }
     let items = args.siteSettings.top_menu.split("|");
 
-    const user = getOwner(this).lookup("service:current-user");
+    const user = getOwnerWithFallback(this).lookup("service:current-user");
     if (user?.new_new_view_enabled) {
       items = items.reject((item) => item === "unread");
     }

--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -1,7 +1,7 @@
 import EmberObject from "@ember/object";
 import { Promise } from "rsvp";
 import { equal } from "@ember/object/computed";
-import { getOwner as getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback as getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { getOwner, setOwner } from "@ember/application";
 import { warn } from "@ember/debug";
 

--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -1,7 +1,7 @@
 import EmberObject from "@ember/object";
 import { Promise } from "rsvp";
 import { equal } from "@ember/object/computed";
-import { getOwnerWithFallback as getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { getOwner, setOwner } from "@ember/application";
 import { warn } from "@ember/debug";
 

--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -9,7 +9,7 @@ import Singleton from "discourse/mixins/singleton";
 import TrustLevel from "discourse/models/trust-level";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { isEmpty } from "@ember/utils";
 import { htmlSafe } from "@ember/template";
 
@@ -132,7 +132,7 @@ const Site = RestModel.extend({
 Site.reopenClass(Singleton, {
   // The current singleton will retrieve its attributes from the `PreloadStore`.
   createCurrent() {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const siteAttributes = PreloadStore.get("site");
     siteAttributes["isReadOnly"] = PreloadStore.get("isReadOnly");
     siteAttributes["isStaffWritesOnly"] = PreloadStore.get("isStaffWritesOnly");

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -4,7 +4,7 @@ import RestModel from "discourse/models/rest";
 import Session from "discourse/models/session";
 import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { isEmpty } from "@ember/utils";
 import { notEmpty } from "@ember/object/computed";
 import deprecated from "discourse-common/lib/deprecated";
@@ -217,7 +217,7 @@ TopicList.reopenClass({
       }
     );
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     return store.findFiltered("topicList", { filter, params });
   },
 

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -26,7 +26,7 @@ import { ajax } from "discourse/lib/ajax";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
 import { emojiUnescape } from "discourse/lib/text";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { isEmpty } from "@ember/utils";
 import { longDate } from "discourse/lib/formatter";
 import { url } from "discourse/lib/computed";
@@ -959,7 +959,7 @@ const User = RestModel.extend({
   },
 
   summary() {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     return ajax(userPath(`${this.username_lower}/summary.json`)).then(
       (json) => {
@@ -1199,7 +1199,7 @@ User.reopenClass(Singleton, {
         this._saveTimezone(userJson);
       }
 
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const currentUser = store.createRecord("user", userJson);
       currentUser.trackStatus();
       return currentUser;

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -6,7 +6,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { findAll } from "discourse/models/login-method";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import getURL from "discourse-common/lib/get-url";
 import logout from "discourse/lib/logout";
 import mobile from "discourse/lib/mobile";
@@ -202,7 +202,7 @@ const ApplicationRoute = DiscourseRoute.extend({
         "createNewTopicViaParam on the application route is deprecated. Use the composer service instead",
         { id: "discourse.createNewTopicViaParams" }
       );
-      getOwner(this).lookup("service:composer").openNewTopic({
+      getOwnerWithFallback(this).lookup("service:composer").openNewTopic({
         title,
         body,
         categoryId,
@@ -220,7 +220,7 @@ const ApplicationRoute = DiscourseRoute.extend({
         "createNewMessageViaParams on the application route is deprecated. Use the composer service instead",
         { id: "discourse.createNewMessageViaParams" }
       );
-      getOwner(this).lookup("service:composer").openNewMessage({
+      getOwnerWithFallback(this).lookup("service:composer").openNewMessage({
         recipients,
         title: topicTitle,
         body: topicBody,

--- a/app/assets/javascripts/discourse/app/routes/discourse.js
+++ b/app/assets/javascripts/discourse/app/routes/discourse.js
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { once } from "@ember/runloop";
 import { seenUser } from "discourse/lib/user-presence";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import deprecated from "discourse-common/lib/deprecated";
 import { inject as service } from "@ember/service";
 
@@ -52,7 +52,7 @@ const DiscourseRoute = Route.extend({
       { id: "discourse.open-topic-draft" }
     );
     if (this.currentUser?.has_topic_draft) {
-      return getOwner(this)
+      return getOwnerWithFallback(this)
         .lookup("service:composer")
         .openNewTopic({ preferDraft: true });
     }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -26,7 +26,7 @@ import deprecated from "discourse-common/lib/deprecated";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression, modKeysPressed } from "discourse/lib/utilities";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { isTesting } from "discourse-common/config/environment";
@@ -138,7 +138,7 @@ export default class ComposerService extends Service {
   @or("replyingToWhisper", "model.whisper") isWhispering;
 
   get topicController() {
-    return getOwner(this).lookup("controller:topic");
+    return getOwnerWithFallback(this).lookup("controller:topic");
   }
 
   @on("init")
@@ -239,7 +239,9 @@ export default class ComposerService extends Service {
 
   @computed
   get showToolbar() {
-    const keyValueStore = getOwner(this).lookup("service:key-value-store");
+    const keyValueStore = getOwnerWithFallback(this).lookup(
+      "service:key-value-store"
+    );
     const storedVal = keyValueStore.get("toolbar-enabled");
     if (this._toolbarEnabled === undefined && storedVal === undefined) {
       // iPhone 6 is 375, anything narrower and toolbar should
@@ -252,7 +254,9 @@ export default class ComposerService extends Service {
   }
 
   set showToolbar(val) {
-    const keyValueStore = getOwner(this).lookup("service:key-value-store");
+    const keyValueStore = getOwnerWithFallback(this).lookup(
+      "service:key-value-store"
+    );
     this._toolbarEnabled = val;
     keyValueStore.set({
       key: "toolbar-enabled",

--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -13,7 +13,7 @@ import {
   destroyUserStatusOnMentions,
   updateUserStatusOnMention,
 } from "discourse/lib/update-user-status-on-mention";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 let _beforeAdoptDecorators = [];
 let _afterAdoptDecorators = [];
@@ -397,7 +397,11 @@ export default class PostCooked {
     const mentions = postElement.querySelectorAll(`a.mention[href="${href}"]`);
 
     mentions.forEach((mention) => {
-      updateUserStatusOnMention(getOwner(this._post()), mention, user.status);
+      updateUserStatusOnMention(
+        getOwnerWithFallback(this._post()),
+        mention,
+        user.status
+      );
     });
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -12,7 +12,7 @@ import {
   getCachedTopicList,
   setCachedTopicList,
 } from "discourse/lib/cached-topic-list";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 acceptance("Personal Message", function (needs) {
   needs.user();
@@ -27,7 +27,7 @@ acceptance("Personal Message", function (needs) {
   });
 
   test("redirects to inbox after topic is archived and clears topicList cache", async function (assert) {
-    const session = getOwner(this).lookup("service:session");
+    const session = getOwnerWithFallback(this).lookup("service:session");
     setCachedTopicList(session, {});
 
     await visit("/t/pm-for-testing/12");

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -18,7 +18,7 @@ import {
   settled,
   triggerKeyEvent,
 } from "@ember/test-helpers";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { run } from "@ember/runloop";
 import { setupApplicationTest } from "ember-qunit";
 import Site from "discourse/models/site";
@@ -247,7 +247,7 @@ export function discourseModule(name, options) {
   if (typeof options === "function") {
     module(name, function (hooks) {
       hooks.beforeEach(function () {
-        this.container = getOwner(this);
+        this.container = getOwnerWithFallback(this);
         this.registry = this.container.registry;
         this.owner = this.container;
         this.siteSettings = currentSettings();
@@ -274,7 +274,7 @@ export function discourseModule(name, options) {
 
   module(name, {
     beforeEach() {
-      this.container = getOwner(this);
+      this.container = getOwnerWithFallback(this);
       this.siteSettings = currentSettings();
       options?.beforeEach?.call(this);
     },
@@ -338,7 +338,8 @@ export function acceptance(name, optionsOrCallback) {
           updateCurrentUser(userChanges);
         }
 
-        User.current().appEvents = getOwner(this).lookup("service:app-events");
+        User.current().appEvents =
+          getOwnerWithFallback(this).lookup("service:app-events");
         User.current().trackStatus();
       }
 
@@ -350,7 +351,7 @@ export function acceptance(name, optionsOrCallback) {
 
       resetSite(siteChanges);
 
-      this.container = getOwner(this);
+      this.container = getOwnerWithFallback(this);
 
       if (!this.owner) {
         this.owner = this.container;
@@ -433,7 +434,7 @@ export function controllerFor(controller, model) {
     }
   );
 
-  controller = getOwner(this).lookup("controller:" + controller);
+  controller = getOwnerWithFallback(this).lookup("controller:" + controller);
   if (model) {
     controller.set("model", model);
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
@@ -3,13 +3,13 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | pending-post", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     store.createRecord("category", { id: 2 });
     const post = store.createRecord("pending-post", {
       id: 1,

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
@@ -6,7 +6,7 @@ import { action } from "@ember/object";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
 import { hbs } from "ember-cli-htmlbars";
 import { registerTemporaryModule } from "discourse/tests/helpers/temporary-module-helper";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import Component from "@glimmer/component";
 import templateOnly from "@ember/component/template-only";
 import { withSilencedDeprecationsAsync } from "discourse-common/lib/deprecated";
@@ -256,7 +256,9 @@ module("Integration | Component | plugin-outlet", function (hooks) {
       "doesn't render conditional outlet"
     );
 
-    getOwner(this).lookup("service:site-settings").always_display = true;
+    getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    ).always_display = true;
     await settled();
     assert.true(exists(".conditional-render"), "renders conditional outlet");
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -4,7 +4,7 @@ import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module(
   "Integration | Component | select-kit/category-chooser",
@@ -267,7 +267,7 @@ module(
     });
 
     test("filter works with non english characters", async function (assert) {
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       store.createRecord("category", {
         id: 1,
         name: "chữ Quốc ngữ",
@@ -287,7 +287,7 @@ module(
     });
 
     test("decodes entities in row title", async function (assert) {
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       store.createRecord("category", {
         id: 1,
         name: "cat-with-entities",

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | select-kit/pinned-options", function (hooks) {
   setupRenderingTest(hooks);
@@ -12,7 +12,7 @@ module("Integration | Component | select-kit/pinned-options", function (hooks) {
     this.siteSettings.automatically_unpin_topics = false;
     this.set("subject", selectKit());
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.set(
       "topic",
       store.createRecord("topic", {
@@ -38,7 +38,7 @@ module("Integration | Component | select-kit/pinned-options", function (hooks) {
   test("pinning", async function (assert) {
     this.siteSettings.automatically_unpin_topics = false;
     this.set("subject", selectKit());
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.set(
       "topic",
       store.createRecord("topic", {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
@@ -5,7 +5,7 @@ import I18n from "I18n";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function buildTopic(opts) {
   return this.store.createRecord("topic", {
@@ -30,7 +30,7 @@ module(
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function () {
-      this.store = getOwner(this).lookup("service:store");
+      this.store = getOwnerWithFallback(this).lookup("service:store");
     });
 
     hooks.afterEach(function () {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
@@ -4,7 +4,7 @@ import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function extractDescriptions(rows) {
   return [...rows].map((el) => el.querySelector(".desc").textContent.trim());
@@ -22,7 +22,7 @@ module(
     setupRenderingTest(hooks);
 
     test("regular topic notification level descriptions", async function (assert) {
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       this.set(
         "topic",
         store.createRecord("topic", {
@@ -63,7 +63,7 @@ module(
     });
 
     test("PM topic notification level descriptions", async function (assert) {
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       this.set(
         "topic",
         store.createRecord("topic", {

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
@@ -3,13 +3,13 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | topic-list-item", function (hooks) {
   setupRenderingTest(hooks);
 
   test("checkbox is rendered checked if topic is in selected array", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const topic = store.createRecord("topic", { id: 24234 });
     const topic2 = store.createRecord("topic", { id: 24235 });
     this.setProperties({

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
@@ -2,13 +2,13 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | topic-list", function (hooks) {
   setupRenderingTest(hooks);
 
   test("bulk select", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.setProperties({
       topics: [
         store.createRecord("topic", { id: 24234 }),

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-stream-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function postStreamTest(name, attrs) {
   test(name, async function (assert) {
@@ -22,8 +22,8 @@ module("Integration | Component | Widget | post-stream", function (hooks) {
 
   postStreamTest("basics", {
     posts() {
-      const site = getOwner(this).lookup("service:site");
-      const store = getOwner(this).lookup("service:store");
+      const site = getOwnerWithFallback(this).lookup("service:site");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const topic = store.createRecord("topic");
       topic.set("details.created_by", { id: 123 });
 
@@ -129,7 +129,7 @@ module("Integration | Component | Widget | post-stream", function (hooks) {
 
   postStreamTest("deleted posts", {
     posts() {
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const topic = store.createRecord("topic");
       topic.set("details.created_by", { id: 123 });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
@@ -10,7 +10,7 @@ import {
 import { hbs } from "ember-cli-htmlbars";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | Widget | post", function (hooks) {
   setupRenderingTest(hooks);
@@ -162,7 +162,7 @@ module("Integration | Component | Widget | post", function (hooks) {
   });
 
   test("like count button", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const topic = store.createRecord("topic", { id: 123 });
     const post = store.createRecord("post", {
       id: 1,
@@ -517,7 +517,7 @@ module("Integration | Component | Widget | post", function (hooks) {
   });
 
   test("expand first post", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.set("args", { expandablePost: true });
     this.set("post", store.createRecord("post", { id: 1234 }));
 
@@ -961,7 +961,7 @@ module("Integration | Component | Widget | post", function (hooks) {
       emoji: "tooth",
       description: "off to dentist",
     };
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { status });
     this.set("args", { user });
 
@@ -976,7 +976,7 @@ module("Integration | Component | Widget | post", function (hooks) {
       emoji: "tooth",
       description: "off to dentist",
     };
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { status });
     this.set("args", { user });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-admin-menu-test.js
@@ -4,7 +4,7 @@ import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import Category from "discourse/models/category";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 const createArgs = (topic) => {
   return {
@@ -37,7 +37,7 @@ module(
         id: 123,
       });
 
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const topic = store.createRecord("topic", {
         user_id: this.currentUser.id,
       });
@@ -60,7 +60,7 @@ module(
         id: 123,
       });
 
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const topic = store.createRecord("topic", {
         user_id: this.currentUser.id,
       });

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
@@ -4,13 +4,13 @@ import { click, render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import TopicStatusIcons from "discourse/helpers/topic-status-icons";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | Widget | topic-status", function (hooks) {
   setupRenderingTest(hooks);
 
   test("basics", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.set("args", {
       topic: store.createRecord("topic", { closed: true }),
       disableActions: true,
@@ -24,7 +24,7 @@ module("Integration | Component | Widget | topic-status", function (hooks) {
   });
 
   test("extendability", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     TopicStatusIcons.addObject([
       "has_accepted_answer",
       "far-check-square",
@@ -45,7 +45,7 @@ module("Integration | Component | Widget | topic-status", function (hooks) {
   });
 
   test("toggling pin status", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.set("args", {
       topic: store.createRecord("topic", { closed: true, pinned: true }),
     });

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -13,7 +13,10 @@ import pretender, {
   resetPretender,
 } from "discourse/tests/helpers/create-pretender";
 import { resetSettings } from "discourse/tests/helpers/site-settings";
-import { getOwner, setDefaultOwner } from "discourse-common/lib/get-owner";
+import {
+  getOwnerWithFallback,
+  setDefaultOwner,
+} from "discourse-common/lib/get-owner";
 import {
   getSettledState,
   isSettled,
@@ -340,7 +343,7 @@ export default function setupTests(config) {
   });
 
   QUnit.testDone(function () {
-    testCleanup(getOwner(app), app);
+    testCleanup(getOwnerWithFallback(app), app);
 
     sinon.restore();
     resetPretender();

--- a/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
@@ -1,15 +1,17 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Controller | reorder-categories", function (hooks) {
   setupTest(hooks);
 
   test("reorder set unique position number", function (assert) {
-    const controller = getOwner(this).lookup("controller:reorder-categories");
-    const store = getOwner(this).lookup("service:store");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:reorder-categories"
+    );
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("categories", [
       store.createRecord("category", { id: 1, position: 0 }),
       store.createRecord("category", { id: 2, position: 0 }),
@@ -24,8 +26,10 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("reorder places subcategories after their parent categories, while maintaining the relative order", function (assert) {
-    const controller = getOwner(this).lookup("controller:reorder-categories");
-    const store = getOwner(this).lookup("service:store");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:reorder-categories"
+    );
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const parent = store.createRecord("category", {
       id: 1,
@@ -51,7 +55,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
     });
 
     const expectedOrderSlugs = ["parent", "child2", "child1", "other"];
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("categories", [child2, parent, other, child1]);
 
     controller.reorder();
@@ -63,8 +67,10 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position number of a category should place it at given position", function (assert) {
-    const controller = getOwner(this).lookup("controller:reorder-categories");
-    const store = getOwner(this).lookup("service:store");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:reorder-categories"
+    );
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const elem1 = store.createRecord("category", {
       id: 1,
@@ -84,7 +90,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("categories", [elem1, elem2, elem3]);
 
     // Move category 'foo' from position 0 to position 2
@@ -98,8 +104,10 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position number of a category should place it at given position and respect children", function (assert) {
-    const controller = getOwner(this).lookup("controller:reorder-categories");
-    const store = getOwner(this).lookup("service:store");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:reorder-categories"
+    );
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const elem1 = store.createRecord("category", {
       id: 1,
@@ -126,7 +134,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("categories", [elem1, child1, elem2, elem3]);
 
     controller.send("change", elem1, { target: { value: 3 } });
@@ -140,8 +148,10 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position through click on arrow of a category should place it at given position and respect children", function (assert) {
-    const controller = getOwner(this).lookup("controller:reorder-categories");
-    const store = getOwner(this).lookup("service:store");
+    const controller = getOwnerWithFallback(this).lookup(
+      "controller:reorder-categories"
+    );
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const child2 = store.createRecord("category", {
       id: 105,
@@ -177,7 +187,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("categories", [elem1, child1, child2, elem2, elem3]);
 
     controller.reorder();

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -5,7 +5,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import EmberObject from "@ember/object";
 import { Placeholder } from "discourse/lib/posts-with-placeholders";
 import { next } from "@ember/runloop";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import sinon from "sinon";
 
 function topicWithStream(streamDetails) {
@@ -18,11 +18,11 @@ module("Unit | Controller | topic", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.store = getOwner(this).lookup("service:store");
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   test("editTopic", function (assert) {
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     const model = this.store.createRecord("topic");
     controller.setProperties({ model });
     assert.notOk(controller.editingTopic, "we are not editing by default");
@@ -59,10 +59,12 @@ module("Unit | Controller | topic", function (hooks) {
     let modalDisplayed = false;
     model.destroy = async () => (destroyed = true);
 
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     siteSettings.min_topic_views_for_delete_confirm = 5;
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({
       model,
       deleteTopicModal: () => (modalDisplayed = true),
@@ -101,7 +103,7 @@ module("Unit | Controller | topic", function (hooks) {
 
   test("toggleMultiSelect", async function (assert) {
     const model = this.store.createRecord("topic");
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.notOk(
@@ -146,7 +148,7 @@ module("Unit | Controller | topic", function (hooks) {
     const model = topicWithStream.call(this, {
       posts: [{ id: 1 }, { id: 2 }, { id: 3 }],
     });
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     controller.set("selectedPostIds", [1, 2, 42]);
@@ -164,7 +166,7 @@ module("Unit | Controller | topic", function (hooks) {
 
   test("selectedAllPosts", function (assert) {
     const model = topicWithStream.call(this, { stream: [1, 2, 3] });
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     controller.set("selectedPostIds", [1, 2]);
@@ -198,7 +200,7 @@ module("Unit | Controller | topic", function (hooks) {
       ],
       stream: [1, 2, 3],
     });
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.strictEqual(
@@ -238,12 +240,12 @@ module("Unit | Controller | topic", function (hooks) {
 
   test("showSelectedPostsAtBottom", function (assert) {
     const model = this.store.createRecord("topic", { posts_count: 3 });
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.notOk(controller.showSelectedPostsAtBottom, "false on desktop");
 
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("mobileView", true);
 
     assert.notOk(
@@ -269,7 +271,7 @@ module("Unit | Controller | topic", function (hooks) {
       stream: [1, 2, 3],
     });
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({
       model,
       currentUser,
@@ -316,7 +318,7 @@ module("Unit | Controller | topic", function (hooks) {
     });
     model.set("details.can_move_posts", false);
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.notOk(
@@ -362,7 +364,7 @@ module("Unit | Controller | topic", function (hooks) {
     });
     model.set("currentUser", currentUser);
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model, currentUser });
 
     assert.notOk(controller.canChangeOwner, "false when no posts are selected");
@@ -394,10 +396,12 @@ module("Unit | Controller | topic", function (hooks) {
     });
     model.set("currentUser", currentUser);
 
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     siteSettings.moderators_change_post_ownership = true;
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model, currentUser });
 
     assert.notOk(controller.canChangeOwner, "false when no posts are selected");
@@ -429,7 +433,7 @@ module("Unit | Controller | topic", function (hooks) {
       stream: [1, 2, 3],
     });
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.notOk(controller.canMergePosts, "false when no posts are selected");
@@ -460,7 +464,7 @@ module("Unit | Controller | topic", function (hooks) {
   });
 
   test("Select/deselect all", function (assert) {
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     const model = topicWithStream.call(this, { stream: [1, 2, 3] });
     controller.setProperties({ model });
 
@@ -486,7 +490,7 @@ module("Unit | Controller | topic", function (hooks) {
   });
 
   test("togglePostSelection", function (assert) {
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
 
     assert.strictEqual(
       controller.selectedPostIds[0],
@@ -510,7 +514,7 @@ module("Unit | Controller | topic", function (hooks) {
   });
 
   test("selectBelow", function (assert) {
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("post_types", { small_action: 3, whisper: 4 });
 
     const model = topicWithStream.call(this, {
@@ -522,7 +526,7 @@ module("Unit | Controller | topic", function (hooks) {
       ],
     });
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     assert.deepEqual(
@@ -544,7 +548,7 @@ module("Unit | Controller | topic", function (hooks) {
       posts: [{ id: 1 }, { id: 2 }],
     });
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
 
     controller.send("selectReplies", { id: 1 });
@@ -582,7 +586,7 @@ module("Unit | Controller | topic", function (hooks) {
     const model = topicWithStream.call(this, {
       posts: [{ id: 1 }],
     });
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model });
     const placeholder = new Placeholder("post-placeholder");
 
@@ -613,7 +617,7 @@ module("Unit | Controller | topic", function (hooks) {
       posts: [post, { id: 3 }, { id: 4 }],
     });
 
-    const controller = getOwner(this).lookup("controller:topic");
+    const controller = getOwnerWithFallback(this).lookup("controller:topic");
     controller.setProperties({ model, currentUser });
 
     const done = assert.async();

--- a/app/assets/javascripts/discourse/tests/unit/lib/build-quote-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/build-quote-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { buildQuote } from "discourse/lib/quote";
 import PrettyText from "pretty-text/pretty-text";
 
@@ -8,7 +8,7 @@ module("Unit | Utility | build-quote", function (hooks) {
   setupTest(hooks);
 
   test("quotes", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", {
       cooked: "<p><b>lorem</b> ipsum</p>",
       username: "eviltrout",
@@ -58,7 +58,7 @@ module("Unit | Utility | build-quote", function (hooks) {
   });
 
   test("quoting a quote", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", {
       cooked: new PrettyText().cook(
         '[quote="sam, post:1, topic:1, full:true"]\nhello\n[/quote]\n*Test*'

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 import { helperContext } from "discourse-common/lib/helpers";
 
@@ -12,7 +12,7 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("Regular categoryBadge", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const category = store.createRecord("category", {
       name: "hello",
       id: 123,
@@ -43,7 +43,7 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("undefined color", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const noColor = store.createRecord("category", { name: "hello", id: 123 });
     const tag = $.parseHTML(categoryBadgeHTML(noColor))[0];
 
@@ -54,7 +54,7 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("topic count", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const category = store.createRecord("category", { name: "hello", id: 123 });
 
     assert.ok(
@@ -69,7 +69,7 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("allowUncategorized", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const uncategorized = store.createRecord("category", {
       name: "uncategorized",
       id: 345,
@@ -89,10 +89,12 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("category names are wrapped in dir-spans", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     siteSettings.support_mixed_text_direction = true;
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const rtlCategory = store.createRecord("category", {
       name: "תכנות עם Ruby",
       id: 123,
@@ -116,8 +118,10 @@ module("Unit | Utility | category-badge", function (hooks) {
   });
 
   test("recursive", function (assert) {
-    const store = getOwner(this).lookup("service:store");
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const store = getOwnerWithFallback(this).lookup("service:store");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     const foo = store.createRecord("category", {
       name: "foo",

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -13,7 +13,7 @@ import { setPrefix } from "discourse-common/lib/get-url";
 import sinon from "sinon";
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utility | computed", function (hooks) {
   setupTest(hooks);
@@ -29,7 +29,9 @@ module("Unit | Utility | computed", function (hooks) {
   });
 
   test("setting", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     let t = EmberObject.extend({
       siteSettings,

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -3,13 +3,15 @@ import { emojiUnescape } from "discourse/lib/text";
 import { module, test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utility | emoji", function (hooks) {
   setupTest(hooks);
 
   test("emojiUnescape", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     const testUnescape = (input, expected, description, settings = {}) => {
       const originalSettings = {};

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -12,7 +12,7 @@ import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import { module, test } from "qunit";
 import domFromString from "discourse-common/lib/dom-from-string";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function formatMins(mins, opts = {}) {
   const dt = new Date(new Date() - mins * 60 * 1000);
@@ -150,7 +150,9 @@ module("Unit | Utility | formatter", function (hooks) {
   });
 
   test("formatting tiny dates", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     const shortDateYear = shortDateTester("MMM 'YY");
     siteSettings.relative_date_duration = 14;

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-lookup-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-lookup-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import LinkLookup from "discourse/lib/link-lookup";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utility | link-lookup", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     this.post = store.createRecord("post");
     this.linkLookup = new LinkLookup({
       "en.wikipedia.org/wiki/handheld_game_console": {

--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -3,7 +3,7 @@ import EmberObject from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utility | plugin-api", function (hooks) {
   setupTest(hooks);
@@ -16,7 +16,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       },
     });
 
-    getOwner(this).register("test-thingy:main", TestThingy);
+    getOwnerWithFallback(this).register("test-thingy:main", TestThingy);
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("test-thingy:main", {
@@ -29,7 +29,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       });
     });
 
-    const thingy = getOwner(this).lookup("test-thingy:main");
+    const thingy = getOwnerWithFallback(this).lookup("test-thingy:main");
     assert.strictEqual(thingy.prop, "hello there");
   });
 
@@ -41,7 +41,10 @@ module("Unit | Utility | plugin-api", function (hooks) {
       }
     }
 
-    getOwner(this).register("native-test-thingy:main", NativeTestThingy);
+    getOwnerWithFallback(this).register(
+      "native-test-thingy:main",
+      NativeTestThingy
+    );
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("native-test-thingy:main", {
@@ -54,7 +57,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       });
     });
 
-    const thingy = getOwner(this).lookup("native-test-thingy:main");
+    const thingy = getOwnerWithFallback(this).lookup("native-test-thingy:main");
     assert.strictEqual(thingy.prop, "howdy partner");
   });
 
@@ -69,9 +72,13 @@ module("Unit | Utility | plugin-api", function (hooks) {
       }
     }
 
-    getOwner(this).register("class-test-thingy:main", new ClassTestThingy(), {
-      instantiate: false,
-    });
+    getOwnerWithFallback(this).register(
+      "class-test-thingy:main",
+      new ClassTestThingy(),
+      {
+        instantiate: false,
+      }
+    );
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("class-test-thingy:main", {
@@ -83,7 +90,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       });
     });
 
-    const thingy = getOwner(this).lookup("class-test-thingy:main");
+    const thingy = getOwnerWithFallback(this).lookup("class-test-thingy:main");
     assert.strictEqual(thingy.keep, "hey!");
     assert.strictEqual(thingy.prop, "g'day");
   });
@@ -95,7 +102,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       },
     });
 
-    getOwner(this).register("test-class:main", Base, {
+    getOwnerWithFallback(this).register("test-class:main", Base, {
       instantiate: false,
     });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -12,14 +12,16 @@ import I18n from "I18n";
 import sinon from "sinon";
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utility | uploads", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.siteSettings = getOwner(this).lookup("service:site-settings");
-    this.store = getOwner(this).lookup("service:store");
+    this.siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   test("validateUploadedFiles", function (assert) {
@@ -347,7 +349,9 @@ module("Unit | Utility | uploads", function (hooks) {
       "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
     );
 
-    const capabilities = getOwner(this).lookup("service:capabilities");
+    const capabilities = getOwnerWithFallback(this).lookup(
+      "service:capabilities"
+    );
     sinon.stub(capabilities, "isIOS").get(() => true);
     assert.strictEqual(
       testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -23,7 +23,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Utilities", function (hooks) {
   setupTest(hooks);
@@ -88,7 +88,9 @@ module("Unit | Utilities", function (hooks) {
     meta.content = "hot";
     document.body.appendChild(meta);
 
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     initializeDefaultHomepage(siteSettings);
 
     assert.strictEqual(
@@ -100,7 +102,9 @@ module("Unit | Utilities", function (hooks) {
   });
 
   test("defaultHomepage via site settings", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     siteSettings.top_menu = "top|latest|hot";
     initializeDefaultHomepage(siteSettings);
 
@@ -112,7 +116,9 @@ module("Unit | Utilities", function (hooks) {
   });
 
   test("setDefaultHomepage", function (assert) {
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     initializeDefaultHomepage(siteSettings);
 
     assert.strictEqual(defaultHomepage(), "latest");

--- a/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
@@ -5,13 +5,13 @@ import pretender, {
 } from "discourse/tests/helpers/create-pretender";
 import Badge from "discourse/models/badge";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | badge", function (hooks) {
   setupTest(hooks);
 
   test("newBadge", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const badge1 = store.createRecord("badge", { name: "New Badge" });
     const badge2 = store.createRecord("badge", { id: 1, name: "Old Badge" });
 
@@ -50,7 +50,7 @@ module("Unit | Model | badge", function (hooks) {
   });
 
   test("updateFromJson", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const badge = store.createRecord("badge", { name: "Badge 1" });
     badge.updateFromJson({
       badge_types: [{ id: 6, name: "Silver 1" }],
@@ -66,7 +66,7 @@ module("Unit | Model | badge", function (hooks) {
   });
 
   test("save", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const badge = store.createRecord("badge", {
       id: 1999,
       name: "New Badge",
@@ -89,7 +89,7 @@ module("Unit | Model | badge", function (hooks) {
   });
 
   test("destroy", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const badge = store.createRecord("badge", {
       name: "New Badge",
       description: "This is a new badge.",

--- a/app/assets/javascripts/discourse/tests/unit/models/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/bookmark-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | bookmark", function (hooks) {
   setupTest(hooks);
 
   test("topicForList - Topic bookmarkable", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const bookmark = store.createRecord("bookmark", {
       id: 1,
       bookmarkable_type: "Topic",
@@ -26,7 +26,7 @@ module("Unit | Model | bookmark", function (hooks) {
   });
 
   test("topicForList - Post bookmarkable", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const bookmark = store.createRecord("bookmark", {
       id: 1,
       bookmarkable_type: "Post",

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -1,14 +1,14 @@
 import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import sinon from "sinon";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | category", function (hooks) {
   setupTest(hooks);
 
   test("slugFor", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const slugFor = function (cat, val, text) {
       assert.strictEqual(Category.slugFor(cat), val, text);
@@ -69,7 +69,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("findBySlug", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {
         id: 2,
@@ -132,7 +132,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("findSingleBySlug", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {
         id: 2,
@@ -195,7 +195,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("findBySlugPathWithID", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const foo = store.createRecord("category", { id: 1, slug: "foo" });
     const bar = store.createRecord("category", {
@@ -219,7 +219,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("minimumRequiredTags", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const foo = store.createRecord("category", {
       id: 1,
@@ -283,7 +283,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("search with category name", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const category1 = store.createRecord("category", {
       id: 1,
       name: "middle term",
@@ -389,7 +389,7 @@ module("Unit | Model | category", function (hooks) {
   });
 
   test("search with category slug", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const category1 = store.createRecord("category", {
       id: 1,
       name: "middle term",

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -7,7 +7,7 @@ import {
 import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 import AppEvents from "discourse/services/app-events";
 import { module, test } from "qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 import pretender, {
   parsePostData,
@@ -17,7 +17,7 @@ import pretender, {
 function createComposer(opts = {}) {
   opts.user ??= currentUser();
   opts.appEvents = AppEvents.create();
-  const store = getOwner(this).lookup("service:store");
+  const store = getOwnerWithFallback(this).lookup("service:store");
   return store.createRecord("composer", opts);
 }
 
@@ -31,7 +31,9 @@ module("Unit | Model | composer", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.siteSettings = getOwner(this).lookup("service:site-settings");
+    this.siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
   });
 
   test("replyLength", function (assert) {
@@ -253,7 +255,7 @@ module("Unit | Model | composer", function (hooks) {
   });
 
   test("Post length for private messages with non human users", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const topic = store.createRecord("topic", { pm_with_non_human_user: true });
     const composer = createComposer.call(this, {
       topic,
@@ -266,7 +268,7 @@ module("Unit | Model | composer", function (hooks) {
     const composer = createComposer();
     assert.ok(!composer.editingFirstPost, "it's false by default");
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", { id: 123, post_number: 2 });
     composer.setProperties({ post, action: EDIT });
     assert.ok(
@@ -282,7 +284,7 @@ module("Unit | Model | composer", function (hooks) {
   });
 
   test("clearState", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const composer = createComposer.call(this, {
       originalText: "asdf",
       reply: "asdf2",
@@ -364,7 +366,7 @@ module("Unit | Model | composer", function (hooks) {
     this.siteSettings.max_topic_title_length = 10;
     const composer = createComposer();
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", {
       id: 123,
       post_number: 2,

--- a/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import { setPrefix } from "discourse-common/lib/get-url";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | email-log", function (hooks) {
   setupTest(hooks);
 
   test("create", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     assert.ok(
       store.createRecord("email-log"),
       "it can be created without arguments"
@@ -32,7 +32,7 @@ module("Unit | Model | email-log", function (hooks) {
           "/forum/letter_avatar_proxy/v2/letter/w/dfb087/{size}.png",
       },
     };
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const emailLog = store.createRecord("email-log", attrs);
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/unit/models/group-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/group-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | group", function (hooks) {
   setupTest(hooks);
 
   test("displayName", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const group = store.createRecord("group", {
       name: "test",
       display_name: "donkey",

--- a/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | invite", function (hooks) {
   setupTest(hooks);
 
   test("create", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     assert.ok(
       store.createRecord("invite"),
       "it can be created without arguments"

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -1,19 +1,19 @@
 import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import NavItem from "discourse/models/nav-item";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | nav-item", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const fooCategory = store.createRecord("category", {
       slug: "foo",
       id: 123,
     });
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.categories.addObject(fooCategory);
   });
 
@@ -34,7 +34,7 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("count", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const navItem = store.createRecord("nav-item", { name: "new" });
 
     assert.strictEqual(navItem.count, 0, "it has no count by default");
@@ -54,7 +54,7 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("displayName", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const navItem = store.createRecord("nav-item", {
       name: "something",
     });
@@ -69,7 +69,7 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("title", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const navItem = store.createRecord("nav-item", {
       name: "something",
     });

--- a/app/assets/javascripts/discourse/tests/unit/models/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/pending-post-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { settled } from "@ember/test-helpers";
 
 module("Unit | Model | pending-post", function (hooks) {
   setupTest(hooks);
 
   test("Properties", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const category = store.createRecord("category", { id: 2 });
     const post = store.createRecord("pending-post", {
       id: 1,
@@ -38,7 +38,7 @@ module("Unit | Model | pending-post", function (hooks) {
   });
 
   test("it cooks raw_text", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("pending-post", {
       raw_text: "**bold text**",
     });

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -4,11 +4,11 @@ import Post from "discourse/models/post";
 import User from "discourse/models/user";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import sinon from "sinon";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 function buildStream(id, stream) {
-  const store = getOwner(this).lookup("service:store");
+  const store = getOwnerWithFallback(this).lookup("service:store");
   const topic = store.createRecord("topic", { id, chunk_size: 5 });
 
   if (stream) {
@@ -24,7 +24,7 @@ module("Unit | Model | post-stream", function (hooks) {
   setupTest(hooks);
 
   test("create", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     assert.ok(
       store.createRecord("postStream"),
       "it can be created with no parameters"
@@ -40,7 +40,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("appending posts", function (assert) {
     const postStream = buildStream.call(this, 4567, [1, 3, 4]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     assert.strictEqual(postStream.lastPostId, 4, "the last post id is 4");
 
@@ -110,7 +110,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("closestPostNumberFor", function (assert) {
     const postStream = buildStream.call(this, 1231);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     assert.blank(
       postStream.closestPostNumberFor(1),
@@ -193,7 +193,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("removePosts", function (assert) {
     const postStream = buildStream.call(this, 10000001, [1, 2, 3]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const p1 = store.createRecord("post", { id: 1, post_number: 2 }),
       p2 = store.createRecord("post", { id: 2, post_number: 3 }),
@@ -532,7 +532,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("identity map", async function (assert) {
     const postStream = buildStream.call(this, 1234);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const p1 = postStream.appendPost(
       store.createRecord("post", { id: 1, post_number: 1 })
@@ -577,7 +577,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("appendMore for megatopic", async function (assert) {
     const postStream = buildStream.call(this, 1234);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", { id: 1, post_number: 1 });
 
     postStream.setProperties({
@@ -600,7 +600,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("prependMore for megatopic", async function (assert) {
     const postStream = buildStream.call(this, 1234);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", { id: 6, post_number: 6 });
 
     postStream.setProperties({
@@ -623,7 +623,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("staging and undoing a new post", function (assert) {
     const postStream = buildStream.call(this, 10101, [1]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const original = store.createRecord("post", {
       id: 1,
@@ -724,7 +724,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("staging and committing a post", function (assert) {
     const postStream = buildStream.call(this, 10101, [1]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const original = store.createRecord("post", {
       id: 1,
@@ -808,7 +808,7 @@ module("Unit | Model | post-stream", function (hooks) {
     // This can happen in a race condition between staging a post and it coming through on the
     // message bus. If the id of a post changes we should reconsider the loadedAllPosts property.
     const postStream = buildStream.call(this, 10101, [1, 2]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const postWithoutId = store.createRecord("post", {
       raw: "hello world this is my new post",
     });
@@ -828,7 +828,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("triggerRecoveredPost", async function (assert) {
     const postStream = buildStream.call(this, 4567);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     [1, 2, 3, 5].forEach((id) => {
       postStream.appendPost(
@@ -857,7 +857,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("committing and triggerNewPostsInStream race condition", function (assert) {
     const postStream = buildStream.call(this, 4964);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     postStream.appendPost(
       store.createRecord("post", { id: 1, post_number: 1 })
@@ -893,7 +893,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("triggerNewPostInStream for ignored posts", async function (assert) {
     const postStream = buildStream.call(this, 280, [1]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     User.resetCurrent(
       store.createRecord("user", {
         username: "eviltrout",
@@ -956,7 +956,7 @@ module("Unit | Model | post-stream", function (hooks) {
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     );
     const postsWithPlaceholders = postStream.postsWithPlaceholders;
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const testProxy = ArrayProxy.create({ content: postsWithPlaceholders });
 
@@ -1029,7 +1029,7 @@ module("Unit | Model | post-stream", function (hooks) {
 
   test("progressIndexOfPostId", function (assert) {
     const postStream = buildStream.call(this, 4567, [1, 3, 4]);
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const post = store.createRecord("post", { id: 1, post_number: 5 });
 
     assert.strictEqual(postStream.progressIndexOfPostId(post), 1);

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | post", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.store = getOwner(this).lookup("service:store");
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   test("defaults", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
@@ -4,7 +4,7 @@ import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 import MessageBus from "message-bus-client";
 import PrivateMessageTopicTrackingState from "discourse/services/pm-topic-tracking-state";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function setupPretender() {
   pretender.get(`/u/test/private-message-topic-tracking-state`, () => {
@@ -24,7 +24,7 @@ module("Unit | Model | private-message-topic-tracking-state", function (hooks) {
   setupTest(hooks);
 
   test("modifying state calls onStateChange callbacks", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const pmTopicTrackingState = PrivateMessageTopicTrackingState.create({
       messageBus: MessageBus,
       currentUser: store.createRecord("user", { id: 77889, username: "test" }),
@@ -50,7 +50,7 @@ module(
 
     test("modifies the topic state only if the topic was not created by the current user", async function (assert) {
       setupPretender();
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const pmTopicTrackingState = PrivateMessageTopicTrackingState.create({
         messageBus: MessageBus,
         currentUser: store.createRecord("user", {
@@ -110,7 +110,7 @@ module(
 
     test("modifies the last_read_post_number and highest_post_number", async function (assert) {
       setupPretender();
-      const store = getOwner(this).lookup("service:store");
+      const store = getOwnerWithFallback(this).lookup("service:store");
       const pmTopicTrackingState = PrivateMessageTopicTrackingState.create({
         messageBus: MessageBus,
         currentUser: store.createRecord("user", {

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -1,10 +1,10 @@
 import { module, test } from "qunit";
 import { setPrefix } from "discourse-common/lib/get-url";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 function reportWithData(data) {
-  const store = getOwner(this).lookup("service:store");
+  const store = getOwnerWithFallback(this).lookup("service:store");
 
   return store.createRecord("report", {
     type: "topics",
@@ -352,7 +352,7 @@ module("Unit | Model | report", function (hooks) {
       { type: "bytes", property: "filesize", title: "Filesize" },
     ];
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const report = store.createRecord("report", {
       type: "topics",
       labels,

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -2,14 +2,14 @@ import { module, test } from "qunit";
 import RestAdapter from "discourse/adapters/rest";
 import RestModel from "discourse/models/rest";
 import sinon from "sinon";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | rest-model", function (hooks) {
   setupTest(hooks);
 
   test("munging", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     class Grape extends RestModel {}
     Grape.reopenClass({
       munge: function (json) {
@@ -18,13 +18,13 @@ module("Unit | Model | rest-model", function (hooks) {
       },
     });
 
-    getOwner(this).register("model:grape", Grape);
+    getOwnerWithFallback(this).register("model:grape", Grape);
     const g = store.createRecord("grape", { store, percent: 0.4 });
     assert.strictEqual(g.inverse, 0.6, "it runs `munge` on `create`");
   });
 
   test("update", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", 123);
     assert.strictEqual(widget.name, "Trout Lure");
     assert.ok(!widget.isSaving, "it is not saving");
@@ -45,7 +45,7 @@ module("Unit | Model | rest-model", function (hooks) {
   });
 
   test("updating simultaneously", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", 123);
 
     const firstPromise = widget.update({ name: "new name" });
@@ -58,7 +58,7 @@ module("Unit | Model | rest-model", function (hooks) {
   });
 
   test("save new", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget");
 
     assert.ok(widget.isNew, "it is a new record");
@@ -84,7 +84,7 @@ module("Unit | Model | rest-model", function (hooks) {
   });
 
   test("creating simultaneously", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget");
 
     const firstPromise = widget.save({ name: "Evil Widget" });
@@ -97,15 +97,15 @@ module("Unit | Model | rest-model", function (hooks) {
   });
 
   test("destroyRecord", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", 123);
 
     assert.ok(await widget.destroyRecord());
   });
 
   test("custom api name", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
-    getOwner(this).register(
+    const store = getOwnerWithFallback(this).lookup("service:store");
+    getOwnerWithFallback(this).register(
       "adapter:my-widget",
       class extends RestAdapter {
         // An adapter like this is used when the server-side key/url

--- a/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | result-set", function (hooks) {
   setupTest(hooks);
 
   test("defaults", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const resultSet = store.createRecord("result-set", { content: [] });
     assert.strictEqual(resultSet.length, 0);
     assert.strictEqual(resultSet.totalRows, 0);
@@ -17,7 +17,7 @@ module("Unit | Model | result-set", function (hooks) {
   });
 
   test("pagination support", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const resultSet = await store.findAll("widget");
     assert.strictEqual(resultSet.length, 2);
     assert.strictEqual(resultSet.totalRows, 4);
@@ -36,7 +36,7 @@ module("Unit | Model | result-set", function (hooks) {
   });
 
   test("refresh support", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const resultSet = await store.findAll("widget");
     assert.strictEqual(
       resultSet.refreshUrl,

--- a/app/assets/javascripts/discourse/tests/unit/models/site-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/site-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import Site from "discourse/models/site";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | site", function (hooks) {
   setupTest(hooks);
 
   test("create", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     assert.ok(store.createRecord("site"), "it can create with no parameters");
   });
 
@@ -21,7 +21,7 @@ module("Unit | Model | site", function (hooks) {
   });
 
   test("create categories", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const site = store.createRecord("site", {
       categories: [
         { id: 3456, name: "Test Subcategory", parent_category_id: 1234 },
@@ -73,7 +73,7 @@ module("Unit | Model | site", function (hooks) {
   });
 
   test("sortedCategories returns categories sorted by topic counts and sorts child categories after parent", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const site = store.createRecord("site", {
       categories: [
         {

--- a/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | staff-action-log", function (hooks) {
   setupTest(hooks);
 
   test("create", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     assert.ok(
       store.createRecord("staff-action-log"),
       "it can be created without arguments"

--- a/app/assets/javascripts/discourse/tests/unit/models/tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/tag-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | tag", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.store = getOwner(this).lookup("service:store");
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   test("totalCount when pm_count is not present", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | theme", function (hooks) {
   setupTest(hooks);
 
   test("can add an upload correctly", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const theme = store.createRecord("theme");
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import User from "discourse/models/user";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | topic-details", function (hooks) {
   setupTest(hooks);
 
   test("defaults", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const topic = store.createRecord("topic", { id: 1234 });
     const details = topic.details;
 
@@ -16,7 +16,7 @@ module("Unit | Model | topic-details", function (hooks) {
   });
 
   test("updateFromJson", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const topic = store.createRecord("topic", { id: 1234 });
     const details = topic.details;
 

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -2,14 +2,14 @@ import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | topic", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.store = getOwner(this).lookup("service:store");
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   test("defaults", function (assert) {
@@ -204,7 +204,9 @@ module("Unit | Model | topic", function (hooks) {
       fancy_title: "This is a test",
     });
 
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
     siteSettings.support_mixed_text_direction = true;
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -11,7 +11,7 @@ import { NotificationLevels } from "discourse/lib/notification-levels";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import User from "discourse/models/user";
 import sinon from "sinon";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 
 module("Unit | Model | topic-tracking-state", function (hooks) {
@@ -19,7 +19,7 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
 
   hooks.beforeEach(function () {
     this.clock = fakeTime("2012-12-31 12:00");
-    this.store = getOwner(this).lookup("service:store");
+    this.store = getOwnerWithFallback(this).lookup("service:store");
   });
 
   hooks.afterEach(function () {
@@ -672,7 +672,7 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   test("getSubCategoryIds", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const foo = store.createRecord("category", { id: 1, slug: "foo" });
     const bar = store.createRecord("category", {
       id: 2,
@@ -693,7 +693,7 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   test("countNew", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const foo = store.createRecord("category", {
       id: 1,
       slug: "foo",
@@ -842,8 +842,10 @@ module("Unit | Model | topic-tracking-state | /unread", function (hooks) {
   };
 
   hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const store = getOwnerWithFallback(this).lookup("service:store");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     this.currentUser = store.createRecord("user", {
       username: "chuck",
@@ -1095,8 +1097,10 @@ module("Unit | Model | topic-tracking-state | /new", function (hooks) {
   };
 
   hooks.beforeEach(function () {
-    const store = getOwner(this).lookup("service:store");
-    const siteSettings = getOwner(this).lookup("service:site-settings");
+    const store = getOwnerWithFallback(this).lookup("service:store");
+    const siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
 
     this.currentUser = store.createRecord("user", {
       username: "chuck",

--- a/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import UserAction from "discourse/models/user-action";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | user-action", function (hooks) {
   setupTest(hooks);
 
   test("collapsing likes", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const actions = UserAction.collapseStream([
       store.createRecord("user-action", {
         action_type: UserAction.TYPES.likes_given,

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -3,7 +3,7 @@ import UserBadge from "discourse/models/user-badge";
 import badgeFixtures from "discourse/tests/fixtures/user-badges";
 import { cloneJSON } from "discourse-common/lib/object";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | user-badge", function (hooks) {
   setupTest(hooks);
@@ -58,14 +58,14 @@ module("Unit | Model | user-badge", function (hooks) {
   });
 
   test("revoke", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const userBadge = store.createRecord("user-badge", { id: 1 });
     const result = await userBadge.revoke();
     assert.deepEqual(result, { success: true });
   });
 
   test("favorite", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const userBadge = store.createRecord("user-badge", { id: 1 });
     assert.notOk(userBadge.is_favorite);
 

--- a/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
@@ -2,13 +2,13 @@ import { module, test } from "qunit";
 import I18n from "I18n";
 import { NEW_TOPIC_KEY } from "discourse/models/composer";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | user-draft", function (hooks) {
   setupTest(hooks);
 
   test("stream", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { id: 1, username: "eviltrout" });
     const stream = user.userDraftsStream;
 
@@ -22,7 +22,7 @@ module("Unit | Model | user-draft", function (hooks) {
   });
 
   test("draft", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const drafts = [
       store.createRecord("user-draft", {
         draft_key: "topic_1",

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -1,13 +1,13 @@
 import { module, test } from "qunit";
 import UserAction from "discourse/models/user-action";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | user-stream", function (hooks) {
   setupTest(hooks);
 
   test("basics", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { id: 1, username: "eviltrout" });
     const stream = user.stream;
     assert.present(stream, "a user has a stream by default");
@@ -21,7 +21,7 @@ module("Unit | Model | user-stream", function (hooks) {
   });
 
   test("filterParam", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { id: 1, username: "eviltrout" });
     const stream = user.stream;
 

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -4,13 +4,13 @@ import PreloadStore from "discourse/lib/preload-store";
 import sinon from "sinon";
 import { settled } from "@ember/test-helpers";
 import User from "discourse/models/user";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Model | user", function (hooks) {
   setupTest(hooks);
 
   test("staff", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { id: 1, username: "eviltrout" });
 
     assert.ok(!user.staff, "user is not staff");
@@ -23,7 +23,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("searchContext", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { id: 1, username: "EvilTrout" });
 
     assert.deepEqual(
@@ -34,7 +34,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("isAllowedToUploadAFile", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { trust_level: 0, admin: true });
     assert.ok(
       user.isAllowedToUploadAFile("image"),
@@ -49,7 +49,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("canMangeGroup", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", { admin: true });
     const group = store.createRecord("group", { automatic: true });
 
@@ -79,7 +79,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("muted ids", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", {
       username: "chuck",
       muted_category_ids: [],
@@ -118,7 +118,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("subsequent calls to trackStatus and stopTrackingStatus increase and decrease subscribers counter", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user");
     assert.strictEqual(user._subscribersCount, 0);
 
@@ -136,7 +136,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("attempt to stop tracking status if status wasn't tracked doesn't throw", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user");
     user.stopTrackingStatus();
     assert.ok(true);
@@ -151,7 +151,7 @@ module("Unit | Model | user", function (hooks) {
       description: "user2 status",
       emoji: "speech_balloon",
     };
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user1 = store.createRecord("user", {
       id: 1,
       status: status1,
@@ -179,7 +179,7 @@ module("Unit | Model | user", function (hooks) {
   });
 
   test("create() doesn't set internal status tracking fields", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const user = store.createRecord("user", {
       _subscribersCount: 10,
       _clearStatusTimerId: 100,

--- a/app/assets/javascripts/discourse/tests/unit/models/wizard-field-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/wizard-field-test.js
@@ -1,4 +1,4 @@
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 
@@ -6,7 +6,7 @@ module("Unit | Model | Wizard | wizard-field", function (hooks) {
   setupTest(hooks);
 
   test("basic state", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const field = store.createRecord("wizard-field", { type: "text" });
     assert.ok(field.unchecked);
     assert.ok(!field.valid);
@@ -14,7 +14,7 @@ module("Unit | Model | Wizard | wizard-field", function (hooks) {
   });
 
   test("text - required - validation", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const field = store.createRecord("wizard-field", {
       type: "text",
       required: true,
@@ -34,7 +34,7 @@ module("Unit | Model | Wizard | wizard-field", function (hooks) {
   });
 
   test("text - optional - validation", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const field = store.createRecord("wizard-field", { type: "text" });
     assert.ok(field.unchecked);
 

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 import Session from "discourse/models/session";
 
@@ -9,7 +9,9 @@ module("Unit | Service | document-title", function (hooks) {
 
   hooks.beforeEach(function () {
     Session.current().hasFocus = true;
-    this.documentTitle = getOwner(this).lookup("service:document-title");
+    this.documentTitle = getOwnerWithFallback(this).lookup(
+      "service:document-title"
+    );
   });
 
   test("it updates the document title", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/services/emoji-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/emoji-store-test.js
@@ -1,12 +1,12 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
 module("Unit | Service | emoji-store", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.emojiStore = getOwner(this).lookup("service:emoji-store");
+    this.emojiStore = getOwnerWithFallback(this).lookup("service:emoji-store");
     this.emojiStore.reset();
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/services/lightbox-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/lightbox-test.js
@@ -6,7 +6,7 @@ import { module, test } from "qunit";
 import { click } from "@ember/test-helpers";
 import { LIGHTBOX_APP_EVENT_NAMES } from "discourse/lib/lightbox/constants";
 import domFromString from "discourse-common/lib/dom-from-string";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { setupTest } from "ember-qunit";
 import sinon from "sinon";
 
@@ -17,8 +17,8 @@ module("Unit | Service | Experimental Lightbox", function (hooks) {
   const selector = ".lightbox";
 
   hooks.beforeEach(function () {
-    this.lightbox = getOwner(this).lookup("service:lightbox");
-    this.appEvents = getOwner(this).lookup("service:app-events");
+    this.lightbox = getOwnerWithFallback(this).lookup("service:lightbox");
+    this.appEvents = getOwnerWithFallback(this).lookup("service:app-events");
   });
 
   test("Lightbox Service has appEvents", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
@@ -7,7 +7,7 @@ import { PresenceChannelNotFound } from "discourse/services/presence";
 import { setTestPresence } from "discourse/lib/user-presence";
 import sinon from "sinon";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 function usersFixture() {
@@ -63,7 +63,7 @@ module("Unit | Service | presence | subscribing", function (hooks) {
   });
 
   test("subscribing and receiving updates", async function (assert) {
-    let presenceService = getOwner(this).lookup("service:presence");
+    let presenceService = getOwnerWithFallback(this).lookup("service:presence");
     let channel = presenceService.getChannel("/test/ch1");
     let changes = 0;
     const countChanges = () => changes++;
@@ -106,7 +106,7 @@ module("Unit | Service | presence | subscribing", function (hooks) {
   });
 
   test("fetches data when no initial state", async function (assert) {
-    let presenceService = getOwner(this).lookup("service:presence");
+    let presenceService = getOwnerWithFallback(this).lookup("service:presence");
     let channel = presenceService.getChannel("/test/ch1");
 
     await channel.subscribe();
@@ -152,7 +152,7 @@ module("Unit | Service | presence | subscribing", function (hooks) {
   });
 
   test("raises error when subscribing to nonexistent channel", async function (assert) {
-    let presenceService = getOwner(this).lookup("service:presence");
+    let presenceService = getOwnerWithFallback(this).lookup("service:presence");
     let channel = presenceService.getChannel("/nonexistent/ch1");
 
     assert.rejects(
@@ -163,7 +163,7 @@ module("Unit | Service | presence | subscribing", function (hooks) {
   });
 
   test("can subscribe to count_only channel", async function (assert) {
-    let presenceService = getOwner(this).lookup("service:presence");
+    let presenceService = getOwnerWithFallback(this).lookup("service:presence");
     let channel = presenceService.getChannel("/count-only/ch1");
 
     await channel.subscribe();
@@ -200,7 +200,7 @@ module("Unit | Service | presence | subscribing", function (hooks) {
   });
 
   test("can share data between multiple PresenceChannel objects", async function (assert) {
-    let presenceService = getOwner(this).lookup("service:presence");
+    let presenceService = getOwnerWithFallback(this).lookup("service:presence");
     let channel = presenceService.getChannel("/test/ch1");
     let channelDup = presenceService.getChannel("/test/ch1");
 
@@ -285,7 +285,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("can join and leave channels", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 
@@ -312,7 +313,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("join should be a no-op if already present", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 
@@ -328,7 +330,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("leave should be a no-op if not present", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 
@@ -352,7 +355,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
       (resolve) => (resolveServerResponse = resolve)
     );
 
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 
@@ -377,7 +381,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("raises an error when entering a non-existent channel", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/blah/does-not-exist");
     await assert.rejects(
@@ -388,7 +393,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("deduplicates calls from multiple PresenceChannel instances", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
     const channelDup = presenceService.getChannel("/test/ch1");
@@ -427,7 +433,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("updates the server presence after going idle", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 
@@ -464,7 +471,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   test("handles the onlyWhileActive flag", async function (assert) {
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
     await channel.enter();
@@ -523,7 +531,8 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
       return response(429, { extras: { wait_seconds: 2 } });
     });
 
-    const presenceService = getOwner(this).lookup("service:presence");
+    const presenceService =
+      getOwnerWithFallback(this).lookup("service:presence");
     presenceService.currentUser = currentUser();
     const channel = presenceService.getChannel("/test/ch1");
 

--- a/app/assets/javascripts/discourse/tests/unit/services/site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/site-settings-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { inject as service } from "@ember/service";
 import EmberObject, { computed } from "@ember/object";
 
@@ -17,7 +17,9 @@ module("Unit | Service | site-settings", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.siteSettings = getOwner(this).lookup("service:site-settings");
+    this.siteSettings = getOwnerWithFallback(this).lookup(
+      "service:site-settings"
+    );
   });
 
   test("contains settings", function (assert) {
@@ -27,8 +29,8 @@ module("Unit | Service | site-settings", function (hooks) {
   test("notifies getters", function (assert) {
     this.siteSettings.title = "original";
 
-    getOwner(this).register("test-class:main", TestClass);
-    const object = getOwner(this).lookup("test-class:main");
+    getOwnerWithFallback(this).register("test-class:main", TestClass);
+    const object = getOwnerWithFallback(this).lookup("test-class:main");
     assert.strictEqual(object.text, "The title: original");
 
     this.siteSettings.title = "updated";

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import pretender, {
   fixturesByUrl,
   response,
@@ -10,7 +10,7 @@ module("Unit | Service | store", function (hooks) {
   setupTest(hooks);
 
   test("createRecord", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget", { id: 111, name: "hello" });
 
     assert.false(widget.isNew, "it is not a new record");
@@ -19,7 +19,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("createRecord without an `id`", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget", { name: "hello" });
 
     assert.true(widget.isNew, "it is a new record");
@@ -27,7 +27,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("createRecord doesn't modify the input `id` field", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget", { id: 1, name: "hello" });
 
     const obj = { id: 1, name: "something" };
@@ -39,7 +39,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("createRecord without attributes", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget");
 
     assert.strictEqual(widget.id, undefined, "there is no id");
@@ -47,7 +47,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("createRecord with a record as attributes returns that record from the map", function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget", { id: 33 });
     const secondWidget = store.createRecord("widget", { id: 33 });
 
@@ -55,7 +55,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("find", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
 
     const widget = await store.find("widget", 123);
     assert.strictEqual(widget.name, "Trout Lure");
@@ -78,19 +78,19 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("find with object id", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", { id: 123 });
     assert.strictEqual(widget.firstObject.name, "Trout Lure");
   });
 
   test("find with query param", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", { name: "Trout Lure" });
     assert.strictEqual(widget.firstObject.id, 123);
   });
 
   test("findStale with no stale results", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const stale = store.findStale("widget", { name: "Trout Lure" });
 
     assert.false(stale.hasResults, "there are no stale results");
@@ -118,7 +118,7 @@ module("Unit | Service | store", function (hooks) {
       }
     });
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const notifications = await store.find("notification", { slug: "souna" });
     assert.strictEqual(notifications.content[0].slug, "souna");
 
@@ -131,19 +131,19 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("update", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const result = await store.update("widget", 123, { name: "hello" });
     assert.strictEqual(result.payload.name, "hello");
   });
 
   test("update with a multi world name", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const result = await store.update("cool-thing", 123, { name: "hello" });
     assert.strictEqual(result.payload.name, "hello");
   });
 
   test("findAll", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const result = await store.findAll("widget");
     assert.strictEqual(result.length, 2);
 
@@ -153,7 +153,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("destroyRecord", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = await store.find("widget", 123);
 
     const result = await store.destroyRecord("widget", widget);
@@ -161,14 +161,14 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("destroyRecord when new", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const widget = store.createRecord("widget", { name: "hello" });
 
     assert.true(await store.destroyRecord("widget", widget));
   });
 
   test("find embedded", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const fruit = await store.find("fruit", 1);
 
     assert.propContains(
@@ -182,7 +182,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("embedded records can be cleared", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     let fruit = await store.find("fruit", 4);
     fruit.set("farmer", { dummy: "object" });
 
@@ -191,7 +191,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("meta types", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const barn = await store.find("barn", 1);
     assert.strictEqual(
       barn.owner.name,
@@ -201,7 +201,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("findAll embedded", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const fruits = await store.findAll("fruit");
     assert.strictEqual(fruits.objectAt(0).farmer.name, "Old MacDonald");
     assert.strictEqual(
@@ -235,7 +235,7 @@ module("Unit | Service | store", function (hooks) {
       });
     });
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const users = await store.findAll("user");
     assert.strictEqual(users.objectAt(0).username, "souna");
   });
@@ -249,7 +249,7 @@ module("Unit | Service | store", function (hooks) {
       return response(fixturesByUrl["/c/bug/1/l/latest.json"]);
     });
 
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const result = await store.findFiltered("topicList", {
       filter: "topics/created-by/trout",
       params: {
@@ -265,7 +265,7 @@ module("Unit | Service | store", function (hooks) {
   });
 
   test("Spec incompliant embedded record name", async function (assert) {
-    const store = getOwner(this).lookup("service:store");
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const fruit = await store.find("fruit", 4);
 
     assert.propContains(

--- a/app/assets/javascripts/discourse/tests/unit/services/user-tips-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/user-tips-test.js
@@ -1,15 +1,15 @@
 import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Unit | Service | user-tips", function (needs) {
   needs.user();
 
   test("hideUserTipForever() makes a single request", async function (assert) {
-    const site = getOwner(this).lookup("service:site");
+    const site = getOwnerWithFallback(this).lookup("service:site");
     site.set("user_tips", { first_notification: 1 });
-    const userTips = getOwner(this).lookup("service:user-tips");
+    const userTips = getOwnerWithFallback(this).lookup("service:user-tips");
 
     let requestsCount = 0;
     pretender.put("/u/eviltrout.json", () => {

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -5,7 +5,7 @@ import { inject as service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DFloatBody from "float-kit/components/d-float-body";
 import concatClass from "discourse/helpers/concat-class";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import DMenuInstance from "float-kit/lib/d-menu-instance";
 
 export default class DMenu extends Component {

--- a/app/assets/javascripts/float-kit/addon/components/d-tooltip.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-tooltip.gjs
@@ -6,7 +6,7 @@ import { inject as service } from "@ember/service";
 import DFloatBody from "float-kit/components/d-float-body";
 import concatClass from "discourse/helpers/concat-class";
 import DTooltipInstance from "float-kit/lib/d-tooltip-instance";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import and from "truth-helpers/helpers/and";
 
 export default class DTooltip extends Component {

--- a/app/assets/javascripts/float-kit/addon/services/toasts.js
+++ b/app/assets/javascripts/float-kit/addon/services/toasts.js
@@ -4,7 +4,7 @@ import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import { action } from "@ember/object";
 import DDefaultToast from "float-kit/components/d-default-toast";
 import DToastInstance from "float-kit/lib/d-toast-instance";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 export default class Toasts extends Service {
   @tracked activeToasts = new TrackedArray();

--- a/app/assets/javascripts/wizard/addon/components/wizard-field-image.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-field-image.js
@@ -3,7 +3,7 @@ import { warn } from "@ember/debug";
 import I18n from "I18n";
 import { dasherize } from "@ember/string";
 import discourseComputed from "discourse-common/utils/decorators";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import getUrl from "discourse-common/lib/get-url";
 import Uppy from "@uppy/core";
 import DropTarget from "@uppy/drop-target";
@@ -18,7 +18,9 @@ export default Component.extend({
   @discourseComputed("field.id")
   previewComponent(id) {
     const componentName = `image-preview-${dasherize(id)}`;
-    const exists = getOwner(this).lookup(`component:${componentName}`);
+    const exists = getOwnerWithFallback(this).lookup(
+      `component:${componentName}`
+    );
     return exists ? componentName : "wizard-image-preview";
   },
 


### PR DESCRIPTION
Our custom implementation of `getOwner` includes a fallback which returns an owner, even if the passed object does not have one set. This is confusing and creates a false sense of security. Generally if the fallback is used, it means there is a problem with the patterns being used.

This commit renames our custom implementation to `getOwnerWithFallback`, while maintaining the old `getOwner` export with a deprecation notice. Core code is updated to use the official `@ember/application` implementation, or the new `getOwnerWithFallback` function.

This commit updates all core uses of `{ getOwner } from discourse-common/lib/get-owner` to use `getOwnerWithFallback`. Future commits will work through and convert many of these to use the official `@ember/application` implementation