### PR TITLE
DEV: Enable USE_TURBO flag for plugin specs in docker.rake

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -242,7 +242,8 @@ task "docker:test" do
             @good &&= run_or_fail("bundle exec rake plugin:spec['#{ENV["SINGLE_PLUGIN"]}']")
           else
             fail_fast = "RSPEC_FAILFAST=1" unless ENV["SKIP_FAILFAST"]
-            @good &&= run_or_fail("#{fail_fast} bundle exec rake plugin:spec")
+            task = ENV["USE_TURBO"] ? "plugin:turbo_spec" : "plugin:spec"
+            @good &&= run_or_fail("#{fail_fast} bundle exec rake #{task}")
           end
 
           if ENV["RUN_SYSTEM_TESTS"]


### PR DESCRIPTION
We run plugin specs in parallel in GitHub actions, so it makes sense to (optionally) do the same in the docker-based tests

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
