### PR TITLE
DEV: Remove deprecated PostAction.remove_act method

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -136,16 +136,6 @@ class PostAction < ActiveRecord::Base
     target_post.post_actions.each { |post_action| post_action.update_counters }
   end
 
-  def self.remove_act(user, post, post_action_type_id)
-    Discourse.deprecate(
-      "PostAction.remove_act is deprecated. Use `PostActionDestroyer` instead.",
-      output_in_test: true,
-      drop_from: "2.9.0",
-    )
-
-    PostActionDestroyer.new(user, post, post_action_type_id).perform
-  end
-
   def remove_act!(user)
     trash!(user)
     # NOTE: save is called to ensure all callbacks are called


### PR DESCRIPTION
### What is this change?

The `PostAction.remove_act` class method has been deprecated and replaced by `PostActionDestroyer`. It was marked for removal in version 2.9.0. This PR removes the method.

### Verification

- [x] A search across all our public and private repositories show no remaining usages.
- [x] A search through the logs of all our hosting shows no deprecation warnings.