### PR TITLE
DEV: Remove dependence on dartsass-sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -228,9 +228,8 @@ gem "logstash-event", require: false
 gem "logstash-logger", require: false
 gem "logster"
 
-# These are forks of sassc and sassc-rails with dart-sass support
+# A fork of sassc with dart-sass support
 gem "dartsass-ruby"
-gem "dartsass-sprockets"
 
 gem "rotp", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,12 +124,6 @@ GEM
       addressable
     dartsass-ruby (3.0.1)
       sass-embedded (~> 1.54)
-    dartsass-sprockets (3.0.0)
-      dartsass-ruby (~> 3.0)
-      railties (>= 4.0.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     date (3.3.3)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
@@ -497,7 +491,6 @@ GEM
     syntax_tree-disable_ternary (1.0.0)
     test-prof (1.2.3)
     thor (1.2.2)
-    tilt (2.3.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -566,7 +559,6 @@ DEPENDENCIES
   cppjieba_rb
   css_parser
   dartsass-ruby
-  dartsass-sprockets
   diffy
   digest
   discourse-fonts

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -24,7 +24,6 @@ module.exports = function (defaults) {
 
   const isEmbroider = process.env.USE_EMBROIDER === "1";
   const isProduction = EmberApp.env().includes("production");
-  const isTest = EmberApp.env().includes("test");
 
   // This is more or less the same as the one in @embroider/test-setup
   const maybeEmbroider = (app, options) => {
@@ -162,20 +161,16 @@ module.exports = function (defaults) {
     .findAddonByName("pretty-text")
     .treeForMarkdownItBundle();
 
-  const extraPublicTrees = [];
+  const testStylesheetTree = mergeTrees([
+    discourseScss(`${discourseRoot}/app/assets/stylesheets`, "qunit.scss"),
+    discourseScss(
+      `${discourseRoot}/app/assets/stylesheets`,
+      "qunit-custom.scss"
+    ),
+  ]);
+  app.project.liveReloadFilterPatterns = [/.*\.scss/];
 
-  if (isTest) {
-    const testemStylesheetTree = mergeTrees([
-      discourseScss(`${discourseRoot}/app/assets/stylesheets`, "qunit.scss"),
-      discourseScss(
-        `${discourseRoot}/app/assets/stylesheets`,
-        "qunit-custom.scss"
-      ),
-    ]);
-    extraPublicTrees.push(testemStylesheetTree);
-  }
-
-  extraPublicTrees.push(
+  const extraPublicTrees = [
     createI18nTree(discourseRoot, vendorJs),
     parsePluginClientSettings(discourseRoot, vendorJs, app),
     funnel(`${discourseRoot}/public/javascripts`, { destDir: "javascripts" }),
@@ -197,8 +192,9 @@ module.exports = function (defaults) {
       outputFile: `assets/markdown-it-bundle.js`,
     }),
     generateScriptsTree(app),
-    discoursePluginsTree
-  );
+    discoursePluginsTree,
+    testStylesheetTree,
+  ];
 
   return maybeEmbroider(app, {
     extraPublicTrees,

--- a/config/application.rb
+++ b/config/application.rb
@@ -181,6 +181,15 @@ module Discourse
                                  charset: :unicode
     Sprockets.register_postprocessor "application/javascript", DiscourseJsProcessor
 
+    class SprocketsSassUnsupported
+      def self.call(*args)
+        raise "Discourse does not support compiling scss/sass files via Sprockets"
+      end
+    end
+
+    Sprockets.register_engine(".sass", SprocketsSassUnsupported, silence_deprecation: true)
+    Sprockets.register_engine(".scss", SprocketsSassUnsupported, silence_deprecation: true)
+
     Discourse::Application.initializer :prepend_ember_assets do |app|
       # Needs to be in its own initializer so it runs after the append_assets_path initializer defined by Sprockets
       app


### PR DESCRIPTION
Discourse has a custom stylesheet pipeline which compiles things 'just in time'. The only place we were running sass files through sprockets was for the `/tests` route in development mode. This can be resolved by compiling the relevant stylesheets through ember-cli instead (which we were already doing for testem runs)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
