### PR TITLE
DEV: Add `tag` argument to extra-nav-item outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -12,6 +12,7 @@
     @navItems={{this.navItems}}
     @filterMode={{this.filterMode}}
     @category={{this.category}}
+    @tag={{this.tag}}
   />
 {{/unless}}
 

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.hbs
@@ -9,5 +9,9 @@
 <PluginOutlet
   @name="extra-nav-item"
   @connectorTagName="li"
-  @outletArgs={{hash category=this.category filterMode=this.filterMode}}
+  @outletArgs={{hash
+    category=this.category
+    tag=this.tag
+    filterMode=this.filterMode
+  }}
 />

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
@@ -17,7 +17,11 @@
     <PluginOutlet
       @name="extra-nav-item"
       @connectorTagName="li"
-      @outletArgs={{hash category=this.category filterMode=this.filterMode}}
+      @outletArgs={{hash
+        category=this.category
+        tag=this.tag
+        filterMode=this.filterMode
+      }}
     />
   </ul>
 {{/if}}


### PR DESCRIPTION
This will make it easier for themes/plugins to introduce nav items which work correctly on tag discovery routes

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
