### PR TITLE
DEV: Limit preloaded categories

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,6 +4,9 @@
 class Site
   include ActiveModel::Serialization
 
+  # Number of categories preloaded when lazy_load_categories is enabled
+  LAZY_LOAD_CATEGORIES_LIMIT = 50
+
   cattr_accessor :preloaded_category_custom_fields
 
   def self.reset_preloaded_category_custom_fields
@@ -115,6 +118,10 @@ class Site
                read_restricted: category[:read_restricted],
              )
             categories << category
+          end
+
+          if SiteSetting.lazy_load_categories && categories.size >= Site::LAZY_LOAD_CATEGORIES_LIMIT
+            break
           end
         end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -183,6 +183,17 @@ RSpec.describe Site do
         DiscoursePluginRegistry.clear_modifiers!
       end
     end
+
+    context "when lazy_load_categories" do
+      before { SiteSetting.lazy_load_categories = true }
+
+      it "limits the number of categories" do
+        stub_const(Site, "LAZY_LOAD_CATEGORIES_LIMIT", 1) do
+          categories = Site.new(Guardian.new).categories
+          expect(categories.size).to eq(1)
+        end
+      end
+    end
   end
 
   it "omits groups user can not see" do


### PR DESCRIPTION
Site data is preloaded on the first page load, which includes categories data. For sites with many categories, site data takes a long time to serialize and to transfer.

In the future, preloaded category data will be completely removed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
