### PR TITLE
FIX: Custom sidebar section link with `/` path leading to blank page

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -2,6 +2,7 @@ import { tracked } from "@glimmer/tracking";
 import { bind } from "discourse-common/utils/decorators";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 import discourseLater from "discourse-common/lib/later";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 const TOUCH_SCREEN_DELAY = 300;
 const MOUSE_DELAY = 250;
@@ -26,7 +27,13 @@ export default class SectionLink {
 
     if (!this.externalOrFullReload) {
       const routeInfoHelper = new RouteInfoHelper(router, value);
-      this.route = routeInfoHelper.route;
+
+      if (routeInfoHelper.route === "discovery.index") {
+        this.route = `discovery.${defaultHomepage()}`;
+      } else {
+        this.route = routeInfoHelper.route;
+      }
+
       this.models = routeInfoHelper.models;
       this.query = routeInfoHelper.query;
     }

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -55,6 +55,21 @@ describe "Custom sidebar sections", type: :system do
     expect(sidebar).to have_section_link("My preferences", target: "_self")
   end
 
+  it "allows the user to create custom section with `/` path which generates a link based on the first item in the `top_menu` site settings" do
+    SiteSetting.top_menu = "read|posted|latest"
+
+    sign_in user
+    visit("/latest")
+
+    sidebar.click_add_section_button
+    section_modal.fill_name("My section")
+    section_modal.fill_link("Home", "/")
+    section_modal.save
+
+    expect(sidebar).to have_section("My section")
+    expect(sidebar).to have_section_link("Home", href: "/read")
+  end
+
   it "allows the user to create custom section with /pub link" do
     sign_in user
     visit("/latest")


### PR DESCRIPTION
What is the problem we are trying to solve here?

The `/` path in our Ember app leads to the `discovery.index` route but
we actually don't render anything on that route leading to a blank page
if the Ember app were to transition to it which is what was happening
when a user adds a custom sidebar section link with the `/` path.

What is the fix there?

Instead of generating a link for the `discovery.index` route when
creating the sidebar section link, we detect if the Ember route is
`discovery.index` and change it to the `discovery.${defaultHomepage()}`
route instead.