### PR TITLE
FIX: correctly sort channels with null last message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -2,7 +2,7 @@ import Service, { inject as service } from "@ember/service";
 import { debounce } from "discourse-common/utils/decorators";
 import Promise from "rsvp";
 import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
@@ -106,6 +106,7 @@ export default class ChatChannelsManager extends Service {
     );
   }
 
+  @cached
   get publicMessageChannels() {
     return this.channels
       .filter(
@@ -115,6 +116,7 @@ export default class ChatChannelsManager extends Service {
       .sort((a, b) => a?.slug?.localeCompare?.(b?.slug));
   }
 
+  @cached
   get directMessageChannels() {
     return this.#sortDirectMessageChannels(
       this.channels.filter((channel) => {
@@ -151,11 +153,11 @@ export default class ChatChannelsManager extends Service {
 
   #sortDirectMessageChannels(channels) {
     return channels.sort((a, b) => {
-      if (!a.lastMessage) {
+      if (!a.lastMessage.id) {
         return 1;
       }
 
-      if (!b.lastMessage) {
+      if (!b.lastMessage.id) {
         return -1;
       }
 


### PR DESCRIPTION
As per https://github.com/discourse/discourse/commit/92839dc722057fcd8dcc2504bb89598423392744 lastMessage won't be null when a message is deleted. This would cause sorting issues when messages from a direct message channels are deleted as we would try to sort on last message and thought it would exist when actually it would be a null message.

I might rethink this design to not return any last_message in this case soon as checking on ID feels dirty and prone to error, so only fixing the issue for now.

This commit is also using `@cached` to avoid replaying the sort logic on each access.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
