### PR TITLE
UX: hide warning if all users mentioned via group are already invited.

### DIFF
--- a/app/controllers/composer_controller.rb
+++ b/app/controllers/composer_controller.rb
@@ -65,8 +65,12 @@ class ComposerController < ApplicationController
                 .count
 
             if notified_count > 0
-              group_reasons[group.name] = :some_not_allowed
-              serialized_group[:notified_count] = notified_count
+              if notified_count == group.user_count
+                group_reasons.delete(group.name)
+              else
+                group_reasons[group.name] = :some_not_allowed
+                serialized_group[:notified_count] = notified_count
+              end
             end
           end
 

--- a/spec/requests/composer_controller_spec.rb
+++ b/spec/requests/composer_controller_spec.rb
@@ -185,10 +185,18 @@ RSpec.describe ComposerController do
         other_group = Fabricate(:group, mentionable_level: Group::ALIAS_LEVELS[:everyone])
         other_group.add(allowed_user)
         other_group.add(user)
-        other_group.add(Fabricate(:user))
 
         # Trying to mention other_group which has not been invited, but two of
         # its members have been (allowed_user directly and user via group).
+        get "/composer/mentions.json", params: { names: [other_group.name], topic_id: topic.id }
+
+        expect(response.status).to eq(200)
+
+        expect(response.parsed_body["groups"]).to eq(other_group.name => { "user_count" => 2 })
+        expect(response.parsed_body["group_reasons"]).to be_empty
+
+        other_group.add(Fabricate(:user))
+
         get "/composer/mentions.json", params: { names: [other_group.name], topic_id: topic.id }
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
Previously, a "`some_not_allowed`" warning message was appeared in composer even when all the users mentioned via group are already invited to the private message directly or via other groups.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
