### PR TITLE
FEATURE: allow topic title decoration for search results

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-result-entry.js
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.js
@@ -1,5 +1,7 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { schedule } from "@ember/runloop";
+import { topicTitleDecorators } from "discourse/components/topic-title";
 import { logSearchLinkClick } from "discourse/lib/search";
 import { modKeysPressed } from "discourse/lib/utilities";
 
@@ -9,6 +11,21 @@ export default Component.extend({
   classNameBindings: ["bulkSelectEnabled"],
   attributeBindings: ["role"],
   role: "listitem",
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    schedule("afterRender", () => {
+      if (this.element && !this.isDestroying && !this.isDestroyed) {
+        const topicTitle = this.element.querySelector(".topic-title");
+        if (topicTitle && this.post.topic) {
+          topicTitleDecorators.forEach((cb) =>
+            cb(this.post.topic, topicTitle, "full-page-search-topic-title")
+          );
+        }
+      }
+    });
+  },
 
   @action
   logClick(topicId, event) {

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -1,5 +1,7 @@
+import { schedule } from "@ember/runloop";
 import { hbs } from "ember-cli-htmlbars";
 import { h } from "virtual-dom";
+import { topicTitleDecorators } from "discourse/components/topic-title";
 import { dateNode } from "discourse/helpers/node";
 import highlightSearch from "discourse/lib/highlight-search";
 import renderTag from "discourse/lib/render-tag";
@@ -106,6 +108,21 @@ function createSearchResult({ type, linkField, builder }) {
       };
     },
 
+    init() {
+      schedule("afterRender", () => {
+        this.attrs.results.map((r) => {
+          const topicTitle = document.querySelector(
+            `.fancy-title-${r.topic_id}`
+          );
+          if (type === "topic" && topicTitle && r.topic) {
+            topicTitleDecorators.forEach((cb) =>
+              cb(r.topic, topicTitle, "search-dropdown-topic-title")
+            );
+          }
+        });
+      });
+    },
+
     html(attrs) {
       return attrs.results.map((r) => {
         let searchResultId;
@@ -121,7 +138,7 @@ function createSearchResult({ type, linkField, builder }) {
           this.attach("link", {
             href: r[linkField],
             contents: () => builder.call(this, r, attrs.term),
-            className: "search-link",
+            className: `search-link fancy-title-${r.topic_id}`,
             searchResultId,
             searchResultType: type,
             searchLogId: attrs.searchLogId,


### PR DESCRIPTION
This commit allows decoration of topic titles using `api.decorateTopicTitle`. The full page search results and dropdown search results title can be decorated using plugin api.
