### PR TITLE
DEV: Improve reactivity of user-tips and remove runloop workarounds

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -15,13 +15,15 @@ export default class UserTip extends Component {
   @service tooltip;
 
   registerTip = modifier(() => {
-    this.userTips.addAvailableTip({
+    const tip = {
       id: this.args.id,
       priority: this.args.priority ?? 0,
-    });
+    };
+
+    this.userTips.addAvailableTip(tip);
 
     return () => {
-      this.userTips.removeAvailableTip({ id: this.args.id });
+      this.userTips.removeAvailableTip(tip);
     };
   });
 
@@ -69,7 +71,7 @@ export default class UserTip extends Component {
   });
 
   get shouldRenderTip() {
-    return this.userTips.renderedId === this.args.id;
+    return this.userTips.shouldRender(this.args.id);
   }
 
   <template>


### PR DESCRIPTION
Previously, the `user-tips` service included a couple of calls to `next()`. These were introduced to work around errors like

```
You attempted to update `availableTips` on `<UserTips:ember659>`, but it had already been used previously in the same computation
```

These errors come from the fact that various `<UserTip>` components are rendering at slightly different times in the runloop and stepping on each other. Normally this doesn't happen in Ember, but the implementation details of our 'Widget' system and its 'RenderGlimmer' helper mean that RenderGlimmer components are rendered later than normal Ember components. Using `next()` avoids the problem because it means that all the updates are scheduled together in the following runloop interation.

However, the use of `next()` can create some subtle timing issues, which have been evident in the recent flakiness of some qunit tests. This commit makes a few changes to improve the situation:

1. Use a TrackedMap to provide fine-grained `shouldRender()` reactivity for each user-tip id. That means that different user tips will not be trying to update the same piece of tracked state (previously the entire `availableTips` array was `@tracked`, and was completely re-assigned every time a new `<UserTip>` was rendered

2. Avoid reassigning any tracked state unless the value has actually changed

3. Remove the `next()` workarounds