### PR TITLE
FIX: Correctly set categoryId on Composer model

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -824,7 +824,10 @@ const Composer = RestModel.extend({
     });
 
     // We set the category id separately for topic templates on opening of composer
-    this.set("categoryId", opts.categoryId || this.get("topic.category.id"));
+    this.set(
+      "categoryId",
+      opts.topicCategoryId || opts.categoryId || this.get("topic.category.id")
+    );
 
     if (!this.categoryId && this.creatingTopic) {
       const categories = this.site.categories;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1450,10 +1450,6 @@ export default class ComposerService extends Service {
       this.model.set("title", opts.topicTitle);
     }
 
-    if (opts.topicCategoryId) {
-      this.model.set("categoryId", opts.topicCategoryId);
-    }
-
     if (opts.topicTags && this.site.can_tag_topics) {
       let tags = escapeExpression(opts.topicTags)
         .split(",")

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -160,6 +160,77 @@ describe "Composer Form Templates", type: :system do
     sign_in user
   end
 
+  describe "discard draft modal" do
+    it "does not show the modal if there is no draft on a topic without a template" do
+      category_page.visit(category_no_template)
+      category_page.new_topic_button.click
+      composer.close
+      expect(composer).to be_not_opened
+    end
+
+    it "shows the modal if there is a draft on a topic without a template" do
+      category_page.visit(category_no_template)
+      category_page.new_topic_button.click
+      composer.fill_content("abc")
+      composer.close
+      expect(composer).to be_opened
+      expect(composer).to have_discard_draft_modal
+    end
+
+    it "does not show the modal if there is no draft on a topic with a topic template" do
+      category_page.visit(category_topic_template)
+      category_page.new_topic_button.click
+      composer.close
+      expect(composer).to be_not_opened
+    end
+
+    it "shows the modal if there is a draft on a topic with a topic template" do
+      category_page.visit(category_topic_template)
+      category_page.new_topic_button.click
+      composer.append_content(" some more content")
+      composer.close
+      expect(composer).to be_opened
+      expect(composer).to have_discard_draft_modal
+    end
+
+    it "does not show the modal if on a topic with a form template" do
+      category_page.visit(category_with_template_1)
+      category_page.new_topic_button.click
+      composer.close
+      expect(composer).to be_not_opened
+    end
+
+    context "when the default template has a topic template" do
+      SiteSetting.default_composer_category =
+        (
+          if SiteSetting.general_category_id != -1
+            SiteSetting.general_category_id
+          else
+            SiteSetting.uncategorized_category_id
+          end
+        )
+      let(:default_category) { Category.find(SiteSetting.default_composer_category) }
+
+      before { default_category.update!(topic_template: "Testing") }
+
+      it "does not show the modal if there is no draft" do
+        category_page.visit(default_category)
+        category_page.new_topic_button.click
+        composer.close
+        expect(composer).to be_not_opened
+      end
+
+      it "shows the modal if there is a draft" do
+        category_page.visit(default_category)
+        category_page.new_topic_button.click
+        composer.append_content(" some more content")
+        composer.close
+        expect(composer).to be_opened
+        expect(composer).to have_discard_draft_modal
+      end
+    end
+  end
+
   it "shows a textarea when no form template is assigned to the category" do
     category_page.visit(category_no_template)
     category_page.new_topic_button.click

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -165,7 +165,7 @@ describe "Composer Form Templates", type: :system do
       category_page.visit(category_no_template)
       category_page.new_topic_button.click
       composer.close
-      expect(composer).to be_not_opened
+      expect(composer).to be_closed
     end
 
     it "shows the modal if there is a draft on a topic without a template" do
@@ -181,7 +181,7 @@ describe "Composer Form Templates", type: :system do
       category_page.visit(category_topic_template)
       category_page.new_topic_button.click
       composer.close
-      expect(composer).to be_not_opened
+      expect(composer).to be_closed
     end
 
     it "shows the modal if there is a draft on a topic with a topic template" do
@@ -197,7 +197,7 @@ describe "Composer Form Templates", type: :system do
       category_page.visit(category_with_template_1)
       category_page.new_topic_button.click
       composer.close
-      expect(composer).to be_not_opened
+      expect(composer).to be_closed
     end
 
     context "when the default template has a topic template" do
@@ -217,7 +217,7 @@ describe "Composer Form Templates", type: :system do
         category_page.visit(default_category)
         category_page.new_topic_button.click
         composer.close
-        expect(composer).to be_not_opened
+        expect(composer).to be_closed
       end
 
       it "shows the modal if there is a draft" do

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -10,6 +10,10 @@ module PageObjects
         page.has_css?("#{COMPOSER_ID}.open")
       end
 
+      def not_opened?
+        page.has_no_css?("#{COMPOSER_ID}.open")
+      end
+
       def open_composer_actions
         find(".composer-action-title .btn").click
         self
@@ -27,6 +31,12 @@ module PageObjects
 
       def fill_content(content)
         composer_input.fill_in(with: content)
+        self
+      end
+
+      def append_content(content)
+        current_content = composer_input.value
+        composer_input.set(current_content + content)
         self
       end
 
@@ -88,6 +98,10 @@ module PageObjects
 
       def preview
         find("#{COMPOSER_ID} .d-editor-preview-wrapper")
+      end
+
+      def has_discard_draft_modal?
+        page.has_css?(".discard-draft-modal")
       end
 
       def has_emoji_autocomplete?

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -10,8 +10,8 @@ module PageObjects
         page.has_css?("#{COMPOSER_ID}.open")
       end
 
-      def not_opened?
-        page.has_no_css?("#{COMPOSER_ID}.open")
+      def closed?
+        page.has_css?("#{COMPOSER_ID}.closed", visible: :all)
       end
 
       def open_composer_actions


### PR DESCRIPTION
This regressed long time ago in 869518e. It resulted in a bug where, if you had a default category with a template, cancelling an empty draft would in most cases result in a dialog asking if you want to dismiss that draft.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
