### PR TITLE
FIX: targeting chat-message-text is more reliable

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -60,12 +60,11 @@ module PageObjects
           text = args[:text]
           text = I18n.t("js.chat.deleted", count: args[:deleted]) if args[:deleted]
 
-          if text
-            @component =
-              find(context).find("#{selector} .chat-message-text", text: /#{Regexp.escape(text)}/)
-          else
-            @component = page.find(context).find(selector)
-          end
+          @component =
+            page.find(
+              "#{context} #{selector} .chat-message-text",
+              text: text ? /#{Regexp.escape(text)}/ : nil,
+            )
 
           self
         end


### PR DESCRIPTION
We were having flakey specs on mobile when clicking with delay on a message, it appears that sometimes the click was too much on a border of the container and was not triggering the event.