### PR TITLE
A11Y: add aria-label to share copy button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/copy-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/copy-button.hbs
@@ -2,4 +2,5 @@
   @icon={{this.copyIcon}}
   @action={{this.copy}}
   class={{this.copyClass}}
+  @ariaLabel={{this.ariaLabel}}
 />

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.hbs
@@ -27,7 +27,7 @@
           @value={{this.url}}
           readonly={{true}}
         />
-        <CopyButton @selector="input.invite-link" />
+        <CopyButton @selector="input.invite-link" @ariaLabel="share.url" />
       </div>
     </div>
 


### PR DESCRIPTION
This blue share button was unlabeled for screen readers 
 
![Screenshot 2023-09-28 at 1 50 29 PM](https://github.com/discourse/discourse/assets/1681963/90e9e399-3aca-4c1c-9e17-63c6d820088e)
