### PR TITLE
Styling Preview bug

### DIFF
--- a/app/assets/javascripts/wizard/addon/components/styling-preview.js
+++ b/app/assets/javascripts/wizard/addon/components/styling-preview.js
@@ -76,7 +76,7 @@ export default WizardPreviewBaseComponent.extend({
     if (slider.scrollLeft < 50) {
       this.set("previewTopic", true);
     }
-    if (slider.scrollLeft > slider.offsetWidth) {
+    if (slider.scrollLeft > slider.offsetWidth - 50) {
       this.set("previewTopic", false);
     }
   },


### PR DESCRIPTION
It seems like the intention is to update the tab selection at the bottom when the scrollable pane changes enough. In my testing (and I think by definition?), it doesn't seem like `scrollLeft` ever exceeds `offsetWidth`, so that tab-switching behavior doesn't ever happen