### PR TITLE
FIX: Pass email correctly when resending activation email

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/not-activated.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/not-activated.hbs
@@ -1,4 +1,8 @@
-<DModal @closeModal={{@closeModal}} @title={{i18n "log_in"}}>
+<DModal
+  @closeModal={{@closeModal}}
+  @title={{i18n "log_in"}}
+  class="not-activated-modal"
+>
   <:body>
     {{html-safe (i18n "login.not_activated" sentTo=@model.sentTo)}}
   </:body>

--- a/app/assets/javascripts/discourse/app/components/modal/not-activated.js
+++ b/app/assets/javascripts/discourse/app/components/modal/not-activated.js
@@ -10,7 +10,7 @@ export default class NotActivated extends Component {
 
   @action
   sendActivationEmail() {
-    resendActivationEmail(this.username).then(() => {
+    resendActivationEmail(this.args.model.currentEmail).then(() => {
       this.modal.show(ActivationResent, {
         model: { currentEmail: this.args.model.currentEmail },
       });

--- a/app/assets/javascripts/discourse/scripts/activate-account.js
+++ b/app/assets/javascripts/discourse/scripts/activate-account.js
@@ -1,19 +1,17 @@
 (function () {
-  setTimeout(function () {
-    const $activateButton = $("#activate-account-button");
-    $activateButton.on("click", function () {
-      $activateButton.prop("disabled", true);
-      const hpPath = document.getElementById("data-activate-account").dataset
-        .path;
-      $.ajax(hpPath)
-        .then(function (hp) {
-          $("#password_confirmation").val(hp.value);
-          $("#challenge").val(hp.challenge.split("").reverse().join(""));
-          $("#activate-account-form").submit();
-        })
-        .fail(function () {
-          $activateButton.prop("disabled", false);
-        });
-    });
-  }, 50);
+  const $activateButton = $("#activate-account-button");
+  $activateButton.on("click", function () {
+    $activateButton.prop("disabled", true);
+    const hpPath = document.getElementById("data-activate-account").dataset
+      .path;
+    $.ajax(hpPath)
+      .then(function (hp) {
+        $("#password_confirmation").val(hp.value);
+        $("#challenge").val(hp.challenge.split("").reverse().join(""));
+        $("#activate-account-form").submit();
+      })
+      .fail(function () {
+        $activateButton.prop("disabled", false);
+      });
+  });
 })();

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -71,10 +71,10 @@ module Helpers
     Guardian.stubs(new: guardian).with(user, anything)
   end
 
-  def wait_for(on_fail: nil, &blk)
+  def wait_for(on_fail: nil, timeout: 1, &blk)
     i = 0
     result = false
-    while !result && i < 1000
+    while !result && i < timeout * 1000
       result = blk.call
       i += 1
       sleep 0.001

--- a/spec/system/user_activation_spec.rb
+++ b/spec/system/user_activation_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "Account activation", type: :system do
+  fab!(:password) { "myverysecurepassword" }
+  fab!(:user) { Fabricate(:user, password: password, active: false) }
+
+  it "can resend activation email and activate account" do
+    Jobs.run_immediately!
+
+    visit "/"
+    find(".login-button").click
+    find("#login-account-name").fill_in with: user.email
+    find("#login-account-password").fill_in with: password
+    find("#login-button").click
+
+    not_activated_modal = find(".not-activated-modal")
+
+    expect(ActionMailer::Base.deliveries.count).to eq(0)
+
+    not_activated_modal.find("button.resend").click
+
+    wait_for(timeout: 5) { ActionMailer::Base.deliveries.count === 1 }
+
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail.to).to contain_exactly(user.email)
+
+    activate_link = mail.body.to_s[%r{/u/activate-account/\S+}, 0]
+
+    visit activate_link
+
+    expect(user.reload.active).to eq(false)
+
+    find("#activate-account-button").click
+
+    wait_for(timeout: 5) { user.reload.active }
+  end
+end


### PR DESCRIPTION
Regressed as part of the refactoring in https://github.com/discourse/discourse/commit/7df4eab03895d7d9b8074619ef32b49224c65951. This commit also introduces a system spec for the activation flow.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
