### PR TITLE
FIX: ensures we reuse existing thread if existing

### DIFF
--- a/plugins/chat/app/services/chat/create_thread.rb
+++ b/plugins/chat/app/services/chat/create_thread.rb
@@ -22,7 +22,7 @@ module Chat
     policy :threading_enabled_for_channel
     model :original_message
     transaction do
-      step :create_thread
+      step :find_or_create_thread
       step :associate_thread_to_message
       step :fetch_membership
       step :publish_new_thread
@@ -59,7 +59,11 @@ module Chat
       channel.threading_enabled
     end
 
-    def create_thread(channel:, original_message:, contract:, **)
+    def find_or_create_thread(channel:, original_message:, contract:, **)
+      if original_message.thread_id.present?
+        return context.thread = ::Chat::Thread.find_by(id: original_message.thread_id)
+      end
+
       context.thread =
         channel.threads.create(
           title: contract.title,

--- a/plugins/chat/spec/services/chat/create_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/create_thread_spec.rb
@@ -97,5 +97,19 @@ RSpec.describe Chat::CreateThread do
 
       it { is_expected.to fail_a_policy(:threading_enabled_for_channel) }
     end
+
+    context "when a thread is already present" do
+      before do
+        Chat::CreateThread.call(
+          guardian: current_user.guardian,
+          original_message_id: message_1.id,
+          channel_id: channel_1.id,
+        )
+      end
+
+      it "uses the existing thread" do
+        expect { result }.to change { Chat::Thread.count }.by(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a special case to ensure that if two users start a thread at the same time, we won't attempt to create a second thread.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
