### PR TITLE
UX: set tag sort based on siteSetting

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tags-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/tags-index.js
@@ -13,6 +13,7 @@ export default Controller.extend({
   modal: service(),
   sortedByCount: true,
   sortedByName: false,
+  sortAlphabetically: alias("siteSettings.tags_sort_alphabetically"),
   canAdminTags: alias("currentUser.staff"),
   groupedByCategory: notEmpty("model.extras.categories"),
   groupedByTagGroup: notEmpty("model.extras.tag_groups"),
@@ -20,7 +21,13 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
 
-    this.sortProperties = ["totalCount:desc", "id"];
+    const isAlphaSort = this.sortAlphabetically;
+
+    this.setProperties({
+      sortedByCount: isAlphaSort ? false : true,
+      sortedByName: isAlphaSort ? true : false,
+      sortProperties: isAlphaSort ? ["id"] : ["totalCount:desc", "id"],
+    });
   },
 
   @discourseComputed("groupedByCategory", "groupedByTagGroup")


### PR DESCRIPTION
When the site setting `tags sort alphabetically` is enabled, we need to change the defaults for the sort toggle here:


![Screenshot 2023-10-27 at 2 44 30 PM](https://github.com/discourse/discourse/assets/1681963/45aa0b5f-5d58-4792-b30e-4cbff24aa21b)


Otherwise it will always default to "count" 