### PR TITLE
FIX: message date is incorrect when replying as new thread

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -70,7 +70,9 @@ export default class ChatMessage {
     this.availableFlags = args.availableFlags || args.available_flags;
     this.hidden = args.hidden || false;
     this.chatWebhookEvent = args.chatWebhookEvent || args.chat_webhook_event;
-    this.createdAt = args.created_at ? new Date(args.created_at) : null;
+    this.createdAt = args.created_at
+      ? new Date(args.created_at)
+      : new Date(args.createdAt);
     this.deletedById = args.deletedById || args.deleted_by_id;
     this._deletedAt = args.deletedAt || args.deleted_at;
     this.expanded =


### PR DESCRIPTION
When creating a new thread by clicking the reply button on a chat message, it shows an invalid date on the OP timestamp.

/t/112100