### PR TITLE
DEV: Automatically retry patch-package on failure

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -13,7 +13,7 @@
     "build": "ember build",
     "start": "ember serve",
     "test": "ember test",
-    "postinstall": "yarn --silent --cwd .. patch-package"
+    "postinstall": "../run-patch-package"
   },
   "dependencies": {
     "@glimmer/syntax": "^0.84.3",

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "run-patch-package"
+    "postinstall": "./run-patch-package"
   },
   "workspaces": [
     "admin",

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "patch-package"
+    "postinstall": "run-patch-package"
   },
   "workspaces": [
     "admin",

--- a/app/assets/javascripts/run-patch-package
+++ b/app/assets/javascripts/run-patch-package
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# We are seeing occasional flakes in `patch-package`, possibly caused by https://github.com/ds300/patch-package/issues/484
+# This script will retry it three times before giving up.
+# Longer-term we hope to upgrade to a package manager with built-in patch support.
+
+for i in {1..3}; do
+  if [ $i -ne 1 ]; then
+    echo "patch-package failed... retry ($i/3)..."
+  fi
+
+  script_dir=$(dirname "$0")
+  yarn --silent --cwd "${script_dir}" patch-package && exit 0;
+done
+
+exit 1;


### PR DESCRIPTION
We are seeing occasional flakes in `patch-package`, possibly caused by https://github.com/ds300/patch-package/issues/484. This wrapper script will retry patch-package three times before giving up. Longer-term we hope to upgrade to a package manager with built-in patch support.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
