### PR TITLE
FIX: correctly untrack topics when dismiss unread

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-read.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-read.hbs
@@ -8,7 +8,7 @@
       <PreferenceCheckbox
         @labelKey="topics.bulk.also_dismiss_topics"
         @checked={{this.dismissTopics}}
-        class="stop-tracking"
+        class="dismiss-read-modal__stop-tracking"
       />
     </p>
   </:body>

--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-read.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-read.hbs
@@ -8,6 +8,7 @@
       <PreferenceCheckbox
         @labelKey="topics.bulk.also_dismiss_topics"
         @checked={{this.dismissTopics}}
+        class="stop-tracking"
       />
     </p>
   </:body>

--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-read.js
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-read.js
@@ -1,0 +1,6 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+export default class DismissRead extends Component {
+  @tracked dismissTopics = false;
+}

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Dismissing New", type: :system do
   let(:topic_list_controls) { PageObjects::Components::TopicListControls.new }
   let(:topic_list) { PageObjects::Components::TopicList.new }
   let(:dismiss_new_modal) { PageObjects::Modals::DismissNew.new }
+  let(:topic_view) { PageObjects::Components::TopicView.new }
 
   describe "when a user has an unread post" do
     fab!(:topic) { Fabricate(:topic, user: user) }
@@ -32,6 +33,24 @@ RSpec.describe "Dismissing New", type: :system do
       expect(topic_list_controls).to have_unread(count: 0)
 
       using_session(:tab_1) { expect(topic_list_controls).to have_unread(count: 0) }
+    end
+
+    it "should untrack topics across sessions after the user dismisses it" do
+      sign_in(user)
+
+      visit("/unread")
+
+      using_session(:tab_1) do
+        sign_in(user)
+
+        visit("/t/#{topic.id}")
+
+        expect(topic_view).to have_tracking_status("tracking")
+      end
+
+      topic_list_controls.dismiss_unread(untrack: true)
+
+      using_session(:tab_1) { expect(topic_view).to have_tracking_status("regular") }
     end
   end
 

--- a/spec/system/page_objects/components/topic_list_controls.rb
+++ b/spec/system/page_objects/components/topic_list_controls.rb
@@ -25,8 +25,9 @@ module PageObjects
         has_css?(".nav-item_unread", text: text)
       end
 
-      def dismiss_unread
+      def dismiss_unread(untrack: false)
         click_button("dismiss-topics-bottom")
+        find(".stop-tracking").click if untrack
         click_button("dismiss-read-confirm")
         self
       end

--- a/spec/system/page_objects/components/topic_list_controls.rb
+++ b/spec/system/page_objects/components/topic_list_controls.rb
@@ -27,7 +27,7 @@ module PageObjects
 
       def dismiss_unread(untrack: false)
         click_button("dismiss-topics-bottom")
-        find(".stop-tracking").click if untrack
+        find(".dismiss-read-modal__stop-tracking").click if untrack
         click_button("dismiss-read-confirm")
         self
       end

--- a/spec/system/page_objects/components/topic_view.rb
+++ b/spec/system/page_objects/components/topic_view.rb
@@ -12,7 +12,11 @@ module PageObjects
       end
 
       def has_tracking_status?(name)
-        page.has_css?("summary[data-name='#{name}']")
+        select_kit =
+          PageObjects::Components::SelectKit.new(
+            "#topic-footer-buttons .topic-notifications-options",
+          )
+        expect(select_kit).to have_selected_name(name)
       end
     end
   end

--- a/spec/system/page_objects/components/topic_view.rb
+++ b/spec/system/page_objects/components/topic_view.rb
@@ -10,6 +10,10 @@ module PageObjects
           wait: Capybara.default_max_wait_time * 2,
         )
       end
+
+      def has_tracking_status?(name)
+        page.has_css?("summary[data-name='#{name}']")
+      end
     end
   end
 end


### PR DESCRIPTION
Bug introduced when dismiss modal was moved to new component-based API - https://github.com/discourse/discourse/pull/22262

We need to track `dismissTopics` property to send correct request to  server.

Meta: https://meta.discourse.org/t/dismiss-all-unread/280948

Demo

https://github.com/discourse/discourse/assets/72780/6f2881b0-f37d-41c5-bad5-c51c8219274b



