### PR TITLE
FEATURE: Link chat notifications directly to message

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -64,7 +64,7 @@ module Jobs
         payload = {
           username: @creator.username,
           notification_type: ::Notification.types[:chat_message],
-          post_url: @chat_channel.relative_url,
+          post_url: @chat_message.url,
           translated_title: ::I18n.t(translation_key, translation_args),
           tag: ::Chat::Notifier.push_notification_tag(:message, @chat_channel.id),
           excerpt: @chat_message.push_notification_excerpt,

--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -250,7 +250,11 @@ module Chat
     end
 
     def url
-      "/chat/c/-/#{self.chat_channel_id}/#{self.id}"
+      if in_thread?
+        "#{Discourse.base_path}/chat/c/-/#{self.chat_channel_id}/t/#{self.thread_id}/#{self.id}"
+      else
+        "#{Discourse.base_path}/chat/c/-/#{self.chat_channel_id}/#{self.id}"
+      end
     end
 
     def create_mentions

--- a/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Jobs::Chat::NotifyWatching do
         {
           username: user1.username,
           notification_type: Notification.types[:chat_message],
-          post_url: channel.relative_url,
+          post_url: message.url,
           translated_title:
             I18n.t(
               "discourse_push_notifications.popup.new_chat_message",
@@ -87,7 +87,7 @@ RSpec.describe Jobs::Chat::NotifyWatching do
             {
               username: user1.username,
               notification_type: Notification.types[:chat_message],
-              post_url: channel.relative_url,
+              post_url: message.url,
               translated_title:
                 I18n.t(
                   "discourse_push_notifications.popup.new_chat_message",
@@ -190,7 +190,7 @@ RSpec.describe Jobs::Chat::NotifyWatching do
         {
           username: user1.username,
           notification_type: Notification.types[:chat_message],
-          post_url: channel.relative_url,
+          post_url: message.url,
           translated_title:
             I18n.t(
               "discourse_push_notifications.popup.new_direct_chat_message",
@@ -227,7 +227,7 @@ RSpec.describe Jobs::Chat::NotifyWatching do
             {
               username: user1.username,
               notification_type: Notification.types[:chat_message],
-              post_url: channel.relative_url,
+              post_url: message.url,
               translated_title:
                 I18n.t(
                   "discourse_push_notifications.popup.new_direct_chat_message",

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -589,4 +589,18 @@ describe Chat::Message do
       expect(message.chat_mentions.pluck(:id)).to include(*existing_mention_ids) # the mentions weren't recreated
     end
   end
+
+  describe "#url" do
+    it "returns message permalink" do
+      expect(message.url).to eq("/chat/c/-/#{message.chat_channel_id}/#{message.id}")
+    end
+
+    it "returns message permalink when in thread" do
+      thread = Fabricate(:chat_thread)
+      first_message = thread.chat_messages.first
+      expect(first_message.url).to eq(
+        "/chat/c/-/#{first_message.chat_channel_id}/t/#{first_message.thread_id}/#{first_message.id}",
+      )
+    end
+  end
 end


### PR DESCRIPTION
- Updates `Chat::Message#url` to work in threads and for subfolder
- Updates Jobs::Chat::NotifyWatching to use message URL instead of channel url

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
