### PR TITLE
FIX: Support PluginOutlet invocations with deprecated tagName

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -83,7 +83,7 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
   }
 
   @bind
-  getConnectors({ hasBlock }) {
+  getConnectors({ hasBlock } = {}) {
     const connectors = renderedConnectorsFor(
       this.args.name,
       this.outletArgsWithDeprecations,

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -460,3 +460,16 @@ module(
     });
   }
 );
+
+module("Integration | Component | plugin-outlet | tagName", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("supports the `@tagName` argument", async function (assert) {
+    await withSilencedDeprecationsAsync(
+      "discourse.plugin-outlet-tag-name",
+      async () =>
+        await render(hbs`<PluginOutlet @name="test-name" @tagName="div" />`)
+    );
+    assert.dom("div").exists();
+  });
+});


### PR DESCRIPTION
This regressed in af305366

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
