### PR TITLE
DEV: Relax auth provider registration restrictions for plugins

### DIFF
--- a/lib/middleware/omniauth_bypass_middleware.rb
+++ b/lib/middleware/omniauth_bypass_middleware.rb
@@ -11,8 +11,6 @@ class Middleware::OmniauthBypassMiddleware
   def initialize(app, options = {})
     @app = app
 
-    Discourse.plugins.each(&:notify_before_auth)
-
     OmniAuth.config.before_request_phase do |env|
       request = ActionDispatch::Request.new(env)
 

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -218,14 +218,14 @@ RSpec.describe Plugin::Instance do
     # No enabled_site_setting
     authenticator = SimpleAuthenticator.new
     plugin.auth_provider(authenticator: authenticator)
-    plugin.notify_before_auth
+    plugin.notify_after_initialize
     expect(authenticator.enabled?).to eq(true)
 
     # With enabled site setting
     plugin = Plugin::Instance.new
     authenticator = SimpleAuthenticator.new
     plugin.auth_provider(enabled_setting: "enable_badges", authenticator: authenticator)
-    plugin.notify_before_auth
+    plugin.notify_after_initialize
     expect(authenticator.enabled?).to eq(false)
 
     # Defines own method
@@ -241,7 +241,7 @@ RSpec.describe Plugin::Instance do
         end
         .new
     plugin.auth_provider(enabled_setting: "enable_badges", authenticator: authenticator)
-    plugin.notify_before_auth
+    plugin.notify_after_initialize
     expect(authenticator.enabled?).to eq(false)
   end
 
@@ -271,7 +271,7 @@ RSpec.describe Plugin::Instance do
       plugin = plugin_from_fixtures("my_plugin")
       plugin.activate!
       expect(DiscoursePluginRegistry.auth_providers.count).to eq(0)
-      plugin.notify_before_auth
+      plugin.notify_after_initialize
       expect(DiscoursePluginRegistry.auth_providers.count).to eq(1)
       auth_provider = DiscoursePluginRegistry.auth_providers.to_a[0]
       expect(auth_provider.authenticator.name).to eq("facebook")


### PR DESCRIPTION
In the past we would build the stack of Omniauth providers at boot, which meant that plugins had to register any authenticators in the root of their plugin.rb (i.e. not in an `after_initialize` block). This could be frustrating because many features are not available that early in boot (e.g. Zeitwerk autoloading).

Now that we build the omniauth strategy stack 'just in time', it is safe for plugins to register their auth methods in an `after_initialize` block. This commit relaxes the old restrictions so that plugin authors have the option to move things around.

(to be reviewed/merged after #24094)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
