### PR TITLE
FIX: Add `rel=0` to youtube lazy videos url

### DIFF
--- a/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
+++ b/plugins/discourse-lazy-videos/assets/javascripts/discourse/components/lazy-iframe.js
@@ -4,7 +4,7 @@ export default class LazyVideo extends Component {
   get iframeSrc() {
     switch (this.args.providerName) {
       case "youtube":
-        let url = `https://www.youtube.com/embed/${this.args.videoId}?autoplay=1`;
+        let url = `https://www.youtube.com/embed/${this.args.videoId}?autoplay=1&rel=0`;
         if (this.args.startTime) {
           url += `&start=${this.convertToSeconds(this.args.startTime)}`;
         }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
