### PR TITLE
DEV: Add meta_topic_id plugin metadata

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-plugin.js
+++ b/app/assets/javascripts/admin/addon/models/admin-plugin.js
@@ -21,6 +21,7 @@ export default class AdminPlugin {
     this.name = args.name;
     this.url = args.url;
     this.version = args.version;
+    this.metaUrl = args.meta_url;
   }
 
   get settingCategoryName() {

--- a/app/serializers/admin_plugin_serializer.rb
+++ b/app/serializers/admin_plugin_serializer.rb
@@ -12,7 +12,8 @@ class AdminPluginSerializer < ApplicationSerializer
              :has_settings,
              :is_official,
              :commit_hash,
-             :commit_url
+             :commit_url,
+             :meta_url
 
   def id
     object.directory_name
@@ -77,5 +78,10 @@ class AdminPluginSerializer < ApplicationSerializer
 
   def commit_url
     object.commit_url
+  end
+
+  def meta_url
+    return if object.metadata.meta_topic_id.blank?
+    "https://meta.discourse.org/t/#{object.metadata.meta_topic_id}"
   end
 end

--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -101,7 +101,17 @@ class Plugin::Metadata
       ],
     )
 
-  FIELDS ||= %i[name about version authors contact_emails url required_version transpile_js]
+  FIELDS ||= %i[
+    name
+    about
+    version
+    authors
+    contact_emails
+    url
+    required_version
+    transpile_js
+    meta_topic_id
+  ]
   attr_accessor(*FIELDS)
 
   def self.parse(text)

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -6,6 +6,7 @@
 # authors: Kane York, Mark VanLandingham, Martin Brennan, Joffrey Jaffeux
 # url: https://github.com/discourse/discourse/tree/main/plugins/chat
 # transpile_js: true
+# meta_topic_id: 230881
 
 enabled_site_setting :chat_enabled
 

--- a/spec/lib/plugin/metadata_spec.rb
+++ b/spec/lib/plugin/metadata_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Plugin::Metadata do
 # contact emails: frankz@example.com
 # url: http://discourse.org
 # required version: 1.3.0beta6+48
+# meta_topic_id: 1234
 
 some_ruby
 TEXT
@@ -22,6 +23,7 @@ TEXT
       expect(metadata.contact_emails).to eq("frankz@example.com")
       expect(metadata.url).to eq("http://discourse.org")
       expect(metadata.required_version).to eq("1.3.0beta6+48")
+      expect(metadata.meta_topic_id).to eq("1234")
     end
   end
 


### PR DESCRIPTION
For the admin plugin list we want to be able to link to
a meta topic for plugins, but we have no standard way to
do this at the moment. This adds support for meta_topic_id
alongside other plugin metadata like authors, URL etc,
that gets built into a Meta topic URL in the serializer.
