### PR TITLE
UX: wider code lines so background takes the whole width

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -412,6 +412,7 @@ pre.onebox code ol.lines li {
   border-left: 1px solid #cfcfcf;
   min-height: 1.5em; //show empty li lines
   white-space: pre;
+  width: max-content;
 }
 
 pre.onebox code li.selected {


### PR DESCRIPTION
Makes each code line as wide as `max-content`.

### Before
<img width="725" alt="image" src="https://github.com/discourse/discourse/assets/3530/4f43735e-c24e-4177-b62d-056bff89f122">

### After
<img width="713" alt="image" src="https://github.com/discourse/discourse/assets/3530/e813d012-e60a-4e8a-aa11-716fefd4bec0">
