### PR TITLE
FIX: revert (edited) layout in chat message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
@@ -1,9 +1,6 @@
 <div class="chat-message-collapser">
   {{#if this.hasUploads}}
     {{html-safe @cooked}}
-    {{#if @isEdited}}
-      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
-    {{/if}}
 
     <Collapser @header={{this.uploadsHeader}} @onToggle={{@onToggleCollapse}}>
       <div class="chat-uploads">
@@ -28,8 +25,5 @@
         {{cooked.body}}
       {{/if}}
     {{/each}}
-    {{#if @isEdited}}
-      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
-    {{/if}}
   {{/if}}
 </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-text.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-text.hbs
@@ -4,13 +4,14 @@
       @cooked={{@cooked}}
       @uploads={{@uploads}}
       @onToggleCollapse={{@onToggleCollapse}}
-      @isEdited={{this.isEdited}}
     />
   {{else}}
     {{html-safe @cooked}}
-    {{#if this.isEdited}}
-      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
-    {{/if}}
   {{/if}}
+
+  {{#if this.isEdited}}
+    <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+  {{/if}}
+
   {{yield}}
 </div>

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -93,7 +93,6 @@
     display: inline-block;
     color: var(--primary-medium);
     font-size: var(--font-down-2);
-    user-select: none;
   }
 
   .chat-message-reaction-list,

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -60,10 +60,6 @@
     min-width: 0;
     width: 100%;
 
-    p {
-      display: inline-block;
-    }
-
     code {
       box-sizing: border-box;
       font-size: var(--font-down-1);


### PR DESCRIPTION
The current solution doesn't work with multiline chat messages done with shift+enter. The only way to position the (edited) info for sure neatly at the end of the line would be if the element is within the cooked html.
