### PR TITLE
UX: update `btn-flat` focus style

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -306,11 +306,19 @@
     color: var(--primary-low-mid);
     transition: color 0.25s;
   }
-  @include hover {
-    background: transparent;
-    color: var(--primary);
-    .d-icon {
+  .discourse-no-touch & {
+    &:hover,
+    &:focus {
       color: var(--primary);
+      .d-icon {
+        color: var(--primary);
+      }
+    }
+    &:hover {
+      background: transparent;
+    }
+    &:focus {
+      background: var(--primary-low);
     }
   }
   &.close {
@@ -320,10 +328,13 @@
     .d-icon {
       color: var(--primary-high);
     }
-    @include hover {
-      background: transparent;
-      .d-icon {
-        color: var(--primary);
+    .discourse-no-touch & {
+      &:hover,
+      &:focus {
+        background: transparent;
+        .d-icon {
+          color: var(--primary);
+        }
       }
     }
   }


### PR DESCRIPTION
Our focus styles on `btn-flat` buttons was a little half-baked, so at times you end up with white text on a light background. 


Before:

![Screenshot 2023-10-30 at 11 45 25 AM](https://github.com/discourse/discourse/assets/1681963/4742b0e4-ebec-4e0c-8656-42b6c940a88d)

![Screenshot 2023-10-30 at 11 50 34 AM](https://github.com/discourse/discourse/assets/1681963/9922014c-a2ad-48c9-a14e-72d2dd5fcda3)

After:

![Screenshot 2023-10-30 at 11 54 37 AM](https://github.com/discourse/discourse/assets/1681963/d986359e-6145-41f2-b78f-a6f43e61ef6f)


![Screenshot 2023-10-30 at 11 51 26 AM](https://github.com/discourse/discourse/assets/1681963/04965ff5-de9e-4350-abef-359072ad3e09)

