### PR TITLE
DEV: Fix translator-bot configuration for footnote plugin

### DIFF
--- a/translator.yml
+++ b/translator.yml
@@ -87,9 +87,6 @@ files:
     destination_path: plugins/checklist/server.yml
     label: checklist
 
-  - source_path: plugins/footnote/config/locales/client.en.yml
-    destination_path: plugins/footnote/client.yml
-    label: footnote
   - source_path: plugins/footnote/config/locales/server.en.yml
     destination_path: plugins/footnote/server.yml
     label: footnote


### PR DESCRIPTION
The footnote plugin doesn't have client translations.