### PR TITLE
A11Y: allow `DTooltip` to trigger on focus, update admin report tooltips

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-report.hbs
@@ -30,16 +30,18 @@
                         rel="noopener noreferrer"
                         href={{this.model.description_link}}
                         class="info"
-                        data-tooltip={{this.model.description}}
                       >
                         {{d-icon "question-circle"}}
+                        <DTooltip>
+                          {{this.model.description}}
+                        </DTooltip>
                       </a>
                     {{else}}
-                      <span
-                        class="info"
-                        data-tooltip={{this.model.description}}
-                      >
+                      <span class="info" tabindex="0">
                         {{d-icon "question-circle"}}
+                        <DTooltip>
+                          {{this.model.description}}
+                        </DTooltip>
                       </span>
                     {{/if}}
                   {{/if}}

--- a/app/assets/javascripts/discourse/app/components/d-tooltip.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-tooltip.gjs
@@ -47,7 +47,7 @@ export default class DiscourseTooltip extends Component {
     this.#tippyInstance = tippy(element.parentElement, {
       content: element,
       interactive: this.args.interactive ?? false,
-      trigger: this.capabilities.touch ? "click" : "mouseenter",
+      trigger: this.capabilities.touch ? "click" : "mouseenter focus",
       theme: this.args.theme || "d-tooltip",
       arrow: this.args.arrow ? iconHTML("tippy-rounded-arrow") : false,
       placement: this.args.placement || "bottom-start",

--- a/app/assets/javascripts/discourse/app/lib/d-tooltip.js
+++ b/app/assets/javascripts/discourse/app/lib/d-tooltip.js
@@ -28,7 +28,7 @@ export class DTooltip {
     return tippy(target, {
       interactive: false,
       content,
-      trigger: this.#hasTouchCapabilities() ? "click" : "mouseenter",
+      trigger: this.#hasTouchCapabilities() ? "click" : "mouseenter focus",
       theme: "d-tooltip",
       arrow: false,
       placement: "bottom-start",


### PR DESCRIPTION
Tippy comes with accessibility support, so this adds the `focus` trigger to utilize this. Previously it was impossible to trigger these with the keyboard. 

I've also updated the admin report tooltips to `DTooltip`


Before:


Can't focus or trigger tooltip... focus skips over the ❔ 

![Screenshot 2023-09-14 at 10 52 30 AM](https://github.com/discourse/discourse/assets/1681963/c25616be-f85c-4517-9cc2-dc2bf08d888e)

![Screenshot 2023-09-14 at 10 52 39 AM](https://github.com/discourse/discourse/assets/1681963/e9d1c189-d0ac-4ae0-956c-112c91e9673d)



After:

Can focus the ❔, and the tooltip triggers 

![Screenshot 2023-09-14 at 10 48 45 AM](https://github.com/discourse/discourse/assets/1681963/07482eae-93af-44b4-b6aa-c9a8c660d3d7)

