### PR TITLE
DEV: Add `CAPYBARA_SERVER_HOST`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -308,7 +308,7 @@ RSpec.configure do |config|
     Capybara.w3c_click_offset = false
 
     Capybara.configure do |capybara_config|
-      capybara_config.server_host = "localhost"
+      capybara_config.server_host = ENV["CAPYBARA_SERVER_HOST"].presence || "localhost"
       capybara_config.server_port = 31_337 + ENV["TEST_ENV_NUMBER"].to_i
     end
 


### PR DESCRIPTION
Why this change?

When running in a Docker container, we want to bind the Rails server
started by Capybara to 0.0.0.0 instead of localhost. This is done via
the `server_host` config for Capybara which can now be configured via
the `CAPYBARA_SERVER_HOST` env.