### PR TITLE
FIX: call UserBadge.grant with badgeReason in admin interface

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-badges.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-badges.js
@@ -73,8 +73,13 @@ export default class AdminUserBadgesController extends Controller {
 
   @action
   performGrantBadge() {
-    UserBadge.grant(this.selectedBadgeId, this.get("user.username")).then(
+    UserBadge.grant(
+      this.selectedBadgeId,
+      this.get("user.username"),
+      this.badgeReason
+    ).then(
       (newBadge) => {
+        this.set("badgeReason", "");
         this.userBadges.pushObject(newBadge);
         next(() => {
           // Update the selected badge ID after the combobox has re-rendered.

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-user-badges-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-user-badges-test.js
@@ -1,6 +1,9 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import Badge from "discourse/models/badge";
+import UserBadge from "discourse/models/user-badge";
+import { settled } from "@ember/test-helpers";
+import sinon from "sinon";
 
 module("Unit | Controller | admin-user-badges", function (hooks) {
   setupTest(hooks);
@@ -57,5 +60,56 @@ module("Unit | Controller | admin-user-badges", function (hooks) {
       "excludes disabled badges"
     );
     assert.deepEqual(badgeNames, sortedNames, "sorts badges by name");
+  });
+
+  test("performGrantBadge", async function (assert) {
+    const GrantBadgeStub = sinon.stub(UserBadge, "grant");
+    const controller = this.owner.lookup("controller:admin-user-badges");
+    const store = this.owner.lookup("service:store");
+
+    const badgeToGrant = store.createRecord("badge", {
+      id: 3,
+      name: "Granted Badge",
+      enabled: true,
+      manually_grantable: true,
+    });
+
+    const otherBadge = store.createRecord("badge", {
+      id: 4,
+      name: "Other Badge",
+      enabled: true,
+      manually_grantable: true,
+    });
+
+    const badgeReason = "Test Reason";
+
+    const user = { username: "jb", name: "jack black", id: 42 };
+
+    controller.setProperties({
+      model: [],
+      adminUser: { model: user },
+      badgeReason,
+      selectedBadgeId: badgeToGrant.id,
+      badges: [badgeToGrant, otherBadge],
+    });
+
+    const newUserBadge = store.createRecord("badge", {
+      id: 88,
+      badge_id: badgeToGrant.id,
+      user_id: user.id,
+    });
+
+    GrantBadgeStub.returns(Promise.resolve(newUserBadge));
+    controller.performGrantBadge();
+    await settled();
+
+    assert.ok(
+      GrantBadgeStub.calledWith(badgeToGrant.id, user.username, badgeReason)
+    );
+
+    assert.equal(controller.badgeReason, "");
+    assert.equal(controller.userBadges.length, 1);
+    assert.equal(controller.userBadges[0].id, newUserBadge.id);
+    assert.equal(controller.selectedBadgeId, otherBadge.id);
   });
 });


### PR DESCRIPTION
#### Context
https://meta.discourse.org/t/grant-badge-reason-not-added-to-the-granted-badge/279304

Regression from https://github.com/discourse/discourse/pull/23668 where we stopped passing in `this.badgeReason` to the badge granting function. This PR fixes that and adds a unit test to cover that code path.

#### How to Test
1. Add a badge as admin, ensure that the `Show post granting badge on badge page` option is selected before saving.
2. Grant the badge to a user with the admin interface (`/admin/users/:user_id/:username/badges`) to grant badges, with the reason filled in with a valid link to a post.
3. Check that the badge is granted with the post link displayed in the user badges index.

**Test artifacts**:
After fix:
<img width="1351" alt="Selecting Badge" src="https://github.com/discourse/discourse/assets/133760061/904da449-0459-460e-8f38-f6581565d0e7">
<img width="862" alt="Badge Granted" src="https://github.com/discourse/discourse/assets/133760061/0a81c976-63fa-4df6-b98e-3b69c192508f">
