### PR TITLE
FEATURE: add support for automatic event filtering

### DIFF
--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -14,10 +14,14 @@ class DiscourseEvent
 
   def self.trigger(event_name, *args, **kwargs)
     events[event_name].each { |event| event.call(*args, **kwargs) }
-    filtered_events[[event_name, args, kwargs]].each { |event| event.call(*args, **kwargs) }
+    lookup_args = []
+    args.each do |arg|
+      lookup_args << arg
+      filtered_events[[event_name, lookup_args]].each { |event| event.call(*args, **kwargs) }
+    end
   end
 
-  def self.on(event_name, *args, **kwargs, &block)
+  def self.on(event_name, *args, &block)
     case event_name
     when :user_badge_removed
       Discourse.deprecate(
@@ -37,8 +41,8 @@ class DiscourseEvent
       # ignore
     end
 
-    if args.present? || kwargs.present?
-      filtered_events[[event_name, args, kwargs]] << block
+    if args.present?
+      filtered_events[[event_name, args]] << block
     else
       events[event_name] << block
     end

--- a/spec/lib/discourse_event_spec.rb
+++ b/spec/lib/discourse_event_spec.rb
@@ -91,33 +91,20 @@ RSpec.describe DiscourseEvent do
   end
 
   describe("#filtered_events") do
-    it "allows filtering events on kwargs" do
-      begin
-        handler =
-          Proc.new do |name:, message:|
-            expect(name).to eq("Supervillain")
-            expect(message).to eq("Two Face")
-          end
-
-        DiscourseEvent.on(:acid_face, name: "Supervillain", &handler)
-        DiscourseEvent.trigger(:acid_face, name: "Supervillain", message: "Two Face")
-        DiscourseEvent.trigger(:acid_face, name: "Supervillain 2", message: "Three Face")
-      ensure
-        DiscourseEvent.off(:acid_face, &handler)
-      end
-    end
-
     it "allows filtering events on args" do
       begin
+        called = false
         handler =
           Proc.new do |name, message|
             expect(name).to eq("Supervillain")
             expect(message).to eq("Two Face")
+            called = true
           end
 
         DiscourseEvent.on(:acid_face, "Supervillain", &handler)
         DiscourseEvent.trigger(:acid_face, "Supervillain", "Two Face")
         DiscourseEvent.trigger(:acid_face, "Hero", "Not Two Face")
+        expect(called).to eq(true)
       ensure
         DiscourseEvent.off(:acid_face, &handler)
       end

--- a/spec/lib/discourse_event_spec.rb
+++ b/spec/lib/discourse_event_spec.rb
@@ -89,4 +89,38 @@ RSpec.describe DiscourseEvent do
       DiscourseEvent.off(:acid_face, &handler)
     end
   end
+
+  describe("#filtered_events") do
+    it "allows filtering events on kwargs" do
+      begin
+        handler =
+          Proc.new do |name:, message:|
+            expect(name).to eq("Supervillain")
+            expect(message).to eq("Two Face")
+          end
+
+        DiscourseEvent.on(:acid_face, name: "Supervillain", &handler)
+        DiscourseEvent.trigger(:acid_face, name: "Supervillain", message: "Two Face")
+        DiscourseEvent.trigger(:acid_face, name: "Supervillain 2", message: "Three Face")
+      ensure
+        DiscourseEvent.off(:acid_face, &handler)
+      end
+    end
+
+    it "allows filtering events on args" do
+      begin
+        handler =
+          Proc.new do |name, message|
+            expect(name).to eq("Supervillain")
+            expect(message).to eq("Two Face")
+          end
+
+        DiscourseEvent.on(:acid_face, "Supervillain", &handler)
+        DiscourseEvent.trigger(:acid_face, "Supervillain", "Two Face")
+        DiscourseEvent.trigger(:acid_face, "Hero", "Not Two Face")
+      ensure
+        DiscourseEvent.off(:acid_face, &handler)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows the eventing system to automatically filter events based on
args or kwargs.

It is a non-breaking change that can be detected by plugins using:

`if DiscourseEvent.respond_to? :filtered_events`

This allows for automatic filtering based on values:


```
DiscourseEvent.on(:site_setting_changed, :my_setting) do

end
```
