### PR TITLE
UX: selected spacing in more topics table

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -39,14 +39,18 @@
     .topic-list-header:after {
       content: "";
       display: block;
-      height: 10px;
+      height: 12px;
     }
 
     .topic-list-body {
       border-top: none;
-
-      .topic-list-item:last-of-type {
-        border-bottom: none;
+      .topic-list-item {
+        &:first-child td {
+          padding-top: 0;
+        }
+        &:last-of-type {
+          border-bottom: none;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR addresses spacing between the selected tr & the topic header, by cancelling out the spacing added between the first table row while still having space between the tabs "Suggested" & "Related"

For reference, this was the initial issue before the previous changes:

![CleanShot 2023-09-29 at 13 11 11](https://github.com/discourse/discourse/assets/69276978/a9d65a62-ca8b-4e33-9cf6-61f64333d883)

Before (with focused):

![CleanShot 2023-09-29 at 13 08 00](https://github.com/discourse/discourse/assets/69276978/d28764af-042c-457e-b5f0-4c2b0062dfdd)

After (with focused):

![CleanShot 2023-09-29 at 13 07 28](https://github.com/discourse/discourse/assets/69276978/1cc92221-42f8-43ac-b7b9-25da375e0fc1)

Before (w/o focused):

![CleanShot 2023-09-29 at 13 09 19](https://github.com/discourse/discourse/assets/69276978/96df7577-6ee5-444f-9ae2-ae277d34316b)


After (w/o focused):

![CleanShot 2023-09-29 at 13 09 40](https://github.com/discourse/discourse/assets/69276978/0d70f4d9-3de0-403b-b694-4a0b6b468b83)


