### PR TITLE
DEV: actually test the primary build on Firefox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -265,10 +265,10 @@ jobs:
         embroider: ["1", "0"]
         browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
         exclude:
-          # Testing Embroider on one browser is good enough for now
-          - embroider: "1"
+          # Testing the classic build on one browser is good enough
+          - embroider: "0"
             browser: Firefox ESR
-          - embroider: "1"
+          - embroider: "0"
             browser: Firefox Evergreen
 
     env:


### PR DESCRIPTION
Previously, classic was the default so we opted to test Embroider only on Chrome. Now that Embroider is the default, we should flip this around.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
