### PR TITLE
DEV: Allow `CAPYBARA_REMOTE_DRIVER_URL` through webmock

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -294,7 +294,8 @@ RSpec.configure do |config|
       allow: [
         *MinioRunner.config.minio_urls,
         URI(MinioRunner::MinioBinary.platform_binary_url).host,
-      ],
+        ENV["CAPYBARA_REMOTE_DRIVER_URL"],
+      ].compact,
     )
 
     if ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].present?


### PR DESCRIPTION
Why this change?

When using a remote capybara driver configured through the
`CAPYBARA_REMOTE_DRIVER_URL` env, webmock is thinking that is an
external request and blocking it. As such, we need to set the URL to the
allowlist for webmock.