### PR TITLE
DEV: Modernize chat helper definitions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
@@ -1,10 +1,9 @@
 import { htmlSafe } from "@ember/template";
 import User from "discourse/models/user";
 import getURL from "discourse-common/lib/get-url";
-import { registerUnbound } from "discourse-common/lib/helpers";
 import I18n from "discourse-i18n";
 
-registerUnbound("format-chat-date", function (message, mode) {
+export default function formatChatDate(message, mode) {
   const currentUser = User.current();
   const tz = currentUser ? currentUser.user_option.timezone : moment.tz.guess();
   const date = moment(new Date(message.createdAt), tz);
@@ -25,4 +24,4 @@ registerUnbound("format-chat-date", function (message, mode) {
       `<a title='${title}' tabindex="-1" class='chat-time' href='${url}'>${display}</a>`
     );
   }
-});
+}

--- a/plugins/chat/assets/javascripts/discourse/helpers/tonable-emoji-title.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/tonable-emoji-title.js
@@ -1,9 +1,7 @@
-import { registerUnbound } from "discourse-common/lib/helpers";
-
-registerUnbound("tonable-emoji-title", function (emoji, diversity) {
+export default function tonableEmojiTitle(emoji, diversity) {
   if (!emoji.tonable || diversity === 1) {
     return `:${emoji.name}:`;
   }
 
   return `:${emoji.name}:t${diversity}:`;
-});
+}

--- a/plugins/chat/assets/javascripts/discourse/helpers/tonable-emoji-url.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/tonable-emoji-url.js
@@ -1,9 +1,7 @@
-import { registerUnbound } from "discourse-common/lib/helpers";
-
-registerUnbound("tonable-emoji-url", function (emoji, scale) {
+export default function tonableEmojiUrl(emoji, scale) {
   if (!emoji.tonable || scale === 1) {
     return emoji.url;
   }
 
   return emoji.url.split(".png")[0] + `/${scale}.png`;
-});
+}


### PR DESCRIPTION
These helpers are never used in raw-hbs. Exporting default functions is enough for them to be picked up by the ember resolver, and also makes it possible to use them in gjs files.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
