### PR TITLE
DEV: Correct sourceMappingURL regex

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -60,7 +60,7 @@ module EmberCli
   end
 
   def self.parse_source_map_path(file)
-    File.read("#{dist_dir}/assets/#{file}")[%r{^//# sourceMappingURL=(.*)$}, 1]
+    File.read("#{dist_dir}/assets/#{file}")[%r{//# sourceMappingURL=(.*)$}, 1]
   end
 
   def self.is_ember_cli_asset?(name)


### PR DESCRIPTION
This comment isn't necessarily on a line by itself, so we need to remove the `^` from the regex. This will fix `EMBER_ENV=development bin/rake assets:precompile`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
