### PR TITLE
DEV: Add class name of action type for flag-action-type container

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
@@ -1,72 +1,74 @@
-{{#if this.isNotifyUser}}
-  <h3>{{this.formattedName}}</h3>
-  <div class="controls">
-    <label class="radio">
-      <input
-        id="radio_{{this.flag.name_key}}"
-        {{on "click" (action "changePostActionType" this.flag)}}
-        type="radio"
-        name="post_action_type_index"
-      />
+<div class={{this.wrapperClassNames}}>
+  {{#if this.isNotifyUser}}
+    <h3>{{this.formattedName}}</h3>
+    <div class="controls">
+      <label class="radio">
+        <input
+          id="radio_{{this.flag.name_key}}"
+          {{on "click" (action "changePostActionType" this.flag)}}
+          type="radio"
+          name="post_action_type_index"
+        />
 
-      <div class="flag-action-type-details">
-        <span class="description">{{html-safe this.flag.description}}</span>
-        {{#if this.showMessageInput}}
-          <Textarea
-            name="message"
-            class="flag-message"
-            placeholder={{this.customPlaceholder}}
-            aria-label={{i18n "flagging.notify_user_textarea_label"}}
-            @value={{this.message}}
-          />
-          <div
-            class={{concat-class
-              "custom-message-length"
-              this.customMessageLengthClasses
-            }}
-          >
-            {{this.customMessageLength}}
-          </div>
-        {{/if}}
-      </div>
-    </label>
-  </div>
-  {{#if this.staffFlagsAvailable}}
-    <hr />
-    <h3>{{i18n "flagging.notify_staff"}}</h3>
+        <div class="flag-action-type-details">
+          <span class="description">{{html-safe this.flag.description}}</span>
+          {{#if this.showMessageInput}}
+            <Textarea
+              name="message"
+              class="flag-message"
+              placeholder={{this.customPlaceholder}}
+              aria-label={{i18n "flagging.notify_user_textarea_label"}}
+              @value={{this.message}}
+            />
+            <div
+              class={{concat-class
+                "custom-message-length"
+                this.customMessageLengthClasses
+              }}
+            >
+              {{this.customMessageLength}}
+            </div>
+          {{/if}}
+        </div>
+      </label>
+    </div>
+    {{#if this.staffFlagsAvailable}}
+      <hr />
+      <h3>{{i18n "flagging.notify_staff"}}</h3>
+    {{/if}}
+  {{else}}
+    <div class="controls {{this.flag.name_key}}">
+      <label class="radio">
+        <input
+          id="radio_{{this.flag.name_key}}"
+          {{on "click" (action "changePostActionType" this.flag)}}
+          type="radio"
+          name="post_action_type_index"
+        />
+        <div class="flag-action-type-details">
+          <strong>{{this.formattedName}}</strong>
+          {{#if this.showDescription}}
+            <div class="description">{{html-safe this.description}}</div>
+          {{/if}}
+          {{#if this.showMessageInput}}
+            <Textarea
+              name="message"
+              class="flag-message"
+              placeholder={{this.customPlaceholder}}
+              aria-label={{i18n "flagging.notify_moderators_textarea_label"}}
+              @value={{this.message}}
+            />
+            <div
+              class={{concat-class
+                "custom-message-length"
+                this.customMessageLengthClasses
+              }}
+            >
+              {{this.customMessageLength}}
+            </div>
+          {{/if}}
+        </div>
+      </label>
+    </div>
   {{/if}}
-{{else}}
-  <div class="controls {{this.flag.name_key}}">
-    <label class="radio">
-      <input
-        id="radio_{{this.flag.name_key}}"
-        {{on "click" (action "changePostActionType" this.flag)}}
-        type="radio"
-        name="post_action_type_index"
-      />
-      <div class="flag-action-type-details">
-        <strong>{{this.formattedName}}</strong>
-        {{#if this.showDescription}}
-          <div class="description">{{html-safe this.description}}</div>
-        {{/if}}
-        {{#if this.showMessageInput}}
-          <Textarea
-            name="message"
-            class="flag-message"
-            placeholder={{this.customPlaceholder}}
-            aria-label={{i18n "flagging.notify_moderators_textarea_label"}}
-            @value={{this.message}}
-          />
-          <div
-            class={{concat-class
-              "custom-message-length"
-              this.customMessageLengthClasses
-            }}
-          >
-            {{this.customMessageLength}}
-          </div>
-        {{/if}}
-      </div>
-    </label>
-  </div>
-{{/if}}
+</div>

--- a/app/assets/javascripts/discourse/app/components/flag-action-type.js
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.js
@@ -5,7 +5,12 @@ import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 
 export default Component.extend({
-  classNames: ["flag-action-type"],
+  tagName: "",
+
+  @discourseComputed("flag.name_key")
+  wrapperClassNames(nameKey) {
+    return `flag-action-type ${nameKey}`;
+  },
 
   @discourseComputed("flag.name_key")
   customPlaceholder(nameKey) {


### PR DESCRIPTION
This adds a classname to each flag-action-type container. I need this class name for a theme customization.

## Old HTML (Boring!!)
<img width="440" alt="Screenshot 2023-10-18 at 9 59 51 AM" src="https://github.com/discourse/discourse/assets/16214023/790c2ebf-23f2-4885-998d-1f7a63bc38a8">

## New HTML (wow, slick!)
<img width="455" alt="Screenshot 2023-10-18 at 9 59 32 AM" src="https://github.com/discourse/discourse/assets/16214023/57668d4f-4d38-433e-8e27-1fc1578e545d">
