### PR TITLE
DEV: Correct addPostAdminMenuButton docs

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -642,22 +642,22 @@ class PluginApi {
    * Example:
    *
    * ```
-   * api.addPostAdminMenuButton((name, attrs) => {
+   * api.addPostAdminMenuButton((post) => {
    *   return {
    *     action: () => {
    *       alert('You clicked on the coffee button!');
    *     },
    *     icon: 'coffee',
    *     className: 'hot-coffee',
-   *     title: 'coffee.title',
+   *     label: 'coffee.title',
    *   };
    * });
    * ```
    **/
-  addPostAdminMenuButton(name, callback) {
+  addPostAdminMenuButton(callback) {
     this.container
       .lookup("service:admin-post-menu-buttons")
-      .addButton(name, callback);
+      .addButton(callback);
   }
 
   /**


### PR DESCRIPTION
The `name` argument doesn't do anything, and 'title' should actually be 'label'

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
