### PR TITLE
FIX: Ensure nested ember components can be used with mustache syntax

### DIFF
--- a/app/assets/javascripts/patches/ember-this-fallback+0.3.1+003+fix-nested-components.patch
+++ b/app/assets/javascripts/patches/ember-this-fallback+0.3.1+003+fix-nested-components.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/ember-this-fallback/lib/helpers/string.js b/node_modules/ember-this-fallback/lib/helpers/string.js
+index c6f4e65..91ed2af 100644
+--- a/node_modules/ember-this-fallback/lib/helpers/string.js
++++ b/node_modules/ember-this-fallback/lib/helpers/string.js
+@@ -21,6 +21,8 @@ function squish(str) {
+ }
+ exports.squish = squish;
+ function classify(str) {
+-    return (0, lodash_1.upperFirst)((0, lodash_1.camelCase)(str));
++    const parts = str.split('/');
++    const classifiedParts = parts.map((p) => (0, lodash_1.upperFirst)((0, lodash_1.camelCase)(p)));
++    return classifiedParts.join('::');
+ }
+ exports.classify = classify;

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 76
+  BASE_COMPILER_VERSION = 77
 
   attr_accessor :child_components
 


### PR DESCRIPTION
We run the ember-this-fallback transformation on plugin and theme code so that they can continue omitting `this.` in `.hbs` templates. A bug in the implementation meant that it was incorrectly transforming things like `{{dir/some-component}}` into `<DirSomeComponent />` (rather than `<Dir::SomeComponent />`).

This commit uses patch-package to apply the fix from https://github.com/tildeio/ember-this-fallback/pull/56

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
