### PR TITLE
UX: update search menu styling to cmd-k style

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -26,6 +26,7 @@ $search-pad-horizontal: 0.5em;
     align-items: center;
     background: var(--secondary-very-high);
     border-radius: var(--d-input-border-radius);
+    margin: 1px;
     padding: 0.25rem;
 
     input#search-term {
@@ -44,6 +45,9 @@ $search-pad-horizontal: 0.5em;
       margin: 2px;
       margin-right: 0;
       white-space: nowrap;
+    }
+    &:focus-within {
+      @include default-focus;
     }
   }
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -22,15 +22,15 @@ $search-pad-horizontal: 0.5em;
 
   .search-input {
     position: relative;
-    margin: 1px;
     display: flex;
     align-items: center;
-    border: 1px solid var(--primary-medium);
-    border-radius: var(--d-border-radius-large);
+    background: var(--secondary-very-high);
+    border-radius: var(--d-input-border-radius);
+    padding: 0.25rem;
 
     input#search-term {
-      border-width: 0;
-      border-radius: var(--d-border-radius-large);
+      background: none;
+      border: 0;
       margin-bottom: 0;
       width: auto;
       flex-grow: 1;
@@ -45,9 +45,6 @@ $search-pad-horizontal: 0.5em;
       margin-right: 0;
       white-space: nowrap;
     }
-    &:focus-within {
-      @include default-focus;
-    }
   }
 
   .heading {
@@ -57,8 +54,10 @@ $search-pad-horizontal: 0.5em;
     }
   }
 
-  input[type="text"] {
-    margin-right: 0px;
+  .menu-panel {
+    border: 0;
+    box-shadow: var(--shadow-dropdown);
+    padding: 1rem;
   }
 
   &.menu-panel-results {
@@ -77,7 +76,6 @@ $search-pad-horizontal: 0.5em;
     display: flex;
     flex-direction: column;
     padding-top: $search-pad-vertical;
-    padding-bottom: $search-pad-vertical;
 
     .list {
       min-width: 100px;
@@ -312,11 +310,6 @@ $search-pad-horizontal: 0.5em;
   }
 
   .searching {
-    position: absolute;
-    top: $search-pad-vertical + 0.2em;
-    right: $search-pad-horizontal;
-    min-height: 20px;
-
     .spinner {
       width: 12px;
       height: 12px;


### PR DESCRIPTION
Updating the search panel for a more modern look in line with the cmd-k modal styling
Before
<img width="513" alt="image" src="https://github.com/discourse/discourse/assets/101828855/54ebaacf-e557-40df-8875-f17e39c0292b">
After
<img width="527" alt="image" src="https://github.com/discourse/discourse/assets/101828855/812be231-2dec-4d7c-923a-c5bd85407862">
with focus
<img width="520" alt="image" src="https://github.com/discourse/discourse/assets/101828855/9d4d221f-0eb6-453c-9cff-cfbcb6c6b6cf">


CSS only