### PR TITLE
DEV: Add hooks to allow overriding notify_user behavior

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -116,6 +116,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :summarization_strategies
 
+  define_filtered_register :post_action_notify_user_handlers
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -58,7 +58,17 @@ module PostGuardian
 
         if action_key == :notify_user &&
              !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
-          return false
+          # the modifier here is used here to add additional permissions to `notify_user` as the behavior
+          # of `notify_user` can be swapped in a plugin to use another system like chat to notify users.
+          can_notify = false
+          can_notify =
+            DiscoursePluginRegistry.apply_modifier(
+              :post_guardian_can_notify_user,
+              can_notify,
+              self,
+              post,
+            )
+          return can_notify
         end
 
         # we allow flagging for trust level 1 and higher

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -58,8 +58,10 @@ module PostGuardian
 
         if action_key == :notify_user &&
              !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
-          # the modifier here is used here to add additional permissions to `notify_user` as the behavior
-          # of `notify_user` can be swapped in a plugin to use another system like chat to notify users.
+          # The modifier below is used here to add additional permissions for notifying users.
+          # In core the only method of notifying a user is personal messages so we check if the
+          # user can PM. Plugins can extend the behavior of users are notifier via `notify_user`
+          # post action, and this allows extension for that use case.
           can_notify = false
           can_notify =
             DiscoursePluginRegistry.apply_modifier(

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -58,9 +58,9 @@ module PostGuardian
 
         if action_key == :notify_user &&
              !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
-          # The modifier below is used here to add additional permissions for notifying users.
+          # The modifier below is used to add additional permissions for notifying users.
           # In core the only method of notifying a user is personal messages so we check if the
-          # user can PM. Plugins can extend the behavior of users are notifier via `notify_user`
+          # user can PM. Plugins can extend the behavior of how users are notifier via `notify_user`
           # post action, and this allows extension for that use case.
           can_notify = false
           can_notify =

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1238,6 +1238,14 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_summarization_strategy(strategy, self)
   end
 
+  ##
+  # Register a block that will be called when PostActionCreator is going to notify a
+  # user of a post action. If any of these handlers returns false the default PostCreator
+  # call will be skipped.
+  def register_post_action_notify_user_handler(handler)
+    DiscoursePluginRegistry.register_post_action_notify_user_handler(handler, self)
+  end
+
   protected
 
   def self.js_path

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -328,19 +328,24 @@ RSpec.describe PostActionCreator do
     end
   end
 
-  describe "#add_notify_user_handlers" do
+  describe "With plugin adding post_action_notify_user_handlers" do
     let(:message) { "oh that was really bad what you said there" }
+    let(:plugin) { Plugin::Instance.new }
 
-    after { PostActionCreator.reset_notify_user_handlers }
+    after { DiscoursePluginRegistry.reset! }
 
     it "evaluates all handlers and creates post if none return false" do
-      PostActionCreator.add_notify_user_handler do |user, post, message|
-        MessageBus.publish("notify_user", { user_id: user.id, message: message })
-      end
+      plugin.register_post_action_notify_user_handler(
+        Proc.new do |user, post, message|
+          MessageBus.publish("notify_user", { user_id: user.id, message: message })
+        end,
+      )
 
-      PostActionCreator.add_notify_user_handler do |user, post, message|
-        MessageBus.publish("notify_user", { poster_id: post.user_id, message: message })
-      end
+      plugin.register_post_action_notify_user_handler(
+        Proc.new do |user, post, message|
+          MessageBus.publish("notify_user", { poster_id: post.user_id, message: message })
+        end,
+      )
 
       messages =
         MessageBus.track_publish("notify_user") do
@@ -365,10 +370,12 @@ RSpec.describe PostActionCreator do
     end
 
     it "evaluates all handlers and doesn't create a post one returns false" do
-      PostActionCreator.add_notify_user_handler do |user, post, message|
-        MessageBus.publish("notify_user", { user_id: user.id, message: message })
-        false
-      end
+      plugin.register_post_action_notify_user_handler(
+        Proc.new do |user, post, message|
+          MessageBus.publish("notify_user", { user_id: user.id, message: message })
+          false
+        end,
+      )
 
       messages =
         MessageBus.track_publish("notify_user") do

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -327,4 +327,66 @@ RSpec.describe PostActionCreator do
       )
     end
   end
+
+  describe "#add_notify_user_handlers" do
+    let(:message) { "oh that was really bad what you said there" }
+
+    after { PostActionCreator.reset_notify_user_handlers }
+
+    it "evaluates all handlers and creates post if none return false" do
+      PostActionCreator.add_notify_user_handler do |user, post, message|
+        MessageBus.publish("notify_user", { user_id: user.id, message: message })
+      end
+
+      PostActionCreator.add_notify_user_handler do |user, post, message|
+        MessageBus.publish("notify_user", { poster_id: post.user_id, message: message })
+      end
+
+      messages =
+        MessageBus.track_publish("notify_user") do
+          result =
+            PostActionCreator.new(
+              user,
+              post,
+              PostActionType.types[:notify_user],
+              message: message,
+              flag_topic: false,
+            ).perform
+          post_action = result.post_action
+          expect(post_action.related_post).to be_present
+        end
+
+      expect(
+        messages.find { |m| m.data[:user_id] == user.id && m.data[:message] == message },
+      ).to be_present
+      expect(
+        messages.find { |m| m.data[:poster_id] == post.user_id && m.data[:message] == message },
+      ).to be_present
+    end
+
+    it "evaluates all handlers and doesn't create a post one returns false" do
+      PostActionCreator.add_notify_user_handler do |user, post, message|
+        MessageBus.publish("notify_user", { user_id: user.id, message: message })
+        false
+      end
+
+      messages =
+        MessageBus.track_publish("notify_user") do
+          result =
+            PostActionCreator.new(
+              user,
+              post,
+              PostActionType.types[:notify_user],
+              message: message,
+              flag_topic: false,
+            ).perform
+          post_action = result.post_action
+          expect(post_action.related_post).not_to be_present
+        end
+
+      expect(
+        messages.find { |m| m.data[:user_id] == user.id && m.data[:message] == message },
+      ).to be_present
+    end
+  end
 end


### PR DESCRIPTION
When notifying a user through the flag modal, core creates a PM. This PR allows different behavior to take place, halting the PM creation process to be overridden via a plugin.

There is also a necessary change to `PostGuardian` to extend permission via a plugin.