### PR TITLE
DEV: add a plugin modifier to change hidden site settings

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -91,8 +91,12 @@ module SiteSettingExtension
     @shadowed_settings ||= []
   end
 
+  def hidden_settings_provider
+    @hidden_settings_provider ||= SiteSettings::HiddenProvider.new
+  end
+
   def hidden_settings
-    @hidden_settings ||= []
+    hidden_settings_provider.all
   end
 
   def refresh_settings
@@ -589,14 +593,14 @@ module SiteSettingExtension
 
       categories[name] = opts[:category] || :uncategorized
 
-      hidden_settings << name if opts[:hidden]
+      hidden_settings_provider.add_hidden(name) if opts[:hidden]
 
       if GlobalSetting.respond_to?(name)
         val = GlobalSetting.public_send(name)
 
         unless val.nil? || (val == "")
           shadowed_val = val
-          hidden_settings << name
+          hidden_settings_provider.add_hidden(name)
           shadowed_settings << name
         end
       end

--- a/lib/site_settings/hidden_provider.rb
+++ b/lib/site_settings/hidden_provider.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SiteSettings
+end
+
+# A class to store and modify hidden site settings
+class SiteSettings::HiddenProvider
+  def initialize
+    @hidden_settings = Set.new
+  end
+
+  def add_hidden(site_setting_name)
+    @hidden_settings << site_setting_name
+  end
+
+  def all
+    DiscoursePluginRegistry.apply_modifier(:hidden_site_settings, @hidden_settings)
+  end
+end

--- a/spec/lib/site_settings/hidden_provider_spec.rb
+++ b/spec/lib/site_settings/hidden_provider_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe SiteSettings::HiddenProvider do
+  let(:provider_local) { SiteSettings::LocalProcessProvider.new }
+  let(:settings) { new_settings(provider_local) }
+  let(:hidden_provider) { SiteSettings::HiddenProvider.new }
+
+  describe "all" do
+    after { DiscoursePluginRegistry.clear_modifiers! }
+
+    it "can return defaults" do
+      hidden_provider.add_hidden(:secret_setting)
+      hidden_provider.add_hidden(:internal_thing)
+      expect(hidden_provider.all).to contain_exactly(:secret_setting, :internal_thing)
+    end
+
+    it "can return results from modifiers" do
+      hidden_provider.add_hidden(:secret_setting)
+      plugin = Plugin::Instance.new
+      plugin.register_modifier(:hidden_site_settings) { |defaults| defaults + [:other_setting] }
+      expect(hidden_provider.all).to contain_exactly(:secret_setting, :other_setting)
+    end
+  end
+end


### PR DESCRIPTION
Plugins can use a new modifier to change which site settings are hidden using the :hidden_site_settings modifier. For example:

```
register_modifier(:hidden_site_settings) do |hidden|
  (hidden + [:invite_only, :login_required]).uniq
end
```
