### PR TITLE
FIX: send email to normalized email owner when hiding emails

### DIFF
--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -834,6 +834,42 @@ RSpec.describe UsersController do
         end
       end
 
+      context "when normalize_emails is enabled" do
+        let (:email) {
+          "jane+100@gmail.com"
+        }
+        let (:dupe_email) {
+          "jane+191@gmail.com"
+        }
+        let! (:user) {
+          Fabricate(:user, email: email, password: "strongpassword")
+        }
+
+        before do
+          SiteSetting.hide_email_address_taken = true
+          SiteSetting.normalize_emails = true
+        end
+
+        it "sends an email to normalized email owner when hide_email_address_taken is enabled" do
+          expect do
+            post "/u.json",
+                 params: {
+                   name: "Jane Doe",
+                   username: "janedoe9999",
+                   password: "strongpassword",
+                   email: dupe_email,
+                 }
+          end.to_not change { User.count }
+
+          expect(response.status).to eq(200)
+          expect(session["user_created_message"]).to be_present
+
+          # expecting a warning emails
+          expect(Jobs::CriticalUserEmail.jobs.size).to eq(1)
+          expect(Jobs::CriticalUserEmail.jobs.first["args"].first["type"]).to eq("account_exists")
+        end
+      end
+
       context "when users already exists with given email" do
         let!(:existing) { Fabricate(:user, email: post_user_params[:email]) }
 
@@ -854,6 +890,10 @@ RSpec.describe UsersController do
 
           expect(response.status).to eq(200)
           expect(session["user_created_message"]).to be_present
+
+          # expecting a warning emails
+          expect(Jobs::CriticalUserEmail.jobs.size).to eq(1)
+          expect(Jobs::CriticalUserEmail.jobs.first["args"].first["type"]).to eq("account_exists")
 
           json = response.parsed_body
           expect(json["active"]).to be_falsey

--- a/spec/support/sidekiq_helpers.rb
+++ b/spec/support/sidekiq_helpers.rb
@@ -32,7 +32,7 @@ module SidekiqHelpers
       eq(expectation),
       (
         if expectation
-          "No enqueued job with #{expected} found"
+          "No enqueued job with #{expected}\nFound:\n #{jobs.inspect}"
         else
           "Enqueued job with #{expected} found"
         end


### PR DESCRIPTION
Previous to this change when both `normalize_emails` and `hide_email_address_taken`
is enabled the expected `account_exists` email was only sent on exact email
matches.

This expands it so it also sends an email to the canonical email owner.
