### PR TITLE
DEV: Deprecate defunct User#flag_level column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,12 +6,15 @@ class User < ActiveRecord::Base
   include HasCustomFields
   include SecondFactorManager
   include HasDestroyedWebHook
+  include HasDeprecatedColumns
 
   DEFAULT_FEATURED_BADGE_COUNT = 3
 
   PASSWORD_SALT_LENGTH = 16
   TARGET_PASSWORD_ALGORITHM =
     "$pbkdf2-#{Rails.configuration.pbkdf2_algorithm}$i=#{Rails.configuration.pbkdf2_iterations},l=32$"
+
+  deprecate_column :flag_level, drop_from: "3.2"
 
   # not deleted on user delete
   has_many :posts

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -14,7 +14,6 @@ class AdminUserListSerializer < BasicUserSerializer
              :created_at_age,
              :trust_level,
              :manual_locked_trust_level,
-             :flag_level,
              :username,
              :title,
              :avatar_template,

--- a/spec/requests/api/schemas/json/admin_user_list_response.json
+++ b/spec/requests/api/schemas/json/admin_user_list_response.json
@@ -65,9 +65,6 @@
           "null"
         ]
       },
-      "flag_level": {
-        "type": "integer"
-      },
       "title": {
         "type": [
           "string",
@@ -109,7 +106,6 @@
       "created_at_age",
       "trust_level",
       "manual_locked_trust_level",
-      "flag_level",
       "title",
       "time_read",
       "staged",

--- a/spec/requests/api/schemas/json/admin_user_response.json
+++ b/spec/requests/api/schemas/json/admin_user_response.json
@@ -46,9 +46,6 @@
     "manual_locked_trust_level": {
       "type": ["string", "null"]
     },
-    "flag_level": {
-      "type": "integer"
-    },
     "title": {
       "type": ["string", "null"]
     },
@@ -509,7 +506,6 @@
     "created_at_age",
     "trust_level",
     "manual_locked_trust_level",
-    "flag_level",
     "title",
     "time_read",
     "staged",


### PR DESCRIPTION
### What is this change?

The `User#flag_level` column has not been in use for a very long time. The "new" reviewable system dynamically calculates  flag scores based on past performance of the user.

This PR removes `flag_level` from the admin user serializer (since it isn't displayed anywhere in admin user lists) and marks the column as deprecated and targeted for removal in the next minor version.