### PR TITLE
DEV: Modernize getOwner usage in `discourse/components`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-toggle.js
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-toggle.js
@@ -1,11 +1,11 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 export default class BulkSelectToggle extends Component {
   @action
   toggleBulkSelect() {
-    const controller = getOwnerWithFallback(this).lookup(
+    const controller = getOwner(this).lookup(
       `controller:${this.args.parentController}`
     );
     const helper = controller.bulkSelectHelper;

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -42,7 +42,7 @@ import {
   initUserStatusHtml,
   renderUserStatusHtml,
 } from "discourse/lib/user-status-on-autocomplete";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 // original string `![image|foo=bar|690x220, 50%|bar=baz](upload://1TjaobgKObzpU7xRMw2HuUc87vO.png "image title")`
 // group 1 `image|foo=bar`
@@ -224,7 +224,7 @@ export default Component.extend(ComposerUploadUppy, {
             categoryId: this.topic?.category_id || this.composer?.categoryId,
             includeGroups: true,
           }).then((result) => {
-            initUserStatusHtml(getOwnerWithFallback(this), result.users);
+            initUserStatusHtml(getOwner(this), result.users);
             return result;
           });
         },

--- a/app/assets/javascripts/discourse/app/components/composer-message.js
+++ b/app/assets/javascripts/discourse/app/components/composer-message.js
@@ -1,16 +1,14 @@
 import Component from "@ember/component";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 export default Component.extend({
   classNameBindings: [":composer-popup", "message.extraClass"],
 
   @discourseComputed("message.templateName")
   layout(templateName) {
-    return getOwnerWithFallback(this).lookup(
-      `template:composer/${templateName}`
-    );
+    return getOwner(this).lookup(`template:composer/${templateName}`);
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/components/custom-html.js
+++ b/app/assets/javascripts/discourse/app/components/custom-html.js
@@ -1,6 +1,6 @@
 import Component from "@ember/component";
 import { getCustomHTML } from "discourse/helpers/custom-html";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import { hbs } from "ember-cli-htmlbars";
 import deprecated from "discourse-common/lib/deprecated";
 
@@ -16,7 +16,7 @@ export default Component.extend({
       this.set("html", html);
       this.set("layout", hbs`{{this.html}}`);
     } else {
-      const template = getOwnerWithFallback(this).lookup(`template:${name}`);
+      const template = getOwner(this).lookup(`template:${name}`);
       if (template) {
         deprecated(
           "Defining an hbs template for CustomHTML rendering is deprecated. Use plugin outlets instead.",

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -3,7 +3,7 @@ import { filterTypeForMode } from "discourse/lib/filter-mode";
 import NavItem from "discourse/models/nav-item";
 import discourseComputed from "discourse-common/utils/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import { htmlSafe } from "@ember/template";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
@@ -144,9 +144,7 @@ export default Component.extend({
 
   @discourseComputed()
   canBulk() {
-    const controller = getOwnerWithFallback(this).lookup(
-      "controller:discovery/topics"
-    );
+    const controller = getOwner(this).lookup("controller:discovery/topics");
     return controller.canBulkSelect;
   },
 

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.js
@@ -11,7 +11,7 @@ import showModal from "discourse/lib/show-modal";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import I18n from "I18n";
 import Category from "discourse/models/category";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
   topic: readOnly("model.topic"),
@@ -108,8 +108,7 @@ const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
     const postStream = this.topic.postStream;
     const postId = this.post?.id || postStream.findPostIdForPostNumber(1);
     const post = postStream.findLoadedPost(postId);
-    const topicController =
-      getOwnerWithFallback(this).lookup("controller:topic");
+    const topicController = getOwner(this).lookup("controller:topic");
     topicController.actions.replyAsNewTopic.call(topicController, post);
     this.closeModal();
   },

--- a/app/assets/javascripts/discourse/app/components/modal/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/components/modal/topic-bulk-actions.js
@@ -9,7 +9,7 @@ import ChangeCategory from "../bulk-actions/change-category";
 import NotificationLevel from "../bulk-actions/notification-level";
 import ChangeTags from "../bulk-actions/change-tags";
 import AppendTags from "../bulk-actions/append-tags";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 const _customButtons = [];
 
@@ -72,7 +72,7 @@ export default class TopicBulkActions extends Component {
       class: "btn-default",
       visible: ({ topics }) => topics.some((t) => t.isPrivateMessage),
       action: ({ performAndRefresh }) => {
-        const userPrivateMessages = getOwnerWithFallback(this).lookup(
+        const userPrivateMessages = getOwner(this).lookup(
           "controller:user-private-messages"
         );
         let params = { type: "archive_messages" };
@@ -90,7 +90,7 @@ export default class TopicBulkActions extends Component {
       class: "btn-default",
       visible: ({ topics }) => topics.some((t) => t.isPrivateMessage),
       action: ({ performAndRefresh }) => {
-        const userPrivateMessages = getOwnerWithFallback(this).lookup(
+        const userPrivateMessages = getOwner(this).lookup(
           "controller:user-private-messages"
         );
         let params = { type: "move_messages_to_inbox" };

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -9,7 +9,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { action, set } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import ExplainReviewableModal from "discourse/components/modal/explain-reviewable";
 
 let _components = {};
@@ -121,7 +121,7 @@ export default Component.extend({
     }
 
     const dasherized = dasherize(type);
-    const owner = getOwnerWithFallback(this);
+    const owner = getOwner(this);
     const componentExists =
       owner.hasRegistration(`component:${dasherized}`) ||
       owner.hasRegistration(`template:components/${dasherized}`);

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
@@ -1,6 +1,6 @@
 import { cached } from "@glimmer/tracking";
 
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 import Component from "@glimmer/component";
 import { bind } from "discourse-common/utils/decorators";
 import GroupMessageSectionLink from "discourse/lib/sidebar/user/messages-section/group-message-section-link";
@@ -85,8 +85,7 @@ export default class SidebarUserMessagesSection extends Component {
       };
 
       if (currentRouteParentName === "topic") {
-        const topicController =
-          getOwnerWithFallback(this).lookup("controller:topic");
+        const topicController = getOwner(this).lookup("controller:topic");
 
         if (topicController.model.isPrivateMessage) {
           attrs.privateMessageTopic = topicController.model;

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -15,7 +15,7 @@ import UserMenuReviewablesList from "./reviewables-list";
 import UserMenuProfileTabContent from "./profile-tab-content";
 import UserMenuOtherNotificationsList from "./other-notifications-list";
 import deprecated from "discourse-common/lib/deprecated";
-import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
+import { getOwner } from "@ember/application";
 
 const DEFAULT_TAB_ID = "all-notifications";
 const DEFAULT_PANEL_COMPONENT = UserMenuNotificationsList;
@@ -281,7 +281,7 @@ export default class UserMenu extends Component {
 
     this.currentTabId = tab.id;
     this.currentPanelComponent = resolvePanelComponent(
-      getOwnerWithFallback(this),
+      getOwner(this),
       tab.panelComponent
     );
 


### PR DESCRIPTION
See 8958b4f76af85ddc89c8a3b6434dcfbd4274d569 for motivation

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
