### PR TITLE
UX: place (edited) on same line

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
@@ -28,5 +28,8 @@
         {{cooked.body}}
       {{/if}}
     {{/each}}
+    {{#if @isEdited}}
+      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+    {{/if}}
   {{/if}}
 </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
@@ -1,6 +1,9 @@
 <div class="chat-message-collapser">
   {{#if this.hasUploads}}
     {{html-safe @cooked}}
+    {{#if @isEdited}}
+      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+    {{/if}}
 
     <Collapser @header={{this.uploadsHeader}} @onToggle={{@onToggleCollapse}}>
       <div class="chat-uploads">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-text.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-text.hbs
@@ -4,14 +4,13 @@
       @cooked={{@cooked}}
       @uploads={{@uploads}}
       @onToggleCollapse={{@onToggleCollapse}}
+      @isEdited={{this.isEdited}}
     />
   {{else}}
     {{html-safe @cooked}}
+    {{#if this.isEdited}}
+      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+    {{/if}}
   {{/if}}
-
-  {{#if this.isEdited}}
-    <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
-  {{/if}}
-
   {{yield}}
 </div>

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -60,6 +60,10 @@
     min-width: 0;
     width: 100%;
 
+    p {
+      display: inline-block;
+    }
+
     code {
       box-sizing: border-box;
       font-size: var(--font-down-1);


### PR DESCRIPTION
Checked simple text, text + link, text + image.
Onebox en video have to remain as is

<img width="1080" alt="image" src="https://github.com/discourse/discourse/assets/101828855/26dbbf52-1bc7-4e0f-9757-a5f3cadb3092">

