### PR TITLE
A11Y: avatar upload button should be focusable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/avatar-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/components/avatar-uploader.hbs
@@ -10,8 +10,8 @@
   @icon="far-image"
   @disabled={{this.uploading}}
   @action={{this.chooseImage}}
+  @title="user.change_avatar.upload_title"
   class="btn-default"
-  title={{i18n "user.change_avatar.upload_title"}}
   data-uploaded={{this.customAvatarUploaded}}
   data-avatar-upload-id={{this.uploadedAvatarId}}
 />

--- a/app/assets/javascripts/discourse/app/components/avatar-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/components/avatar-uploader.hbs
@@ -1,24 +1,20 @@
-<label
-  class="btn btn-default btn-icon-text"
+<input
+  class="hidden-upload-field"
   disabled={{this.uploading}}
+  type="file"
+  accept="image/*"
+  aria-hidden="true"
+/>
+<DButton
+  @translatedLabel={{this.uploadLabel}}
+  @icon="far-image"
+  @disabled={{this.uploading}}
+  @action={{this.chooseImage}}
+  class="btn-default"
   title={{i18n "user.change_avatar.upload_title"}}
   data-uploaded={{this.customAvatarUploaded}}
   data-avatar-upload-id={{this.uploadedAvatarId}}
->
-  {{d-icon "far-image"}}
-  {{#if this.uploading}}
-    {{i18n "uploading"}}
-    {{this.uploadProgress}}%
-  {{else}}
-    {{i18n "upload"}}
-  {{/if}}
-  <input
-    class="hidden-upload-field"
-    disabled={{this.uploading}}
-    type="file"
-    accept="image/*"
-  />
-</label>
+/>
 
 {{#if this.imageIsNotASquare}}
   <div class="warning">{{i18n "user.change_avatar.image_is_not_a_square"}}</div>

--- a/app/assets/javascripts/discourse/app/components/avatar-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/avatar-uploader.js
@@ -2,6 +2,8 @@ import Component from "@ember/component";
 import { isBlank } from "@ember/utils";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
+import I18n from "I18n";
 
 export default Component.extend(UppyUploadMixin, {
   type: "avatar",
@@ -30,5 +32,17 @@ export default Component.extend(UppyUploadMixin, {
   @discourseComputed("user_id")
   data(user_id) {
     return { user_id };
+  },
+
+  @discourseComputed("uploading", "uploadProgress")
+  uploadLabel() {
+    return this.uploading
+      ? `${I18n.t("uploading")} ${this.uploadProgress}%`
+      : I18n.t("upload");
+  },
+
+  @action
+  chooseImage() {
+    this.fileInputEl.click();
   },
 });


### PR DESCRIPTION
This avatar upload button was a label styled like a button, and therefore wasn't focusable with keyboard navigation. 

This converts it to a legit button, which naturally allows keyboard focus. Functionality and appearance remain the same. 

![Screenshot 2023-09-13 at 5 58 58 PM](https://github.com/discourse/discourse/assets/1681963/bc4bc1cb-5df2-4fc3-85a9-8772ae58df43)
