### PR TITLE
DEV: Remove post-admin-menu placeholder

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
@@ -1,4 +1,0 @@
-import { createWidget } from "discourse/widgets/widget";
-
-// placeholder for now
-export default createWidget("post-admin-menu", {});


### PR DESCRIPTION
This widget is no longer used. It's better to remove it completely, so that `decorateWidget` and `reopenWidget` calls print a warning to the console rather than failing silently.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
