### PR TITLE
DEV: Disable Webpack parallelization for low-memory environments

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -11,9 +11,16 @@ task "assets:precompile:before": "environment" do
   if ENV["EMBER_CLI_COMPILE_DONE"] != "1"
     compile_command = "yarn --cwd app/assets/javascripts/discourse run ember build"
 
-    if check_node_heap_size_limit < 1024
-      STDERR.puts "Detected low Node.js heap_size_limit. Using --max-old-space-size=1024."
+    heap_size_limit = check_node_heap_size_limit
+
+    if heap_size_limit < 1024
+      STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 1024MB. Setting --max-old-space-size=1024."
       compile_command = "NODE_OPTIONS='--max-old-space-size=1024' #{compile_command}"
+    end
+
+    if heap_size_limit < 2048
+      STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 2048MB. Disabling Webpack parallelization with JOBS=0 to conserve memory."
+      compile_command = "JOBS=0 #{compile_command}"
     end
 
     compile_command = "EMBER_ENV=production #{compile_command}" if ENV["EMBER_ENV"].nil?


### PR DESCRIPTION
This reduces memory usage for Embroider-based builds on low-memory servers (e.g. entry-level Digital Ocean droplets)