### PR TITLE
FEATURE: Add all user update API scopes

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -126,7 +126,14 @@ class ApiKeyScope < ActiveRecord::Base
             params: %i[username],
           },
           update: {
-            actions: %w[users#update],
+            actions: %w[
+              users#update
+              users#badge_title
+              users#pick_avatar
+              users#select_avatar
+              users#feature_topic
+              users#clear_featured_topic
+            ],
             params: %i[username],
           },
           log_out: {

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -464,6 +464,21 @@ RSpec.describe Admin::ApiController do
 
         expect(scopes["posts"].any? { |h| h["urls"].include?("/posts (GET)") }).to be_truthy
         expect(scopes["posts"].any? { |h| h["urls"].include?("/private-posts (GET)") }).to be_truthy
+
+        expect(scopes["users"].find { _1["key"] == "update" }["urls"]).to contain_exactly(
+          "/users/:username (PUT)",
+          "/users/:username/preferences/badge_title (PUT)",
+          "/users/:username/preferences/avatar/pick (PUT)",
+          "/users/:username/preferences/avatar/select (PUT)",
+          "/users/:username/feature-topic (PUT)",
+          "/users/:username/clear-featured-topic (PUT)",
+          "/u/:username (PUT)",
+          "/u/:username/preferences/badge_title (PUT)",
+          "/u/:username/preferences/avatar/pick (PUT)",
+          "/u/:username/preferences/avatar/select (PUT)",
+          "/u/:username/feature-topic (PUT)",
+          "/u/:username/clear-featured-topic (PUT)",
+        )
       end
     end
 


### PR DESCRIPTION
There are a few PUT requests that users can do in their preferences tab that aren't going through the standard `user#update` action.

This commit adds all the "trivial" ones (aka. except the security-related one, username and email changes) so you can now change the badge title, the avatar or featured topic of a user via the API.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
