### PR TITLE
UX: selected indicator more topics spacing

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -36,7 +36,7 @@
   }
 
   .more-topics__list {
-    .topic-list-header:after {
+    .topic-list-header:before {
       content: "";
       display: block;
       height: 10px;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -36,7 +36,7 @@
   }
 
   .more-topics__list {
-    .topic-list-header {
+    .topic-list-header:before {
       content: "";
       display: block;
       height: 10px;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -36,7 +36,7 @@
   }
 
   .more-topics__list {
-    .topic-list-header:before {
+    .topic-list-header {
       content: "";
       display: block;
       height: 10px;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -36,7 +36,7 @@
   }
 
   .more-topics__list {
-    .topic-list-header:before {
+    .topic-list-header:after {
       content: "";
       display: block;
       height: 10px;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -35,11 +35,13 @@
     }
   }
 
-  .topic-list .topic-list-data:first-of-type {
-    padding-left: 5px;
-  }
-
   .more-topics__list {
+    .topic-list-header {
+      content: "";
+      display: block;
+      height: 10px;
+    }
+    
     .topic-list-body {
       border-top: none;
 

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -41,7 +41,7 @@
       display: block;
       height: 10px;
     }
-    
+
     .topic-list-body {
       border-top: none;
 

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -36,7 +36,7 @@
   }
 
   .more-topics__list {
-    .topic-list-header {
+    .topic-list-header:after {
       content: "";
       display: block;
       height: 10px;

--- a/app/assets/stylesheets/mobile/components/more-topics.scss
+++ b/app/assets/stylesheets/mobile/components/more-topics.scss
@@ -1,6 +1,7 @@
 .more-topics__container {
   .nav {
     margin-block: 0.5em 1em;
+    border-bottom: 1px solid var(--primary-low);
   }
 
   .more-content-topics {


### PR DESCRIPTION
In relation to the selected indicator, this PR addresses a vertical and horizontal issue with the indicator touching the table header and its left alignment to be more consistent with the regular topic list feed.


Before:
![CleanShot 2023-09-27 at 17 15 12](https://github.com/discourse/discourse/assets/69276978/8b6de0e2-e483-484d-b6c3-c9138d8ea19c)

After, table header & text no longer touching .selected indicator: 
![CleanShot 2023-09-27 at 17 10 25](https://github.com/discourse/discourse/assets/69276978/f5319c07-a1ca-4f7a-98a3-80d2b87b8125)

