### PR TITLE
FIX: hide consolidated chat message notifications temporarily

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -10,3 +10,15 @@
     display: none;
   }
 }
+
+// TODO (davidb): remove once consolidated chat notifications is complete
+.user-stream .large-notifications .item {
+  &:has(.chat-message) {
+    display: none;
+  }
+}
+
+// TODO (davidb): remove once consolidated chat notifications is complete
+.user-menu .quick-access-panel .chat-message {
+  display: none;
+}


### PR DESCRIPTION
We put consolidated chat notifications live for a short amount of time then reverted the commit due to UX concerns.

The result of this is that there are a few users affected that will have notifications in a blank state.

As a workaround this PR will hide those notifications until the feature is ready to merge again.