### PR TITLE
DEV: Correct decorateWidget error checking logic

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -41,11 +41,11 @@ export function deleteFromRegistry(name) {
 const _decorators = {};
 
 export function decorateWidget(widgetName, cb) {
-  if (!_registry[name]) {
+  if (!_registry[widgetName]) {
     // eslint-disable-next-line no-console
     console.error(
       consolePrefix(),
-      `decorateWidget: Could not find widget '${name}' in registry`
+      `decorateWidget: Could not find widget '${widgetName}' in registry`
     );
   }
   _decorators[widgetName] ??= [];


### PR DESCRIPTION
`name` referred to `window.name`, so the mistake wasn't detected by eslint 🤦‍♂️

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
