### PR TITLE
FIX: Disallow moderators from custom public sidebar sections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
@@ -83,7 +83,7 @@
         />
       {{/if}}
 
-      {{#if (and this.currentUser.staff)}}
+      {{#if (and this.currentUser.admin)}}
         <div
           class="row-wrapper mark-public-wrapper
             {{if this.transformedModel.sectionType '-disabled'}}"

--- a/app/assets/javascripts/discourse/app/lib/sidebar/section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section.js
@@ -37,7 +37,7 @@ export default class Section {
   }
 
   get headerActions() {
-    if (!this.section.public || this.currentUser?.staff) {
+    if (!this.section.public || this.currentUser?.admin) {
       return [
         {
           action: () => {


### PR DESCRIPTION
### What is this change?

Currently moderators can see the custom public sidebar section edit button, but they are prevented from making any changes by an error. According to the back-end, moderators can not access these.

**Trying to edit or create:**

<img width="508" alt="Screenshot 2023-09-27 at 3 48 14 PM" src="https://github.com/discourse/discourse/assets/5259935/c95584f9-1368-4181-a4f1-450e23852734">

**Trying to delete:**

<img width="255" alt="Screenshot 2023-09-27 at 3 48 21 PM" src="https://github.com/discourse/discourse/assets/5259935/3f333622-555e-45f8-b163-341f4c6a3df9">

This PR hides the custom public sidebar section edit button, as well as the "make public" checkbox of the create modal, if the user is not an admin, bringing the UI in line with the back-end.

If needed, we can add a site setting to allow moderator access when the need arises.