### PR TITLE
DEV: Check for mobile upload button presence

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -636,7 +636,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       );
       this.mobileUploadButton?.addEventListener(
         "click",
-        this.mobileUploadButtonEventListener,
+        this._mobileUploadButtonEventListener,
         false
       );
     }
@@ -650,7 +650,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
   _unbindMobileUploadButton() {
     this.mobileUploadButton?.removeEventListener(
       "click",
-      this.mobileUploadButtonEventListener
+      this._mobileUploadButtonEventListener
     );
   },
 

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -634,15 +634,17 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       this.mobileUploadButton = document.getElementById(
         this.mobileFileUploaderId
       );
-      this.mobileUploadButtonEventListener = () => {
-        document.getElementById(this.fileUploadElementId).click();
-      };
-      this.mobileUploadButton.addEventListener(
+      this.mobileUploadButton?.addEventListener(
         "click",
         this.mobileUploadButtonEventListener,
         false
       );
     }
+  },
+
+  @bind
+  _mobileUploadButtonEventListener() {
+    document.getElementById(this.fileUploadElementId).click();
   },
 
   _unbindMobileUploadButton() {


### PR DESCRIPTION
If rendering would break before `_bindMobileUploadButton` - this would fail too, obscuring the original issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
