### PR TITLE
UX: Correct description on 'create topic' composer dropdown

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -225,9 +225,7 @@ export default DropdownSelectBoxComponent.extend({
     if (items.length === 0) {
       items.push({
         name: I18n.t("composer.composer_actions.create_topic.label"),
-        description: I18n.t(
-          "composer.composer_actions.reply_as_new_topic.desc"
-        ),
+        description: I18n.t("composer.composer_actions.create_topic.desc"),
         icon: "share",
         id: "create_topic",
       });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2496,6 +2496,7 @@ en:
           desc: Whispers are only visible to staff members
         create_topic:
           label: "New Topic"
+          desc: Create a new topic
         shared_draft:
           label: "Shared Draft"
           desc: "Draft a topic that will only be visible to allowed users"


### PR DESCRIPTION
The 'create topic' entry in the dropdown was incorrectly using the 'reply as new topic' description. This fixes the logic to use a separate locale key for the description.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
