### PR TITLE
UX: Update highlight.js styles

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -11,7 +11,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-comment,
-.hljs-doctag {
+.hljs-doctag,
+.hljs-code {
   color: var(--hljs-comment);
   font-style: italic;
 }
@@ -33,12 +34,18 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 .hljs-string,
 .hljs-tag .hljs-string,
+.hljs-template-tag,
+.hljs-template-variable,
 .tex .hljs-formula {
   color: var(--hljs-string);
 }
 
 .hljs-title,
 .hljs-name,
+.hljs-quote,
+.hljs-operator,
+.hljs-selector-pseudo,
+.hljs-selector-tag,
 .coffeescript .hljs-params,
 .scss .hljs-meta {
   color: var(--hljs-string);
@@ -68,6 +75,9 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-attribute,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id,
 .css .hljs-keyword,
 .hljs-variable,
 .lisp .hljs-body {
@@ -108,6 +118,24 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 .diff .hljs-meta {
   color: var(--primary-low);
+}
+
+.hljs-section {
+  color: var(--hljs-builtin-name);
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  color: var(--hljs-attribute);
+}
+
+.hljs-emphasis {
+  color: var(--hljs-comment);
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
 }
 
 /*


### PR DESCRIPTION
We were missing some selectors that affect markdown highlighting in particular.

Before

<img width="846" alt="image" src="https://github.com/discourse/discourse/assets/368961/5df355bc-261e-4eb5-b901-30f042c49ec2">

After

<img width="853" alt="image" src="https://github.com/discourse/discourse/assets/368961/5412b6bb-a852-4a73-8815-2af9f5f4e7f9">

Reported in https://meta.discourse.org/t/markdown-syntax-highlighting-in-post-editor/282665/4 
