### PR TITLE
DEV: adds a `:chat_thread_created` trigger

### DIFF
--- a/plugins/chat/app/services/chat/create_thread.rb
+++ b/plugins/chat/app/services/chat/create_thread.rb
@@ -26,6 +26,7 @@ module Chat
       step :associate_thread_to_message
       step :fetch_membership
       step :publish_new_thread
+      step :trigger_chat_thread_created_event
     end
 
     # @!visibility private
@@ -83,6 +84,10 @@ module Chat
 
     def publish_new_thread(channel:, original_message:, **)
       ::Chat::Publisher.publish_thread_created!(channel, original_message, context.thread.id)
+    end
+
+    def trigger_chat_thread_created_event
+      ::DiscourseEvent.trigger(:chat_thread_created, context.thread)
     end
   end
 end

--- a/plugins/chat/spec/services/chat/create_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/create_thread_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe Chat::CreateThread do
         expect(message.data["type"]).to eq("thread_created")
       end
 
+      it "triggers a discourse event `chat_thread_created`" do
+        event = DiscourseEvent.track_events(:chat_thread_created) { result }.first
+
+        expect(event[:params][0]).to eq(result.thread)
+      end
+
       it "sets the title when existing" do
         params[:title] = "Restaurant for Saturday"
         result


### PR DESCRIPTION
Usage:

```ruby
DiscourseEvent.on(:chat_thread_created) do |thread|
end
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
