### PR TITLE
DEV: remove dead mutation code

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -536,7 +536,6 @@ export function setup(opts, siteSettings, state) {
   };
 
   opts.discourse = copy;
-  getOptions.f = () => opts.discourse;
 
   opts.discourse.limitedSiteSettings = {
     secureUploads: siteSettings.secure_uploads,


### PR DESCRIPTION
The call sequence is:

1. on L471 we initialize `getOptions.f = ()=> opts`
2. on L503 we pass it to `createHelpers` so that the feature setup code can call `helpers.getOptions()` to get `opts`
3. the setup code is run synchronously right there and then
4. on the line I changed, we mutate `getOptions.f = () => opts.discourse`
5. we never do anything else with it after the mutation

The only reason to do this is:

1. we expect the feature setup code to hold on to the `helpers` object, AND
2. they may call `getOptions` at a later point, AND
3. if they called `getOptions` synchronously, we want them to get `opts` but it they called it later we want them to get `opts.discourse`

...however, I think a more likely explanation is that this was a rebase error at some point in the past

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
