### PR TITLE
DEV: Resolve and prevent user fixture changes leaking between tests

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/object.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/object.js
@@ -59,3 +59,19 @@ export function deepEqual(obj1, obj2) {
 export function cloneJSON(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
+
+export function deepFreeze(object) {
+  // Retrieve the property names defined on object
+  const propNames = Reflect.ownKeys(object);
+
+  // Freeze properties before freezing self
+  for (const name of propNames) {
+    const value = object[name];
+
+    if ((value && typeof value === "object") || typeof value === "function") {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(object);
+}

--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -1,5 +1,7 @@
+import { deepFreeze } from "discourse-common/lib/object";
+
 export default {
-  "/session/current.json": {
+  "/session/current.json": deepFreeze({
     current_user: {
       id: 19,
       username: "eviltrout",
@@ -133,5 +135,5 @@ export default {
         },
       ]
     },
-  },
+  }),
 };

--- a/app/assets/javascripts/discourse/tests/helpers/notification-types-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/notification-types-helper.js
@@ -2,6 +2,7 @@ import { getRenderDirector } from "discourse/lib/notification-types-manager";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import sessionFixtures from "discourse/tests/fixtures/session-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
 
 export function createRenderDirector(
   notification,
@@ -11,7 +12,9 @@ export function createRenderDirector(
   const director = getRenderDirector(
     notificationType,
     notification,
-    User.create(sessionFixtures["/session/current.json"].current_user),
+    User.create(
+      cloneJSON(sessionFixtures["/session/current.json"].current_user)
+    ),
     siteSettings,
     Site.current()
   );

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -96,7 +96,9 @@ import { _clearSnapshots } from "select-kit/components/composer-actions";
 import { cleanupTemporaryModuleRegistrations } from "./temporary-module-helper";
 
 export function currentUser() {
-  return User.create(sessionFixtures["/session/current.json"].current_user);
+  return User.create(
+    cloneJSON(sessionFixtures["/session/current.json"].current_user)
+  );
 }
 
 let _initialized = new Set();

--- a/app/assets/javascripts/discourse/tests/helpers/reviewable-types-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/reviewable-types-helper.js
@@ -2,12 +2,15 @@ import { getRenderDirector } from "discourse/lib/reviewable-types-manager";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import sessionFixtures from "discourse/tests/fixtures/session-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
 
 export function createRenderDirector(reviewable, reviewableType, siteSettings) {
   const director = getRenderDirector(
     reviewableType,
     reviewable,
-    User.create(sessionFixtures["/session/current.json"].current_user),
+    User.create(
+      cloneJSON(sessionFixtures["/session/current.json"].current_user)
+    ),
     siteSettings,
     Site.current()
   );


### PR DESCRIPTION
- Introduces a `deepFreeze` helper to block any mutations to the current-user fixture

- Add `cloneJSON` to any places which were previously causing mutations

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
