### PR TITLE
DEV: extend `withSilencedDeprecations` to work for ember deprecations

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -3,6 +3,8 @@ const disabledDeprecations = new Set();
 const emberCliDeprecationWorkflows =
   window.deprecationWorkflow?.config?.workflow;
 
+let emberDeprecationSilencer;
+
 /**
  * Display a deprecation warning with the provided message. The warning will be prefixed with the theme/plugin name
  * if it can be automatically determined based on the current stack.
@@ -72,6 +74,7 @@ export function registerDeprecationHandler(callback) {
  * @param {function} callback The function to call while deprecations are silenced.
  */
 export function withSilencedDeprecations(deprecationIds, callback) {
+  ensureEmberDeprecationSilencer();
   const idArray = [].concat(deprecationIds);
   try {
     idArray.forEach((id) => disabledDeprecations.add(id));
@@ -94,11 +97,32 @@ export function withSilencedDeprecations(deprecationIds, callback) {
  * @param {function} callback The asynchronous function to call while deprecations are silenced.
  */
 export async function withSilencedDeprecationsAsync(deprecationIds, callback) {
+  ensureEmberDeprecationSilencer();
   const idArray = [].concat(deprecationIds);
   try {
     idArray.forEach((id) => disabledDeprecations.add(id));
     return await callback();
   } finally {
     idArray.forEach((id) => disabledDeprecations.delete(id));
+  }
+}
+
+function ensureEmberDeprecationSilencer() {
+  if (emberDeprecationSilencer) {
+    return;
+  }
+
+  emberDeprecationSilencer = (message, options, next) => {
+    if (options?.id && disabledDeprecations.has(options.id)) {
+      return;
+    } else {
+      next(message, options);
+    }
+  };
+
+  if (require.has("@ember/debug")) {
+    require("@ember/debug").registerDeprecationHandler(
+      emberDeprecationSilencer
+    );
   }
 }

--- a/app/assets/javascripts/discourse/app/services/modal.js
+++ b/app/assets/javascripts/discourse/app/services/modal.js
@@ -6,7 +6,9 @@ import { dasherize } from "@ember/string";
 import $ from "jquery";
 import { CLOSE_INITIATED_BY_MODAL_SHOW } from "discourse/components/d-modal";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
-import deprecated from "discourse-common/lib/deprecated";
+import deprecated, {
+  withSilencedDeprecations,
+} from "discourse-common/lib/deprecated";
 import I18n from "discourse-i18n";
 
 // Known legacy modals in core. Silence deprecation warnings for these so the messages
@@ -178,7 +180,12 @@ export default class ModalServiceWithLegacySupport extends ModalService {
 
     const modalName = `modal/${templateName}`;
     const fullName = opts.admin ? `admin/templates/${modalName}` : modalName;
-    route.render(fullName, renderArgs);
+
+    // Any use of the legacy modal system will trigger Discourse's own deprecation message
+    // so we can silence Ember's message here.
+    withSilencedDeprecations("route-render-template", () => {
+      route.render(fullName, renderArgs);
+    });
 
     if (opts.panels) {
       if (controller.actions.onSelectPanel) {
@@ -214,9 +221,16 @@ export default class ModalServiceWithLegacySupport extends ModalService {
       return;
     }
 
-    getOwner(this)
-      .lookup("route:application")
-      .render("hide-modal", { into: "application", outlet: "modalBody" });
+    const applicationRoute = getOwner(this).lookup("route:application");
+
+    // Any use of the legacy modal system will trigger Discourse's own deprecation message
+    // so we can silence Ember's message here.
+    withSilencedDeprecations("route-render-template", () => {
+      applicationRoute.render("hide-modal", {
+        into: "application",
+        outlet: "modalBody",
+      });
+    });
     $(".d-modal.fixed-modal").modal("hide");
 
     if (controller) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
@@ -1,3 +1,4 @@
+import { deprecate as emberDeprecate } from "@ember/debug";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import Sinon from "sinon";
@@ -214,6 +215,27 @@ module("Unit | Utility | deprecated", function (hooks) {
       this.counterStub.callCount,
       1,
       "counter is incremented outside the silenced function"
+    );
+  });
+
+  test("can silence Ember deprecations", function (assert) {
+    withSilencedDeprecations("fake-ember-deprecation", () => {
+      emberDeprecate("fake ember deprecation message", false, {
+        id: "fake-ember-deprecation",
+        for: "not-ember-source",
+        since: "v0",
+        until: "v999",
+      });
+    });
+    assert.strictEqual(
+      this.warnStub.callCount,
+      0,
+      "console.warn is not called"
+    );
+    assert.strictEqual(
+      this.counterStub.callCount,
+      0,
+      "counter is not incremented"
     );
   });
 });


### PR DESCRIPTION
This will allow us to globally unsilence deprecations for plugin/theme authors while silencing specific cases in Discourse core.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
