### PR TITLE
DEV: Remove deprecated queue_jobs site setting

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -106,14 +106,6 @@ class SiteSetting < ActiveRecord::Base
     ListController.best_period_with_topics_for(duration)
   end
 
-  def self.queue_jobs=(val)
-    Discourse.deprecate(
-      "queue_jobs is deprecated. Please use Jobs.run_immediately! instead",
-      drop_from: "2.9.0",
-    )
-    val ? Jobs.run_later! : Jobs.run_immediately!
-  end
-
   def self.email_polling_enabled?
     SiteSetting.manual_polling_enabled? || SiteSetting.pop3_polling_enabled? ||
       DiscoursePluginRegistry.mail_pollers.any?(&:enabled?)

--- a/plugins/footnote/spec/pretty_text_spec.rb
+++ b/plugins/footnote/spec/pretty_text_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe PrettyText do
-  before { SiteSetting.queue_jobs = false }
+  before { Jobs.run_immediately! }
 
   it "can be disabled" do
     SiteSetting.enable_markdown_footnotes = false


### PR DESCRIPTION
### What is this change?

Using `SiteSetting.queue_jobs=` to configure job asynchronicity was deprecated [here](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) four years ago and marked for removal in version 2.9.0. This PR removes the fallback method we kept since then. The method was there because it was still being used in a bunch of plugin tests (now fixed as can be seen below.)

Plugin tests passing serves as validation that all plugins have been patched.

### Plugin fixes

- https://github.com/discourse/discourse-prometheus-alert-receiver/pull/75
- https://github.com/discourse/discourse-kolide/pull/79
- https://github.com/discourse/discourse-github/pull/91
- https://github.com/discourse/discourse-patreon/pull/124
- https://github.com/discourse/discourse-policy/pull/112
- https://github.com/discourse/discourse-translator/pull/119
- https://github.com/discourse/discourse-affiliate/pull/56
- https://github.com/discourse/discourse-oauth2-basic/pull/88
- https://github.com/discourse/discourse-rss-polling/pull/62
- https://github.com/discourse/discourse-calendar/pull/464