### PR TITLE
FIX: Order result set of category search

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -352,12 +352,13 @@ class CategoriesController < ApplicationController
 
     categories = categories.order(<<~SQL) if prioritized_category_id.present?
       CASE
-      WHEN id = #{prioritized_category_id} OR parent_category_id = #{prioritized_category_id} THEN 0
-      ELSE 1
+      WHEN id = #{prioritized_category_id} THEN 1
+      WHEN parent_category_id = #{prioritized_category_id} THEN 2
+      ELSE 3
       END
     SQL
 
-    categories = categories.order(:read_restricted)
+    categories.order(:id)
 
     render json: categories, each_serializer: SiteCategorySerializer
   end


### PR DESCRIPTION
The previous order was too different from the logic we have on the frontend.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
