### PR TITLE
A11Y: correctly markup `/about` stat table headers, tweak style

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -97,14 +97,17 @@
           <h3>{{d-icon "far-chart-bar"}} {{i18n "about.stats"}}</h3>
 
           <table class="table">
-            <tbody>
+            <thead>
               <tr>
-                <th>&nbsp;</th>
+                <th>
+                </th>
                 <th>{{i18n "about.stat.last_day"}}</th>
                 <th>{{i18n "about.stat.last_7_days"}}</th>
                 <th>{{i18n "about.stat.last_30_days"}}</th>
                 <th>{{i18n "about.stat.all_time"}}</th>
               </tr>
+            </thead>
+            <tbody>
               <tr class="about-topic-count">
                 <td class="title">{{i18n "about.topic_count"}}</td>
                 <td>{{number this.model.stats.topics_last_day}}</td>

--- a/app/assets/stylesheets/common/base/about.scss
+++ b/app/assets/stylesheets/common/base/about.scss
@@ -1,19 +1,24 @@
 section.about {
-  margin-bottom: 40px;
+  margin-bottom: 3em;
 
   h3 {
-    margin-bottom: 15px;
+    margin-bottom: 1em;
+    display: flex;
+    align-items: center;
+    .d-icon {
+      margin-right: 0.5em;
+      color: var(--primary-high);
+    }
   }
 
-  table {
-    width: auto;
-
-    td {
-      padding: 10px;
-    }
-
-    td.title {
-      width: 33%;
+  &.stats {
+    table {
+      td {
+        padding: 0.67em;
+        &:not(:first-child) {
+          text-align: center;
+        }
+      }
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -317,7 +317,7 @@ en:
       our_moderators: "Our Moderators"
       moderators: "Moderators"
       stat:
-        all_time: "All Time"
+        all_time: "All time"
         last_day: "24 hours"
         last_7_days: "7 days"
         last_30_days: "30 days"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -318,15 +318,15 @@ en:
       moderators: "Moderators"
       stat:
         all_time: "All Time"
-        last_day: "Last 24 hours"
-        last_7_days: "Last 7 days"
-        last_30_days: "Last 30 days"
+        last_day: "24 hours"
+        last_7_days: "7 days"
+        last_30_days: "30 days"
       like_count: "Likes"
       topic_count: "Topics"
       post_count: "Posts"
-      user_count: "Sign-Ups"
-      active_user_count: "Active Users"
-      contact: "Contact Us"
+      user_count: "Sign-ups"
+      active_user_count: "Active users"
+      contact: "Contact us"
       contact_info: "In the event of a critical issue or urgent matter affecting this site, please contact us at %{contact_info}."
 
     bookmarked:

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -24,9 +24,9 @@ en:
           name: "Chat message event"
           details: "When a chat message is created, edited, trashed or restored."
     about:
-      chat_messages_count: "Chat Messages"
-      chat_channels_count: "Chat Channels"
-      chat_users_count: "Chat Users"
+      chat_messages_count: "Chat messages"
+      chat_channels_count: "Chat channels"
+      chat_users_count: "Chat users"
 
     chat:
       deleted_chat_username: deleted


### PR DESCRIPTION
The headings in this table weren't wrapped with `thead` so they didn't function well with screen readers. 

I've also
* Removed the redundant "last" from "last 24 hours" "last 7 days" "last 30 days"... this seems needlessly wordy 
* Adjusted from title case to sentence case 
* Cleaned up the styles a little bit 

Before:
![Screenshot 2023-09-29 at 4 48 37 PM](https://github.com/discourse/discourse/assets/1681963/d73fae14-d238-48c8-b447-c64a344426f9)


After: 

![Screenshot 2023-09-29 at 4 51 12 PM](https://github.com/discourse/discourse/assets/1681963/740e6944-b042-489f-9da2-ff5ed63ac9fc)
