### PR TITLE
DEV: Fix badge tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
@@ -1,4 +1,8 @@
 import { module, test } from "qunit";
+import pretender, {
+  parsePostData,
+  response,
+} from "discourse/tests/helpers/create-pretender";
 import Badge from "discourse/models/badge";
 import { setupTest } from "ember-qunit";
 import { getOwner } from "discourse-common/lib/get-owner";
@@ -61,27 +65,48 @@ module("Unit | Model | badge", function (hooks) {
     );
   });
 
-  test("save", function (assert) {
-    assert.expect(0);
+  test("save", async function (assert) {
     const store = getOwner(this).lookup("service:store");
     const badge = store.createRecord("badge", {
+      id: 1999,
       name: "New Badge",
       description: "This is a new badge.",
       badge_type_id: 1,
     });
-    badge.save(["name", "description", "badge_type_id"]);
+
+    pretender.put("/admin/badges/1999", (request) => {
+      const params = parsePostData(request.requestBody);
+      assert.deepEqual(params, { description: "A special badge!" });
+      assert.step("called API");
+      return response({});
+    });
+
+    await badge.save({
+      description: "A special badge!",
+    });
+
+    assert.verifySteps(["called API"]);
   });
 
-  test("destroy", function (assert) {
-    assert.expect(0);
+  test("destroy", async function (assert) {
     const store = getOwner(this).lookup("service:store");
     const badge = store.createRecord("badge", {
       name: "New Badge",
       description: "This is a new badge.",
       badge_type_id: 1,
     });
-    badge.destroy();
+
+    pretender.delete("/admin/badges/3", () => {
+      assert.step("called API");
+      return response({});
+    });
+
+    // Doesn't call the API if destroying a new badge
+    await badge.destroy();
+
     badge.set("id", 3);
-    badge.destroy();
+    await badge.destroy();
+
+    assert.verifySteps(["called API"]);
   });
 });


### PR DESCRIPTION
`badge.save(["name", "description", "badge_type_id"])` api it was testing isn't a thing anymore.

Also: replaces `assert.expect(0)` with more useful assertions

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
