### PR TITLE
FIX: do not check if inside cooked early

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -223,6 +223,10 @@ export default class PostTextSelection extends Component {
 
   @bind
   onSelectionChanged() {
+    if (this.isSelecting) {
+      return;
+    }
+
     const { isIOS, isWinphone, isAndroid } = this.capabilities;
     const wait = isIOS || isWinphone || isAndroid ? INPUT_DELAY : 25;
     this.selectionChangeHandler = discourseDebounce(
@@ -233,25 +237,13 @@ export default class PostTextSelection extends Component {
   }
 
   @bind
-  mousedown(event) {
-    this.validMouseDown = true;
-
-    if (!event.target.closest(".cooked")) {
-      this.validMouseDown = false;
-      return;
-    }
-
+  mousedown() {
     this.isSelecting = true;
   }
 
   @bind
   mouseup() {
     this.isSelecting = false;
-
-    if (!this.validMouseDown) {
-      return;
-    }
-
     this.onSelectionChanged();
   }
 


### PR DESCRIPTION
We already do this check inside `selectionChanged` and this was preventing us to correctly set `isSelecting` to true. This was causing issues when starting your selection from outside cooked.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
