### PR TITLE
UX: fix mobile timeline footer button positioning

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -26,6 +26,8 @@
     .topic-timeline {
       .timeline-footer-controls {
         display: flex;
+        flex-wrap: wrap;
+        max-width: calc(100% - 9em); // 9em is the width of the timeline
       }
     }
     .timeline-controls {
@@ -114,14 +116,6 @@
         bottom: 20px;
         left: 10px;
 
-        .topic-notifications-button {
-          margin-right: 0.5em;
-        }
-
-        .jump-to-post {
-          margin-bottom: 0.5em;
-        }
-
         .topic-admin-menu-button-container {
           display: flex;
         }
@@ -206,9 +200,6 @@
       button:last-child {
         margin-right: 0;
       }
-    }
-    .show-summary {
-      margin-bottom: 0.5em;
     }
 
     .start-date {


### PR DESCRIPTION
when `summary timeline button` is enabled, the buttons are too wide and overlap the timeline; this allows them to wrap and removes some margins that are no longer needed (they were replaced with `gap` at some point, so the margins were just making the button sizes inconsistent) 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/e0d5fb62-d099-465a-90c9-1c8e10a85c5b)


After:
![Screenshot 2023-09-07 at 5 35 53 PM](https://github.com/discourse/discourse/assets/1681963/2bfaa0f7-751e-4f80-ad2c-09bdbb9b5e50)
