### PR TITLE
DEV: Add new chat metrics

### DIFF
--- a/plugins/chat/lib/chat/statistics.rb
+++ b/plugins/chat/lib/chat/statistics.rb
@@ -48,6 +48,7 @@ module Chat
       {
         :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
         "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
         "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
         :count => query.count,
       }
@@ -60,6 +61,7 @@ module Chat
       {
         :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
         "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
         "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
         :count => query.count,
       }
@@ -68,7 +70,7 @@ module Chat
     def self.open_channels_with_threads_enabled
       query = Chat::Channel.where(threading_enabled: true, status: :open)
 
-      { :last_day => 0, "7_days" => 0, "30_days" => 0, :count => query.count }
+      { :last_day => 0, "7_days" => 0, "28_days": 0, "30_days" => 0, :count => query.count }
     end
 
     def self.threaded_messages
@@ -77,6 +79,7 @@ module Chat
       {
         :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
         "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
         "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
         :count => query.count,
       }

--- a/plugins/chat/lib/chat/statistics.rb
+++ b/plugins/chat/lib/chat/statistics.rb
@@ -46,11 +46,11 @@ module Chat
         Chat::Message.joins(:chat_channel).where.not(chat_channel: { type: "DirectMessageChannel" })
 
       {
-        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
-        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
-        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
-        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
-        :count => query.count,
+        last_day: query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days": query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days": query.where("chat_messages.created_at > ?", 28.days.ago).count,
+        "30_days": query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        count: query.count,
       }
     end
 
@@ -59,29 +59,29 @@ module Chat
         Chat::Message.joins(:chat_channel).where(chat_channel: { type: "DirectMessageChannel" })
 
       {
-        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
-        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
-        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
-        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
-        :count => query.count,
+        last_day: query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days": query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days": query.where("chat_messages.created_at > ?", 28.days.ago).count,
+        "30_days": query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        count: query.count,
       }
     end
 
     def self.open_channels_with_threads_enabled
       query = Chat::Channel.where(threading_enabled: true, status: :open)
 
-      { :last_day => 0, "7_days" => 0, "28_days": 0, "30_days" => 0, :count => query.count }
+      { last_day: 0, "7_days": 0, "28_days": 0, "30_days": 0, count: query.count }
     end
 
     def self.threaded_messages
       query = Chat::Message.where.not(thread: nil)
 
       {
-        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
-        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
-        "28_days" => query.where("chat_messages.created_at > ?", 28.days.ago).count,
-        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
-        :count => query.count,
+        last_day: query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days": query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "28_days": query.where("chat_messages.created_at > ?", 28.days.ago).count,
+        "30_days": query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        count: query.count,
       }
     end
 

--- a/plugins/chat/lib/chat/statistics.rb
+++ b/plugins/chat/lib/chat/statistics.rb
@@ -41,6 +41,47 @@ module Chat
       }
     end
 
+    def self.channel_messages
+      query =
+        Chat::Message.joins(:chat_channel).where.not(chat_channel: { type: "DirectMessageChannel" })
+
+      {
+        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        :count => query.count,
+      }
+    end
+
+    def self.direct_messages
+      query =
+        Chat::Message.joins(:chat_channel).where(chat_channel: { type: "DirectMessageChannel" })
+
+      {
+        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        :count => query.count,
+      }
+    end
+
+    def self.open_channels_with_threads_enabled
+      query = Chat::Channel.where(threading_enabled: true, status: :open)
+
+      { :last_day => 0, "7_days" => 0, "30_days" => 0, :count => query.count }
+    end
+
+    def self.threaded_messages
+      query = Chat::Message.where.not(thread: nil)
+
+      {
+        :last_day => query.where("chat_messages.created_at > ?", 1.days.ago).count,
+        "7_days" => query.where("chat_messages.created_at > ?", 7.days.ago).count,
+        "30_days" => query.where("chat_messages.created_at > ?", 30.days.ago).count,
+        :count => query.count,
+      }
+    end
+
     def self.monthly
       start_of_month = Time.zone.now.beginning_of_month
       {

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -489,10 +489,15 @@ after_initialize do
   register_stat("chat_messages", show_in_ui: true, expose_via_api: true) do
     Chat::Statistics.about_messages
   end
-
+  register_stat("chat_users", expose_via_api: true) { Chat::Statistics.about_users }
   register_stat("chat_channels", expose_via_api: true) { Chat::Statistics.about_channels }
 
-  register_stat("chat_users", expose_via_api: true) { Chat::Statistics.about_users }
+  register_stat("chat_channel_messages") { Chat::Statistics.channel_messages }
+  register_stat("chat_direct_messages") { Chat::Statistics.direct_messages }
+  register_stat("chat_open_channels_with_threads_enabled") do
+    Chat::Statistics.open_channels_with_threads_enabled
+  end
+  register_stat("chat_threaded_messages") { Chat::Statistics.threaded_messages }
 
   # Make sure to update spec/system/hashtag_autocomplete_spec.rb when changing this.
   register_hashtag_data_source(Chat::ChannelHashtagDataSource)

--- a/plugins/chat/spec/lib/chat/statistics_spec.rb
+++ b/plugins/chat/spec/lib/chat/statistics_spec.rb
@@ -131,8 +131,8 @@ describe Chat::Statistics do
     fab!(:message3) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 5.days) }
     fab!(:message4) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 10.days) }
     fab!(:message5) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 12.days) }
-    fab!(:message6) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 20.days) }
-    fab!(:message7) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 21.days) }
+    fab!(:message6) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 27.days) }
+    fab!(:message7) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 29.days) }
     fab!(:message8) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 30.days) }
     fab!(:message9) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 40.days) }
     fab!(:message10) do
@@ -161,6 +161,7 @@ describe Chat::Statistics do
       channel_messages = described_class.channel_messages
       expect(channel_messages[:last_day]).to eq(1)
       expect(channel_messages["7_days"]).to eq(3)
+      expect(channel_messages["28_days"]).to eq(6)
       expect(channel_messages["30_days"]).to eq(7)
       expect(channel_messages[:count]).to eq(10)
     end
@@ -189,10 +190,10 @@ describe Chat::Statistics do
       Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 12.days)
     end
     fab!(:message6) do
-      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 20.days)
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 27.days)
     end
     fab!(:message7) do
-      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 21.days)
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 29.days)
     end
     fab!(:message8) do
       Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 30.days)
@@ -226,6 +227,7 @@ describe Chat::Statistics do
       direct_messages = described_class.direct_messages
       expect(direct_messages[:last_day]).to eq(1)
       expect(direct_messages["7_days"]).to eq(3)
+      expect(direct_messages["28_days"]).to eq(6)
       expect(direct_messages["30_days"]).to eq(7)
       expect(direct_messages[:count]).to eq(10)
     end
@@ -278,10 +280,10 @@ describe Chat::Statistics do
       Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 12.days)
     end
     fab!(:threaded_message6) do
-      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 20.days)
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 27.days)
     end
     fab!(:threaded_message7) do
-      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 21.days)
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 29.days)
     end
     fab!(:threaded_message8) do
       Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 30.days)
@@ -329,6 +331,7 @@ describe Chat::Statistics do
       threaded_messages = described_class.threaded_messages
       expect(threaded_messages[:last_day]).to eq(3)
       expect(threaded_messages["7_days"]).to eq(5)
+      expect(threaded_messages["28_days"]).to eq(8)
       expect(threaded_messages["30_days"]).to eq(9)
       expect(threaded_messages[:count]).to eq(12)
     end

--- a/plugins/chat/spec/lib/chat/statistics_spec.rb
+++ b/plugins/chat/spec/lib/chat/statistics_spec.rb
@@ -160,9 +160,9 @@ describe Chat::Statistics do
     it "counts messages count accurately" do
       channel_messages = described_class.channel_messages
       expect(channel_messages[:last_day]).to eq(1)
-      expect(channel_messages["7_days"]).to eq(3)
-      expect(channel_messages["28_days"]).to eq(6)
-      expect(channel_messages["30_days"]).to eq(7)
+      expect(channel_messages[:"7_days"]).to eq(3)
+      expect(channel_messages[:"28_days"]).to eq(6)
+      expect(channel_messages[:"30_days"]).to eq(7)
       expect(channel_messages[:count]).to eq(10)
     end
   end
@@ -226,9 +226,9 @@ describe Chat::Statistics do
     it "counts messages count accurately" do
       direct_messages = described_class.direct_messages
       expect(direct_messages[:last_day]).to eq(1)
-      expect(direct_messages["7_days"]).to eq(3)
-      expect(direct_messages["28_days"]).to eq(6)
-      expect(direct_messages["30_days"]).to eq(7)
+      expect(direct_messages[:"7_days"]).to eq(3)
+      expect(direct_messages[:"28_days"]).to eq(6)
+      expect(direct_messages[:"30_days"]).to eq(7)
       expect(direct_messages[:count]).to eq(10)
     end
   end
@@ -330,9 +330,9 @@ describe Chat::Statistics do
     it "counts messages count accurately" do
       threaded_messages = described_class.threaded_messages
       expect(threaded_messages[:last_day]).to eq(3)
-      expect(threaded_messages["7_days"]).to eq(5)
-      expect(threaded_messages["28_days"]).to eq(8)
-      expect(threaded_messages["30_days"]).to eq(9)
+      expect(threaded_messages[:"7_days"]).to eq(5)
+      expect(threaded_messages[:"28_days"]).to eq(8)
+      expect(threaded_messages[:"30_days"]).to eq(9)
       expect(threaded_messages[:count]).to eq(12)
     end
   end

--- a/plugins/chat/spec/lib/chat/statistics_spec.rb
+++ b/plugins/chat/spec/lib/chat/statistics_spec.rb
@@ -117,3 +117,220 @@ describe Chat::Statistics do
     end
   end
 end
+
+describe Chat::Statistics do
+  describe "#channel_messages" do
+    now = Time.now
+
+    fab!(:channel_1) { Fabricate(:chat_channel, status: :open) }
+    fab!(:channel_2) { Fabricate(:chat_channel, status: :closed) }
+    fab!(:channel_3) { Fabricate(:chat_channel, status: :archived) }
+
+    fab!(:message1) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 1.hour) }
+    fab!(:message2) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 3.days) }
+    fab!(:message3) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 5.days) }
+    fab!(:message4) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 10.days) }
+    fab!(:message5) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 12.days) }
+    fab!(:message6) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 20.days) }
+    fab!(:message7) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 21.days) }
+    fab!(:message8) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 30.days) }
+    fab!(:message9) { Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 40.days) }
+    fab!(:message10) do
+      Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 50.days)
+    end
+
+    fab!(:dm_channel_1) { Fabricate(:direct_message_channel) }
+    fab!(:dm_channel_2) { Fabricate(:direct_message_channel) }
+    fab!(:dm_channel_3) { Fabricate(:direct_message_channel) }
+
+    # these DM channel messages should be ignored when counting:
+    fab!(:dm_message1) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 1.hour)
+    end
+    fab!(:dm_message2) do
+      Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 3.days)
+    end
+    fab!(:dm_message3) do
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 20.days)
+    end
+    fab!(:dm_message4) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 50.days)
+    end
+
+    it "counts messages count accurately" do
+      channel_messages = described_class.channel_messages
+      expect(channel_messages[:last_day]).to eq(1)
+      expect(channel_messages["7_days"]).to eq(3)
+      expect(channel_messages["30_days"]).to eq(7)
+      expect(channel_messages[:count]).to eq(10)
+    end
+  end
+
+  describe "#direct_messages" do
+    now = Time.now
+
+    fab!(:dm_channel_1) { Fabricate(:direct_message_channel, status: :open) }
+    fab!(:dm_channel_2) { Fabricate(:direct_message_channel, status: :closed) }
+    fab!(:dm_channel_3) { Fabricate(:direct_message_channel, status: :archived) }
+
+    fab!(:message1) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 1.hour)
+    end
+    fab!(:message2) do
+      Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 3.days)
+    end
+    fab!(:message3) do
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 5.days)
+    end
+    fab!(:message4) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 10.days)
+    end
+    fab!(:message5) do
+      Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 12.days)
+    end
+    fab!(:message6) do
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 20.days)
+    end
+    fab!(:message7) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 21.days)
+    end
+    fab!(:message8) do
+      Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 30.days)
+    end
+    fab!(:message9) do
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 40.days)
+    end
+    fab!(:message10) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 50.days)
+    end
+
+    # these non DM channel messages should be ignored when counting:
+    fab!(:channel_1) { Fabricate(:chat_channel, status: :open) }
+    fab!(:channel_2) { Fabricate(:chat_channel, status: :closed) }
+    fab!(:channel_3) { Fabricate(:chat_channel, status: :archived) }
+
+    fab!(:dm_message1) do
+      Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 1.hour)
+    end
+    fab!(:dm_message2) do
+      Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 3.days)
+    end
+    fab!(:dm_message3) do
+      Fabricate(:chat_message, chat_channel: channel_3, created_at: now - 20.days)
+    end
+    fab!(:dm_message4) do
+      Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 50.days)
+    end
+
+    it "counts messages count accurately" do
+      direct_messages = described_class.direct_messages
+      expect(direct_messages[:last_day]).to eq(1)
+      expect(direct_messages["7_days"]).to eq(3)
+      expect(direct_messages["30_days"]).to eq(7)
+      expect(direct_messages[:count]).to eq(10)
+    end
+  end
+
+  describe "#open_channels_with_threads_enabled" do
+    fab!(:open_channel_with_threads_enabled_1) do
+      Fabricate(:chat_channel, threading_enabled: true, status: :open)
+    end
+    fab!(:open_channel_with_threads_enabled_2) do
+      Fabricate(:chat_channel, threading_enabled: true, status: :open)
+    end
+
+    fab!(:channel3) { Fabricate(:chat_channel, threading_enabled: true, status: :closed) }
+    fab!(:channel4) { Fabricate(:chat_channel, threading_enabled: true, status: :archived) }
+    fab!(:channel5) { Fabricate(:chat_channel, threading_enabled: false, status: :open) }
+    fab!(:channel6) { Fabricate(:chat_channel, threading_enabled: false, status: :closed) }
+    fab!(:channel7) { Fabricate(:chat_channel, threading_enabled: false, status: :archived) }
+
+    it "counts channels count accurately" do
+      channels = described_class.open_channels_with_threads_enabled
+      expect(channels[:count]).to eq(2)
+    end
+  end
+
+  describe "#threaded_messages" do
+    now = Time.now
+
+    fab!(:channel_1) { Fabricate(:chat_channel, status: :open) }
+    fab!(:channel_2) { Fabricate(:chat_channel, status: :closed) }
+
+    # note that fabricating a thread also fabricates the first message in that thread
+    # so these two threads add up 2 messages
+    fab!(:thread_1) { Fabricate(:chat_thread, channel: channel_1) }
+    fab!(:thread_2) { Fabricate(:chat_thread, channel: channel_2) }
+
+    fab!(:threaded_message1) do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 1.hour)
+    end
+    fab!(:threaded_message2) do
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 3.days)
+    end
+    fab!(:threaded_message3) do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 5.days)
+    end
+    fab!(:threaded_message4) do
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 10.days)
+    end
+    fab!(:threaded_message5) do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 12.days)
+    end
+    fab!(:threaded_message6) do
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 20.days)
+    end
+    fab!(:threaded_message7) do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 21.days)
+    end
+    fab!(:threaded_message8) do
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 30.days)
+    end
+    fab!(:threaded_message9) do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1, created_at: now - 40.days)
+    end
+    fab!(:threaded_message10) do
+      Fabricate(:chat_message, chat_channel: channel_2, thread: thread_2, created_at: now - 50.days)
+    end
+
+    # these messages are not in a thread, so they should be ignored when counting:
+    fab!(:message1) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 1.hour) }
+    fab!(:message2) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 3.days) }
+    fab!(:message3) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 5.days) }
+    fab!(:message4) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 10.days) }
+    fab!(:message5) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 12.days) }
+    fab!(:message6) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 20.days) }
+    fab!(:message7) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 21.days) }
+    fab!(:message8) { Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 30.days) }
+    fab!(:message9) { Fabricate(:chat_message, chat_channel: channel_1, created_at: now - 40.days) }
+    fab!(:message10) do
+      Fabricate(:chat_message, chat_channel: channel_2, created_at: now - 50.days)
+    end
+
+    fab!(:dm_channel_1) { Fabricate(:direct_message_channel) }
+    fab!(:dm_channel_2) { Fabricate(:direct_message_channel) }
+    fab!(:dm_channel_3) { Fabricate(:direct_message_channel) }
+
+    # these DM channel messages should be ignored when counting:
+    fab!(:dm_message1) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 1.hour)
+    end
+    fab!(:dm_message2) do
+      Fabricate(:chat_message, chat_channel: dm_channel_2, created_at: now - 3.days)
+    end
+    fab!(:dm_message3) do
+      Fabricate(:chat_message, chat_channel: dm_channel_3, created_at: now - 20.days)
+    end
+    fab!(:dm_message4) do
+      Fabricate(:chat_message, chat_channel: dm_channel_1, created_at: now - 50.days)
+    end
+
+    it "counts messages count accurately" do
+      threaded_messages = described_class.threaded_messages
+      expect(threaded_messages[:last_day]).to eq(3)
+      expect(threaded_messages["7_days"]).to eq(5)
+      expect(threaded_messages["30_days"]).to eq(9)
+      expect(threaded_messages[:count]).to eq(12)
+    end
+  end
+end


### PR DESCRIPTION
This adds the following chat metrics:

- _chat_open_channels_with_threads_enabled_ — a count of open channels where threading is enabled.
- _chat_channel_messages_ — a count of messages sent in a chat channel (i.e. not a personal chat / direct message), within a thread or outside of a thread.
- _chat_threaded_messages_ — a count of messages sent within a thread in a chat channel (i.e. not a personal chat / direct messages).
- _chat_direct_messages_ — a count of messages sent in a personal chat / direct messages.

The metrics added using the plugin API introduced in 098ab29d, and extended in d91456fd.

Note that these stats won't be exposed at the `about.json` and the `site/statistics.json` routes.