### PR TITLE
DEV: Update admin-plugins-chat queryParams definition

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/controllers/admin-plugins-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/admin-plugins-chat.js
@@ -8,7 +8,11 @@ import { inject as service } from "@ember/service";
 
 export default class AdminPluginsChatController extends Controller {
   @service dialog;
-  queryParams = { selectedWebhookId: "id" };
+  queryParams = [
+    {
+      selectedWebhookId: "id",
+    },
+  ];
 
   loading = false;
   creatingNew = false;


### PR DESCRIPTION
Controller queryParam configuration should be wrapped in an array. Omitting the array wrapper seems to work under Ember 3.28, but causes an error under Ember 5.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
