### PR TITLE
FIX: Ensure declarative DModals do not interfere with service

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -4,6 +4,7 @@
 <ConditionalInElement
   @element={{this.modal.containerElement}}
   @inline={{@inline}}
+  @append={{true}}
 >
   <this.dynamicElement
     class={{concat-class

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-service-test.gjs
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-service-test.gjs
@@ -11,6 +11,8 @@ import DModal, {
 } from "discourse/components/d-modal";
 import { action } from "@ember/object";
 import { on } from "@ember/modifier";
+import { tracked } from "@glimmer/tracking";
+import { registerTemporaryModule } from "discourse/tests/helpers/temporary-module-helper";
 
 class MyModalClass extends Component {
   <template>
@@ -149,6 +151,56 @@ acceptance("Modal service: component-based API", function () {
       ["constructor: argumentValue", "willDestroy: argumentValue"],
       "constructor called with args available"
     );
+  });
+
+  test("alongside declarative modals", async function (assert) {
+    class State {
+      @tracked showDeclarativeModal;
+    }
+
+    const testState = new State();
+    const closeModal = () => (testState.showDeclarativeModal = false);
+
+    const MyConnector = <template>
+      {{#if testState.showDeclarativeModal}}
+        <DModal
+          class="declarative-modal"
+          @title="Declarative modal"
+          @closeModal={{closeModal}}
+        >
+          <span class="declarative-modal-content">Declarative modal content</span>
+        </DModal>
+      {{/if}}
+    </template>;
+
+    registerTemporaryModule(
+      "discourse/plugins/my-plugin/connectors/below-footer/connector-name",
+      MyConnector
+    );
+
+    await visit("/");
+
+    const modalService = getOwner(this).lookup("service:modal");
+
+    modalService.show(MyModalClass);
+    await settled();
+    assert.dom(".d-modal.service-modal").exists("modal should appear");
+
+    testState.showDeclarativeModal = true;
+    await settled();
+    assert
+      .dom(".d-modal.declarative-modal")
+      .exists("declarative modal should appear");
+    assert.dom(".d-modal.service-modal").exists("service modal should remain");
+
+    await click(".d-modal.declarative-modal .modal-close");
+    assert
+      .dom(".d-modal.declarative-modal")
+      .doesNotExist("declarative modal should close");
+    assert.dom(".d-modal.service-modal").exists("service modal should remain");
+
+    await click(".d-modal.service-modal .modal-close");
+    assert.dom(".d-modal").doesNotExist("all modals closed");
   });
 
   // (See also, `tests/integration/component/d-modal-test.js`)


### PR DESCRIPTION
While it's generally not recommended from a UX perspective, the DModal system is intended to allow multiple modals to be rendered simultaneously when using the declarative API. This wasn't working because `{{#in-element` was configured to replace the content of the container rather than append a new modal.

This commit fixes that and adds a test for the functionality.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
