### PR TITLE
FIX: Return 403 instead of redirect on username routes when hiding profiles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -106,7 +106,9 @@ class UsersController < ApplicationController
   end
 
   def show(for_card: false)
-    return redirect_to path("/login") if SiteSetting.hide_user_profiles_from_public && !current_user
+    if SiteSetting.hide_user_profiles_from_public && !current_user
+      raise Discourse::InvalidAccess.new(custom_message: "invalid_access")
+    end
 
     @user =
       fetch_user_from_params(
@@ -158,7 +160,7 @@ class UsersController < ApplicationController
     return redirect_to path("/login") if SiteSetting.hide_user_profiles_from_public && !current_user
 
     user_ids = params.require(:user_ids).split(",").map(&:to_i)
-    raise Discourse::InvalidParameters.new(:user_ids) if user_ids.length > 50
+    raise Discourse::InvalidAccess.new(:user_ids) if user_ids.length > 50
 
     users =
       User.where(id: user_ids).includes(

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -107,7 +107,7 @@ class UsersController < ApplicationController
 
   def show(for_card: false)
     if SiteSetting.hide_user_profiles_from_public && !current_user
-      raise Discourse::InvalidAccess.new(custom_message: "invalid_access")
+      raise Discourse::NotFound.new(custom_message: "invalid_access", status: 403)
     end
 
     @user =

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -157,10 +157,12 @@ class UsersController < ApplicationController
 
   # This route is not used in core, but is used by theme components (e.g. https://meta.discourse.org/t/144479)
   def cards
-    return redirect_to path("/login") if SiteSetting.hide_user_profiles_from_public && !current_user
+    if SiteSetting.hide_user_profiles_from_public && !current_user
+      raise Discourse::NotFound.new(custom_message: "invalid_access", status: 403)
+    end
 
     user_ids = params.require(:user_ids).split(",").map(&:to_i)
-    raise Discourse::InvalidAccess.new(:user_ids) if user_ids.length > 50
+    raise Discourse::InvalidParameters.new(:user_ids) if user_ids.length > 50
 
     users =
       User.where(id: user_ids).includes(

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4478,7 +4478,7 @@ RSpec.describe UsersController do
       it "should redirect to login page for anonymous user when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}.json"
-        expect(response).to redirect_to "/login"
+        expect(response).to have_http_status(:forbidden)
       end
 
       describe "user profile views" do
@@ -4684,7 +4684,7 @@ RSpec.describe UsersController do
       it "should redirect to login page for anonymous user when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}/card.json"
-        expect(response).to redirect_to "/login"
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4479,6 +4479,8 @@ RSpec.describe UsersController do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}.json"
         expect(response).to have_http_status(:forbidden)
+        get "/u/#{user.username}/messages.json"
+        expect(response).to have_http_status(:forbidden)
       end
 
       describe "user profile views" do
@@ -4681,7 +4683,7 @@ RSpec.describe UsersController do
         expect(parsed["trust_level"]).to be_present
       end
 
-      it "should redirect to login page for anonymous user when profiles are hidden" do
+      it "should have http status 403 for anonymous user when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}/card.json"
         expect(response).to have_http_status(:forbidden)
@@ -4740,10 +4742,10 @@ RSpec.describe UsersController do
       expect(parsed.map { |u| u["username"] }).to contain_exactly(user.username, user2.username)
     end
 
-    it "should redirect to login page for anonymous user when profiles are hidden" do
+    it "should have http status 403 for anonymous user when profiles are hidden" do
       SiteSetting.hide_user_profiles_from_public = true
       get "/user-cards.json?user_ids=#{user.id},#{user2.id}"
-      expect(response).to redirect_to "/login"
+      expect(response).to have_http_status(:forbidden)
     end
 
     context "when `hide_profile_and_presence` user option is checked" do


### PR DESCRIPTION
**Context**
The `hide_user_profiles_from_public` Site Setting allows customers to hide user profiles from anonusers. Currently, when an anonuser tries to go to another user's profile while this Site Setting is enabled, the anonuser is redirected.

**Problem**
The redirect can cause some unwanted extra traffic 

**Solution**
Instead of redirecting to the `/login` route return a `403` status