### PR TITLE
DEV: Improve error messaging

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/webauthn.js
+++ b/app/assets/javascripts/discourse/app/lib/webauthn.js
@@ -146,12 +146,19 @@ export async function getPasskeyCredential(
       userHandle: bufferToBase64(credential.response.userHandle),
     };
   } catch (error) {
+    if (error.name === "AbortError") {
+      // no need to show an error when the cancelling a pending ceremony
+      // this happens when switching from the conditional method (username input autofill)
+      // to the optional method (login button) or vice versa
+      return null;
+    }
+
     if (mediation === "conditional") {
       // The conditional method gets triggered in the background
       // it's not helpful to show errors for it in the UI
       // eslint-disable-next-line no-console
       console.error(error);
-      return;
+      return null;
     }
 
     if (error.name === "NotAllowedError") {
@@ -162,11 +169,6 @@ export async function getPasskeyCredential(
           message: error.message,
         })
       );
-    } else if (error.name === "AbortError") {
-      // no need to show an error when the cancelling a pending ceremony
-      // this happens when switching from the conditional method (username input autofill)
-      // to the optional method (login button) or vice versa
-      return null;
     } else {
       return errorCallback(error.message);
     }

--- a/app/assets/javascripts/discourse/app/lib/webauthn.js
+++ b/app/assets/javascripts/discourse/app/lib/webauthn.js
@@ -146,15 +146,29 @@ export async function getPasskeyCredential(
       userHandle: bufferToBase64(credential.response.userHandle),
     };
   } catch (error) {
+    if (mediation === "conditional") {
+      // The conditional method gets triggered in the background
+      // it's not helpful to show errors for it in the UI
+      // eslint-disable-next-line no-console
+      console.error(error);
+      return;
+    }
+
     if (error.name === "NotAllowedError") {
       return errorCallback(I18n.t("login.security_key_not_allowed_error"));
+    } else if (error.name === "SecurityError") {
+      return errorCallback(
+        I18n.t("login.passkey_security_error", {
+          message: error.message,
+        })
+      );
     } else if (error.name === "AbortError") {
       // no need to show an error when the cancelling a pending ceremony
       // this happens when switching from the conditional method (username input autofill)
       // to the optional method (login button) or vice versa
       return null;
     } else {
-      return errorCallback(error);
+      return errorCallback(error.message);
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2203,6 +2203,7 @@ en:
       security_key_no_matching_credential_error: "No matching credentials could be found in the provided security key."
       security_key_support_missing_error: "Your current device or browser does not support the use of security keys. Please use a different method."
       security_key_invalid_response_error: "The security key authentication process failed due to an invalid response."
+      passkey_security_error: "There was a security error: %{message}"
       email_placeholder: "Email / Username"
       caps_lock_warning: "Caps Lock is on"
       error: "Unknown error"


### PR DESCRIPTION
Applies to passkeys, visible in a dev environment when using a non-standard host. The error modal should only be shown when invoking the passkey login button.

