### PR TITLE
A11Y: add `aria-current` to active navigation item

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.hbs
@@ -1,4 +1,8 @@
-<a href={{this.hrefLink}} class={{this.activeClass}}>
+<a
+  href={{this.hrefLink}}
+  class={{this.activeClass}}
+  aria-current={{if this.activeClass "true"}}
+>
   {{#if this.hasIcon}}
     <span class={{this.content.name}}></span>
   {{/if}}


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current

> When you have a group of related elements, such as several links in a breadcrumb or steps in a multi-step flow, with one element in the group styled differently from the others to indicate to the sighted user that this is the current element within its group, the aria-current should be used to inform the assistive technology user what has been indicated via styling.

When `activeClass` is false, `aria-current` is not added. 