### PR TITLE
UX: more topics mobile spacing

### DIFF
--- a/app/assets/stylesheets/mobile/components/more-topics.scss
+++ b/app/assets/stylesheets/mobile/components/more-topics.scss
@@ -1,6 +1,6 @@
 .more-topics__container {
   .nav {
-    margin-block: 0.5em 1em;
+    margin-block: 0 7px;
     border-bottom: 1px solid var(--primary-low);
   }
 


### PR DESCRIPTION
This PR adjusts the mobile spacing between the more topics tabs & more topics table

BEFORE:
![133764654807ed0c01b48982d0c780e1d6b0ce1d](https://github.com/discourse/discourse/assets/69276978/890d9905-e75c-49a6-b6f5-1de10005d28a)

AFTER (exact spacing, 7px padding copied as margin):
![CleanShot 2023-10-02 at 15 26 33](https://github.com/discourse/discourse/assets/69276978/825d18ab-0a35-41b4-8162-29ffd496b25b)
