### PR TITLE
DEV: Replace `_eak_seen` with `entries`

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -90,7 +90,7 @@ function loadInitializers(app) {
   let discourseInitializers = [];
   let discourseInstanceInitializers = [];
 
-  for (let moduleName of Object.keys(requirejs._eak_seen)) {
+  for (let moduleName of Object.keys(requirejs.entries)) {
     if (moduleName.startsWith("discourse/") && !moduleName.endsWith("-test")) {
       // In discourse core, initializers follow standard Ember conventions
       if (moduleName.startsWith("discourse/initializers/")) {

--- a/app/assets/javascripts/discourse/app/mapping-router.js
+++ b/app/assets/javascripts/discourse/app/mapping-router.js
@@ -111,7 +111,7 @@ export function mapRoutes() {
   // will be built automatically. You can supply a `resource` property to
   // automatically put it in that resource, such as `admin`. That way plugins
   // can define admin routes.
-  Object.keys(requirejs._eak_seen).forEach(function (key) {
+  Object.keys(requirejs.entries).forEach(function (key) {
     if (/route-map$/.test(key)) {
       let module = requirejs(key, null, null, true);
       if (!module || !module.default) {

--- a/app/assets/javascripts/discourse/tests/helpers/fixture-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/fixture-pretender.js
@@ -3,7 +3,7 @@ export default function (helpers) {
   const fixturesByUrl = {};
 
   // Load any fixtures automatically
-  Object.keys(require._eak_seen).forEach((entry) => {
+  Object.keys(require.entries).forEach((entry) => {
     if (/^discourse\/tests\/fixtures/.test(entry)) {
       const fixture = require(entry, null, null, true);
       if (fixture && fixture.default) {

--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -479,7 +479,7 @@ export function setup(opts, siteSettings, state) {
   // all of the modules under discourse-markdown or markdown-it
   // directories are considered additional markdown "features" which
   // may define their own rules
-  Object.keys(require._eak_seen).forEach((entry) => {
+  Object.keys(require.entries).forEach((entry) => {
     if (check.test(entry)) {
       const module = requirejs(entry);
       if (module && module.setup) {


### PR DESCRIPTION
TIL: `require._eak_seen` is an old alias for `require.entries` and it comes from Ember App Kit (a blast from the past!)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
