### PR TITLE
FIX: Add checkbox-label class to site setting checkboxes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/bool.hbs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/bool.hbs
@@ -1,4 +1,4 @@
-<label>
+<label class="checkbox-label">
   <Input @type="checkbox" @checked={{this.enabled}} />
   <span>{{html-safe this.setting.description}}</span>
 </label>


### PR DESCRIPTION
Followup to e2d9117378ead0dbfcc6533d7cf6a7bf8a14d033, which
made these labels bold because they were missing the correct
class.

Fixes this:

![image](https://github.com/discourse/discourse/assets/920448/8ad98675-041c-476a-b578-3d5db45b7cbe)
