### PR TITLE
A11Y: keep bookmark modal open when using keyboard

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/bookmark.hbs
@@ -15,7 +15,6 @@
         @value={{this.bookmark.name}}
         name="bookmark-name"
         class="bookmark-name"
-        @enter={{action "saveAndClose"}}
         placeholder={{i18n "post.bookmarks.name_placeholder"}}
         aria-label={{i18n "post.bookmarks.name_input_label"}}
       />


### PR DESCRIPTION
At the moment when you navigate to the bookmark button under a post using your keyboard, it opens and closes the modal instantly. 


https://github.com/discourse/discourse/assets/1681963/fa8ffc01-aca7-4543-ba35-6983167b399c

removing `@enter` from the input seems to fix this, and doesn't seem to have any adverse effects... hitting enter while in the input still seems to function and save without it

https://github.com/discourse/discourse/assets/1681963/f40a5789-736f-4b3d-a92c-bb9cf0527309


