### PR TITLE
DEV: don't relying on global jQuery, import "jquery" instead

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ace-editor.js
+++ b/app/assets/javascripts/admin/addon/components/ace-editor.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { classNames } from "@ember-decorators/component";
 import { observes, on } from "@ember-decorators/object";
+import $ from "jquery";
 import loadScript from "discourse/lib/load-script";
 import getURL from "discourse-common/lib/get-url";
 import { bind } from "discourse-common/utils/decorators";

--- a/app/assets/javascripts/admin/addon/components/ip-lookup.js
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import EmberObject, { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { classNames } from "@ember-decorators/component";
+import $ from "jquery";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import copyText from "discourse/lib/copy-text";

--- a/app/assets/javascripts/discourse/app/components/badge-selector.js
+++ b/app/assets/javascripts/discourse/app/components/badge-selector.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import $ from "jquery";
 import { makeArray } from "discourse-common/lib/helpers";
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
 import discourseComputed, {

--- a/app/assets/javascripts/discourse/app/components/basic-topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/basic-topic-list.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { alias, not } from "@ember/object/computed";
+import $ from "jquery";
 import discourseComputed, {
   bind,
   observes,

--- a/app/assets/javascripts/discourse/app/components/choose-message.js
+++ b/app/assets/javascripts/discourse/app/components/choose-message.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { action, get } from "@ember/object";
 import { next } from "@ember/runloop";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import { searchForTerm } from "discourse/lib/search";
 import { debounce, observes } from "discourse-common/utils/decorators";
 

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -4,6 +4,7 @@ import EmberObject from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { next, schedule, throttle } from "@ember/runloop";
 import { BasePlugin } from "@uppy/core";
+import $ from "jquery";
 import { resolveAllShortUrls } from "pretty-text/upload-short-url";
 import { ajax } from "discourse/lib/ajax";
 import {

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -3,6 +3,7 @@ import { action, computed } from "@ember/object";
 import { schedule, scheduleOnce } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import ItsATrap from "@discourse/itsatrap";
+import $ from "jquery";
 import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
 import { translations } from "pretty-text/emoji/data";
 import { resolveCachedShortUrls } from "pretty-text/upload-short-url";

--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -5,6 +5,7 @@ import { DEBUG } from "@glimmer/env";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 
 const LEGACY_ERROR =

--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { alias } from "@ember/object/computed";
 import { schedule, scheduleOnce, throttle } from "@ember/runloop";
 import { isBlank } from "@ember/utils";
+import $ from "jquery";
 import ClickTrack from "discourse/lib/click-track";
 import DiscourseURL from "discourse/lib/url";
 import { highlightPost } from "discourse/lib/utilities";

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import LoadMore from "discourse/mixins/load-more";
 import UrlRefresh from "discourse/mixins/url-refresh";
 import { observes, on } from "discourse-common/utils/decorators";

--- a/app/assets/javascripts/discourse/app/components/expanding-text-area.js
+++ b/app/assets/javascripts/discourse/app/components/expanding-text-area.js
@@ -1,5 +1,6 @@
 import { TextArea } from "@ember/legacy-built-in-components";
 import { schedule } from "@ember/runloop";
+import $ from "jquery";
 import autosize from "discourse/lib/autosize";
 import { observes, on } from "discourse-common/utils/decorators";
 

--- a/app/assets/javascripts/discourse/app/components/featured-topic.js
+++ b/app/assets/javascripts/discourse/app/components/featured-topic.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import $ from "jquery";
 
 export default Component.extend({
   classNameBindings: [":featured-topic"],

--- a/app/assets/javascripts/discourse/app/components/group-flair-inputs.js
+++ b/app/assets/javascripts/discourse/app/components/group-flair-inputs.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import $ from "jquery";
 import { ajax } from "discourse/lib/ajax";
 import discourseDebounce from "discourse-common/lib/debounce";
 import getURL from "discourse-common/lib/get-url";

--- a/app/assets/javascripts/discourse/app/components/group-selector.js
+++ b/app/assets/javascripts/discourse/app/components/group-selector.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
 import discourseComputed, {
   observes,

--- a/app/assets/javascripts/discourse/app/components/link-to-input.js
+++ b/app/assets/javascripts/discourse/app/components/link-to-input.js
@@ -1,5 +1,7 @@
 import Component from "@ember/component";
 import { schedule } from "@ember/runloop";
+import $ from "jquery";
+
 export default Component.extend({
   showInput: false,
 

--- a/app/assets/javascripts/discourse/app/components/mobile-nav.js
+++ b/app/assets/javascripts/discourse/app/components/mobile-nav.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import { on } from "discourse-common/utils/decorators";
 
 export default Component.extend({

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -3,6 +3,7 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { next } from "@ember/runloop";
+import $ from "jquery";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import DiscourseURL from "discourse/lib/url";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";

--- a/app/assets/javascripts/discourse/app/components/radio-button.js
+++ b/app/assets/javascripts/discourse/app/components/radio-button.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import $ from "jquery";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({

--- a/app/assets/javascripts/discourse/app/components/scroll-tracker.js
+++ b/app/assets/javascripts/discourse/app/components/scroll-tracker.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { next } from "@ember/runloop";
+import $ from "jquery";
 import Scrolling from "discourse/mixins/scrolling";
 
 export default Component.extend(Scrolling, {

--- a/app/assets/javascripts/discourse/app/components/search-text-field.js
+++ b/app/assets/javascripts/discourse/app/components/search-text-field.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import TextField from "discourse/components/text-field";
 import { applySearchAutocomplete } from "discourse/lib/search";
 import discourseComputed, { on } from "discourse-common/utils/decorators";

--- a/app/assets/javascripts/discourse/app/components/topic-entrance.js
+++ b/app/assets/javascripts/discourse/app/components/topic-entrance.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { scheduleOnce } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import DiscourseURL from "discourse/lib/url";
 import CleansUp from "discourse/mixins/cleans-up";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -5,6 +5,7 @@ import { on } from "@ember/object/evented";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import $ from "jquery";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL, { groupPath } from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import EmberObject from "@ember/object";
 import { next } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import PanEvents, {
   SWIPE_DISTANCE_THRESHOLD,

--- a/app/assets/javascripts/discourse/app/components/topic-status.js
+++ b/app/assets/javascripts/discourse/app/components/topic-status.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { htmlSafe } from "@ember/template";
+import $ from "jquery";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
@@ -4,6 +4,7 @@ import { or } from "@ember/object/computed";
 import { next } from "@ember/runloop";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import lightbox, {
   cleanupLightboxes,
   setupLightboxes,

--- a/app/assets/javascripts/discourse/app/components/user-stream.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { on } from "@ember/object/evented";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import ClickTrack from "discourse/lib/click-track";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -4,6 +4,7 @@ import EmberObject, { action } from "@ember/object";
 import { notEmpty } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import { Promise } from "rsvp";
 import LoginModal from "discourse/components/modal/login";
 import { ajax } from "discourse/lib/ajax";

--- a/app/assets/javascripts/discourse/app/instance-initializers/clean-dom-on-route-change.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/clean-dom-on-route-change.js
@@ -1,4 +1,5 @@
 import { scheduleOnce } from "@ember/runloop";
+import $ from "jquery";
 
 function _clean(transition) {
   if (window.MiniProfiler && transition.from) {

--- a/app/assets/javascripts/discourse/app/instance-initializers/click-interceptor.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/click-interceptor.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import interceptClick from "discourse/lib/intercept-click";
 import DiscourseURL from "discourse/lib/url";
 

--- a/app/assets/javascripts/discourse/app/instance-initializers/csrf-token.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/csrf-token.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 //  Append our CSRF token to AJAX requests when necessary.
 
 let installed = false;

--- a/app/assets/javascripts/discourse/app/instance-initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/jquery-plugins.js
@@ -1,5 +1,8 @@
+import "bootstrap/js/modal";
 import bootbox from "bootbox";
+import $ from "jquery";
 import autocomplete from "discourse/lib/autocomplete";
+import { caret, caretPosition } from "discourse/lib/caret-position";
 import deprecated from "discourse-common/lib/deprecated";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 
@@ -51,6 +54,10 @@ export default {
 
     // Initialize the autocomplete tool
     $.fn.autocomplete = autocomplete;
+
+    // Initialize caretPosition
+    $.fn.caret = caret;
+    $.fn.caretPosition = caretPosition;
 
     jqueryPluginsConfigured = true;
   },

--- a/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { handleLogoff } from "discourse/lib/ajax";
 import userPresent, { onPresenceChange } from "discourse/lib/user-presence";
 import { isProduction, isTesting } from "discourse-common/config/environment";

--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -1,4 +1,5 @@
 import { htmlSafe } from "@ember/template";
+import $ from "jquery";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import I18n from "I18n";
 

--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -1,4 +1,5 @@
 import { run } from "@ember/runloop";
+import $ from "jquery";
 import { Promise } from "rsvp";
 import userPresent from "discourse/lib/user-presence";
 import Session from "discourse/models/session";

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -1,5 +1,6 @@
 import { cancel } from "@ember/runloop";
 import { createPopper } from "@popperjs/core";
+import $ from "jquery";
 import { isDocumentRTL } from "discourse/lib/text-direction";
 import { caretPosition, setCaretPosition } from "discourse/lib/utilities";
 import Site from "discourse/models/site";

--- a/app/assets/javascripts/discourse/app/lib/caret-position.js
+++ b/app/assets/javascripts/discourse/app/lib/caret-position.js
@@ -1,26 +1,27 @@
-// TODO: This code should be moved to lib, it was heavily modified by us over the years, and mostly written by us
+import $ from "jquery";
+
+// This was heavily modified by us over the years, and mostly written by us
 // except for the little snippet from StackOverflow
 //
 // http://stackoverflow.com/questions/263743/how-to-get-caret-position-in-textarea
-var clone = null;
+let clone = null;
 
-$.fn.caret = function(elem) {
-  var getCaret = function(el) {
-    if (el.selectionStart) {
-      return el.selectionStart;
-    }
-    return 0;
-  };
+function getCaret(el) {
+  if (el.selectionStart) {
+    return el.selectionStart;
+  }
+  return 0;
+}
+
+export function caret(elem) {
   return getCaret(elem || this[0]);
-};
+}
 
 /**
-  This is a jQuery plugin to retrieve the caret position in a textarea
-
-  @module $.fn.caretPosition
+  retrieve the caret position in a textarea
 **/
-$.fn.caretPosition = function(options) {
-  var after,
+export function caretPosition(options) {
+  let after,
     before,
     getStyles,
     guard,
@@ -32,17 +33,15 @@ $.fn.caretPosition = function(options) {
     p,
     pPos,
     pos,
-    span,
     styles,
     textarea,
     val;
   if (clone) {
     clone.remove();
   }
-  span = $("#pos span");
   textarea = $(this);
 
-  getStyles = function(el) {
+  getStyles = function (el) {
     if (el.currentStyle) {
       return el.currentStyle;
     } else {
@@ -50,7 +49,7 @@ $.fn.caretPosition = function(options) {
     }
   };
 
-  important = function(prop) {
+  important = function (prop) {
     return styles.getPropertyValue(prop);
   };
 
@@ -58,7 +57,7 @@ $.fn.caretPosition = function(options) {
   clone = $("<div><p></p></div>").appendTo("body");
   p = clone.find("p");
 
-  var isRTL = $("html").hasClass("rtl");
+  let isRTL = $("html").hasClass("rtl");
   clone.css({
     border: "1px solid black",
     padding: important("padding"),
@@ -68,7 +67,7 @@ $.fn.caretPosition = function(options) {
     "word-wrap": "break-word",
     position: "absolute",
     left: isRTL ? "auto" : "-7000px",
-    right: isRTL ? "-7000px" : "auto"
+    right: isRTL ? "-7000px" : "auto",
   });
 
   p.css({
@@ -78,7 +77,7 @@ $.fn.caretPosition = function(options) {
     "letter-spacing": important("letter-spacing"),
     "font-family": important("font-family"),
     "font-size": important("font-size"),
-    "line-height": important("line-height")
+    "line-height": important("line-height"),
   });
 
   clone.width(textarea.width());
@@ -87,7 +86,7 @@ $.fn.caretPosition = function(options) {
   pos =
     options && (options.pos || options.pos === 0)
       ? options.pos
-      : $.caret(textarea[0]);
+      : getCaret(textarea[0]);
 
   val = textarea.val().replace("\r", "");
   if (options && options.key) {
@@ -102,18 +101,20 @@ $.fn.caretPosition = function(options) {
     insertSpaceAfterBefore = true;
   }
 
-  guard = function(v) {
-    var buf;
+  guard = function (v) {
+    let buf;
     buf = v.replace(/</g, "&lt;");
     buf = buf.replace(/>/g, "&gt;");
     buf = buf.replace(/[ ]/g, "&#x200b;&nbsp;&#x200b;");
     return buf.replace(/\n/g, "<br />");
   };
 
-  makeCursor = function(pos, klass, color) {
-    var l;
-    l = val.substring(pos, pos + 1);
-    if (l === "\n") return "<br>";
+  makeCursor = function (index, klass, color) {
+    let l;
+    l = val.substring(index, index + 1);
+    if (l === "\n") {
+      return "<br>";
+    }
     return (
       "<span class='" +
       klass +
@@ -152,11 +153,11 @@ $.fn.caretPosition = function(options) {
   }
 
   pPos = p.offset();
-  var position = {
+  let position = {
     left: pos.left - pPos.left,
-    top: pos.top - pPos.top - clone.scrollTop()
+    top: pos.top - pPos.top - clone.scrollTop(),
   };
 
   clone.remove();
   return position;
-};
+}

--- a/app/assets/javascripts/discourse/app/lib/discourse-location.js
+++ b/app/assets/javascripts/discourse/app/lib/discourse-location.js
@@ -1,5 +1,6 @@
 import EmberObject from "@ember/object";
 import { guidFor } from "@ember/object/internals";
+import $ from "jquery";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { withoutPrefix } from "discourse-common/lib/get-url";
 

--- a/app/assets/javascripts/discourse/app/lib/eyeline.js
+++ b/app/assets/javascripts/discourse/app/lib/eyeline.js
@@ -1,5 +1,6 @@
 import EmberObject from "@ember/object";
 import Evented from "@ember/object/evented";
+import $ from "jquery";
 import { isTesting } from "discourse-common/config/environment";
 
 let _skipUpdate;

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { SELECTORS } from "discourse/lib/lightbox/constants";
 import loadScript from "discourse/lib/load-script";

--- a/app/assets/javascripts/discourse/app/lib/link-hashtags.js
+++ b/app/assets/javascripts/discourse/app/lib/link-hashtags.js
@@ -1,7 +1,7 @@
 // TODO (martin) Delete this after core PR and any other PRs that depend
 // on this file (e.g. discourse-encrypt) are merged.
 
-import jQuery from "jquery";
+import $ from "jquery";
 import { ajax } from "discourse/lib/ajax";
 import { replaceSpan } from "discourse/lib/category-hashtags";
 import { TAG_HASHTAG_POSTFIX } from "discourse/lib/tag-hashtags";
@@ -12,7 +12,7 @@ const tagHashtags = {};
 const checkedHashtags = new Set();
 
 export function linkSeenHashtags(elem) {
-  if (elem instanceof jQuery) {
+  if (elem instanceof $) {
     elem = elem[0];
 
     deprecated("linkSeenHashtags now expects a DOM node as first parameter", {

--- a/app/assets/javascripts/discourse/app/lib/mobile.js
+++ b/app/assets/javascripts/discourse/app/lib/mobile.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { isTesting } from "discourse-common/config/environment";
 
 let mobileForced = false;

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { h } from "virtual-dom";
 import {
   addComposerUploadHandler,

--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { helperContext } from "discourse-common/lib/helpers";

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -2,6 +2,7 @@ import { setOwner } from "@ember/application";
 import EmberObject from "@ember/object";
 import { next, schedule } from "@ember/runloop";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import LockOn from "discourse/lib/lock-on";
 import offsetCalculator from "discourse/lib/offset-calculator";
 import { defaultHomepage } from "discourse/lib/utilities";

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -1,4 +1,5 @@
 import Handlebars from "handlebars";
+import $ from "jquery";
 import toMarkdown from "discourse/lib/to-markdown";
 import { capabilities } from "discourse/services/capabilities";
 import * as AvatarUtils from "discourse-common/lib/avatar-utils";

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -2,6 +2,7 @@ import { alias, match } from "@ember/object/computed";
 import Mixin from "@ember/object/mixin";
 import { schedule, throttle } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/app/mixins/mobile-scroll-direction.js
+++ b/app/assets/javascripts/discourse/app/mixins/mobile-scroll-direction.js
@@ -1,4 +1,5 @@
 import Mixin from "@ember/object/mixin";
+import $ from "jquery";
 import discourseDebounce from "discourse-common/lib/debounce";
 
 // Small buffer so that very tiny scrolls don't trigger mobile header switch

--- a/app/assets/javascripts/discourse/app/models/static-page.js
+++ b/app/assets/javascripts/discourse/app/models/static-page.js
@@ -1,4 +1,5 @@
 import EmberObject from "@ember/object";
+import $ from "jquery";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -2,6 +2,7 @@ import { action, get } from "@ember/object";
 import { cancel, schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
+import $ from "jquery";
 import AddPmParticipants from "discourse/components/modal/add-pm-participants";
 import ChangeOwnerModal from "discourse/components/modal/change-owner";
 import ChangeTimestampModal from "discourse/components/modal/change-timestamp";

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -1,4 +1,5 @@
 import { action } from "@ember/object";
+import $ from "jquery";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";

--- a/app/assets/javascripts/discourse/app/services/client-error-handler.js
+++ b/app/assets/javascripts/discourse/app/services/client-error-handler.js
@@ -1,6 +1,6 @@
 import { getOwner } from "@ember/application";
 import Service, { inject as service } from "@ember/service";
-import Ember from "ember";
+import $ from "jquery";
 import { getAndClearUnhandledThemeErrors } from "discourse/app";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import identifySource, {
@@ -108,7 +108,7 @@ function reportToLogster(name, error) {
   };
 
   // TODO: To be moved out into a logster-provided lib
-  Ember.$.ajax(getURL("/logs/report_js_error"), {
+  $.ajax(getURL("/logs/report_js_error"), {
     data,
     type: "POST",
   });

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -5,6 +5,7 @@ import Service, { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { observes, on } from "@ember-decorators/object";
+import $ from "jquery";
 import { Promise } from "rsvp";
 import DiscardDraftModal from "discourse/components/modal/discard-draft";
 import PostEnqueuedModal from "discourse/components/modal/post-enqueued";

--- a/app/assets/javascripts/discourse/app/services/modal.js
+++ b/app/assets/javascripts/discourse/app/services/modal.js
@@ -3,6 +3,7 @@ import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import Service, { inject as service } from "@ember/service";
 import { dasherize } from "@ember/string";
+import $ from "jquery";
 import { CLOSE_INITIATED_BY_MODAL_SHOW } from "discourse/components/d-modal";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import deprecated from "discourse-common/lib/deprecated";

--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { h } from "virtual-dom";
 import DiscourseURL from "discourse/lib/url";
 import { createWidget } from "discourse/widgets/widget";

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -1,5 +1,6 @@
 import { schedule } from "@ember/runloop";
 import { hbs } from "ember-cli-htmlbars";
+import $ from "jquery";
 import { h } from "virtual-dom";
 import { addExtraUserClasses } from "discourse/helpers/user-avatar";
 import { wantsNewWindow } from "discourse/lib/intercept-click";

--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -1,4 +1,5 @@
 /*eslint no-loop-func:0*/
+import $ from "jquery";
 
 const CLICK_ATTRIBUTE_NAME = "_discourse_click_widget";
 const DOUBLE_CLICK_ATTRIBUTE_NAME = "_discourse_double_click_widget";

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { h } from "virtual-dom";
 import { addWidgetCleanCallback } from "discourse/components/mount-widget";
 import { Placeholder } from "discourse/lib/posts-with-placeholders";

--- a/app/assets/javascripts/discourse/app/widgets/raw-html.js
+++ b/app/assets/javascripts/discourse/app/widgets/raw-html.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 export default class RawHtml {
   constructor(attrs) {
     this.html = attrs.html;

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { h } from "virtual-dom";
 import { applyDecorators, createWidget } from "discourse/widgets/widget";
 

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -133,10 +133,7 @@ module.exports = function (defaults) {
   });
 
   // WARNING: We should only import scripts here if they are not in NPM.
-  // For example: our very specific version of bootstrap-modal.
   app.import(vendorJs + "bootbox.js");
-  app.import("node_modules/bootstrap/js/modal.js");
-  app.import(vendorJs + "caret_position.js");
   app.import("node_modules/ember-source/dist/ember-template-compiler.js", {
     type: "test",
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
@@ -1,4 +1,5 @@
 import { click, settled, visit, waitFor } from "@ember/test-helpers";
+import $ from "jquery";
 import { test } from "qunit";
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -1,5 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest as emberSetupRenderingTest } from "ember-qunit";
+import $ from "jquery";
 import QUnit, { test } from "qunit";
 import { autoLoadModules } from "discourse/instance-initializers/auto-load-modules";
 import Session from "discourse/models/session";

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -7,6 +7,7 @@ import {
 } from "@ember/test-helpers";
 import { isEmpty } from "@ember/utils";
 import { setupApplicationTest } from "ember-qunit";
+import $ from "jquery";
 import MessageBus from "message-bus-client";
 import { resetCache as resetOneboxCache } from "pretty-text/oneboxer";
 import QUnit, { module, skip, test } from "qunit";

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -1,6 +1,6 @@
 import { click, fillIn, triggerEvent } from "@ember/test-helpers";
 import { isEmpty } from "@ember/utils";
-import jQuery from "jquery";
+import $ from "jquery";
 import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 function checkSelectKitIsNotExpanded(selector) {
@@ -65,7 +65,7 @@ async function keyboardHelper(value, target, selector) {
 
   if (value === "selectAll") {
     // special casing the only one not working with triggerEvent
-    const event = jQuery.Event("keydown");
+    const event = $.Event("keydown");
     event.key = "A";
     event.keyCode = 65;
     event.metaKey = true;

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -9,9 +9,10 @@ import {
   setApplication,
   setResolver,
 } from "@ember/test-helpers";
+import "bootstrap/js/modal";
 import bootbox from "bootbox";
 import { addModuleExcludeMatcher } from "ember-cli-test-loader/test-support/index";
-import jQuery from "jquery";
+import $ from "jquery";
 import MessageBus from "message-bus-client";
 import QUnit from "qunit";
 import sinon from "sinon";
@@ -393,7 +394,7 @@ export default function setupTests(config) {
   addModuleExcludeMatcher((name) => !shouldLoadModule(name));
 
   // forces 0 as duration for all jquery animations
-  jQuery.fx.off = true;
+  $.fx.off = true;
 
   setupToolbar();
   reportMemoryUsageAfterTests();

--- a/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from "ember-qunit";
 import { compile } from "handlebars";
+import $ from "jquery";
 import { module, test } from "qunit";
 import autocomplete from "discourse/lib/autocomplete";
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -1,5 +1,6 @@
 import { getOwner } from "@ember/application";
 import { setupTest } from "ember-qunit";
+import $ from "jquery";
 import { module, test } from "qunit";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import { helperContext } from "discourse-common/lib/helpers";

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -1,4 +1,5 @@
 import { setupTest } from "ember-qunit";
+import $ from "jquery";
 import { module, skip, test } from "qunit";
 import sinon from "sinon";
 import ClickTrack from "discourse/lib/click-track";

--- a/app/assets/javascripts/select-kit/addon/components/icon-picker.js
+++ b/app/assets/javascripts/select-kit/addon/components/icon-picker.js
@@ -1,4 +1,5 @@
 import { computed } from "@ember/object";
+import $ from "jquery";
 import { ajax } from "discourse/lib/ajax";
 import { isDevelopment } from "discourse-common/config/environment";
 import { makeArray } from "discourse-common/lib/helpers";

--- a/app/assets/javascripts/wizard/addon/components/wizard-step.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-step.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import $ from "jquery";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import I18n from "I18n";
 

--- a/vendor/assets/javascripts/bootbox.js
+++ b/vendor/assets/javascripts/bootbox.js
@@ -1,11 +1,16 @@
-/**
- * bootbox.js v3.2.0
- *
- * http://bootboxjs.com/license.txt
- */
-var bootbox =
-  window.bootbox ||
-  (function (document, $) {
+define("bootbox", ["jquery", "exports"], function (jQuery, __exports__) {
+  if ("bootbox" in window) {
+    throw new Error("bootbox unexpectedly loaded twice!");
+  }
+
+  /**
+   * bootbox.js v3.2.0
+   *
+   * http://bootboxjs.com/license.txt
+   */
+  var bootbox =
+    window.bootbox ||
+    (function (document, $) {
     /*jshint scripturl:true sub:true */
 
     var _locale = "en",
@@ -705,11 +710,10 @@ var bootbox =
     }
 
     return that;
-  })(document, window.jQuery);
+  })(document, jQuery);
 
-// @see https://github.com/makeusabrew/bootbox/issues/71
-window.bootbox = bootbox;
+  // @see https://github.com/makeusabrew/bootbox/issues/71
+  window.bootbox = bootbox;
 
-define("bootbox", ["exports"], function (__exports__) {
   __exports__.default = window.bootbox;
 });


### PR DESCRIPTION
This is extracted from #23916 but without dropping `@ember/jquery`. There are some shenanigans in Ember 3.x that complicates the switch, which would be easier to do after landing the Ember upgrade. For now, these imports are still good and should be harmless to merge, since `@ember/jquery` also brings an AMD shim for the `jquery` module, as long as we don't have a dependency on the actual `jquery` package, it should hit the fallback `require('jquery')` path and find the AMD shim.

Not included in this PR: someone else can pick it up but we may want to adjust the eslint rules for core to ban the globals