### PR TITLE
DEV: Filter files included by theme DirectoryImporter

### DIFF
--- a/lib/theme_store/directory_importer.rb
+++ b/lib/theme_store/directory_importer.rb
@@ -8,7 +8,10 @@ module ThemeStore
 
     def import!
       FileUtils.mkdir_p(temp_folder)
-      FileUtils.cp_r("#{@theme_dir}/.", temp_folder)
+      Dir.glob("*", base: @theme_dir) do |entry|
+        next if %w[node_modules src spec].include?(entry)
+        FileUtils.cp_r(File.join(@theme_dir, entry), temp_folder)
+      end
     end
   end
 end


### PR DESCRIPTION
To match discourse_theme CLI behavior, we should skip hidden files/directories (e.g. `.git`), and two regular directories: `node_modules/` and `src/`.

Without these excludes, it's very easy for a theme to hit the file count limit. e.g. when trying this with discourse-kanban-board, I got:

> The number of files (20366) in the theme has exceeded the maximum allowed number of files (1024)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
