### PR TITLE
FIX: focus state color on `.btn[href]`

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -75,6 +75,9 @@
   }
   &[href] {
     color: $text-color;
+    &:focus {
+      color: $hover-text-color;
+    }
   }
   .discourse-no-touch &:active:not(:hover):not(:focus),
   .discourse-no-touch &.btn-active:not(:hover):not(:focus),


### PR DESCRIPTION
Before:
![Screenshot 2023-09-07 at 5 12 39 PM](https://github.com/discourse/discourse/assets/1681963/083a8371-6adc-423b-8772-1be2416777c0)


After: 
![Screenshot 2023-09-07 at 5 12 29 PM](https://github.com/discourse/discourse/assets/1681963/2c364e69-4f13-425f-883e-29c9551d07d4)
