### PR TITLE
DEV: Serialize categories in topic lists

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -169,8 +169,8 @@ TopicList.reopenClass({
     const users = extractByKey(result.users, User);
     const groups = extractByKey(result.primary_groups, EmberObject);
 
-    if (result.categories) {
-      result.categories.forEach((c) => {
+    if (result.topic_list.categories) {
+      result.topic_list.categories.forEach((c) => {
         Site.current().updateCategory(c);
       });
     }

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -5,6 +5,7 @@ import { isEmpty } from "@ember/utils";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import RestModel from "discourse/models/rest";
+import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import deprecated from "discourse-common/lib/deprecated";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
@@ -167,6 +168,12 @@ TopicList.reopenClass({
 
     const users = extractByKey(result.users, User);
     const groups = extractByKey(result.primary_groups, EmberObject);
+
+    if (result.categories) {
+      result.categories.forEach((c) => {
+        Site.current().updateCategory(c);
+      });
+    }
 
     return result.topic_list[listKey].map((t) => {
       t.posters.forEach((p) => {

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -76,6 +76,10 @@ class TopicList
     @topics ||= load_topics
   end
 
+  def categories
+    @categories ||= topics.map { |t| [t.category, t.category.parent_category] }.uniq.flatten.compact
+  end
+
   def load_topics
     @topics = @topics_input
 
@@ -128,7 +132,12 @@ class TopicList
       ft.topic_list = self
     end
 
-    topic_preloader_associations = [:image_upload, { topic_thumbnails: :optimized_image }]
+    topic_preloader_associations = [
+      :image_upload,
+      { topic_thumbnails: :optimized_image },
+      { category: :parent_category },
+    ]
+
     topic_preloader_associations.concat(DiscoursePluginRegistry.topic_preloader_associations.to_a)
 
     ActiveRecord::Associations::Preloader.new(

--- a/app/serializers/topic_category_serializer.rb
+++ b/app/serializers/topic_category_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class TopicCategorySerializer < ApplicationSerializer
+  attributes :id,
+             :name,
+             :color,
+             :text_color,
+             :slug,
+             :description_text,
+             :read_restricted,
+             :parent_category_id
+
+  def include_parent_category_id?
+    parent_category_id
+  end
+
+  def name
+    if object.uncategorized?
+      I18n.t("uncategorized_category_name", locale: SiteSetting.default_locale)
+    else
+      object.name
+    end
+  end
+
+  def description_text
+    if object.uncategorized?
+      I18n.t("category.uncategorized_description", locale: SiteSetting.default_locale)
+    else
+      object.description_text
+    end
+  end
+end

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -19,6 +19,7 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
   has_many :participants, serializer: TopicPosterSerializer, embed: :objects
+  has_one :category, serializer: TopicCategorySerializer
 
   def include_participant_groups?
     object.private_message?
@@ -92,5 +93,9 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   def include_allowed_user_count?
     object.private_message?
+  end
+
+  def include_category?
+    SiteSetting.lazy_load_categories
   end
 end

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -19,7 +19,6 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
   has_many :participants, serializer: TopicPosterSerializer, embed: :objects
-  has_one :category, serializer: TopicCategorySerializer
 
   def include_participant_groups?
     object.private_message?
@@ -93,9 +92,5 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   def include_allowed_user_count?
     object.private_message?
-  end
-
-  def include_category?
-    SiteSetting.lazy_load_categories
   end
 end

--- a/app/serializers/topic_list_serializer.rb
+++ b/app/serializers/topic_list_serializer.rb
@@ -12,6 +12,7 @@ class TopicListSerializer < ApplicationSerializer
   has_many :topics, serializer: TopicListItemSerializer, embed: :objects
   has_many :shared_drafts, serializer: TopicListItemSerializer, embed: :objects
   has_many :tags, serializer: TagSerializer, embed: :objects
+  has_many :categories, serializer: TopicCategorySerializer, embed: :objects
 
   def can_create_topic
     scope.can_create?(Topic)
@@ -35,5 +36,9 @@ class TopicListSerializer < ApplicationSerializer
 
   def include_tags?
     SiteSetting.tagging_enabled && object.tags.present?
+  end
+
+  def include_categories?
+    SiteSetting.lazy_load_categories
   end
 end

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2178,6 +2178,9 @@ developer:
   instrument_gc_stat_per_request:
     default: false
     hidden: true
+  lazy_load_categories:
+    default: false
+    hidden: true
 
 navigation:
   navigation_menu:

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -223,6 +223,35 @@ RSpec.describe ListController do
         expect(response.body).not_to include(restricted_tag.name)
       end
     end
+
+    context "with lazy_load_categories" do
+      fab!(:category) { Fabricate(:category) }
+
+      before { topic.update!(category: category) }
+
+      it "returns categories if true" do
+        SiteSetting.lazy_load_categories = true
+
+        get "/latest.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_list"]["topics"].length).to eq(1)
+        expect(response.parsed_body["topic_list"]["topics"][0]["id"]).to eq(topic.id)
+        expect(response.parsed_body["categories"].length).to eq(1)
+        expect(response.parsed_body["categories"][0]["id"]).to eq(topic.category_id)
+      end
+
+      it "does not return categories if not true" do
+        SiteSetting.lazy_load_categories = false
+
+        get "/latest.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_list"]["topics"].length).to eq(1)
+        expect(response.parsed_body["topic_list"]["topics"][0]["id"]).to eq(topic.id)
+        expect(response.parsed_body["categories"]).to eq(nil)
+      end
+    end
   end
 
   describe "categories and X" do

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -226,10 +226,11 @@ RSpec.describe ListController do
 
     context "with lazy_load_categories" do
       fab!(:category) { Fabricate(:category) }
+      fab!(:subcategory) { Fabricate(:category, parent_category: category) }
 
-      before { topic.update!(category: category) }
+      before { topic.update!(category: subcategory) }
 
-      it "returns categories if true" do
+      it "returns categories and parent categories if true" do
         SiteSetting.lazy_load_categories = true
 
         get "/latest.json"
@@ -237,8 +238,10 @@ RSpec.describe ListController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["topic_list"]["topics"].length).to eq(1)
         expect(response.parsed_body["topic_list"]["topics"][0]["id"]).to eq(topic.id)
-        expect(response.parsed_body["categories"].length).to eq(1)
-        expect(response.parsed_body["categories"][0]["id"]).to eq(topic.category_id)
+        expect(response.parsed_body["topic_list"]["categories"].length).to eq(2)
+        expect(
+          response.parsed_body["topic_list"]["categories"].map { |c| c["id"] },
+        ).to contain_exactly(category.id, subcategory.id)
       end
 
       it "does not return categories if not true" do
@@ -249,7 +252,7 @@ RSpec.describe ListController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["topic_list"]["topics"].length).to eq(1)
         expect(response.parsed_body["topic_list"]["topics"][0]["id"]).to eq(topic.id)
-        expect(response.parsed_body["categories"]).to eq(nil)
+        expect(response.parsed_body["topic_list"]["categories"]).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
In the future, categories will no longer be preloaded through site data. This commit add information about categories in topic list and ensures that data is used to display topic list items.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
