### PR TITLE
FIX: Add back missing 'delete spammer' flag option

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.hbs
@@ -68,7 +68,7 @@
 
     {{#if this.showDeleteSpammer}}
       <DButton
-        class="btn-danger"
+        class="btn-danger delete-spammer"
         @action={{this.deleteSpammer}}
         @disabled={{not this.submitEnabled}}
         @icon="exclamation-triangle"

--- a/app/assets/javascripts/discourse/app/components/modal/flag.js
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.js
@@ -67,6 +67,10 @@ export default class Flag extends Component {
     );
   }
 
+  get showDeleteSpammer() {
+    return this.spammerDetails?.canDelete && this.selected?.name_key === "spam";
+  }
+
   get submitLabel() {
     if (this.selected?.is_custom_flag) {
       return this.args.model.flagTarget.customSubmitLabel();

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -26,7 +26,7 @@ async function pressEnter(element, modifier) {
 }
 
 acceptance("flagging", function (needs) {
-  needs.user();
+  needs.user({ admin: true });
   needs.pretender((server, helper) => {
     server.get("/u/uwe_keim.json", () => {
       return helper.response(userFixtures["/u/charlie.json"]);
@@ -53,7 +53,8 @@ acceptance("flagging", function (needs) {
         public_admission: false,
         allow_membership_requests: true,
         membership_request_template: "Please add me",
-        full_name: null,
+        can_be_deleted: true,
+        can_delete_all_posts: true,
       });
     });
     server.get("/admin/users/5.json", () => {
@@ -127,6 +128,14 @@ acceptance("flagging", function (needs) {
 
     await click(".perform-penalize");
     assert.ok(!exists(".modal-body"));
+  });
+
+  test("Can delete spammer from spam", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await openFlagModal();
+    await click("#radio_spam");
+
+    assert.ok(exists(".delete-spammer"));
   });
 
   test("Gets dismissable warning from canceling incomplete silence from take action", async function (assert) {


### PR DESCRIPTION
### What is this fix?

When we [migrated the flag modal to DModal and Glimmer](https://github.com/discourse/discourse/pull/23279/files#diff-ba94b17bf01f86a7d5ef772c2177bd090a9d5cdf7dba61ed4a8f19a4ec38b4c1L111-L114), we accidentally lost this method used by the template to render the "Delete spammer" button if that action is available. This PR adds it back.

### Does it even work?

![delete-spammer-option](https://github.com/discourse/discourse/assets/5259935/308eac0b-c9af-44a1-9403-f4d6254ec42f)
