### PR TITLE
A11Y: remove positive tabindex from create modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/login-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.hbs
@@ -4,7 +4,6 @@
     class="btn btn-social {{b.name}}"
     {{on "click" (action this.externalLogin b)}}
     aria-label={{b.screenReaderTitle}}
-    tabindex="3"
   >
     {{#if b.isGoogle}}
       <GoogleIcon />


### PR DESCRIPTION
The positive tabindex on these third-party auth buttons means that screenreader users have to tab through the entire form, then the browser chrome, to get to them. This makes them very hard to find. Tested on Firefox and Chrome. 