### PR TITLE
DEV: Format `UserStatus#ends_at` as a ISO8601 timestamp

### DIFF
--- a/app/serializers/user_status_serializer.rb
+++ b/app/serializers/user_status_serializer.rb
@@ -3,6 +3,10 @@
 class UserStatusSerializer < ApplicationSerializer
   attributes :description, :emoji, :ends_at, :message_bus_last_id
 
+  def ends_at
+    object.ends_at.iso8601
+  end
+
   def message_bus_last_id
     MessageBus.last_id("/user-status")
   end

--- a/app/serializers/user_status_serializer.rb
+++ b/app/serializers/user_status_serializer.rb
@@ -4,7 +4,7 @@ class UserStatusSerializer < ApplicationSerializer
   attributes :description, :emoji, :ends_at, :message_bus_last_id
 
   def ends_at
-    object.ends_at.iso8601
+    object.ends_at&.iso8601
   end
 
   def message_bus_last_id

--- a/spec/requests/user_status_controller_spec.rb
+++ b/spec/requests/user_status_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UserStatusController do
       it "returns user status" do
         status = "off to dentist"
         status_emoji = "tooth"
-        ends_at = "2100-01-01T18:00:00.000Z"
+        ends_at = "2100-01-01T18:00:00Z"
         user.set_status!(status, status_emoji, DateTime.parse(ends_at))
 
         get "/user-status.json"

--- a/spec/serializers/user_status_serializer_spec.rb
+++ b/spec/serializers/user_status_serializer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe UserStatusSerializer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:user_status) do
+    Fabricate(:user_status, user: user, ends_at: Time.parse("2023-09-29T03:25:00Z"))
+  end
+
+  describe "#ends_at" do
+    it "is formatted as a ISO8601 timestamp" do
+      serialized = described_class.new(user_status, scope: Guardian.new(user), root: false).as_json
+      expect(serialized[:ends_at]).to eq("2023-09-29T03:25:00Z")
+    end
+  end
+end

--- a/spec/serializers/user_status_serializer_spec.rb
+++ b/spec/serializers/user_status_serializer_spec.rb
@@ -3,7 +3,12 @@
 RSpec.describe UserStatusSerializer do
   fab!(:user) { Fabricate(:user) }
   fab!(:user_status) do
-    Fabricate(:user_status, user: user, ends_at: Time.parse("2023-09-29T03:25:00Z"))
+    Fabricate(
+      :user_status,
+      user: user,
+      set_at: Time.parse("2023-09-29T02:20:00Z"),
+      ends_at: Time.parse("2023-09-29T03:25:00Z"),
+    )
   end
 
   describe "#ends_at" do


### PR DESCRIPTION
…as we do when publishing a mesage bus update: https://github.com/discourse/discourse/blob/07c93918ecbc82cda6cd9a079f27cfed432bcb7e/app/models/user.rb#L871-L871

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
