### PR TITLE
FIX: Adjust placement and animation of labels for custom user fields

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-fields/dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/dropdown.hbs
@@ -1,4 +1,7 @@
-<label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
+<label
+  class="control-label alt-placeholder"
+  for={{concat "user-" this.elementId}}
+>
   {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>

--- a/app/assets/javascripts/discourse/app/components/user-fields/dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/dropdown.hbs
@@ -1,4 +1,4 @@
-<label class="control-label" for={{concat "user-" this.elementId}}>
+<label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
   {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>

--- a/app/assets/javascripts/discourse/app/components/user-fields/multiselect.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/multiselect.hbs
@@ -1,4 +1,7 @@
-<label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
+<label
+  class="control-label alt-placeholder"
+  for={{concat "user-" this.elementId}}
+>
   {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>

--- a/app/assets/javascripts/discourse/app/components/user-fields/multiselect.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/multiselect.hbs
@@ -1,4 +1,4 @@
-<label class="control-label" for={{concat "user-" this.elementId}}>
+<label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
   {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>

--- a/app/assets/javascripts/discourse/app/components/user-fields/text.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/text.hbs
@@ -4,7 +4,10 @@
     @value={{this.value}}
     maxlength={{this.site.user_field_max_length}}
   />
-  <label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
+  <label
+    class="control-label alt-placeholder"
+    for={{concat "user-" this.elementId}}
+  >
     {{this.field.name}}
     {{#if this.field.required}}<span class="required">*</span>{{/if}}
   </label>

--- a/app/assets/javascripts/discourse/app/components/user-fields/text.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/text.hbs
@@ -1,13 +1,13 @@
 <div class="controls">
-  <label class="control-label" for={{concat "user-" this.elementId}}>
-    {{this.field.name}}
-    {{#if this.field.required}}<span class="required">*</span>{{/if}}
-  </label>
   <Input
     id={{concat "user-" this.elementId}}
     @value={{this.value}}
     maxlength={{this.site.user_field_max_length}}
   />
+  <label class="control-label alt-placeholder" for={{concat "user-" this.elementId}}>
+    {{this.field.name}}
+    {{#if this.field.required}}<span class="required">*</span>{{/if}}
+  </label>
   <InputTip
     @validation={{this.validation}}
     class={{unless this.validation " hidden"}}

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -177,7 +177,6 @@ body.invite-page {
         top: -8px;
         left: calc(1em - 0.25em);
         background-color: var(--secondary);
-        padding: 0 0.25em 0 0.25em;
         font-size: $font-down-1;
       }
       .user-field.text:focus-within,

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -972,3 +972,23 @@
     }
   }
 }
+
+// Due to special login animations, the order here needs to be changed
+.control-group[data-setting-name="user-user-fields"]
+  .user-field.text
+  .controls {
+  display: flex;
+  flex-direction: column;
+  .control-label.alt-placeholder {
+    order: 1;
+  }
+  .ember-text-field {
+    order: 2;
+  }
+  .tip {
+    order: 3;
+  }
+  .instructions {
+    order: 4;
+  }
+}

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -311,6 +311,7 @@
       input.value-entered + label.alt-placeholder {
         top: -8px;
         left: calc(3em - 0.25em);
+        font-size: var(--font-down-1);
       }
     }
     .password-confirmation {


### PR DESCRIPTION
Custom user fields on the sign up screen were not animating their labels out of the input area on focus. This issue was solved in the past but needed to be reverted due to the css affecting the user page.

### Before
<img width="500" src="https://github.com/discourse/discourse/assets/30537603/464aa01d-ca2e-438a-a674-ee4cf66b8e2e"/>

<img width="500" alt="image" src="https://github.com/discourse/discourse/assets/30537603/508aa4a1-9229-4cb0-961b-2d21ed224f88">

The labels for custom user *text* fields here are appearing below the input. This is expected for the signup page, as it needs to be this way for the animation. Here though, since we are re-using the same component, we just need to set the order appropriately.

### After
<img width="500" alt="image" src="https://github.com/discourse/discourse/assets/30537603/8e850f19-fe69-4cca-9c7d-4d0abde4a70e">

<img width="500" alt="image" src="https://github.com/discourse/discourse/assets/30537603/14b5a89e-523d-4264-ba2a-b7fe3ebbca33">

