### PR TITLE
UX: Fixes for mobile "create account" modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -274,12 +274,13 @@
           />
 
         {{/if}}
-        {{#unless this.hasAuthOptions}}
-          <div class="create-account-login-buttons">
-            <LoginButtons @externalLogin={{action "externalLogin"}} />
-          </div>
-        {{/unless}}
-
+        {{#if this.site.desktopView}}
+          {{#unless this.hasAuthOptions}}
+            <div class="create-account-login-buttons">
+              <LoginButtons @externalLogin={{action "externalLogin"}} />
+            </div>
+          {{/unless}}
+        {{/if}}
         {{#if this.skipConfirmation}}
           {{loading-spinner size="large"}}
         {{/if}}

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -333,6 +333,12 @@ body.invite-page {
 .toggle-password-mask {
   align-self: start;
   line-height: 1.4; // aligns with input description text
+  .ios-device & {
+    // reset form-item-sizing mixin styles
+    padding-top: 0;
+    padding-bottom: 0;
+    font-size: var(--font-0);
+  }
 }
 
 // admin invite page

--- a/app/assets/stylesheets/mobile/login.scss
+++ b/app/assets/stylesheets/mobile/login.scss
@@ -212,7 +212,8 @@
     border-bottom: 1px solid var(--primary-low);
   }
   .login-form {
-    margin-bottom: 0.75em;
+    margin-bottom: 0;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
- Don't include login buttons on mobile (this is quite unnecessary because on mobile the user flow is to show the login buttons screen first, then users can toggle to "create an account")
- Fix padding/spacing

Before / After

<img width="230" alt="image" src="https://github.com/discourse/discourse/assets/368961/18ddb5bd-4401-46bc-a69d-cc9e91d619f7"> <img width="230" alt="image" src="https://github.com/discourse/discourse/assets/368961/7a6244be-86d6-4e48-b7e4-2b6340629754">
