### PR TITLE
FEATURE: `enableClientReducedMotion` API for A11Y

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -91,7 +91,10 @@ import {
 import { registerTopicFooterButton } from "discourse/lib/register-topic-footer-button";
 import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer-dropdown";
 import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
-import { replaceFormatter } from "discourse/lib/utilities";
+import {
+  enableClientReducedMotion,
+  replaceFormatter,
+} from "discourse/lib/utilities";
 import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { registerCustomLastUnreadUrlCallback } from "discourse/models/topic";
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
@@ -133,7 +136,7 @@ import { isTesting } from "discourse-common/config/environment";
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-export const PLUGIN_API_VERSION = "1.11.0";
+export const PLUGIN_API_VERSION = "1.12.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -2456,6 +2459,19 @@ class PluginApi {
    */
   addBulkActionButton(opts) {
     _addBulkButton(opts);
+  }
+
+  /**
+   * Forces prefersReducedMotion() to true regardless of OS preference
+   * and also sets all CSS animation durations to 0s
+   *
+   * Example:
+   * ```
+   * api.enableClientReducedMotion();
+   * ```
+   **/
+  enableClientReducedMotion() {
+    enableClientReducedMotion();
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -8,6 +8,7 @@ import * as AvatarUtils from "discourse-common/lib/avatar-utils";
 import { capabilities } from "discourse/services/capabilities";
 
 let _defaultHomepage;
+let _clientReducedMotion;
 
 function deprecatedAvatarUtil(name) {
   return function () {
@@ -406,8 +407,16 @@ export function areCookiesEnabled() {
   }
 }
 
+export function enableClientReducedMotion() {
+  _clientReducedMotion = true;
+  document.documentElement.classList.add("prefers-reduced-motion");
+}
+
 export function prefersReducedMotion() {
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const osSetting = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  return osSetting || _clientReducedMotion || false;
 }
 
 export function postRNWebviewMessage(prop, value) {

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -42,6 +42,11 @@ html {
   &.text-size-largest {
     font-size: var(--base-font-size-largest);
   }
+
+  &.prefers-reduced-motion * {
+    // allows all CSS animations to be force-disabled by using api.enableClientReducedMotion();
+    animation-duration: 0s !important;
+  }
 }
 
 // Links

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,14 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2023-09-25
+
+### Added
+
+- Adds `enableClientReducedMotion` which allows plugins and themes to force `prefersReducedMotion()`
+  to `true` regardless of OS preference. This disables autoplaying GIF images in posts, 
+  and also adds a `.prefers-reduced-motion` class to the `html` tag to set all CSS animation durations to 0s. 
+
 ## [1.11.0] - 2023-08-30
 
 ### Added


### PR DESCRIPTION
This will allow themes and plugins to set `api.enableClientReducedMotion();` to disable autoplaying GIFs and CSS animations. 

This enables the ability to create a reduced-motion theme or a plugin that adds a reduced-motion user preference. Utilizing the API means this can function even in cases where a user may not want to enable `reduced motion` across their entire OS. 