### PR TITLE
A11Y: Activate user menu tab on keydown too

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-tab.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-tab.hbs
@@ -9,6 +9,7 @@
   data-tab-number={{@tab.position}}
   href={{@tab.linkWhenActive}}
   {{on "click" @onTabClick}}
+  {{on "keydown" @onTabClick}}
 >
   {{d-icon @tab.icon}}
   {{#if @tab.count}}

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -273,6 +273,10 @@ export default class UserMenu extends Component {
       return;
     }
 
+    if (event.type === "keydown" && event.keyCode !== 13) {
+      return;
+    }
+
     event.preventDefault();
 
     this.currentTabId = tab.id;

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, triggerKeyEvent, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
@@ -818,6 +818,22 @@ acceptance("User menu", function (needs) {
     } finally {
       window.removeEventListener("click", interceptor);
     }
+  });
+
+  test("tabs without hrefs can be visited with the keyboard", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+
+    await triggerKeyEvent(
+      "#user-menu-button-other-notifications",
+      "keydown",
+      "Enter"
+    );
+
+    assert.ok(
+      exists("#quick-access-other-notifications"),
+      "the other notifications panel can display using keyboard navigation"
+    );
   });
 });
 


### PR DESCRIPTION
When there's no `href` set on a tab, you can't switch the panel with keyboard navigation. For example, the `chat` tab or the `other` tab.  

![Screenshot 2023-09-14 at 12 09 56 PM](https://github.com/discourse/discourse/assets/1681963/38dc150f-c40f-4805-8de6-bc91b883a72e)

This PR reuses the `onTabClick` action for `keydown` as well, so <kbd>Enter</kbd> can also activate `href`-less tabs. 