### PR TITLE
DEV: prevents flakey spec with dots

### DIFF
--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -63,7 +63,7 @@ end
 Fabricator(:chat_message_without_service, class_name: "Chat::Message") do
   user
   chat_channel
-  message { Faker::Lorem.paragraph_by_chars(number: 500) }
+  message { Faker::Lorem.paragraph_by_chars(number: 500).gsub("...", "…") }
 
   after_build { |message, attrs| message.cook }
   after_create { |message, attrs| message.create_mentions }
@@ -89,7 +89,8 @@ Fabricator(:chat_message_with_service, class_name: "Chat::CreateMessage") do
     resolved_class.call(
       chat_channel_id: channel.id,
       guardian: user.guardian,
-      message: transients[:message] || Faker::Lorem.paragraph_by_chars(number: 500),
+      message:
+        transients[:message] || Faker::Lorem.paragraph_by_chars(number: 500).gsub("...", "…"),
       thread_id: transients[:thread]&.id,
       in_reply_to_id: transients[:in_reply_to]&.id,
       upload_ids: transients[:upload_ids],


### PR DESCRIPTION
Faker can generate test containing `...` which will get converted to `…` by `PrettyText`, it means that we can't use the input to check the output. This commit simply normalise the generated text to ensure this part of the input is not modified.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
