### PR TITLE
FIX: Memoization in EmberCli ruby helper class

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -10,7 +10,7 @@ module EmberCli
   end
 
   def self.script_chunks
-    return @chunk_infos if defined?(@chunk_infos)
+    return @chunk_infos if @chunk_infos
 
     chunk_infos = {}
 
@@ -80,7 +80,7 @@ module EmberCli
   end
 
   def self.clear_cache!
-    remove_instance_variable :@chunk_infos
-    remove_instance_variable :@assets
+    @chunk_infos = nil
+    @assets = nil
   end
 end

--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -6,11 +6,11 @@ module EmberCli
   end
 
   def self.assets
-    @@assets ||= Dir.glob("**/*.{js,map,txt}", base: "#{dist_dir}/assets")
+    @assets ||= Dir.glob("**/*.{js,map,txt}", base: "#{dist_dir}/assets")
   end
 
   def self.script_chunks
-    return @@chunk_infos if defined?(@@chunk_infos)
+    return @chunk_infos if defined?(@chunk_infos)
 
     chunk_infos = {}
 
@@ -24,7 +24,7 @@ module EmberCli
     index_html = File.read("#{dist_dir}/index.html")
     chunk_infos.merge! parse_chunks_from_html(index_html)
 
-    @@chunk_infos = chunk_infos if Rails.env.production?
+    @chunk_infos = chunk_infos if Rails.env.production?
     chunk_infos
   rescue Errno::ENOENT
     {}
@@ -80,7 +80,7 @@ module EmberCli
   end
 
   def self.clear_cache!
-    @@chunk_infos = nil
-    @@assets = nil
+    remove_instance_variable :@chunk_infos
+    remove_instance_variable :@assets
   end
 end


### PR DESCRIPTION
Previously we were memoizing based on `defined?`, but the `clear_cache!` method was doing `@blah = nil`. That meant that after the cache was cleared, future calls to the memoized method would return `nil` instead of triggering a recalculation.

Followup to c124c698332a50d8372c8e55a48282edf77a9043

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
