### PR TITLE
DEV: Introduce S3 transfer acceleration for uploads behind hidden setting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -225,6 +225,7 @@ s3_cdn_url =
 s3_endpoint =
 s3_http_continue_timeout =
 s3_install_cors_rule =
+s3_enable_transfer_acceleration =
 
 # Optionally, specify a separate CDN to be used for static JS assets stored on S3
 s3_asset_cdn_url =

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1462,7 +1462,7 @@ files:
   enable_s3_uploads:
     default: false
     client: true
-  enable_s3_upload_acceleration:
+  enable_s3_transfer_acceleration:
     default: false
     hidden: true
   s3_use_iam_profile:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1462,6 +1462,9 @@ files:
   enable_s3_uploads:
     default: false
     client: true
+  enable_s3_upload_acceleration:
+    default: false
+    hidden: true
   s3_use_iam_profile:
     default: false
   s3_access_key_id:

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -25,6 +25,7 @@ module FileStore
         S3Helper.new(
           s3_bucket,
           Rails.configuration.multisite ? multisite_tombstone_prefix : TOMBSTONE_PREFIX,
+          use_accelerate_endpoint: SiteSetting.enable_s3_transfer_acceleration,
         )
     end
 

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -262,6 +262,9 @@ class S3Helper
 
     opts[:endpoint] = SiteSetting.s3_endpoint if SiteSetting.s3_endpoint.present?
     opts[:http_continue_timeout] = SiteSetting.s3_http_continue_timeout
+    opts[:use_accelerate_endpoint] = SiteSetting.enable_s3_upload_acceleration
+    opts[:logger] = Logger.new(STDOUT)
+    opts[:log_level] = :debug
 
     unless obj.s3_use_iam_profile
       opts[:access_key_id] = obj.s3_access_key_id
@@ -349,7 +352,12 @@ class S3Helper
   def presigned_url(key, method:, expires_in: S3Helper::UPLOAD_URL_EXPIRES_AFTER_SECONDS, opts: {})
     Aws::S3::Presigner.new(client: s3_client).presigned_url(
       method,
-      { bucket: s3_bucket_name, key: key, expires_in: expires_in }.merge(opts),
+      {
+        bucket: s3_bucket_name,
+        key: key,
+        expires_in: expires_in,
+        use_accelerate_endpoint: SiteSetting.enable_s3_upload_acceleration,
+      }.merge(opts),
     )
   end
 
@@ -362,7 +370,12 @@ class S3Helper
   )
     Aws::S3::Presigner.new(client: s3_client).presigned_request(
       method,
-      { bucket: s3_bucket_name, key: key, expires_in: expires_in }.merge(opts),
+      {
+        bucket: s3_bucket_name,
+        key: key,
+        expires_in: expires_in,
+        use_accelerate_endpoint: SiteSetting.enable_s3_upload_acceleration,
+      }.merge(opts),
     )
   end
 


### PR DESCRIPTION
This commit adds an `enable_s3_transfer_acceleration` site setting,
which is hidden to begin with. We are adding this because in certain
regions, using https://aws.amazon.com/s3/transfer-acceleration/ can
drastically speed up uploads, sometimes as much as 70% in certain
regions depending on the target bucket region. This is important for
us because we have direct S3 multipart uploads enabled everywhere
on our hosting.

To start, we only want this on the uploads bucket, not the backup one.
Also, this will accelerate both uploads **and** downloads, depending
on whether a presigned URL is used for downloading. This is the case
when secure uploads is enabled, not anywhere else at this time. To
enable the S3 acceleration on downloads more generally would be a
more in-depth change, since we currently store S3 Upload record URLs
like this:

```
 url: "//test.s3.dualstack.us-east-2.amazonaws.com/original/2X/6/123456.png"
```

For acceleration, `s3.dualstack` would need to be changed to `s3-accelerate.dualstack`
here.

Note that for this to have any effect, Transfer Acceleration must be enabled
on the S3 bucket used for uploads per https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-examples.html.