### PR TITLE
A11Y: UI emoji are decorative, use `alt=""`

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/index.hbs
@@ -1,10 +1,6 @@
 <section class="current-badges">
   <div class="badge-intro admin-intro">
-    <img
-      src={{this.badgeIntroEmoji}}
-      class="badge-intro-emoji"
-      alt={{i18n "admin.badges.badge_intro.emoji"}}
-    />
+    <img src={{this.badgeIntroEmoji}} class="badge-intro-emoji" alt="" />
     <div class="content-wrapper">
       <h1>{{i18n "admin.badges.badge_intro.title"}}</h1>
       <div class="external-resources">

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-index.hbs
@@ -1,8 +1,5 @@
 <div class="themes-intro admin-intro">
-  <img
-    src={{this.womanArtistEmojiURL}}
-    alt={{i18n "admin.customize.theme.themes_intro_emoji"}}
-  />
+  <img src={{this.womanArtistEmojiURL}} alt="" />
   <div class="content-wrapper">
     <h1>{{i18n "admin.customize.theme.themes_intro"}}</h1>
     <div class="create-actions">

--- a/app/assets/javascripts/discourse/app/templates/account-created/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/account-created/index.hbs
@@ -7,7 +7,7 @@
   <div class="ac-page">
     <div class="two-col">
       <div class="col-image">
-        <img src={{this.envelopeImageUrl}} alt={{i18n "invites.emoji"}} />
+        <img src={{this.envelopeImageUrl}} alt="" />
       </div>
       <div class="col-form">
         <div class="success-info">

--- a/app/assets/javascripts/discourse/app/templates/email-login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/email-login.hbs
@@ -1,11 +1,7 @@
 <div class="container email-login clearfix">
   <div class="content-wrapper">
     <div class="image-wrapper">
-      <img
-        src={{this.lockImageUrl}}
-        class="password-reset-img"
-        alt={{i18n "email_login.emoji"}}
-      />
+      <img src={{this.lockImageUrl}} class="password-reset-img" alt="" />
     </div>
 
     <form>

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -13,7 +13,7 @@
     <div class={{if this.successMessage "invite-success" "invite-form"}}>
       <div class="two-col">
         <div class="col-image">
-          <img src={{this.inviteImageUrl}} alt={{i18n "invites.emoji"}} />
+          <img src={{this.inviteImageUrl}} alt="" />
         </div>
 
         <div class="col-form">

--- a/app/assets/javascripts/discourse/app/templates/password-reset.hbs
+++ b/app/assets/javascripts/discourse/app/templates/password-reset.hbs
@@ -1,10 +1,6 @@
 <div class="container password-reset clearfix">
   <div class="pull-left col-image">
-    <img
-      src={{this.lockImageUrl}}
-      class="password-reset-img"
-      alt={{i18n "user.change_password.emoji"}}
-    />
+    <img src={{this.lockImageUrl}} class="password-reset-img" alt="" />
   </div>
 
   <div class="pull-left col-form">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1420,7 +1420,6 @@ en:
         success: "(email sent)"
         in_progress: "(sending email)"
         error: "(error)"
-        emoji: "lock emoji"
         action: "Send Password Reset Email"
         set_password: "Set Password"
         choose_new: "Choose a new password"
@@ -2136,7 +2135,6 @@ en:
       link_label: "Email me a login link"
       button_label: "with email"
       login_link: "Skip the password; email me a login link"
-      emoji: "lock emoji"
       complete_username: "If an account matches the username <b>%{username}</b>, you should receive an email with a login link shortly."
       complete_email: "If an account matches <b>%{email}</b>, you should receive an email with a login link shortly."
       complete_username_found: "We found an account that matches the username <b>%{username}</b>, you should receive an email with a login link shortly."
@@ -2230,7 +2228,6 @@ en:
         security_key: "Use a security key instead"
     invites:
       accept_title: "Invitation"
-      emoji: "envelope emoji"
       welcome_to: "Welcome to %{site_name}!"
       invited_by: "You were invited by:"
       social_login_available: "You'll also be able to sign in with any social login using that email."
@@ -5128,7 +5125,6 @@ en:
           theme_name: "Theme name"
           component_name: "Component name"
           themes_intro: "Select an existing theme or install a new one to get started"
-          themes_intro_emoji: "woman artist emoji"
           beginners_guide_title: "Beginner’s guide to using Discourse Themes"
           developers_guide_title: "Developer’s guide to Discourse Themes"
           browse_themes: "Browse community themes"
@@ -6294,7 +6290,6 @@ en:
             with_time: <span class="username">%{username}</span> at <span class="time">%{time}</span>
         badge_intro:
           title: "Select an existing badge or create a new one to get started"
-          emoji: "woman student emoji"
           what_are_badges_title: "What are badges?"
           badge_query_examples_title: "Badge query examples"
         mass_award:


### PR DESCRIPTION
Since these emoji are decorative, they don't need descriptions for screen readers. A null `alt` attribute will result in these being skipped.