### PR TITLE
DEV: Support components under /index paths in themes/plugins

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -147,7 +147,14 @@ function lookupModuleBySuffix(suffix) {
       }
     });
   }
-  return moduleSuffixTrie.withSuffix(suffix, 1)[0];
+  return (
+    moduleSuffixTrie.withSuffix(suffix, 1)[0] ||
+    moduleSuffixTrie.withSuffix(`${suffix}/index`, 1)[0]
+  );
+}
+
+export function expireModuleTrieCache() {
+  moduleSuffixTrie = null;
 }
 
 export function buildResolver(baseName) {

--- a/app/assets/javascripts/discourse/tests/helpers/temporary-module-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/temporary-module-helper.js
@@ -1,5 +1,6 @@
 import DiscourseTemplateMap from "discourse-common/lib/discourse-template-map";
 import { expireConnectorCache } from "discourse/lib/plugin-connectors";
+import { expireModuleTrieCache } from "discourse-common/resolver";
 
 const modifications = [];
 
@@ -21,6 +22,7 @@ export function registerTemporaryModule(moduleName, defaultExport) {
   define(moduleName, ["exports"], generateTemporaryModule(defaultExport));
   modifications.push(modificationData);
   expireConnectorCache();
+  expireModuleTrieCache();
   DiscourseTemplateMap.setModuleNames(Object.keys(requirejs.entries));
 }
 

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -12,6 +12,10 @@ function lookupTemplate(assert, name, expectedTemplate, message) {
   assert.strictEqual(result, expectedTemplate, message);
 }
 
+function resolve(name) {
+  return resolver.resolve(name);
+}
+
 function setTemplates(templateModuleNames) {
   for (const name of templateModuleNames) {
     registerTemporaryModule(name, name);
@@ -681,6 +685,23 @@ module("Unit | Ember | resolver", function (hooks) {
       "template:components/bar",
       "discourse/templates/components/bar",
       "uses standard match when both exist"
+    );
+  });
+
+  test("resolves plugin/theme components with and without /index", function (assert) {
+    registerTemporaryModule(
+      "discourse/plugins/my-fake-plugin/discourse/components/my-component",
+      "my-component"
+    );
+    registerTemporaryModule(
+      "discourse/plugins/my-fake-plugin/discourse/components/my-second-component/index",
+      "my-second-component"
+    );
+
+    assert.strictEqual(resolve("component:my-component"), "my-component");
+    assert.strictEqual(
+      resolve("component:my-second-component"),
+      "my-second-component"
     );
   });
 });


### PR DESCRIPTION
Normally, modules defined under `blah/index` can be imported as `blah`. This is also true of Ember resolver lookups - `<MyComponent />` should resolve to the same as `<MyComponent::Index />`. This was working as expected in Discourse core, but we had not implemented the same in our custom resolver logic for themes/plugins.

This commit implements the `/index` fallback, and adds a test for the behaviour.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
