### PR TITLE
DEV: Hide anonymous_posting_min_trust_level setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -682,6 +682,7 @@ users:
     default: 1
     enum: "TrustLevelSetting"
     client: true
+    hidden: true
   anonymous_posting_allowed_groups:
     default: "11" # auto group trust_level_1
     type: group_list


### PR DESCRIPTION
Followup to 9db4eaa870551a42103a53d780216eef83227810,
I thought deprecating a setting hid it in the UI too,
but this is not the case.
