### PR TITLE
SECURITY: Add a default limit as to when logs should be truncated

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -408,11 +408,7 @@ const SiteHeaderComponent = MountWidget.extend(
     },
 
     _dropDownHeaderEnabled() {
-      return (
-        (!this.sidebarEnabled &&
-          this.siteSettings.navigation_menu !== "legacy") ||
-        this.site.narrowDesktopView
-      );
+      return !this.sidebarEnabled || this.site.narrowDesktopView;
     },
   }
 );

--- a/app/assets/javascripts/discourse/app/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.hbs
@@ -76,16 +76,14 @@
       <span>{{i18n "user.preferences_nav.interface"}}</span>
     </DNavigationItem>
 
-    {{#if (not-eq this.siteSettings.navigation_menu "legacy")}}
-      <DNavigationItem
-        @route="preferences.navigation-menu"
-        @ariaCurrentContext="subNav"
-        class="user-nav__preferences-navigation-menu"
-      >
-        {{d-icon "bars"}}
-        <span>{{i18n "user.preferences_nav.navigation_menu"}}</span>
-      </DNavigationItem>
-    {{/if}}
+    <DNavigationItem
+      @route="preferences.navigation-menu"
+      @ariaCurrentContext="subNav"
+      class="user-nav__preferences-navigation-menu"
+    >
+      {{d-icon "bars"}}
+      <span>{{i18n "user.preferences_nav.navigation_menu"}}</span>
+    </DNavigationItem>
 
     <PluginOutlet
       @name="user-preferences-nav-under-interface"

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -255,24 +255,6 @@ createWidget("header-icons", {
       action: "toggleHamburger",
       href: "",
       classNames: ["hamburger-dropdown"],
-
-      contents() {
-        let { currentUser } = this;
-        if (
-          currentUser?.reviewable_count &&
-          this.siteSettings.navigation_menu === "legacy"
-        ) {
-          return h(
-            "div.badge-notification.reviewables",
-            {
-              attributes: {
-                title: I18n.t("notifications.reviewable_items"),
-              },
-            },
-            this.currentUser.reviewable_count
-          );
-        }
-      },
     });
 
     if (!attrs.sidebarEnabled || this.site.mobileView) {
@@ -483,9 +465,8 @@ export default createWidget("header", {
       } else if (state.hamburgerVisible) {
         if (
           attrs.navigationMenuQueryParamOverride === "header_dropdown" ||
-          (attrs.navigationMenuQueryParamOverride !== "legacy" &&
-            this.siteSettings.navigation_menu !== "legacy" &&
-            (!attrs.sidebarEnabled || this.site.narrowDesktopView))
+          !attrs.sidebarEnabled ||
+          this.site.narrowDesktopView
         ) {
           panels.push(this.attach("revamped-hamburger-menu-wrapper", {}));
         } else {
@@ -598,24 +579,15 @@ export default createWidget("header", {
   },
 
   toggleHamburger() {
-    if (
-      this.siteSettings.navigation_menu !== "legacy" &&
-      this.attrs.sidebarEnabled &&
-      !this.site.narrowDesktopView
-    ) {
+    if (this.attrs.sidebarEnabled && !this.site.narrowDesktopView) {
       this.sendWidgetAction("toggleSidebar");
     } else {
       this.state.hamburgerVisible = !this.state.hamburgerVisible;
       this.toggleBodyScrolling(this.state.hamburgerVisible);
 
       schedule("afterRender", () => {
-        if (this.siteSettings.navigation_menu !== "legacy") {
-          // Remove focus from hamburger toggle button
-          document.querySelector("#toggle-hamburger-menu")?.blur();
-        } else {
-          // auto focus on first link in dropdown
-          document.querySelector(".hamburger-panel .menu-links a")?.focus();
-        }
+        // Remove focus from hamburger toggle button
+        document.querySelector("#toggle-hamburger-menu")?.blur();
       });
     }
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -25,9 +25,6 @@ acceptance("Enforce Second Factor", function (needs) {
       });
     });
   });
-  needs.settings({
-    navigation_menu: "legacy",
-  });
 
   test("as an admin", async function (assert) {
     await visit("/u/eviltrout/preferences/second-factor");

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -11,9 +11,7 @@ acceptance(
   "Opening the hamburger menu with some reviewables",
   function (needs) {
     needs.user();
-    needs.settings({
-      navigation_menu: "legacy",
-    });
+
     test("As a staff member", async function (assert) {
       updateCurrentUser({ moderator: true, admin: false, reviewable_count: 3 });
 
@@ -28,10 +26,7 @@ acceptance(
   }
 );
 
-acceptance("Hamburger Menu accessibility", function (needs) {
-  needs.settings({
-    navigation_menu: "legacy",
-  });
+acceptance("Hamburger Menu accessibility", function () {
   test("Escape key closes hamburger menu", async function (assert) {
     await visit("/");
     await click("#toggle-hamburger-menu");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
@@ -10,24 +10,6 @@ import {
 import Sinon from "sinon";
 
 acceptance(
-  "Sidebar - Logged on user - Legacy navigation menu enabled",
-  function (needs) {
-    needs.user();
-
-    needs.settings({
-      navigation_menu: "legacy",
-    });
-
-    test("clicking header hamburger icon displays old hamburger dropdown", async function (assert) {
-      await visit("/");
-      await click(".hamburger-dropdown");
-
-      assert.ok(exists(".menu-container-general-links"));
-    });
-  }
-);
-
-acceptance(
   "Sidebar - Logged on user - Mobile view - Header dropdown navigation menu enabled",
   function (needs) {
     needs.user();

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -37,16 +37,6 @@ module("Integration | Component | site-header", function (hooks) {
     assert.strictEqual(unreadBadge.textContent, "5");
   });
 
-  test("hamburger menu icon shows pending reviewables count", async function (assert) {
-    this.siteSettings.navigation_menu = "legacy";
-    this.currentUser.set("reviewable_count", 1);
-    await render(hbs`<SiteHeader />`);
-    let pendingReviewablesBadge = query(
-      ".hamburger-dropdown .badge-notification"
-    );
-    assert.strictEqual(pendingReviewablesBadge.textContent, "1");
-  });
-
   test("hamburger menu icon doesn't show pending reviewables count for non-legacy navigation menu", async function (assert) {
     this.currentUser.set("reviewable_count", 1);
     this.siteSettings.navigation_menu = "sidebar";

--- a/app/controllers/reviewable_claimed_topics_controller.rb
+++ b/app/controllers/reviewable_claimed_topics_controller.rb
@@ -49,8 +49,6 @@ class ReviewableClaimedTopicsController < ApplicationController
 
     MessageBus.publish("/reviewable_claimed", data, group_ids: group_ids.to_a)
 
-    if !SiteSetting.legacy_navigation_menu?
-      Jobs.enqueue(:refresh_users_reviewable_counts, group_ids: group_ids.to_a)
-    end
+    Jobs.enqueue(:refresh_users_reviewable_counts, group_ids: group_ids.to_a)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2014,20 +2014,18 @@ class UsersController < ApplicationController
     permitted.concat UserUpdater::TAG_NAMES.keys
     permitted << UserUpdater::NOTIFICATION_SCHEDULE_ATTRS
 
-    if !SiteSetting.legacy_navigation_menu?
-      if params.has_key?(:sidebar_category_ids) && params[:sidebar_category_ids].blank?
-        params[:sidebar_category_ids] = []
+    if params.has_key?(:sidebar_category_ids) && params[:sidebar_category_ids].blank?
+      params[:sidebar_category_ids] = []
+    end
+
+    permitted << { sidebar_category_ids: [] }
+
+    if SiteSetting.tagging_enabled
+      if params.has_key?(:sidebar_tag_names) && params[:sidebar_tag_names].blank?
+        params[:sidebar_tag_names] = []
       end
 
-      permitted << { sidebar_category_ids: [] }
-
-      if SiteSetting.tagging_enabled
-        if params.has_key?(:sidebar_tag_names) && params[:sidebar_tag_names].blank?
-          params[:sidebar_tag_names] = []
-        end
-
-        permitted << { sidebar_tag_names: [] }
-      end
+      permitted << { sidebar_tag_names: [] }
     end
 
     if SiteSetting.enable_user_status

--- a/app/models/navigation_menu_site_setting.rb
+++ b/app/models/navigation_menu_site_setting.rb
@@ -3,7 +3,6 @@
 class NavigationMenuSiteSetting < EnumSiteSetting
   SIDEBAR = "sidebar"
   HEADER_DROPDOWN = "header dropdown"
-  LEGACY = "legacy"
 
   def self.valid_value?(val)
     values.any? { |v| v[:value] == val }
@@ -13,7 +12,6 @@ class NavigationMenuSiteSetting < EnumSiteSetting
     @values ||= [
       { name: "admin.navigation_menu.sidebar", value: SIDEBAR },
       { name: "admin.navigation_menu.header_dropdown", value: HEADER_DROPDOWN },
-      { name: "admin.navigation_menu.legacy", value: LEGACY },
     ]
   end
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -257,10 +257,6 @@ class SiteSetting < ActiveRecord::Base
     c.present? && c.to_i != SiteSetting.uncategorized_category_id.to_i
   end
 
-  def self.legacy_navigation_menu?
-    SiteSetting.navigation_menu == "legacy"
-  end
-
   protected
 
   def self.clear_cache!

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -143,7 +143,7 @@ class TopicTrackingState
     #   perhaps cut down to users that are around in the last 7 days as well
     tags = nil
     tag_ids = nil
-    tag_ids, tags = post.topic.tags.pluck(:id, :name).transpose if include_tags_in_report?
+    tag_ids, tags = post.topic.tags.pluck(:id, :name).transpose
 
     # We don't need to publish unread to the person who just made the post,
     # this is why they are excluded from the initial scope.
@@ -276,11 +276,7 @@ class TopicTrackingState
   end
 
   def self.include_tags_in_report?
-    SiteSetting.tagging_enabled && (@include_tags_in_report || !SiteSetting.legacy_navigation_menu?)
-  end
-
-  def self.include_tags_in_report=(v)
-    @include_tags_in_report = v
+    SiteSetting.tagging_enabled
   end
 
   # Sam: this is a hairy report, in particular I need custom joins and fancy conditions
@@ -340,7 +336,7 @@ class TopicTrackingState
   end
 
   def self.tags_included_wrapped_sql(sql)
-    return <<~SQL if SiteSetting.tagging_enabled && TopicTrackingState.include_tags_in_report?
+    return <<~SQL if SiteSetting.tagging_enabled
         WITH tags_included_cte AS (
           #{sql}
         )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2041,7 +2041,6 @@ class User < ActiveRecord::Base
   private
 
   def set_default_sidebar_section_links(update: false)
-    return if SiteSetting.legacy_navigation_menu?
     return if staged? || bot?
 
     if SiteSetting.default_navigation_menu_categories.present?

--- a/app/serializers/concerns/user_sidebar_mixin.rb
+++ b/app/serializers/concerns/user_sidebar_mixin.rb
@@ -42,7 +42,6 @@ module UserSidebarMixin
   private
 
   def sidebar_navigation_menu?
-    !SiteSetting.legacy_navigation_menu? ||
-      %w[sidebar header_dropdown].include?(options[:navigation_menu_param])
+    %w[sidebar header_dropdown].include?(options[:navigation_menu_param])
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -268,7 +268,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def include_navigation_menu_site_top_tags?
-    !SiteSetting.legacy_navigation_menu? && SiteSetting.tagging_enabled
+    SiteSetting.tagging_enabled
   end
 
   def anonymous_default_navigation_menu_tags

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -688,21 +688,20 @@ RSpec.describe TopicTrackingState do
       expect(row.tags).to contain_exactly("apples", "bananas")
     end
 
-    it "includes tags when TopicTrackingState.include_tags_in_report option is enabled" do
-      SiteSetting.navigation_menu = "legacy"
+    it "includes tags based on the `tagging_enabled` site setting" do
+      SiteSetting.tagging_enabled = false
+
       report = TopicTrackingState.report(user)
       expect(report.length).to eq(1)
       row = report[0]
       expect(row.respond_to? :tags).to eq(false)
 
-      TopicTrackingState.include_tags_in_report = true
+      SiteSetting.tagging_enabled = true
 
       report = TopicTrackingState.report(user)
       expect(report.length).to eq(1)
       row = report[0]
       expect(row.tags).to contain_exactly("apples", "bananas")
-    ensure
-      TopicTrackingState.include_tags_in_report = false
     end
   end
 

--- a/spec/serializers/topic_tracking_state_item_serializer_spec.rb
+++ b/spec/serializers/topic_tracking_state_item_serializer_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe TopicTrackingStateItemSerializer do
     expect(serialized.has_key?(:tags)).to eq(false)
   end
 
-  it "includes tags attribute when tags are present" do
-    TopicTrackingState.include_tags_in_report = true
+  it "includes tags attribute when `tagging_enabled` site settings" do
+    SiteSetting.tagging_enabled = true
 
     post.topic.notifier.watch_topic!(post.topic.user_id)
 
@@ -38,7 +38,5 @@ RSpec.describe TopicTrackingStateItemSerializer do
     serialized = described_class.new(report[0], scope: Guardian.new(user), root: false).as_json
 
     expect(serialized[:tags]).to contain_exactly("bananas", "apples")
-  ensure
-    TopicTrackingState.include_tags_in_report = false
   end
 end


### PR DESCRIPTION
Why this change?

This ensures that malicious requests cannot end up causing the logs to
quickly fill up. The default chosen is sufficient for most legitimate
requests to the Discourse application.

When truncation happens, parsing of logs in supported format like
lograge may break down.<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
