### PR TITLE
FIX: add missing `type` to form template upload

### DIFF
--- a/app/assets/javascripts/discourse/app/components/form-template-field/upload.js
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/upload.js
@@ -15,6 +15,8 @@ export default class FormTemplateFieldUpload extends Component.extend(
   @tracked fileUploadElementId = `${dasherize(this.id)}-uploader`;
   @tracked fileInputSelector = `#${this.fileUploadElementId}`;
 
+  type = "composer";
+
   @computed("uploading", "uploadValue")
   get uploadStatus() {
     if (!this.uploading && !this.uploadValue) {


### PR DESCRIPTION
Its omission was breaking uploads when `enable_direct_s3_uploads` was `true`.