### PR TITLE
UX: fix overflow channel row + mobile remove styling tweak

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
@@ -9,6 +9,8 @@
 
   &__content {
     display: flex;
+    justify-content: space-between;
+    max-width: 100%;
     align-items: center;
     flex-grow: 1;
   }
@@ -69,7 +71,6 @@
   }
 
   .chat-channel-title {
-    width: 100%;
     overflow: hidden;
 
     &__users-count {

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -30,6 +30,10 @@
       transition: margin-right 0.15s ease-out;
       margin-right: 0px !important;
     }
+    &:not(.-animate-reset) {
+      border-top-right-radius: 0.25rem;
+      border-bottom-right-radius: 0.25rem;
+    }
   }
 
   &__action-btn {

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -19,8 +19,6 @@
   }
 
   &__content {
-    display: flex;
-    flex-grow: 1;
     padding-inline: 1.5rem;
     z-index: 2;
     background: var(--primary-very-low);

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -50,7 +50,7 @@
     color: var(--primary-very-low);
 
     .d-icon {
-      transform-origin: center center;
+      transform-origin: 50% 50%;
       transform-box: fill-box;
       transition: scale 0.2s ease-out;
       margin-inline: 0 1.5rem;

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -39,6 +39,7 @@
   &__action-btn {
     z-index: 1;
     display: flex;
+    justify-content: flex-end;
     align-items: center;
     position: absolute;
     top: 0px;
@@ -49,11 +50,10 @@
     color: var(--primary-very-low);
 
     .d-icon {
-      transform-origin: 50% 50%;
+      transform-origin: center center;
       transform-box: fill-box;
       transition: scale 0.2s ease-out;
-      margin: 0 1rem 0 auto;
-      padding-left: 1rem;
+      margin-inline: 0 1.5rem;
     }
 
     &.-not-at-threshold {


### PR DESCRIPTION
Fixed the ellipsis overflow on a channel row with the new structure
Added the missing(?) changing border radius for the swipe gesture (transition was there, but end-state styling wasn't)
Tweaked the icon positioning for the swipe delete 
