### PR TITLE
DEV: enforces system user membership

### DIFF
--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -24,6 +24,7 @@ module Chat
     model :channel
     policy :allowed_to_join_channel
     policy :allowed_to_create_message_in_channel, class_name: Chat::Channel::MessageCreationPolicy
+    step :enforce_system_membership
     model :channel_membership
     model :reply, optional: true
     policy :ensure_reply_consistency
@@ -70,6 +71,10 @@ module Chat
 
     def allowed_to_join_channel(guardian:, channel:, **)
       guardian.can_join_chat_channel?(channel)
+    end
+
+    def enforce_system_membership(guardian:, channel:, **)
+      channel.add(guardian.user) if guardian.user.is_system_user?
     end
 
     def fetch_channel_membership(guardian:, channel:, **)

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -183,6 +183,12 @@ RSpec.describe Chat::CreateMessage do
             it { is_expected.to fail_a_policy(:allowed_to_join_channel) }
           end
 
+          context "when user is system" do
+            fab!(:user) { Discourse.system_user }
+
+            it { is_expected.to be_a_success }
+          end
+
           context "when user can join channel" do
             before { user.groups << Group.find(Group::AUTO_GROUPS[:trust_level_1]) }
 


### PR DESCRIPTION
System user will automatically adds itself to the channel when trying to send a message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
