### PR TITLE
DEV: Add outlet and API for adding/controlling post selection buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -59,7 +59,7 @@ export default class PostTextSelectionToolbar extends Component {
           @name="post-text-after-primary-actions"
           @outletArgs={{hash
             data=@data
-            hidePrimaryActions=this.hidePrimaryActions
+            togglePrimaryActions=this.togglePrimaryActions
           }}
         />
 
@@ -178,8 +178,8 @@ export default class PostTextSelectionToolbar extends Component {
   }
 
   @action
-  hidePrimaryActions() {
-    this.showPrimaryActions = false;
+  togglePrimaryActions(value) {
+    this.showPrimaryActions = value;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -33,7 +33,11 @@ export default class PostTextSelectionToolbar extends Component {
       {{this.appEventsListeners}}
     >
       <div class="buttons">
-        {{#if this.showPrimaryActions}}
+        <PluginOutlet
+          @name="post-text-buttons"
+          @defaultGlimmer={{true}}
+          @outletArgs={{hash data=@data}}
+        >
           {{#if this.embedQuoteButton}}
             <DButton
               @icon="quote-left"
@@ -53,43 +57,35 @@ export default class PostTextSelectionToolbar extends Component {
               {{on "click" this.toggleFastEdit}}
             />
           {{/if}}
-        {{/if}}
 
-        <PluginOutlet
-          @name="post-text-after-primary-actions"
-          @outletArgs={{hash
-            data=@data
-            togglePrimaryActions=this.togglePrimaryActions
-          }}
-        />
-
-        {{#if this.quoteSharingEnabled}}
-          <span class="quote-sharing">
-            {{#if this.quoteSharingShowLabel}}
-              <DButton
-                @icon="share"
-                @label="post.quote_share"
-                class="btn-flat quote-share-label"
-              />
-            {{/if}}
-
-            <span class="quote-share-buttons">
-              {{#each this.quoteSharingSources as |source|}}
+          {{#if this.quoteSharingEnabled}}
+            <span class="quote-sharing">
+              {{#if this.quoteSharingShowLabel}}
                 <DButton
-                  @action={{fn this.share source}}
-                  @translatedTitle={{source.title}}
-                  @icon={{source.icon}}
-                  class="btn-flat"
+                  @icon="share"
+                  @label="post.quote_share"
+                  class="btn-flat quote-share-label"
                 />
-              {{/each}}
+              {{/if}}
 
-              <PluginOutlet
-                @name="quote-share-buttons-after"
-                @connectorTagName="span"
-              />
+              <span class="quote-share-buttons">
+                {{#each this.quoteSharingSources as |source|}}
+                  <DButton
+                    @action={{fn this.share source}}
+                    @translatedTitle={{source.title}}
+                    @icon={{source.icon}}
+                    class="btn-flat"
+                  />
+                {{/each}}
+
+                <PluginOutlet
+                  @name="quote-share-buttons-after"
+                  @connectorTagName="span"
+                />
+              </span>
             </span>
-          </span>
-        {{/if}}
+          {{/if}}
+        </PluginOutlet>
       </div>
 
       <div class="extra">
@@ -113,7 +109,6 @@ export default class PostTextSelectionToolbar extends Component {
   @service appEvents;
 
   @tracked isFastEditing = false;
-  @tracked showPrimaryActions = true;
 
   appEventsListeners = modifier(() => {
     this.appEvents.on("quote-button:edit", this, "toggleFastEdit");
@@ -139,7 +134,6 @@ export default class PostTextSelectionToolbar extends Component {
 
   get quoteSharingEnabled() {
     return (
-      this.showPrimaryActions &&
       this.site.desktopView &&
       this.quoteSharingSources.length > 0 &&
       !this.topic.invisible &&
@@ -175,11 +169,6 @@ export default class PostTextSelectionToolbar extends Component {
       (canCreatePost || canReplyAsNewTopic) &&
       this.currentUser?.get("user_option.enable_quoting")
     );
-  }
-
-  @action
-  togglePrimaryActions(value) {
-    this.showPrimaryActions = value;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -56,7 +56,7 @@ export default class PostTextSelectionToolbar extends Component {
         {{/if}}
 
         <PluginOutlet
-          @name="post-text-selection-buttons-after"
+          @name="post-text-after-primary-actions"
           @outletArgs={{hash
             data=@data
             hidePrimaryActions=this.hidePrimaryActions

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -8,7 +8,7 @@ import FastEditModal from "discourse/components/modal/fast-edit";
 import Component from "@glimmer/component";
 import concatClass from "discourse/helpers/concat-class";
 import DButton from "discourse/components/d-button";
-import { fn } from "@ember/helper";
+import { fn, hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import FastEdit from "discourse/components/fast-edit";
 import { on } from "@ember/modifier";
@@ -33,25 +33,35 @@ export default class PostTextSelectionToolbar extends Component {
       {{this.appEventsListeners}}
     >
       <div class="buttons">
-        {{#if this.embedQuoteButton}}
-          <DButton
-            @icon="quote-left"
-            @label="post.quote_reply"
-            @title="post.quote_reply_shortcut"
-            class="btn-flat insert-quote"
-            @action={{@data.insertQuote}}
-          />
+        {{#if this.showPrimaryActions}}
+          {{#if this.embedQuoteButton}}
+            <DButton
+              @icon="quote-left"
+              @label="post.quote_reply"
+              @title="post.quote_reply_shortcut"
+              class="btn-flat insert-quote"
+              @action={{@data.insertQuote}}
+            />
+          {{/if}}
+
+          {{#if @data.canEditPost}}
+            <DButton
+              @icon="pencil-alt"
+              @label="post.quote_edit"
+              @title="post.quote_edit_shortcut"
+              class="btn-flat quote-edit-label"
+              {{on "click" this.toggleFastEdit}}
+            />
+          {{/if}}
         {{/if}}
 
-        {{#if @data.canEditPost}}
-          <DButton
-            @icon="pencil-alt"
-            @label="post.quote_edit"
-            @title="post.quote_edit_shortcut"
-            class="btn-flat quote-edit-label"
-            {{on "click" this.toggleFastEdit}}
-          />
-        {{/if}}
+        <PluginOutlet
+          @name="post-text-selection-buttons-after"
+          @outletArgs={{hash
+            data=@data
+            hidePrimaryActions=this.hidePrimaryActions
+          }}
+        />
 
         {{#if this.quoteSharingEnabled}}
           <span class="quote-sharing">
@@ -103,6 +113,7 @@ export default class PostTextSelectionToolbar extends Component {
   @service appEvents;
 
   @tracked isFastEditing = false;
+  @tracked showPrimaryActions = true;
 
   appEventsListeners = modifier(() => {
     this.appEvents.on("quote-button:edit", this, "toggleFastEdit");
@@ -128,6 +139,7 @@ export default class PostTextSelectionToolbar extends Component {
 
   get quoteSharingEnabled() {
     return (
+      this.showPrimaryActions &&
       this.site.desktopView &&
       this.quoteSharingSources.length > 0 &&
       !this.topic.invisible &&
@@ -163,6 +175,11 @@ export default class PostTextSelectionToolbar extends Component {
       (canCreatePost || canReplyAsNewTopic) &&
       this.currentUser?.get("user_option.enable_quoting")
     );
+  }
+
+  @action
+  hidePrimaryActions() {
+    this.showPrimaryActions = false;
   }
 
   @action


### PR DESCRIPTION
This PR adds the ability for plugins/theme-components to add and control `post-text-selection-toolbar` buttons.

**Specifically**:
- it adds a `<PluginOutlet>` wrapper inside `<div class="buttons">` so the post text selection buttons can be replaced
- plugins can also `{{yield}}` to show the original buttons

This is intended for usage by Discourse AI with the AI helper feature (https://github.com/discourse/discourse-ai/pull/244) but also is generally beneficial for any other plugin/theme-component hooking into this feature.