### PR TITLE
FIX: use the `destination_url` cookie as `return_path` if present

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -1,3 +1,4 @@
+import cookie from "discourse/lib/cookie";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
@@ -230,7 +231,9 @@ const ApplicationRoute = DiscourseRoute.extend({
 
   handleShowLogin() {
     if (this.siteSettings.enable_discourse_connect) {
-      const returnPath = encodeURIComponent(window.location.pathname);
+      const returnPath = cookie("destination_url")
+        ? getURL("/")
+        : encodeURIComponent(window.location.pathname);
       window.location = getURL("/session/sso?return_path=" + returnPath);
     } else {
       this.modal.show(LoginModal, {


### PR DESCRIPTION
It avoids an edge case where accessing `/new-topic` as an anonymous user on an SSO-enabled instance goes through the SSO flow and returns to the wrong route, because at the point we hit `handleShowLogin`, `window.location.pathname` is the default home page, not the originally visited `/new-topic` route.

`/new-topic` stores the current URL on the `destination_url` cookie and it's correctly used if `return_path` is the root path:

https://github.com/discourse/discourse/blob/38c8fc613640d2381a5a84dc32713c8ea7c3982f/app/controllers/session_controller.rb#L30-L33