### PR TITLE
DEV: Upgrade pg gem to 1.5.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    pg (1.4.6)
+    pg (1.5.4)
     prettier_print (1.2.1)
     progress (3.6.0)
     pry (0.14.2)


### PR DESCRIPTION
We stopped upgrading due to deprecation notices in Rails. See https://github.com/discourse/discourse/pull/21271#issuecomment-1524348726

pg 1.5.3 and Rails 7.0.5 should have fixed the issue. See https://github.com/rails/rails/issues/48046#issuecomment-1527743307 and https://github.com/rails/rails/pull/48048#issuecomment-1564046629