### PR TITLE
FIX: Typo in migration

### DIFF
--- a/db/migrate/20231024034031_migrate_tl_to_group_settings_anonymous_posting_min_tl.rb
+++ b/db/migrate/20231024034031_migrate_tl_to_group_settings_anonymous_posting_min_tl.rb
@@ -25,7 +25,7 @@ class MigrateTlToGroupSettingsAnonymousPostingMinTl < ActiveRecord::Migration[7.
         end
 
       # Data_type 20 is group_list.
-      exec(<<~SQL, setting: anonymous_posting_allowed_groups)
+      DB.exec(<<~SQL, setting: anonymous_posting_allowed_groups)
         INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
         VALUES('anonymous_posting_allowed_groups', :setting, '20', NOW(), NOW())
       SQL


### PR DESCRIPTION
Should be DB.exec not just exec, silly typo fix for
9db4eaa870551a42103a53d780216eef83227810
