### PR TITLE
DEV: Adjust site setting search limiter

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -92,7 +92,7 @@ export default class AdminSiteSettingsController extends Controller {
             (item.get("value") || "").toString().toLowerCase().includes(filter);
           if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
             // Tightens up fuzzy search results a bit.
-            const fuzzySearchLimiter = 15;
+            const fuzzySearchLimiter = 25;
             const strippedSetting = setting.replace(/[^a-z0-9]/gi, "");
             if (
               strippedSetting.length <=

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -40,6 +40,11 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
             value: "",
             setting: "pending_users_reminder_delay_minutes",
           }),
+          SiteSetting.create({
+            description: "",
+            value: "",
+            setting: "min_personal_message_post_length",
+          }),
         ],
       },
     ];
@@ -58,5 +63,13 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
     results = controller.performSearch("digest", settings2);
     assert.deepEqual(results[0].siteSettings.length, 1);
     assert.deepEqual(results[0].siteSettings[0].setting, "digest_logo");
+
+    // ensures fuzzy search limiter doesn't limit too much
+    results = controller.performSearch("min length", settings2);
+    assert.deepEqual(results[0].siteSettings.length, 1);
+    assert.deepEqual(
+      results[0].siteSettings[0].setting,
+      "min_personal_message_post_length"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -66,8 +66,8 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
 
     // ensures fuzzy search limiter doesn't limit too much
     results = controller.performSearch("min length", settings2);
-    assert.deepEqual(results[0].siteSettings.length, 1);
-    assert.deepEqual(
+    assert.strictEqual(results[0].siteSettings.length, 1);
+    assert.strictEqual(
       results[0].siteSettings[0].setting,
       "min_personal_message_post_length"
     );


### PR DESCRIPTION
This opens up the site setting search limiter some more so that when
searching for "min length" it will contain
"min_personal_message_post_length" as one of the results, but not open
it up so much so that when searching for "digest",
"pending_users_reminder_delay_minutes" won't show up in the results
because it isn't really related.
