### PR TITLE
UX: removes username from bookmark notification

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/bookmark-reminder.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/bookmark-reminder.js
@@ -16,6 +16,10 @@ export default class extends NotificationTypeBase {
     return super.description || this.notification.data.title;
   }
 
+  get label() {
+    return null;
+  }
+
   get linkHref() {
     let linkHref = super.linkHref;
     if (linkHref) {


### PR DESCRIPTION
Showing the username doesn't make sense, as it will always be yourself.

Before:
![Screenshot 2023-10-03 at 17 29 51](https://github.com/discourse/discourse/assets/339945/57a2d3e5-0405-4fe2-9635-d19ef202321b)

After:
![Screenshot 2023-10-03 at 17 29 17](https://github.com/discourse/discourse/assets/339945/0179d506-d224-4986-81e2-5ee3f8fb76ab)


No test, as there's not existing test, and testing notifications items is quite impractical.
