### PR TITLE
DEV: Add category style deprecation check warning

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -207,7 +207,8 @@ class AdminDashboardData
                       :unreachable_themes,
                       :watched_words_check,
                       :google_analytics_version_check,
-                      :translation_overrides_check
+                      :translation_overrides_check,
+                      :deprecated_category_style_check
 
     register_default_scheduled_problem_checks
 
@@ -445,6 +446,12 @@ class AdminDashboardData
     return unless themes.present?
 
     themes_html_format(themes, "dashboard.unreachable_themes")
+  end
+
+  def deprecated_category_style_check
+    if SiteSetting.category_style != "bullet"
+      I18n.t("dashboard.category_style_deprecated", base_path: Discourse.base_path)
+    end
   end
 
   private

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -449,9 +449,7 @@ class AdminDashboardData
   end
 
   def deprecated_category_style_check
-    if SiteSetting.category_style != "bullet"
-      I18n.t("dashboard.category_style_deprecated", base_path: Discourse.base_path)
-    end
+    I18n.t("dashboard.category_style_deprecated") if SiteSetting.category_style != "bullet"
   end
 
   private

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1502,6 +1502,7 @@ en:
     unreachable_themes: "We were unable to check for updates on the following themes:"
     watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
     v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
+    category_style_deprecated: "Your Discourse is currently using a deprecated category style which will be removed before the final beta release of Discourse 3.2. Please refer to <a href='https://meta.discourse.org/t/282441'>Moving to a Single Category Style Site Setting</a> for instructions on how to keep your selected category style."
 
   site_settings:
     allow_bulk_invite: "Allow bulk invites by uploading a CSV file"

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -367,4 +367,26 @@ RSpec.describe AdminDashboardData do
       end
     end
   end
+
+  describe "#deprecated_category_style_check" do
+    subject(:dashboard_data) { described_class.new }
+
+    context "with a non-default category style" do
+      before { SiteSetting.set(:category_style, "box") }
+
+      it "outputs the correct message" do
+        expect(dashboard_data.deprecated_category_style_check).to eq(
+          I18n.t("dashboard.category_style_deprecated", base_path: Discourse.base_path),
+        )
+      end
+    end
+
+    context "when there are no outdated translations" do
+      before { SiteSetting.set(:category_style, "bullet") }
+
+      it "outputs nothing" do
+        expect(dashboard_data.deprecated_category_style_check).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -376,12 +376,12 @@ RSpec.describe AdminDashboardData do
 
       it "outputs the correct message" do
         expect(dashboard_data.deprecated_category_style_check).to eq(
-          I18n.t("dashboard.category_style_deprecated", base_path: Discourse.base_path),
+          I18n.t("dashboard.category_style_deprecated"),
         )
       end
     end
 
-    context "when there are no outdated translations" do
+    context "with the default category style" do
       before { SiteSetting.set(:category_style, "bullet") }
 
       it "outputs nothing" do


### PR DESCRIPTION
The category style site setting is being deprecated. This commit will
show a warning on the admin dashboard if a site isn't using the default
category style (bullet).
