### PR TITLE
FIX: correctly clear the quote state

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -102,6 +102,9 @@ export default class PostTextSelection extends Component {
     const selection = window.getSelection();
 
     if (selection.isCollapsed) {
+      if (!this.menuInstance?.expanded) {
+        this.args.quoteState.clear();
+      }
       return;
     }
 
@@ -233,12 +236,8 @@ export default class PostTextSelection extends Component {
   }
 
   @bind
-  mousedown(event) {
+  mousedown() {
     this.holdingMouseDown = false;
-
-    if (!event.target.closest(".cooked")) {
-      return;
-    }
 
     this.isMousedown = true;
     this.holdingMouseDownHandler = discourseLater(() => {

--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -236,8 +236,12 @@ export default class PostTextSelection extends Component {
   }
 
   @bind
-  mousedown() {
+  mousedown(event) {
     this.holdingMouseDown = false;
+
+    if (!event.target.closest(".cooked")) {
+      return;
+    }
 
     this.isMousedown = true;
     this.holdingMouseDownHandler = discourseLater(() => {


### PR DESCRIPTION
Prior to this fix clicking outside text and reseting the selection wouldn't clear the quote state, which would cause a click on "reply" or "create" to start the composer with the quote state.

This commit attempts to simplify this behaviour by not mutating quote state while the menu is opened. The quote state will now only be cleared when the menu is closed.

No tests have ever been written for this complex and subtle behavior (both `mousedown` and `selectionchange` events can trigger the final `selectionChanged` codepath); which prevents us to for example stop the event when clicking quote as it will still change the selection even if we can prevent the `mousedown`. Ideally a huge part of this code should be rewritten to be easier to test, this commit only attempt to fix a regression introduced when using FloatKit to position the menu.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
