### PR TITLE
FIX: Everyone should be aware a cached summary is outdated.

### DIFF
--- a/app/services/topic_summarization.rb
+++ b/app/services/topic_summarization.rb
@@ -18,9 +18,7 @@ class TopicSummarization
 
     if use_cached?(existing_summary, can_summarize, current_topic_sha, !!opts[:skip_age_check])
       # It's important that we signal a cached summary is outdated
-      if can_summarize && new_targets?(existing_summary, current_topic_sha)
-        existing_summary.mark_as_outdated
-      end
+      existing_summary.mark_as_outdated if new_targets?(existing_summary, current_topic_sha)
 
       return existing_summary
     end


### PR DESCRIPTION
This should be the case even they cannot regenerate it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
