### PR TITLE
DEV: Add env to configure Capybara to run against a remote chrome

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -381,14 +381,22 @@ RSpec.configure do |config|
           options.add_preference("download.default_directory", Downloads::FOLDER)
         end
 
+    driver_options = { browser: :chrome }
+
+    if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
+      driver_options[:browser] = :remote
+      driver_options[:url] = ENV["CAPYBARA_REMOTE_DRIVER_URL"]
+    end
+
+    desktop_driver_options = driver_options.merge(options: chrome_browser_options)
+
     Capybara.register_driver :selenium_chrome do |app|
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_browser_options)
+      Capybara::Selenium::Driver.new(app, **desktop_driver_options)
     end
 
     Capybara.register_driver :selenium_chrome_headless do |app|
       chrome_browser_options.add_argument("--headless=new")
-
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_browser_options)
+      Capybara::Selenium::Driver.new(app, **desktop_driver_options)
     end
 
     mobile_chrome_browser_options =
@@ -402,13 +410,15 @@ RSpec.configure do |config|
           apply_base_chrome_options(options)
         end
 
+    mobile_driver_options = driver_options.merge(options: mobile_chrome_browser_options)
+
     Capybara.register_driver :selenium_mobile_chrome do |app|
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: mobile_chrome_browser_options)
+      Capybara::Selenium::Driver.new(app, **mobile_driver_options)
     end
 
     Capybara.register_driver :selenium_mobile_chrome_headless do |app|
       mobile_chrome_browser_options.add_argument("--headless=new")
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: mobile_chrome_browser_options)
+      Capybara::Selenium::Driver.new(app, **mobile_driver_options)
     end
 
     if ENV["ELEVATED_UPLOADS_ID"]


### PR DESCRIPTION
What motivated this change?

We are currently working on allowing system tests to be run within a
Docker container. While system tests are usually ran in chrome headless
mode, it is useful to also be able to run the system tests with chrome
in the non-headless mode. However, running a GUI application from within
a docker container is not usually recommended and from our research
quite difficult. As such, we want to allow running system tests against
a remote browser.

For example, one can run a `chromedriver` server on localhost and then
configure Capybara to connect to the `chromedriver` from within the
container.

What does this change do?

This change adds support for a `CAPYBARA_REMOTE_DRIVER_URL` env variable
which will switch Capybara to use the remote driver instead of the
`chrome` driver. Currently, we expect the remote driver to be a
`chromedriver` server.