### PR TITLE
FIX: Optimize a slow query when mentioning groups in chat messages

### DIFF
--- a/plugins/chat/lib/chat/parsed_mentions.rb
+++ b/plugins/chat/lib/chat/parsed_mentions.rb
@@ -51,7 +51,8 @@ module Chat
     end
 
     def group_mentions
-      chat_users.includes(:groups).joins(:groups).where(groups: mentionable_groups)
+      mentionable_groups_ids = mentionable_groups.pluck(:id)
+      chat_users.includes(:groups).joins(:groups).where("groups.id IN (?)", mentionable_groups_ids)
     end
 
     def here_mentions


### PR DESCRIPTION
Before:

<img width="1645" alt="Screenshot 2023-10-25 at 22 49 33" src="https://github.com/discourse/discourse/assets/1274517/9af436ac-18b7-4daf-8a14-78c0a312116c">

After:

<img width="1649" alt="Screenshot 2023-10-26 at 14 53 40" src="https://github.com/discourse/discourse/assets/1274517/c6e365fc-9b1d-4118-b6b7-569892d968de">



