### PR TITLE
DEV: remove ember-auto-import from lazy bundle addons

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "discourse-common": "1.0.0",
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-template-imports": "^4.0.0"

--- a/app/assets/javascripts/discourse-plugins/package.json
+++ b/app/assets/javascripts/discourse-plugins/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "deprecation-silencer": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-template-imports": "^4.0.0",

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -55,43 +55,45 @@ module.exports = function (defaults) {
       // This forces the use of `fast-sourcemap-concat` which works in production.
       enabled: true,
     },
-    autoImport: {
-      forbidEval: true,
-      insertScriptsAt: "ember-auto-import-scripts",
-      watchDependencies: ["discourse-i18n"],
-      webpack: {
-        // Workarounds for https://github.com/ef4/ember-auto-import/issues/519 and https://github.com/ef4/ember-auto-import/issues/478
-        devtool: isProduction ? false : "source-map", // Sourcemaps contain reference to the ephemeral broccoli cache dir, which changes on every deploy
-        optimization: {
-          moduleIds: "size", // Consistent module references https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
-        },
-        resolve: {
-          fallback: {
-            // Sinon needs a `util` polyfill
-            util: require.resolve("util/"),
-            // Also for sinon
-            timers: false,
-          },
-        },
-        module: {
-          rules: [
-            // Sinon/`util` polyfill accesses the `process` global,
-            // so we need to provide a mock
-            {
-              test: require.resolve("util/"),
-              use: [
+    autoImport: isEmbroider
+      ? {}
+      : {
+          forbidEval: true,
+          insertScriptsAt: "ember-auto-import-scripts",
+          watchDependencies: ["discourse-i18n"],
+          webpack: {
+            // Workarounds for https://github.com/ef4/ember-auto-import/issues/519 and https://github.com/ef4/ember-auto-import/issues/478
+            devtool: isProduction ? false : "source-map", // Sourcemaps contain reference to the ephemeral broccoli cache dir, which changes on every deploy
+            optimization: {
+              moduleIds: "size", // Consistent module references https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
+            },
+            resolve: {
+              fallback: {
+                // Sinon needs a `util` polyfill
+                util: require.resolve("util/"),
+                // Also for sinon
+                timers: false,
+              },
+            },
+            module: {
+              rules: [
+                // Sinon/`util` polyfill accesses the `process` global,
+                // so we need to provide a mock
                 {
-                  loader: "imports-loader",
-                  options: {
-                    additionalCode: "var process = { env: {} };",
-                  },
+                  test: require.resolve("util/"),
+                  use: [
+                    {
+                      loader: "imports-loader",
+                      options: {
+                        additionalCode: "var process = { env: {} };",
+                      },
+                    },
+                  ],
                 },
               ],
             },
-          ],
+          },
         },
-      },
-    },
     fingerprint: {
       // Handled by Rails asset pipeline
       enabled: false,

--- a/app/assets/javascripts/wizard/package.json
+++ b/app/assets/javascripts/wizard/package.json
@@ -14,7 +14,6 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0"
   },


### PR DESCRIPTION
`admin`, `discourse-plugins` and `wizard` are not traditional Ember addons, they are basically just fancy Broccoli build files that we run manually. `ember-auto-import` doesn't really work or do anything for them but it seems to be causing an extra Webpack build to happen needlessly in Embroider mode when we construct the `extraPublicTrees` all just to generate a few mostly empty stub files.

On my computer it also seems to make the build marginally faster.