### PR TITLE
FIX: Empty query param in group-index url

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -11,7 +11,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default Controller.extend({
   queryParams: ["order", "asc", "filter"],
 
-  order: "",
+  order: null,
   asc: true,
   filter: null,
   filterInput: null,


### PR DESCRIPTION
This prevents an empty `order=` query param from appearing in the URL when navigating from `/g` to a group page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
