### PR TITLE
A11Y: add title to account activation page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/account-created.js
+++ b/app/assets/javascripts/discourse/app/routes/account-created.js
@@ -1,7 +1,12 @@
 import PreloadStore from "discourse/lib/preload-store";
-import Route from "@ember/routing/route";
+import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 
-export default Route.extend({
+export default DiscourseRoute.extend({
+  titleToken() {
+    return I18n.t("create_account.activation_title");
+  },
+
   setupController(controller) {
     controller.set("accountCreated", PreloadStore.get("accountCreated"));
   },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2114,6 +2114,7 @@ en:
       title: "Create your account"
       failed: "Something went wrong, perhaps this email is already registered, try the forgot password link"
       associate: "Already have an account? <a href='%{associate_link}'>Log In</a> to link your %{provider} account."
+      activation_title: "Activate your account"
 
     forgot_password:
       title: "Password Reset"


### PR DESCRIPTION
This adds a page title to the account activation step, so screen readers have a little context about the page they've been navigated to after filling out the signup form

Before:
![Screenshot 2023-09-29 at 5 42 53 PM](https://github.com/discourse/discourse/assets/1681963/4893bd07-dac2-4dfc-889a-1842e63b9a7a)

After:
![Screenshot 2023-09-29 at 5 42 39 PM](https://github.com/discourse/discourse/assets/1681963/72298a89-8c72-421f-bf31-a6a90d915cce)
