### PR TITLE
FIX: Update upload security on post rebake from UI

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -647,7 +647,11 @@ class PostsController < ApplicationController
     guardian.ensure_can_rebake!
 
     post = find_post_from_params
-    post.rebake!(invalidate_oneboxes: true, invalidate_broken_images: true)
+    post.rebake!(
+      invalidate_oneboxes: true,
+      invalidate_broken_images: true,
+      update_upload_security: true,
+    )
 
     render body: nil
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -748,7 +748,12 @@ class Post < ActiveRecord::Base
     problems
   end
 
-  def rebake!(invalidate_broken_images: false, invalidate_oneboxes: false, priority: nil)
+  def rebake!(
+    invalidate_broken_images: false,
+    invalidate_oneboxes: false,
+    priority: nil,
+    update_upload_security: false
+  )
     new_cooked = cook(raw, topic_id: topic_id, invalidate_oneboxes: invalidate_oneboxes)
     old_cooked = cooked
 
@@ -764,6 +769,10 @@ class Post < ActiveRecord::Base
     # Extracts urls from the body
     TopicLink.extract_from(self)
     QuotedPost.extract_from(self)
+
+    # Settings may have changed before rebake, so any uploads linked to the post
+    # should have their secure status reexamined.
+    update_uploads_secure_status(source: "post rebake") if update_upload_security
 
     # make sure we trigger the post process
     trigger_post_process(bypass_bump: true, priority: priority)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1392,6 +1392,37 @@ RSpec.describe Post do
     ensure
       InlineOneboxer.invalidate("http://testonebox.com/vvf22")
     end
+
+    context "when secure uploads are enabled" do
+      before do
+        setup_s3
+        SiteSetting.secure_uploads = true
+      end
+
+      it "does not enqueue job to update secure status by default" do
+        post = create_post
+        expect_not_enqueued_with(
+          job: :update_post_uploads_secure_status,
+          args: {
+            post_id: post.id,
+            source: "post rebake",
+          },
+        ) { post.rebake! }
+      end
+
+      context "when passing update_upload_security: true option" do
+        it "does enqueue job to update secure status" do
+          post = create_post
+          expect_enqueued_with(
+            job: :update_post_uploads_secure_status,
+            args: {
+              post_id: post.id,
+              source: "post rebake",
+            },
+          ) { post.rebake!(update_upload_security: true) }
+        end
+      end
+    end
   end
 
   describe "#set_owner" do


### PR DESCRIPTION
When a user creates or edits a post, we already were updating
the security of uploads in the post based on site settings and
their access control post, which is important since these uploads
may be switched from secure/not secure based on configuration.
The `with_secure_uploads?` method on a post is used to determine
whether to use the secure-uploads URL for all uploads in the post,
regardless of their individual security, so if this is false and
some of the posts are still secure when rebaking, we end up with
broken URLs.

This commit just makes it so rebaking via the UI also re-evaluates
upload security so that when the post is loaded again after processing,
all of the uploads have the correct security.
