### PR TITLE
DEV: Show separate error message for backup uploads

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -241,8 +241,16 @@ export function isAudio(path) {
   return /\.(mp3|og[ga]|opus|wav|m4[abpr]|aac|flac)$/i.test(path);
 }
 
+export function isBackup(path) {
+  return /^\w[\w\.-]*-v\d+\.(tar\.gz)$/i.test(path);
+}
+
 function uploadTypeFromFileName(fileName) {
-  return isImage(fileName) ? "image" : "attachment";
+  return isImage(fileName)
+    ? "image"
+    : isBackup(fileName)
+    ? "backup"
+    : "attachment";
 }
 
 export function allowsImages(staff, siteSettings) {
@@ -342,12 +350,16 @@ function displayErrorByResponseStatus(status, body, fileName, siteSettings) {
     // entity too large, usually returned from the web server
     case 413:
       const type = uploadTypeFromFileName(fileName);
-      const max_size_kb = siteSettings[`max_${type}_size_kb`];
-      dialog.alert(
-        I18n.t("post.errors.file_too_large_humanized", {
-          max_size: I18n.toHumanSize(max_size_kb * 1024),
-        })
-      );
+      if (type === "backup") {
+        dialog.alert(I18n.t("post.errors.backup_too_large"));
+      } else {
+        const max_size_kb = siteSettings[`max_${type}_size_kb`];
+        dialog.alert(
+          I18n.t("post.errors.file_too_large_humanized", {
+            max_size: I18n.toHumanSize(max_size_kb * 1024),
+          })
+        );
+      }
       return true;
 
     // the error message is provided by the server

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -355,6 +355,48 @@ module("Unit | Utility | uploads", function (hooks) {
     );
   });
 
+  test("displayErrorForUpload - non-backup tar.gz file too large", function (assert) {
+    sinon.stub(dialog, "alert");
+    displayErrorForUpload(
+      {
+        jqXHR: {
+          status: 413,
+          responseJSON: {
+            message: I18n.t("post.errors.file_too_large_humanized"),
+          },
+        },
+      },
+      { max_attachment_size_kb: 4096, max_image_size_kb: 4096 },
+      "non-backup-tar-gz-file.tar.gz"
+    );
+    assert.ok(
+      dialog.alert.calledWith(
+        I18n.t("post.errors.file_too_large_humanized", {
+          max_size: I18n.toHumanSize(4096 * 1024),
+        })
+      ),
+      "the alert is called"
+    );
+  });
+
+  test("displayErrorForUpload - backup file too large", function (assert) {
+    sinon.stub(dialog, "alert");
+    displayErrorForUpload(
+      {
+        jqXHR: {
+          status: 413,
+          responseJSON: { message: I18n.t("post.errors.backup_too_large") },
+        },
+      },
+      { max_attachment_size_kb: 4096, max_image_size_kb: 4096 },
+      "backup-2023-09-07-092329-v20230728055813.tar.gz"
+    );
+    assert.ok(
+      dialog.alert.calledWith(I18n.t("post.errors.backup_too_large")),
+      "the alert is called"
+    );
+  });
+
   test("displayErrorForUpload - jquery file upload - jqXHR present", function (assert) {
     sinon.stub(dialog, "alert");
     displayErrorForUpload(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3473,6 +3473,7 @@ en:
         create: "Sorry, there was an error creating your post. Please try again."
         edit: "Sorry, there was an error editing your post. Please try again."
         upload: "Sorry, there was an error uploading %{file_name}. Please try again."
+        backup_too_large: "Sorry, that backup file is too large."
         file_too_large: "Sorry, that file is too big (maximum size is %{max_size_kb}kb). Why not upload your large file to a cloud sharing service, then paste the link?"
         file_size_zero: "Sorry, it looks like something has gone wrong, the file you are trying to upload is 0 bytes. Please try again."
         file_too_large_humanized: "Sorry, that file is too big (maximum size is %{max_size}). Why not upload your large file to a cloud sharing service, then paste the link?"


### PR DESCRIPTION
Due to server upload limits backups may receive a 413 error so we need
to display a different error message than the default one we have set
for attachments.
