### PR TITLE
FIX: Embroider breaking index html structure

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -209,10 +209,7 @@ function replaceIn(bootstrap, template, id, headers, baseURL) {
   if (id === "html-tag") {
     return template.replace(`<html>`, contents);
   } else {
-    return template.replace(
-      `<bootstrap-content key="${id}"></bootstrap-content>`,
-      contents
-    );
+    return template.replace(`<!-- bootstrap-content ${id} -->`, contents);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -12,14 +12,17 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover">
 
-    <bootstrap-content key="before-script-load"></bootstrap-content>
+    <!-- bootstrap-content before-script-load -->
     {{content-for "before-script-load"}}
 
-    <bootstrap-content key="discourse-preload-stylesheets"></bootstrap-content>
+    <!-- bootstrap-content discourse-preload-stylesheets -->
     {{content-for "discourse-preload-stylesheets"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/discourse.css" />
+
+    <!-- bootstrap-content head -->
+    {{content-for "head"}}
 
     <discourse-chunked-script entrypoint="vendor">
       <script defer src="{{rootURL}}assets/vendor.js"></script>
@@ -29,33 +32,30 @@
       <ember-auto-import-scripts defer entrypoint="app"></ember-auto-import-scripts>
       <script defer src="{{rootURL}}assets/discourse.js"></script>
     </discourse-chunked-script>
-
-    <bootstrap-content key="head"></bootstrap-content>
-    {{content-for "head"}}
   </head>
   <body>
     <discourse-assets>
       <discourse-assets-stylesheets>
-        <bootstrap-content key="discourse-stylesheets"></bootstrap-content>
+        <!-- bootstrap-content discourse-stylesheets -->
         {{content-for "discourse-stylesheets"}}
       </discourse-assets-stylesheets>
       <discourse-assets-json>
-        <bootstrap-content key="preloaded"></bootstrap-content>
+        <!-- bootstrap-content preloaded -->
       </discourse-assets-json>
       <discourse-assets-icons></discourse-assets-icons>
     </discourse-assets>
 
-    <bootstrap-content key="body"></bootstrap-content>
+    <!-- bootstrap-content body -->
     {{content-for "body"}}
 
     <section id='main'>
     </section>
 
-    <bootstrap-content key="hidden-login-form"></bootstrap-content>
+    <!-- bootstrap-content hidden-login-form -->
 
     <script defer src="{{rootURL}}assets/start-discourse.js" data-embroider-ignore></script>
 
-    <bootstrap-content key="body-footer"></bootstrap-content>
+    <!-- bootstrap-content body-footer -->
     {{content-for "body-footer"}}
   </body>
 </html>


### PR DESCRIPTION
The custom html elements we were using for bootstrapping were causing Embroider to end the `<head>` tag and immediately start `<body>`. As a result most of `<meta>` tags ended up in the `<body>`.

That meant (among possibly other issues) that the app did not have CSRF token set properly on launch (in the development env)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
