### PR TITLE
FIX: Add checkbox-label to more checkbox label elements

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-form-row.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-form-row.hbs
@@ -1,13 +1,17 @@
 <div class="form-element label-area">
   {{#if this.label}}
-    <label>{{i18n this.label}}</label>
+    <label
+      class={{concat-class (if (eq @type "checkbox") "checkbox-label")}}
+    >{{i18n this.label}}</label>
   {{else}}
     &nbsp;
   {{/if}}
 </div>
 <div class="form-element input-area">
   {{#if this.wrapLabel}}
-    <label>{{yield}}</label>
+    <label
+      class={{concat-class (if (eq @type "checkbox") "checkbox-label")}}
+    >{{yield}}</label>
   {{else}}
     {{yield}}
   {{/if}}

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -30,27 +30,27 @@
       </AdminFormRow>
     {{/if}}
 
-    <AdminFormRow @wrapLabel="true">
+    <AdminFormRow @wrapLabel="true" @type="checkbox">
       <Input @type="checkbox" @checked={{this.buffered.editable}} />
       <span>{{i18n "admin.user_fields.editable.title"}}</span>
     </AdminFormRow>
 
-    <AdminFormRow @wrapLabel="true">
+    <AdminFormRow @wrapLabel="true" @type="checkbox">
       <Input @type="checkbox" @checked={{this.buffered.required}} />
       <span>{{i18n "admin.user_fields.required.title"}}</span>
     </AdminFormRow>
 
-    <AdminFormRow @wrapLabel="true">
+    <AdminFormRow @wrapLabel="true" @type="checkbox">
       <Input @type="checkbox" @checked={{this.buffered.show_on_profile}} />
       <span>{{i18n "admin.user_fields.show_on_profile.title"}}</span>
     </AdminFormRow>
 
-    <AdminFormRow @wrapLabel="true">
+    <AdminFormRow @wrapLabel="true" @type="checkbox">
       <Input @type="checkbox" @checked={{this.buffered.show_on_user_card}} />
       <span>{{i18n "admin.user_fields.show_on_user_card.title"}}</span>
     </AdminFormRow>
 
-    <AdminFormRow @wrapLabel="true">
+    <AdminFormRow @wrapLabel="true" @type="checkbox">
       <Input @type="checkbox" @checked={{this.buffered.searchable}} />
       <span>{{i18n "admin.user_fields.searchable.title"}}</span>
     </AdminFormRow>

--- a/app/assets/javascripts/admin/addon/components/modal/start-backup.hbs
+++ b/app/assets/javascripts/admin/addon/components/modal/start-backup.hbs
@@ -10,7 +10,7 @@
         }}</div>
     {{/if}}
     {{#if this.canManageUploadsInBackup}}
-      <label>
+      <label class="checkbox-label">
         <Input @type="checkbox" @checked={{this.includeUploads}} />
         {{i18n "admin.backups.operations.backup.include_uploads"}}
       </label>

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/award.hbs
@@ -24,7 +24,7 @@
         />
       </div>
       <div class="control-group">
-        <label>
+        <label class="checkbox-label">
           <Input @type="checkbox" @checked={{this.replaceBadgeOwners}} />
           {{i18n "admin.badges.mass_award.replace_owners"}}
         </label>

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -229,7 +229,7 @@
 
     <div class="control-group">
       <div>
-        <label>
+        <label class="checkbox-label">
           <Input @type="checkbox" @checked={{this.buffered.allow_title}} />
           {{i18n "admin.badges.allow_title"}}
         </label>

--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -56,7 +56,7 @@
             @modelId={{this.model.id}}
           />
         {{else}}
-          <label>
+          <label class="checkbox-label">
             <Input @type="checkbox" @checked={{this.model.user_selectable}} />
             {{i18n "admin.customize.theme.color_scheme_user_selectable"}}
           </label>
@@ -65,7 +65,7 @@
 
       {{#unless this.model.theme_id}}
         <div class="pull-right">
-          <label>
+          <label class="checkbox-label">
             <Input @type="checkbox" @checked={{this.onlyOverridden}} />
             {{i18n "admin.settings.show_overriden"}}
           </label>

--- a/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
@@ -141,7 +141,7 @@
     </label>
 
     <div>
-      <label>
+      <label class="checkbox-label">
         <Input @type="checkbox" name="active" @checked={{this.model.active}} />
         {{i18n "admin.web_hooks.active"}}
       </label>

--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.hbs
@@ -61,7 +61,7 @@
 
   {{#if this.siteSettings.enable_badges}}
     <section class="field allow-badges">
-      <label>
+      <label class="checkbox-label">
         <Input @type="checkbox" @checked={{this.category.allow_badges}} />
         {{i18n "category.allow_badges_label"}}
       </label>
@@ -83,7 +83,7 @@
   {{/if}}
 
   <section class="field navigate-to-first-post-after-read">
-    <label>
+    <label class="checkbox-label">
       <Input
         @type="checkbox"
         @checked={{this.category.navigate_to_first_post_after_read}}
@@ -93,14 +93,14 @@
   </section>
 
   <section class="field all-topics-wiki">
-    <label>
+    <label class="checkbox-label">
       <Input @type="checkbox" @checked={{this.category.all_topics_wiki}} />
       {{i18n "category.all_topics_wiki"}}
     </label>
   </section>
 
   <section class="field allow-unlimited-owner-edits-on-first-post">
-    <label>
+    <label class="checkbox-label">
       <Input
         @type="checkbox"
         @checked={{this.category.allow_unlimited_owner_edits_on_first_post}}
@@ -125,7 +125,7 @@
   {{/if}}
 
   <section class="field require-topic-approval">
-    <label>
+    <label class="checkbox-label">
       <Input
         @type="checkbox"
         @checked={{this.category.category_setting.require_topic_approval}}
@@ -135,7 +135,7 @@
   </section>
 
   <section class="field require-reply-approval">
-    <label>
+    <label class="checkbox-label">
       <Input
         @type="checkbox"
         @checked={{this.category.category_setting.require_reply_approval}}
@@ -172,7 +172,7 @@
           @onChange={{action "onAutoCloseDurationChange"}}
         />
       </div>
-      <label>
+      <label class="checkbox-label">
         <Input
           @type="checkbox"
           @checked={{this.category.auto_close_based_on_last_post}}
@@ -283,7 +283,7 @@
 
   {{#if this.isParentCategory}}
     <section class="field show-subcategory-list-field">
-      <label>
+      <label class="checkbox-label">
         <Input
           @type="checkbox"
           @checked={{this.category.show_subcategory_list}}
@@ -337,7 +337,7 @@
     </section>
 
     <section class="field email-in-allow-strangers">
-      <label>
+      <label class="checkbox-label">
         <Input
           @type="checkbox"
           @checked={{this.category.email_in_allow_strangers}}
@@ -347,7 +347,7 @@
     </section>
 
     <section class="field mailinglist-mirror">
-      <label>
+      <label class="checkbox-label">
         <Input @type="checkbox" @checked={{this.category.mailinglist_mirror}} />
         {{i18n "category.mailinglist_mirror"}}
       </label>

--- a/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
@@ -32,7 +32,7 @@
     </div>
 
     <div class="control-group remember">
-      <label>
+      <label class="checkbox-label">
         <Input @type="checkbox" @checked={{this.remember}} />
         <span>{{i18n "download_calendar.remember"}}</span>
       </label>


### PR DESCRIPTION
Followup to e2d9117378ead0dbfcc6533d7cf6a7bf8a14d033, which
made these labels bold because they were missing the correct
class.
