### PR TITLE
FIX: Remove reference to removed site setting from num_users_to_silence_new_user setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1644,7 +1644,7 @@ en:
     tl3_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl3 (regular) by multiplying with this number"
     tl4_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl4 (leader) by multiplying with this number"
 
-    num_users_to_silence_new_user: "If a new user's posts get num_spam_flags_to_silence_new_user spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable."
+    num_users_to_silence_new_user: "If a new user's posts exceed the hide_post_sensitivity setting, and has spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable."
     num_tl3_flags_to_silence_new_user: "If a new user's posts get this many flags from num_tl3_users_to_silence_new_user different trust level 3 users, hide all their posts and prevent future posting. 0 to disable."
     num_tl3_users_to_silence_new_user: "If a new user's posts get num_tl3_flags_to_silence_new_user flags from this many different trust level 3 users, hide all their posts and prevent future posting. 0 to disable."
     notify_mods_when_user_silenced: "If a user is automatically silenced, send a message to all moderators."


### PR DESCRIPTION
### What is this change?

The `num_users_to_silence_new_user` setting is referencing `num_spam_flags_to_silence_new_user`, which has been [superceded](https://github.com/discourse/discourse/commit/b58867b6e9#diff-bff2842c9891df212adcbe8eb22a4a17c9644c676260a0cfa6e7a3953852c5e8L1340) [twice](https://github.com/discourse/discourse/commit/89b84651c3#diff-bff2842c9891df212adcbe8eb22a4a17c9644c676260a0cfa6e7a3953852c5e8L1371).

<img width="641" alt="Screenshot 2023-09-29 at 4 47 13 PM" src="https://github.com/discourse/discourse/assets/5259935/be21b8a0-5d3d-4bb7-8204-89891dd19e2f">

This change updates the description to reflect that it now operates on the new "sensitivity score" system.