### PR TITLE
DEV: refactor rake asset precompile tasks

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -28,11 +28,15 @@ task "assets:precompile:build" do
       "EMBER_ENV"
     ].nil?
 
+    only_ember_precompile_build_remaining =
+      (ARGV.last == "assets:precompile:build")
     only_assets_precompile_remaining = (ARGV.last == "assets:precompile")
 
-    if only_assets_precompile_remaining
-      # Using exec to free up Rails app memory during ember build
-      exec "#{compile_command} && SKIP_EMBER_CLI_COMPILE=1 bin/rake assets:precompile"
+    # Using exec to free up Rails app memory during ember build
+    if only_ember_precompile_build_remaining
+      exec "#{compile_command}
+    elsif only_assets_precompile_remaining
+      exec " #{compile_command} && SKIP_EMBER_CLI_COMPILE=1 bin/rake assets:precompile"
     else
       system compile_command, exception: true
     end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -8,15 +8,13 @@ end
 
 task "assets:precompile:build" do
   if ENV["SKIP_EMBER_CLI_COMPILE"] != "1"
-    compile_command =
-      "yarn --cwd app/assets/javascripts/discourse run ember build"
+    compile_command = "yarn --cwd app/assets/javascripts/discourse run ember build"
 
     heap_size_limit = check_node_heap_size_limit
 
     if heap_size_limit < 1024
       STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 1024MB. Setting --max-old-space-size=1024."
-      compile_command =
-        "NODE_OPTIONS='--max-old-space-size=1024' #{compile_command}"
+      compile_command = "NODE_OPTIONS='--max-old-space-size=1024' #{compile_command}"
     end
 
     if heap_size_limit < 2048
@@ -24,12 +22,9 @@ task "assets:precompile:build" do
       compile_command = "JOBS=0 #{compile_command}"
     end
 
-    compile_command = "EMBER_ENV=production #{compile_command}" if ENV[
-      "EMBER_ENV"
-    ].nil?
+    compile_command = "EMBER_ENV=production #{compile_command}" if ENV["EMBER_ENV"].nil?
 
-    only_ember_precompile_build_remaining =
-      (ARGV.last == "assets:precompile:build")
+    only_ember_precompile_build_remaining = (ARGV.last == "assets:precompile:build")
     only_assets_precompile_remaining = (ARGV.last == "assets:precompile")
 
     # Using exec to free up Rails app memory during ember build
@@ -78,8 +73,7 @@ task "assets:precompile:before": %w[
   require "digest/sha1"
 
   # Add ember cli chunks
-  chunk_files =
-    EmberCli.script_chunks.values.flatten.map { |name| "#{name}.js" }
+  chunk_files = EmberCli.script_chunks.values.flatten.map { |name| "#{name}.js" }
   map_files = chunk_files.map { |file| EmberCli.parse_source_map_path(file) }
   Rails.configuration.assets.precompile.push(*chunk_files, *map_files)
 end
@@ -111,9 +105,7 @@ task "assets:precompile:css" => "environment" do
           Stylesheet::Manager.recalculate_fs_asset_cachebuster!
           Stylesheet::Manager.precompile_css if db == "default"
           Stylesheet::Manager.precompile_theme_css
-        rescue PG::UndefinedColumn,
-               ActiveModel::MissingAttributeError,
-               NoMethodError => e
+        rescue PG::UndefinedColumn, ActiveModel::MissingAttributeError, NoMethodError => e
           STDERR.puts "#{e.class} #{e.message}: #{e.backtrace.join("\n")}"
           STDERR.puts "Skipping precompilation of CSS cause schema is old, you are precompiling prior to running migrations."
         end
@@ -139,11 +131,7 @@ end
 
 def check_node_heap_size_limit
   output, status =
-    Open3.capture2(
-      "node",
-      "-e",
-      "console.log(v8.getHeapStatistics().heap_size_limit/1024/1024)"
-    )
+    Open3.capture2("node", "-e", "console.log(v8.getHeapStatistics().heap_size_limit/1024/1024)")
   raise "Failed to fetch node memory limit" if status != 0
   output.to_f
 end
@@ -194,15 +182,12 @@ def compress_ruby(from, to)
       comments: :none,
       source_map: {
         filename: File.basename(from),
-        output_filename: File.basename(to)
-      }
+        output_filename: File.basename(to),
+      },
     ).compile_with_map(data)
   dest = "#{assets_path}/#{to}"
 
-  File.write(
-    dest,
-    uglified << "\n//# sourceMappingURL=#{cdn_path "/assets/#{to}.map"}"
-  )
+  File.write(dest, uglified << "\n//# sourceMappingURL=#{cdn_path "/assets/#{to}.map"}")
   File.write(dest + ".map", map)
 
   GC.start
@@ -211,9 +196,7 @@ end
 def gzip(path)
   STDERR.puts "gzip -f -c -9 #{path} > #{path}.gz"
   STDERR.puts `gzip -f -c -9 #{path} > #{path}.gz`.strip
-  if $?.exitstatus != 0
-    raise "gzip compression failed: exit code #{$?.exitstatus}"
-  end
+  raise "gzip compression failed: exit code #{$?.exitstatus}" if $?.exitstatus != 0
 end
 
 # different brotli versions use different parameters
@@ -225,9 +208,7 @@ end
 def brotli(path, max_compress)
   STDERR.puts brotli_command(path, max_compress)
   STDERR.puts `#{brotli_command(path, max_compress)}`
-  if $?.exitstatus != 0
-    raise "brotli compression failed: exit code #{$?.exitstatus}"
-  end
+  raise "brotli compression failed: exit code #{$?.exitstatus}" if $?.exitstatus != 0
   STDERR.puts `chmod +r #{path}.br`.strip
   raise "chmod failed: exit code #{$?.exitstatus}" if $?.exitstatus != 0
 end
@@ -253,9 +234,7 @@ def concurrent?
     executor = Concurrent::FixedThreadPool.new(Concurrent.processor_count)
     yield(
       Proc.new do |&block|
-        concurrent_compressors << Concurrent::Future.execute(
-          executor: executor
-        ) { block.call }
+        concurrent_compressors << Concurrent::Future.execute(executor: executor) { block.call }
       end
     )
     concurrent_compressors.each(&:wait!)
@@ -334,10 +313,7 @@ task "assets:precompile:compress_js": "environment" do
 
     if GlobalSetting.fallback_assets_path.present?
       begin
-        FileUtils.cp_r(
-          "#{Rails.root}/public/assets/.",
-          GlobalSetting.fallback_assets_path
-        )
+        FileUtils.cp_r("#{Rails.root}/public/assets/.", GlobalSetting.fallback_assets_path)
       rescue => e
         STDERR.puts "Failed to backup assets to #{GlobalSetting.fallback_assets_path}"
         STDERR.puts e

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -7,7 +7,7 @@ task "assets:precompile:prereqs" do
 end
 
 task "assets:precompile:build" do
-  if ENV["EMBER_CLI_COMPILE_DONE"] != "1"
+  if ENV["SKIP_EMBER_CLI_COMPILE"] != "1"
     compile_command =
       "yarn --cwd app/assets/javascripts/discourse run ember build"
 
@@ -32,7 +32,7 @@ task "assets:precompile:build" do
 
     if only_assets_precompile_remaining
       # Using exec to free up Rails app memory during ember build
-      exec "#{compile_command} && EMBER_CLI_COMPILE_DONE=1 bin/rake assets:precompile"
+      exec "#{compile_command} && SKIP_EMBER_CLI_COMPILE=1 bin/rake assets:precompile"
     else
       system compile_command, exception: true
     end


### PR DESCRIPTION
add a separate ember build task that does not depend on rails env allowing us to compile assets without db+redis connections.

split assets:precompile:before into
assets:precompile:prereqs -- check for prereqs
assets:precompile:build -- ember cli build

ember cli builds can then be triggered separately from the rest of the asset builds, and future asset pipelines can be triggered without ember build with `SKIP_EMBER_CLI_COMPILE=1`.

EmberCLI takes up the majority of the asset pipeline times, and it'd be great to have the option to run these tasks without a full rails setup with db+redis connections.