### PR TITLE
DEV: Explicitly disable Ember string prototype extensions

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -15,6 +15,7 @@ module.exports = function (environment) {
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
         Date: false,
+        String: false,
       },
     },
     exportApplicationGlobal: true,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,7 @@ module ApplicationHelper
         },
         EXTEND_PROTOTYPES: {
           Date: false,
+          String: false,
         },
         _APPLICATION_TEMPLATE_WRAPPER: false,
         _DEFAULT_ASYNC_OBSERVERS: true,


### PR DESCRIPTION
These have been deprecated for some time, and the vast majority of themes/plugins have already removed their use. The prototype extensions were unexpectedly disabled as a side effect of 895036bd7a057f2430c5c917040319577fcf6b95 (more details in https://github.com/discourse/discourse/pull/24101).

Given that restoring the functionality now involves significant complexity, and would only be delaying the inevitable removal in a matter of months, we've decided to keep them disabled. This commit explicitly sets the flag in the ember environment config to make things clearer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
