### PR TITLE
DEV: Revert hide_plugin for chat

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -25,7 +25,6 @@ register_svg_icon "file-image"
 
 # route: /admin/plugins/chat
 add_admin_route "chat.admin.title", "chat"
-hide_plugin
 
 GlobalSetting.add_default(:allow_unsecure_chat_uploads, false)
 


### PR DESCRIPTION
Partial revert of 97a812f022f3e7baa51f354e8f632bec0683fb6d.
Calling hide_plugin also hides the Chat tab in the plugins
section of admin, which is a way plugins can add an advanced
UI (in the case of chat Export and Webhooks).

Until we decide what to do in this case, it's better to revert,
since all this will do is make the discourse-chat plugin show
up again in the plugin list and restore the missing tab.
