### PR TITLE
A11Y: composer tip close link should be a button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-tip-close-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-tip-close-button.hbs
@@ -1,0 +1,7 @@
+<DButton
+  @action={{fn @closeAction @message}}
+  @icon="times"
+  @label="composer.esc"
+  @ariaLabel="composer.esc_label"
+  class="btn-flat close"
+/>

--- a/app/assets/javascripts/discourse/app/components/composer-tip-close-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-tip-close-button.hbs
@@ -1,5 +1,5 @@
 <DButton
-  @action={{fn @closeAction @message}}
+  @action={{@action}}
   @icon="times"
   @label="composer.esc"
   @ariaLabel="composer.esc_label"

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,12 +1,7 @@
-<a
-  href
-  {{on "click" (fn this.closeMessage this.message)}}
-  class="close"
-  aria-label={{i18n "composer.esc_label"}}
->
-  {{i18n "composer.esc"}}
-  {{d-icon "times"}}
-</a>
+<ComposerTipCloseButton
+  @closeAction={{this.closeMessage}}
+  @message={{this.message}}
+/>
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,6 +1,5 @@
 <ComposerTipCloseButton
-  @closeAction={{this.closeMessage}}
-  @message={{this.message}}
+  @action={{fn this.closeMessage this.message}}
 />
 
 {{html-safe this.message.body}}

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,6 +1,4 @@
-<ComposerTipCloseButton
-  @action={{fn this.closeMessage this.message}}
-/>
+<ComposerTipCloseButton @action={{fn this.closeMessage this.message}} />
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/education.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/education.hbs
@@ -1,7 +1,4 @@
-<ComposerTipCloseButton
-  @closeAction={{this.closeMessage}}
-  @message={{this.message}}
-/>
+<ComposerTipCloseButton @action={{fn this.closeMessage this.message}} />
 
 {{#if this.message.title}}
   <h3>{{this.message.title}}</h3>

--- a/app/assets/javascripts/discourse/app/templates/composer/education.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/education.hbs
@@ -1,12 +1,7 @@
-<a
-  href
-  {{on "click" (fn this.closeMessage this.message)}}
-  class="close"
-  aria-label={{i18n "composer.esc_label"}}
->
-  {{i18n "composer.esc"}}
-  {{d-icon "times"}}
-</a>
+<ComposerTipCloseButton
+  @closeAction={{this.closeMessage}}
+  @message={{this.message}}
+/>
 
 {{#if this.message.title}}
   <h3>{{this.message.title}}</h3>

--- a/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
@@ -1,7 +1,4 @@
-<ComposerTipCloseButton
-  @closeAction={{this.closeMessage}}
-  @message={{this.message}}
-/>
+<ComposerTipCloseButton @action={{fn this.closeMessage this.message}} />
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
@@ -1,12 +1,7 @@
-<a
-  href
-  {{on "click" (fn this.closeMessage this.message)}}
-  class="close"
-  aria-label={{i18n "composer.esc_label"}}
->
-  {{i18n "composer.esc"}}
-  {{d-icon "times"}}
-</a>
+<ComposerTipCloseButton
+  @closeAction={{this.closeMessage}}
+  @message={{this.message}}
+/>
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
@@ -1,7 +1,4 @@
-<ComposerTipCloseButton
-  @closeAction={{this.closeMessage}}
-  @message={{this.message}}
-/>
+<ComposerTipCloseButton @action={{fn this.closeMessage this.message}} />
 
 <p>
   {{html-safe this.message.body}}

--- a/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
@@ -1,11 +1,8 @@
-<a
-  href
-  {{on "click" (fn this.closeMessage this.message)}}
-  class="close"
-  aria-label={{i18n "composer.esc_label"}}
->
-  {{i18n "composer.esc"}}
-  {{d-icon "times"}}
-</a>
+<ComposerTipCloseButton
+  @closeAction={{this.closeMessage}}
+  @message={{this.message}}
+/>
 
-{{html-safe this.message.body}}
+<p>
+  {{html-safe this.message.body}}
+</p>

--- a/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
@@ -1,12 +1,7 @@
-<a
-  href
-  {{on "click" (fn this.closeMessage this.message)}}
-  class="close"
-  aria-label={{i18n "composer.esc_label"}}
->
-  {{i18n "composer.esc"}}
-  {{d-icon "times"}}
-</a>
+<ComposerTipCloseButton
+  @closeAction={{this.closeMessage}}
+  @message={{this.message}}
+/>
 
 <h3>{{i18n "composer.similar_topics"}}</h3>
 

--- a/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
@@ -1,7 +1,4 @@
-<ComposerTipCloseButton
-  @closeAction={{this.closeMessage}}
-  @message={{this.message}}
-/>
+<ComposerTipCloseButton @action={{fn this.closeMessage this.message}} />
 
 <h3>{{i18n "composer.similar_topics"}}</h3>
 

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -92,6 +92,14 @@
   box-shadow: var(--shadow-dropdown);
   background: var(--highlight-bg);
 
+  > p,
+  h3 {
+    &:first-of-type {
+      margin-top: 0;
+      margin-right: 3em;
+    }
+  }
+
   &.urgent {
     background: var(--danger-low);
   }
@@ -105,10 +113,9 @@
     bottom: unset;
     padding: 2.25em 6em 2.5em 2.25em;
     p {
-      margin-top: 0;
       font-size: var(--font-up-1);
     }
-    button {
+    button:not(.close) {
       margin-top: 0.5em;
     }
   }
@@ -117,21 +124,27 @@
     margin-bottom: 10px;
   }
 
-  a.close {
-    display: flex;
+  .btn.close {
+    flex-direction: row-reverse;
     align-items: center;
     position: absolute;
-    right: 10px;
-    top: 10px;
-    color: var(--primary);
-    opacity: 0.5;
+    right: 0.67em;
+    top: 0.67em;
+    color: var(--primary-medium);
     font-size: var(--font-0);
     .d-icon {
+      color: currentColor;
       font-size: var(--font-up-1);
-      margin-left: 0.25em;
+      margin: 0 0 0 0.25em;
     }
-    &:hover {
-      opacity: 1;
+    .discourse-no-touch & {
+      &:active,
+      &:focus {
+        background: transparent;
+        .d-icon {
+          color: var(--primary);
+        }
+      }
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2354,7 +2354,7 @@ en:
       drafts_offline: "drafts offline"
       edit_conflict: "edit conflict"
       esc: "esc"
-      esc_label: "Click or press Esc to dismiss"
+      esc_label: "dismiss message"
       ok_proceed: "Ok, proceed"
 
       group_mentioned_limit:


### PR DESCRIPTION
This puts the composer tip <kbd>esc X</kbd> action into a button instead of a link, because it functions as a button and not a link

I've also put it into a new component `composerTipCloseButton`, cleaned up some styling, and made the aria label less wordy. 

![Screenshot 2023-09-29 at 2 23 14 PM](https://github.com/discourse/discourse/assets/1681963/715ee2d1-d08b-430e-9153-0cdedc7f4073)
![Screenshot 2023-09-29 at 2 23 21 PM](https://github.com/discourse/discourse/assets/1681963/e245f9df-2595-40db-9899-929126b9a7d4)
