### PR TITLE
FIX: Always use the current session token in uppy

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -544,9 +544,9 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
   _useXHRUploads() {
     this._uppyInstance.use(XHRUpload, {
       endpoint: getURL(`/uploads.json?client_id=${this.messageBus.clientId}`),
-      headers: {
+      headers: () => ({
         "X-CSRF-Token": this.session.csrfToken,
-      },
+      }),
     });
   },
 

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -350,9 +350,9 @@ export default Mixin.create(UppyS3Multipart, ExtendableUploader, {
   _useXHRUploads() {
     this._uppyInstance.use(XHRUpload, {
       endpoint: this._xhrUploadUrl(),
-      headers: {
+      headers: () => ({
         "X-CSRF-Token": this.session.csrfToken,
-      },
+      }),
     });
   },
 


### PR DESCRIPTION
…rather than the value at the time when uppy is initialized.

Future TODO: extract csrf-fetching logic from ajax helper to Session service.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
