### PR TITLE
Add category custom field preloading to CategoryList

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -6,6 +6,9 @@ class CategoryList
   cattr_accessor :preloaded_topic_custom_fields
   self.preloaded_topic_custom_fields = Set.new
 
+  cattr_accessor :preloaded_category_custom_fields
+  self.preloaded_category_custom_fields = Set.new
+
   attr_accessor :categories, :uncategorized
 
   def self.register_included_association(association)
@@ -137,6 +140,10 @@ class CategoryList
       DiscoursePluginRegistry.apply_modifier(:category_list_find_categories_query, query, self)
 
     @categories = query.to_a
+
+    if preloaded_category_custom_fields.any?
+      Category.preload_custom_fields(@categories, preloaded_category_custom_fields)
+    end
 
     include_subcategories = @options[:include_subcategories] == true
 

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -291,6 +291,13 @@ class Plugin::Instance
     Upload.add_in_use_callback(&block)
   end
 
+  # Registers a category custom field to be loaded when rendering a category list
+  # Example usage:
+  #   register_category_list_preloaded_category_custom_fields("custom_field")
+  def register_category_list_preloaded_category_custom_fields(field)
+    CategoryList.preloaded_category_custom_fields << field
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       UserLookup.lookup_columns << column

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -357,4 +357,21 @@ RSpec.describe CategoryList do
       DiscoursePluginRegistry.clear_modifiers!
     end
   end
+
+  describe "with custom fields" do
+    fab!(:category) { Fabricate(:category, user: admin) }
+
+    before { category.upsert_custom_fields("bob" => "marley") }
+    after { CategoryList.preloaded_category_custom_fields = Set.new }
+
+    it "can preloads custom fields" do
+      CategoryList.preloaded_category_custom_fields << "bob"
+
+      expect(category_list.categories[-1].custom_field_preloaded?("bob")).to eq(true)
+    end
+
+    it "does not preload fields that were not set for preloading" do
+      expect(category_list.categories[-1].custom_field_preloaded?("bob")).to be_falsey
+    end
+  end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe CategoriesController do
 
       before do
         plugin.enabled = false
-        clear_custom_fields
+        category.clear_custom_fields
       end
 
       def add_custom_fields
@@ -393,15 +393,6 @@ RSpec.describe CategoriesController do
         plugin.add_to_serializer(:basic_category, :bob) { object.custom_fields["bob"] }
         category.custom_fields["bob"] = "marley"
         category.save
-      end
-
-      def clear_custom_fields
-        category.clear_custom_fields
-      end
-
-      def warmup
-        get "/categories.json"
-        expect(response.status).to eq(200)
       end
 
       def queries_without_custom_fields
@@ -428,7 +419,10 @@ RSpec.describe CategoriesController do
         before { CategoryList.preloaded_category_custom_fields = Set.new }
 
         it "increases the query count" do
-          warmup
+          # warmup
+          get "/categories.json"
+          expect(response.status).to eq(200)
+
           without_custom_fields = queries_without_custom_fields
           add_custom_fields
           with_custom_fields = queries_with_custom_fields
@@ -440,7 +434,10 @@ RSpec.describe CategoriesController do
         before { CategoryList.preloaded_category_custom_fields << "bob" }
 
         it "does not increase the query count" do
-          warmup
+          # warmup
+          get "/categories.json"
+          expect(response.status).to eq(200)
+
           without_custom_fields = queries_without_custom_fields
           add_custom_fields
           with_custom_fields = queries_with_custom_fields


### PR DESCRIPTION
I came across this gap in custom field preloading while working on performance in the ActivityPub plugin. Hopefully the specs describe this sufficiently, but let me know if further explanation is needed.
