### PR TITLE
UX: remove excerpt + style change to thread list item

### DIFF
--- a/plugins/chat/app/queries/chat/thread_participant_query.rb
+++ b/plugins/chat/app/queries/chat/thread_participant_query.rb
@@ -2,12 +2,12 @@
 
 module Chat
   # Builds a query to find the total count of participants for one
-  # or more threads (on a per-thread basis), as well as up to 3
+  # or more threads (on a per-thread basis), as well as up to 10
   # participants in the thread. The participants will be made up
   # of:
   #
-  # - Participant 1 & 2 - The most frequent participants in the thread.
-  # - Participant 3 - The most recent participant in the thread.
+  # - Participant 1 -9 - The most frequent participants in the thread.
+  # - Participant 10 - The most recent participant in the thread.
   #
   # This result should be cached to avoid unnecessary queries,
   # since the participants will not often change for a thread,
@@ -69,7 +69,7 @@ module Chat
 
         # If we want to return more of the top N users in the thread we
         # can just increase the number here.
-        if thread_participants[thread_id][:users].length < 2 &&
+        if thread_participants[thread_id][:users].length < 9 &&
              thread_participant_stat.user_id != most_recent_participants[thread_id][:id]
           thread_participants[thread_id][:users].push(
             {

--- a/plugins/chat/app/queries/chat/thread_participant_query.rb
+++ b/plugins/chat/app/queries/chat/thread_participant_query.rb
@@ -6,8 +6,11 @@ module Chat
   # participants in the thread. The participants will be made up
   # of:
   #
-  # - Participant 1 -9 - The most frequent participants in the thread.
-  # - Participant 10 - The most recent participant in the thread.
+  # The most frequent participants in the thread:
+  # - Participant 1-2 (preview)
+  # - Participant 1-9 (thread list)
+  # The most recent participant in the thread.
+  # - Participant 10
   #
   # This result should be cached to avoid unnecessary queries,
   # since the participants will not often change for a thread,
@@ -15,8 +18,9 @@ module Chat
   # count it is not a big deal.
   class ThreadParticipantQuery
     # @param thread_ids [Array<Integer>] The IDs of the threads to query.
+    # @param preview [Boolean] Determines the number of participants to return.
     # @return [Hash<Integer, Hash>] A hash of thread IDs to participant data.
-    def self.call(thread_ids:)
+    def self.call(thread_ids:, preview: true)
       return {} if thread_ids.blank?
 
       # We only want enough data for BasicUserSerializer, since the participants
@@ -60,6 +64,8 @@ module Chat
           hash
         end
 
+      total_participants = preview ? 2 : 9
+
       thread_participants = {}
       thread_participant_stats.each do |thread_participant_stat|
         thread_id = thread_participant_stat.thread_id
@@ -69,7 +75,7 @@ module Chat
 
         # If we want to return more of the top N users in the thread we
         # can just increase the number here.
-        if thread_participants[thread_id][:users].length < 9 &&
+        if thread_participants[thread_id][:users].length < total_participants &&
              thread_participant_stat.user_id != most_recent_participants[thread_id][:id]
           thread_participants[thread_id][:users].push(
             {

--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -135,7 +135,8 @@ module Chat
     end
 
     def fetch_participants(threads:, **)
-      context.participants = ::Chat::ThreadParticipantQuery.call(thread_ids: threads.map(&:id))
+      context.participants =
+        ::Chat::ThreadParticipantQuery.call(thread_ids: threads.map(&:id), preview: false)
     end
 
     def build_load_more_url(contract:, **)

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
@@ -14,6 +14,10 @@
       {{on "click" (fn this.openThread @thread) passive=true}}
     >
       <div class="chat-thread-list-item__header">
+        <Chat::UserAvatar
+          @user={{@thread.originalMessage.user}}
+          @showPresence={{false}}
+        />
         <div class="chat-thread-list-item__title">
           {{#if this.title}}
             {{replace-emoji this.title}}
@@ -26,15 +30,6 @@
         </div>
       </div>
 
-      <div class="chat-thread-list-item__body">
-        <span class="chat-thread-list-item__last-reply-author">
-          @{{@thread.preview.lastReplyUser.username}}:
-        </span>
-        <span class="chat-thread-list-item__last-reply-excerpt">
-          {{replace-emoji (html-safe @thread.preview.lastReplyExcerpt)}}
-        </span>
-      </div>
-
       <div class="chat-thread-list-item__metadata">
 
         <div class="chat-thread-list-item__last-reply-timestamp">
@@ -44,10 +39,6 @@
           {{/if}}
         </div>
 
-        <Chat::UserAvatar
-          @user={{@thread.originalMessage.user}}
-          @showPresence={{false}}
-        />
         <Chat::Thread::Participants
           @thread={{@thread}}
           @includeOriginalMessageUser={{false}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
@@ -14,10 +14,6 @@
       {{on "click" (fn this.openThread @thread) passive=true}}
     >
       <div class="chat-thread-list-item__header">
-        <Chat::UserAvatar
-          @user={{@thread.originalMessage.user}}
-          @showPresence={{false}}
-        />
         <div class="chat-thread-list-item__title">
           {{#if this.title}}
             {{replace-emoji this.title}}
@@ -32,18 +28,24 @@
 
       <div class="chat-thread-list-item__metadata">
 
+        <div class="chat-thread-list-item__members">
+          <Chat::UserAvatar
+            @user={{@thread.originalMessage.user}}
+            @showPresence={{false}}
+          />
+          <Chat::Thread::Participants
+            @thread={{@thread}}
+            @includeOriginalMessageUser={{false}}
+            class="chat-thread-list-item__participants"
+          />
+        </div>
+
         <div class="chat-thread-list-item__last-reply-timestamp">
           {{#if @thread.preview.lastReplyCreatedAt}}
-            <span>{{i18n "chat.thread.last_reply"}}</span>
             {{format-date @thread.preview.lastReplyCreatedAt leaveAgo="true"}}
           {{/if}}
         </div>
 
-        <Chat::Thread::Participants
-          @thread={{@thread}}
-          @includeOriginalMessageUser={{false}}
-          class="chat-thread-list-item__participants"
-        />
       </div>
     </div>
   </div>

--- a/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
@@ -29,9 +29,18 @@
     }
   }
 
-  &__participants {
+  &__members {
     display: flex;
     align-items: center;
+    overflow: hidden;
+  }
+
+  &__participants {
+    position: relative;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    margin-right: 0.25rem;
   }
 
   &__main {
@@ -61,11 +70,14 @@
   &__metadata {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-
+    gap: 0.5rem;
     .chat-user-avatar {
+      &__container {
+        padding: 0;
+      }
       .avatar {
         border: 2px solid var(--primary-very-low);
+        padding: 0;
 
         .chat-thread-list-item:hover & {
           border-color: var(--d-hover);
@@ -73,33 +85,33 @@
       }
 
       &:not(:last-child) {
-        margin-right: -8px;
+        margin-right: -6px;
       }
+    }
+    .chat-thread-participants__avatar-group {
+      overflow: hidden;
+      justify-content: flex-start;
     }
   }
 
-  &__participants {
-    margin-right: 0.25rem;
-  }
-
   &__last-reply-timestamp {
+    flex-shrink: 0;
     color: var(--primary-medium);
     font-size: var(--font-down-2);
     @include ellipsis;
-    margin-right: auto;
+    margin-left: auto;
   }
 
   &__header {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.5rem;
   }
 
   &__title {
     flex: 1 1 auto;
     @include ellipsis;
-    margin-left: 0.5rem;
   }
 
   &__unread-indicator {

--- a/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
@@ -19,7 +19,6 @@
   .touch & {
     &:active {
       background-color: var(--d-hover);
-      border: 1px solid var(--primary-300);
     }
   }
 
@@ -27,7 +26,6 @@
     &:hover,
     &:active {
       background-color: var(--d-hover);
-      border: 1px solid var(--primary-300);
     }
   }
 
@@ -67,7 +65,11 @@
 
     .chat-user-avatar {
       .avatar {
-        border: 1px solid var(--primary-very-low);
+        border: 2px solid var(--primary-very-low);
+
+        .chat-thread-list-item:hover & {
+          border-color: var(--d-hover);
+        }
       }
 
       &:not(:last-child) {

--- a/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-list-item.scss
@@ -96,12 +96,8 @@
 
   &__title {
     flex: 1 1 auto;
-    font-weight: bold;
     @include ellipsis;
-  }
-
-  &__last-reply-excerpt {
-    font-size: var(--font-down-1);
+    margin-left: 0.5rem;
   }
 
   &__unread-indicator {

--- a/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Chat::ThreadParticipantQuery do
     fab!(:user_1) { Fabricate(:user) }
     fab!(:user_2) { Fabricate(:user) }
     fab!(:user_3) { Fabricate(:user) }
+    fab!(:user_4) { Fabricate(:user) }
+    fab!(:user_5) { Fabricate(:user) }
+    fab!(:user_6) { Fabricate(:user) }
+    fab!(:user_7) { Fabricate(:user) }
+    fab!(:user_8) { Fabricate(:user) }
+    fab!(:user_9) { Fabricate(:user) }
 
     before do
       Fabricate(:chat_message, thread: thread_1, user: user_1)
@@ -16,10 +22,22 @@ RSpec.describe Chat::ThreadParticipantQuery do
       Fabricate(:chat_message, thread: thread_1, user: user_2)
       Fabricate(:chat_message, thread: thread_1, user: user_2)
       Fabricate(:chat_message, thread: thread_1, user: user_3)
+      Fabricate(:chat_message, thread: thread_1, user: user_4)
+      Fabricate(:chat_message, thread: thread_1, user: user_5)
+      Fabricate(:chat_message, thread: thread_1, user: user_6)
+      Fabricate(:chat_message, thread: thread_1, user: user_7)
+      Fabricate(:chat_message, thread: thread_1, user: user_8)
+      Fabricate(:chat_message, thread: thread_1, user: user_9)
 
       thread_1.add(user_1)
       thread_1.add(user_2)
       thread_1.add(user_3)
+      thread_1.add(user_4)
+      thread_1.add(user_5)
+      thread_1.add(user_6)
+      thread_1.add(user_7)
+      thread_1.add(user_8)
+      thread_1.add(user_9)
     end
 
     it "has all the user details needed for BasicUserSerializer" do
@@ -34,12 +52,12 @@ RSpec.describe Chat::ThreadParticipantQuery do
       )
     end
 
-    it "does not return more than 3 thread participants" do
+    it "does not return more than 9 thread participants" do
       other_user = Fabricate(:user)
       thread_1.add(other_user)
       Fabricate(:chat_message, thread: thread_1, user: other_user)
       result = described_class.call(thread_ids: [thread_1.id])
-      expect(result[thread_1.id][:users].length).to eq(3)
+      expect(result[thread_1.id][:users].length).to eq(9)
     end
 
     it "calculates the top messagers in a thread as well as the last messager" do
@@ -74,8 +92,21 @@ RSpec.describe Chat::ThreadParticipantQuery do
     end
 
     it "calculates the total number of thread participants" do
-      result = described_class.call(thread_ids: [thread_1.id, thread_2.id])
-      expect(result[thread_1.id][:total_count]).to eq(4)
+      result =
+        described_class.call(
+          thread_ids: [
+            thread_1.id,
+            thread_2.id,
+            thread_3.id,
+            thread_4.id,
+            thread_5.id,
+            thread_6.id,
+            thread_7.id,
+            thread_8.id,
+            thread_9.id,
+          ],
+        )
+      expect(result[thread_1.id][:total_count]).to eq(10)
     end
 
     it "gets results for both threads" do

--- a/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Chat::ThreadParticipantQuery do
 
   context "when using preview false" do
     1..9.times do |i|
-      user = "user_#{i + 1}".to_sym
+      user = "user_#{i}".to_sym
       fab!(user) { Fabricate(:user) }
     end
 
     before do
       1..9.times do |i|
-        user = "user_#{i + 1}".to_sym
+        user = "user_#{i}".to_sym
         thread_3.add(public_send(user))
         Fabricate(:chat_message, thread: thread_3, user: public_send(user))
       end

--- a/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_participant_query_spec.rb
@@ -3,17 +3,12 @@
 RSpec.describe Chat::ThreadParticipantQuery do
   fab!(:thread_1) { Fabricate(:chat_thread) }
   fab!(:thread_2) { Fabricate(:chat_thread) }
+  fab!(:thread_3) { Fabricate(:chat_thread) }
 
   context "when users have messaged in the thread" do
     fab!(:user_1) { Fabricate(:user) }
     fab!(:user_2) { Fabricate(:user) }
     fab!(:user_3) { Fabricate(:user) }
-    fab!(:user_4) { Fabricate(:user) }
-    fab!(:user_5) { Fabricate(:user) }
-    fab!(:user_6) { Fabricate(:user) }
-    fab!(:user_7) { Fabricate(:user) }
-    fab!(:user_8) { Fabricate(:user) }
-    fab!(:user_9) { Fabricate(:user) }
 
     before do
       Fabricate(:chat_message, thread: thread_1, user: user_1)
@@ -22,22 +17,10 @@ RSpec.describe Chat::ThreadParticipantQuery do
       Fabricate(:chat_message, thread: thread_1, user: user_2)
       Fabricate(:chat_message, thread: thread_1, user: user_2)
       Fabricate(:chat_message, thread: thread_1, user: user_3)
-      Fabricate(:chat_message, thread: thread_1, user: user_4)
-      Fabricate(:chat_message, thread: thread_1, user: user_5)
-      Fabricate(:chat_message, thread: thread_1, user: user_6)
-      Fabricate(:chat_message, thread: thread_1, user: user_7)
-      Fabricate(:chat_message, thread: thread_1, user: user_8)
-      Fabricate(:chat_message, thread: thread_1, user: user_9)
 
       thread_1.add(user_1)
       thread_1.add(user_2)
       thread_1.add(user_3)
-      thread_1.add(user_4)
-      thread_1.add(user_5)
-      thread_1.add(user_6)
-      thread_1.add(user_7)
-      thread_1.add(user_8)
-      thread_1.add(user_9)
     end
 
     it "has all the user details needed for BasicUserSerializer" do
@@ -52,12 +35,10 @@ RSpec.describe Chat::ThreadParticipantQuery do
       )
     end
 
-    it "does not return more than 9 thread participants" do
-      other_user = Fabricate(:user)
-      thread_1.add(other_user)
-      Fabricate(:chat_message, thread: thread_1, user: other_user)
+    it "does not return more than 3 thread participants by default" do
+      thread_1.add(Fabricate(:user))
       result = described_class.call(thread_ids: [thread_1.id])
-      expect(result[thread_1.id][:users].length).to eq(9)
+      expect(result[thread_1.id][:users].length).to eq(3)
     end
 
     it "calculates the top messagers in a thread as well as the last messager" do
@@ -92,21 +73,8 @@ RSpec.describe Chat::ThreadParticipantQuery do
     end
 
     it "calculates the total number of thread participants" do
-      result =
-        described_class.call(
-          thread_ids: [
-            thread_1.id,
-            thread_2.id,
-            thread_3.id,
-            thread_4.id,
-            thread_5.id,
-            thread_6.id,
-            thread_7.id,
-            thread_8.id,
-            thread_9.id,
-          ],
-        )
-      expect(result[thread_1.id][:total_count]).to eq(10)
+      result = described_class.call(thread_ids: [thread_1.id, thread_2.id])
+      expect(result[thread_1.id][:total_count]).to eq(4)
     end
 
     it "gets results for both threads" do
@@ -134,6 +102,29 @@ RSpec.describe Chat::ThreadParticipantQuery do
         [thread_2.original_message.user_id],
       )
       expect(result[thread_2.id][:total_count]).to eq(1)
+    end
+  end
+
+  context "when using preview false" do
+    1..9.times do |i|
+      user = "user_#{i + 1}".to_sym
+      fab!(user) { Fabricate(:user) }
+    end
+
+    before do
+      1..9.times do |i|
+        user = "user_#{i + 1}".to_sym
+        thread_3.add(public_send(user))
+        Fabricate(:chat_message, thread: thread_3, user: public_send(user))
+      end
+    end
+
+    it "does not return more than 10 thread participants when preview is false" do
+      other_user = Fabricate(:user)
+      thread_3.add(other_user)
+      Fabricate(:chat_message, thread: thread_3, user: other_user)
+      result = described_class.call(thread_ids: [thread_3.id], preview: false)
+      expect(result[thread_3.id][:users].length).to eq(10)
     end
   end
 end


### PR DESCRIPTION
UX Change to thread item:
- layout changes
- drop "last reply" timestamp copy
- drop last reply excerpt
- show up 9+OP members

DESKTOP
<img width="477" alt="image" src="https://github.com/discourse/discourse/assets/101828855/eda84674-211e-4342-ade1-9755165651a6">

MOBILE
<img width="372" alt="image" src="https://github.com/discourse/discourse/assets/101828855/e79932f4-6d8f-493a-acf8-a62b610d59c0">

Only problem I have is on desktop, with a very narrow panel, you can get an avatar cutoff halfway and the logic isn't visually correct: it still says +2 but since more avatars are now hidden from view, technically it's no longer correct
<img width="277" alt="image" src="https://github.com/discourse/discourse/assets/101828855/861b9c6f-9dff-4bdd-8f98-0df25f4c6da0">

I can live with that; it would need JS to fix it properly and the amount of work for what you gain is not worth it imo.



