### PR TITLE
FIX: Add support for OffscreenCanvas in media optimization worker

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
@@ -40,10 +40,17 @@ function drawableToImageData(drawable) {
     sw = width,
     sh = height;
 
+  const offscreenCanvasSupported = typeof OffscreenCanvas !== "undefined";
+
   // Make canvas same size as image
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
+  let canvas;
+  if (offscreenCanvasSupported) {
+    canvas = new OffscreenCanvas(width, height);
+  } else {
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+  }
 
   // Draw image onto canvas
   const ctx = canvas.getContext("2d");
@@ -52,7 +59,11 @@ function drawableToImageData(drawable) {
   }
   ctx.drawImage(drawable, sx, sy, sw, sh, 0, 0, width, height);
   const imageData = ctx.getImageData(0, 0, width, height);
-  canvas.remove();
+
+  if (!offscreenCanvasSupported) {
+    canvas.remove();
+  }
+
   return imageData;
 }
 


### PR DESCRIPTION
Back in c31772879bc9df51b71f75edc529bfed878d65d1 we introduced
SiteSetting.composer_ios_media_optimisation_image_enabled and
disabled media optimization on safari iOS because of performance
issues when rendering to canvas, and OffscreenCanvas support
was not yet available.

Safari now supports OffscreenCanvas, so now we can give this
another go, and also use OffscreenCanvas everywhere it is supported.
