### PR TITLE
DEV: Move theme-error-handler initializer to service

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/boot-client-error-handler.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/boot-client-error-handler.js
@@ -1,0 +1,5 @@
+export default {
+  initialize(owner) {
+    owner.lookup("service:client-error-handler");
+  },
+};

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -777,7 +777,7 @@ table {
   }
 }
 
-.broken-theme-alert {
+.broken-theme-alert-banner {
   font-size: var(--base-font-size);
   font-weight: bold;
   padding: 5px 0;


### PR DESCRIPTION
This will make it easier for other parts of the app to display similar error banners

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
