### PR TITLE
DEV: Print error when decorateWidget target does not exist

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -41,7 +41,14 @@ export function deleteFromRegistry(name) {
 const _decorators = {};
 
 export function decorateWidget(widgetName, cb) {
-  _decorators[widgetName] = _decorators[widgetName] || [];
+  if (!_registry[name]) {
+    // eslint-disable-next-line no-console
+    console.error(
+      consolePrefix(),
+      `decorateWidget: Could not find widget '${name}' in registry`
+    );
+  }
+  _decorators[widgetName] ??= [];
   _decorators[widgetName].push(cb);
 }
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
