### PR TITLE
UX: impove badge granted spacing with grid

### DIFF
--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -228,11 +228,9 @@
 }
 
 .badges-granted {
-  display: flex;
-  flex-wrap: wrap;
-  @media screen and (max-width: $small-width) {
-    justify-content: space-between;
-  }
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18em, 1fr));
+  gap: 3em 2em;
 }
 
 .container.badges {

--- a/app/assets/stylesheets/desktop/components/user-info.scss
+++ b/app/assets/stylesheets/desktop/components/user-info.scss
@@ -1,15 +1,6 @@
 .user-info {
   &.medium {
-    flex: 0 0 32%;
-    margin: 0 2% 4vh 0;
     display: flex;
-    &:nth-of-type(3n) {
-      margin-right: 0;
-    }
-    @media screen and (max-width: $small-width) {
-      flex: 0 0 48%;
-      margin-right: 0;
-    }
     .user-image {
       width: 55px;
       margin-right: 0;


### PR DESCRIPTION
This simplifies our CSS here by using `grid` and `gap` for spacing, and fixes a mobile issue with missing space. 


Before:
![Screenshot 2023-10-27 at 6 14 11 PM](https://github.com/discourse/discourse/assets/1681963/0cc672ab-c341-4564-a166-29633ef4c903)
![Screenshot 2023-10-27 at 6 14 26 PM](https://github.com/discourse/discourse/assets/1681963/68cd8a50-4aa0-421f-a5aa-34eeaba4e33c)

After: 
![Screenshot 2023-10-27 at 6 12 31 PM](https://github.com/discourse/discourse/assets/1681963/5f78e07b-8f51-4d6e-9193-578c0d92256a)
![Screenshot 2023-10-27 at 6 15 35 PM](https://github.com/discourse/discourse/assets/1681963/2a118e6b-ab1c-4bcd-9a39-0c808bd22186)


