### PR TITLE
FIX: Make CookText component reactive

### DIFF
--- a/app/assets/javascripts/discourse/app/components/cook-text.gjs
+++ b/app/assets/javascripts/discourse/app/components/cook-text.gjs
@@ -16,6 +16,7 @@ export default class CookText extends Component {
       {{didUpdate this.buildOneboxes this.cooked}}
       {{didUpdate this.resolveShortUrls this.cooked}}
       {{didUpdate this.calculateOffsetHeight this.cooked}}
+      {{didUpdate this.loadCookedText @rawText}}
     >
       {{this.cooked}}
     </div>
@@ -29,6 +30,7 @@ export default class CookText extends Component {
     this.loadCookedText();
   }
 
+  @action
   async loadCookedText() {
     const cooked = await cookAsync(this.args.rawText);
     this.cooked = cooked;


### PR DESCRIPTION
### What is the problem?

When navigating between renewables through the Ember router, e.g. through the links in the notifications menu:

<img width="236" alt="Screenshot 2023-09-29 at 9 58 30 AM" src="https://github.com/discourse/discourse/assets/5259935/5e44d885-51c5-42cb-8b12-0b43934a0af4">

the body of the reviewable (rendered by the `CookText` component) won't update, resulting in the same post body incorrectly being shown for all subsequent reviewables.

This is happening because there is no update path between the `rawText` attribute being passed to `CookText` and the computed `cooked` attribute, since this is being set explicitly using an async function.

### How does this fix it?

This PR adds the missing link between `rawText` and `cooked` by listening for `didUpdate` and triggering the async function.

### Verification

**Before:**

![reviewable-body-before](https://github.com/discourse/discourse/assets/5259935/dd80ae21-8e1b-41d7-99d5-95e8a1be2ad2)

**After:**

![reviewable-body-after](https://github.com/discourse/discourse/assets/5259935/94ca289e-ed9b-4399-bff6-2564fe5a081d)
