### PR TITLE
FIX: Ensure JS transpiler is available for multisite-migrate

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -116,7 +116,12 @@ class SeedHelper
   end
 end
 
-task "multisite:migrate" => %w[db:load_config environment set_locale] do |_, args|
+task "multisite:migrate" => %w[
+       db:load_config
+       environment
+       set_locale
+       assets:precompile:theme_transpiler
+     ] do |_, args|
   raise "Multisite migrate is only supported in production" if ENV["RAILS_ENV"] != "production"
 
   DistributedMutex.synchronize(


### PR DESCRIPTION
Previously done for the normal `db:migrate` command in 1e59e18ad2553f81c6efde51796be298392ca8fc

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
