### PR TITLE
FEATURE: Validate watched words in Ruby and JS

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -66,20 +66,51 @@ class WordWatcher
       .values
       .group_by { |attrs| attrs[:case_sensitive] ? :case_sensitive : :case_insensitive }
       .map do |group_key, attrs_list|
-        words = attrs_list.map { |attrs| attrs[:word] }
+        # Validate words
+        words =
+          attrs_list
+            .map { |attrs| attrs[:word] }
+            .map do |word|
+              # Validate Ruby regular expression
+              rb_regexp = word_to_regexp(word, engine: :ruby)
+
+              begin
+                Regexp.new(rb_regexp)
+              rescue RegexpError
+                if raise_errors
+                  raise
+                else
+                  next
+                end
+              end
+
+              # Validate JavaScript regular expression
+              js_regexp = word_to_regexp(word, engine: :js)
+
+              begin
+                PrettyText.v8.eval("new RegExp(#{js_regexp.inspect}, 'gu')")
+              rescue MiniRacer::RuntimeError
+                if raise_errors
+                  raise
+                else
+                  next
+                end
+              end
+
+              word
+            end
+            .select { |r| r.present? }
 
         # Compile all watched words into a single regular expression
         regexp =
           words
             .map do |word|
-              r = word_to_regexp(word, match_word: SiteSetting.watched_words_regular_expressions?)
-              begin
-                r if Regexp.new(r)
-              rescue RegexpError
-                raise if raise_errors
-              end
+              word_to_regexp(
+                word,
+                engine: engine,
+                match_word: SiteSetting.watched_words_regular_expressions?,
+              )
             end
-            .select { |r| r.present? }
             .join("|")
 
         # Add word boundaries to the regexp for regular watched words

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -63,8 +63,9 @@ RSpec.describe WordWatcher do
     end
 
     context "when watched_words_regular_expressions = true" do
+      before { SiteSetting.watched_words_regular_expressions = true }
+
       it "returns the proper regexp" do
-        SiteSetting.watched_words_regular_expressions = true
         regexps = described_class.compiled_regexps_for_action(:block)
 
         expect(regexps).to be_an(Array)
@@ -72,6 +73,22 @@ RSpec.describe WordWatcher do
           "/(#{word1})|(#{word2})/i",
           "/(#{word3})|(#{word4})/",
         )
+      end
+
+      it "validates regexp in Ruby" do
+        Fabricate(:watched_word, word: "*test", action: WatchedWord.actions[:block])
+
+        expect {
+          described_class.compiled_regexps_for_action(:block, raise_errors: true)
+        }.to raise_error(RegexpError)
+      end
+
+      it "validates regexp in JavaScript" do
+        Fabricate(:watched_word, word: "a\\-b", action: WatchedWord.actions[:block])
+
+        expect {
+          described_class.compiled_regexps_for_action(:block, raise_errors: true)
+        }.to raise_error(MiniRacer::RuntimeError)
       end
     end
 


### PR DESCRIPTION
We used to only validate watched words in Ruby, but this meant that watched words could still be invalid in JavaScript and cause errors.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
