### PR TITLE
FIX: form template upload type validation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/form-template-field/upload.gjs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/upload.gjs
@@ -12,7 +12,6 @@ export default class FormTemplateFieldUpload extends Component.extend(
   UppyUploadMixin
 ) {
   @tracked uploadValue;
-  @tracked uploadComplete = false;
   @tracked uploadedFiles = [];
   @tracked disabled = this.uploadingOrProcessing;
   @tracked fileUploadElementId = `${dasherize(this.id)}-uploader`;
@@ -50,7 +49,7 @@ export default class FormTemplateFieldUpload extends Component.extend(
 
   uploadDone(upload) {
     // If re-uploading, clear the existing file if multiple aren't allowed
-    if (!this.attributes.allow_multiple && this.uploadComplete) {
+    if (!this.attributes.allow_multiple && this.uploadValue) {
       this.uploadedFiles = [];
       this.uploadValue = "";
     }

--- a/app/assets/javascripts/discourse/app/components/form-template-field/upload.gjs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/upload.gjs
@@ -35,7 +35,7 @@ export default class FormTemplateFieldUpload extends Component.extend(
    * @param file
    * @returns {boolean}
    */
-  validateUploadedFile(file) {
+  isUploadedFileAllowed(file) {
     // same logic from PickFilesButton._hasAcceptedExtensionOrType
     const fileTypes = this.attributes.file_types;
     const extension = file.name.split(".").pop();

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -47,6 +47,17 @@ export default Mixin.create(UppyS3Multipart, ExtendableUploader, {
     return {};
   },
 
+  /**
+   * Overridable for custom file validations, executed before uploading.
+   *
+   * @param {object} file
+   *
+   * @returns {boolean}
+   */
+  validateUploadedFile() {
+    return true;
+  },
+
   uploadingOrProcessing: or("uploading", "processing"),
 
   @on("willDestroyElement")
@@ -112,7 +123,9 @@ export default Mixin.create(UppyS3Multipart, ExtendableUploader, {
           },
           this.validateUploadedFilesOptions()
         );
-        const isValid = validateUploadedFile(currentFile, validationOpts);
+        const isValid =
+          validateUploadedFile(currentFile, validationOpts) &&
+          this.validateUploadedFile(currentFile);
         this.setProperties({
           uploadProgress: 0,
           uploading: isValid && this.autoStartUploads,

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -54,7 +54,7 @@ export default Mixin.create(UppyS3Multipart, ExtendableUploader, {
    *
    * @returns {boolean}
    */
-  validateUploadedFile() {
+  isUploadedFileAllowed() {
     return true;
   },
 
@@ -125,7 +125,7 @@ export default Mixin.create(UppyS3Multipart, ExtendableUploader, {
         );
         const isValid =
           validateUploadedFile(currentFile, validationOpts) &&
-          this.validateUploadedFile(currentFile);
+          this.isUploadedFileAllowed(currentFile);
         this.setProperties({
           uploadProgress: 0,
           uploading: isValid && this.autoStartUploads,

--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -370,6 +370,7 @@ describe "Composer Form Templates", type: :system do
     expect(find("#dialog-holder .dialog-body p", visible: :all)).to have_content(
       I18n.t("js.pick_files_button.unsupported_file_picked", { types: ".jpg, .png" }),
     )
+    expect(page).to have_no_css(".form-template-field__uploaded-files")
   end
 
   it "creates a post with multiple uploads" do
@@ -399,6 +400,22 @@ describe "Composer Form Templates", type: :system do
     expect(find("#{topic_page.post_by_number_selector(1)} .cooked")).to have_css(
       ".video-placeholder-container",
     )
+  end
+
+  it "overrides uploaded file if allow_multiple false" do
+    topic_title = "Peter Parker's Medication"
+
+    category_page.visit(category_with_upload_template)
+    category_page.new_topic_button.click
+    attach_file "prescription-uploader",
+                "#{Rails.root}/spec/fixtures/images/logo.png",
+                make_visible: true
+    composer.fill_title(topic_title)
+    attach_file "prescription-uploader",
+                "#{Rails.root}/spec/fixtures/images/fake.jpg",
+                make_visible: true
+
+    expect(find(".form-template-field__uploaded-files")).to have_css("li", count: 1)
   end
 
   it "shows labels and descriptions when a form template is assigned to the category" do


### PR DESCRIPTION
When submitting files through the form template upload field, we were having an issue where, although a validation error message was being presented to the user, the upload was still coming through, because `PickFilesButton`'s validation happens **after** the Uppy mixin finished the upload and hit `uploadDone`.

This PR adds a new overridable method to the Uppy mixin and overrides it with the custom validation, which now happens before the file is sent.

Additionally, we're now also using `uploadingOrProcessing` as the source of truth to show the upload/uploading label, which seems more reliable.