### PR TITLE
DEV: Correctly identify Embroider chunks

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -64,7 +64,7 @@ module EmberCli
   end
 
   def self.is_ember_cli_asset?(name)
-    assets.include?(name) || name.start_with?("chunk.")
+    assets.include?(name) || script_chunks.values.flatten.include?(name.delete_suffix(".js"))
   end
 
   def self.ember_version


### PR DESCRIPTION
This method is used by assets:precompile to decide whether to apply `terser` to a file. Embroider chunks do not necessarily start with `chunk.`, and so they were incorrectly being re-terser'd by our assets:precompile task. This is inefficient, and also led to broken sourcemaps on some assets.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
