### PR TITLE
UX: Prevent unexpected preview scroll in Firefox when using grid

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -62,6 +62,7 @@
   flex-direction: column;
   margin-left: 16px;
   overflow: auto;
+  overflow-anchor: none;
   cursor: default;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;


### PR DESCRIPTION
### Problem

- make sure you're in Firefox
- create a topic with multiple paragraphs, a grid of images followed by a few more paragraphs
- scroll to the bottom of the textarea and start typing

You'll notice that the preview scrolls up unexpectedly on the first few key presses. 

### Analysis

The most likely reason why this issue happens is due to the order of operations when we prepare the preview. Currently we do this: 

1. run prettyText on the raw markdown and update the DOM right away with the result (which is an intermediate state of the preview)
2. resolve short URLs for uploads
3. apply other decorators: lightboxes, checkboxes, polls, oneboxes, and grid and update each individually

This is inefficient, and deserving of improvement in the future, but what contributes to the bug is that initially we render the images without a grid and without proper URLs, and only apply the grid after resolving short URLs (and after running other manipulations). Firefox seems to redraw the preview element before the grid structure has been applied, and therefore the preview element's height is taller than it would be with the grid. Further, it looks like Firefox is applying [scrolling anchoring](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring) to this element. 

### Solution

This PR disables scroll anchoring for the preview element. This fixes the issue on Firefox locally, and it's probably a better default for the composer preview since our app does its own scroll adjustments for the preview and other DOM manipulations when editing are likely to cause similar issues. 

Even though this issue was only reproducible on Firefox, we have seen issues on other browsers with unexpected scrolling of the preview, especially with long posts. These are harder to reproduce consistently, but there's a chance this PR addresses those cases as well. 