### PR TITLE
FIX: log for CleanUpTags job

### DIFF
--- a/app/jobs/scheduled/clean_up_tags.rb
+++ b/app/jobs/scheduled/clean_up_tags.rb
@@ -8,7 +8,14 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.automatically_clean_unused_tags
-      Tag.unused.where("tags.created_at < ?", GRACE_PERIOD_MINUTES.minutes.ago).destroy_all
+      Tag.transaction do
+        tags = Tag.unused.where("tags.created_at < ?", GRACE_PERIOD_MINUTES.minutes.ago)
+        StaffActionLogger.new(Discourse.system_user).log_custom(
+          "deleted_unused_tags",
+          tags: tags.pluck(:name),
+        )
+        tags.destroy_all
+      end
     end
   end
 end


### PR DESCRIPTION
In previous [PR](https://github.com/discourse/discourse/pull/23864) we introduced setting to automatically delete unused tags. This action should be logged.

<img width="864" alt="Screenshot 2023-10-18 at 12 14 02 pm" src="https://github.com/discourse/discourse/assets/72780/5feabae8-60ee-42ba-8a21-2f180a19db15">
