### PR TITLE
DEV: Remove spec calling add_to_serializer

### DIFF
--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -372,44 +372,6 @@ RSpec.describe CategoriesController do
         response.parsed_body["category_list"]["categories"].map { |x| x["id"] },
       ).not_to include(uncategorized.id)
     end
-
-    describe "with serialized category custom fields" do
-      class CategoryPlugin < Plugin::Instance
-      end
-
-      let!(:plugin) do
-        plugin = CategoryPlugin.new
-        plugin.add_to_serializer(:basic_category, :bob) { object.custom_fields["bob"] }
-        plugin
-      end
-
-      before { category.upsert_custom_fields("bob" => "marley") }
-      after { CategoryList.preloaded_category_custom_fields = Set.new }
-
-      context "when custom fields are not preloaded" do
-        it "increases the query count" do
-          queries = track_sql_queries { get "/categories.json" }
-
-          expect(response.status).to eq(200)
-          category = response.parsed_body["category_list"]["categories"][-1]
-          expect(category["bob"]).to eq("marley")
-          expect(queries.count).to eq(7)
-        end
-      end
-
-      context "when custom fields are preloaded" do
-        before { CategoryList.preloaded_category_custom_fields << "bob" }
-
-        it "does not increase the query count" do
-          queries = track_sql_queries { get "/categories.json" }
-
-          expect(response.status).to eq(200)
-          category = response.parsed_body["category_list"]["categories"][-1]
-          expect(category["bob"]).to eq("marley")
-          expect(queries.count).to eq(6)
-        end
-      end
-    end
   end
 
   describe "extensibility event" do


### PR DESCRIPTION
Calling add_to_serializer is an irreversible operation which affects all the following tests in the suite. This lead to other tests failing because they weren't expecting the extra field on the category serializer.

Followup to 2a75656ff24ba750b19838e27e559828a3aaf719

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
