### PR TITLE
UX: improve activity column title data

### DIFF
--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -89,10 +89,13 @@ const Bookmark = RestModel.extend({
 
   @discourseComputed("bumpedAt", "createdAt")
   bumpedAtTitle(bumpedAt, createdAt) {
-    return I18n.t("topic.bumped_at_title", {
-      createdAtDate: longDate(createdAt),
-      bumpedAtDate: longDate(bumpedAt),
-    });
+    return bumpedAt.toISOString().slice(0, 19) !==
+      createdAt.toISOString().slice(0, 19) // excludes milliseconds
+      ? `${I18n.t("topic.created_at", { date: longDate(createdAt) })}\n${I18n.t(
+          "topic.bumped_at",
+          { date: longDate(bumpedAt) }
+        )}`
+      : I18n.t("topic.created_at", { date: longDate(createdAt) });
   },
 
   @discourseComputed("created_at")

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -89,13 +89,17 @@ const Bookmark = RestModel.extend({
 
   @discourseComputed("bumpedAt", "createdAt")
   bumpedAtTitle(bumpedAt, createdAt) {
-    return bumpedAt.toISOString().slice(0, 19) !==
-      createdAt.toISOString().slice(0, 19) // excludes milliseconds
-      ? `${I18n.t("topic.created_at", { date: longDate(createdAt) })}\n${I18n.t(
-          "topic.bumped_at",
-          { date: longDate(bumpedAt) }
-        )}`
-      : I18n.t("topic.created_at", { date: longDate(createdAt) });
+    const BUMPED_FORMAT = "YYYY-MM-DDTHH:mm:ss";
+    if (moment(bumpedAt).isValid() && moment(createdAt).isValid()) {
+      const bumpedAtStr = moment(bumpedAt).format(BUMPED_FORMAT);
+      const createdAtStr = moment(createdAt).format(BUMPED_FORMAT);
+
+      return bumpedAtStr !== createdAtStr
+        ? `${I18n.t("topic.created_at", {
+            date: longDate(createdAt),
+          })}\n${I18n.t("topic.bumped_at", { date: longDate(bumpedAt) })}`
+        : I18n.t("topic.created_at", { date: longDate(createdAt) });
+    }
   },
 
   @discourseComputed("created_at")

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -127,10 +127,13 @@ const Topic = RestModel.extend({
 
   @discourseComputed("bumpedAt", "createdAt")
   bumpedAtTitle(bumpedAt, createdAt) {
-    return I18n.t("topic.bumped_at_title", {
-      createdAtDate: longDate(createdAt),
-      bumpedAtDate: longDate(bumpedAt),
-    });
+    return bumpedAt.toISOString().slice(0, 19) !==
+      createdAt.toISOString().slice(0, 19) // excludes milliseconds
+      ? `${I18n.t("topic.created_at", { date: longDate(createdAt) })}\n${I18n.t(
+          "topic.bumped_at",
+          { date: longDate(bumpedAt) }
+        )}`
+      : I18n.t("topic.created_at", { date: longDate(createdAt) });
   },
 
   @discourseComputed("created_at")

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -127,13 +127,17 @@ const Topic = RestModel.extend({
 
   @discourseComputed("bumpedAt", "createdAt")
   bumpedAtTitle(bumpedAt, createdAt) {
-    return bumpedAt.toISOString().slice(0, 19) !==
-      createdAt.toISOString().slice(0, 19) // excludes milliseconds
-      ? `${I18n.t("topic.created_at", { date: longDate(createdAt) })}\n${I18n.t(
-          "topic.bumped_at",
-          { date: longDate(bumpedAt) }
-        )}`
-      : I18n.t("topic.created_at", { date: longDate(createdAt) });
+    const BUMPED_FORMAT = "YYYY-MM-DDTHH:mm:ss";
+    if (moment(bumpedAt).isValid() && moment(createdAt).isValid()) {
+      const bumpedAtStr = moment(bumpedAt).format(BUMPED_FORMAT);
+      const createdAtStr = moment(createdAt).format(BUMPED_FORMAT);
+
+      return bumpedAtStr !== createdAtStr
+        ? `${I18n.t("topic.created_at", {
+            date: longDate(createdAt),
+          })}\n${I18n.t("topic.bumped_at", { date: longDate(bumpedAt) })}`
+        : I18n.t("topic.created_at", { date: longDate(createdAt) });
+    }
   },
 
   @discourseComputed("created_at")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3013,7 +3013,7 @@ en:
           other {}
         }
 
-      created_at: "First post: %{date}"
+      created_at: "Created: %{date}"
       bumped_at: "Latest: %{date}"
 
       browse_all_categories_latest: "<a href='%{basePath}/categories'>Browse all categories</a> or <a href='%{basePath}/latest'>view latest topics</a>."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3013,9 +3013,8 @@ en:
           other {}
         }
 
-      bumped_at_title: |
-        First post: %{createdAtDate}
-        Posted: %{bumpedAtDate}
+      created_at: "First post: %{date}"
+      bumped_at: "Latest: %{date}"
 
       browse_all_categories_latest: "<a href='%{basePath}/categories'>Browse all categories</a> or <a href='%{basePath}/latest'>view latest topics</a>."
       browse_all_categories_latest_or_top: "<a href='%{basePath}/categories'>Browse all categories</a>, <a href='%{basePath}/latest'>view latest topics</a> or see top:"


### PR DESCRIPTION
This is a little nitpicky, but this has bugged me for a while:

This is a topic with 1 post, which has been edited: 
![Screenshot 2023-09-15 at 11 58 01 AM](https://github.com/discourse/discourse/assets/1681963/68d69093-8546-4465-b237-f1c51c57dd69)

"Posted" is the edited time, which doesn't make a lot of sense to me when contrasted with "First post" 

This is a topic with 1 post:
![Screenshot 2023-09-15 at 11 58 06 AM](https://github.com/discourse/discourse/assets/1681963/0e57eb47-dc2b-43cc-9669-0190ddce3f56)

"First post" and "Posted" are identical

In this PR I'm comparing the two times (ignoring milliseconds, which are slightly different for `bumpedAt` & `createdAt`!) and if they match, I only show the first. 

I've also updated the text to be more accurate: 
* "First post" -> "Created" 
* "Posted" -> "Latest" 


Topic with 1 post, which has been edited:
![Screenshot 2023-09-15 at 12 07 10 PM](https://github.com/discourse/discourse/assets/1681963/aaabc079-adae-419d-aac5-06c3ac940a87)


Topic with 1 post:
![Screenshot 2023-09-15 at 12 07 16 PM](https://github.com/discourse/discourse/assets/1681963/b66becbb-cd38-4ddf-a7ea-ea24a123cbe0)


Topic with multiple posts:
![Screenshot 2023-09-15 at 12 07 20 PM](https://github.com/discourse/discourse/assets/1681963/c8ba24d5-87a2-4688-b97d-b176c849af57)

