### PR TITLE
DEV: Expand custom emojis allowed image types

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/components/emoji-uploader.hbs
@@ -37,7 +37,7 @@
         disabled={{this.uploading}}
         type="file"
         multiple="true"
-        accept=".png,.gif"
+        accept="image/*, .heif, .heic"
       />
       <DButton
         @translatedLabel={{this.buttonLabel}}


### PR DESCRIPTION
The custom emoji file input only accepts `png` and `gif`. No check is made server side, and uploading any image format supported by Discourse works. This fix allows upload of any image type supported by `"image/*"`, plus `heif` and `heic` since Discourse also officially supports them.

As far as I know, there are no related tests, so I didn't do anything regarding this.

It's worth noting that the avatar file input is currently set as `accept="image/*"`
