### PR TITLE
FIX: ensures automation can send chat message

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -417,10 +417,10 @@ after_initialize do
         placeholders = { channel_name: channel.title(sender) }.merge(context["placeholders"] || {})
 
         creator =
-          Chat::CreateMessage.call(
-            chat_channel: channel,
+          ::Chat::CreateMessage.call(
+            chat_channel_id: channel.id,
             guardian: sender.guardian,
-            content: utils.apply_placeholders(fields.dig("message", "value"), placeholders),
+            message: utils.apply_placeholders(fields.dig("message", "value"), placeholders),
           )
 
         if creator.failure?


### PR DESCRIPTION
It's been broken in https://github.com/discourse/discourse/commit/243793ec6ea41a9bf53dc6b9585ba9239dfc4c85. Sadly it's not very practical to write cross plugins tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
