### PR TITLE
DEV: Future-proof `htmlSafe` interactions

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/change-post-notice.js
+++ b/app/assets/javascripts/discourse/app/controllers/change-post-notice.js
@@ -47,7 +47,7 @@ export default Controller.extend(ModalFunctionality, {
             ? {
                 type: "custom",
                 raw: notice,
-                cooked: cooked.string,
+                cooked: cooked.toString(),
               }
             : null
         )

--- a/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
@@ -69,7 +69,7 @@ export default RestModel.extend({
         const promises = result.drafts.map((draft) => {
           draft.data = JSON.parse(draft.data);
           return cookAsync(draft.data.reply).then((cooked) => {
-            draft.excerpt = excerpt(cooked.string, 300);
+            draft.excerpt = excerpt(cooked.toString(), 300);
             draft.post_number = draft.data.postId || null;
             if (
               draft.draft_key === NEW_PRIVATE_MESSAGE_KEY ||

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -172,6 +172,6 @@ module("Unit | Utility | computed", function (hooks) {
       desc: htmlSafe("cookies"),
     }).create({ cookies });
 
-    assert.strictEqual(t.desc.string, cookies);
+    assert.strictEqual(t.desc.toString(), cookies);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/lightbox/process-html-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/lightbox/process-html-test.js
@@ -58,8 +58,8 @@ module("Unit | lib | Experimental lightbox | processHTML()", function () {
     assert.strictEqual(item.index, LIGHTBOX_IMAGE_FIXTURES.first.index);
 
     assert.strictEqual(
-      item.cssVars.string,
-      LIGHTBOX_IMAGE_FIXTURES.first.cssVars.string
+      item.cssVars.toString(),
+      LIGHTBOX_IMAGE_FIXTURES.first.cssVars.toString()
     );
 
     assert.strictEqual(startingIndex, 0);
@@ -140,7 +140,7 @@ module("Unit | lib | Experimental lightbox | processHTML()", function () {
     assert.strictEqual(items[0].aspectRatio, null);
 
     assert.strictEqual(
-      items[0].cssVars.string,
+      items[0].cssVars.toString(),
       `--dominant-color: #${LIGHTBOX_IMAGE_FIXTURES.first.dominantColor};--small-url: url(${LIGHTBOX_IMAGE_FIXTURES.first.smallURL});`
     );
   });
@@ -171,7 +171,7 @@ module("Unit | lib | Experimental lightbox | processHTML()", function () {
     assert.strictEqual(items[0].dominantColor, null);
 
     assert.strictEqual(
-      items[0].cssVars.string,
+      items[0].cssVars.toString(),
       `--aspect-ratio: ${LIGHTBOX_IMAGE_FIXTURES.first.aspectRatio};--small-url: url(${LIGHTBOX_IMAGE_FIXTURES.first.smallURL});`
     );
   });
@@ -250,7 +250,7 @@ module("Unit | lib | Experimental lightbox | processHTML()", function () {
     );
 
     assert.strictEqual(
-      item.cssVars.string,
+      item.cssVars.toString(),
       `--small-url: url(${LIGHTBOX_IMAGE_FIXTURES.first.fullsizeURL});`
     );
   });

--- a/app/assets/javascripts/discourse/tests/unit/models/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/pending-post-test.js
@@ -47,7 +47,7 @@ module("Unit | Model | pending-post", function (hooks) {
     await settled();
 
     assert.strictEqual(
-      post.expandedExcerpt.string,
+      post.expandedExcerpt.toString(),
       "<p><strong>bold text</strong></p>"
     );
   });

--- a/plugins/checklist/test/javascripts/lib/checklist-test.js
+++ b/plugins/checklist/test/javascripts/lib/checklist-test.js
@@ -16,7 +16,7 @@ async function prepare(raw) {
   const model = Post.create({ id: 42, can_edit: true });
   const decoratorHelper = { widget, getModel: () => model };
 
-  const $elem = $(`<div>${cooked.string}</div>`);
+  const $elem = $(`<div>${cooked.toString()}</div>`);
   checklistSyntax($elem[0], decoratorHelper);
 
   currentRaw = raw;

--- a/plugins/styleguide/assets/javascripts/discourse/components/styleguide-markdown.js
+++ b/plugins/styleguide/assets/javascripts/discourse/components/styleguide-markdown.js
@@ -6,6 +6,8 @@ export default Component.extend({
     this._super(...arguments);
 
     const contents = $(this.element).html();
-    cookAsync(contents).then((cooked) => $(this.element).html(cooked.string));
+    cookAsync(contents).then((cooked) =>
+      $(this.element).html(cooked.toString())
+    );
   },
 });


### PR DESCRIPTION
See https://github.com/discourse/discourse-encrypt/pull/282

> `cooked` was an Ember SafeString. The internal storage of the string changed from `.string` to `.__string` at some point between Ember 3.28 and Ember 5. Instead, we can use `toString()` which is guaranteed to work in all situations

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
