### PR TITLE
A11Y: improve about page profile link markup

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page-users.hbs
+++ b/app/assets/javascripts/discourse/app/components/about-page-users.hbs
@@ -2,7 +2,7 @@
   <a
     href={{userTemplate.userPath}}
     data-user-card={{userTemplate.username}}
-    aria-label={{i18n "user.profile_posessive" username=userTemplate.username}}
+    aria-label={{i18n "user.profile_possessive" username=userTemplate.username}}
   >
     <div data-username={{userTemplate.username}} class="user-info small">
       <div class="user-image">

--- a/app/assets/javascripts/discourse/app/components/about-page-users.hbs
+++ b/app/assets/javascripts/discourse/app/components/about-page-users.hbs
@@ -1,34 +1,32 @@
 {{#each this.usersTemplates as |userTemplate|}}
-  <div data-username={{userTemplate.username}} class="user-info small">
-    <div class="user-image">
-      <div class="user-image-inner">
-        <a
-          href={{userTemplate.userPath}}
-          data-user-card={{userTemplate.username}}
-        >
+  <a
+    href={{userTemplate.userPath}}
+    data-user-card={{userTemplate.username}}
+    aria-label={{i18n "user.profile_posessive" username=userTemplate.username}}
+  >
+    <div data-username={{userTemplate.username}} class="user-info small">
+      <div class="user-image">
+        <div class="user-image-inner">
+
           {{html-safe userTemplate.avatar}}
-        </a>
+
+        </div>
       </div>
-    </div>
-    <div class="user-detail">
-      <div class="name-line">
-        <span class="username">
-          <a
-            href={{userTemplate.userPath}}
-            data-user-card={{userTemplate.username}}
-          >
+      <div class="user-detail">
+        <div class="name-line">
+          <span class="username">
             {{#if
               userTemplate.prioritizeName
             }}{{userTemplate.name}}{{else}}{{userTemplate.username}}{{/if}}
-          </a>
-        </span>
-        <span class="name">
-          {{#if
-            userTemplate.prioritizeName
-          }}{{userTemplate.username}}{{else}}{{userTemplate.name}}{{/if}}
-        </span>
+          </span>
+          <span class="name">
+            {{#if
+              userTemplate.prioritizeName
+            }}{{userTemplate.username}}{{else}}{{userTemplate.name}}{{/if}}
+          </span>
+        </div>
+        <div class="title">{{userTemplate.title}}</div>
       </div>
-      <div class="title">{{userTemplate.title}}</div>
     </div>
-  </div>
+  </a>
 {{/each}}

--- a/app/assets/stylesheets/common/components/user-info.scss
+++ b/app/assets/stylesheets/common/components/user-info.scss
@@ -25,24 +25,16 @@
 
     .name-line {
       @include ellipsis;
-    }
+      color: var(--primary-high);
 
-    .bold a {
-      font-weight: bold;
-    }
-
-    .margin a {
-      margin-left: 5px;
-    }
-
-    .name a,
-    .username a {
-      color: var(--primary-high-or-secondary-low);
+      span:first-child {
+        color: var(--primary);
+      }
     }
 
     .title {
       margin-top: 3px;
-      color: var(--primary-med-or-secondary-med);
+      color: var(--primary-medium);
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1076,7 +1076,7 @@ en:
     user:
       said: "%{username}:"
       profile: "Profile"
-      profile_posessive: "%{username}'s profile"
+      profile_possessive: "%{username}'s profile"
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1076,6 +1076,7 @@ en:
     user:
       said: "%{username}:"
       profile: "Profile"
+      profile_posessive: "%{username}'s profile"
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive:


### PR DESCRIPTION
<img width="642" alt="Screenshot 2023-09-27 at 4 16 36 PM" src="https://github.com/discourse/discourse/assets/1681963/57ad1494-25fa-4f44-9418-a3d09ae15da5">

This improves the markup for the user's on /about

* Wraps the user information in a single link, rather than a separate link for the avatar and username. This ensures the entire region is clickable, and screen readers aren't reading out multiple links with the same purpose. 
* Adds an aria-label to the link in the format of "username's profile" 
* Removes some CSS that no longer appears to be in use