### PR TITLE
DEV: Remove accidentally hardcoded Redis port in `docker.rake`

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -28,7 +28,7 @@ def setup_redis
   log "Starting background redis"
   data_directory = "#{Rails.root}/tmp/test_data/redis"
   `rm -rf #{data_directory} && mkdir -p #{data_directory}`
-  Process.spawn("redis-server --dir #{data_directory} --port 1234")
+  Process.spawn("redis-server --dir #{data_directory}")
 end
 
 def migrate_databases(parallel: false, load_plugins: false)


### PR DESCRIPTION
Follow up to 9caba30d5c9adb81c11185e67b986d13545f5152