### PR TITLE
DEV: Remove the upload processing placeholder

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -362,24 +362,26 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
 
     this._uppyInstance.on("cancel-all", () => {
       // Do the manual cancelling work only if the user clicked cancel
-      if (this.userCancelled) {
-        if (this.useUploadPlaceholders) {
-          for (const placeholder of Object.values(this.placeholders)) {
-            run(() => {
+      run(() => {
+        if (this.userCancelled) {
+          if (this.useUploadPlaceholders) {
+            for (const placeholder of this.placeholders.values()) {
               this.appEvents.trigger(
                 `${this.composerEventPrefix}:replace-text`,
                 placeholder,
                 ""
               );
-            });
+            }
           }
+
+          this.set("userCancelled", false);
+          this._reset();
+
+          this.appEvents.trigger(
+            `${this.composerEventPrefix}:uploads-cancelled`
+          );
         }
-
-        this.set("userCancelled", false);
-        this._reset();
-
-        this.appEvents.trigger(`${this.composerEventPrefix}:uploads-cancelled`);
-      }
+      });
     });
 
     this._setupPreProcessors();

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -426,7 +426,6 @@ en:
     uploading: "Uploading…"
     processing: "Processing…"
     uploading_filename: "Uploading: %{filename}…"
-    processing_filename: "Processing: %{filename}…"
     clipboard: "clipboard"
     uploaded: "Uploaded!"
 


### PR DESCRIPTION
Just use a the single "Uploading…" placeholder. End user doesn't benefit much from knowing at what point in the processing pipeline their upload is. 😃

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
