### PR TITLE
DEV: Standardize session confirmation prompt

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -540,9 +540,8 @@ const User = RestModel.extend({
     });
   },
 
-  loadSecondFactorCodes(password) {
+  loadSecondFactorCodes() {
     return ajax("/u/second_factors.json", {
-      data: { password },
       type: "POST",
     });
   },

--- a/app/assets/javascripts/discourse/app/routes/preferences-second-factor.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-second-factor.js
@@ -5,6 +5,7 @@ import RestrictedUserRoute from "discourse/routes/restricted-user";
 export default RestrictedUserRoute.extend({
   currentUser: service(),
   siteSettings: service(),
+  router: service(),
 
   model() {
     return this.modelFor("user");
@@ -15,15 +16,15 @@ export default RestrictedUserRoute.extend({
     controller.set("loading", true);
 
     model
-      .loadSecondFactorCodes("")
+      .loadSecondFactorCodes()
       .then((response) => {
         if (response.error) {
           controller.set("errorMessage", response.error);
+        } else if (response.unconfirmed_session) {
+          this.router.transitionTo("preferences.security");
         } else {
           controller.setProperties({
             errorMessage: null,
-            loaded: !response.password_required,
-            dirty: !!response.password_required,
             totps: response.totps,
             security_keys: response.security_keys,
           });

--- a/app/assets/javascripts/discourse/app/templates/preferences-second-factor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences-second-factor.hbs
@@ -19,194 +19,140 @@
         <div class="alert alert-error">{{this.errorMessage}}</div>
       {{/if}}
 
-      {{#if this.loaded}}
-        <div class="control-group totp">
-          <div class="controls">
-            <h2>{{i18n "user.second_factor.totp.title"}}</h2>
-            {{#each this.totps as |totp|}}
-              <div class="second-factor-item row">
-                <div class="details">
-                  {{#if totp.name}}
-                    {{totp.name}}
-                  {{else}}
-                    {{i18n "user.second_factor.totp.default_name"}}
-                  {{/if}}
-                </div>
-                {{#if this.isCurrentUser}}
-                  <div class="actions">
-                    <TokenBasedAuthDropdown
-                      @totp={{totp}}
-                      @editSecondFactor={{action "editSecondFactor"}}
-                      @disableSingleSecondFactor={{action
-                        "disableSingleSecondFactor"
-                      }}
-                    />
-                  </div>
-                {{/if}}
-              </div>
-            {{/each}}
-            <DButton
-              @action={{action "createTotp"}}
-              @icon="plus"
-              @disabled={{this.loading}}
-              @label="user.second_factor.totp.add"
-              class="btn-default new-totp"
-            />
-          </div>
-        </div>
-
-        <div class="control-group security-key">
-          <div class="controls">
-            <h2>{{i18n "user.second_factor.security_key.title"}}</h2>
-            {{#each this.security_keys as |security_key|}}
-              <div class="second-factor-item row">
-                <div class="details">
-                  {{#if security_key.name}}
-                    {{security_key.name}}
-                  {{else}}
-                    {{i18n "user.second_factor.security_key.default_name"}}
-                  {{/if}}
-                </div>
-
-                {{#if this.isCurrentUser}}
-                  <div class="actions">
-                    <SecurityKeyDropdown
-                      @securityKey={{security_key}}
-                      @editSecurityKey={{action "editSecurityKey"}}
-                      @disableSingleSecondFactor={{action
-                        "disableSingleSecondFactor"
-                      }}
-                    />
-                  </div>
-                {{/if}}
-              </div>
-            {{/each}}
-            <DButton
-              @action={{action "createSecurityKey"}}
-              @icon="plus"
-              @disabled={{this.loading}}
-              @label="user.second_factor.security_key.add"
-              class="btn-default new-security-key"
-            />
-          </div>
-        </div>
-
-        <div class="control-group pref-second-factor-backup">
-          <div class="controls pref-second-factor-backup">
-            <h2>{{i18n "user.second_factor_backup.title"}}</h2>
+      <div class="control-group totp">
+        <div class="controls">
+          <h2>{{i18n "user.second_factor.totp.title"}}</h2>
+          {{#each this.totps as |totp|}}
             <div class="second-factor-item row">
-              {{#if this.model.second_factor_enabled}}
-                <div class="details">
-                  {{#if this.model.second_factor_backup_enabled}}
-                    {{html-safe
-                      (i18n
-                        "user.second_factor_backup.manage"
-                        count=this.model.second_factor_remaining_backup_codes
-                      )
-                    }}
-                  {{else}}
-                    <DButton
-                      @action={{action "editSecondFactorBackup"}}
-                      @icon="plus"
-                      @disabled={{this.loading}}
-                      @label="user.second_factor_backup.enable_long"
-                      class="btn-default new-second-factor-backup"
-                    />
-                  {{/if}}
-                </div>
-
-                {{#if
-                  (and
-                    this.model.second_factor_backup_enabled this.isCurrentUser
-                  )
-                }}
-                  <div class="actions">
-                    <TwoFactorBackupDropdown
-                      @secondFactorBackupEnabled={{this.model.second_factor_backup_enabled}}
-                      @editSecondFactorBackup={{action
-                        "editSecondFactorBackup"
-                      }}
-                      @disableSecondFactorBackup={{action
-                        "disableSecondFactorBackup"
-                      }}
-                    />
-                  </div>
+              <div class="details">
+                {{#if totp.name}}
+                  {{totp.name}}
+                {{else}}
+                  {{i18n "user.second_factor.totp.default_name"}}
                 {{/if}}
-
-              {{else}}
-                {{i18n "user.second_factor_backup.enable_prerequisites"}}
+              </div>
+              {{#if this.isCurrentUser}}
+                <div class="actions">
+                  <TokenBasedAuthDropdown
+                    @totp={{totp}}
+                    @editSecondFactor={{action "editSecondFactor"}}
+                    @disableSingleSecondFactor={{action
+                      "disableSingleSecondFactor"
+                    }}
+                  />
+                </div>
               {{/if}}
             </div>
-          </div>
+          {{/each}}
+          <DButton
+            @action={{action "createTotp"}}
+            @icon="plus"
+            @disabled={{this.loading}}
+            @label="user.second_factor.totp.add"
+            class="btn-default new-totp"
+          />
         </div>
+      </div>
 
-        {{#if this.model.second_factor_enabled}}
-          {{#unless this.showEnforcedNotice}}
-            <div class="control-group pref-second-factor-disable-all">
-              <div class="controls -actions">
-                <DButton
-                  @icon="ban"
-                  @action={{action "disableAllSecondFactors"}}
-                  @disabled={{this.loading}}
-                  @label="user.second_factor.disable_all"
-                  class="btn-danger"
-                />
-                <CancelLink
-                  @route="preferences.security"
-                  @args={{this.model.username}}
-                />
+      <div class="control-group security-key">
+        <div class="controls">
+          <h2>{{i18n "user.second_factor.security_key.title"}}</h2>
+          {{#each this.security_keys as |security_key|}}
+            <div class="second-factor-item row">
+              <div class="details">
+                {{#if security_key.name}}
+                  {{security_key.name}}
+                {{else}}
+                  {{i18n "user.second_factor.security_key.default_name"}}
+                {{/if}}
               </div>
-            </div>
-          {{/unless}}
-        {{/if}}
-      {{else}}
-        <div class="control-group">
-          <label class="control-label">{{i18n "user.password.title"}}</label>
 
-          <div class="controls">
-            <div>
-              <TextField
-                @value={{this.password}}
-                @id="password"
-                @type="password"
-                @classNames="input-large"
-                @autofocus="autofocus"
-              />
+              {{#if this.isCurrentUser}}
+                <div class="actions">
+                  <SecurityKeyDropdown
+                    @securityKey={{security_key}}
+                    @editSecurityKey={{action "editSecurityKey"}}
+                    @disableSingleSecondFactor={{action
+                      "disableSingleSecondFactor"
+                    }}
+                  />
+                </div>
+              {{/if}}
             </div>
-            <div class="instructions">
-              {{i18n "user.second_factor.confirm_password_description"}}
-            </div>
+          {{/each}}
+          <DButton
+            @action={{action "createSecurityKey"}}
+            @icon="plus"
+            @disabled={{this.loading}}
+            @label="user.second_factor.security_key.add"
+            class="btn-default new-security-key"
+          />
+        </div>
+      </div>
+
+      <div class="control-group pref-second-factor-backup">
+        <div class="controls pref-second-factor-backup">
+          <h2>{{i18n "user.second_factor_backup.title"}}</h2>
+          <div class="second-factor-item row">
+            {{#if this.model.second_factor_enabled}}
+              <div class="details">
+                {{#if this.model.second_factor_backup_enabled}}
+                  {{html-safe
+                    (i18n
+                      "user.second_factor_backup.manage"
+                      count=this.model.second_factor_remaining_backup_codes
+                    )
+                  }}
+                {{else}}
+                  <DButton
+                    @action={{action "editSecondFactorBackup"}}
+                    @icon="plus"
+                    @disabled={{this.loading}}
+                    @label="user.second_factor_backup.enable_long"
+                    class="btn-default new-second-factor-backup"
+                  />
+                {{/if}}
+              </div>
+
+              {{#if
+                (and this.model.second_factor_backup_enabled this.isCurrentUser)
+              }}
+                <div class="actions">
+                  <TwoFactorBackupDropdown
+                    @secondFactorBackupEnabled={{this.model.second_factor_backup_enabled}}
+                    @editSecondFactorBackup={{action "editSecondFactorBackup"}}
+                    @disableSecondFactorBackup={{action
+                      "disableSecondFactorBackup"
+                    }}
+                  />
+                </div>
+              {{/if}}
+
+            {{else}}
+              {{i18n "user.second_factor_backup.enable_prerequisites"}}
+            {{/if}}
           </div>
         </div>
+      </div>
 
-        <div class="control-group">
-          <div class="controls -actions">
-            <DButton
-              @action={{action "confirmPassword"}}
-              @disabled={{this.loading}}
-              @label="continue"
-              type="submit"
-              class="btn-primary"
-            />
-
-            {{#unless this.showEnforcedNotice}}
+      {{#if this.hasSecondFactors}}
+        {{#unless this.showEnforcedNotice}}
+          <div class="control-group pref-second-factor-disable-all">
+            <div class="controls -actions">
+              <DButton
+                @icon="ban"
+                @action={{action "disableAllSecondFactors"}}
+                @disabled={{this.loading}}
+                @label="user.second_factor.disable_all"
+                class="btn-danger"
+              />
               <CancelLink
                 @route="preferences.security"
                 @args={{this.model.username}}
               />
-            {{/unless}}
+            </div>
           </div>
-          <div class="controls" style="margin-top: 5px">
-            {{this.resetPasswordProgress}}
-            {{#unless this.resetPasswordLoading}}
-              <a
-                href
-                class="instructions"
-                {{on "click" this.resetPassword}}
-              >{{i18n "user.second_factor.forgot_password"}}</a>
-            {{/unless}}
-          </div>
-        </div>
+        {{/unless}}
       {{/if}}
     </form>
   </ConditionalLoadingSpinner>

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -19,28 +19,26 @@
     <UserPreferences::UserPasskeys @model={{@model}} />
   {{/if}}
 
-  <div
-    class="control-group pref-second-factor"
-    data-setting-name="user-second-factor"
-  >
-    <label class="control-label">{{i18n "user.second_factor.title"}}</label>
-    {{#unless this.model.second_factor_enabled}}
+  {{#if this.isCurrentUser}}
+    <div
+      class="control-group pref-second-factor"
+      data-setting-name="user-second-factor"
+    >
+      <label class="control-label">{{i18n "user.second_factor.title"}}</label>
       <div class="instructions">
         {{i18n "user.second_factor.short_description"}}
       </div>
-    {{/unless}}
-    <div class="controls pref-second-factor">
-      {{#if this.isCurrentUser}}
-        <LinkTo
-          @route="preferences.second-factor"
-          class="btn btn-default btn-second-factor"
-        >
-          {{d-icon "lock"}}
-          <span>{{i18n "user.second_factor.enable"}}</span>
-        </LinkTo>
-      {{/if}}
+
+      <div class="controls pref-second-factor">
+        <DButton
+          @action={{this.manage2FA}}
+          @icon="lock"
+          @label="user.second_factor.enable"
+          class="btn-second-factor"
+        />
+      </div>
     </div>
-  </div>
+  {{/if}}
 {{/if}}
 
 {{#if this.canCheckEmails}}

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -15,13 +15,13 @@ async function catchAbortedTransition() {
   }
 }
 
-acceptance("Enforce Second Factor", function (needs) {
+acceptance("Enforce Second Factor for unconfirmed session", function (needs) {
   needs.user();
   needs.pretender((server, helper) => {
     server.post("/u/second_factors.json", () => {
       return helper.response({
         success: "OK",
-        password_required: "true",
+        unconfirmed_session: "true",
       });
     });
   });
@@ -30,22 +30,10 @@ acceptance("Enforce Second Factor", function (needs) {
     await visit("/u/eviltrout/preferences/second-factor");
     this.siteSettings.enforce_second_factor = "staff";
 
-    await catchAbortedTransition();
-
     assert.strictEqual(
       currentRouteName(),
-      "preferences.second-factor",
-      "it will not transition from second-factor preferences"
-    );
-
-    await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='admin']"
-    );
-
-    assert.strictEqual(
-      currentRouteName(),
-      "preferences.second-factor",
-      "it stays at second-factor preferences"
+      "preferences.security",
+      "it transitions to security preferences"
     );
   });
 
@@ -55,26 +43,10 @@ acceptance("Enforce Second Factor", function (needs) {
     await visit("/u/eviltrout/preferences/second-factor");
     this.siteSettings.enforce_second_factor = "all";
 
-    await catchAbortedTransition();
-
     assert.strictEqual(
       currentRouteName(),
-      "preferences.second-factor",
-      "it will not transition from second-factor preferences"
-    );
-
-    await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
-    );
-
-    await click(
-      ".sidebar-section[data-section-name='community'] .sidebar-section-link[data-link-name='about']"
-    );
-
-    assert.strictEqual(
-      currentRouteName(),
-      "preferences.second-factor",
-      "it stays at second-factor preferences"
+      "preferences.security",
+      "it will transition to security preferences"
     );
   });
 

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -518,6 +518,23 @@
 }
 
 .user-preferences {
+  .form-vertical {
+    width: 500px;
+    max-width: 100%;
+
+    .control-group {
+      margin-bottom: 2em;
+    }
+  }
+
+  .category-selector,
+  .tag-chooser,
+  textarea,
+  input.user-selector,
+  .user-chooser {
+    width: 100%;
+  }
+
   textarea {
     height: 100px;
   }
@@ -734,6 +751,10 @@
         }
       }
     }
+  }
+
+  .pref-second-factor {
+    margin-top: 0.5em;
   }
 }
 

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -107,10 +107,6 @@
   }
 }
 
-.pref-second-factor {
-  margin-top: 10px;
-}
-
 .invite-controls .btn {
   margin-right: 0px;
 }
@@ -250,21 +246,6 @@ table.user-invite-list {
 
 .user-messages {
   margin-right: 0.2em;
-}
-
-.user-preferences {
-  .form-vertical {
-    width: 500px;
-    max-width: 100%;
-  }
-
-  .category-selector,
-  .tag-chooser,
-  textarea,
-  input.user-selector,
-  .user-chooser {
-    width: 100%;
-  }
 }
 
 .user-crawler {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1533,12 +1533,6 @@ class UsersController < ApplicationController
       raise Discourse::NotFound
     end
 
-    if params[:password].present?
-      if !confirm_secure_session
-        return render json: failed_json.merge(error: I18n.t("login.incorrect_password"))
-      end
-    end
-
     if secure_session_confirmed?
       totp_second_factors =
         current_user
@@ -1555,7 +1549,7 @@ class UsersController < ApplicationController
 
       render json: success_json.merge(totps: totp_second_factors, security_keys: security_keys)
     else
-      render json: success_json.merge(password_required: true)
+      render json: success_json.merge(unconfirmed_session: true)
     end
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1461,8 +1461,6 @@ en:
         title: "Two-Factor Authentication"
         enable: "Manage Two-Factor Authentication"
         disable_all: "Disable All"
-        forgot_password: "Forgot password?"
-        confirm_password_description: "Please confirm your password to continue"
         name: "Name"
         label: "Code"
         rate_limit: "Please wait before trying another authentication code."

--- a/spec/system/page_objects/pages/user_preferences_security.rb
+++ b/spec/system/page_objects/pages/user_preferences_security.rb
@@ -9,10 +9,10 @@ module PageObjects
       end
 
       def visit_second_factor(password)
-        click_link(class: "btn-second-factor")
+        click_button "Manage Two-Factor Authentication"
 
-        find(".second-factor input#password").fill_in(with: password)
-        find(".second-factor .btn-primary").click
+        find(".dialog-body input#password").fill_in(with: password)
+        find(".dialog-body .btn-primary").click
       end
     end
   end


### PR DESCRIPTION
Switches to using a dialog to confirm a session (i.e. sudo mode for account changes where we want to be extra sure the current user is who they say they are) to match what we do with passkeys.

The UX change is to replace this state of the `/u/username/preferences/second-factor` screen: 

<img width="500" alt="image" src="https://github.com/discourse/discourse/assets/368961/fcf493e8-da0e-4c89-a41b-d2ec39b14c9a">

with a dialog, same as the one used for passkeys: 

<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/368961/ecbdeabb-cc7a-44f7-98e9-6f067a243f80">

This saves us from having the same UI/logic copied in two different places. The long-term plan is to move this to a dedicated screen. 

(Note that the "Forgot Password" functionality has been removed here because the dialog is opened from the Security tab where the "Send Password Reset Email" button is present.) 