### PR TITLE
FIX: ensures threads list button is not showing

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-full-page-header.js
@@ -14,6 +14,7 @@ export default class ChatFullPageHeader extends Component {
     return (
       this.args.channel.threadingEnabled &&
       this.router.currentRoute.name !== "chat.channel.threads" &&
+      this.router.currentRoute.name !== "chat.channel.thread.index" &&
       this.router.currentRoute.name !== "chat.channel.thread"
     );
   }


### PR DESCRIPTION
We were incorrectly showing it when the the panel is opened.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
