### PR TITLE
DEV: Simplify I18n shim check

### DIFF
--- a/app/assets/javascripts/discourse-i18n/src/index.js
+++ b/app/assets/javascripts/discourse-i18n/src/index.js
@@ -1,4 +1,4 @@
-if ("I18n" in globalThis) {
+if (window.I18n) {
   throw new Error(
     "I18n already defined, discourse-i18n unexpectedly loaded twice!"
   );


### PR DESCRIPTION
We have identified some third-party analytics scripts which do things like `window.I18n = window.I18n` 🤦‍♂️. This leads to the window object having a null I18n property, but `"I18n" in globalThis` returns true.

This commit checks whether `window.I18n` is a truthy value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
