### PR TITLE
A11Y: fix keyboard nav for custom bookmark time

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tap-tile.js
+++ b/app/assets/javascripts/discourse/app/components/tap-tile.js
@@ -21,6 +21,7 @@ export default Component.extend({
 
   keyDown(e) {
     if (e.key === "Enter") {
+      e.stopPropagation();
       this.onChange(this.tileId);
     }
   },


### PR DESCRIPTION
When trying to select the custom bookmark time from the modal with the keyboard, the modal would close, making it impossible to set a time. 

https://github.com/discourse/discourse/assets/1681963/aa2cb2d5-0122-41f5-b7ce-c561030aa5b2

stopping the enter keydown event from propagating fixes this, and enter still functions properly on the non-custom options 



https://github.com/discourse/discourse/assets/1681963/4b42d752-4abe-4993-b4fa-ae5b858c2dc6


