### PR TITLE
FIX: Send push notifications for category/tag watching notifications

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -392,6 +392,7 @@ class PostAlerter
       private_message
       group_mentioned
       watching_first_post
+      watching_category_or_tag
       event_reminder
       event_invitation
     ].map { |t| Notification.types[t] }

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1516,11 +1516,14 @@ RSpec.describe PostAlerter do
 
       level = CategoryUser.notification_levels[:watching_first_post]
       CategoryUser.set_notification_level_for_category(user, level, category.id)
-      events = DiscourseEvent.track_events { PostAlerter.new.after_save_post(post, true) }
+      events =
+        DiscourseEvent.track_events(:push_notification) do
+          PostAlerter.new.after_save_post(post, true)
+        end
 
       expect(
         events.detect do |e|
-          e[:event_name] == :push_notification && e[:params][0] == user &&
+          e[:params][0] == user &&
             e[:params][1][:notification_type] == Notification.types[:watching_first_post]
         end,
       ).to be_present
@@ -1855,11 +1858,11 @@ RSpec.describe PostAlerter do
         post = Fabricate(:post, topic: topic)
         level = CategoryUser.notification_levels[:watching]
         CategoryUser.set_notification_level_for_category(user, level, category.id)
-        events = DiscourseEvent.track_events { PostAlerter.post_created(post) }
+        events = DiscourseEvent.track_events(:push_notification) { PostAlerter.post_created(post) }
 
         expect(
           events.detect do |e|
-            e[:event_name] == :push_notification && e[:params][0] == user &&
+            e[:params][0] == user &&
               e[:params][1][:notification_type] == Notification.types[:watching_category_or_tag]
           end,
         ).to be_present

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1530,7 +1530,6 @@ RSpec.describe PostAlerter do
       _post = Fabricate(:post, user: user, topic: topic)
       reply = Fabricate(:post, topic: topic, reply_to_post_number: 1)
       events = DiscourseEvent.track_events { PostAlerter.post_created(reply) }
-
       expect(events).to include(
         event_name: :before_create_notifications_for_users,
         params: [[user], reply],

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe PostAlerter do
   end
 
   def setup_push_notification_subscription_for(user:)
-    SiteSetting.allowed_user_api_push_urls = "https://site.com/push|https://site2.com/push"
     2.times do |i|
       UserApiKey.create!(
         user_id: user.id,
@@ -1183,7 +1182,10 @@ RSpec.describe PostAlerter do
     let(:mention_post) { create_post_with_alerts(user: user, raw: "Hello @eviltrout :heart:") }
     let(:topic) { mention_post.topic }
 
-    before { setup_push_notification_subscription_for(user: evil_trout) }
+    before do
+      SiteSetting.allowed_user_api_push_urls = "https://site.com/push|https://site2.com/push"
+      setup_push_notification_subscription_for(user: evil_trout)
+    end
 
     describe "DiscoursePluginRegistry#push_notification_filters" do
       it "sends push notifications when all filters pass" do


### PR DESCRIPTION
Problem and solution are outlined here on Meta - https://meta.discourse.org/t/watching-a-category-does-not-cause-push-notifications/282794?u=markvanlan

This adds 2 tests - 
1. First test is for the case of a push notification caused by `watching_first_post`. This worked already and the test passed without a core change.
2. Second test is for the case of a push notification caused by `watching_category_or_tag`. This _did not pass initially_ but does with `watching_category_or_tag` added to the list of `NOTIFIABLE_TYPES`... which is the whole point of this PR riggggggggght?! 