### PR TITLE
DEV: Remove chat related code from core

### DIFF
--- a/spec/serializers/topic_tracking_state_item_serializer_spec.rb
+++ b/spec/serializers/topic_tracking_state_item_serializer_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe TopicTrackingStateItemSerializer do
   fab!(:user) { Fabricate(:user) }
   fab!(:post) { create_post }
 
-  before do
-    SiteSetting.navigation_menu = "legacy"
-    SiteSetting.chat_enabled = false if defined?(::Chat)
-  end
+  before { SiteSetting.navigation_menu = "legacy" }
 
   it "serializes topic tracking state reports" do
     report = TopicTrackingState.report(user)

--- a/spec/serializers/web_hook_user_serializer_spec.rb
+++ b/spec/serializers/web_hook_user_serializer_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe WebHookUserSerializer do
     WebHookUserSerializer.new(user, scope: Guardian.new(admin), root: false)
   end
 
-  before do
-    SiteSetting.navigation_menu = "legacy"
-    SiteSetting.chat_enabled = false if defined?(::Chat)
-  end
+  before { SiteSetting.navigation_menu = "legacy" }
 
   it "should include relevant user info" do
     payload = serializer.as_json


### PR DESCRIPTION
I'm not sure why this is necessary and it doesn't seem to affect
anything if I remove it. Either way, we shouldn't have plugin related
code polluting core.