### PR TITLE
FIX: correctly checks user activation on use

### DIFF
--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -3,7 +3,7 @@ const APPLE_USER_AGENT_DATA_PLATFORM = /macOS/;
 
 function calculateCapabilities() {
   const capabilities = {
-    get userHasbeenActive() {
+    get userHasBeenActive() {
       return (
         !("userActivation" in navigator) ||
         navigator.userActivation.hasBeenActive

--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -2,7 +2,14 @@ const APPLE_NAVIGATOR_PLATFORMS = /iPhone|iPod|iPad|Macintosh|MacIntel/;
 const APPLE_USER_AGENT_DATA_PLATFORM = /macOS/;
 
 function calculateCapabilities() {
-  const capabilities = {};
+  const capabilities = {
+    get userHasbeenActive() {
+      return (
+        !("userActivation" in navigator) ||
+        navigator.userActivation.hasBeenActive
+      );
+    },
+  };
 
   const ua = navigator.userAgent;
 
@@ -55,11 +62,5 @@ export default class CapabilitiesService {
 
   static create() {
     return capabilities;
-  }
-
-  get userHasbeenActive() {
-    return (
-      !("userActivation" in navigator) || navigator.userActivation.hasBeenActive
-    );
   }
 }

--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -56,4 +56,10 @@ export default class CapabilitiesService {
   static create() {
     return capabilities;
   }
+
+  get userHasbeenActive() {
+    return (
+      !("userActivation" in navigator) || navigator.userActivation.hasBeenActive
+    );
+  }
 }

--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -38,10 +38,7 @@ function calculateCapabilities() {
   capabilities.hasContactPicker =
     "contacts" in navigator && "ContactsManager" in window;
 
-  capabilities.canVibrate =
-    "vibrate" in navigator &&
-    (!("userActivation" in navigator) ||
-      navigator.userActivation.hasBeenActive);
+  capabilities.canVibrate = "vibrate" in navigator;
 
   capabilities.isPwa =
     window.matchMedia("(display-mode: standalone)").matches ||

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -10,7 +10,6 @@ import {
   NO_REMINDER_ICON,
   WITH_REMINDER_ICON,
 } from "discourse/models/bookmark";
-import { isTesting } from "discourse-common/config/environment";
 import DeleteTopicDisallowedModal from "discourse/components/modal/delete-topic-disallowed";
 import RenderGlimmer from "discourse/widgets/render-glimmer";
 import { hbs } from "ember-cli-htmlbars";
@@ -820,7 +819,7 @@ export default createWidget("post-menu", {
       return this.sendWidgetAction("showLogin");
     }
 
-    if (this.capabilities.canVibrate && !isTesting()) {
+    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(VIBRATE_DURATION);
     }
 

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -819,7 +819,7 @@ export default createWidget("post-menu", {
       return this.sendWidgetAction("showLogin");
     }
 
-    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
+    if (this.capabilities.userHasBeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(VIBRATE_DURATION);
     }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -4,7 +4,6 @@ import { getOwner } from "@ember/application";
 import { tracked } from "@glimmer/tracking";
 import discourseLater from "discourse-common/lib/later";
 import { action } from "@ember/object";
-import { isTesting } from "discourse-common/config/environment";
 import { inject as service } from "@ember/service";
 import and from "truth-helpers/helpers/and";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -142,7 +141,7 @@ export default class ChatMessageActionsMobile extends Component {
   fadeAndVibrate() {
     discourseLater(this.#addFadeIn.bind(this));
 
-    if (this.capabilities.canVibrate && !isTesting()) {
+    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(5);
     }
   }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -141,7 +141,7 @@ export default class ChatMessageActionsMobile extends Component {
   fadeAndVibrate() {
     discourseLater(this.#addFadeIn.bind(this));
 
-    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
+    if (this.capabilities.userHasBeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(5);
     }
   }

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -283,7 +283,7 @@ export default class ChatMessageInteractor {
       return;
     }
 
-    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
+    if (this.capabilities.userHasBeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(5);
     }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -7,7 +7,6 @@ import { BookmarkFormData } from "discourse/lib/bookmark";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { isTesting } from "discourse-common/config/environment";
 import { clipboardCopy } from "discourse/lib/utilities";
 import ChatMessageReaction, {
   REACTIONS,
@@ -284,7 +283,7 @@ export default class ChatMessageInteractor {
       return;
     }
 
-    if (this.capabilities.canVibrate && !isTesting()) {
+    if (this.capabilities.userHasbeenActive && this.capabilities.canVibrate) {
       navigator.vibrate(5);
     }
 


### PR DESCRIPTION
We can't have it computed only at start of the application as the state wouldn't most likely be false at this point in time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
