### PR TITLE
UX: Fix deselect text location in edit sidebar category/tag modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -56,6 +56,8 @@
                     {{/if}}
                   </div>
                 {{/if}}
+
+                {{yield to="belowModalTitle"}}
               </div>
 
               {{yield to="headerBelowTitle"}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.hbs
@@ -3,7 +3,7 @@
   @title={{i18n @title}}
   @closeModal={{@closeModal}}
 >
-  <:headerBelowTitle>
+  <:belowModalTitle>
     <p class="sidebar__edit-navigation-menu__deselect-wrapper">
       <DButton
         @label="sidebar.edit_navigation_modal_form.deselect_button_text"
@@ -14,7 +14,7 @@
 
       {{@deselectAllText}}
     </p>
-  </:headerBelowTitle>
+  </:belowModalTitle>
 
   <:belowHeader>
     <div class="sidebar__edit-navigation-menu__filter">


### PR DESCRIPTION
### Why this change?

In 38d32080274a864580c86827e98ab1de914269a5, the position of the
`headerBelowTitle` outlet was changed causing the deselect text in the
edit sidebar catgegory/tag modals to appear inline with the title which
we do not want.

### What does this change do?

This change introduces the `belowModalTitle` outlet in `DModal` which is
where the `headerBelowTitle` outlet was located before it was changed.

### Screenshot

#### Before 

![Screenshot from 2023-10-18 11-17-38](https://github.com/discourse/discourse/assets/4335742/73fbbdf1-beb9-411b-851c-45684ab80e60)

#### After

![Screenshot from 2023-10-18 11-17-27](https://github.com/discourse/discourse/assets/4335742/f9c47c03-e43d-4f91-9ac2-911372d88bbd)
