### PR TITLE
DEV: Do not squash commits in `version_bump:stage_security_fixes`

### DIFF
--- a/lib/tasks/version_bump.rake
+++ b/lib/tasks/version_bump.rake
@@ -406,11 +406,7 @@ task "version_bump:stage_security_fixes", [:base] do |t, args|
       git "fetch", origin, origin_branch
 
       first_commit_on_branch = git("log", "--format=%H", "origin/#{base}..#{ref}").lines.last.strip
-      author = git("log", "-n", "1", "--format=%an <%ae>", first_commit_on_branch).strip
-      message = git("log", "-n", "1", "--format=%B", first_commit_on_branch).strip
-
-      git "merge", "--squash", ref
-      git "commit", "--author", author, "-m", message
+      git "cherry-pick", "#{first_commit_on_branch}^..#{ref}"
     end
 
     puts "Finished merging commits into a locally-staged #{branch} branch. Git log is:"

--- a/spec/tasks/version_bump_spec.rb
+++ b/spec/tasks/version_bump_spec.rb
@@ -213,7 +213,12 @@ RSpec.describe "tasks/version_bump" do
     Dir.chdir(origin_path) do
       # Check each fix has been added as a single commit, with the message matching the first commit on the branch
       expect(run("git", "log", "--pretty=%s", "main").lines.map(&:strip)).to eq(
-        ["security fix two", "security fix one, commit one", "Initial commit"],
+        [
+          "security fix two",
+          "security fix one, commit two",
+          "security fix one, commit one",
+          "Initial commit",
+        ],
       )
 
       # Check all the files from both fixes are present


### PR DESCRIPTION
Sometimes fixes will deliberately keep commits separate, and we don't want to undo that

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
