### PR TITLE
DEV: Improve plugin/theme deprecation prefixes

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -39,7 +39,7 @@ export default function deprecated(msg, options = {}) {
   msg = msg.join(" ");
 
   let consolePrefix = "";
-  if (window.Discourse) {
+  if (require.has("discourse/lib/source-identifier")) {
     // This module doesn't exist in pretty-text/wizard/etc.
     consolePrefix =
       require("discourse/lib/source-identifier").consolePrefix() || "";

--- a/app/assets/javascripts/discourse/app/initializers/deprecation-identify-source.js
+++ b/app/assets/javascripts/discourse/app/initializers/deprecation-identify-source.js
@@ -1,0 +1,23 @@
+import { registerDeprecationHandler } from "@ember/debug";
+import { consolePrefix } from "discourse/lib/source-identifier";
+
+let registered = false;
+
+export default {
+  initialize() {
+    if (registered) {
+      return;
+    }
+
+    registerDeprecationHandler((message, options, next) => {
+      let prefix = consolePrefix();
+      if (prefix) {
+        next(`${prefix} ${message}`, options);
+      } else {
+        next(message, options);
+      }
+    });
+
+    registered = true;
+  },
+};

--- a/app/assets/javascripts/discourse/app/lib/source-identifier.js
+++ b/app/assets/javascripts/discourse/app/lib/source-identifier.js
@@ -1,5 +1,5 @@
+import DEBUG from "@glimmer/env";
 import PreloadStore from "discourse/lib/preload-store";
-import { isDevelopment } from "discourse-common/config/environment";
 import getURL from "discourse-common/lib/get-url";
 
 export default function identifySource(error) {
@@ -30,20 +30,20 @@ export default function identifySource(error) {
 
   let plugin;
 
-  // Source-mapped:
-  plugin = plugin || error.stack.match(/plugins\/([\w-]+)\//)?.[1];
+  if (DEBUG) {
+    // Development (no fingerprinting)
+    plugin ??= error.stack.match(/assets\/plugins\/([\w-]+)\.js/)?.[1];
 
-  if (isDevelopment()) {
-    // Un-source-mapped:
-    plugin = plugin || error.stack.match(/assets\/plugins\/([\w-]+)\.js/)?.[1];
+    // Test files:
+    plugin ??= error.stack.match(
+      /assets\/plugins\/test\/([\w-]+)_tests\.js/
+    )?.[1];
   }
 
-  // Production mode
-  plugin =
-    plugin ||
-    error.stack.match(
-      /assets\/plugins\/_?([\w-]+)-[0-9a-f]+(?:\.br)?\.js/
-    )?.[1];
+  // Production (with fingerprints)
+  plugin ??= error.stack.match(
+    /assets\/plugins\/_?([\w-]+)-[0-9a-f]+(?:\.br)?\.js/
+  )?.[1];
 
   if (plugin) {
     return {


### PR DESCRIPTION
- Add prefixes to Ember deprecations (previously was just Discourse deprecations)

- Allow logic to work in tests (where window.Discourse is not defined)

- Detect `{plugin}_tests.js` files

- Optimise dev/test regex logic out of the production build using `if(DEBUG)`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
