### PR TITLE
FIX: Preserve `preview_theme_id` param on topic redirects

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1253,7 +1253,7 @@ class TopicsController < ApplicationController
       raise(SiteSetting.detailed_404 ? ex : Discourse::NotFound)
     end
 
-    opts = params.slice(:page, :print, :filter_top_level_replies)
+    opts = params.slice(:page, :print, :filter_top_level_replies, :preview_theme_id)
     opts.delete(:page) if params[:page] == 0
 
     url = topic.relative_url

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2177,7 +2177,7 @@ RSpec.describe TopicsController do
     it "preserves only select query params" do
       get "/t/external_id/asdf.json", params: { filter_top_level_replies: true }
       expect(response.status).to eq(301)
-      expect(response).to redirect_to(topic.relative_url + ".json?filter_top_level_replies=true")
+      expect(response).to redirect_to("#{topic.relative_url}.json?filter_top_level_replies=true")
 
       get "/t/external_id/asdf.json", params: { not_valid: true }
       expect(response.status).to eq(301)
@@ -2186,13 +2186,18 @@ RSpec.describe TopicsController do
       get "/t/external_id/asdf.json", params: { filter_top_level_replies: true, post_number: 9999 }
       expect(response.status).to eq(301)
       expect(response).to redirect_to(
-        topic.relative_url + "/9999.json?filter_top_level_replies=true",
+        "#{topic.relative_url}/9999.json?filter_top_level_replies=true",
       )
 
-      get "/t/external_id/asdf.json", params: { filter_top_level_replies: true, print: true }
+      get "/t/external_id/asdf.json",
+          params: {
+            filter_top_level_replies: true,
+            print: true,
+            preview_theme_id: 9999,
+          }
       expect(response.status).to eq(301)
       expect(response).to redirect_to(
-        topic.relative_url + ".json?print=true&filter_top_level_replies=true",
+        "#{topic.relative_url}.json?print=true&filter_top_level_replies=true&preview_theme_id=9999",
       )
     end
 


### PR DESCRIPTION
Why this change?

When the URL `/t/1234?preview_theme_id=21` is loaded, we redirect to
`/t/<topic slug>/1234` stripping the `preview_theme_id` query params.

What does this change do?

This change builds on 61248652cdbcc04cecccad939c53139a73b5313d and
simply adds the `preview_theme_id` query param when redirecting.