### PR TITLE
DEV: convert I18n pseudo package into real package (discourse-i18n) – a less ambitious alternative, for now

### DIFF
--- a/app/assets/javascripts/discourse-i18n/addon-main.cjs
+++ b/app/assets/javascripts/discourse-i18n/addon-main.cjs
@@ -1,0 +1,4 @@
+"use strict";
+
+const { addonV1Shim } = require("@embroider/addon-shim");
+module.exports = addonV1Shim(__dirname);

--- a/app/assets/javascripts/discourse-i18n/package.json
+++ b/app/assets/javascripts/discourse-i18n/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "discourse-i18n",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Discourse's i18n",
+  "author": "Discourse <team@discourse.org>",
+  "license": "GPL-2.0-only",
+  "keywords": [
+    "ember-addon"
+  ],
+  "exports": {
+    ".": "./src/index.js",
+    "./addon-main.js": "./addon-main.cjs"
+  },
+  "files": [
+    "addon-main.cjs",
+    "src"
+  ],
+  "dependencies": {
+    "@embroider/addon-shim": "^1.0.0"
+  },
+  "engines": {
+    "node": "16.* || >= 18",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.21.1"
+  },
+  "ember": {
+    "edition": "octane"
+  },
+  "ember-addon": {
+    "version": 2,
+    "type": "addon",
+    "main": "addon-main.cjs",
+    "app-js": {}
+  }
+}

--- a/app/assets/javascripts/discourse-i18n/src/index.js
+++ b/app/assets/javascripts/discourse-i18n/src/index.js
@@ -1,0 +1,9 @@
+// Eventually, we would like to flip things around, where this package hosts
+// the actual I18n code, see https://github.com/discourse/discourse/pull/23867
+
+if (!"I18n" in globalThis) {
+  throw new Error("I18n not loaded!");
+}
+
+// Re-export a default/global instance
+export default globalThis.I18n;

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -58,6 +58,7 @@ module.exports = function (defaults) {
     autoImport: {
       forbidEval: true,
       insertScriptsAt: "ember-auto-import-scripts",
+      watchDependencies: ["discourse-i18n"],
       webpack: {
         // Workarounds for https://github.com/ef4/ember-auto-import/issues/519 and https://github.com/ef4/ember-auto-import/issues/478
         devtool: isProduction ? false : "source-map", // Sourcemaps contain reference to the ephemeral broccoli cache dir, which changes on every deploy
@@ -198,6 +199,13 @@ module.exports = function (defaults) {
     packagerOptions: {
       webpackConfig: {
         devtool: "source-map",
+        resolve: {
+          alias: {
+            // This is a build-time alias is for code in core only – plugins
+            // and legacy bundles go through the runtime loader.js shim
+            I18n: "discourse-i18n",
+          },
+        },
         externals: [
           function ({ request }, callback) {
             if (

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -62,6 +62,7 @@
     "deprecation-silencer": "1.0.0",
     "dialog-holder": "1.0.0",
     "discourse-common": "1.0.0",
+    "discourse-i18n": "1.0.0",
     "discourse-plugins": "1.0.0",
     "ember-auto-import": "^2.6.3",
     "ember-buffered-proxy": "^2.1.1",

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -11,6 +11,7 @@
     "discourse",
     "discourse-common",
     "discourse-hbr",
+    "discourse-i18n",
     "discourse-plugins",
     "discourse-widget-hbs",
     "ember-cli-progress-ci",


### PR DESCRIPTION
A less ambitious version of #23867. It gets the job done to unblock depending on I18n in v2 packages, but doesn't solve nor introduce other problems, and can be readily merged with little consequences.

If we merge this for the time being, we should still eventually aim to flip things around, i.e. finish the job on #23867.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
