### PR TITLE
UX: render reviewable table with cooked styles

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1114,6 +1114,7 @@ blockquote > *:last-child {
   }
 }
 
+.reviewable .post-body,
 .cooked table,
 .d-editor-preview table {
   thead {


### PR DESCRIPTION
tables in the review queue don't get the cooked styles like topics, this includes them

before:
![Screenshot 2023-11-03 at 4 17 15 PM](https://github.com/discourse/discourse/assets/1681963/41362379-9ec4-41e4-8f49-b8b4e597f4b2)


after:
![Screenshot 2023-11-03 at 4 16 27 PM](https://github.com/discourse/discourse/assets/1681963/c612b5e2-dd5e-4190-8c2e-f2e2eb3daff7)
