### PR TITLE
FIX: don't nest all user info in one link

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page-users.hbs
+++ b/app/assets/javascripts/discourse/app/components/about-page-users.hbs
@@ -1,20 +1,26 @@
 {{#each this.usersTemplates as |userTemplate|}}
   <div data-username={{userTemplate.username}} class="user-info small">
-    <a
-      href={{userTemplate.userPath}}
-      data-user-card={{userTemplate.username}}
-      aria-label={{i18n
-        "user.profile_possessive"
-        username=userTemplate.username
-      }}
-    >
-      <div class="user-image">
-        <div class="user-image-inner">
+    <div class="user-image">
+      <div class="user-image-inner">
+        <a
+          href={{userTemplate.userPath}}
+          data-user-card={{userTemplate.username}}
+          aria-hidden="true"
+        >
           {{html-safe userTemplate.avatar}}
-        </div>
+        </a>
       </div>
-      <div class="user-detail">
-        <div class="name-line">
+    </div>
+    <div class="user-detail">
+      <div class="name-line">
+        <a
+          href={{userTemplate.userPath}}
+          data-user-card={{userTemplate.username}}
+          aria-label={{i18n
+            "user.profile_possessive"
+            username=userTemplate.username
+          }}
+        >
           <span class="username">
             {{#if
               userTemplate.prioritizeName
@@ -25,9 +31,9 @@
               userTemplate.prioritizeName
             }}{{userTemplate.username}}{{else}}{{userTemplate.name}}{{/if}}
           </span>
-        </div>
-        <div class="title">{{userTemplate.title}}</div>
+        </a>
       </div>
-    </a>
+      <div class="title">{{userTemplate.title}}</div>
+    </div>
   </div>
 {{/each}}

--- a/app/assets/javascripts/discourse/app/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-info.hbs
@@ -51,10 +51,8 @@
   {{/if}}
 </div>
 
-<span>
-  <PluginOutlet
-    @name="after-user-info"
-    @connectorTagName="div"
-    @outletArgs={{hash user=this.user}}
-  />
-</span>
+<PluginOutlet
+  @name="after-user-info"
+  @connectorTagName="div"
+  @outletArgs={{hash user=this.user}}
+/>

--- a/app/assets/javascripts/discourse/app/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-info.hbs
@@ -1,55 +1,60 @@
-<a
-  href={{if this.includeLink this.userPath}}
-  data-user-card={{if this.includeLink @user.username}}
-  aria-label={{if
-    (and this.includeLink @user.username)
-    (i18n "user.profile_possessive" username=@user.username)
-  }}
->
-  {{#if this.includeAvatar}}
-    <div class="user-image">
-      <div class="user-image-inner">
-        {{avatar @user imageSize="large"}}
-        <UserAvatarFlair @user={{@user}} />
-      </div>
+{{#if this.includeAvatar}}
+  <div class="user-image">
+    <div class="user-image-inner">
+      <a
+        href={{this.userPath}}
+        data-user-card={{@user.username}}
+        aria-hidden="true"
+      >{{avatar @user imageSize="large"}}</a>
+      <UserAvatarFlair @user={{@user}} />
     </div>
-  {{/if}}
-  <div class="user-detail">
-    <div class="name-line">
+  </div>
+{{/if}}
+<div class="user-detail">
+  <div class="name-line">
+    {{#if this.includeLink}}
+      <a href={{this.userPath}} data-user-card={{@user.username}}>
+        <span class={{if this.nameFirst "name" "username"}}>
+          {{if this.nameFirst @user.name (format-username @user.username)}}
+        </span>
+        <span class={{if this.nameFirst "username" "name"}}>
+          {{if this.nameFirst (format-username @user.username) @user.name}}
+        </span>
+      </a>
+    {{else}}
       <span class={{if this.nameFirst "name" "username"}}>
         {{if this.nameFirst @user.name (format-username @user.username)}}
       </span>
       <span class={{if this.nameFirst "username" "name"}}>
         {{if this.nameFirst (format-username @user.username) @user.name}}
       </span>
-      {{#if (and @showStatus @user.status)}}
-        <UserStatusMessage
-          @status={{@user.status}}
-          @showDescription={{@showStatusDescription}}
-        />
-      {{/if}}
-      <span>
-        <PluginOutlet
-          @name="after-user-name"
-          @connectorTagName="span"
-          @outletArgs={{hash user=this.user}}
-        />
-      </span>
-    </div>
-    <div class="title">{{@user.title}}</div>
-    {{#if (has-block)}}
-      <div class="details">
-        {{yield}}
-      </div>
     {{/if}}
+    {{#if (and @showStatus @user.status)}}
+      <UserStatusMessage
+        @status={{@user.status}}
+        @showDescription={{@showStatusDescription}}
+      />
+    {{/if}}
+    <span>
+      <PluginOutlet
+        @name="after-user-name"
+        @connectorTagName="span"
+        @outletArgs={{hash user=this.user}}
+      />
+    </span>
   </div>
+  <div class="title">{{@user.title}}</div>
+  {{#if (has-block)}}
+    <div class="details">
+      {{yield}}
+    </div>
+  {{/if}}
+</div>
 
-  <span>
-    <PluginOutlet
-      @name="after-user-info"
-      @connectorTagName="div"
-      @outletArgs={{hash user=this.user}}
-    />
-  </span>
-
-</a>
+<span>
+  <PluginOutlet
+    @name="after-user-info"
+    @connectorTagName="div"
+    @outletArgs={{hash user=this.user}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-info.hbs
@@ -35,13 +35,11 @@
         @showDescription={{@showStatusDescription}}
       />
     {{/if}}
-    <span>
-      <PluginOutlet
-        @name="after-user-name"
-        @connectorTagName="span"
-        @outletArgs={{hash user=this.user}}
-      />
-    </span>
+    <PluginOutlet
+      @name="after-user-name"
+      @connectorTagName="span"
+      @outletArgs={{hash user=this.user}}
+    />
   </div>
   <div class="title">{{@user.title}}</div>
   {{#if (has-block)}}

--- a/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
@@ -33,10 +33,12 @@ module("Integration | Component | user-info", function (hooks) {
     );
 
     this.set("includeLink", true);
-    assert.ok(exists(`a[href="/u/${this.currentUser.username}"]`));
+    assert.ok(exists(`.name-line a[href="/u/${this.currentUser.username}"]`));
 
     this.set("includeLink", false);
-    assert.notOk(exists(`a[href="/u/${this.currentUser.username}"]`));
+    assert.notOk(
+      exists(`.name-line a[href="/u/${this.currentUser.username}"]`)
+    );
   });
 
   test("includeAvatar", async function (assert) {

--- a/app/assets/stylesheets/common/components/user-info.scss
+++ b/app/assets/stylesheets/common/components/user-info.scss
@@ -10,7 +10,7 @@
 
   .user-detail {
     min-width: 0;
-    @include breakpoint(tablet) {
+    @include breakpoint(mobile-medium) {
       font-size: var(--font-down-1);
     }
 

--- a/app/assets/stylesheets/common/components/user-info.scss
+++ b/app/assets/stylesheets/common/components/user-info.scss
@@ -1,10 +1,7 @@
 // Common styles for "user-info" component
 .user-info {
-  > a {
-    display: flex;
-    gap: 1em;
-    min-width: 0;
-  }
+  display: flex;
+  gap: 1em;
 
   .user-image-inner {
     position: relative;
@@ -18,16 +15,17 @@
     }
 
     .name-line {
-      display: flex;
-      gap: 0.5em;
-      color: var(--primary-high);
+      > a {
+        display: flex;
+        gap: 0.5em;
+        color: var(--primary-high);
+      }
       .name,
       .username {
         @include ellipsis;
       }
 
       span:first-child {
-        flex: 0 0 auto;
         font-weight: bold;
       }
     }
@@ -40,7 +38,6 @@
     }
 
     .title {
-      margin-top: 0.25em;
       color: var(--primary-medium);
     }
   }


### PR DESCRIPTION
Previously in f3a7ebf I was attempting to wrap all the user-info in one link, to reduce repetition for screen readers. This partially reverts that because some pages (like the badge reward list page) add a link to the user info, and wrapping everything in a single link was breaking the nested link. 

So instead I'm partially reverting it back to 2 sibling links, but markup one (the avatar) using `aria-hidden="true"` so screen readers aren't reading the same link twice. 