### PR TITLE
FIX: remove background image from lightbox backdrop

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-lightbox.js
+++ b/app/assets/javascripts/discourse/app/components/d-lightbox.js
@@ -65,7 +65,7 @@ export default class DLightbox extends Component {
       return htmlSafe(variables.join(""));
     }
 
-    const { width, height, aspectRatio, dominantColor, fullsizeURL, smallURL } =
+    const { width, height, aspectRatio, dominantColor, fullsizeURL } =
       this.currentItem;
 
     variables.push(
@@ -74,8 +74,7 @@ export default class DLightbox extends Component {
       `${base}-height: ${height}px`,
       `${base}-aspect-ratio: ${aspectRatio}`,
       `${base}-dominant-color: #${dominantColor}`,
-      `${base}-full-size-url: url(${encodeURI(fullsizeURL)})`,
-      `${base}-small-url: url(${encodeURI(smallURL)})`
+      `${base}-full-size-url: url(${encodeURI(fullsizeURL)})`
     );
 
     return htmlSafe(variables.filter(Boolean).join(";"));

--- a/app/assets/stylesheets/common/components/d-lightbox.scss
+++ b/app/assets/stylesheets/common/components/d-lightbox.scss
@@ -19,6 +19,7 @@ html.has-lightbox {
   --d-lightbox-primary: #ffffff;
   --d-lightbox-secondary: #000000;
   --d-lightbox-secondary-translucent: rgba(0, 0, 0, 0.25);
+  --d-lightbox-tertiary: #222222;
 }
 
 /* Lightbox element*/
@@ -280,11 +281,7 @@ html.has-lightbox {
     left: 0;
     height: 100%;
     width: 100%;
-    background-size: cover;
-    background-position: center;
-    filter: blur(15px) brightness(0.25);
-    background-color: var(--d-lightbox-secondary);
-    background-image: var(--d-lightbox-image-small-url);
+    background-color: var(--d-lightbox-tertiary);
   }
 
   &__main-image {


### PR DESCRIPTION
This change removes the background image (which is the small version of the uploaded image) from the lightbox backdrop.

Now a solid color (dark grey) is used for the backdrop so we can distinguish between the lightbox's head, body and footer.

Very small cosmetic change so no tests included.