### PR TITLE
DEV: Change `PageObjects::Components::Chat::Message#exists?` to exact match

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -78,7 +78,7 @@ module PageObjects
             page.find(context).send(
               selector_method,
               selector + " " + ".chat-message-text",
-              text: /#{Regexp.escape(text)}/,
+              exact_text: text,
             )
           else
             page.find(context).send(selector_method, selector)

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -19,6 +19,7 @@ describe "Uploading files in chat messages", type: :system do
     it "allows uploading a single file" do
       chat.visit_channel(channel_1)
       file_path = file_from_fixtures("logo.png", "images").path
+
       attach_file(file_path) do
         channel_page.open_action_menu
         channel_page.click_action_button("chat-upload-btn")
@@ -29,7 +30,12 @@ describe "Uploading files in chat messages", type: :system do
       channel_page.send_message("upload testing")
 
       expect(page).not_to have_css(".chat-composer-upload")
-      expect(channel_page.messages).to have_message(text: "upload testing", persisted: true)
+
+      expect(channel_page.messages).to have_message(
+        text: "upload testing\n#{File.basename(file_path)}",
+        persisted: true,
+      )
+
       expect(Chat::Message.last.uploads.count).to eq(1)
     end
 
@@ -47,14 +53,20 @@ describe "Uploading files in chat messages", type: :system do
       channel_page.send_message("upload testing")
 
       expect(page).not_to have_css(".chat-composer-upload")
-      expect(channel_page.messages).to have_message(text: "upload testing", persisted: true)
+      expect(channel_page.messages).to have_message(
+        text: "upload testing\n#{I18n.t("js.chat.uploaded_files", count: 2)}",
+        persisted: true,
+      )
       expect(Chat::Message.last.uploads.count).to eq(2)
     end
 
-    xit "allows uploading a huge image file with preprocessing" do
+    it "allows uploading a huge image file with preprocessing" do
+      skip("This test is flaky on CI") if ENV["CI"]
+
       SiteSetting.composer_media_optimization_image_bytes_optimization_threshold = 200.kilobytes
       chat.visit_channel(channel_1)
       file_path = file_from_fixtures("huge.jpg", "images").path
+
       attach_file(file_path) do
         channel_page.open_action_menu
         channel_page.click_action_button("chat-upload-btn")
@@ -69,7 +81,12 @@ describe "Uploading files in chat messages", type: :system do
       channel_page.send_message("upload testing")
 
       expect(page).not_to have_css(".chat-composer-upload")
-      expect(channel_page.messages).to have_message(text: "upload testing", persisted: true)
+
+      expect(channel_page.messages).to have_message(
+        text: "upload testing\n#{File.basename(file_path)}",
+        persisted: true,
+      )
+
       expect(Chat::Message.last.uploads.count).to eq(1)
     end
   end


### PR DESCRIPTION
Why this change?

Before this change, we were doing a partial match when checking for
existence. This is a source of flaky tests because a chat message with
text `this is a message` will match any substring like `message` or `a`.

What does this change do?

This change removes the partial match and instead opts for the
`exact_text` option instead.