### PR TITLE
DEV: remove tag from create-topic-button outlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -50,7 +50,6 @@
 
   <PluginOutlet
     @name="before-create-topic-button"
-    @connectorTagName="div"
     @outletArgs={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled
@@ -76,7 +75,6 @@
 
   <PluginOutlet
     @name="after-create-topic-button"
-    @connectorTagName="div"
     @outletArgs={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled


### PR DESCRIPTION
I don't think these are necessary, and they have a tendency to create unwanted space and other layout issues 


e.g., here we have a theme component installed on Meta, but the conditions aren't met for showing the button here... so we get an empty connector div that impacts margin between the admin and new topic button

![Screenshot 2023-09-18 at 5 52 14 PM](https://github.com/discourse/discourse/assets/1681963/145996dd-327d-4748-b480-a78390f1951b)
