### PR TITLE
DEV: active record validations for maxlength on text columns

### DIFF
--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -36,8 +36,8 @@ module Chat
               },
               presence: true,
               allow_nil: true
-    validates :description, length: { maximum: 1000 }
-    validates :slug, length: { maximum: 500 }, if: -> { slug.present? }
+    validates :description, length: { maximum: 500 }
+    validates :slug, length: { maximum: 100 }
     validate :ensure_slug_ok, if: :slug_changed?
     before_validation :generate_auto_slug
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/edit-channel-name.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/edit-channel-name.js
@@ -7,6 +7,8 @@ import { extractError } from "discourse/lib/ajax-error";
 import { tracked } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
 
+const SLUG_MAX_LENGTH = 100;
+
 export default class ChatModalEditChannelName extends Component {
   @service chatApi;
   @service siteSettings;
@@ -26,7 +28,8 @@ export default class ChatModalEditChannelName extends Component {
     return (
       (this.channel.title === this.editedName &&
         this.channel.slug === this.editedSlug) ||
-      this.editedName?.length > this.siteSettings.max_topic_title_length
+      this.editedName?.length > this.siteSettings.max_topic_title_length ||
+      this.editedSlug?.length > SLUG_MAX_LENGTH
     );
   }
 

--- a/plugins/chat/spec/models/chat/category_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/category_channel_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Chat::CategoryChannel do
 
   it { is_expected.to delegate_method(:read_restricted?).to(:category) }
   it { is_expected.to delegate_method(:url).to(:chatable).with_prefix }
-  it { is_expected.to validate_length_of(:description).is_at_most(1000) }
-  it { is_expected.to validate_length_of(:slug).is_at_most(500) }
+  it { is_expected.to validate_length_of(:description).is_at_most(500) }
+  it { is_expected.to validate_length_of(:slug).is_at_most(100) }
 
   describe "#category_channel?" do
     it "always returns true" do

--- a/plugins/chat/spec/models/chat/channel_spec.rb
+++ b/plugins/chat/spec/models/chat/channel_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Chat::Channel do
   fab!(:category_channel_1) { Fabricate(:category_channel) }
   fab!(:dm_channel_1) { Fabricate(:direct_message_channel) }
 
-  it { is_expected.to validate_length_of(:description).is_at_most(1000) }
-  it { is_expected.to validate_length_of(:slug).is_at_most(500) }
+  it { is_expected.to validate_length_of(:description).is_at_most(500) }
+  it { is_expected.to validate_length_of(:slug).is_at_most(100) }
 
   describe ".find_by_id_or_slug" do
     subject(:find_channel) { described_class.find_by_id_or_slug(channel_id) }

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Chat::DirectMessageChannel do
   it_behaves_like "a chat channel model"
 
   it { is_expected.to delegate_method(:allowed_user_ids).to(:direct_message).as(:user_ids) }
-  it { is_expected.to validate_length_of(:description).is_at_most(1000) }
+  it { is_expected.to validate_length_of(:description).is_at_most(500) }
 
   describe "#category_channel?" do
     it "always returns false" do


### PR DESCRIPTION
Introduce max length on text columns for `description` and `slug` fields within chat.

At a later date we will probably want to convert these text columns to string/varchar through a migration, but for now this introduces a limit within the active record model based on discussions in the topic below.

/t/90319