### PR TITLE
FIX: correctly display escaped thread titles

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.hbs
@@ -15,8 +15,8 @@
     >
       <div class="chat-thread-list-item__header">
         <div class="chat-thread-list-item__title">
-          {{#if this.title}}
-            {{replace-emoji this.title}}
+          {{#if @thread.title}}
+            {{replace-emoji @thread.title}}
           {{else}}
             {{replace-emoji @thread.originalMessage.excerpt}}
           {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
@@ -6,10 +6,6 @@ import { htmlSafe } from "@ember/template";
 export default class ChatThreadListItem extends Component {
   @service router;
 
-  get title() {
-    return htmlSafe(this.args.thread.escapedTitle);
-  }
-
   @action
   openThread(thread) {
     this.router.transitionTo("chat.channel.thread", ...thread.routeModels);

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 
 export default class ChatThreadListItem extends Component {
   @service router;

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/item.js
@@ -1,12 +1,13 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 
 export default class ChatThreadListItem extends Component {
   @service router;
 
   get title() {
-    return this.args.thread.escapedTitle;
+    return htmlSafe(this.args.thread.escapedTitle);
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.hbs
@@ -14,7 +14,7 @@
   </div>
 
   <span class="chat-thread-header__label overflow-ellipsis">
-    {{replace-emoji this.label}}
+    {{replace-emoji @thread.title}}
   </span>
 
   <div

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import ChatModalThreadSettings from "discourse/plugins/chat/discourse/components/chat/modal/thread-settings";
@@ -37,7 +38,7 @@ export default class ChatThreadHeader extends Component {
   }
 
   get label() {
-    return this.args.thread.escapedTitle;
+    return htmlSafe(this.args.thread.escapedTitle);
   }
 
   get canChangeThreadSettings() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import ChatModalThreadSettings from "discourse/plugins/chat/discourse/components/chat/modal/thread-settings";

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.js
@@ -37,10 +37,6 @@ export default class ChatThreadHeader extends Component {
     };
   }
 
-  get label() {
-    return htmlSafe(this.args.thread.escapedTitle);
-  }
-
   get canChangeThreadSettings() {
     if (!this.args.thread) {
       return false;

--- a/plugins/chat/assets/javascripts/discourse/lib/fabricators.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/fabricators.js
@@ -127,6 +127,7 @@ function threadFabricator(args = {}) {
   const channel = args.channel || channelFabricator();
   return ChatThread.create(channel, {
     id: args.id || sequence++,
+    title: args.title,
     original_message: args.original_message || messageFabricator({ channel }),
     preview: args.preview || threadPreviewFabricator({ channel }),
   });

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
@@ -1,6 +1,5 @@
 import { tracked } from "@glimmer/tracking";
 import guid from "pretty-text/guid";
-import { escapeExpression } from "discourse/lib/utilities";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import ChatMessagesManager from "discourse/plugins/chat/discourse/lib/chat-messages-manager";
 import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
@@ -72,9 +71,5 @@ export default class ChatThread {
 
   get routeModels() {
     return [...this.channel.routeModels, this.id];
-  }
-
-  get escapedTitle() {
-    return escapeExpression(this.title);
   }
 }

--- a/plugins/chat/test/javascripts/components/chat-thread-header-test.js
+++ b/plugins/chat/test/javascripts/components/chat-thread-header-test.js
@@ -1,0 +1,24 @@
+import { render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { query } from "discourse/tests/helpers/qunit-helpers";
+import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Discourse Chat | Component | chat-thread-header", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it safely renders title", async function (assert) {
+    const title = "<style>body { background: red;}</style>";
+    this.thread = fabricators.thread({ title });
+
+    await render(hbs`
+      <Chat::Thread::Header @thread={{this.thread}} @channel={{this.thread.channel}} />
+    `);
+
+    assert.equal(
+      query(".chat-thread-header__label").innerHTML.trim(),
+      "&lt;style&gt;body { background: red;}&lt;/style&gt;"
+    );
+  });
+});

--- a/plugins/chat/test/javascripts/components/chat-thread-list-item-test.js
+++ b/plugins/chat/test/javascripts/components/chat-thread-list-item-test.js
@@ -1,0 +1,24 @@
+import { render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { query } from "discourse/tests/helpers/qunit-helpers";
+import fabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Discourse Chat | Component | chat-thread-list-item", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it safely renders title", async function (assert) {
+    const title = "<style>body { background: red;}</style>";
+    this.thread = fabricators.thread({ title });
+
+    await render(hbs`
+      <Chat::ThreadList::Item @thread={{this.thread}} />
+    `);
+
+    assert.equal(
+      query(".chat-thread-list-item__title").innerHTML.trim(),
+      "&lt;style&gt;body { background: red;}&lt;/style&gt;"
+    );
+  });
+});


### PR DESCRIPTION
Prior to this fix, titles with a quote `'` for example, would be rendered as: `&#x27`