### PR TITLE
Bring back deprecated String prototype extensions

### DIFF
--- a/app/assets/javascripts/discourse/app/loader-shims.js
+++ b/app/assets/javascripts/discourse/app/loader-shims.js
@@ -4,6 +4,7 @@ import loaderShim from "discourse-common/lib/loader-shim";
 // AMD shims for the app bunndle, see the comment in loader-shim.js
 // These effectively become public APIs for plugins, so add/remove them carefully
 loaderShim("@discourse/itsatrap", () => importSync("@discourse/itsatrap"));
+loaderShim("@ember/string", () => importSync("@ember/string"));
 loaderShim("@ember-compat/tracked-built-ins", () =>
   importSync("@ember-compat/tracked-built-ins")
 );

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -34,7 +34,6 @@
     "@ember/legacy-built-in-components": "^0.5.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.1.0",
-    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^2.9.4",
     "@embroider/compat": "^3.2.3",
     "@embroider/core": "^3.3.0",

--- a/app/assets/javascripts/patches/@embroider+shared-internals+2.5.0.patch
+++ b/app/assets/javascripts/patches/@embroider+shared-internals+2.5.0.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/@embroider/shared-internals/src/ember-standard-modules.js b/node_modules/@embroider/shared-internals/src/ember-standard-modules.js
+index 8664bb2..e05ace9 100644
+--- a/node_modules/@embroider/shared-internals/src/ember-standard-modules.js
++++ b/node_modules/@embroider/shared-internals/src/ember-standard-modules.js
+@@ -25,9 +25,14 @@ exports.emberVirtualPackages = new Set(mappings_json_1.default.map((m) => m.modu
+ // a v1 addon in between the app and a v2 addon might not declare the peerDep,
+ // breaking the deeper v2 addon.
+ exports.emberVirtualPeerDeps = new Set(['@glimmer/component', '@glimmer/tracking']);
++
++// !! DANGER !!
+ // this is a real package, even though it's still listed in rfc176
+-exports.emberVirtualPackages.delete('@ember/string');
+-exports.emberVirtualPeerDeps.add('@ember/string');
++// exports.emberVirtualPackages.delete('@ember/string');
++// exports.emberVirtualPeerDeps.add('@ember/string');
++// ...except it is not a real package because we are on 3.28...
++// ...remove this patch when we upgrade...
++
+ // these can also appear in ember code and should get compiled away by babel,
+ // but we may need to tell a build tool that is inspecting pre-transpiled code
+ // (like snowpack) not to worry about these packages.


### PR DESCRIPTION
Brings back: `"foo".camelize()` => `"Foo"` + "please import from `@ember/string"

A bit of a brain-twister. This apparently stopped working after https://github.com/discourse/discourse/pull/24034

In 3.28, `@ember/string` is one of the magic modules provided by `ember-source`, just like `@ember/component` etc,  as opposed to a real package you install.

Later on in the 4.x cycle that was extracted into a real package so the code can be deprecated and removed from core, and you only ship those bytes if your app opt-into it.

We are on 3.28, but we _also_ installed the real package version. This is fine, the real package doesn't do anything so fancy that it wouldn't work with 3.28 apps, we are just duplicating the code in the payload but otherwise it's alright.

However, the real package version, extracted in 4.x, does not add the prototype extensions, which was deprecated in 3.x for removal by 4.0, so depending on which version (the `ember-source` one or the real package one), there is that difference in behavior.

The layout of the bundles looks something like this:

```js
// vendor.js

// ember-source
define("@ember/string/index", [...], function (exports, ...deps) {
  // first copy of @ember/string
  exports.camelize = function camelize() {};

  String.prototype.camelize = withDeprecation(camelize);
});

define("@ember/component/index", ["@ember/string", ...], function (exports, ...deps) {
  // ...
});
```

```js
// one of the webpack chunks
webpack.modules.push({
  "something-something-implicit-modules": () => {
    define("@ember/string", [], function () {
      return __webpack__require__("node_modules/@ember/string/index.js");
    });

    // ...
  },
  "node_modules/@ember/string/index.js": () => {
    // second copy of @ember/string
    __webpack_exports__.camelize = function camelize() {};

    // no prototype extensions here
  }
});
```

I think what ends up happening in this situation is that Webpack compiled modules end up using the real package version, and addons etc, will load it via loader.js, and depending on their luck, one of the two `defined()`-ed version gets picked up.

However, prior to #24034, we have a patch that ends up causing something to this effect to be appended to the end of `vendor.js`:

```js
// bottom of vendor.js
(function() {
  require("@ember/component");
})();
```

I think that patch was to work around some build issues of the module shims, but because the require happens synchronously inside `vendor.js`, it ends up deterministically running the version of `@ember/string` with the prototype extensions and ensured any loader.js consumers will see that version of the module.

The patch was removed with #24034, and so that stopped working reliably as reported in https://meta.discourse.org/t/topic-list-previews-theme-component/209973/376

Ordinarily the solution is probably to just remove the package version for now, but Embroider also seems to assum that everyone is already on the package version, so a patch is needed for that to work.

All of these needs to be reverted when we upgrade Ember. Or we can just accept not having the prototype extensions since they are already deprecated anyway (and the slight cost of shipping two copies of that code).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
