### PR TITLE
FIX: Maintain destination_url after passkey login

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/login.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login.js
@@ -148,7 +148,13 @@ export default class Login extends Component {
         });
 
         if (authResult && !authResult.error) {
-          window.location.reload();
+          const destinationUrl = cookie("destination_url");
+          if (destinationUrl) {
+            removeCookie("destination_url");
+            window.location.assign(destinationUrl);
+          } else {
+            window.location.reload();
+          }
         } else {
           this.dialog.alert(authResult.error);
         }

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -60,6 +60,13 @@ describe "User preferences for Security", type: :system do
         )
       authenticator = page.driver.browser.add_virtual_authenticator(options)
 
+      page.driver.browser.manage.add_cookie(
+        domain: Discourse.current_hostname,
+        name: "destination_url",
+        value: "/new",
+        path: "/",
+      )
+
       user_preferences_security_page.visit(user)
 
       find(".pref-passkeys__add .btn").click
@@ -93,6 +100,9 @@ describe "User preferences for Security", type: :system do
       find(".d-header .login-button").click
 
       expect(page).to have_css(".header-dropdown-toggle.current-user")
+
+      # ensures that we are redirected to the destination_url cookie
+      expect(page.driver.current_url).to include("/new")
 
       # clear authenticator (otherwise it will interfere with other tests)
       authenticator.remove!


### PR DESCRIPTION
Similar to regular login and SSO login, when logging in via passkey we
need to respect the `destination_url` cookie. This fixes an issue with
the iOS app where the redirect to the app authorization screen was not
working after logging in via passkey.