### PR TITLE
DEV: Enable sourcemaps in production under Embroider

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -199,6 +199,7 @@ module.exports = function (defaults) {
     extraPublicTrees,
     packagerOptions: {
       webpackConfig: {
+        devtool: "source-map",
         externals: [
           function ({ request }, callback) {
             if (


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
