### PR TITLE
FIX: Don't show like error on topic creation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -285,7 +285,7 @@ export default Component.extend(ComposerUploadUppy, {
         count: minimumPostLength,
       });
       const tl = this.get("currentUser.trust_level");
-      if ((tl === 0 || tl === 1) && !this._isNewTopic()) {
+      if ((tl === 0 || tl === 1) && !this.get("_isNewTopic")) {
         reason +=
           "<br/>" +
           I18n.t("composer.error.try_like", {

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -285,7 +285,7 @@ export default Component.extend(ComposerUploadUppy, {
         count: minimumPostLength,
       });
       const tl = this.get("currentUser.trust_level");
-      if ((tl === 0 || tl === 1) && !this._newTopicState()) {
+      if ((tl === 0 || tl === 1) && !this._isNewTopic()) {
         reason +=
           "<br/>" +
           I18n.t("composer.error.try_like", {
@@ -305,7 +305,7 @@ export default Component.extend(ComposerUploadUppy, {
     }
   },
 
-  _newTopicState() {
+  get _isNewTopic() {
     return (
       this.composer.creatingTopic ||
       this.composer.editingFirstPost ||

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -1,6 +1,6 @@
 import { getOwner } from "@ember/application";
 import Component from "@ember/component";
-import EmberObject from "@ember/object";
+import EmberObject, { computed } from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { next, schedule, throttle } from "@ember/runloop";
 import { BasePlugin } from "@uppy/core";
@@ -285,7 +285,7 @@ export default Component.extend(ComposerUploadUppy, {
         count: minimumPostLength,
       });
       const tl = this.get("currentUser.trust_level");
-      if ((tl === 0 || tl === 1) && !this.get("_isNewTopic")) {
+      if ((tl === 0 || tl === 1) && !this._isNewTopic) {
         reason +=
           "<br/>" +
           I18n.t("composer.error.try_like", {
@@ -305,6 +305,7 @@ export default Component.extend(ComposerUploadUppy, {
     }
   },
 
+  @computed("composer.{creatingTopic,editingFirstPost,creatingSharedDraft}")
   get _isNewTopic() {
     return (
       this.composer.creatingTopic ||

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -285,7 +285,7 @@ export default Component.extend(ComposerUploadUppy, {
         count: minimumPostLength,
       });
       const tl = this.get("currentUser.trust_level");
-      if (tl === 0 || tl === 1) {
+      if ((tl === 0 || tl === 1) && !this._newTopicState()) {
         reason +=
           "<br/>" +
           I18n.t("composer.error.try_like", {
@@ -303,6 +303,14 @@ export default Component.extend(ComposerUploadUppy, {
         lastShownAt: lastValidatedAt,
       });
     }
+  },
+
+  _newTopicState() {
+    return (
+      this.composer.creatingTopic ||
+      this.composer.editingFirstPost ||
+      this.composer.creatingSharedDraft
+    );
   },
 
   _resetShouldBuildScrollMap() {

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+describe "Composer Post Validations", type: :system, js: true do
+  fab!(:tl0_user) { Fabricate(:user, trust_level: 0) }
+  fab!(:tl1_user) { Fabricate(:user, trust_level: 1) }
+  fab!(:tl2_user) { Fabricate(:user, trust_level: 2) }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  describe "trust level 0 user" do
+    before { sign_in(tl0_user) }
+
+    context "when creating a topic" do
+      it "shows an error when post length is insufficient" do
+        visit("/latest")
+        page.find("#create-topic").click
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error(I18n.t("js.composer.error.post_length"))
+      end
+    end
+
+    context "when replying to a topic" do
+      it "shows an error to like instead when post length is insufficient" do
+        topic_page.visit_topic_and_open_composer(topic)
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error(
+          "#{I18n.t("js.composer.error.post_length")} #{I18n.t("js.composer.error.try_like")}",
+        )
+      end
+    end
+  end
+
+  describe "trust level 1 user" do
+    before { sign_in(tl1_user) }
+
+    context "when creating a topic" do
+      it "shows an error when post length is insufficient" do
+        visit("/latest")
+        page.find("#create-topic").click
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error(I18n.t("js.composer.error.post_length"))
+      end
+    end
+
+    context "when replying to a topic" do
+      it "shows an error to like instead when post length is insufficient" do
+        topic_page.visit_topic_and_open_composer(topic)
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error(
+          "#{I18n.t("js.composer.error.post_length")} #{I18n.t("js.composer.error.try_like")}",
+        )
+      end
+    end
+  end
+
+  describe "trust level 2 user" do
+    before { sign_in(tl2_user) }
+
+    context "when creating a topic" do
+      it "shows an error when post length is insufficient" do
+        visit("/latest")
+        page.find("#create-topic").click
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error(I18n.t("js.composer.error.post_length"))
+      end
+    end
+
+    context "when replying to a topic" do
+      it "does not show an error to like when post length is insufficient" do
+        topic_page.visit_topic_and_open_composer(topic)
+        composer.fill_content("abc")
+        composer.create
+        composer.have_post_error("#{I18n.t("js.composer.error.post_length")}")
+        composer.have_no_post_error(
+          "#{I18n.t("js.composer.error.post_length")} #{I18n.t("js.composer.error.try_like")}",
+        )
+      end
+    end
+  end
+end

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -10,9 +10,7 @@ describe "Composer Post Validations", type: :system, js: true do
   let(:composer) { PageObjects::Components::Composer.new }
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
-  describe "trust level 0 user" do
-    before { sign_in(tl0_user) }
-
+  shared_examples "post length validation" do
     context "when creating a topic" do
       it "shows an error when post length is insufficient" do
         visit("/latest")
@@ -35,29 +33,14 @@ describe "Composer Post Validations", type: :system, js: true do
     end
   end
 
+  describe "trust level 0 user" do
+    before { sign_in(tl0_user) }
+    include_examples "post length validation"
+  end
+
   describe "trust level 1 user" do
     before { sign_in(tl1_user) }
-
-    context "when creating a topic" do
-      it "shows an error when post length is insufficient" do
-        visit("/latest")
-        page.find("#create-topic").click
-        composer.fill_content("abc")
-        composer.create
-        composer.have_post_error(I18n.t("js.composer.error.post_length"))
-      end
-    end
-
-    context "when replying to a topic" do
-      it "shows an error to like instead when post length is insufficient" do
-        topic_page.visit_topic_and_open_composer(topic)
-        composer.fill_content("abc")
-        composer.create
-        composer.have_post_error(
-          "#{I18n.t("js.composer.error.post_length")} #{I18n.t("js.composer.error.try_like")}",
-        )
-      end
-    end
+    include_examples "post length validation"
   end
 
   describe "trust level 2 user" do

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -192,6 +192,14 @@ module PageObjects
         page.has_css?(".form-template-field__description", text: description)
       end
 
+      def has_post_error?(error)
+        page.has_css?(".popup-tip", text: error, visible: all)
+      end
+
+      def has_no_post_error?(error)
+        page.has_no_css?(".popup-tip", text: error, visible: all)
+      end
+
       def composer_input
         find("#{COMPOSER_ID} .d-editor .d-editor-input")
       end


### PR DESCRIPTION
As identified on [Meta](https://meta.discourse.org/t/have-you-tried-the-button-text-is-irrelevant-on-topic/278626), the popup error for insufficient post content should not show the suggestion to click ❤️ like instead, when a TL0/TL1 user is creating a topic.


## Before (In create topic context)
![Screenshot 2023-10-24 at 12 24 56](https://github.com/discourse/discourse/assets/30090424/457aa921-c453-433b-92e2-125187a57181)

## After (In create topic context)
![Screenshot 2023-10-24 at 12 25 21](https://github.com/discourse/discourse/assets/30090424/8dd440be-74ac-4327-9b5d-556e2ff5841d)

