### PR TITLE
UX: mini design change to input field + label styling

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -135,6 +135,11 @@ label {
   display: flex;
   margin-bottom: 5px;
   align-items: flex-start;
+  color: var(--primary-high);
+
+  &:not(.checkbox-label) {
+    font-weight: bold;
+  }
   > .d-icon {
     align-self: center;
     margin-right: 4px;
@@ -225,7 +230,7 @@ input {
     margin-bottom: 9px;
     color: var(--primary);
     background-color: var(--secondary);
-    border: 1px solid var(--primary-medium);
+    border: 1px solid var(--primary-400);
     border-radius: var(--d-input-border-radius);
     &:focus {
       @include default-focus;
@@ -269,7 +274,7 @@ textarea {
   box-sizing: border-box;
   height: auto;
   background-color: var(--secondary);
-  border: 1px solid var(--primary-medium);
+  border: 1px solid var(--primary-400);
   border-radius: 0;
 
   &:focus {

--- a/app/assets/stylesheets/common/select-kit/combo-box.scss
+++ b/app/assets/stylesheets/common/select-kit/combo-box.scss
@@ -27,7 +27,7 @@
 
     .select-kit-header {
       background: var(--secondary);
-      border-color: var(--primary-medium);
+      border-color: var(--primary-400);
 
       &.is-focused {
         @include default-focus;

--- a/app/assets/stylesheets/common/select-kit/multi-select.scss
+++ b/app/assets/stylesheets/common/select-kit/multi-select.scss
@@ -47,7 +47,7 @@
 
     .multi-select-header {
       background: var(--secondary);
-      border-color: var(--primary-medium);
+      border-color: var(--primary-400);
 
       .formatted-selection {
         margin: 0;


### PR DESCRIPTION
* bit lighter border for input fields
* making all labels conform bold + lighter color, excluding checkbox labels

Styleguide after changes:
![image](https://github.com/discourse/discourse/assets/101828855/72acfb7e-8f45-435e-82ef-79f3f181c316)

