### PR TITLE
DEV: Remove deprecated PostAction.act method

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -123,19 +123,6 @@ class PostAction < ActiveRecord::Base
     RateLimiter.new(user, "post_action-#{post.id}_#{post_action_type_id}", 4, 1.minute).performed!
   end
 
-  def self.act(created_by, post, post_action_type_id, opts = {})
-    Discourse.deprecate(
-      "PostAction.act is deprecated. Use `PostActionCreator` instead.",
-      output_in_test: true,
-      drop_from: "2.9.0",
-    )
-
-    result =
-      PostActionCreator.new(created_by, post, post_action_type_id, message: opts[:message]).perform
-
-    result.success? ? result.post_action : nil
-  end
-
   def self.copy(original_post, target_post)
     cols_to_copy = (column_names - %w[id post_id]).join(", ")
 


### PR DESCRIPTION
### What is this change?

The `PostAction.act` class method was deprecated four years ago and marked for removal in 2.9.0. This PR removes it.

### Verification

I have replaced the last remaining usages of this in [`discourse-sift`](https://github.com/discourse-org/discourse-sift/pull/16) and [`discourse-perspective-api`](https://github.com/discourse/discourse-perspective-api/pull/69) plugins.

- [x] A search for `PostAction.act` yields no results in our GitHub repos.
- [x] No deprecation warnings are showing up in logs across all our hosting.