### PR TITLE
FIX: clear state if selected text is empty

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -95,6 +95,14 @@ export default class PostTextSelection extends Component {
 
     const _selectedText = selectedText();
 
+    const selection = window.getSelection();
+    if (selection.isCollapsed || _selectedText === "") {
+      if (!this.menuInstance?.expanded) {
+        this.args.quoteState.clear();
+      }
+      return;
+    }
+
     // avoid hard loops in quote selection unconditionally
     // this can happen if you triple click text in firefox
     // it's also generally unecessary work to go
@@ -107,14 +115,6 @@ export default class PostTextSelection extends Component {
     }
 
     this.prevSelectedText = _selectedText;
-
-    const selection = window.getSelection();
-    if (selection.isCollapsed) {
-      if (!this.menuInstance?.expanded) {
-        this.args.quoteState.clear();
-      }
-      return;
-    }
 
     // ensure we selected content inside 1 post *only*
     let postId;


### PR DESCRIPTION
This would cause a loop and some very fast flashing of the selection in safari when scrolling the selection until the bottom of the page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
