### PR TITLE
UX: fix "More" menu at small tablet width

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -60,4 +60,11 @@
 
 .sidebar-more-section-links-details {
   position: relative;
+  @include breakpoint(tablet) {
+    grid-column-start: 1;
+    grid-column-end: 3;
+    .sidebar-more-section-links-details-content-main {
+      gap: 0 1em;
+    }
+  }
 }


### PR DESCRIPTION
Before:

<img width="374" alt="Screenshot 2023-09-15 at 5 17 37 PM" src="https://github.com/discourse/discourse/assets/1681963/5841d36c-8eaa-49e0-956e-36729590cf26">

After (both left col and right col positions): 

![Screenshot 2023-09-15 at 5 06 49 PM](https://github.com/discourse/discourse/assets/1681963/479c42fe-3aea-4221-8ec7-4c9f8082566a)
![Screenshot 2023-09-15 at 5 07 11 PM](https://github.com/discourse/discourse/assets/1681963/0228c90e-7e92-4429-9c72-a1fd115baaad)
