### PR TITLE
updated description of company_name field

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2404,7 +2404,7 @@ en:
     create_post_for_category_and_tag_changes: "Create a small action post when a topic's category or tags change"
     watched_precedence_over_muted: "Notify me about topics in categories or tags I’m watching that also belong to one I have muted"
 
-    company_name: "Company Name"
+    company_name: "Name of your company or organization. If left blank, no boilerplate Terms of Service or Privacy Notice will be provided."
     governing_law: "Governing Law"
     city_for_disputes: "City for Disputes"
 


### PR DESCRIPTION
If company name field is left blank, no boilerplate TOS or Privacy Notice is provided. Updated the description to make this explicit. For more info, see: https://meta.discourse.org/t/updates-to-new-site-experience-and-the-getting-started-guide/273189#login-page-is-more-welcoming-on-private-sites-3

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
