### PR TITLE
FEATURE: Add keywords support for site_settings search

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -89,7 +89,10 @@ export default class AdminSiteSettingsController extends Controller {
             setting.includes(filter) ||
             setting.replace(/_/g, " ").includes(filter) ||
             item.get("description").toLowerCase().includes(filter) ||
-            (item.get("keywords") || "").toLowerCase().includes(filter) ||
+            (item.get("keywords") || "")
+              .replace(/_/g, " ")
+              .toLowerCase()
+              .includes(filter.replace(/_/g, " ")) ||
             (item.get("value") || "").toString().toLowerCase().includes(filter);
           if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
             // Tightens up fuzzy search results a bit.

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -89,6 +89,7 @@ export default class AdminSiteSettingsController extends Controller {
             setting.includes(filter) ||
             setting.replace(/_/g, " ").includes(filter) ||
             item.get("description").toLowerCase().includes(filter) ||
+            (item.get("keywords") || "").toLowerCase().includes(filter) ||
             (item.get("value") || "").toString().toLowerCase().includes(filter);
           if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
             // Tightens up fuzzy search results a bit.

--- a/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/admin-site-settings-test.js
@@ -34,6 +34,7 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
             description: "",
             value: "",
             setting: "digest_logo",
+            keywords: "capybara",
           }),
           SiteSetting.create({
             description: "",
@@ -71,5 +72,10 @@ module("Unit | Controller | admin-site-settings", function (hooks) {
       results[0].siteSettings[0].setting,
       "min_personal_message_post_length"
     );
+
+    // ensures keyword search is working
+    results = controller.performSearch("capybara", settings2);
+    assert.deepEqual(results[0].siteSettings.length, 1);
+    assert.deepEqual(results[0].siteSettings[0].setting, "digest_logo");
   });
 });

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2520,6 +2520,8 @@ en:
       invalid_uncategorized_category_setting: 'The "Uncategorized" category cannot be selected if ''allow uncategorized topics'' is not enabled.'
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
 
+    keywords:
+
     placeholder:
       discourse_connect_provider_secrets:
         key: "www.example.com"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2521,6 +2521,7 @@ en:
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
 
     keywords:
+      anonymous_posting_allowed_groups: "anonymous_posting_min_trust_level"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -199,6 +199,7 @@ module SiteSettingExtension
         opts = {
           setting: s,
           description: description(s),
+          keywords: keywords(s),
           default: default,
           value: value.to_s,
           category: categories[s],
@@ -216,6 +217,10 @@ module SiteSettingExtension
 
   def description(setting)
     I18n.t("site_settings.#{setting}", base_path: Discourse.base_path)
+  end
+
+  def keywords(setting)
+    I18n.t("site_settings.keywords.#{setting}", default: "")
   end
 
   def placeholder(setting)

--- a/spec/system/admin_site_setting_search_spec.rb
+++ b/spec/system/admin_site_setting_search_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe "Admin Site Setting Search", type: :system do
+  let(:settings_page) { PageObjects::Pages::AdminSettings.new }
+  fab!(:admin) { Fabricate(:admin) }
+
+  before do
+    SiteSetting.title = "Discourse"
+    sign_in(admin)
+  end
+
+  describe "when searching for keywords" do
+    it "finds the associated site setting" do
+      settings_page.visit
+      settings_page.type_in_search("anonymous_posting_min_trust_level")
+      expect(settings_page).to have_search_result("anonymous_posting_allowed_groups")
+    end
+
+    it "can search for previous site setting without underscores" do
+      settings_page.visit
+      settings_page.type_in_search("anonymous posting min")
+      expect(settings_page).to have_search_result("anonymous_posting_allowed_groups")
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_settings.rb
+++ b/spec/system/page_objects/pages/admin_settings.rb
@@ -4,12 +4,12 @@ module PageObjects
   module Pages
     class AdminSettings < PageObjects::Pages::Base
       def visit_filtered_plugin_setting(filter)
-        visit("/admin/site_settings/category/plugins?filter=#{filter}")
+        page.visit("/admin/site_settings/category/plugins?filter=#{filter}")
         self
       end
 
       def visit
-        page.visit("/admin/site_settings/")
+        page.visit("/admin/site_settings")
         self
       end
 

--- a/spec/system/page_objects/pages/admin_settings.rb
+++ b/spec/system/page_objects/pages/admin_settings.rb
@@ -8,6 +8,11 @@ module PageObjects
         self
       end
 
+      def visit
+        page.visit("/admin/site_settings/")
+        self
+      end
+
       def visit_category(category)
         page.visit("/admin/site_settings/category/#{category}")
         self
@@ -33,6 +38,15 @@ module PageObjects
           .all(:css, ".setting-value .values .value .value-input span")
           .map { |e| vals << e.text }
         vals
+      end
+
+      def type_in_search(input)
+        find("input#setting-filter").send_keys(input)
+        self
+      end
+
+      def has_search_result?(setting)
+        page.has_selector?("div[data-setting='#{setting}']")
       end
     end
   end


### PR DESCRIPTION
This change allows for a new `keywords` field that can be added to site
settings in order to help with searching. Keywords are not visible in
the UI, but site settings matching one of the contained keywords will
appear when searching for that keyword.

Keywords can be added for site settings inside of the
`config/locales/server.en.yml` file under the new `keywords` key.

```
site_settings
  example_1: "fancy description"
  example_2: "another description"

  keywords:
    example_1: "capybara"
```
