### PR TITLE
FIX: ensures swipe works with scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -166,8 +166,6 @@ export default class ChatChannelRow extends Component {
 
   @bind
   onSwipe(event) {
-    event.preventDefault();
-
     const touchX = event.changedTouches[0].screenX;
     const diff = this.initialX - touchX;
 
@@ -193,8 +191,10 @@ export default class ChatChannelRow extends Component {
       this.isCancelling = !this._towardsThreshold;
     }
 
-    this.actionButton.style.width = diff + "px";
-    this.swipableRow.style.left = -(this.initialX - touchX) + "px";
+    if (diff > 25) {
+      this.actionButton.style.width = diff + "px";
+      this.swipableRow.style.left = -(this.initialX - touchX) + "px";
+    }
   }
 
   @bind


### PR DESCRIPTION
- do not prevent the event (it was a violation anyways as the touchstart is passive)
- waits for at least 25px horizontal move before showing the remove action, it avoids showing the remove while scrolling and moving a little bit horizontally

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
