### PR TITLE
DEV: Cleanup autoimport-related config from ember-cli-build

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "discourse-common": "1.0.0",
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-template-imports": "^4.0.0"

--- a/app/assets/javascripts/discourse-plugins/package.json
+++ b/app/assets/javascripts/discourse-plugins/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "deprecation-silencer": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-template-imports": "^4.0.0",

--- a/app/assets/javascripts/wizard/package.json
+++ b/app/assets/javascripts/wizard/package.json
@@ -14,7 +14,6 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0"
   },


### PR DESCRIPTION
Running addonPostprocessTree manually was causing ember-auto-import's postprocess hook to run and generate extra unnecessary chunks. The only reason called addonPostprocessTree directly was to allow the terser plugin to run on the extra public trees. We can do the terser postprocessing manually instead.

This commit is approximately the inverse of e1d27400f5d8be345383b52bd118e652724a517e.

This commit also removes ember-auto-import as dependencies of admin/wizard/discourse-plugins because they are not 'real' ember addons, and so it isn't serving any useful purpose. (see also https://github.com/discourse/discourse/pull/23974)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
