### PR TITLE
FIX: synonym tags are not considered as unused

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,7 +30,7 @@ class Tag < ActiveRecord::Base
   # tags that have never been used and don't belong to a tag group
   scope :unused,
         -> {
-          where(staff_topic_count: 0, pm_topic_count: 0).joins(
+          where(staff_topic_count: 0, pm_topic_count: 0, target_tag_id: nil).joins(
             "LEFT JOIN tag_group_memberships tgm ON tags.id = tgm.tag_id",
           ).where("tgm.tag_id IS NULL")
         }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -299,6 +299,7 @@ RSpec.describe Tag do
       )
     end
     let!(:tag_group) { Fabricate(:tag_group, tag_names: [tag_in_group.name]) }
+    let!(:synonym_tag) { Fabricate(:tag, target_tag: tags.first) }
 
     it "returns the correct tags" do
       expect(Tag.unused.pluck(:name)).to contain_exactly("unused1", "unused2")


### PR DESCRIPTION
Currently, `Tag.unused` scope is used to delete unused tags on `/tags` and by CleanUpTags job. Synonym tags, should not be included and treated as unused. Synonyms are only deleted when main tag is deleted:

https://github.com/discourse/discourse/blob/main/app/models/tag.rb#L57

<img width="1123" alt="Screenshot 2023-10-17 at 9 08 07 am" src="https://github.com/discourse/discourse/assets/72780/3931fd10-d43e-4890-9b57-3786b2e75a1e">

