### PR TITLE
UX: Restore wizard confetti in final step

### DIFF
--- a/app/assets/javascripts/wizard/addon/components/wizard-canvas.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-canvas.js
@@ -7,18 +7,10 @@ const SIZE = 144;
 let width, height;
 
 const COLORS = [
-  "#BF1E2E",
-  "#F1592A",
-  "#F7941D",
-  "#9EB83B",
-  "#3AB54A",
-  "#12A89D",
-  "#25AAE2",
-  "#0E76BD",
-  "#652D90",
-  "#92278F",
-  "#ED207B",
-  "#8C6238",
+  "--tertiary",
+  "--quaternary",
+  "--tertiary-medium",
+  "--quaternary-low",
 ];
 
 class Particle {
@@ -34,7 +26,8 @@ class Particle {
     this.ang = Math.random() * 2 * Math.PI;
     this.scale = Math.random() * 0.4 + 0.2;
     this.radius = Math.random() * 25 + 25;
-    this.color = COLORS[Math.floor(Math.random() * COLORS.length)];
+    const colorVar = COLORS[Math.floor(Math.random() * COLORS.length)];
+    this.color = getComputedStyle(document.body).getPropertyValue(colorVar);
     this.flipped = Math.random() > 0.5 ? 1 : -1;
   }
 

--- a/app/assets/javascripts/wizard/addon/controllers/wizard.js
+++ b/app/assets/javascripts/wizard/addon/controllers/wizard.js
@@ -1,0 +1,8 @@
+import Controller, { inject as controller } from "@ember/controller";
+
+export default class extends Controller {
+  @controller wizardStep;
+  get showCanvas() {
+    return this.wizardStep.get("step.id") === "ready";
+  }
+}

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -44,6 +44,10 @@ body.wizard {
       }
     }
   }
+
+  .wizard-canvas {
+    position: absolute;
+  }
 }
 
 // Refactored SCSS

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -33,6 +33,7 @@ body.wizard {
   }
 
   .discourse-logo svg {
+    position: relative;
     height: 70px;
     width: auto;
     @include breakpoint("mobile-extra-large") {
@@ -46,7 +47,9 @@ body.wizard {
   }
 
   .wizard-canvas {
-    position: absolute;
+    position: fixed;
+    top: 0;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
This was accidentally removed as part of the refactoring in fcb4e5a1a15631cef9c20489866a68600ecf768d

<img width="1946" alt="SCR-20230912-krwz" src="https://github.com/discourse/discourse/assets/6270921/72acaa34-812c-4ac6-9b3f-1ba702f8b83f">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
