### PR TITLE
A11Y: move new account disclaimer above buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -244,6 +244,10 @@
           </div>
 
           <div class="modal-footer">
+            <div class="disclaimer">
+              {{html-safe this.disclaimerHtml}}
+            </div>
+
             <DButton
               @action={{action "createAccount"}}
               @disabled={{this.submitDisabled}}
@@ -262,9 +266,6 @@
               />
             {{/unless}}
 
-            <div class="disclaimer">
-              {{html-safe this.disclaimerHtml}}
-            </div>
           </div>
 
           <PluginOutlet

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -287,7 +287,7 @@ body.invite-page {
 .create-account {
   .disclaimer {
     color: var(--primary-medium);
-    margin-top: 0.5em;
+    margin-bottom: 0.5em;
   }
 
   @media screen and (min-width: 701px) {


### PR DESCRIPTION
When the disclaimer is positioned below the create your account button, a screenreader user can complete the account creation process without being made aware of its existence. Moving it ensures that's it's accessible to all. 

Before:
![Screenshot 2023-10-10 at 5 00 50 PM](https://github.com/discourse/discourse/assets/1681963/c29cab11-a732-447b-9397-bcd557d479f7)


After:
![Screenshot 2023-10-10 at 4 58 47 PM](https://github.com/discourse/discourse/assets/1681963/81bc1acd-aa63-4720-8ff9-4521f13d6934)
