### PR TITLE
FIX: properly create a mention when followed by dots

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -211,6 +211,7 @@ module Chat
       strikethrough
       blockquote
       emphasis
+      replacements
     ]
 
     def self.cook(message, opts = {})

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -20,6 +20,13 @@ describe Chat::Message do
       expect(cooked).to eq("<p>&lt;h1&gt;test&lt;/h1&gt;</p>")
     end
 
+    it "correctly extracts mentions with dots" do
+      user = Fabricate(:user)
+      cooked = described_class.cook("@#{user.username}...test")
+
+      expect(cooked).to eq("<p><a class=\"mention\" href=\"/u/bruce2\">@bruce2</a>…test</p>")
+    end
+
     it "does not support headings" do
       cooked = described_class.cook("## heading 2")
 

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -24,7 +24,9 @@ describe Chat::Message do
       user = Fabricate(:user)
       cooked = described_class.cook("@#{user.username}...test")
 
-      expect(cooked).to eq("<p><a class=\"mention\" href=\"/u/bruce2\">@bruce2</a>…test</p>")
+      expect(cooked).to eq(
+        "<p><a class=\"mention\" href=\"/u/#{user.username}\">@#{user.username}</a>…test</p>",
+      )
     end
 
     it "does not support headings" do
@@ -33,10 +35,10 @@ describe Chat::Message do
       expect(cooked).to eq("<p>## heading 2</p>")
     end
 
-    it "does not support horizontal rules" do
+    it "supports horizontal replacement" do
       cooked = described_class.cook("---")
 
-      expect(cooked).to eq("<p>---</p>")
+      expect(cooked).to eq("<p>—</p>")
     end
 
     it "supports backticks rule" do
@@ -102,7 +104,7 @@ describe Chat::Message do
       <div class="quote-controls"></div>
       <img loading="lazy" alt="" width="24" height="24" src="#{avatar_src}" class="avatar"><a href="http://test.localhost/t/some-quotable-topic/#{topic.id}/#{post.post_number}">#{topic.title}</a></div>
       <blockquote>
-      <p>Mark me...this will go down in history.</p>
+      <p>Mark me…this will go down in history.</p>
       </blockquote>
       </aside>
       COOKED


### PR DESCRIPTION
At the moment writing a mention similar to `@bob...hi` would have resulted in chat trying to find a user named `bob...hi` which would fail.

This was due to the `replacements` rule not being present in the rules used to cook chat messages. When the rule is present `...` will be replaced by `…` which will prevent the issue as not considered as a valid char when processing mentions.

We are still missing few default rules like: normalize, smartquotes, text_join, ... which don't seem to be necessary but could be added if we found a reason for. More info at: https://github.com/markdown-it/markdown-it/blob/e476f78bc3ea3576beb61bdc94322d0a6b2d85cc/lib/parser_core.js

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
