### PR TITLE
FIX: Add checkbox-label CSS class to flag modal labels

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
@@ -2,7 +2,7 @@
   {{#if this.isNotifyUser}}
     <h3>{{this.formattedName}}</h3>
     <div class="controls">
-      <label class="radio">
+      <label class="radio checkbox-label">
         <input
           id="radio_{{this.flag.name_key}}"
           {{on "click" (action "changePostActionType" this.flag)}}
@@ -38,7 +38,7 @@
     {{/if}}
   {{else}}
     <div class="controls {{this.flag.name_key}}">
-      <label class="radio">
+      <label class="radio checkbox-label">
         <input
           id="radio_{{this.flag.name_key}}"
           {{on "click" (action "changePostActionType" this.flag)}}


### PR DESCRIPTION
Avoids a similar bolding issue to 88ae4c7b5ce7c9dd0de8ac81c863103cdbc73a87

![image](https://github.com/discourse/discourse/assets/920448/94ef0a07-c9bb-4f5f-8a34-898cde46afef)
