### PR TITLE
UX: form template simpler "value missing" i18n

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/form-template-validation.js
+++ b/app/assets/javascripts/discourse/app/lib/form-template-validation.js
@@ -102,13 +102,7 @@ function _validateFormTemplateData(form) {
 function _showErrorMessage(field, element) {
   if (field.validity.valueMissing) {
     const prefix = "form_templates.errors.valueMissing";
-    const types = [
-      "select-one",
-      "select-multiple",
-      "checkbox",
-      "text",
-      "number",
-    ];
+    const types = ["select-one", "select-multiple", "checkbox"];
     _showErrorByType(element, field, prefix, types);
   } else if (field.validity.typeMismatch) {
     const prefix = "form_templates.errors.typeMismatch";

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4610,7 +4610,6 @@ en:
       errors:
         valueMissing:
           default: "Please fill out this field."
-          text: "Please fill out this field."
           select-one: "Please select an item in the list."
           select-multiple: "Please select at least one item in the list."
           checkbox: "Please check this box if you want to proceed."


### PR DESCRIPTION
We were missing the [`form_templates.errors.valueMissing.number`](https://meta.discourse.org/t/introducing-experimental-form-templates/278631/14) locale key.

This PR unifies this value missing validation string between `text`, `number`, and `default` to a single entry: `_showErrorByType` falls back to `default` if the type isn't one of the 3 exceptions, `select-one`, `select-multiple`, or `checkbox`.