### PR TITLE
UX: remove unsupported filterable attr from form template sample

### DIFF
--- a/app/assets/javascripts/admin/addon/lib/template-form-fields.js
+++ b/app/assets/javascripts/admin/addon/lib/template-form-fields.js
@@ -47,7 +47,6 @@ export const templateFormFields = [
       "admin.form_templates.field_placeholders.none_label"
     )}"
     label: "${I18n.t("admin.form_templates.field_placeholders.label")}"
-    filterable: false
   validations:
     # ${I18n.t("admin.form_templates.field_placeholders.validations")}`,
   },

--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -178,7 +178,6 @@ describe "Admin Customize Form Templates", type: :system do
   attributes:
     none_label: "Select an item"
     label: "Enter label here"
-    filterable: false
   validations:
     # enter validations here',
       )


### PR DESCRIPTION
The form template [dropdown component](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/form-template-field/dropdown.hbs) doesn't support a `filterable` attribute, removing it from the sample.