### PR TITLE
FIX: Parse the `digest_suppress_tags` setting correctly

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -586,11 +586,14 @@ class Topic < ActiveRecord::Base
         )
     end
     if SiteSetting.digest_suppress_tags.present?
-      topics =
-        topics.joins("LEFT JOIN topic_tags tg ON topics.id = tg.topic_id").where(
-          "tg.tag_id NOT IN (?) OR tg.tag_id IS NULL",
-          SiteSetting.digest_suppress_tags.split("|").map(&:to_i),
-        )
+      tag_ids = Tag.where_name(SiteSetting.digest_suppress_tags.split("|")).pluck(:id)
+      if tag_ids.present?
+        topics =
+          topics.joins("LEFT JOIN topic_tags tg ON topics.id = tg.topic_id").where(
+            "tg.tag_id NOT IN (?) OR tg.tag_id IS NULL",
+            tag_ids,
+          )
+      end
     end
     remove_category_ids << SiteSetting.shared_drafts_category if SiteSetting.shared_drafts_enabled?
     if remove_category_ids.present?

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2368,9 +2368,10 @@ RSpec.describe Topic do
         topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
         topic2 = Fabricate(:topic, category: category, created_at: 1.minute.ago)
         tag = Fabricate(:tag)
+        tag2 = Fabricate(:tag)
         Fabricate(:topic_tag, topic: topic, tag: tag)
 
-        SiteSetting.digest_suppress_tags = "#{tag.id}"
+        SiteSetting.digest_suppress_tags = "#{tag.name}|#{tag2.name}"
         topics = Topic.for_digest(user, 1.year.ago, top_order: true)
         expect(topics).to eq([topic2])
 


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/suppress-these-tags-from-summary-emails-settings-is-not-working-in-preview-digest-email/279196?u=osama

Follow-up to https://github.com/discourse/discourse/commit/477a5dd371e9605a0c0058d0805c767c77fa7c93

The `digest_suppress_tags` setting is designed to be a list of pipe-delimited tag names, but the tag-based topic suppression logic assumes (incorrectly) that the setting contains pipe-delimited tag IDs. This mismatch in expectations led to the setting not working as expected.

This PR adds a step that converts the list of tag names in the setting to their corresponding IDs, which is then used to suppress topics tagged with those specific tags.