### PR TITLE
DEV: Deprecate implicit injections for all services

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/implicit-injections-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/implicit-injections-test.js
@@ -3,16 +3,19 @@ import { test } from "qunit";
 import RestModel from "discourse/models/rest";
 import Service, { inject as service } from "@ember/service";
 import { getOwner, setOwner } from "@ember/application";
+import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
 
 acceptance("Implicit injections shims", function () {
   test("it provides legacy injections on common models", function (assert) {
     const serviceInstance = Service.create();
     setOwner(serviceInstance, getOwner(this));
 
-    assert.strictEqual(
-      serviceInstance.session,
-      getOwner(this).lookup("service:session")
-    );
+    withSilencedDeprecations("discourse.implicit-injections.service", () => {
+      assert.strictEqual(
+        serviceInstance.session,
+        getOwner(this).lookup("service:session")
+      );
+    });
   });
 
   test("it allows overlaying explicit injections", function (assert) {
@@ -22,10 +25,12 @@ acceptance("Implicit injections shims", function () {
     const serviceInstance = MyService.create();
     setOwner(serviceInstance, getOwner(this));
 
-    assert.strictEqual(
-      serviceInstance.session,
-      getOwner(this).lookup("service:session")
-    );
+    withSilencedDeprecations("discourse.implicit-injections.service", () => {
+      assert.strictEqual(
+        serviceInstance.session,
+        getOwner(this).lookup("service:session")
+      );
+    });
   });
 
   test("it allows overriding values by assignment", function (assert) {


### PR DESCRIPTION
Ember's implementation of implicit injections is removed in Ember 4.x. In Discourse, we've implemented a shim for the behavior via 743be2d59660a7642c60031a60d3652f9a27e14b to buy us more time. This commit takes an incremental step towards removing the shim by introducing a deprecation notice for all implicit injections on "Service" classes, which should be the easiest to fix up.

Eventually we will want to do something similar for Controller/Route/etc, so this commit implements the deprecation notice in a generic way.

Before merging this commit, we'll need to fix up the remaining implicit injections in core services. (in the core test suite, relying on deprecations causes test failures)