### PR TITLE
DEV: Use string key instead of symbol for mobile view param

### DIFF
--- a/lib/mobile_detection.rb
+++ b/lib/mobile_detection.rb
@@ -9,9 +9,9 @@ module MobileDetection
   def self.resolve_mobile_view!(user_agent, params, session)
     return false unless SiteSetting.enable_mobile_theme
 
-    session[:mobile_view] = params[:mobile_view] if params && params.has_key?(:mobile_view)
-    session[:mobile_view] = nil if params && params.has_key?(:mobile_view) &&
-      params[:mobile_view] == "auto"
+    session[:mobile_view] = params["mobile_view"] if params && params.has_key?("mobile_view")
+    session[:mobile_view] = nil if params && params.has_key?("mobile_view") &&
+      params["mobile_view"] == "auto"
 
     if session && session[:mobile_view]
       session[:mobile_view] == "1"


### PR DESCRIPTION
The params look like that locally 
```
{"for_url"=>"/admin/plugins?mobile_view=true", "mobile_view"=>"true", "controller"=>"bootstrap", "action"=>"index", "format"=>"json"}
```

So the `:mobile_view` check would always be false unfortunately. This fixes that.

Here is what it looks like when a background style is added and also seen in `mobile_view=true`

![image](https://github.com/discourse/discourse/assets/1555215/609c1f74-2506-4507-833c-e75d810a7c28)
