### PR TITLE
DEV: Check for model when adding codeblock buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/codeblock-buttons.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/codeblock-buttons.js
@@ -23,7 +23,12 @@ export default {
           return;
         }
 
-        const post = helper.getModel();
+        const post = helper.getModel?.();
+
+        if (!post) {
+          return;
+        }
+
         const cb = new CodeblockButtons({
           showFullscreen: true,
           showCopy: true,

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
@@ -8,8 +8,6 @@ module("Integration | Component | Widget | post-cooked", function (hooks) {
   setupRenderingTest(hooks);
 
   test("quotes with no username and no valid topic", async function (assert) {
-    this.siteSettings.show_copy_button_on_codeblocks = false;
-
     this.set("args", {
       cooked: `<aside class=\"quote no-group quote-post-not-found\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`,
     });


### PR DESCRIPTION
Followup to ca39417
