### PR TITLE
DEV: Ensure current-post-changed is fired when switching between topics

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -37,7 +37,7 @@ export default MountWidget.extend({
   widget: "post-stream",
   _topVisible: null,
   _bottomVisible: null,
-  _currentPost: null,
+  _currentPostObj: null,
   _currentVisible: null,
   _currentPercent: null,
 
@@ -219,11 +219,11 @@ export default MountWidget.extend({
         this.bottomVisibleChanged({ post: last, refresh });
       }
 
-      const changedPost = this._currentPost !== currentPost;
+      const currentPostObj = posts.objectAt(currentPost);
+      const changedPost = this._currentPostObj !== currentPostObj;
       if (changedPost) {
-        this._currentPost = currentPost;
-        const post = posts.objectAt(currentPost);
-        this.currentPostChanged({ post });
+        this._currentPostObj = currentPostObj;
+        this.currentPostChanged({ post: currentPostObj });
       }
 
       if (percent !== null) {
@@ -237,7 +237,7 @@ export default MountWidget.extend({
     } else {
       this._topVisible = null;
       this._bottomVisible = null;
-      this._currentPost = null;
+      this._currentPostObj = null;
       this._currentPercent = null;
     }
 


### PR DESCRIPTION
Previously this logic was only checking the post number. That meant that navigating between the first post of two topics would not trigger the event.

In the past, the event would be triggered anyway because the ScrollingPostStream would be destroyed/re-created when navigating between topics. But now that we use the 'loading slider' technique, the same component instance is re-used.

The motivation for this commit is to fix the 'DiscoToc' theme component, which relies on the event firing when navigating between topics.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
