### PR TITLE
FIX: remove unused root max width in wizard

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -12,10 +12,6 @@
   }
 }
 
-:root {
-  --d-max-width: 100%;
-}
-
 body.wizard {
   background-color: var(--primary-50);
   color: var(--primary-very-high);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

This PR is to remove the root max width that is forcing the layout to be left aligned.