### PR TITLE
DEV: Correctly test post-cooked "widget"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/mount-widget.js
+++ b/app/assets/javascripts/discourse/app/components/mount-widget.js
@@ -47,6 +47,21 @@ export default Component.extend({
     this._super(...arguments);
     const name = this.widget;
 
+    if (name === "post-cooked") {
+      throw [
+        "Cannot use <MountWidget /> with `post-cooked`.",
+        "It's a special-case that needs to be wrapped in another widget.",
+        "For example:",
+        "  createWidget('test-widget', {",
+        "    html(attrs) {",
+        "      return [",
+        "        new PostCooked(attrs, new DecoratorHelper(this), this.currentUser),",
+        "      ];",
+        "    },",
+        "  });",
+      ].join("\n");
+    }
+
     this.register = getRegister(this);
 
     this._widgetClass =

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
@@ -1,23 +1,31 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import DecoratorHelper from "discourse/widgets/decorator-helper";
+import PostCooked from "discourse/widgets/post-cooked";
+import { createWidget } from "discourse/widgets/widget";
 
 module("Integration | Component | Widget | post-cooked", function (hooks) {
   setupRenderingTest(hooks);
 
   test("quotes with no username and no valid topic", async function (assert) {
-    this.siteSettings.show_copy_button_on_codeblocks = false;
-
     this.set("args", {
       cooked: `<aside class=\"quote no-group quote-post-not-found\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`,
     });
 
+    createWidget("test-widget", {
+      html(attrs) {
+        return [
+          new PostCooked(attrs, new DecoratorHelper(this), this.currentUser),
+        ];
+      },
+    });
+
     await render(
-      hbs`<MountWidget @widget="post-cooked" @args={{this.args}} />`
+      hbs`<MountWidget @widget="test-widget" @args={{this.args}} />`
     );
 
-    assert.strictEqual(query("blockquote").innerText, "abcd");
+    assert.dom("blockquote").hasText("abcd");
   });
 });


### PR DESCRIPTION
It's a special case widget - its constructor has different contructor arguments:

```js
export default class PostCooked {
  constructor(attrs, decoratorHelper, currentUser) {
...
```

vs

```js
export default class Widget {
  constructor(attrs, register, opts) {
...
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
