### PR TITLE
FIX: Use correct subfolder format for ember-cli config

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function (environment) {
   const ENV = {
     modulePrefix: "discourse",
     environment,
-    rootURL: `${process.env.DISCOURSE_RELATIVE_URL_ROOT}/`, // Add a trailing slash (not required by the Rails app in this env variable)
+    rootURL: `${process.env.DISCOURSE_RELATIVE_URL_ROOT ?? ""}/`, // Add a trailing slash (not required by the Rails app in this env variable)
     locationType: "history",
     historySupportMiddleware: false,
     EmberENV: {

--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function (environment) {
   const ENV = {
     modulePrefix: "discourse",
     environment,
-    rootURL: process.env.DISCOURSE_RELATIVE_URL_ROOT || "/",
+    rootURL: `${process.env.DISCOURSE_RELATIVE_URL_ROOT}/`, // Add a trailing slash (not required by the Rails app in this env variable)
     locationType: "history",
     historySupportMiddleware: false,
     EmberENV: {


### PR DESCRIPTION
Ember expects a trailing slash on this value, which is different to the Rails app's behavior. Values without a trailing slash seemed to work for legacy ember-cli builds, but would lead to errors under embroider.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
