### PR TITLE
FIX: Hashtags were not decorated in user activity list

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/hashtag-post-decorations.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/hashtag-post-decorations.js
@@ -8,9 +8,7 @@ export default {
     const site = owner.lookup("service:site");
 
     withPluginApi("0.8.7", (api) => {
-      api.decorateCookedElement((post) => decorateHashtags(post, site), {
-        onlyStream: true,
-      });
+      api.decorateCookedElement((post) => decorateHashtags(post, site));
     });
   },
 };

--- a/spec/system/hashtag_autocomplete_spec.rb
+++ b/spec/system/hashtag_autocomplete_spec.rb
@@ -192,6 +192,56 @@ describe "Using #hashtag autocompletion to search for and lookup categories and 
     end
   end
 
+  it "decorates the user activity stream hashtags" do
+    post =
+      Fabricate(
+        :post,
+        raw: "this is a #cool-cat category and a #cooltag tag",
+        topic: topic,
+        user: current_user,
+      )
+    UserActionManager.enable
+    UserActionManager.post_created(post)
+
+    visit("/u/#{current_user.username}/activity")
+    expect(find(".user-stream-item [data-post-id=\"#{post.id}\"]")["innerHTML"]).to have_tag(
+      "a",
+      with: {
+        class: "hashtag-cooked",
+        href: category.url,
+        "data-type": "category",
+        "data-slug": category.slug,
+        "data-id": category.id,
+        "aria-label": category.name,
+      },
+    ) do
+      with_tag(
+        "span",
+        with: {
+          class: "hashtag-category-badge hashtag-color--category-#{category.id}",
+        },
+      )
+    end
+    expect(find(".user-stream-item [data-post-id=\"#{post.id}\"]")["innerHTML"]).to have_tag(
+      "a",
+      with: {
+        class: "hashtag-cooked",
+        href: tag.url,
+        "data-type": "tag",
+        "data-slug": tag.name,
+        "data-id": tag.id,
+        "aria-label": tag.name,
+      },
+    ) do
+      with_tag(
+        "svg",
+        with: {
+          class: "fa d-icon d-icon-tag svg-icon hashtag-color--tag-#{tag.id} svg-string",
+        },
+      ) { with_tag("use", with: { href: "#tag" }) }
+    end
+  end
+
   context "when a user cannot access the category for a hashtag cooked in another post" do
     fab!(:admin) { Fabricate(:admin) }
     fab!(:manager_group) { Fabricate(:group, name: "Managers") }


### PR DESCRIPTION
This was just a case of removing the `onlyStream: true`
operation from `decorateCookedElement`, since that restricts
the decoration only to topic page posts.

Before

![image](https://github.com/discourse/discourse/assets/920448/b8806ac3-8b26-4cec-b306-3098fa0ac02d)

After

![image](https://github.com/discourse/discourse/assets/920448/90f0e314-0635-4bc5-b162-ab580e06e998)
