### PR TITLE
FIX: allow history modal columns to shrink content width

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -45,7 +45,8 @@
 
   .-tag-revisions span,
   .revision-content {
-    flex: 0 0 calc(50% - (var(--gap-width) / 2));
+    flex: 0 1 calc(50% - (var(--gap-width) / 2));
+    min-width: 0;
   }
 
   table.markdown {


### PR DESCRIPTION
This fixes the issue described here: https://meta.discourse.org/t/width-of-edit-history-with-formated-code-on-moblie/280359

Without this, `pre code` blocks can cause the columns to be too wide. 

Follow-up to bbb4e19