### PR TITLE
FIX: tooltips can be over the header

### DIFF
--- a/app/assets/stylesheets/common/float-kit/d-tooltip.scss
+++ b/app/assets/stylesheets/common/float-kit/d-tooltip.scss
@@ -13,7 +13,7 @@
   border-radius: var(--d-border-radius);
   border: 1px solid var(--primary-low);
   box-shadow: var(--shadow-menu-panel);
-  z-index: z("tooltip");
+  z-index: z("max");
   width: max-content;
   position: absolute;
   top: 0;


### PR DESCRIPTION
As a result they need a high z-index

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
