### PR TITLE
DEV: Actually fix decorateWidget error checking logic

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -40,7 +40,8 @@ export function deleteFromRegistry(name) {
 
 const _decorators = {};
 
-export function decorateWidget(widgetName, cb) {
+export function decorateWidget(decorateIdentifier, cb) {
+  const widgetName = decorateIdentifier.split(":")[0];
   if (!_registry[widgetName]) {
     // eslint-disable-next-line no-console
     console.error(
@@ -48,8 +49,8 @@ export function decorateWidget(widgetName, cb) {
       `decorateWidget: Could not find widget '${widgetName}' in registry`
     );
   }
-  _decorators[widgetName] ??= [];
-  _decorators[widgetName].push(cb);
+  _decorators[decorateIdentifier] ??= [];
+  _decorators[decorateIdentifier].push(cb);
 }
 
 export function traverseCustomWidgets(tree, callback) {


### PR DESCRIPTION
We need to separate the `:before` / `:after` suffix before looking up in the registry 🤦‍♂️🤦‍♂️

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
