### PR TITLE
DEV: Add meaningful class to the metadata section in topic-list-item

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
@@ -9,7 +9,7 @@
     <a href="{{topic.lastPostUrl}}" aria-label="{{i18n 'latest_poster_link' username=topic.lastPosterUser.username}}" data-user-card="{{topic.lastPosterUser.username}}">{{avatar topic.lastPosterUser imageSize="large"}}</a>
     {{/if}}
   </div>
-  <div class='right'>
+  <div class='topic-item-metadata right'>
     {{!--
       The `~` syntax strip spaces between the elements, making it produce
       `<a class=topic-post-badges>Some text</a><span class=topic-post-badges>`,


### PR DESCRIPTION
Currently, the UI section that contains the title+category+tags of a topic list item (the mobile version) has only one and very generic CSS class, `.right`. Plugins and themes that need to target this section for styling would have to use awkward/very specific CSS selectors in order to avoid incorrectly styling other elements that happen to have the same generic CSS class.

This PR adds an additional class `.topic-item-metadata` to the section to allow easier and more maintainable styling for it.

See https://github.com/discourse/discourse-clickable-topic/pull/4 for a theme that will benefit from this change.