### PR TITLE
DEV: Parallel scheduled admin checks

### DIFF
--- a/app/jobs/regular/problem_check.rb
+++ b/app/jobs/regular/problem_check.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Jobs
+  # This job runs a singular scheduled admin check. It is scheduled by
+  # the ProblemChecks (plural) scheduled job.
+  class ProblemCheck < ::Jobs::Base
+    sidekiq_options retry: false
+
+    def execute(args)
+      identifier = args[:check_identifier]
+
+      AdminDashboardData.execute_scheduled_check(identifier.to_sym)
+    end
+  end
+end

--- a/app/jobs/scheduled/problem_checks.rb
+++ b/app/jobs/scheduled/problem_checks.rb
@@ -5,6 +5,8 @@ module Jobs
   # on a regular basis. To add a problem check for this scheduled job run
   # call AdminDashboardData.add_scheduled_problem_check
   class ProblemChecks < ::Jobs::Scheduled
+    sidekiq_options retry: false
+
     every 10.minutes
 
     def execute(_args)

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -145,27 +145,8 @@ class AdminDashboardData
   end
 
   def self.execute_scheduled_checks
-    found_problems = []
-    problem_scheduled_check_blocks.each do |check_identifier, blk|
-      problems = nil
-
-      begin
-        problems = instance_exec(&blk)
-      rescue StandardError => err
-        Discourse.warn_exception(
-          err,
-          message: "A scheduled admin dashboard problem check (#{check_identifier}) errored.",
-        )
-        # we don't want to hold up other checks because this one errored
-        next
-      end
-
-      found_problems += Array.wrap(problems)
-    end
-
-    found_problems.compact.each do |problem|
-      next if !problem.is_a?(Problem)
-      add_found_scheduled_check_problem(problem)
+    problem_scheduled_check_blocks.keys.each do |check_identifier|
+      Jobs.enqueue(:problem_check, check_identifier:)
     end
   end
 

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -35,7 +35,7 @@ class AdminDashboardData
   GLOBAL_REPORTS ||= []
 
   PROBLEM_MESSAGE_PREFIX = "admin-problem:"
-  SCHEDULED_PROBLEM_STORAGE_KEY = "admin-found-scheduled-problems"
+  SCHEDULED_PROBLEM_STORAGE_KEY = "admin-found-scheduled-problems-list"
 
   def initialize(opts = {})
     @opts = opts
@@ -89,12 +89,11 @@ class AdminDashboardData
     if problem.identifier.present?
       return if problems.find { |p| p.identifier == problem.identifier }
     end
-    problems << problem
-    set_found_scheduled_check_problems(problems)
+    set_found_scheduled_check_problem(problem)
   end
 
-  def self.set_found_scheduled_check_problems(problems)
-    Discourse.redis.setex(SCHEDULED_PROBLEM_STORAGE_KEY, 300, JSON.dump(problems.map(&:to_h)))
+  def self.set_found_scheduled_check_problem(problem)
+    Discourse.redis.rpush(SCHEDULED_PROBLEM_STORAGE_KEY, JSON.dump(problem.to_h))
   end
 
   def self.clear_found_scheduled_check_problems
@@ -103,21 +102,25 @@ class AdminDashboardData
 
   def self.clear_found_problem(identifier)
     problems = load_found_scheduled_check_problems
-    problems.reject! { |p| p.identifier == identifier }
-    set_found_scheduled_check_problems(problems)
+    problem = problems.find { |p| p.identifier == identifier }
+    Discourse.redis.lrem(SCHEDULED_PROBLEM_STORAGE_KEY, 1, JSON.dump(problem.to_h))
   end
 
   def self.load_found_scheduled_check_problems
-    found_problems_json = Discourse.redis.get(SCHEDULED_PROBLEM_STORAGE_KEY)
-    return [] if found_problems_json.blank?
-    begin
-      JSON.parse(found_problems_json).map { |problem| Problem.from_h(problem) }
-    rescue JSON::ParserError => err
-      Discourse.warn_exception(
-        err,
-        message: "Error parsing found problem JSON in admin dashboard: #{found_problems_json}",
-      )
-      []
+    found_problems = Discourse.redis.lrange(SCHEDULED_PROBLEM_STORAGE_KEY, 0, -1)
+
+    return [] if found_problems.blank?
+
+    found_problems.filter_map do |problem|
+      begin
+        Problem.from_h(JSON.parse(problem))
+      rescue JSON::ParserError => err
+        Discourse.warn_exception(
+          err,
+          message: "Error parsing found problem JSON in admin dashboard: #{problem}",
+        )
+        nil
+      end
     end
   end
 
@@ -146,7 +149,7 @@ class AdminDashboardData
 
   def self.execute_scheduled_checks
     problem_scheduled_check_blocks.keys.each do |check_identifier|
-      Jobs.enqueue(:problem_check, check_identifier:)
+      Jobs.enqueue(:problem_check, check_identifier: check_identifier.to_s)
     end
   end
 

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -169,6 +169,26 @@ class AdminDashboardData
     end
   end
 
+  def self.execute_scheduled_check(identifier)
+    check = problem_scheduled_check_blocks[identifier]
+
+    problems = instance_exec(&check)
+
+    Array
+      .wrap(problems)
+      .compact
+      .each do |problem|
+        next if !problem.is_a?(Problem)
+
+        add_found_scheduled_check_problem(problem)
+      end
+  rescue StandardError => err
+    Discourse.warn_exception(
+      err,
+      message: "A scheduled admin dashboard problem check (#{identifier}) errored.",
+    )
+  end
+
   ##
   # We call this method in the class definition below
   # so all of the problem checks in this class are registered on

--- a/spec/jobs/problem_check_spec.rb
+++ b/spec/jobs/problem_check_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::ProblemCheck do
+  after do
+    Discourse.redis.flushdb
+    AdminDashboardData.reset_problem_checks
+  end
+
+  it "runs the scheduled problem check that has been added and adds the messages to the load_found_scheduled_check_problems array" do
+    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
+      AdminDashboardData::Problem.new("big problem")
+    end
+
+    described_class.new.execute(check_identifier: :test_identifier)
+    problems = AdminDashboardData.load_found_scheduled_check_problems
+    expect(problems.count).to eq(1)
+    expect(problems.first).to be_a(AdminDashboardData::Problem)
+    expect(problems.first.to_s).to eq("big problem")
+  end
+
+  it "can handle the problem check returning multiple problems" do
+    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
+      [
+        AdminDashboardData::Problem.new("big problem"),
+        AdminDashboardData::Problem.new(
+          "yuge problem",
+          priority: "high",
+          identifier: "config_is_a_mess",
+        ),
+      ]
+    end
+
+    described_class.new.execute(check_identifier: :test_identifier)
+    problems = AdminDashboardData.load_found_scheduled_check_problems
+    expect(problems.map(&:to_s)).to match_array(["big problem", "yuge problem"])
+  end
+
+  it "does not add the same problem twice if the identifier already exists" do
+    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
+      [
+        AdminDashboardData::Problem.new(
+          "yuge problem",
+          priority: "high",
+          identifier: "config_is_a_mess",
+        ),
+        AdminDashboardData::Problem.new(
+          "nasty problem",
+          priority: "high",
+          identifier: "config_is_a_mess",
+        ),
+      ]
+    end
+
+    described_class.new.execute(check_identifier: :test_identifier)
+    problems = AdminDashboardData.load_found_scheduled_check_problems
+    expect(problems.map(&:to_s)).to match_array(["yuge problem"])
+  end
+
+  it "handles errors from a troublesome check" do
+    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
+      raise StandardError.new("something went wrong")
+      AdminDashboardData::Problem.new("polling issue")
+    end
+
+    described_class.new.execute(check_identifier: :test_identifier)
+    expect(AdminDashboardData.load_found_scheduled_check_problems.count).to eq(0)
+  end
+end

--- a/spec/jobs/problem_checks_spec.rb
+++ b/spec/jobs/problem_checks_spec.rb
@@ -1,63 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::ProblemChecks do
+  before { Jobs.run_immediately! }
+
   after do
     Discourse.redis.flushdb
     AdminDashboardData.reset_problem_checks
   end
 
-  it "runs the scheduled problem check that has been added and adds the messages to the load_found_scheduled_check_problems array" do
-    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
-      AdminDashboardData::Problem.new("big problem")
-    end
-
-    described_class.new.execute(nil)
-    problems = AdminDashboardData.load_found_scheduled_check_problems
-    expect(problems.count).to eq(1)
-    expect(problems.first).to be_a(AdminDashboardData::Problem)
-    expect(problems.first.to_s).to eq("big problem")
-  end
-
-  it "can handle the problem check returning multiple problems" do
-    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
-      [
-        AdminDashboardData::Problem.new("big problem"),
-        AdminDashboardData::Problem.new(
-          "yuge problem",
-          priority: "high",
-          identifier: "config_is_a_mess",
-        ),
-      ]
-    end
-
-    described_class.new.execute(nil)
-    problems = AdminDashboardData.load_found_scheduled_check_problems
-    expect(problems.map(&:to_s)).to match_array(["big problem", "yuge problem"])
-  end
-
-  it "does not add the same problem twice if the identifier already exists" do
-    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
-      [
-        AdminDashboardData::Problem.new(
-          "yuge problem",
-          priority: "high",
-          identifier: "config_is_a_mess",
-        ),
-        AdminDashboardData::Problem.new(
-          "nasty problem",
-          priority: "high",
-          identifier: "config_is_a_mess",
-        ),
-      ]
-    end
-
-    described_class.new.execute(nil)
-    problems = AdminDashboardData.load_found_scheduled_check_problems
-    expect(problems.map(&:to_s)).to match_array(["yuge problem"])
-  end
-
   it "starts with a blank slate every time the checks are run to avoid duplicate problems and to clear no longer firing problems" do
     problem_should_fire = true
+    AdminDashboardData.reset_problem_checks
     AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
       if problem_should_fire
         problem_should_fire = false
@@ -69,18 +22,5 @@ RSpec.describe Jobs::ProblemChecks do
     expect(AdminDashboardData.load_found_scheduled_check_problems.count).to eq(1)
     described_class.new.execute(nil)
     expect(AdminDashboardData.load_found_scheduled_check_problems.count).to eq(0)
-  end
-
-  it "handles errors from a troublesome check and proceeds with the rest" do
-    AdminDashboardData.add_scheduled_problem_check(:test_identifier) do
-      raise StandardError.new("something went wrong")
-      AdminDashboardData::Problem.new("polling issue")
-    end
-    AdminDashboardData.add_scheduled_problem_check(:test_identifier_2) do
-      AdminDashboardData::Problem.new("yuge problem", priority: "high")
-    end
-
-    described_class.new.execute(nil)
-    expect(AdminDashboardData.load_found_scheduled_check_problems.count).to eq(1)
   end
 end

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -101,6 +101,36 @@ RSpec.describe AdminDashboardData do
     include_examples "stats cacheable"
   end
 
+  describe ".execute_scheduled_check" do
+    context "when problems are found" do
+      let(:blk) { -> { self::Problem.new("Problem") } }
+
+      before do
+        AdminDashboardData.add_scheduled_problem_check(:foo, &blk)
+        AdminDashboardData.expects(:add_found_scheduled_check_problem).once
+      end
+
+      after { AdminDashboardData.reset_problem_checks }
+
+      it do
+        expect(described_class.execute_scheduled_check(:foo)).to all(be_a(described_class::Problem))
+      end
+    end
+
+    context "when check errors out" do
+      let(:blk) { -> { raise StandardError } }
+
+      before do
+        AdminDashboardData.add_scheduled_problem_check(:foo, &blk)
+        Discourse.expects(:warn_exception).once
+      end
+
+      after { AdminDashboardData.reset_problem_checks }
+
+      it { expect(described_class.execute_scheduled_check(:foo)).to eq(nil) }
+    end
+  end
+
   describe "#problem_message_check" do
     let(:key) { AdminDashboardData.problem_messages.first }
 

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe AdminDashboardData do
     end
 
     it "does not error when loading malformed problems saved in redis" do
-      Discourse.redis.set(AdminDashboardData::SCHEDULED_PROBLEM_STORAGE_KEY, "{ 'badjson")
+      Discourse.redis.rpush(AdminDashboardData::SCHEDULED_PROBLEM_STORAGE_KEY, "{ 'badjson")
       expect(AdminDashboardData.load_found_scheduled_check_problems).to eq([])
     end
 


### PR DESCRIPTION
### What is this change?

This PR does some preparatory refactoring of scheduled admin checks in order for us to be able to do custom retry strategies for some of them.

Instead of running all checks in sequence inside a single, scheduled job, the scheduled job spawns one new job per check.

**Before:**

<img width="641" alt="Screenshot 2023-11-02 at 11 06 08 AM" src="https://github.com/discourse/discourse/assets/5259935/ce8b548e-d7aa-4260-94bd-23a935355ad3">

**After:**

<img width="820" alt="Screenshot 2023-11-02 at 11 08 30 AM" src="https://github.com/discourse/discourse/assets/5259935/76d43e49-d384-4747-b3d9-13cdb0558f45">

As a side effect it also speeds up the checking process.

### Change of Redis data structure

In order to be concurrency-safe, we need to change the existing Redis data structure from a string (of serialized JSON) to a list of strings (of serialized JSON). This is in order to avoid a stale read problem, like below:

1. Check A reads and deserializes problem list.
2. Check B -"-.
3. Check A adds its problem to the list and writes it.
4. Check B -"-. 💣 

Here Check B in step 4 overwrites the new list Check A wrote in step 3.

This PR changes the data structure to a Redis list of serialized hashes. Since list append is concurrency safe in Redis this does the trick.

I considered adding each problem with its own key instead of using a list, but using a list requires the smallest (and hence safest) change to the existing code, so I went with that so that I can get on with the actual change that this unlocks.