### PR TITLE
DEV: skip mobile copy link spec

### DIFF
--- a/plugins/chat/spec/system/chat_message/channel_spec.rb
+++ b/plugins/chat/spec/system/chat_message/channel_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Chat message - channel", type: :system do
         expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
       end
 
-      it "[mobile] copies the link to the message", mobile: true do
+      xit "[mobile] copies the link to the message", mobile: true do
         chat_page.visit_channel(channel_1)
 
         channel_page.messages.copy_link(thread_1.original_message)


### PR DESCRIPTION
Most likely on CI sometimes it makes a press instead of a long press because there's a thread preview underneath.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
