### PR TITLE
DEV: Use click once for video place holder

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
@@ -13,7 +13,6 @@ export default {
         const overlay = wrapper.querySelector(".video-placeholder-overlay");
 
         parentDiv.style.cursor = "";
-        parentDiv.removeEventListener("click", handleVideoPlaceholderClick);
         overlay.innerHTML = spinnerHTML;
 
         const videoHTML = `
@@ -83,7 +82,7 @@ export default {
           container.addEventListener(
             "click",
             handleVideoPlaceholderClick.bind(null, helper),
-            false
+            { once: true }
           );
           overlay.innerHTML = `${iconHTML("play")}`;
           wrapper.appendChild(overlay);


### PR DESCRIPTION
Rather than removing the event listener just use `{once: true}`.

docs: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once

meta: https://meta.discourse.org/t/283596
