### PR TITLE
FIX: user got notified about a mention inside a chat message quote

### DIFF
--- a/app/models/post_analyzer.rb
+++ b/app/models/post_analyzer.rb
@@ -146,11 +146,9 @@ class PostAnalyzer
   def cooked_stripped
     @cooked_stripped ||=
       begin
-        doc = Nokogiri::HTML5.fragment(cook(@raw, topic_id: @topic_id))
-        doc.css(
-          "pre .mention, aside.quote > .title, aside.quote .mention, aside.quote .mention-group, .onebox, .elided",
-        ).remove
-        doc
+        cooked = cook(@raw, topic_id: @topic_id)
+        fragment = Nokogiri::HTML5.fragment(cooked)
+        PostStripper.strip(fragment)
       end
   end
 

--- a/app/models/post_stripper.rb
+++ b/app/models/post_stripper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# We strip posts before detecting mentions, oneboxes, attachments etc.
+# We strip those elements that shouldn't be detected. For example,
+# a mention inside a quote should be ignored, so we strip it off.
+class PostStripper
+  def self.strip(nokogiri_fragment)
+    nokogiri_fragment.css(
+      "pre .mention, aside.quote > .title, aside.quote .mention, aside.quote .mention-group, .onebox, .elided",
+    ).remove
+    nokogiri_fragment
+  end
+end

--- a/app/models/post_stripper.rb
+++ b/app/models/post_stripper.rb
@@ -5,9 +5,24 @@
 # a mention inside a quote should be ignored, so we strip it off.
 class PostStripper
   def self.strip(nokogiri_fragment)
+    run_core_strippers(nokogiri_fragment)
+    run_plugin_strippers(nokogiri_fragment)
+    nokogiri_fragment
+  end
+
+  private
+
+  def self.run_core_strippers(nokogiri_fragment)
     nokogiri_fragment.css(
       "pre .mention, aside.quote > .title, aside.quote .mention, aside.quote .mention-group, .onebox, .elided",
     ).remove
-    nokogiri_fragment
   end
+
+  def self.run_plugin_strippers(nokogiri_fragment)
+    DiscoursePluginRegistry.post_strippers.each do |stripper|
+      stripper[:block].call(nokogiri_fragment)
+    end
+  end
+
+  private_class_method :run_core_strippers, :run_plugin_strippers
 end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -122,6 +122,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :post_action_notify_user_handlers
 
+  define_filtered_register :post_strippers
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1254,6 +1254,14 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_post_action_notify_user_handler(handler, self)
   end
 
+  # We strip posts before detecting mentions, oneboxes, attachments etc.
+  # We strip those elements that shouldn't be detected. For example,
+  # a mention inside a quote should be ignored, so we strip it off.
+  # Using this API plugins can register their own post strippers.
+  def register_post_stripper(&block)
+    DiscoursePluginRegistry.register_post_stripper({ block: block }, self)
+  end
+
   protected
 
   def self.js_path

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -493,6 +493,10 @@ after_initialize do
   register_hashtag_type_priority_for_context("tag", "chat-composer", 50)
   register_hashtag_type_priority_for_context("channel", "topic-composer", 10)
 
+  register_post_stripper do |nokogiri_fragment|
+    nokogiri_fragment.css(".chat-transcript .mention").remove
+  end
+
   Site.markdown_additional_options["chat"] = {
     limited_pretty_text_features: Chat::Message::MARKDOWN_FEATURES,
     limited_pretty_text_markdown_rules: Chat::Message::MARKDOWN_IT_RULES,

--- a/spec/models/post_stripper_spec.rb
+++ b/spec/models/post_stripper_spec.rb
@@ -33,4 +33,20 @@ RSpec.describe PostStripper do
 
     expect(fragment.to_s).to_not include(onebox)
   end
+
+  context "with plugins" do
+    it "runs strippers registered by plugins" do
+      plugin_element = '<div class="plugin_class"></div>'
+
+      block = Proc.new { |nokogiri_fragment| nokogiri_fragment.css(".plugin_class").remove }
+      plugin = stub(enabled?: true)
+      DiscoursePluginRegistry.register_post_stripper({ block: block }, plugin)
+
+      fragment = Nokogiri::HTML5.fragment("<p>#{plugin_element}</p>")
+
+      PostStripper.strip(fragment)
+
+      expect(fragment.to_s).to_not include(plugin_element)
+    end
+  end
 end

--- a/spec/models/post_stripper_spec.rb
+++ b/spec/models/post_stripper_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe PostStripper do
   end
 
   context "with plugins" do
+    after { DiscoursePluginRegistry.reset_register!(:post_strippers) }
+
     it "runs strippers registered by plugins" do
       plugin_element = '<div class="plugin_class"></div>'
 

--- a/spec/models/post_stripper_spec.rb
+++ b/spec/models/post_stripper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PostStripper do
       plugin_element = '<div class="plugin_class"></div>'
 
       block = Proc.new { |nokogiri_fragment| nokogiri_fragment.css(".plugin_class").remove }
-      plugin = stub(enabled?: true)
+      plugin = OpenStruct.new(enabled?: true)
       DiscoursePluginRegistry.register_post_stripper({ block: block }, plugin)
 
       fragment = Nokogiri::HTML5.fragment("<p>#{plugin_element}</p>")

--- a/spec/models/post_stripper_spec.rb
+++ b/spec/models/post_stripper_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe PostStripper do
+  it "strips mentions in quotes" do
+    mention = '<a class="mention">@andrei</a>'
+    cooked = "<aside class='quote'>#{mention}</aside>"
+    fragment = Nokogiri::HTML5.fragment(cooked)
+
+    PostStripper.strip(fragment)
+
+    expect(fragment.to_s).to_not include(mention)
+  end
+
+  it "strips group mentions in quotes" do
+    group_mention = '<a class="mention-group">@moderators</a>'
+    cooked = "<aside class='quote'>#{group_mention}</aside>"
+    fragment = Nokogiri::HTML5.fragment(cooked)
+
+    PostStripper.strip(fragment)
+
+    expect(fragment.to_s).to_not include(group_mention)
+  end
+
+  it "strips oneboxes" do
+    onebox =
+      '<aside class="onebox">
+        Onebox content
+      </aside>'
+    cooked = "<p>#{onebox}</p>"
+    fragment = Nokogiri::HTML5.fragment(cooked)
+
+    PostStripper.strip(fragment)
+
+    expect(fragment.to_s).to_not include(onebox)
+  end
+end


### PR DESCRIPTION
When quoting a chat message in a post, if that message contains a mention, that mention should be ignored. But we've been detecting them and sending notifications to users. This PR fixes the problem. Since this fix is for the chat plugin, I had to introduce a new API for plugins:

https://github.com/discourse/discourse/blob/8d719245822eb9ea42e7be266a11c221e38d6e8b/lib/plugin/instance.rb#L1251-L1257


