### PR TITLE
A11Y: "more" nav link should use aria-expanded

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
@@ -8,6 +8,7 @@
     @action={{this.toggleSectionLinks}}
     @label="sidebar.more"
     class="btn-flat sidebar-more-section-links-details-summary"
+    aria-expanded={{if this.open "true" "false"}}
   />
 </li>
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -60,6 +60,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       "additional section links are displayed"
     );
 
+    assert.ok(
+      exists(
+        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary[aria-expanded='true']"
+      ),
+      "aria-expanded toggles to true when additional links are displayed"
+    );
+
     await click(
       ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
     );
@@ -82,6 +89,13 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
         ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-content"
       ),
       "additional section links are hidden when clicking outside"
+    );
+
+    assert.ok(
+      exists(
+        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary[aria-expanded='false']"
+      ),
+      "aria-expanded toggles to false when additional links are hidden"
     );
   });
 


### PR DESCRIPTION
This informs screen reader users about the state of this section in the sidebar nav. 

![Screenshot 2023-09-15 at 10 33 30 AM](https://github.com/discourse/discourse/assets/1681963/7c1c3381-e4f3-4486-b6e4-21743044a6b5)
