### PR TITLE
FIX: Skip animated gif treatment for onebox avatar

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/animated-images-pause-on-click.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/animated-images-pause-on-click.js
@@ -58,7 +58,7 @@ export default {
           return;
         }
 
-        let images = post.querySelectorAll("img.animated");
+        let images = post.querySelectorAll("img.animated:not(.onebox-avatar)");
 
         images.forEach((img) => {
           // skip for edge case of multiple animated images in same block


### PR DESCRIPTION
This fixes an edge case where the layout of a onebox with a gif avatar was broken. Oneboxes have specific styling attached to avatar images and the pausable animated image treatment was breaking that styling.

Before

<img width="795" alt="image" src="https://github.com/discourse/discourse/assets/368961/d31e502a-c9ca-4843-abe0-98d986b46b98">

After

<img width="775" alt="image" src="https://github.com/discourse/discourse/assets/368961/09d2f0f2-1500-4aa6-9cc0-058bbcbae74f">

(Ignore the color difference, that's due to different color schemes in the instances)