### PR TITLE
UX: fix minor chat transcript overflow

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -1,5 +1,6 @@
 .chat-transcript {
   @extend .chat-message-container;
+  box-sizing: border-box;
   min-height: 50px;
   padding: 12px;
   margin: 1rem 0;


### PR DESCRIPTION
The padding on this container can cause overflow in some cases (note the `l` being cropped here):


Before: 

![Screenshot 2023-10-30 at 1 42 21 PM](https://github.com/discourse/discourse/assets/1681963/84d9bbfa-f74b-4a18-9aff-9fc646300d9a)


After: 
![Screenshot 2023-10-30 at 1 46 58 PM](https://github.com/discourse/discourse/assets/1681963/d48d2256-93f3-45c9-a8d2-f00c1572e607)



(border-box means the padding is taken into consideration for width calculations, vs the default content-box which ignores padding) 
