### PR TITLE
DEV: component attribute for admin-post-menu

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
@@ -20,6 +20,8 @@ module("Integration | Component | admin-post-menu", function (hooks) {
   });
 
   test("renders button from API", async function (assert) {
+    this.data = { transformedPost: { id: 1 } };
+
     withPluginApi("1.15.0", (api) => {
       api.addPostAdminMenuButton(() => {
         return {
@@ -29,7 +31,7 @@ module("Integration | Component | admin-post-menu", function (hooks) {
       });
     });
 
-    await render(hbs`<AdminPostMenu  />`);
+    await render(hbs`<AdminPostMenu  @data={{this.data}} />`);
 
     assert.dom(".test-button").hasText("test");
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
@@ -20,7 +20,7 @@ module("Integration | Component | admin-post-menu", function (hooks) {
   });
 
   test("renders button from API", async function (assert) {
-    withPluginApi("1.16.0", (api) => {
+    withPluginApi("1.15.0", (api) => {
       api.addPostAdminMenuButton(() => {
         return {
           translatedLabel: "test",

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-post-menu-test.js
@@ -1,0 +1,36 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { module, test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import I18n from "I18n";
+
+module("Integration | Component | admin-post-menu", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders default button", async function (assert) {
+    this.currentUser.admin = true;
+    this.data = { transformedPost: { id: 1 } };
+
+    await render(hbs`<AdminPostMenu @data={{this.data}} />`);
+
+    assert
+      .dom(".moderation-history")
+      .hasText(I18n.t("review.moderation_history"));
+  });
+
+  test("renders button from API", async function (assert) {
+    withPluginApi("1.16.0", (api) => {
+      api.addPostAdminMenuButton(() => {
+        return {
+          translatedLabel: "test",
+          className: "test-button",
+        };
+      });
+    });
+
+    await render(hbs`<AdminPostMenu  />`);
+
+    assert.dom(".test-button").hasText("test");
+  });
+});


### PR DESCRIPTION
This commit introduces a new possible attribute when using the `addPostAdminMenuButton` api:

```javascript
api.addPostAdminMenuButton((attrs) => {
  return {
    component: MyComponent,
    data: attrs,
  };
})
```

`MyComponent` has to be an imported component and will be rendered as `<MyComponent @data={{attrs}} />`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
