### PR TITLE
UX: avoid footer admin menu from overflowing top on short topics

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import { h } from "virtual-dom";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { applyDecorators, createWidget } from "discourse/widgets/widget";
 
 createWidget("admin-menu-button", {
@@ -328,6 +329,7 @@ export default createWidget("topic-admin-menu", {
   buildAttributes(attrs) {
     let { top, left, outerHeight } = attrs.position;
     const position = this.site.mobileView ? "fixed" : "absolute";
+    const approxMenuHeight = attrs.actionButtons.length * 42;
 
     if (attrs.rightSide) {
       return;
@@ -341,6 +343,11 @@ export default createWidget("topic-admin-menu", {
 
       if (documentHeight > mainHeight) {
         bottom = bottom - (documentHeight - mainHeight) - outerHeight;
+      }
+
+      if (top < approxMenuHeight) {
+        bottom =
+          bottom - (approxMenuHeight - outerHeight - top) - headerOffset();
       }
 
       if (this.site.mobileView) {


### PR DESCRIPTION
This will help distance the menu from the top of the page based on the header height and approximate menu height (based on button count). This only applies in cases of very short topics.

Before:

![Screenshot 2023-10-27 at 4 07 50 PM](https://github.com/discourse/discourse/assets/1681963/ca34dc5b-358c-465c-8f0a-3cae1d895a50)

After: 

![Screenshot 2023-10-27 at 4 15 46 PM](https://github.com/discourse/discourse/assets/1681963/0551d808-c11d-4c2b-aab2-b84c2c3644cb)
