### PR TITLE
UX: convert share modal margin to gap

### DIFF
--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -3,9 +3,8 @@
 .link-share-container,
 .notify-user-input {
   display: flex;
-  .btn {
-    margin-left: 0.5em;
-  }
+  gap: 0.5em;
+
   input,
   .select-kit {
     cursor: auto;


### PR DESCRIPTION
This updates this button's margin to gap, which helps avoid some margin issues in themes like: 

![Screenshot 2023-10-30 at 12 10 03 PM](https://github.com/discourse/discourse/assets/1681963/f1b641a7-44d2-4cbe-b919-8529b0ad1d9c)

so there will always be a gap between the button and input like this: 

![Screenshot 2023-10-30 at 12 10 33 PM](https://github.com/discourse/discourse/assets/1681963/93c10b00-2fa0-4736-a9b3-2a1a5f42f41a)
