### PR TITLE
FIX: Further optimize mentioning groups in chat messages (part 2)

### DIFF
--- a/plugins/chat/lib/chat/parsed_mentions.rb
+++ b/plugins/chat/lib/chat/parsed_mentions.rb
@@ -99,7 +99,7 @@ module Chat
 
     def chat_users
       User
-        .includes(:user_chat_channel_memberships, :group_users)
+        .includes(:user_chat_channel_memberships)
         .distinct
         .joins(:user_option)
         .real

--- a/plugins/chat/lib/chat/parsed_mentions.rb
+++ b/plugins/chat/lib/chat/parsed_mentions.rb
@@ -101,7 +101,6 @@ module Chat
       User
         .includes(:user_chat_channel_memberships, :group_users)
         .distinct
-        .joins("LEFT OUTER JOIN user_chat_channel_memberships uccm ON uccm.user_id = users.id")
         .joins(:user_option)
         .real
         .where(user_options: { chat_enabled: true })

--- a/plugins/chat/lib/chat/parsed_mentions.rb
+++ b/plugins/chat/lib/chat/parsed_mentions.rb
@@ -89,7 +89,7 @@ module Chat
     private
 
     def channel_members
-      chat_users.where(
+      chat_users.includes(:user_chat_channel_memberships).where(
         user_chat_channel_memberships: {
           following: true,
           chat_channel_id: @message.chat_channel.id,
@@ -98,12 +98,7 @@ module Chat
     end
 
     def chat_users
-      User
-        .includes(:user_chat_channel_memberships)
-        .distinct
-        .joins(:user_option)
-        .real
-        .where(user_options: { chat_enabled: true })
+      User.distinct.joins(:user_option).real.where(user_options: { chat_enabled: true })
     end
 
     def mentionable_groups


### PR DESCRIPTION
This is a follow-up to e6299a31. I additionally fixed these three things:
1. Since e6299a31 there's no need anymore to join the `group_users` table when looking for users who were reached by a group mention, so I removed that join in that commit. But turned out we were joining the `group_users` table twice, so I [removed](https://github.com/discourse/discourse/pull/24185/commits/1ba1578eb0195872917a1a54dab094f95223ebfd) the second join in this PR. That drastically speeded up my test query, from 6 sec to 0.26 sec.
2. We also were joining twice the `user_chat_channel_memebership` table, so I [removed](https://github.com/discourse/discourse/pull/24185/commits/eef8dc602e4ee8168529a0027d022995d1c43e3b) the second unnecessary join too.
3. We actually need to join the `user_chat_channel_memebership` table only in certain cases, and we don't need to do that for group mentions, so I [fixed](https://github.com/discourse/discourse/pull/24185/commits/150ab98d912a5fb66e3f797eabe01b799723c8f6) that too.

As a result of these changes, time of my test query fall down from 6 sec to 0.001 sec. And the resulting SQL query now contains only one JOIN statement.