### PR TITLE
UX: video placeholder icon should always be white

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -935,7 +935,7 @@ aside.onebox.mixcloud-preview {
     background-position: center;
     max-width: 30%;
     .d-icon {
-      color: var(--secondary);
+      color: white;
       height: 2em;
       width: 2em;
       transition: width 0.15s, height 0.15s;


### PR DESCRIPTION
Since the placeholder background in always black, the icon should always be white... this is fairly standard for video, and some themes don't have a lot of contrast between black and var(--secondary)

before
<img width="580" alt="Screenshot 2023-10-18 at 5 41 31 PM" src="https://github.com/discourse/discourse/assets/1681963/97b5b85b-06e2-45a6-9d8e-e8b6d4c3f754">


after 
<img width="577" alt="Screenshot 2023-10-18 at 5 41 21 PM" src="https://github.com/discourse/discourse/assets/1681963/ff72e9e7-ef7d-4a13-a242-6b6063dd6ae6">
