### PR TITLE
FEATURE: experimental support for passkeys (passwordless login)

### DIFF
--- a/app/assets/javascripts/discourse/app/components/login-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.hbs
@@ -16,4 +16,9 @@
     {{b.title}}
   </button>
 {{/each}}
+
+{{#if this.canUsePasskeys}}
+  <PasskeyLoginButton />
+{{/if}}
+
 <PluginOutlet @name="after-login-buttons" />

--- a/app/assets/javascripts/discourse/app/components/login-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { findAll } from "discourse/models/login-method";
+import { isWebauthnSupported } from "discourse/lib/webauthn";
 
 export default Component.extend({
   elementId: "login-buttons",
@@ -14,6 +15,11 @@ export default Component.extend({
   @discourseComputed
   buttons() {
     return findAll();
+  },
+
+  @discourseComputed
+  canUsePasskeys() {
+    return isWebauthnSupported() && this.siteSettings.experimental_passkeys;
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/components/modal/second-factor-add-security-key.js
+++ b/app/assets/javascripts/discourse/app/components/modal/second-factor-add-security-key.js
@@ -98,9 +98,7 @@ export default class SecondFactorAddSecurityKey extends Component {
       timeout: 20000,
       attestation: "none",
       authenticatorSelection: {
-        // see https://chromium.googlesource.com/chromium/src/+/master/content/browser/webauth/uv_preferred.md for why
-        // default value of preferred is not necessarily what we want, it limits webauthn to only devices that support
-        // user verification, which usually requires entering a PIN
+        // for 2FA, we don't want user verification, which usually requires entering a PIN / touch / face ID
         userVerification: "discouraged",
       },
     };

--- a/app/assets/javascripts/discourse/app/components/passkey-login-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/passkey-login-button.hbs
@@ -1,0 +1,6 @@
+<DButton
+  @action={{this.passkeyLogin}}
+  @icon="user"
+  @label="login.passkey.name"
+  class="btn btn-social passkey-button"
+/>

--- a/app/assets/javascripts/discourse/app/components/passkey-login-button.js
+++ b/app/assets/javascripts/discourse/app/components/passkey-login-button.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { prepPasskeyCredential } from "discourse/lib/webauthn";
 import { inject as service } from "@ember/service";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default class PasskeyLoginButton extends Component {
   @service dialog;
@@ -29,13 +30,9 @@ export default class PasskeyLoginButton extends Component {
                 this.dialog.alert(result.error);
               }
             })
-            .catch((res) => {
-              this.dialog.alert(res.error);
-            });
+            .catch(popupAjaxError);
         });
       })
-      .catch((res) => {
-        this.dialog.alert(res.error);
-      });
+      .catch(popupAjaxError);
   }
 }

--- a/app/assets/javascripts/discourse/app/components/passkey-login-button.js
+++ b/app/assets/javascripts/discourse/app/components/passkey-login-button.js
@@ -1,0 +1,41 @@
+import Component from "@ember/component";
+import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { prepPasskeyCredential } from "discourse/lib/webauthn";
+import { inject as service } from "@ember/service";
+
+export default class PasskeyLoginButton extends Component {
+  @service dialog;
+  tagName = "";
+
+  @action
+  passkeyLogin() {
+    ajax("/session/passkey/challenge.json")
+      .then((response) => {
+        prepPasskeyCredential(response.challenge, (errorMessage) => {
+          this.dialog.alert(errorMessage);
+        }).then((credential) => {
+          ajax("/session/passkey/auth.json", {
+            type: "POST",
+            data: {
+              publicKeyCredential: credential,
+              timezone: moment.tz.guess(),
+            },
+          })
+            .then((result) => {
+              if (result && !result.error) {
+                window.location.reload();
+              } else {
+                this.dialog.alert(result.error);
+              }
+            })
+            .catch((res) => {
+              this.dialog.alert(res.error);
+            });
+        });
+      })
+      .catch((res) => {
+        this.dialog.alert(res.error);
+      });
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/user-preferences/passkey-options-dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/passkey-options-dropdown.js
@@ -1,0 +1,40 @@
+import DropdownSelectBoxComponent from "select-kit/components/dropdown-select-box";
+import I18n from "I18n";
+import { computed } from "@ember/object";
+
+export default DropdownSelectBoxComponent.extend({
+  classNames: ["token-based-auth-dropdown"],
+
+  selectKitOptions: {
+    icon: "wrench",
+    showFullTitle: false,
+  },
+
+  content: computed(function () {
+    return [
+      {
+        id: "edit",
+        icon: "pencil-alt",
+        name: I18n.t("user.second_factor.edit"),
+      },
+      {
+        id: "delete",
+        icon: "trash-alt",
+        name: I18n.t("user.second_factor.delete"),
+      },
+    ];
+  }),
+
+  actions: {
+    onChange(id) {
+      switch (id) {
+        case "edit":
+          this.renamePasskey(this.passkeyId);
+          break;
+        case "delete":
+          this.deletePasskey(this.passkeyId);
+          break;
+      }
+    },
+  },
+});

--- a/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.hbs
@@ -1,6 +1,6 @@
 <div class="rename-passkey__form">
   <div class="rename-passkey__message">
-    <p>{{i18n "discourse_passkeys.rename_message"}}</p>
+    <p>{{i18n "user.first_factor.rename_passkey_instructions"}}</p>
   </div>
   <form>
     <div class="rename-passkey__form inline-form">

--- a/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.hbs
@@ -1,0 +1,16 @@
+<div class="rename-passkey__form">
+  <div class="rename-passkey__message">
+    <p>{{i18n "discourse_passkeys.rename_message"}}</p>
+  </div>
+  <form>
+    <div class="rename-passkey__form inline-form">
+      <TextField @value={{this.passkeyName}} autofocus={{true}} />
+      <DButton
+        @class="btn-primary"
+        @type="submit"
+        @action={{action "saveRename"}}
+        @translatedLabel="Save"
+      />
+    </div>
+  </form>
+</div>

--- a/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.js
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/rename-passkey.js
@@ -1,0 +1,25 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { tracked } from "@glimmer/tracking";
+
+export default class RenamePasskey extends Component {
+  @tracked passkeyName;
+
+  constructor() {
+    super(...arguments);
+    this.passkeyName = this.args.model.name;
+  }
+
+  @action
+  saveRename() {
+    ajax(`/u/rename_passkey/${this.args.model.id}`, {
+      type: "POST",
+      data: {
+        name: this.passkeyName,
+      },
+    }).then(() => {
+      window.location.reload();
+    });
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.hbs
@@ -1,0 +1,53 @@
+<div class="row pref-passkeys">
+  <div class="control-group">
+    <label class="control-label">Passkeys</label>
+    {{#each @model.user_passkeys as |passkey|}}
+      <div class="row">
+        <div class="passkey-left">
+          <div><b>{{passkey.name}}</b></div>
+          <div class="row-passkey__created-date">{{format-date
+              passkey.created_at
+              format="medium"
+              leaveAgo="true"
+              prefix="Added "
+            }}</div>
+          <div class="row-passkey__used-date">
+            {{#if passkey.last_used}}
+              {{format-date
+                passkey.last_used
+                format="medium"
+                leaveAgo="true"
+                prefix="Last used "
+              }}
+            {{else}}
+              Never used
+            {{/if}}
+          </div>
+        </div>
+        <div class="passkey-right">
+          {{#if this.isCurrentUser}}
+            <div class="actions">
+              <UserPreferences::PasskeyOptionsDropdown
+                @passkeyId={{passkey.id}}
+                @deletePasskey={{action "deletePasskey" passkey.id}}
+                @renamePasskey={{action
+                  "renamePasskey"
+                  passkey.id
+                  passkey.name
+                }}
+              />
+            </div>
+          {{/if}}
+        </div>
+      </div>
+    {{/each}}
+  </div>
+
+  {{#if this.isCurrentUser}}
+    <DButton
+      @action={{action "addPasskey"}}
+      @icon="plus"
+      @translatedLabel="Add Passkey"
+    />
+  {{/if}}
+</div>

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.js
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.js
@@ -1,0 +1,117 @@
+import I18n from "I18n";
+import { bufferToBase64, stringToBuffer } from "discourse/lib/webauthn";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import RenamePasskey from "discourse/components/user-preferences/rename-passkey";
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+
+export default class UserPasskeys extends Component {
+  @service dialog;
+  @service currentUser;
+
+  get isCurrentUser() {
+    return this.currentUser.id === this.args.model.id;
+  }
+
+  @action
+  addPasskey() {
+    this.args.model.createPasskey().then((response) => {
+      const publicKeyCredentialCreationOptions = {
+        challenge: Uint8Array.from(response.challenge, (c) => c.charCodeAt(0)),
+        rp: {
+          name: response.rp_name,
+          id: response.rp_id,
+        },
+        user: {
+          id: Uint8Array.from(response.user_secure_id, (c) => c.charCodeAt(0)),
+          name: this.currentUser.username,
+          displayName: this.currentUser.username,
+        },
+        pubKeyCredParams: response.supported_algorithms.map((alg) => {
+          return { type: "public-key", alg };
+        }),
+        excludeCredentials: response.existing_passkey_credential_ids.map(
+          (credentialId) => {
+            return {
+              type: "public-key",
+              id: stringToBuffer(atob(credentialId)),
+            };
+          }
+        ),
+      };
+
+      navigator.credentials
+        .create({
+          publicKey: publicKeyCredentialCreationOptions,
+        })
+        .then(
+          (credential) => {
+            let serverData = {
+              id: credential.id,
+              rawId: bufferToBase64(credential.rawId),
+              type: credential.type,
+              attestation: bufferToBase64(
+                credential.response.attestationObject
+              ),
+              clientData: bufferToBase64(credential.response.clientDataJSON),
+              name: "placeholder",
+            };
+
+            this.args.model
+              .registerPasskey(serverData)
+              .then((resp) => {
+                if (resp.error) {
+                  popupAjaxError(resp.error);
+                  return;
+                }
+
+                // Show rename alert after creating/saving new key
+                this.dialog.dialog({
+                  title: "Success! Passkey was created.",
+                  type: "notice",
+                  bodyComponent: RenamePasskey,
+                  bodyComponentModel: resp,
+                });
+              })
+              .catch(popupAjaxError);
+          },
+          (err) => {
+            if (err.name === "InvalidStateError") {
+              this.errorMessage = I18n.t(
+                "user.second_factor.security_key.already_added_error"
+              );
+            }
+            if (err.name === "NotAllowedError") {
+              this.errorMessage = I18n.t(
+                "user.second_factor.security_key.not_allowed_error"
+              );
+            }
+            this.dialog.alert(this.errorMessage);
+          }
+        );
+    });
+  }
+
+  @action
+  deletePasskey(id) {
+    this.dialog.deleteConfirm({
+      title: "Are you sure you want to delete this passkey?",
+      didConfirm: () => {
+        this.args.model.deletePasskey(id).then(() => {
+          window.location.reload();
+        });
+      },
+    });
+  }
+
+  @action
+  renamePasskey(id, name) {
+    this.dialog.dialog({
+      title: "Rename Passkey",
+      type: "notice",
+      bodyComponent: RenamePasskey,
+      bodyComponentModel: { id, name },
+    });
+  }
+}

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -10,6 +10,7 @@ import CanCheckEmails from "discourse/mixins/can-check-emails";
 import I18n from "I18n";
 import { inject as service } from "@ember/service";
 import AuthTokenModal from "discourse/components/modal/auth-token";
+import { isWebauthnSupported } from "discourse/lib/webauthn";
 
 // Number of tokens shown by default.
 const DEFAULT_AUTH_TOKENS_COUNT = 2;
@@ -19,6 +20,11 @@ export default Controller.extend(CanCheckEmails, {
   passwordProgress: null,
   subpageTitle: I18n.t("user.preferences_nav.security"),
   showAllAuthTokens: false,
+
+  @discourseComputed
+  canUsePasskeys() {
+    return isWebauthnSupported() && this.siteSettings.experimental_passkeys;
+  },
 
   @discourseComputed("model.is_anonymous")
   canChangePassword(isAnonymous) {

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -559,6 +559,25 @@ const User = RestModel.extend({
     });
   },
 
+  createPasskey() {
+    return ajax("/u/create_passkey.json", {
+      type: "POST",
+    });
+  },
+
+  registerPasskey(credential) {
+    return ajax("/u/register_passkey.json", {
+      data: credential,
+      type: "POST",
+    });
+  },
+
+  deletePasskey(id) {
+    return ajax(`/u/delete_passkey/${id}`, {
+      type: "DELETE",
+    });
+  },
+
   createSecondFactorTotp() {
     return ajax("/u/create_second_factor_totp.json", {
       type: "POST",

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -109,6 +109,10 @@
   </div>
 {{/if}}
 
+{{#if this.canUsePasskeys}}
+  <UserPreferences::UserPasskeys @model={{@model}} />
+{{/if}}
+
 <UserPreferences::UserApiKeys @model={{@model}} />
 
 <span>

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -709,55 +709,6 @@ table {
   }
 }
 
-.pref-auth-tokens {
-  .row {
-    border-bottom: 1px solid #ddd;
-    margin: 5px 0px;
-    padding-bottom: 5px;
-
-    &:last-child {
-      border-bottom: 0;
-    }
-  }
-
-  .auth-token-icon {
-    color: var(--primary-medium);
-    font-size: 2.25em;
-    float: left;
-    margin-right: 10px;
-  }
-
-  .auth-token-first {
-    font-size: 1.1em;
-
-    .auth-token-device {
-      font-weight: bold;
-    }
-  }
-
-  .auth-token-second {
-    color: var(--primary-medium);
-
-    .active {
-      color: var(--success);
-      font-weight: bold;
-    }
-  }
-
-  .auth-token-dropdown {
-    float: right;
-
-    .btn,
-    .btn:hover {
-      background: transparent;
-
-      .d-icon {
-        color: var(--primary-high);
-      }
-    }
-  }
-}
-
 .topic-statuses {
   // avoid adding margin/padding on this parent; sometimes it appears as an empty container
   float: left;

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -651,6 +651,71 @@
     align-items: center;
     gap: 1em;
   }
+
+  .pref-auth-tokens {
+    .auth-token-icon {
+      color: var(--primary-medium);
+      font-size: 2.25em;
+      float: left;
+      margin-right: 10px;
+    }
+
+    .auth-token-first {
+      font-size: 1.1em;
+
+      .auth-token-device {
+        font-weight: bold;
+      }
+    }
+
+    .auth-token-second {
+      color: var(--primary-medium);
+
+      .active {
+        color: var(--success);
+        font-weight: bold;
+      }
+    }
+
+    .auth-token-dropdown {
+      float: right;
+
+      .btn,
+      .btn:hover {
+        background: transparent;
+
+        .d-icon {
+          color: var(--primary-high);
+        }
+      }
+    }
+  }
+
+  .pref-passkeys,
+  .pref-auth-tokens {
+    .row {
+      border-top: 1px solid var(--primary-low);
+      padding: 0.5em 0;
+      margin: 0.5em 0;
+
+      &:last-child {
+        border-bottom: 1px solid var(--primary-low);
+      }
+    }
+  }
+
+  .pref-passkeys {
+    .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+
+      .row-passkey__created-date,
+      .row-passkey__used-date {
+        color: var(--primary-medium);
+      }
+    }
+  }
 }
 
 .paginated-topics-list {

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -350,7 +350,7 @@ class SessionController < ApplicationController
       not_activated(user)
     end
   rescue ::DiscourseWebauthn::SecurityKeyError => err
-    render json: failed_json.merge(error: err.message)
+    render_json_error(err.message, status: 401)
   end
 
   def email_login_info

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1625,7 +1625,7 @@ class UsersController < ApplicationController
 
     render json: success_json.merge(id: key.id, name: key.name)
   rescue ::DiscourseWebauthn::SecurityKeyError => err
-    render json: failed_json.merge(error: err.message)
+    render_json_error(err.message, status: 401)
   end
 
   def delete_passkey

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1581,7 +1581,7 @@ class UsersController < ApplicationController
     ::DiscourseWebauthn::RegistrationService.new(
       current_user,
       params,
-      challenge: DiscourseWebauthn.challenge(current_user, secure_session),
+      session: secure_session,
       factor_type: UserSecurityKey.factor_types[:second_factor],
     ).register_security_key
     render json: success_json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1693,7 +1693,7 @@ class UsersController < ApplicationController
   def disable_second_factor
     # delete all second factors for a user
     current_user.user_second_factors.destroy_all
-    current_user.security_keys.destroy_all
+    current_user.second_factor_security_keys.destroy_all
 
     Jobs.enqueue(
       :critical_user_email,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1582,7 +1582,8 @@ class UsersController < ApplicationController
       current_user,
       params,
       challenge: DiscourseWebauthn.challenge(current_user, secure_session),
-    ).register_second_factor_security_key
+      factor_type: UserSecurityKey.factor_types[:second_factor],
+    ).register_security_key
     render json: success_json
   rescue ::DiscourseWebauthn::SecurityKeyError => err
     render json: failed_json.merge(error: err.message)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1582,8 +1582,6 @@ class UsersController < ApplicationController
       current_user,
       params,
       challenge: DiscourseWebauthn.challenge(current_user, secure_session),
-      rp_id: DiscourseWebauthn.rp_id,
-      origin: Discourse.base_url,
     ).register_second_factor_security_key
     render json: success_json
   rescue ::DiscourseWebauthn::SecurityKeyError => err

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1578,7 +1578,7 @@ class UsersController < ApplicationController
     params.require(:attestation)
     params.require(:clientData)
 
-    ::DiscourseWebauthn::SecurityKeyRegistrationService.new(
+    ::DiscourseWebauthn::RegistrationService.new(
       current_user,
       params,
       challenge: DiscourseWebauthn.challenge(current_user, secure_session),

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -166,7 +166,7 @@ module SecondFactorManager
     ::DiscourseWebauthn::AuthenticationService.new(
       self,
       security_key_credential,
-      challenge: DiscourseWebauthn.challenge(self, secure_session),
+      session: secure_session,
     ).authenticate_security_key
   end
 

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -167,8 +167,6 @@ module SecondFactorManager
       self,
       security_key_credential,
       challenge: DiscourseWebauthn.challenge(self, secure_session),
-      rp_id: DiscourseWebauthn.rp_id,
-      origin: Discourse.base_url,
     ).authenticate_security_key
   end
 

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -163,7 +163,7 @@ module SecondFactorManager
   end
 
   def authenticate_security_key(secure_session, security_key_credential)
-    ::DiscourseWebauthn::SecurityKeyAuthenticationService.new(
+    ::DiscourseWebauthn::AuthenticationService.new(
       self,
       security_key_credential,
       challenge: DiscourseWebauthn.challenge(self, secure_session),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1729,6 +1729,13 @@ class User < ActiveRecord::Base
       .pluck(:credential_id)
   end
 
+  def first_factor_security_key_credential_ids
+    security_keys
+      .select(:credential_id)
+      .where(factor_type: UserSecurityKey.factor_types[:first_factor])
+      .pluck(:credential_id)
+  end
+
   def encoded_username(lower: false)
     UrlHelper.encode_component(lower ? username_lower : username)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1722,6 +1722,10 @@ class User < ActiveRecord::Base
     new_secure_identifier
   end
 
+  def second_factor_security_keys
+    security_keys.where(factor_type: UserSecurityKey.factor_types[:second_factor])
+  end
+
   def second_factor_security_key_credential_ids
     security_keys
       .select(:credential_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1729,7 +1729,7 @@ class User < ActiveRecord::Base
       .pluck(:credential_id)
   end
 
-  def first_factor_security_key_credential_ids
+  def passkey_credential_ids
     security_keys
       .select(:credential_id)
       .where(factor_type: UserSecurityKey.factor_types[:first_factor])

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -59,6 +59,7 @@ class UserSerializer < UserCardSerializer
                      :can_change_website,
                      :can_change_tracking_preferences,
                      :user_api_keys,
+                     :user_passkeys,
                      :user_auth_tokens,
                      :user_notification_schedule,
                      :use_logo_small_as_avatar,
@@ -164,6 +165,13 @@ class UserSerializer < UserCardSerializer
     )
   end
 
+  def user_passkeys
+    UserSecurityKey
+      .where(user_id: object.id, factor_type: UserSecurityKey.factor_types[:first_factor])
+      .map do |usk|
+        { id: usk.id, name: usk.name, last_used: usk.last_used, created_at: usk.created_at }
+      end
+  end
   def bio_raw
     object.user_profile.bio_raw
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -172,6 +172,11 @@ class UserSerializer < UserCardSerializer
         { id: usk.id, name: usk.name, last_used: usk.last_used, created_at: usk.created_at }
       end
   end
+
+  def include_user_passkeys?
+    SiteSetting.experimental_passkeys
+  end
+
   def bio_raw
     object.user_profile.bio_raw
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1502,7 +1502,15 @@ en:
           save: "Save"
           edit_description: "Physical Security Key Name"
           name_required_error: "You must provide a name for your security key."
-
+      first_factor:
+        rename_passkey: "Rename Passkey"
+        confirm_delete_passkey: "Are you sure you want to delete this passkey?"
+        passkey_successfully_created: "Success! Your new passkey was created."
+        rename_passkey_instructions: "Pick a passkey name that will easily identify it for you, for example, use the name of your password manager."
+        name:
+          default: "Main Passkey"
+          google_password_manager: "Google Password Manager"
+          icloud_keychain: "iCloud Keychain"
       change_about:
         title: "Change About Me"
         error: "There was an error changing this value."
@@ -2224,6 +2232,8 @@ en:
         name: "Discord"
         title: "Log in with Discord"
         sr_title: "Log in with Discord"
+      passkey:
+        name: "Login with a passkey"
       second_factor_toggle:
         totp: "Use an authenticator app instead"
         backup_code: "Use a backup code instead"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1019,6 +1019,7 @@ en:
       ownership_error: "The security key is not owned by the user."
       not_found_error: "A security key with the provided credential ID could not be found."
       unknown_cose_algorithm_error: "The algorithm used for the security key is not recognized."
+      malformed_public_key_credential_error: "The provided public key is invalid."
 
   topic_flag_types:
     spam:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1010,6 +1010,7 @@ en:
       invalid_origin_error: "The origin of the authentication request does not match the server origin."
       malformed_attestation_error: "There was an error decoding the attestation data."
       invalid_relying_party_id_error: "The Relying Party ID of the authentication request does not match the server Relying Party ID."
+      user_presence_error: "User presence is required."
       user_verification_error: "User verification is required."
       unsupported_public_key_algorithm_error: "The provided public key algorithm is not supported by the server."
       unsupported_attestation_format_error: "The attestation format is not supported by the server."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,6 +428,8 @@ Discourse::Application.routes.draw do
     if Rails.env.test?
       post "session/2fa/test-action" => "session#test_second_factor_restricted_route"
     end
+    get "session/passkey/challenge" => "session#passkey_challenge"
+    post "session/passkey/auth" => "session#passkey_auth_perform"
     get "session/scopes" => "session#scopes"
     get "composer/mentions" => "composer#mentions"
     get "composer_messages" => "composer_messages#index"
@@ -481,8 +483,8 @@ Discourse::Application.routes.draw do
 
       post "#{root_path}/create_passkey" => "users#create_passkey"
       post "#{root_path}/register_passkey" => "users#register_passkey"
-      post "#{root_path}/rename_passkey/:id" => "passkeys#rename_passkey"
-      delete "#{root_path}/delete_passkey/:id" => "passkeys#delete_passkey"
+      post "#{root_path}/rename_passkey/:id" => "users#rename_passkey"
+      delete "#{root_path}/delete_passkey/:id" => "users#delete_passkey"
 
       put "#{root_path}/update-activation-email" => "users#update_activation_email"
       post "#{root_path}/email-login" => "users#email_login"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -479,6 +479,11 @@ Discourse::Application.routes.draw do
 
       put "#{root_path}/second_factors_backup" => "users#create_second_factor_backup"
 
+      post "#{root_path}/create_passkey" => "users#create_passkey"
+      post "#{root_path}/register_passkey" => "users#register_passkey"
+      post "#{root_path}/rename_passkey/:id" => "passkeys#rename_passkey"
+      delete "#{root_path}/delete_passkey/:id" => "passkeys#delete_passkey"
+
       put "#{root_path}/update-activation-email" => "users#update_activation_email"
       post "#{root_path}/email-login" => "users#email_login"
       get "#{root_path}/admin-login" => "users#admin_login"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2158,6 +2158,10 @@ developer:
   experimental_topics_filter:
     client: true
     default: false
+  experimental_passkeys:
+    client: true
+    default: false
+    hidden: true
   experimental_search_menu_groups:
     type: group_list
     list_type: compact

--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -36,7 +36,9 @@ module DiscourseWebauthn
   end
   class MalformedAttestationError < SecurityKeyError
   end
-  class NotFoundError < SecurityKeyError
+  class KeyNotFoundError < SecurityKeyError
+  end
+  class MalformedPublicKeyCredentialError < SecurityKeyError
   end
   class OwnershipError < SecurityKeyError
   end

--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -22,6 +22,8 @@ module DiscourseWebauthn
   end
   class UserVerificationError < SecurityKeyError
   end
+  class UserPresenceError < SecurityKeyError
+  end
   class ChallengeMismatchError < SecurityKeyError
   end
   class InvalidTypeError < SecurityKeyError

--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require "webauthn/challenge_generator"
-require "webauthn/security_key_base_validation_service"
-require "webauthn/security_key_registration_service"
-require "webauthn/security_key_authentication_service"
+require "webauthn/base_validation_service"
+require "webauthn/registration_service"
+require "webauthn/authentication_service"
 
 module DiscourseWebauthn
   ACCEPTABLE_REGISTRATION_TYPE = "webauthn.create"

--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -68,7 +68,18 @@ module DiscourseWebauthn
   end
 
   def self.rp_id
-    Discourse.current_hostname
+    Rails.env.production? ? Discourse.current_hostname : "localhost"
+  end
+
+  def self.origin
+    case Rails.env
+    when "development"
+      "http://localhost:4200"
+    when "test"
+      "http://localhost:3000"
+    else
+      Discourse.base_url
+    end
   end
 
   def self.rp_name

--- a/lib/webauthn/authentication_service.rb
+++ b/lib/webauthn/authentication_service.rb
@@ -2,7 +2,7 @@
 require "cose"
 
 module DiscourseWebauthn
-  class SecurityKeyAuthenticationService < SecurityKeyBaseValidationService
+  class AuthenticationService < BaseValidationService
     ##
     # See https://w3c.github.io/webauthn/#sctn-verifying-assertion for
     # the steps followed here. Memoized methods are called in their

--- a/lib/webauthn/authentication_service.rb
+++ b/lib/webauthn/authentication_service.rb
@@ -9,13 +9,16 @@ module DiscourseWebauthn
     # place in the step flow to make the process clearer.
     def authenticate_security_key
       if @params.blank? || (!@params.is_a?(Hash) && !@params.is_a?(ActionController::Parameters))
-        return false
+        raise(
+          MalformedPublicKeyCredentialError,
+          I18n.t("webauthn.validation.malformed_public_key_credential_error"),
+        )
       end
 
       # 3. Identify the user being authenticated and verify that this user is the
       #    owner of the public key credential source credentialSource identified by credential.id:
       security_key = UserSecurityKey.find_by(credential_id: @params[:credentialId])
-      raise(NotFoundError, I18n.t("webauthn.validation.not_found_error")) if security_key.blank?
+      raise(KeyNotFoundError, I18n.t("webauthn.validation.not_found_error")) if security_key.blank?
       if @factor_type == UserSecurityKey.factor_types[:second_factor] &&
            security_key.user != @current_user
         raise(OwnershipError, I18n.t("webauthn.validation.ownership_error"))

--- a/lib/webauthn/authentication_service.rb
+++ b/lib/webauthn/authentication_service.rb
@@ -92,7 +92,7 @@ module DiscourseWebauthn
       # Success! Update the last used at time for the key.
       security_key.update(last_used: Time.zone.now)
 
-      # Return security key record so login controller can use it to update the session
+      # Return security key record so controller can use it to update the session
       security_key
     rescue OpenSSL::PKey::PKeyError
       raise(PublicKeyError, I18n.t("webauthn.validation.public_key_error"))

--- a/lib/webauthn/base_validation_service.rb
+++ b/lib/webauthn/base_validation_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseWebauthn
-  class SecurityKeyBaseValidationService
+  class BaseValidationService
     def initialize(current_user, params, challenge_params)
       @current_user = current_user
       @params = params

--- a/lib/webauthn/base_validation_service.rb
+++ b/lib/webauthn/base_validation_service.rb
@@ -2,10 +2,11 @@
 
 module DiscourseWebauthn
   class BaseValidationService
-    def initialize(current_user, params, challenge_params)
+    def initialize(current_user, params, options = {})
       @current_user = current_user
       @params = params
-      @challenge_params = challenge_params
+      @challenge = options[:challenge]
+      @factor_type = options[:factor_type]
     end
 
     def validate_webauthn_type(type_to_check)
@@ -52,7 +53,7 @@ module DiscourseWebauthn
     end
 
     def challenge_match?
-      Base64.decode64(client_data["challenge"]) == @challenge_params[:challenge]
+      Base64.decode64(client_data["challenge"]) == @challenge
     end
 
     def origin_match?

--- a/lib/webauthn/base_validation_service.rb
+++ b/lib/webauthn/base_validation_service.rb
@@ -5,8 +5,8 @@ module DiscourseWebauthn
     def initialize(current_user, params, options = {})
       @current_user = current_user
       @params = params
-      @challenge = options[:challenge]
       @factor_type = options[:factor_type]
+      @session = options[:session]
     end
 
     def validate_webauthn_type(type_to_check)
@@ -53,7 +53,8 @@ module DiscourseWebauthn
     end
 
     def challenge_match?
-      Base64.decode64(client_data["challenge"]) == @challenge
+      Base64.decode64(client_data["challenge"]) ==
+        DiscourseWebauthn.challenge(@current_user, @session)
     end
 
     def origin_match?

--- a/lib/webauthn/base_validation_service.rb
+++ b/lib/webauthn/base_validation_service.rb
@@ -32,9 +32,26 @@ module DiscourseWebauthn
       )
     end
 
+    ## flags per specification
+    # https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data
+    # bit 0 - user presence
+    # bit 1 - reserved for future use
+    # bit 2 - user verification
+    # bit 3-5 - reserved for future use
+    # bit 6 - attested credential data
+    # bit 7 - extension data
+
+    def validate_user_presence
+      flags = auth_data[32].unpack("b*")[0].split("")
+      # bit 0 - user presence
+      return if flags[0] == "1"
+      raise(UserPresenceError, I18n.t("webauthn.validation.user_presence_error"))
+    end
+
     def validate_user_verification
       flags = auth_data[32].unpack("b*")[0].split("")
-      return if flags[0] == "1"
+      # bit 2 - user verification
+      return if flags[2] == "1"
       raise(UserVerificationError, I18n.t("webauthn.validation.user_verification_error"))
     end
 

--- a/lib/webauthn/registration_service.rb
+++ b/lib/webauthn/registration_service.rb
@@ -101,7 +101,7 @@ module DiscourseWebauthn
       #     the Relying Party SHOULD fail this registration ceremony, or it MAY decide to accept
       #     the registration, e.g. while deleting the older registration.
       encoded_credential_id = Base64.strict_encode64(credential_id)
-      endcoded_public_key = Base64.strict_encode64(credential_public_key_bytes)
+      encoded_public_key = Base64.strict_encode64(credential_public_key_bytes)
       if UserSecurityKey.exists?(credential_id: encoded_credential_id)
         raise(CredentialIdInUseError, I18n.t("webauthn.validation.credential_id_in_use_error"))
       end
@@ -113,7 +113,7 @@ module DiscourseWebauthn
       UserSecurityKey.create!(
         user: @current_user,
         credential_id: encoded_credential_id,
-        public_key: endcoded_public_key,
+        public_key: encoded_public_key,
         name: @params[:name],
         factor_type: @factor_type,
       )

--- a/lib/webauthn/registration_service.rb
+++ b/lib/webauthn/registration_service.rb
@@ -8,7 +8,7 @@ module DiscourseWebauthn
     # See https://w3c.github.io/webauthn/#sctn-registering-a-new-credential for
     # the registration steps followed here. Memoized methods are called in their
     # place in the step flow to make the process clearer.
-    def register_second_factor_security_key
+    def register_security_key
       # 4. Verify that the value of C.type is webauthn.create.
       validate_webauthn_type(::DiscourseWebauthn::ACCEPTABLE_REGISTRATION_TYPE)
 
@@ -114,7 +114,7 @@ module DiscourseWebauthn
         credential_id: encoded_credential_id,
         public_key: endcoded_public_key,
         name: @params[:name],
-        factor_type: UserSecurityKey.factor_types[:second_factor],
+        factor_type: @factor_type,
       )
     rescue CBOR::UnpackError, CBOR::TypeError, CBOR::MalformedFormatError, CBOR::StackError
       raise MalformedAttestationError, I18n.t("webauthn.validation.malformed_attestation_error")

--- a/lib/webauthn/registration_service.rb
+++ b/lib/webauthn/registration_service.rb
@@ -38,11 +38,12 @@ module DiscourseWebauthn
       # 11. Verify that the User Present bit of the flags in authData is set.
       # https://blog.bigbinary.com/2011/07/20/ruby-pack-unpack.html
       #
-      # bit 0 is the least significant bit - LSB first
+      validate_user_presence
+
       #
       # 12. If user verification is required for this registration, verify that
       #     the User Verified bit of the flags in authData is set.
-      validate_user_verification
+      validate_user_verification if @factor_type == UserSecurityKey.factor_types[:first_factor]
 
       # 13. Verify that the "alg" parameter in the credential public key in authData matches the alg
       #     attribute of one of the items in options.pubKeyCredParams.

--- a/lib/webauthn/registration_service.rb
+++ b/lib/webauthn/registration_service.rb
@@ -3,7 +3,7 @@ require "cbor"
 require "cose"
 
 module DiscourseWebauthn
-  class SecurityKeyRegistrationService < SecurityKeyBaseValidationService
+  class RegistrationService < BaseValidationService
     ##
     # See https://w3c.github.io/webauthn/#sctn-registering-a-new-credential for
     # the registration steps followed here. Memoized methods are called in their

--- a/lib/webauthn/security_key_base_validation_service.rb
+++ b/lib/webauthn/security_key_base_validation_service.rb
@@ -56,11 +56,11 @@ module DiscourseWebauthn
     end
 
     def origin_match?
-      client_data["origin"] == @challenge_params[:origin]
+      client_data["origin"] == DiscourseWebauthn.origin
     end
 
     def rp_id_hash_match?
-      auth_data[0..31] == OpenSSL::Digest::SHA256.digest(@challenge_params[:rp_id])
+      auth_data[0..31] == OpenSSL::Digest::SHA256.digest(DiscourseWebauthn.rp_id)
     end
 
     def client_data_hash

--- a/spec/fabricators/user_security_key_fabricator.rb
+++ b/spec/fabricators/user_security_key_fabricator.rb
@@ -24,3 +24,9 @@ Fabricator(:user_security_key_with_random_credential, from: :user_security_key) 
   credential_id { SecureRandom.base64(40) }
   public_key { SecureRandom.base64(40) }
 end
+
+Fabricator(:passkey_with_random_credential, from: :user_security_key) do
+  credential_id { SecureRandom.base64(40) }
+  public_key { SecureRandom.base64(40) }
+  factor_type { UserSecurityKey.factor_types[:first_factor] }
+end

--- a/spec/lib/webauthn/authentication_service_spec.rb
+++ b/spec/lib/webauthn/authentication_service_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
     let(:authenticator_data) { valid_passkey_auth_data[:authenticatorData] }
     let(:challenge) { valid_passkey_challenge }
 
-    let(:client_data_param) { valid_passkey_client_data_param }
+    let(:client_data_param) { passkey_client_data_param("webauthn.get") }
 
     let!(:security_key) do
       Fabricate(

--- a/spec/lib/webauthn/authentication_service_spec.rb
+++ b/spec/lib/webauthn/authentication_service_spec.rb
@@ -109,15 +109,21 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
 
   context "when params is blank" do
     let(:params) { nil }
-    it "returns false with no validation" do
-      expect(service.authenticate_security_key).to eq(false)
+    it "raises a MalformedPublicKeyCredentialError" do
+      expect { service.authenticate_security_key }.to raise_error(
+        DiscourseWebauthn::MalformedPublicKeyCredentialError,
+        I18n.t("webauthn.validation.malformed_public_key_credential_error"),
+      )
     end
   end
 
   context "when params is not blank and not a hash" do
     let(:params) { "test" }
-    it "returns false with no validation" do
-      expect(service.authenticate_security_key).to eq(false)
+    it "raises a MalformedPublicKeyCredentialError" do
+      expect { service.authenticate_security_key }.to raise_error(
+        DiscourseWebauthn::MalformedPublicKeyCredentialError,
+        I18n.t("webauthn.validation.malformed_public_key_credential_error"),
+      )
     end
   end
 
@@ -126,7 +132,7 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
 
     it "raises a NotFoundError" do
       expect { service.authenticate_security_key }.to raise_error(
-        DiscourseWebauthn::NotFoundError,
+        DiscourseWebauthn::KeyNotFoundError,
         I18n.t("webauthn.validation.not_found_error"),
       )
     end

--- a/spec/lib/webauthn/authentication_service_spec.rb
+++ b/spec/lib/webauthn/authentication_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "discourse_webauthn"
-require "webauthn/security_key_registration_service"
+require "webauthn/registration_service"
 
 ##
 # These tests use the following parameters generated on a local discourse
@@ -36,7 +36,7 @@ require "webauthn/security_key_registration_service"
 #
 # The origin params just need to be whatever your localhost URL for Discourse is.
 
-RSpec.describe DiscourseWebauthn::SecurityKeyAuthenticationService do
+RSpec.describe DiscourseWebauthn::AuthenticationService do
   subject(:service) { described_class.new(current_user, params, challenge_params) }
 
   let(:security_key_user) { current_user }

--- a/spec/lib/webauthn/authentication_service_spec.rb
+++ b/spec/lib/webauthn/authentication_service_spec.rb
@@ -37,7 +37,7 @@ require "webauthn/registration_service"
 # The origin params just need to be whatever your localhost URL for Discourse is.
 
 RSpec.describe DiscourseWebauthn::AuthenticationService do
-  subject(:service) { described_class.new(current_user, params, challenge_params) }
+  subject(:service) { described_class.new(current_user, params, options) }
 
   let(:security_key_user) { current_user }
   let!(:security_key) do
@@ -55,6 +55,7 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
   let(:credential_id) do
     "mJAJ4CznTO0SuLkJbYwpgK75ao4KMNIPlU5KWM92nq39kRbXzI9mSv6GxTcsMYoiPgaouNw7b7zBiS4vsQaO6A=="
   end
+  let(:secure_session) { SecureSession.new("tester") }
   let(:challenge) { "81d4acfbd69eafa8f02bc2ecbec5267be8c9b28c1e0ba306d52b79f0f13d" }
   let(:client_data_challenge) { Base64.strict_encode64(challenge) }
   let(:client_data_webauthn_type) { "webauthn.get" }
@@ -87,8 +88,13 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
     }
   end
 
-  let(:challenge_params) { { challenge: challenge } }
+  let(:options) { { session: secure_session } }
   let(:current_user) { Fabricate(:user) }
+
+  before do
+    # we have to stub here because the public key was created using this specific challenge
+    DiscourseWebauthn.stubs(:challenge).returns(challenge)
+  end
 
   it "updates last_used when the security key and params are valid" do
     expect(service.authenticate_security_key).to eq(true)

--- a/spec/lib/webauthn/registration_service_spec.rb
+++ b/spec/lib/webauthn/registration_service_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require "discourse_webauthn"
-require "webauthn/security_key_registration_service"
+require "webauthn/registration_service"
 
-RSpec.describe DiscourseWebauthn::SecurityKeyRegistrationService do
+RSpec.describe DiscourseWebauthn::RegistrationService do
   subject(:service) { described_class.new(current_user, params, challenge_params) }
 
   let(:client_data_challenge) { Base64.encode64(challenge) }

--- a/spec/lib/webauthn/registration_service_spec.rb
+++ b/spec/lib/webauthn/registration_service_spec.rb
@@ -210,10 +210,10 @@ RSpec.describe DiscourseWebauthn::RegistrationService do
       expect(key.factor_type).to eq(UserSecurityKey.factor_types[:first_factor])
     end
 
-    context "when the user verification flag is false" do
+    context "when the user verification flag in the key is false" do
       it "raises a UserVerificationError" do
         # simulate missing user verification by flipping third bit to 0
-        flags = "10000010"
+        flags = "10000010" # correct flag sequence is "10100010"
         overridenAuthData = service.send(:auth_data)
         overridenAuthData[32] = [flags].pack("b*")
 

--- a/spec/lib/webauthn/registration_service_spec.rb
+++ b/spec/lib/webauthn/registration_service_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe DiscourseWebauthn::RegistrationService do
     end
   end
 
-  describe "registering a first factor key" do
+  describe "registering a passkey" do
     let(:options) do
       { factor_type: UserSecurityKey.factor_types[:first_factor], session: secure_session }
     end

--- a/spec/lib/webauthn/security_key_registration_service_spec.rb
+++ b/spec/lib/webauthn/security_key_registration_service_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe DiscourseWebauthn::SecurityKeyRegistrationService do
   ##
   # The above attestation was generated in localhost; Discourse.current_hostname
   # returns test.localhost which we do not want
-  let(:rp_id) { "localhost" }
-  let(:challenge_params) { { challenge: challenge, rp_id: rp_id, origin: "http://localhost:3000" } }
+  let(:challenge_params) { { challenge: challenge } }
   let(:challenge) { "f1e04530f34a1b6a08d032d8550e23eb8330be04e4166008f26c0e1b42ad" }
   let(:current_user) { Fabricate(:user) }
 
@@ -71,9 +70,9 @@ RSpec.describe DiscourseWebauthn::SecurityKeyRegistrationService do
   end
 
   context "when the sha256 hash of the relaying party ID does not match the one in attestation.authData" do
-    let(:rp_id) { "bad_rp_id" }
-
     it "raises a InvalidRelyingPartyIdError" do
+      DiscourseWebauthn.stubs(:rp_id).returns("http://a.different.host")
+
       expect { service.register_second_factor_security_key }.to raise_error(
         DiscourseWebauthn::InvalidRelyingPartyIdError,
         I18n.t("webauthn.validation.invalid_relying_party_id_error"),

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SessionController do
           expect(response_body_parsed["challenge"]).to eq(
             DiscourseWebauthn.challenge(user, secure_session),
           )
-          expect(DiscourseWebauthn.rp_id).to eq(Discourse.current_hostname)
+          expect(DiscourseWebauthn.rp_id).to eq("localhost")
         end
       end
     end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe SessionController do
             [user_security_key.credential_id],
           )
           secure_session = SecureSession.new(session["secure_session_id"])
+
           expect(response_body_parsed["challenge"]).to eq(
             DiscourseWebauthn.challenge(user, secure_session),
           )

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2001,7 +2001,9 @@ RSpec.describe SessionController do
             expect(session[:current_user_id]).to eq(nil)
             response_body = response.parsed_body
             expect(response_body["failed"]).to eq("FAILED")
-            expect(response_body["error"]).to eq(I18n.t("login.invalid_security_key"))
+            expect(response_body["error"]).to eq(
+              I18n.t("webauthn.validation.malformed_public_key_credential_error"),
+            )
           end
         end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5835,7 +5835,6 @@ RSpec.describe UsersController do
 
     context "when the creation parameters are invalid" do
       it "shows a security key error and does not create a key" do
-        stub_as_dev_localhost
         create_second_factor_security_key
         _response_parsed = response.parsed_body
 

--- a/spec/support/webauthn_integration_helpers.rb
+++ b/spec/support/webauthn_integration_helpers.rb
@@ -70,9 +70,9 @@ module DiscourseWebauthnIntegrationHelpers
     "66b47014ef72937d8320ed893dc797e8a9a6d5098b89b185ca3d439b3656"
   end
 
-  def valid_passkey_client_data_param
+  def passkey_client_data_param(type)
     {
-      type: "webauthn.get",
+      type: type,
       challenge: Base64.strict_encode64(valid_passkey_challenge),
       origin: "http://localhost:3000",
       crossOrigin: false,
@@ -81,7 +81,7 @@ module DiscourseWebauthnIntegrationHelpers
 
   def valid_passkey_auth_data
     {
-      clientData: Base64.strict_encode64(valid_passkey_client_data_param.to_json),
+      clientData: Base64.strict_encode64(passkey_client_data_param("webauthn.get").to_json),
       credentialId: "JFeriwVn1elZk7N8nwSC4magQ8zM1XIUxRZB9Pm7VDM=",
       authenticatorData: "SZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2MFAAAAAA==",
       signature:

--- a/spec/support/webauthn_integration_helpers.rb
+++ b/spec/support/webauthn_integration_helpers.rb
@@ -60,10 +60,44 @@ module DiscourseWebauthnIntegrationHelpers
   end
 
   def simulate_localhost_webauthn_challenge
-    DiscourseWebauthn::ChallengeGenerator.stubs(:generate).returns(
-      DiscourseWebauthn::ChallengeGenerator::ChallengeSession.new(
-        challenge: valid_security_key_challenge_data[:challenge],
-      ),
-    )
+    DiscourseWebauthn.stubs(:challenge).returns(valid_security_key_challenge_data[:challenge])
+  end
+
+  # Passkey data sourced from a key generated in a local browser
+  # with webauthn.create that includes the user verification flag on localhost:3000
+  # usin puts statements in the passkeys session controllers
+  def valid_passkey_challenge
+    "66b47014ef72937d8320ed893dc797e8a9a6d5098b89b185ca3d439b3656"
+  end
+
+  def valid_passkey_client_data_param
+    {
+      type: "webauthn.get",
+      challenge: Base64.strict_encode64(valid_passkey_challenge),
+      origin: "http://localhost:3000",
+      crossOrigin: false,
+    }
+  end
+
+  def valid_passkey_auth_data
+    {
+      clientData: Base64.strict_encode64(valid_passkey_client_data_param.to_json),
+      credentialId: "JFeriwVn1elZk7N8nwSC4magQ8zM1XIUxRZB9Pm7VDM=",
+      authenticatorData: "SZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2MFAAAAAA==",
+      signature:
+        "MEUCIG5AFaw2Nfy69hHjeRLqm3LzQRMFb+TRbUAz19WJymegAiEAyEEyGdAMB2/NBwRCHM47IwtjKWCLEtabAX2BaK6fD8g=",
+    }
+  end
+
+  def valid_passkey_data
+    {
+      credential_id: "JFeriwVn1elZk7N8nwSC4magQ8zM1XIUxRZB9Pm7VDM=",
+      public_key:
+        "pQECAyYgASFYILjOiAHAwNrXkCk/tmyYRiE87QyV/15wUvhcXhr1JfwtIlggClQywgQvSxTsqV/FSK0cNHTTmuwfzzREqE6eLDmPxmI=",
+    }
+  end
+
+  def simulate_localhost_passkey_challenge
+    DiscourseWebauthn.stubs(:challenge).returns(valid_passkey_challenge)
   end
 end

--- a/spec/support/webauthn_integration_helpers.rb
+++ b/spec/support/webauthn_integration_helpers.rb
@@ -17,6 +17,10 @@ module DiscourseWebauthnIntegrationHelpers
   # This is because the challenge is embedded
   # in the post data's authenticatorData and must match up. See
   # simulate_localhost_webauthn_challenge for a real example.
+
+  # All of the valid security key data is sourced from a localhost
+  # login (with origin http://localhost:3000).
+
   def valid_security_key_data
     {
       credential_id:
@@ -55,15 +59,7 @@ module DiscourseWebauthnIntegrationHelpers
     }
   end
 
-  # all of the valid security key data is sourced from a localhost
-  # login, if this is not set the specs for webauthn WILL NOT WORK
-  def stub_as_dev_localhost
-    Discourse.stubs(:current_hostname).returns("localhost")
-    Discourse.stubs(:base_url).returns("http://localhost:3000")
-  end
-
   def simulate_localhost_webauthn_challenge
-    stub_as_dev_localhost
     DiscourseWebauthn::ChallengeGenerator.stubs(:generate).returns(
       DiscourseWebauthn::ChallengeGenerator::ChallengeSession.new(
         challenge: valid_security_key_challenge_data[:challenge],

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -14,6 +14,9 @@ describe "User preferences for Security", type: :system do
 
   describe "Security keys" do
     it "adds a 2F security key and logs in with it" do
+      # system specs run on their own host + port
+      DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+
       # simulate browser credential authorization
       options = ::Selenium::WebDriver::VirtualAuthenticatorOptions.new
       page.driver.browser.add_virtual_authenticator(options)


### PR DESCRIPTION
Depends on https://github.com/discourse/discourse/pull/23465. 

The feature added in this PR is behind a hidden site setting, `experimental_passkeys`. It's still an early version. 

This PR adds 
- UI elements for users to register passkeys and log in with them
- Add routes and controllers to handle passkey registration and login
- Refactors the `webauthn` registration services to allow passkey registration/authentication
- Updates 2FA registration to ensure only user presence is validated
- Ensures that for passkeys, the validation includes both user presence and user verification (the latter means that authenticators must prompt for PIN or biometric data (face id, fingerprint)

The PR is in draft mode because I still need to add some more specs and post a screen recording of the feature in action. 
