### PR TITLE
DEV: Copy button JS test failures

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
@@ -8,6 +8,8 @@ module("Integration | Component | Widget | post-cooked", function (hooks) {
   setupRenderingTest(hooks);
 
   test("quotes with no username and no valid topic", async function (assert) {
+    this.siteSettings.show_copy_button_on_codeblocks = false;
+
     this.set("args", {
       cooked: `<aside class=\"quote no-group quote-post-not-found\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`,
     });

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -33,4 +33,19 @@ describe "Topic page", type: :system do
       end
     end
   end
+
+  context "with a post containing a code block" do
+    before { Fabricate(:post, topic: topic, raw: <<~RAW) }
+      this a code block
+      ```
+      echo "hello world"
+      ```
+      RAW
+
+    it "includes the copy button" do
+      visit("/t/#{topic.slug}/#{topic.id}")
+
+      expect(".codeblock-button-wrapper").to be_present
+    end
+  end
 end


### PR DESCRIPTION
The "quotes with no username and no valid topic" JS test expects `show_copy_button_on_codeblocks` to be false (false was the default value for that setting before #23662). There is probably a different issue at play here that I haven't dug into yet.

This PR sets it back to `false` for that specific test, and also adds a system test to ensure copy button is present for code blocks with default site settings enabled.
