### PR TITLE
UX: keep timestamp on single line

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-info.scss
@@ -11,6 +11,9 @@
   & + .chat-message-info__bot-indicator,
   & + .chat-message-info__date {
     margin-left: 0.25em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
Preventing
![image](https://github.com/discourse/discourse/assets/101828855/478f5a21-9552-4a2b-9e13-0d07e84086d5)
