### PR TITLE
UX: improve history modal layout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
@@ -1,7 +1,7 @@
 <div id="revisions" data-post-id={{@model.post_id}} class={{@hiddenClasses}}>
   {{#if @model.title_changes}}
     <div class="row">
-      <h2>{{html-safe @titleDiff}}</h2>
+      <h2 class="revision__title">{{html-safe @titleDiff}}</h2>
     </div>
   {{/if}}
   {{#if @mobileView}}
@@ -39,15 +39,20 @@
     {{/if}}
   {{/if}}
   {{#if @model.tags_changes}}
-    <div class="row">
-      {{i18n "tagging.changed"}}
-      {{#each @previousTagChanges as |t|}}
-        {{discourse-tag t.name style=(if t.deleted "diff-del")}}
-      {{/each}}
-      &rarr;&nbsp;
-      {{#each @currentTagChanges as |t|}}
-        {{discourse-tag t.name style=(if t.inserted "diff-ins")}}
-      {{/each}}
+    <div class="row -tag-revisions">
+      <span class="discourse-tags">
+        {{#each @previousTagChanges as |t|}}
+          {{discourse-tag t.name extraClass=(if t.deleted "diff-del")}}
+        {{/each}}
+      </span>
+      {{#if (and @mobileView @previousTagChanges @previousTagChanges)}}
+        &rarr;&nbsp;
+      {{/if}}
+      <span class="discourse-tags">
+        {{#each @currentTagChanges as |t|}}
+          {{discourse-tag t.name extraClass=(if t.inserted "diff-ins")}}
+        {{/each}}
+      </span>
     </div>
   {{/if}}
   {{#if @model.featured_link_changes}}

--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
@@ -45,7 +45,7 @@
           {{discourse-tag t.name extraClass=(if t.deleted "diff-del")}}
         {{/each}}
       </span>
-      {{#if (and @mobileView @previousTagChanges @previousTagChanges)}}
+      {{#if (and @mobileView @previousTagChanges @currentTagChanges)}}
         &rarr;&nbsp;
       {{/if}}
       <span class="discourse-tags">

--- a/app/assets/javascripts/discourse/app/components/modal/history/topic-footer.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/topic-footer.hbs
@@ -1,37 +1,41 @@
 <div id="revision-controls">
-  <DButton
-    class="btn-default first-revision"
-    @action={{@loadFirstVersion}}
-    @icon="fast-backward"
-    @title="post.revisions.controls.first"
-    @disabled={{@loadFirstDisabled}}
-  />
-  <DButton
-    class="btn-default previous-revision"
-    @action={{@loadPreviousVersion}}
-    @icon="backward"
-    @title="post.revisions.controls.previous"
-    @disabled={{@loadPreviousDisabled}}
-  />
+  <div class="revision-controls--back">
+    <DButton
+      class="btn-default first-revision"
+      @action={{@loadFirstVersion}}
+      @icon="fast-backward"
+      @title="post.revisions.controls.first"
+      @disabled={{@loadFirstDisabled}}
+    />
+    <DButton
+      class="btn-default previous-revision"
+      @action={{@loadPreviousVersion}}
+      @icon="backward"
+      @title="post.revisions.controls.previous"
+      @disabled={{@loadPreviousDisabled}}
+    />
+  </div>
   <div id="revision-numbers" class={{unless @displayRevisions "invisible"}}>
     <ConditionalLoadingSpinner @condition={{@loading}} @size="small">
       {{html-safe @revisionsText}}
     </ConditionalLoadingSpinner>
   </div>
-  <DButton
-    class="btn-default next-revision"
-    @action={{@loadNextVersion}}
-    @icon="forward"
-    @title="post.revisions.controls.next"
-    @disabled={{@loadNextDisabled}}
-  />
-  <DButton
-    class="btn-default last-revision"
-    @action={{@loadLastVersion}}
-    @icon="fast-forward"
-    @title="post.revisions.controls.last"
-    @disabled={{@loadLastDisabled}}
-  />
+  <div class="revision-controls--forward">
+    <DButton
+      class="btn-default next-revision"
+      @action={{@loadNextVersion}}
+      @icon="forward"
+      @title="post.revisions.controls.next"
+      @disabled={{@loadNextDisabled}}
+    />
+    <DButton
+      class="btn-default last-revision"
+      @action={{@loadLastVersion}}
+      @icon="fast-forward"
+      @title="post.revisions.controls.last"
+      @disabled={{@loadLastDisabled}}
+    />
+  </div>
 </div>
 
 <div id="revision-footer-buttons">

--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -35,6 +35,9 @@ export function defaultRenderTag(tag, params) {
   if (siteSettings.tag_style || params.style) {
     classes.push(params.style || siteSettings.tag_style);
   }
+  if (params.extraClass) {
+    classes.push(params.extraClass);
+  }
   if (params.size) {
     classes.push(params.size);
   }

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -12,23 +12,59 @@
   }
 
   #revision {
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 0.5em;
+    align-items: center;
     overflow: auto;
     border-bottom: 3px solid var(--primary-low);
   }
 
-  table.markdown > tbody > tr > td,
-  .revision-content {
-    width: 47.5%;
-    float: left;
-    min-height: 1px;
-
-    &:nth-of-type(2) {
-      margin-left: 5%;
+  #revision-details {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5em;
+    .d-icon {
+      align-self: center;
     }
   }
 
-  #revision-details {
-    padding: 5px;
+  .revision__title,
+  .body-diff,
+  table.markdown > tbody > tr,
+  .-tag-revisions {
+    --gap-width: 1rem;
+    display: flex;
+    gap: 0 var(--gap-width);
+  }
+
+  .revision__title {
+    margin: 0;
+    line-height: var(--line-height-medium);
+  }
+
+  .-tag-revisions span,
+  .revision-content {
+    flex: 0 0 calc(50% - (var(--gap-width) / 2));
+  }
+
+  table.markdown {
+    tbody {
+      border: none;
+    }
+  }
+
+  #revision-controls {
+    display: flex;
+    align-items: center;
+    .btn {
+      margin: 0;
+    }
+  }
+
+  [class^="revision-controls--"] {
+    display: flex;
+    gap: 0 1em;
   }
 
   #revisions {
@@ -50,6 +86,14 @@
           max-width: none;
         }
       }
+    }
+  }
+
+  #revision-footer-buttons {
+    display: flex;
+    gap: 0.5em;
+    button {
+      margin: 0;
     }
   }
 
@@ -126,7 +170,7 @@
     padding: 3px 5px 5px 5px;
   }
   .d-icon-ban {
-    color: #f00;
+    color: var(--danger);
   }
   .hidden-revision-either {
     opacity: 0.5;

--- a/app/assets/stylesheets/desktop/history.scss
+++ b/app/assets/stylesheets/desktop/history.scss
@@ -7,21 +7,6 @@
   .modal-body {
     height: 70vh;
   }
-  #revision-controls {
-    .btn[disabled] {
-      cursor: not-allowed;
-      background-color: var(--primary-low);
-    }
-    .btn-danger[disabled] {
-      background-color: var(--danger-medium);
-    }
-  }
-
-  #revision {
-    display: flex;
-    justify-content: space-between;
-    padding-bottom: 0.5em;
-  }
 
   #revisions {
     word-wrap: break-word;
@@ -46,14 +31,10 @@
   }
   .markdown {
     font-family: monospace;
-    font-size: var(--font-down-1);
     width: 100%;
     border-collapse: collapse;
     border-spacing: 0;
     td {
-      width: 50%;
-      vertical-align: top;
-      max-width: 440px;
       word-wrap: break-word;
       white-space: pre-wrap;
     }
@@ -65,12 +46,8 @@
       box-sizing: border-box;
     }
   }
-  .modal-header {
-    height: 42px;
-  }
 
   .modal-footer {
-    display: flex;
     justify-content: space-between;
   }
 }

--- a/app/assets/stylesheets/mobile/history.scss
+++ b/app/assets/stylesheets/mobile/history.scss
@@ -1,18 +1,14 @@
 .modal.history-modal {
-  button {
-    float: none;
-  }
   .modal-body {
     height: 62vh;
   }
   .modal-inner-container {
     min-height: 400px;
   }
-  #revision-numbers {
-    line-height: var(--line-height-large);
-  }
+
   img {
-    max-width: 95%;
+    box-sizing: border-box;
+    max-width: 100%;
     height: auto;
   }
   .revision-content {
@@ -23,17 +19,19 @@
     }
   }
 
-  .modal-footer {
-    text-align: center;
-  }
-
   #revision-controls {
-    margin-bottom: 5px;
+    width: 100%;
+    justify-content: space-between;
+    margin-bottom: 0.5em;
   }
 
   #revision-footer-buttons {
     button {
       @extend .btn-small;
     }
+  }
+
+  .-tag-revisions {
+    display: block;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4229,7 +4229,6 @@ en:
       other_tags: "Other Tags"
       selector_all_tags: "all tags"
       selector_no_tags: "no tags"
-      changed: "tags changed:"
       tags: "Tags"
       choose_for_topic: "optional tags"
       choose_for_topic_required:


### PR DESCRIPTION
This removes floats in favor of flexbox, so it should avoid issues like this:
![Screenshot 2023-09-26 at 2 22 23 PM](https://github.com/discourse/discourse/assets/1681963/2b68ba73-a2c9-42cb-846b-176675396165)

It also:
* Improves tag change layout so it's inline with the correct revision
* Updates tag styles to better match how they appear in titles 
* Improves the footer button layout on mobile 
* Consolidates some mobile and desktop styles into common 
* Increases the size of the text on the markdown tab 


Before:
![Screenshot 2023-09-26 at 2 26 07 PM](https://github.com/discourse/discourse/assets/1681963/a1dd3542-7090-4847-8188-c396d7457d71)
![Screenshot 2023-09-26 at 2 26 12 PM](https://github.com/discourse/discourse/assets/1681963/f36a8d94-a768-4ea1-a3af-0f22ed18c622)


After:


![Screenshot 2023-09-26 at 2 24 50 PM](https://github.com/discourse/discourse/assets/1681963/876f50c8-751e-4725-b60d-094f8b58e2ee)
![Screenshot 2023-09-26 at 2 25 06 PM](https://github.com/discourse/discourse/assets/1681963/094ea236-8cd7-496a-882b-0712f6de37b6)


Before:

![Screenshot 2023-09-26 at 2 25 59 PM](https://github.com/discourse/discourse/assets/1681963/01b685ea-a8d3-40d7-b534-fa097f89a815)


After:
![Screenshot 2023-09-26 at 1 37 47 PM](https://github.com/discourse/discourse/assets/1681963/464c42c5-2cf3-4436-a90f-55d1316649a7)
