### PR TITLE
PERF: Stop eagerly-loading core helper modules

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/auto-load-modules.js
@@ -7,12 +7,22 @@ import {
 import RawHandlebars from "discourse-common/lib/raw-handlebars";
 import { registerRawHelpers } from "discourse-common/lib/raw-handlebars-helpers";
 
+function isThemeOrPluginHelper(path) {
+  return (
+    path.includes("/helpers/") &&
+    (path.startsWith("discourse/theme-") ||
+      path.startsWith("discourse/plugins/")) &&
+    !path.endsWith("-test")
+  );
+}
+
 export function autoLoadModules(owner, registry) {
   Object.keys(requirejs.entries).forEach((entry) => {
-    if (/\/helpers\//.test(entry) && !/-test/.test(entry)) {
+    if (isThemeOrPluginHelper(entry)) {
+      // Once the discourse.register-unbound deprecation is resolved, we can remove this eager loading
       requirejs(entry, null, null, true);
     }
-    if (/\/widgets\//.test(entry) && !/-test/.test(entry)) {
+    if (entry.includes("/widgets/") && !entry.endsWith("-test")) {
       requirejs(entry, null, null, true);
     }
   });
@@ -31,7 +41,7 @@ export function autoLoadModules(owner, registry) {
 
   createHelperContext(context);
   registerHelpers(registry);
-  registerRawHelpers(RawHandlebars, Handlebars);
+  registerRawHelpers(RawHandlebars, Handlebars, owner);
 }
 
 export default {


### PR DESCRIPTION
Now that core has a file structure and default imports, Ember's resolver can load helpers lazily. So we can remove the lazy loading, and helpers in ember templates will continue to work. This should provide a slight performance improvement for initial boot.

However, there is a slight complication: some of our helpers are also registered with our Raw Handlebars system as a side-effect of loading the module. Therefore, this commit adds a `helperMissing` helper to our RawHandlebars system. This looks up the helper by name in the ember resolver, which triggers the relevant module to be evaluated, and the raw helper to be registered as a side effect.

For backwards-compatibility, plugin and theme helpers continue to be eagerly evaluated. Once the `discourse.register-unbound` deprecation is resolved, we can safely remove this eager loading.

(for review/merge after #23802 has landed) 