### PR TITLE
DEV: Fix Ember inspector error on anonymous user

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -34,7 +34,7 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get showCount() {
-    return this.currentUser.sidebarShowCountOfNewItems;
+    return this.currentUser?.sidebarShowCountOfNewItems;
   }
 
   get name() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
@@ -28,7 +28,7 @@ export default class ReviewSectionLink extends BaseSectionLink {
   get badgeText() {
     // force a tracker for reviewable_count by using .get to ensure badgeText
     // rerenders when reviewable_count changes
-    if (this.currentUser.get("reviewable_count") > 0) {
+    if (this.currentUser?.get("reviewable_count") > 0) {
       return I18n.t("sidebar.sections.community.links.review.pending_count", {
         count: this.currentUser.reviewable_count,
       });


### PR DESCRIPTION
<img width="1497" alt="image" src="https://github.com/discourse/discourse/assets/368961/5b061331-178b-47ae-97a5-00ab98b69f55">

I would see the above error locally with the Ember Inspector extension enabled and visiting the page as an unauthenticated user. 

This seems also like an indicator of a bigger issue, these getters should likely not be hit for non-auth users. 