### PR TITLE
DEV: Update asset config for embroider

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -21,7 +21,9 @@
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/discourse.css" />
 
-    <script defer src="{{rootURL}}assets/vendor.js"></script>
+    <discourse-chunked-script entrypoint="vendor">
+      <script defer src="{{rootURL}}assets/vendor.js"></script>
+    </discourse-chunked-script>
 
     <discourse-chunked-script entrypoint="discourse">
       <ember-auto-import-scripts defer entrypoint="app"></ember-auto-import-scripts>
@@ -51,7 +53,7 @@
 
     <bootstrap-content key="hidden-login-form"></bootstrap-content>
 
-    <script defer src="{{rootURL}}assets/start-discourse.js"></script>
+    <script defer src="{{rootURL}}assets/start-discourse.js" data-embroider-ignore></script>
 
     <bootstrap-content key="body-footer"></bootstrap-content>
     {{content-for "body-footer"}}

--- a/app/assets/javascripts/discourse/tests/index.html
+++ b/app/assets/javascripts/discourse/tests/index.html
@@ -41,14 +41,16 @@
       }
     </style>
 
-    <script src="{{rootURL}}assets/test-i18n.js"></script>
-    <script src="{{rootURL}}assets/test-site-settings.js"></script>
+    <script src="{{rootURL}}assets/test-i18n.js" data-embroider-ignore></script>
+    <script src="{{rootURL}}assets/test-site-settings.js" data-embroider-ignore></script>
   </head>
   <body>
     {{content-for "body"}} {{content-for "test-body"}}
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
-    <script src="{{rootURL}}assets/vendor.js"></script>
+    <discourse-chunked-script entrypoint="vendor">
+      <script src="{{rootURL}}assets/vendor.js"></script>
+    </discourse-chunked-script>
     
     <discourse-chunked-script entrypoint="test-support">
       <script src="{{rootURL}}assets/test-support.js"></script>
@@ -69,8 +71,8 @@
       {{content-for "test-plugin-css"}}
       {{content-for "test-plugin-js"}}
       {{content-for "test-plugin-tests-js"}}
-      <script defer src="{{rootURL}}assets/scripts/discourse-test-trigger-ember-cli-boot.js"></script>
-      <script defer src="{{rootURL}}assets/scripts/discourse-boot.js"></script>
+      <script defer src="{{rootURL}}assets/scripts/discourse-test-trigger-ember-cli-boot.js" data-embroider-ignore></script>
+      <script defer src="{{rootURL}}assets/scripts/discourse-boot.js" data-embroider-ignore></script>
       {{content-for "body-footer"}} {{content-for "test-body-footer"}}
     </template>
 
@@ -78,7 +80,7 @@
     </discourse-dynamic-test-js>
 
     <!-- This script takes the <template>, filters plugin assets as required, then appends to discourse-dynamic-test-js -->
-    <script src="{{rootURL}}assets/scripts/discourse-test-load-dynamic-js.js"></script>
+    <script src="{{rootURL}}assets/scripts/discourse-test-load-dynamic-js.js" data-embroider-ignore></script>
 
   </body>
 </html>


### PR DESCRIPTION
- Add data-embroider-ignore to all script tags which are not currently being compiled by embroider

- Ensure all remaining script tags are wrapped in `<discourse-chunked-script>` so that Rails will follow any renames which Embroider makes (e.g. when it adds fingerprints to filenames)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
