### PR TITLE
DEV: Replace custom Onebox symbolize_keys implementation with ActiveSupport

### DIFF
--- a/lib/onebox/engine/gfycat_onebox.rb
+++ b/lib/onebox/engine/gfycat_onebox.rb
@@ -76,7 +76,7 @@ module Onebox
         script = page.at_css('script[type="application/ld+json"]')
 
         if json_string = script&.text
-          @og_data = Onebox::Helpers.symbolize_keys(::MultiJson.load(json_string))
+          @og_data = ::MultiJson.load(json_string, symbolize_keys: true)
         else
           @og_data = {}
         end

--- a/lib/onebox/engine/imgur_onebox.rb
+++ b/lib/onebox/engine/imgur_onebox.rb
@@ -53,7 +53,7 @@ module Onebox
           rescue StandardError
             "{}"
           end
-        oembed_data = Onebox::Helpers.symbolize_keys(::MultiJson.load(response))
+        oembed_data = ::MultiJson.load(response, symbolize_keys: true)
         imgur_data_id = Nokogiri.HTML(oembed_data[:html]).xpath("//blockquote").attr("data-id")
         imgur_data_id.to_s[%r{a/}]
       end

--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -34,7 +34,7 @@ module Onebox
 
       def oembed_data
         response = Onebox::Helpers.fetch_response("https://vimeo.com/api/oembed.json?url=#{url}")
-        @oembed_data = Onebox::Helpers.symbolize_keys(::MultiJson.load(response))
+        @oembed_data = ::MultiJson.load(response, symbolize_keys: true)
       rescue StandardError
         "{}"
       end

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -9,17 +9,6 @@ module Onebox
 
     IGNORE_CANONICAL_DOMAINS ||= %w[www.instagram.com medium.com youtube.com]
 
-    def self.symbolize_keys(hash)
-      return {} if hash.nil?
-
-      hash.inject({}) do |result, (key, value)|
-        new_key = key.is_a?(String) ? key.to_sym : key
-        new_value = value.is_a?(Hash) ? symbolize_keys(value) : value
-        result[new_key] = new_value
-        result
-      end
-    end
-
     def self.clean(html)
       html.gsub(/<[^>]+>/, " ").gsub(/\n/, "")
     end

--- a/lib/onebox/layout.rb
+++ b/lib/onebox/layout.rb
@@ -12,7 +12,7 @@ module Onebox
     attr_reader :view
 
     def initialize(name, record)
-      @record = Onebox::Helpers.symbolize_keys(record)
+      @record = record.deep_symbolize_keys
 
       # Fix any relative paths
       if @record[:image] && @record[:image] =~ %r{\A/[^/]}

--- a/lib/onebox/oembed.rb
+++ b/lib/onebox/oembed.rb
@@ -3,7 +3,7 @@
 module Onebox
   class Oembed < OpenGraph
     def initialize(response)
-      @data = Onebox::Helpers.symbolize_keys(::MultiJson.load(response))
+      @data = ::MultiJson.load(response, symbolize_keys: true)
 
       # never use oembed from WordPress 4.4 (it's broken)
       @data.delete(:html) if @data[:html] && @data[:html]["wp-embedded-content"]

--- a/spec/lib/onebox/engine/google_maps_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_maps_onebox_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Onebox::Engine::GoogleMapsOnebox do
     end
   end
 
-  let(:data) { Onebox::Helpers.symbolize_keys(onebox.send(:data)) }
+  let(:data) { onebox.send(:data).deep_symbolize_keys }
   let(:link) { |example| URLS[example.metadata[:urltype] || :short][:test] }
 
   include_context "an engine", urltype: :short

--- a/spec/support/onebox_helpers.rb
+++ b/spec/support/onebox_helpers.rb
@@ -22,7 +22,7 @@ module OneboxHelpers
 
     let(:onebox) { described_class.new(link) }
     let(:html) { onebox.to_html }
-    let(:data) { Onebox::Helpers.symbolize_keys(onebox.send(:data)) }
+    let(:data) { onebox.send(:data).deep_symbolize_keys }
     let(:link) { @link }
   end
 


### PR DESCRIPTION
### What is this change?

We have a custom implementation of `#symbolize_keys` in our Onebox helpers. This is likely a legacy from when Onebox was a standalone gem. This change replaces all usages with either `#deep_symbolize_keys` from ActiveSupport, or appropriate option to the JSON parser gem used.

### Tip to reviewer

In this case the whole PR is one-for-one replacements. The easiest way to review is to go line by line and check the substitute matches the original. 🙏