### PR TITLE
DEV: Remove deprecated UrlHelper#escape_uri helper

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -66,15 +66,6 @@ class UrlHelper
     self.absolute(Upload.secure_uploads_url_from_upload_url(url), nil)
   end
 
-  def self.escape_uri(uri)
-    Discourse.deprecate(
-      "UrlHelper.escape_uri is deprecated. For normalization of user input use `.normalized_encode`. For true encoding, use `.encode`",
-      output_in_test: true,
-      drop_from: "3.0",
-    )
-    normalized_encode(uri)
-  end
-
   def self.normalized_encode(uri)
     url = uri.to_s
 


### PR DESCRIPTION
### What is this change?

The `UrlHelper#escape_uri` helper has been deprecated and replaced by `UrlHelper#normalized_encode`, and was marked for removal in 3.0. This PR removes the method.

### Verification

- [x] In a search across all public and private repositories, there are no usages found.
- [x] In the logs across all hosting, there are no deprecation warnings indicating use of this method.