### PR TITLE
DEV: Validate before and bumped_before options in TopicQuery

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -19,6 +19,8 @@ class TopicQuery
         array_or_string = lambda { |x| Array === x || String === x }
 
         {
+          before: zero_up_to_max_int,
+          bumped_before: zero_up_to_max_int,
           max_posts: zero_up_to_max_int,
           min_posts: zero_up_to_max_int,
           page: zero_up_to_max_int,

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe ListController do
 
       get "/latest?tags[1]=hello"
       expect(response.status).to eq(400)
+
+      get "/latest?before[1]=haxx"
+      expect(response.status).to eq(400)
+
+      get "/latest?bumped_before[1]=haxx"
+      expect(response.status).to eq(400)
     end
 
     it "returns 200 for legit requests" do


### PR DESCRIPTION
### What is this change?

We're seeing a lot of log noise from malicious scanners trying to exfiltrate date using different crafted parameters which end up in the `TopicQuery`. These are currently erroring out as unhandled `NoMethodError` exceptions.

This PR adds validation for the `before` and `bumped_before` parameters which are frequently targeted and unvalidated.