### PR TITLE
DEV: Ensure Embroider sourcemaps are collected by Sprockets

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -59,6 +59,10 @@ module EmberCli
     {}
   end
 
+  def self.parse_source_map_path(file)
+    File.read("#{dist_dir}/assets/#{file}")[%r{^//# sourceMappingURL=(.*)$}, 1]
+  end
+
   def self.is_ember_cli_asset?(name)
     assets.include?(name) || name.start_with?("chunk.")
   end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -53,9 +53,9 @@ task "assets:precompile:before": "environment" do
   require "digest/sha1"
 
   # Add ember cli chunks
-  Rails.configuration.assets.precompile.push(
-    *EmberCli.script_chunks.values.flatten.flat_map { |name| ["#{name}.js", "#{name}.map"] },
-  )
+  chunk_files = EmberCli.script_chunks.values.flatten.map { |name| "#{name}.js" }
+  map_files = chunk_files.map { |file| EmberCli.parse_source_map_path(file) }
+  Rails.configuration.assets.precompile.push(*chunk_files, *map_files)
 end
 
 task "assets:precompile:css" => "environment" do


### PR DESCRIPTION
Names of sourcemaps are not necessarily equal to the js file names. Instead, we can check the `sourceMappingURL` comment to find the map's filename.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
