### PR TITLE
FIX: cancel post toolbar on click outside

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -233,9 +233,14 @@ export default class PostTextSelection extends Component {
   }
 
   @bind
-  async mousedown() {
-    this.isMousedown = true;
+  async mousedown(event) {
     this.holdingMouseDown = false;
+
+    if (!event.target.closest(".cooked")) {
+      return;
+    }
+
+    this.isMousedown = true;
     this.holdingMouseDownHandler = discourseLater(() => {
       this.holdingMouseDown = true;
     }, 100);

--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -233,7 +233,7 @@ export default class PostTextSelection extends Component {
   }
 
   @bind
-  async mousedown(event) {
+  mousedown(event) {
     this.holdingMouseDown = false;
 
     if (!event.target.closest(".cooked")) {


### PR DESCRIPTION
On `mousedown` if the click is outside a cooked element cancel the `mousedown`/`mouseup` sequence and only rely on the `selectionchange` event.

This change ensures a click on avatar for example will work, even if user is doing a rather slow click (meaning: the mousedown has been hold for more than 100ms).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
