### PR TITLE
FIX: Add translation for new `watching_category_or_tag` push notification

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5174,6 +5174,7 @@ en:
       private_message: '%{username} sent you a private message in "%{topic}" - %{site_title}'
       linked: '%{username} linked to your post from "%{topic}" - %{site_title}'
       watching_first_post: '%{username} created a new topic "%{topic}" - %{site_title}'
+      watching_category_or_tag: '%{username} created a new post "%{topic}" - %{site_title}'
       confirm_title: "Notifications enabled - %{site_title}"
       confirm_body: "Success! Notifications have been enabled."
       custom: "Notification from %{username} on %{site_title}"


### PR DESCRIPTION
Followup on this commit https://github.com/discourse/discourse/commit/88874389d2d80e638954e28c4f4145e7a3cdd105

We need a translation for the new push notification.