### PR TITLE
FIX: change max-width size to make the background image expand the same width as the browser

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -18,6 +18,10 @@ body.wizard {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
 
+  .wrap {
+    max-width: 100%;
+  }
+
   #wizard-main {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION

### Before
<img width="1473" alt="image" src="https://github.com/discourse/discourse/assets/2790986/5563d692-ca86-4e70-8758-0225a72860a8">


### After
<img width="1489" alt="image" src="https://github.com/discourse/discourse/assets/2790986/ff794872-7fa3-4f2e-8245-f8ac088cfb8d">
