### PR TITLE
FIX: Disable overflow-anchor on composer textarea

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -86,6 +86,7 @@
   height: 100%;
   overflow-x: hidden;
   overscroll-behavior: contain;
+  overflow-anchor: none;
   resize: none;
 }
 


### PR DESCRIPTION
This fixes an issue where, on a textarea with a lot of text, the cursor would jump when adding a new line. 

This is a Chrome bug with scroll anchoring.

Refs: https://bugs.chromium.org/p/chromium/issues/detail?id=997266

The fix here disables `overflow-anchor` on the composer textarea. There should be no side effects to this change, as scroll anchoring is likely not needed for the composer textarea element.


https://github.com/discourse/discourse/assets/368961/cbd685e1-88d4-4db2-bc5f-4dcad39237f0

