### PR TITLE
FIX: Only check for conditional mediation when needed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/login.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login.js
@@ -19,6 +19,7 @@ import escape from "discourse-common/lib/escape";
 import I18n from "discourse-i18n";
 
 export default class Login extends Component {
+  @service capabilities;
   @service dialog;
   @service siteSettings;
   @service site;
@@ -116,6 +117,18 @@ export default class Login extends Component {
   @action
   async passkeyLogin(mediation = "optional") {
     try {
+      // we need to check isConditionalMediationAvailable for Firefox
+      // without it, Firefox will throw console errors
+      // We cannot do a general check because iOS Safari and Chrome in Selenium quietly support the feature
+      // but they do not support the PublicKeyCredential.isConditionalMediationAvailable() method
+      if (mediation === "conditional" && this.capabilities.isFirefox) {
+        const isCMA =
+          // eslint-disable-next-line no-undef
+          await PublicKeyCredential.isConditionalMediationAvailable();
+        if (!isCMA) {
+          return;
+        }
+      }
       const response = await ajax("/session/passkey/challenge.json");
 
       const publicKeyCredential = await getPasskeyCredential(

--- a/app/assets/javascripts/discourse/app/components/modal/login.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login.js
@@ -121,7 +121,11 @@ export default class Login extends Component {
       // without it, Firefox will throw console errors
       // We cannot do a general check because iOS Safari and Chrome in Selenium quietly support the feature
       // but they do not support the PublicKeyCredential.isConditionalMediationAvailable() method
-      if (mediation === "conditional" && this.capabilities.isFirefox) {
+      if (
+        mediation === "conditional" &&
+        this.capabilities.isFirefox &&
+        window.PublicKeyCredential
+      ) {
         const isCMA =
           // eslint-disable-next-line no-undef
           await PublicKeyCredential.isConditionalMediationAvailable();

--- a/app/assets/javascripts/discourse/app/components/modal/login/local-login-form.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login/local-login-form.js
@@ -36,15 +36,9 @@ export default class LocalLoginBody extends Component {
 
   @action
   passkeyConditionalLogin() {
-    if (
-      // eslint-disable-next-line no-undef
-      !PublicKeyCredential.isConditionalMediationAvailable ||
-      !this.args.canUsePasskeys
-    ) {
-      return;
+    if (this.args.canUsePasskeys) {
+      this.args.passkeyLogin("conditional");
     }
-
-    this.args.passkeyLogin("conditional");
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/lib/webauthn.js
+++ b/app/assets/javascripts/discourse/app/lib/webauthn.js
@@ -124,6 +124,14 @@ export async function getPasskeyCredential(
     return errorCallback(I18n.t("login.security_key_support_missing_error"));
   }
 
+  if (mediation === "conditional") {
+    // eslint-disable-next-line no-undef
+    const isCMA = await PublicKeyCredential.isConditionalMediationAvailable();
+    if (!isCMA) {
+      return;
+    }
+  }
+
   try {
     const credential = await navigator.credentials.get({
       publicKey: {

--- a/app/assets/javascripts/discourse/app/lib/webauthn.js
+++ b/app/assets/javascripts/discourse/app/lib/webauthn.js
@@ -124,14 +124,6 @@ export async function getPasskeyCredential(
     return errorCallback(I18n.t("login.security_key_support_missing_error"));
   }
 
-  if (mediation === "conditional") {
-    // eslint-disable-next-line no-undef
-    const isCMA = await PublicKeyCredential.isConditionalMediationAvailable();
-    if (!isCMA) {
-      return;
-    }
-  }
-
   try {
     const credential = await navigator.credentials.get({
       publicKey: {


### PR DESCRIPTION
Some browsers still don't support conditional mediation. This PR fixes issues with:

- TOR browser (it doesn't have `PublicKeyCredential` at all)
- Firefox 119 (`isConditionalMediationAvailable` support is behind a flag, was failing silently)
