### PR TITLE
FIX: correctly reset active message on destroy

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
@@ -313,6 +313,7 @@ export default class ChatMessage extends Component {
     cancel(this._makeMessageActiveHandler);
     cancel(this._debounceDecorateCookedMessageHandler);
     this.#teardownMentionedUsers();
+    this.chat.activeMessage = null;
   }
 
   @action


### PR DESCRIPTION
It should prevent any message action to still show after a transition while hovering a message (eg: link to channel settings from a message).

No test as it's minor annoyance and is hard to test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
