### PR TITLE
DEV: Convert document-title to a native class

### DIFF
--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -12,15 +12,15 @@ export default class DocumentElement extends Service {
 
   contextCount = 0;
   notificationCount = 0;
-  _title = null;
-  _backgroundNotify = null;
+  #title = null;
+  #backgroundNotify = null;
 
   getTitle() {
-    return this._title;
+    return this.#title;
   }
 
   setTitle(title) {
-    this._title = title;
+    this.#title = title;
     this._renderTitle();
   }
 
@@ -29,10 +29,10 @@ export default class DocumentElement extends Service {
 
     session.hasFocus = focus;
 
-    if (session.hasFocus && this._backgroundNotify) {
+    if (session.hasFocus && this.#backgroundNotify) {
       this.updateContextCount(0);
     }
-    this._backgroundNotify = false;
+    this.#backgroundNotify = false;
 
     if (session.hasFocus) {
       this.notificationCount = 0;
@@ -57,7 +57,7 @@ export default class DocumentElement extends Service {
 
   incrementBackgroundContextCount() {
     if (!this.session.hasFocus) {
-      this._backgroundNotify = true;
+      this.#backgroundNotify = true;
       this.contextCount += 1;
       this._renderFavicon();
       this._renderTitle();
@@ -71,7 +71,7 @@ export default class DocumentElement extends Service {
   }
 
   _renderTitle() {
-    let title = this._title || this.siteSettings.title;
+    let title = this.#title || this.siteSettings.title;
 
     let displayCount = this._displayCount();
     let dynamicFavicon = this.currentUser?.user_option.dynamic_favicon;

--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -15,13 +15,6 @@ export default class DocumentElement extends Service {
   _title = null;
   _backgroundNotify = null;
 
-  reset() {
-    this.contextCount = 0;
-    this.notificationCount = 0;
-    this._title = null;
-    this._backgroundNotify = null;
-  }
-
   getTitle() {
     return this._title;
   }

--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -1,35 +1,35 @@
 import Service, { inject as service } from "@ember/service";
 import getURL from "discourse-common/lib/get-url";
 import updateTabCount from "discourse/lib/update-tab-count";
+import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 
-export default Service.extend({
-  appEvents: service(),
-  currentUser: service(),
-  contextCount: null,
-  notificationCount: null,
-  _title: null,
-  _backgroundNotify: null,
+@disableImplicitInjections
+export default class DocumentElement extends Service {
+  @service appEvents;
+  @service currentUser;
+  @service session;
+  @service siteSettings;
 
-  init() {
-    this._super(...arguments);
-    this.reset();
-  },
+  contextCount = 0;
+  notificationCount = 0;
+  _title = null;
+  _backgroundNotify = null;
 
   reset() {
     this.contextCount = 0;
     this.notificationCount = 0;
     this._title = null;
     this._backgroundNotify = null;
-  },
+  }
 
   getTitle() {
     return this._title;
-  },
+  }
 
   setTitle(title) {
     this._title = title;
     this._renderTitle();
-  },
+  }
 
   setFocus(focus) {
     let { session } = this;
@@ -47,12 +47,12 @@ export default Service.extend({
     this.appEvents.trigger("discourse:focus-changed", session.hasFocus);
     this._renderFavicon();
     this._renderTitle();
-  },
+  }
 
   updateContextCount(count) {
     this.contextCount = count;
     this._renderTitle();
-  },
+  }
 
   updateNotificationCount(count, { forced = false } = {}) {
     if (!this.session.hasFocus || forced) {
@@ -60,7 +60,7 @@ export default Service.extend({
       this._renderFavicon();
       this._renderTitle();
     }
-  },
+  }
 
   incrementBackgroundContextCount() {
     if (!this.session.hasFocus) {
@@ -69,14 +69,13 @@ export default Service.extend({
       this._renderFavicon();
       this._renderTitle();
     }
-  },
+  }
 
   _displayCount() {
-    return this.currentUser &&
-      this.currentUser.user_option.title_count_mode === "notifications"
+    return this.currentUser?.user_option.title_count_mode === "notifications"
       ? this.notificationCount
       : this.contextCount;
-  },
+  }
 
   _renderTitle() {
     let title = this._title || this.siteSettings.title;
@@ -94,7 +93,7 @@ export default Service.extend({
     }
 
     document.title = title;
-  },
+  }
 
   _renderFavicon() {
     if (this.currentUser?.user_option.dynamic_favicon) {
@@ -109,5 +108,5 @@ export default Service.extend({
 
       updateTabCount(url, this._displayCount());
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -8,14 +8,8 @@ module("Unit | Service | document-title", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    const session = Session.current();
-    session.hasFocus = true;
-
+    Session.current().hasFocus = true;
     this.documentTitle = getOwner(this).lookup("service:document-title");
-  });
-
-  hooks.afterEach(function () {
-    this.documentTitle.reset();
   });
 
   test("it updates the document title", function (assert) {


### PR DESCRIPTION
Included: removed the `reset` method, used private fields, added explicit service injections