### PR TITLE
FIX: Correct error on add user modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/group-add-members.js
+++ b/app/assets/javascripts/discourse/app/components/modal/group-add-members.js
@@ -63,7 +63,7 @@ export default class GroupAddMembers extends Component {
         });
         this.args.closeModal();
       })
-      .catch((e) => (this.flash = e))
+      .catch((e) => (this.flash = e.jqXHR.responseJSON.errors.join(". ")))
       .finally(() => (this.loading = false));
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -66,7 +66,7 @@
             @icon="plus"
             @action={{route-action "showInviteModal"}}
             @label="groups.manage.invite_members"
-            class="btn-default group-members-add"
+            class="btn-default group-members-invite"
           />
         {{/if}}
       </div>

--- a/spec/system/groups/group_members_spec.rb
+++ b/spec/system/groups/group_members_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe "Group members", type: :system do
+  let(:group_page) { PageObjects::Pages::Group.new }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:group) { Fabricate(:group) }
+
+  before { sign_in(admin) }
+
+  describe "adds a user to the group" do
+    it "should show that the user is already in the group" do
+      group_page.visit(group).add_users.select_user_and_add(admin)
+
+      expect(
+        group_page.find(".group-members .directory-table__cell--username.group-member .username"),
+      ).to have_text(admin.username)
+
+      group_page.add_users.select_user_and_add(admin)
+
+      expect(page.find(".modal-container #modal-alert")).to have_text(
+        "'#{admin.username}' is already a member of this group",
+      )
+    end
+  end
+end

--- a/spec/system/page_objects/pages/group.rb
+++ b/spec/system/page_objects/pages/group.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Group < PageObjects::Pages::Base
+      def visit(group)
+        page.visit("/g/#{group.name}")
+        self
+      end
+
+      def find(selector)
+        page.find(".group #{selector}")
+      end
+
+      def add_users
+        find(".group-members-manage button.group-members-add").click
+        self
+      end
+
+      def select_user_and_add(user)
+        page.find(
+          ".modal-container .user-chooser .multi-select-header .select-kit-header-wrapper",
+        ).click
+        page.find(".modal-container .user-chooser .filter-input").set(user.username)
+        page.find(
+          ".modal-container li.email-group-user-chooser-row[data-value='#{user.username}']",
+        ).click
+        page.find(".modal-container button.add.btn-primary").click
+        self
+      end
+    end
+  end
+end


### PR DESCRIPTION
Show the correct error when the user is already in the group we want to add them in.

Before:
![image](https://github.com/discourse/discourse/assets/1555215/a3caf43e-70ad-4404-a913-bcc3affa177f)

After:
<img width="622" alt="Screenshot 2023-09-27 at 12 54 14 PM" src="https://github.com/discourse/discourse/assets/1555215/33b6fc82-5202-42c3-b80a-a87ee7ea5dc3">
