### PR TITLE
UX: creates a vertical space between the title and the back link

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -210,7 +210,7 @@ header .discourse-tag {
     grid-area: header;
     background: var(--primary-very-low);
     padding: 20px;
-    margin-bottom: 1em;
+    margin: 1em 0;
   }
   .tag-groups-sidebar {
     grid-area: sidebar;


### PR DESCRIPTION
The link was too close to the title; there was no vertical space. Adding a space makes element spacing more even on the page.

Before:
![image](https://github.com/discourse/discourse/assets/5654300/a041b6a9-a0cb-4b1e-84fe-6e00458b9118)

After:
![image](https://github.com/discourse/discourse/assets/5654300/3cc14f27-743f-44bd-bbb0-12a3d71b4fca)
