### PR TITLE
DEV: Remove deprecated PostsController#all_reply_ids

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -310,13 +310,6 @@ class PostsController < ApplicationController
     render json: post.reply_ids(guardian).to_json
   end
 
-  def all_reply_ids
-    Discourse.deprecate("/posts/:id/reply-ids/all is deprecated.", drop_from: "3.0")
-
-    post = find_post_from_params
-    render json: post.reply_ids(guardian, only_replies_to_single_post: false).to_json
-  end
-
   def destroy
     post = find_post_from_params
     force_destroy = ActiveModel::Type::Boolean.new.cast(params[:force_destroy])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1025,7 +1025,6 @@ Discourse::Application.routes.draw do
     get "posts/by-date/:topic_id/:date" => "posts#by_date"
     get "posts/:id/reply-history" => "posts#reply_history"
     get "posts/:id/reply-ids" => "posts#reply_ids"
-    get "posts/:id/reply-ids/all" => "posts#all_reply_ids"
     get "posts/:username/deleted" => "posts#deleted_posts",
         :constraints => {
           username: RouteFormat.username,


### PR DESCRIPTION
### What is this change?

The `PostsController#all_reply_ids` was deprecated [here](https://github.com/discourse/discourse/commit/bb153c49a14ca7e91bba714c7cfbe3a0ed2ffb6f) and marked for removal in 3.0. This PR removes the controller action and the route.

### Verification

- [x] Checking the front-end app for usages based on the URL shows no usages.
- [x] A search in the logs show no deprecation warnings.