### PR TITLE
FEATURE: Improve push notification msg for watching_category_or_tag notifications

### DIFF
--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -20,14 +20,7 @@ class PushNotificationPusher
         ActionController::Base.helpers.image_url("push-notifications/#{notification_icon_name}.png")
 
       message = {
-        title:
-          payload[:translated_title] ||
-            I18n.t(
-              "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}",
-              site_title: SiteSetting.title,
-              topic: payload[:topic_title],
-              username: payload[:username],
-            ),
+        title: payload[:translated_title] || title(payload),
         body: payload[:excerpt],
         badge: get_badge,
         icon: notification_icon,
@@ -41,6 +34,27 @@ class PushNotificationPusher
     end
 
     message
+  end
+
+  def self.title(payload)
+    translation_key =
+      case payload[:notification_type]
+      when Notification.types[:watching_category_or_tag]
+        # For watching_category_or_tag, the notification could be for either a new post or new topic.
+        # Instead of duplicating translations, we can rely on 'watching_first_post' for new topics,
+        # and 'posted' for new posts.
+        type = payload[:post_number] == 1 ? "watching_first_post" : "posted"
+        "discourse_push_notifications.popup.#{type}"
+      else
+        "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}"
+      end
+
+    I18n.t(
+      translation_key,
+      site_title: SiteSetting.title,
+      topic: payload[:topic_title],
+      username: payload[:username],
+    )
   end
 
   def self.subscriptions(user)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5190,7 +5190,6 @@ en:
       private_message: '%{username} sent you a private message in "%{topic}" - %{site_title}'
       linked: '%{username} linked to your post from "%{topic}" - %{site_title}'
       watching_first_post: '%{username} created a new topic "%{topic}" - %{site_title}'
-      watching_category_or_tag: '%{username} created a new post "%{topic}" - %{site_title}'
       confirm_title: "Notifications enabled - %{site_title}"
       confirm_body: "Success! Notifications have been enabled."
       custom: "Notification from %{username} on %{site_title}"


### PR DESCRIPTION
I added a new push notification/transtionlation here  - https://github.com/discourse/discourse/commit/1d96b0a99adb0c2236c90fc4fa949734451f9351

I've outline the issue [here on Meta](https://meta.discourse.org/t/watching-a-category-does-not-cause-push-notifications/282794/9?u=markvanlan). Basically this push notification will be triggered via a new post **or** a new topic. The previous message would not differeniate between the two.

This PR adds a bit more logic in `PushNotificationPusher` to check if the notification type is `watching_category_or_tag` and then looks at `post_number` to determine which translation to use. Pretty ez.

Now for new topics it'll read:
> username created a new topic "title here!" - Marks' Discourse

And for new posts:
> username posted in "title here!" - Marks' Discourse