### PR TITLE
FIX: uses correct label on mobile view for members

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -316,7 +316,7 @@ export default class ChatAboutScreen extends Component {
   categoryLabel = I18n.t("chat.settings.category_label");
   historyLabel = I18n.t("chat.settings.history_label");
   adminSectionTitle = I18n.t("chat.settings.admin_title");
-  membersLabel = I18n.t("chat.settings.tabs.members_label");
+  membersLabel = I18n.t("chat.channel_info.tabs.members");
   descriptionSectionTitle = I18n.t("chat.about_view.description");
   titleSectionTitle = I18n.t("chat.about_view.title");
   descriptionPlaceholder = I18n.t(


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
