### PR TITLE
A11Y: Improve small-post markup for screen readers

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -94,7 +94,17 @@ export function resetPostSmallActionClassesCallbacks() {
 
 export default createWidget("post-small-action", {
   buildKey: (attrs) => `post-small-act-${attrs.id}`,
-  tagName: "div.small-action.onscreen-post",
+  tagName: "article.small-action.onscreen-post",
+
+  buildAttributes(attrs) {
+    return {
+      "aria-label": I18n.t("share.post", {
+        postNumber: attrs.post_number,
+        username: attrs.username,
+      }),
+      role: "region",
+    };
+  },
 
   buildId(attrs) {
     return `post_${attrs.post_number}`;
@@ -130,6 +140,7 @@ export default createWidget("post-small-action", {
         template: attrs.avatar_template,
         username: attrs.username,
         url: attrs.usernameUrl,
+        ariaHidden: false,
       })
     );
 

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -59,7 +59,7 @@ export function avatarImg(wanted, attrs) {
       height: size,
       src: getURLWithCDN(url),
       title,
-      "aria-label": title,
+      "aria-hidden": true,
       loading: "lazy",
       tabindex: "-1",
     },
@@ -73,8 +73,19 @@ export function avatarFor(wanted, attrs, linkAttrs) {
   const attributes = {
     href: attrs.url,
     "data-user-card": attrs.username,
-    "aria-hidden": true,
   };
+
+  // often avatars are paired with usernames,
+  // making them redundant for screen readers
+  // so we hide the avatar from screen readers by default
+  if (attrs.ariaHidden === false) {
+    attributes["aria-label"] = I18n.t("user.profile_posessive", {
+      username: attrs.username,
+    });
+  } else {
+    attributes["aria-hidden"] = true;
+  }
+
   if (linkAttrs) {
     Object.assign(attributes, linkAttrs);
   }

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -79,7 +79,7 @@ export function avatarFor(wanted, attrs, linkAttrs) {
   // making them redundant for screen readers
   // so we hide the avatar from screen readers by default
   if (attrs.ariaHidden === false) {
-    attributes["aria-label"] = I18n.t("user.profile_posessive", {
+    attributes["aria-label"] = I18n.t("user.profile_possessive", {
       username: attrs.username,
     });
   } else {


### PR DESCRIPTION
This improves the small post markup (pins, topic closures, etc). Note that there's a new translation in here dependent on this PR being merged (`user.profile_possessive`): https://github.com/discourse/discourse/pull/23695

What this does is:
* Marks up small posts with `article` instead of `div`, like regular posts
* Adds `role="region"` and an `aria-label` to the article (matching regular posts)
* Adds an `aria-label` to describe the user profile link, while hiding the avatar (which would be redundant to the link's purpose) 