### PR TITLE
DEV: Add failing test for pull-hotlinked codeblocks

### DIFF
--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -385,6 +385,18 @@ RSpec.describe InlineUploads do
         MD
       end
 
+      it "should not replace identical markdown in code blocks", skip: "Known issue" do
+        md = <<~MD
+        `![image|690x290](#{upload.url})`
+        ![image|690x290](#{upload.url})
+        MD
+
+        expect(InlineUploads.process(md)).to eq(<<~MD)
+        `![image|690x290](#{upload.url})`
+        ![image|690x290](#{upload.short_url})
+        MD
+      end
+
       it "should not be affected by an emoji" do
         CustomEmoji.create!(name: "test", upload: upload3)
         Emoji.clear_cache


### PR DESCRIPTION
If a codeblock contains **exactly** the same markdown as an image which has been retrieved by the 'pull hotlinked' job, then it will be replaced with the new URL. This commit adds failing (skipped) tests for this issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
