### PR TITLE
A11Y: aria-label for mobile topic list avatar

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/avatar-utils.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/avatar-utils.js
@@ -75,7 +75,7 @@ export function avatarImg(options, customGetURL) {
   let title = "";
   if (options.title) {
     const escaped = escape(options.title || "");
-    title = ` title='${escaped}' aria-label='${escaped}'`;
+    title = ` title='${escaped}'`;
   }
 
   return `<img loading='lazy' alt='' width='${size}' height='${size}' src='${url}' class='${classes}'${title}>`;

--- a/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
@@ -6,7 +6,7 @@
         <input type="checkbox" class="bulk-select" id="bulk-select-{{topic.id}}">
       </label>
     {{else}}
-      <a href="{{topic.lastPostUrl}}" data-user-card="{{topic.lastPosterUser.username}}">{{avatar topic.lastPosterUser imageSize="large"}}</a>
+    <a href="{{topic.lastPostUrl}}" aria-label="{{i18n 'latest_poster_link' username=topic.lastPosterUser.username}}" data-user-card="{{topic.lastPosterUser.username}}">{{avatar topic.lastPosterUser imageSize="large"}}</a>
     {{/if}}
   </div>
   <div class='right'>

--- a/app/assets/javascripts/discourse/tests/unit/lib/avatar-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/avatar-utils-test.js
@@ -69,7 +69,7 @@ module("Unit | Utilities", function (hooks) {
         size: "tiny",
         title: "evilest trout",
       }),
-      "<img loading='lazy' alt='' width='24' height='24' src='/path/to/avatar/48.png' class='avatar' title='evilest trout' aria-label='evilest trout'>",
+      "<img loading='lazy' alt='' width='24' height='24' src='/path/to/avatar/48.png' class='avatar' title='evilest trout'>",
       "it adds a title if supplied"
     );
 

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -370,7 +370,7 @@ module("Unit | Model | report", function (hooks) {
     const computedUsernameLabel = usernameLabel.compute(row);
     assert.strictEqual(
       computedUsernameLabel.formattedValue,
-      "<a href='/admin/users/1/joffrey'><img loading='lazy' alt='' width='24' height='24' src='/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
+      "<a href='/admin/users/1/joffrey'><img loading='lazy' alt='' width='24' height='24' src='/' class='avatar' title='joffrey'><span class='username'>joffrey</span></a>"
     );
     assert.strictEqual(computedUsernameLabel.value, "joffrey");
 
@@ -459,7 +459,7 @@ module("Unit | Model | report", function (hooks) {
     const userLink = computedLabels[0].compute(row).formattedValue;
     assert.strictEqual(
       userLink,
-      "<a href='/forum/admin/users/1/joffrey'><img loading='lazy' alt='' width='24' height='24' src='/forum/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
+      "<a href='/forum/admin/users/1/joffrey'><img loading='lazy' alt='' width='24' height='24' src='/forum/' class='avatar' title='joffrey'><span class='username'>joffrey</span></a>"
     );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3933,6 +3933,7 @@ en:
         other {}
       }
 
+    latest_poster_link: "%{username}'s profile, latest poster"
     original_post: "Original Post"
     views: "Views"
     sr_views: "Sort by views"


### PR DESCRIPTION
Labeling the avatar with the username isn't incredibly helpful for screen readers, what we should do instead is markup the link with its purpose. 

This removes the aria-label from the avatar, and instead adds a more descriptive aria-label (`username's profile, latest poster`) to the avatar's wrapping link on the mobile topic list (this avatar seen here) 

<img width="370" alt="Screenshot 2023-09-27 at 3 29 29 PM" src="https://github.com/discourse/discourse/assets/1681963/b557f5c7-f210-4b91-8145-168b1e6e53b7">
