### PR TITLE
DEV: fix setting isTesting

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -2,10 +2,11 @@ import Application from "@ember/application";
 import "./global-compat";
 import "./loader-shims";
 import require from "require";
+import { normalizeEmberEventHandling } from "discourse/lib/ember-events";
 import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-injections";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { isTesting } from "discourse-common/config/environment";
 import { buildResolver } from "discourse-common/resolver";
-import { normalizeEmberEventHandling } from "./lib/ember-events";
 
 const _pluginCallbacks = [];
 let _unhandledThemeErrors = [];
@@ -147,8 +148,6 @@ function loadInitializers(app) {
   }
 
   // Plugins that are registered via `<script>` tags.
-  const { withPluginApi } = require("discourse/lib/plugin-api");
-
   for (let [i, callback] of _pluginCallbacks.entries()) {
     app.instanceInitializer({
       name: `_discourse_plugin_${i}`,

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
@@ -1,1 +1,2 @@
+require("discourse-common/config/environment").setEnvironment("testing");
 require("discourse/tests/test-boot-ember-cli");

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-trigger-ember-cli-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-trigger-ember-cli-boot.js
@@ -1,1 +1,2 @@
+require("discourse-common/config/environment").setEnvironment("testing");
 require("discourse/tests/test-boot-ember-cli");

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -4,10 +4,7 @@ import { start } from "ember-qunit";
 import * as QUnit from "qunit";
 import { setup } from "qunit-dom";
 import setupTests from "discourse/tests/setup-tests";
-import { setEnvironment } from "discourse-common/config/environment";
 import config from "../config/environment";
-
-setEnvironment("testing");
 
 document.addEventListener("discourse-booted", () => {
   // eslint-disable-next-line no-undef


### PR DESCRIPTION
This started out as a seemingly benign refactor to replace the `require` for `withPluginApi` to an actual import. However, it broke the test in seemingly random places.

It turns out that in serveral places, we are calling `isTesting()` in module scope and assigning the result to a constant. For example we do that in the composer service to disable checking drafts when testing.

This is problematic because `isTesting` isn’t really set until the `discourse-bootstrap` initializer is run, and so any modules that are evaluated before then will have locked in the wrong value for `isTesting()`.

If we are going to use and treat `isTesting()` like a constant then we will have to make sure we set it sufficiently early before any code-loading happens.