### PR TITLE
FIX: Open invite modal correctly from topic share UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.js
@@ -45,7 +45,7 @@ export default Component.extend(bufferedProperty("invite"), {
     });
 
     this.set("invite", this.model.invite || Invite.create());
-    this.set("topics", this.invite?.topics || []);
+    this.set("topics", this.invite?.topics || this.model.topics || []);
 
     this.buffered.setProperties({
       max_redemptions_allowed: 1,
@@ -53,6 +53,8 @@ export default Component.extend(bufferedProperty("invite"), {
         .add(this.siteSettings.invite_expiry_days, "days")
         .format(FORMAT),
       groupIds: this.model?.groupIds,
+      topicId: this.model.topicId,
+      topicTitle: this.model.topicTitle,
     });
   },
 

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.js
@@ -2,9 +2,10 @@ import { getOwner } from "@ember/application";
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { readOnly } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
+import CreateInvite from "discourse/components/modal/create-invite";
 import { longDateNoYear } from "discourse/lib/formatter";
 import Sharing from "discourse/lib/sharing";
-import showModal from "discourse/lib/show-modal";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import Category from "discourse/models/category";
 import { getAbsoluteURL } from "discourse-common/lib/get-url";
@@ -18,6 +19,7 @@ const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
   post: readOnly("model.post"),
   category: readOnly("model.category"),
   allowInvites: readOnly("model.allowInvites"),
+  modal: service(),
 
   didInsertElement() {
     this._showRestrictedGroupWarning();
@@ -92,14 +94,13 @@ const ShareTopicModal = Component.extend(bufferedProperty("invite"), {
 
   @action
   inviteUsers() {
-    const controller = showModal("create-invite");
-    controller.setProperties({
-      inviteToTopic: true,
-      topics: [this.topic],
-    });
-    controller.buffered.setProperties({
-      topicId: this.topic.id,
-      topicTitle: this.topic.title,
+    this.modal.show(CreateInvite, {
+      model: {
+        inviteToTopic: true,
+        topics: [this.topic],
+        topicId: this.topic.id,
+        topicTitle: this.topic.title,
+      },
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -54,6 +54,10 @@ acceptance("Share and Invite modal", function (needs) {
       exists(".link-share-actions .invite"),
       "it shows the invite button"
     );
+
+    await click(".link-share-actions .invite");
+
+    assert.dom(".create-invite-modal").exists();
   });
 
   test("Post date link", async function (assert) {


### PR DESCRIPTION
This regressed when the create-invite modal was converted to the new component-based API in 8a7b5b00eac157be99b922b0ecc9bca68e5c385d

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
