### PR TITLE
UX: Move public sidebar section checkbox up to make it obvious

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
@@ -7,6 +7,31 @@
 >
   <:body>
     <form class="form-horizontal sidebar-section-form">
+      {{#if (and this.currentUser.admin)}}
+        <div
+          class="row-wrapper mark-public-wrapper
+            {{if this.transformedModel.sectionType '-disabled'}}"
+        >
+          <label class="checkbox-label">
+            {{#if this.transformedModel.sectionType}}
+              <DTooltip
+                @icon="check-square"
+                @content={{i18n "sidebar.sections.custom.always_public"}}
+                class="always-public-tooltip"
+              />
+            {{else}}
+              <Input
+                @type="checkbox"
+                @checked={{this.transformedModel.public}}
+                class="mark-public"
+                disabled={{this.transformedModel.sectionType}}
+              />
+            {{/if}}
+            <span>{{i18n "sidebar.sections.custom.public"}}</span>
+          </label>
+        </div>
+      {{/if}}
+
       {{#unless this.transformedModel.hideTitleInput}}
         <div class="sidebar-section-form__input-wrapper">
           <label for="section-name">
@@ -81,31 +106,6 @@
           @ariaLabel="sidebar.sections.custom.links.add"
           class="btn-flat btn-text add-link"
         />
-      {{/if}}
-
-      {{#if (and this.currentUser.admin)}}
-        <div
-          class="row-wrapper mark-public-wrapper
-            {{if this.transformedModel.sectionType '-disabled'}}"
-        >
-          <label class="checkbox-label">
-            {{#if this.transformedModel.sectionType}}
-              <DTooltip
-                @icon="check-square"
-                @content={{i18n "sidebar.sections.custom.always_public"}}
-                class="always-public-tooltip"
-              />
-            {{else}}
-              <Input
-                @type="checkbox"
-                @checked={{this.transformedModel.public}}
-                class="mark-public"
-                disabled={{this.transformedModel.sectionType}}
-              />
-            {{/if}}
-            <span>{{i18n "sidebar.sections.custom.public"}}</span>
-          </label>
-        </div>
       {{/if}}
     </form>
   </:body>

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -201,8 +201,6 @@
       grid-column: 2;
     }
     &.mark-public-wrapper {
-      margin-top: 1em;
-      padding-bottom: 0;
       &.-disabled label {
         cursor: not-allowed;
       }


### PR DESCRIPTION
Moving the checkbox to the top of the modal can make it more obvious to admins that the sidebar section is public.

<img width="972" alt="Screenshot 2023-10-19 at 8 12 37 PM" src="https://github.com/discourse/discourse/assets/1555215/f07512ef-22b1-4a44-a409-be52e78b37c2">
