### PR TITLE
DEV: Remove deprecated EmailValidator.email_regex

### DIFF
--- a/lib/validators/email_validator.rb
+++ b/lib/validators/email_validator.rb
@@ -52,13 +52,4 @@ class EmailValidator < ActiveModel::EachValidator
     Rails.configuration.respond_to?(:developer_emails) &&
       Rails.configuration.developer_emails.include?(value)
   end
-
-  def self.email_regex
-    Discourse.deprecate(
-      "EmailValidator.email_regex is deprecated. Please use EmailAddressValidator instead.",
-      output_in_test: true,
-      drop_from: "2.9.0",
-    )
-    EmailAddressValidator.email_regex
-  end
 end


### PR DESCRIPTION
### What is this change?

The `EmailValidator.email_regex` method was moved to `EmailAddressValidator.email_regex` [here](https://github.com/discourse/discourse/commit/3bf3b9a4a5e066598482bc7add7a44dcb334178c) and marked for removal in 2.9.0. The method was proxied for backwards compatibility in plugins. This PR removes the method.

Note: the below plugin patch must be merged before merging this. (Plugin tests are expected to fail until it is merged.)

### Plugin patches

https://github.com/discourse/discourse-invite-tokens/pull/43