### PR TITLE
DEV: Change share quote visibility setting default to 'all'

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -233,7 +233,7 @@ basic:
   share_quote_visibility:
     client: true
     type: enum
-    default: "anonymous"
+    default: "all"
     choices:
       - none
       - anonymous


### PR DESCRIPTION
### What is this change?

As pointed out on [Meta](https://meta.discourse.org/t/change-share-quote-visibility-default-from-anonymous-to-all/280462), having this default to `all` (anonymous- and logged in users) is probably more sensible than just `anonymous`.