### PR TITLE
UX: move global option to sidebar modal footer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
@@ -82,34 +82,8 @@
           class="btn-flat btn-text add-link"
         />
       {{/if}}
-
-      {{#if (and this.currentUser.admin)}}
-        <div
-          class="row-wrapper mark-public-wrapper
-            {{if this.transformedModel.sectionType '-disabled'}}"
-        >
-          <label class="checkbox-label">
-            {{#if this.transformedModel.sectionType}}
-              <DTooltip
-                @icon="check-square"
-                @content={{i18n "sidebar.sections.custom.always_public"}}
-                class="always-public-tooltip"
-              />
-            {{else}}
-              <Input
-                @type="checkbox"
-                @checked={{this.transformedModel.public}}
-                class="mark-public"
-                disabled={{this.transformedModel.sectionType}}
-              />
-            {{/if}}
-            <span>{{i18n "sidebar.sections.custom.public"}}</span>
-          </label>
-        </div>
-      {{/if}}
     </form>
   </:body>
-
   <:footer>
     <DButton
       @action={{this.save}}
@@ -119,6 +93,30 @@
       id="save-section"
       class="btn-primary"
     />
+    {{#if (and this.currentUser.admin)}}
+      <div
+        class="mark-public-wrapper
+          {{if this.transformedModel.sectionType '-disabled'}}"
+      >
+        <label class="checkbox-label">
+          {{#if this.transformedModel.sectionType}}
+            <DTooltip
+              @icon="check-square"
+              @content={{i18n "sidebar.sections.custom.always_public"}}
+              class="always-public-tooltip"
+            />
+          {{else}}
+            <Input
+              @type="checkbox"
+              @checked={{this.transformedModel.public}}
+              class="mark-public"
+              disabled={{this.transformedModel.sectionType}}
+            />
+          {{/if}}
+          <span>{{i18n "sidebar.sections.custom.public"}}</span>
+        </label>
+      </div>
+    {{/if}}
     {{#if this.canDelete}}
       <DButton
         @icon="trash-alt"

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -200,16 +200,7 @@
     .link-icon {
       grid-column: 2;
     }
-    &.mark-public-wrapper {
-      margin-top: 1em;
-      padding-bottom: 0;
-      &.-disabled label {
-        cursor: not-allowed;
-      }
-      label {
-        grid-column: 1 / -1;
-      }
-    }
+
     .input-group {
       margin: 0 0.5em;
       @include breakpoint(mobile-large) {
@@ -239,11 +230,29 @@
     }
   }
   .modal-footer {
-    display: flex;
-    justify-content: space-between;
-
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.5em;
+    @include breakpoint(mobile-extra-large) {
+      grid-template-columns: auto 1fr;
+      justify-items: left;
+      .mark-public-wrapper {
+        grid-row: 1;
+        grid-column: 1 / span 2;
+      }
+    }
+    .reset-link,
     .delete {
-      margin-right: 0;
+      margin: 0;
+      justify-self: right;
+    }
+    .mark-public-wrapper {
+      &.-disabled label {
+        cursor: not-allowed;
+      }
+      .checkbox-label {
+        margin: 0;
+      }
     }
   }
   .select-kit.multi-select .multi-select-header .formatted-selection {


### PR DESCRIPTION
This moves the global checkbox to the modal footer, so it's harder to overlook on tall modals with scroll. 

Before:
![Screenshot 2023-10-19 at 11 31 02 AM](https://github.com/discourse/discourse/assets/1681963/48afba3d-2a15-4de8-962f-c38b8e10e7af)
![Screenshot 2023-10-19 at 11 30 53 AM](https://github.com/discourse/discourse/assets/1681963/8148f79f-b233-4f3b-9645-801f7bb0f9f2)



After:
![Screenshot 2023-10-19 at 11 24 16 AM](https://github.com/discourse/discourse/assets/1681963/af2af0fc-54b4-4089-857c-6625e9286898)
![Screenshot 2023-10-19 at 11 24 27 AM](https://github.com/discourse/discourse/assets/1681963/9ede5770-be7e-4619-9fca-94b8ac1ec298)
![Screenshot 2023-10-19 at 11 24 41 AM](https://github.com/discourse/discourse/assets/1681963/6cfd4383-dae3-4c63-b41b-25776aec3249)
