### PR TITLE
FIX: enable copy code block by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1005,8 +1005,8 @@ posting:
     client: true
     list_type: compact
   show_copy_button_on_codeblocks:
-    client: true
-    default: false
+    default: true
+    hidden: true
   delete_old_hidden_posts: true
   enable_emoji:
     default: true


### PR DESCRIPTION
Copy button on code blocks should be enabled by default and this setting should be hidden.

Having a “copy” button enabled is pretty standard now on the Internet, and I feel it would be better to have it enabled by default instead.

/t/111389
