### PR TITLE
UX: Make "×" pure styling for topic count

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -101,7 +101,7 @@ function buildTopicCount(count) {
   return `<span class="topic-count" aria-label="${I18n.t(
     "category_row.topic_count",
     { count }
-  )}">&times; ${count}</span>`;
+  )}">${count}</span>`;
 }
 
 export function defaultCategoryLinkRenderer(category, opts) {

--- a/app/assets/stylesheets/common/select-kit/category-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/category-drop.scss
@@ -61,6 +61,10 @@
           font-weight: normal;
           color: var(--primary-medium);
           font-size: var(--font-down-1);
+
+          &:before {
+            content: "× ";
+          }
         }
 
         .badge-wrapper {


### PR DESCRIPTION
For those who want to customize how the topic count is displayed, let's remove "×" from the inline HTML and have it a CSS pseudo-element.

<img width="269" alt="image" src="https://github.com/discourse/discourse/assets/37538241/450e3899-715d-491e-9ef1-e7052a8b918f">


---

Moving the marker to CSS allows us to customize it however we'd like—

<img width="218" alt="image" src="https://github.com/discourse/discourse/assets/37538241/682d8a5d-21c0-4660-9962-fa5a798654c6">

<img width="256" alt="image" src="https://github.com/discourse/discourse/assets/37538241/1e8584a8-8e7c-401c-b89a-7a192586de98">
