### PR TITLE
A11Y: remove title from notification menu icons

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-row.hbs
@@ -2,7 +2,7 @@
   <div class="icons">
     <span class="selection-indicator"></span>
     {{#each this.icons as |icon|}}
-      {{d-icon icon translatedTitle=(dasherize this.title)}}
+      {{d-icon icon}}
     {{/each}}
   </div>
 {{/if}}

--- a/app/assets/javascripts/select-kit/addon/components/notifications-button/notifications-button-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/notifications-button/notifications-button-row.js
@@ -13,9 +13,7 @@ export default DropdownSelectBoxRowComponent.extend({
     return escapeExpression(I18n.t(`${this._start}.title`));
   }),
 
-  title: readOnly("label"),
-
-  icons: computed("title", "item.icon", function () {
+  icons: computed("item.icon", function () {
     return [escapeExpression(this.item.icon)];
   }),
 


### PR DESCRIPTION
These icons were marked up with title tags that match the heading text, so screen readers were reading "Watching Watching You will automatically..." this is redundant. These icons are decorative as the menu list item purpose is clear based on the text alone. 

![Screenshot 2023-09-29 at 5 17 36 PM](https://github.com/discourse/discourse/assets/1681963/28ed9d92-ec0d-4a0a-a1f5-b4661ff61a36)
