### PR TITLE
DEV: Update importers from PostUpload to UploadReference

### DIFF
--- a/script/bulk_import/discourse_merger.rb
+++ b/script/bulk_import/discourse_merger.rb
@@ -2,6 +2,8 @@
 
 require_relative "base"
 
+raise "This importer needs to be updated from using PostUpload to UploadReference"
+
 class BulkImport::DiscourseMerger < BulkImport::Base
   NOW ||= "now()"
   CUSTOM_FIELDS = %w[category group post topic user]

--- a/script/import_scripts/bbpress.rb
+++ b/script/import_scripts/bbpress.rb
@@ -310,9 +310,7 @@ class ImportScripts::Bbpress < ImportScripts::Base
               if !post.raw[html]
                 post.raw << "\n\n" << html
                 post.save!
-                unless PostUpload.where(post: post, upload: upload).exists?
-                  PostUpload.create!(post: post, upload: upload)
-                end
+                UploadReference.ensure_exist!(upload_ids: [upload.id], target: post)
               end
             end
           end
@@ -360,9 +358,7 @@ class ImportScripts::Bbpress < ImportScripts::Base
               if !post.raw[html]
                 post.raw << "\n\n" << html
                 post.save!
-                unless PostUpload.where(post: post, upload: upload).exists?
-                  PostUpload.create!(post: post, upload: upload)
-                end
+                UploadReference.ensure_exist!(upload_ids: [upload.id], target: post)
               end
             end
           end

--- a/script/import_scripts/higher_logic.rb
+++ b/script/import_scripts/higher_logic.rb
@@ -189,9 +189,7 @@ class ImportScripts::HigherLogic < ImportScripts::Base
 
               post.raw << "\n\n" << html
               post.save!
-              unless PostUpload.where(post: post, upload: upload).exists?
-                PostUpload.create!(post: post, upload: upload)
-              end
+              UploadReference.ensure_exist!(upload_ids: [upload.id], target: post)
             end
           end
         end

--- a/script/import_scripts/phorum.rb
+++ b/script/import_scripts/phorum.rb
@@ -270,10 +270,10 @@ class ImportScripts::Phorum < ImportScripts::Base
         if !post.raw[html]
           post.raw += "\n\n#{html}\n\n"
           post.save!
-          if PostUpload.where(post: post, upload: upl_obj).exists?
+          if UploadReference.where(target: post, upload: upl_obj).exists?
             puts "skipping creating uploaded for previously uploaded file #{upload["file_id"]}"
           else
-            PostUpload.create!(post: post, upload: upl_obj)
+            UploadReference.ensure_exist!(upload_ids: [upl_obj.id], target: post)
           end
           # PostUpload.create!(post: post, upload: upl_obj) unless PostUpload.where(post: post, upload: upl_obj).exists?
         else

--- a/script/import_scripts/smf1.rb
+++ b/script/import_scripts/smf1.rb
@@ -452,10 +452,10 @@ class ImportScripts::Smf1 < ImportScripts::Base
 
         if upload = create_upload(post.user_id, path, u["filename"])
           html = html_for_upload(upload, u["filename"])
-          unless post.raw[html] || PostUpload.where(upload: upload, post: post).exists?
+          unless post.raw[html] || UploadReference.where(upload: upload, target: post).exists?
             post.raw += "\n\n#{html}\n\n"
             post.save
-            PostUpload.create(upload: upload, post: post)
+            UploadReference.ensure_exist!(upload_ids: [upload.id], target: post)
           end
         end
 

--- a/script/import_scripts/vbulletin5.rb
+++ b/script/import_scripts/vbulletin5.rb
@@ -439,9 +439,7 @@ class ImportScripts::VBulletin < ImportScripts::Base
         if !post.raw[html]
           post.raw += "\n\n#{html}\n\n"
           post.save!
-          unless PostUpload.where(post: post, upload: upl_obj).exists?
-            PostUpload.create!(post: post, upload: upl_obj)
-          end
+          UploadReference.ensure_exist!(upload_ids: [upl_obj.id], target: post)
         end
       else
         puts "Fail"


### PR DESCRIPTION
Discourse stopped using PostUpload in https://github.com/discourse/discourse/commit/9db8f00b3dd6f2881adf1b786e29426889225e7a. Since then, these importers have been writing to the table, but any data was totally unused. This commit updates the easy cases to use UploadReference, and adds an error to the discourse_merger import script, which needs more significant work.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
