### PR TITLE
DEV: Fix flaky tests due to the lack of ordering

### DIFF
--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -278,7 +278,7 @@ class SiteSerializer < ApplicationSerializer
           SiteSetting.default_navigation_menu_tags.split("|") -
             DiscourseTagging.hidden_tag_names(scope)
 
-        serialize_tags(Tag.where(name: tag_names))
+        serialize_tags(Tag.where(name: tag_names).order(:name))
       end
   end
 


### PR DESCRIPTION
Why this change?

The following test was flaky due to the lack of ordering in
`SiteSerializer#anonymous_default_navigation_menu_tags` when fetching
the tags.

```
  1) SiteSerializer#anonymous_default_navigation_menu_tags includes only tags user can see in the serialised object when user is anonymous
     Failure/Error:
       expect(serialized[:anonymous_default_navigation_menu_tags]).to eq(
         [
           { name: "dev", description: "some description", pm_only: false },
           { name: "random", description: tag2.description, pm_only: false },
         ],
       )
```

What does this change do?

Add ordering by name when fetching tags in `SiteSerializer#anonymous_default_navigation_menu_tags`