### PR TITLE
FIX: Correctly sanitize negative integers in site settings

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -33,7 +33,7 @@ class Admin::SiteSettingsController < Admin::AdminController
 
     case SiteSetting.type_supervisor.get_type(id)
     when :integer
-      value = value.gsub(/\D/, "")
+      value = value.tr("^-0-9", "")
     when :uploaded_image_list
       value = Upload.get_from_urls(value.split("|")).to_a
     end

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -276,6 +276,16 @@ RSpec.describe Admin::SiteSettingsController do
         expect(SiteSetting.suggested_topics).to eq(1000)
       end
 
+      it "sanitizes negative integer values correctly" do
+        put "/admin/site_settings/pending_users_reminder_delay_minutes.json",
+            params: {
+              pending_users_reminder_delay_minutes: "-1",
+            }
+
+        expect(response.status).to eq(200)
+        expect(SiteSetting.pending_users_reminder_delay_minutes).to eq(-1)
+      end
+
       context "with default user options" do
         let!(:user1) { Fabricate(:user) }
         let!(:user2) { Fabricate(:user) }


### PR DESCRIPTION
### What is the issue?

As part of https://github.com/discourse/discourse/pull/23816, which sought to strip out thousand separators, we also accidentally strip out signs. This is making it impossible to disable some settings which require a `-1` to disable.

### How does this fix it?

Instead of stripping non-digits, strip anything that isn't a sign or a digit.