### PR TITLE
DEV: Remove deprecated `BulkSelectButton`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-button.js
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-button.js
@@ -1,4 +1,0 @@
-import Component from "@ember/component";
-
-// TODO: Remove in December 2021
-export default Component.extend({});


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
