### PR TITLE
UX: Update user field styling in the create-account modal

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -157,6 +157,7 @@ body.invite-page {
         min-height: 1.4em; // prevents height increase due to tips
       }
       label.alt-placeholder,
+      .user-field.text label.control-label,
       .user-field.dropdown label.control-label,
       .user-field.multiselect label.control-label {
         color: var(--primary-medium);
@@ -169,6 +170,7 @@ body.invite-page {
         box-shadow: 0 0 0 0px rgba(var(--tertiary-rgb), 0);
         transition: 0.2s ease all;
       }
+      .user-field.text label.control-label,
       .user-field.dropdown label.control-label,
       .user-field.multiselect label.control-label {
         z-index: 999;
@@ -178,9 +180,10 @@ body.invite-page {
         padding: 0 0.25em 0 0.25em;
         font-size: $font-down-1;
       }
+      .user-field.text:focus-within,
       .user-field.dropdown:focus-within,
       .user-field.multiselect:focus-within {
-        z-index: 1000; // this ensures the active dropdown is always on top of sibling dropdown labels
+        z-index: 1000; // ensures the active input is always on top of sibling input labels
       }
       input:focus + label.alt-placeholder,
       input.value-entered + label.alt-placeholder {

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -157,7 +157,8 @@ body.invite-page {
         min-height: 1.4em; // prevents height increase due to tips
       }
       label.alt-placeholder,
-      .user-field.dropdown label.control-label {
+      .user-field.dropdown label.control-label,
+      .user-field.multiselect label.control-label {
         color: var(--primary-medium);
         font-size: 16px;
         font-weight: normal;
@@ -168,7 +169,8 @@ body.invite-page {
         box-shadow: 0 0 0 0px rgba(var(--tertiary-rgb), 0);
         transition: 0.2s ease all;
       }
-      .user-field.dropdown label.control-label {
+      .user-field.dropdown label.control-label,
+      .user-field.multiselect label.control-label {
         z-index: 999;
         top: -8px;
         left: calc(1em - 0.25em);
@@ -176,7 +178,8 @@ body.invite-page {
         padding: 0 0.25em 0 0.25em;
         font-size: $font-down-1;
       }
-      .user-field.dropdown:focus-within {
+      .user-field.dropdown:focus-within,
+      .user-field.multiselect:focus-within {
         z-index: 1000; // this ensures the active dropdown is always on top of sibling dropdown labels
       }
       input:focus + label.alt-placeholder,

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -261,8 +261,8 @@ body.invite-page {
             text-overflow: ellipsis;
           }
         }
-        span.name,
-        span.formatted-selection {
+        details:not(.has-selection) span.name,
+        details:not(.has-selection) span.formatted-selection {
           color: var(--primary-medium);
         }
         .select-kit-row span.name {

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -258,7 +258,8 @@ body.invite-page {
             text-overflow: ellipsis;
           }
         }
-        span.name {
+        span.name,
+        span.formatted-selection {
           color: var(--primary-medium);
         }
         .select-kit-row span.name {

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -356,9 +356,6 @@
     }
     display: flex;
     flex-direction: column;
-    &.confirm {
-      margin-top: 5px;
-    }
   }
 
   .invites-show {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -523,7 +523,8 @@ blockquote {
   -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.dropdown {
+.dropdown,
+.multiselect {
   position: relative;
 }
 

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -438,7 +438,8 @@ tr.category-topic-link {
 // Misc. stuff
 // --------------------------------------------------
 
-.dropdown {
+.dropdown,
+.multiselect {
   position: relative;
 }
 .dropdown-toggle:active,


### PR DESCRIPTION
1. Removes accidental bold from `text` and `multiselect` labels/placeholders
2. Adds the animated label/placeholder combo to `multiselect`
3. Makes the `multiselect` placeholder lighter to match other fields
4. Makes the `dropdown` values darker to match other fields
5. Removes the extra 5px spacing before `confirmation` fields

Before / After

<img width="308" alt="Screenshot 2023-10-25 at 11 59 10" src="https://github.com/discourse/discourse/assets/66961/feaabf5b-94dd-4918-a73b-c321f2b25cef"> <img width="308" alt="Screenshot 2023-10-25 at 11 58 49" src="https://github.com/discourse/discourse/assets/66961/3897ab87-4f3b-4292-9049-7d982cf6ac09">

The default fields for context

<img width="336" alt="Screenshot 2023-10-25 at 11 11 45" src="https://github.com/discourse/discourse/assets/66961/071fc2ca-fe14-4610-b8c2-95503a691099">
