### PR TITLE
DEV: Remove hashtag autocomplete experimental setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2450,7 +2450,6 @@ en:
     navigation_menu: "Determine which navigation menu to use. Sidebar and header navigation are customizable by users. Legacy option is available for backward compatibility."
     default_navigation_menu_categories: "Selected categories will be displayed under Navigation Menu's Categories section by default."
     default_navigation_menu_tags: "Selected tags will be displayed under Navigation Menu's Tags section by default."
-    enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
     experimental_new_new_view_groups: 'EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
     enable_custom_sidebar_sections: "EXPERIMENTAL: Enable custom sidebar sections"
     experimental_topics_filter: "EXPERIMENTAL: Enables the experimental topics filter route at /filter"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2135,10 +2135,6 @@ developer:
   enable_safe_mode:
     default: true
     client: true
-  enable_experimental_hashtag_autocomplete:
-    default: true
-    client: true
-    hidden: true
   experimental_hashtag_search_result_limit:
     default: 20
     client: true

--- a/db/migrate/20231017044708_remove_enable_experimental_hashtag_autocomplete_setting.rb
+++ b/db/migrate/20231017044708_remove_enable_experimental_hashtag_autocomplete_setting.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveEnableExperimentalHashtagAutocompleteSetting < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'enable_experimental_hashtag_autocomplete'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Everything relying on this was removed in
09223e5ae72ff1ced8f08143b7578122b462c6d6
