### PR TITLE
FIX: long press chat message test failure

### DIFF
--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -31,12 +31,10 @@ function calculateCapabilities() {
   capabilities.hasContactPicker =
     "contacts" in navigator && "ContactsManager" in window;
 
-  capabilities.canVibrate = "vibrate" in navigator;
-  const supportsStickyActivation = "userActivation" in navigator;
-  if (supportsStickyActivation) {
-    capabilities.canVibrate =
-      capabilities.canVibrate && navigator.userActivation.hasBeenActive;
-  }
+  capabilities.canVibrate =
+    "vibrate" in navigator &&
+    (!("userActivation" in navigator) ||
+      navigator.userActivation.hasBeenActive);
 
   capabilities.isPwa =
     window.matchMedia("(display-mode: standalone)").matches ||

--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -30,7 +30,14 @@ function calculateCapabilities() {
 
   capabilities.hasContactPicker =
     "contacts" in navigator && "ContactsManager" in window;
+
   capabilities.canVibrate = "vibrate" in navigator;
+  const supportsStickyActivation = "userActivation" in navigator;
+  if (supportsStickyActivation) {
+    capabilities.canVibrate =
+      capabilities.canVibrate && navigator.userActivation.hasBeenActive;
+  }
+
   capabilities.isPwa =
     window.matchMedia("(display-mode: standalone)").matches ||
     window.navigator.standalone ||

--- a/plugins/chat/spec/system/chat_message/channel_spec.rb
+++ b/plugins/chat/spec/system/chat_message/channel_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "Chat message - channel", type: :system do
 
     it "[mobile] copies the text of a single message", mobile: true do
       chat_page.visit_channel(channel_1)
-      channel_page.click_composer # ensures we don't block on vibrate due to no action
 
       channel_page.messages.copy_text(message_1)
 

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe "Chat message - thread", type: :system do
 
     it "[mobile] copies the text of a single message", mobile: true do
       chat_page.visit_thread(thread_message_1.thread)
-      thread_page.click_composer # ensures we don't block on vibrate due to no action
 
       thread_page.messages.copy_text(thread_message_1)
 

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -53,7 +53,7 @@ module PageObjects
           end
 
           if page.has_css?("html.mobile-view", wait: 0)
-            component.click(delay: 0.4)
+            component.click(delay: 0.6)
             page.find(".chat-message-actions [data-id=\"select\"]").click
           else
             hover


### PR DESCRIPTION
This commit brings two fixes.

- increase the delay to trigger the action menu

- check of user activation before using vibrate:

https://developer.mozilla.org/en-US/docs/Glossary/Sticky_activation
https://developer.mozilla.org/en-US/docs/Web/Security/User_activation
https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/hasBeenActive

> Sticky activation is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset after it has been set initially (unlike transient activation).
> APIs that require sticky activation (not exhaustive):
> - Navigator.vibrate()
> - VirtualKeyboard.show()
> - Autoplay of Media and Web Audio APIs (in particular for AudioContexts).


Before this fix, we could end up with this error in the console in tests:

> Blocked call to navigator.vibrate because user hasn't tapped on the frame or any embedded 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
