### PR TITLE
FIX: Properly collect `assets/images/*` during assets:precompile

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,12 +16,15 @@ Rails.application.config.assets.paths << "#{Rails.root}/public/javascripts"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 
-# explicitly precompile any images in plugins ( /assets/images ) path
-Rails.application.config.assets.precompile += [
-  lambda do |filename, path|
-    path =~ %r{assets/images} && !%w[.js .css].include?(File.extname(filename))
-  end,
-]
+# Core images
+Rails.application.config.assets.precompile << lambda do |logical_path, path|
+  path.start_with?("#{Rails.root}/assets/images")
+end
+
+# Plugin images
+Rails.application.config.assets.precompile << lambda do |logical_path, path|
+  path =~ %r{assets/images} && !%w[.js .css].include?(File.extname(logical_path))
+end
 
 Rails.application.config.assets.precompile += %w[
   break_string.js


### PR DESCRIPTION
Followup to c124c698332a50d8372c8e55a48282edf77a9043

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
