### PR TITLE
DEV: common CSS property for content backgrounds

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -4,7 +4,7 @@
 
 <PluginOutlet @name="before-groups-index-container" @connectorTagName="div" />
 
-<DSection @pageClass="groups">
+<DSection @pageClass="groups" @class="container groups-index">
   <div class="groups-header">
     {{#if this.currentUser.can_create_group}}
       <DButton

--- a/app/assets/javascripts/discourse/app/templates/tags/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.hbs
@@ -2,59 +2,63 @@
   <DiscourseBanner @user={{this.currentUser}} @banner={{this.site.banner}} />
 </div>
 
-<div class="list-controls">
-  <div class="container tags-controls">
-    {{#if this.canAdminTags}}
-      <TagsAdminDropdown @actionsMapping={{this.actionsMapping}} />
-    {{/if}}
-    <h2>{{i18n "tagging.tags"}}</h2>
+<div class="container tags-index">
+
+  <div class="list-controls">
+    <div class="container tags-controls">
+      {{#if this.canAdminTags}}
+        <TagsAdminDropdown @actionsMapping={{this.actionsMapping}} />
+      {{/if}}
+      <h2>{{i18n "tagging.tags"}}</h2>
+    </div>
   </div>
-</div>
 
-<div>
-  <PluginOutlet
-    @name="tags-below-title"
-    @connectorTagName="div"
-    @outletArgs={{hash model=this.model}}
-  />
-</div>
-
-<div class="tag-sort-options">
-  {{i18n "tagging.sort_by"}}
-  <span class="tag-sort-count {{if this.sortedByCount 'active'}}"><a
-      href
-      {{on "click" this.sortByCount}}
-    >{{i18n "tagging.sort_by_count"}}</a></span>
-  <span class="tag-sort-name {{if this.sortedByName 'active'}}"><a
-      href
-      {{on "click" this.sortById}}
-    >{{i18n "tagging.sort_by_name"}}</a></span>
-</div>
-
-<hr />
-
-<div class="all-tag-lists">
-  {{#each this.model.extras.categories as |category|}}
-    <TagList
-      @tags={{category.tags}}
-      @sortProperties={{this.sortProperties}}
-      @categoryId={{category.id}}
+  <div>
+    <PluginOutlet
+      @name="tags-below-title"
+      @connectorTagName="div"
+      @outletArgs={{hash model=this.model}}
     />
-  {{/each}}
+  </div>
 
-  {{#each this.model.extras.tag_groups as |tagGroup|}}
-    <TagList
-      @tags={{tagGroup.tags}}
-      @sortProperties={{this.sortProperties}}
-      @tagGroupName={{tagGroup.name}}
-    />
-  {{/each}}
+  <div class="tag-sort-options">
+    {{i18n "tagging.sort_by"}}
+    <span class="tag-sort-count {{if this.sortedByCount 'active'}}"><a
+        href
+        {{on "click" this.sortByCount}}
+      >{{i18n "tagging.sort_by_count"}}</a></span>
+    <span class="tag-sort-name {{if this.sortedByName 'active'}}"><a
+        href
+        {{on "click" this.sortById}}
+      >{{i18n "tagging.sort_by_name"}}</a></span>
+  </div>
 
-  {{#if this.model}}
-    <TagList
-      @tags={{this.model}}
-      @sortProperties={{this.sortProperties}}
-      @titleKey={{this.otherTagsTitleKey}}
-    />
-  {{/if}}
+  <hr />
+
+  <div class="all-tag-lists">
+    {{#each this.model.extras.categories as |category|}}
+      <TagList
+        @tags={{category.tags}}
+        @sortProperties={{this.sortProperties}}
+        @categoryId={{category.id}}
+      />
+    {{/each}}
+
+    {{#each this.model.extras.tag_groups as |tagGroup|}}
+      <TagList
+        @tags={{tagGroup.tags}}
+        @sortProperties={{this.sortProperties}}
+        @tagGroupName={{tagGroup.name}}
+      />
+    {{/each}}
+
+    {{#if this.model}}
+      <TagList
+        @tags={{this.model}}
+        @sortProperties={{this.sortProperties}}
+        @titleKey={{this.otherTagsTitleKey}}
+      />
+    {{/if}}
+  </div>
+
 </div>

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -10,6 +10,7 @@ $mobile-breakpoint: 700px;
   width: 100%;
   overflow: hidden;
   height: 100%;
+  background: var(--d-content-background);
 
   @include breakpoint(tablet) {
     width: calc(100% + 10px);

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -1,6 +1,8 @@
 // Topic list navigation & controls
 
 .list-controls {
+  background: var(--d-content-background);
+
   a.badge-category {
     padding: 3px 12px;
     font-size: var(--font-up-1);
@@ -113,6 +115,10 @@
 
 .topic-list.shared-drafts {
   margin-bottom: 1.5em;
+}
+
+#header-list-area {
+  background: var(--d-content-background);
 }
 
 // Topic list body
@@ -369,6 +375,7 @@
 }
 
 #list-area {
+  background: var(--d-content-background);
   margin-bottom: 100px;
 
   .empty-topic-list {

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -5,6 +5,7 @@
 
 .directory {
   margin-bottom: 100px;
+  background: var(--d-content-background);
 
   &.users-directory {
     .directory-group-selector {

--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -2,6 +2,7 @@
   /* covers /about, /faq, /guidelines, /tos, /privacy, and login-required */
   width: 100%;
   max-width: 700px;
+  background: var(--d-content-background);
   .about-page & {
     max-width: unset;
     section:not(.admins):not(.moderators):not(.category-moderators) {

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -4,6 +4,10 @@
 
 @use "sass:math";
 
+.container.group {
+  background: var(--d-content-background);
+}
+
 .group-details-container {
   background: var(--primary-very-low);
   padding: 20px;

--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.container.groups-index {
+  background: var(--d-content-background);
+}
+
 .groups-boxes {
   display: grid;
   grid-gap: 1em;

--- a/app/assets/stylesheets/common/base/not-found.scss
+++ b/app/assets/stylesheets/common/base/not-found.scss
@@ -1,5 +1,9 @@
 // Page not found styles
 
+.not-found-container {
+  background: var(--d-content-background);
+}
+
 .page-not-found {
   margin: 0 0 40px 0;
 

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -1,4 +1,6 @@
 .reviewable {
+  background: var(--d-content-background);
+
   .flagged-post-header {
     width: 100%;
     display: flex;

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -11,6 +11,8 @@
 }
 
 .search-container {
+  background: var(--d-content-background);
+
   .search-header {
     @include search-page-spacing();
     background: var(--primary-very-low);

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -1,3 +1,7 @@
+.container.tags-index {
+  background: var(--d-content-background);
+}
+
 .topic-title-outlet.choose-tags {
   margin-left: 25px;
   margin-top: 3px;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1,3 +1,7 @@
+#main-outlet > .regular {
+  background: var(--d-content-background);
+}
+
 .button-count.has-pending {
   span {
     background-color: var(--danger);

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -330,6 +330,7 @@ a.badge-category {
 }
 
 .private_message {
+  background: var(--d-content-background);
   #topic-title {
     .edit-topic-title {
       position: relative;

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -1,4 +1,8 @@
 /* Default badge styles. */
+.show-badge {
+  background: var(--d-content-background);
+}
+
 .user-badge {
   padding: 3px 8px;
   color: var(--primary);
@@ -229,6 +233,10 @@
   @media screen and (max-width: $small-width) {
     justify-content: space-between;
   }
+}
+
+.container.badges {
+  background: var(--d-content-background);
 }
 
 .badge-groups {

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -78,6 +78,8 @@
 }
 
 .user-main {
+  background: var(--d-content-background);
+
   .about {
     width: 100%;
     margin-bottom: 0;

--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -7,7 +7,7 @@
   // selectors below are its children
   .item,
   .user-stream-item {
-    background-color: var(--secondary);
+    background: var(--d-content-background, var(--secondary));
     border-bottom: 1px solid var(--primary-low);
     padding: 1em 0.53em;
     list-style: none;

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -11,6 +11,7 @@
   --d-nav-pill-border-radius: var(--d-border-radius);
   --d-button-border-radius: var(--d-border-radius);
   --d-input-border-radius: var(--d-border-radius);
+  --d-content-background: initial;
 }
 
 // --------------------------------------------------

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -92,7 +92,7 @@
   margin-top: 2em;
   padding-bottom: 12px;
   margin-bottom: 12px;
-  background-color: var(--secondary);
+  background: var(--d-content-background, var(--secondary));
   box-sizing: border-box;
 
   .btn.right {

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -195,6 +195,7 @@ body.has-full-page-chat {
 .full-page-chat {
   display: grid;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
+  background: var(--d-content-background);
 
   .chat-full-page-header {
     border-top: 1px solid var(--primary-low);

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -168,7 +168,7 @@
 }
 
 .chat-message-container {
-  background-color: var(--secondary);
+  background-color: var(--d-content-background, var(--secondary));
 
   &.-errored {
     color: var(--primary-medium);


### PR DESCRIPTION
This defines a common variable on `:root` called `--d-content-background`, which is set to `initial` by default. 

This allows themes to set a background like this...

 ```css
:root {
  --d-content-background: lightblue;
}
```

...which adds backgrounds to all main content areas.

Some examples using the above `lightblue` declaration:  





![Screenshot 2023-09-07 at 3 42 42 PM](https://github.com/discourse/discourse/assets/1681963/6c14bd7d-db7b-4787-acce-f7c5c6c96b8e)
![Screenshot 2023-09-07 at 3 42 56 PM](https://github.com/discourse/discourse/assets/1681963/d01ba6e5-326b-43d3-a03d-aa5dc25f73f5)
![Screenshot 2023-09-07 at 3 43 04 PM](https://github.com/discourse/discourse/assets/1681963/03c96e55-1ace-47c0-b479-8a0d9afc04e3)
![Screenshot 2023-09-07 at 3 43 16 PM](https://github.com/discourse/discourse/assets/1681963/9d1e2d94-6d11-4edd-b764-4b44e372ead4)
![Screenshot 2023-09-07 at 3 45 34 PM](https://github.com/discourse/discourse/assets/1681963/5b1584ac-a8e5-46be-8750-51005f0af4f0)
![Screenshot 2023-09-07 at 3 45 42 PM](https://github.com/discourse/discourse/assets/1681963/c54b8600-8b7e-49de-bf68-7e48c4fc4da9)


![Screenshot 2023-09-07 at 3 45 50 PM](https://github.com/discourse/discourse/assets/1681963/8829af12-671e-427c-ab15-3d1adff8ad89)

So in the common case of adding a background color to content areas, this should simplify implementation. 