### PR TITLE
FIX: display error when moving post fails

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
@@ -3,6 +3,8 @@
   @title={{i18n "topic.move_to.title"}}
   @closeModal={{@closeModal}}
   class="choose-topic-modal"
+  @flash={{this.flash}}
+  @flashType="error"
 >
   <:body>
     {{#if @model.topic.isPrivateMessage}}

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
@@ -19,6 +19,7 @@ export default class MoveToTopic extends Component {
   @tracked chronologicalOrder = false;
   @tracked selection = "new_topic";
   @tracked selectedTopicId;
+  @tracked flash;
 
   constructor() {
     super(...arguments);

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -9,6 +9,13 @@ import { test } from "qunit";
 
 acceptance("Topic move posts", function (needs) {
   needs.user();
+  needs.pretender((server, helper) => {
+    server.post("/t/280/move-posts", () => {
+      return helper.response(404, {
+        errors: ["Invalid title"],
+      });
+    });
+  });
 
   test("default", async function (assert) {
     await visit("/t/internationalization-localization");
@@ -50,6 +57,20 @@ acceptance("Topic move posts", function (needs) {
         I18n.t("topic.move_to_new_message.radio_label")
       ),
       "it shows an option to move to new message"
+    );
+  });
+
+  test("display error when new topic has invalid title", async function (assert) {
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-multi-select .btn");
+    await click("#post_11 .select-below");
+    await click(".selected-posts .move-to-topic");
+    await fillIn(".choose-topic-modal #split-topic-name", "Existing topic");
+    await click(".choose-topic-modal .modal-footer .btn-primary");
+    assert.strictEqual(
+      query("#modal-alert").innerText.trim(),
+      I18n.t("topic.move_to.error")
     );
   });
 


### PR DESCRIPTION
This fix ensures that an error modal is displayed when a post is moved to a new topic that has an invalid title.

<img width="639" alt="Screenshot 2023-10-10 at 11 16 21 am" src="https://github.com/discourse/discourse/assets/72780/faa03b77-c0df-48b3-96e2-9e016fee2cd5">

