### PR TITLE
FIX: copy codeblocks needs `client: true`

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1005,6 +1005,7 @@ posting:
     client: true
     list_type: compact
   show_copy_button_on_codeblocks:
+    client: true
     default: true
     hidden: true
   delete_old_hidden_posts: true


### PR DESCRIPTION
follow-up to 81f3f56, this needs `client: true` 