### PR TITLE
DEV: Simplify watched word data structures

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
+++ b/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
@@ -1,9 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
+import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
 
 export default class WatchedWordTest extends Component {
   @tracked value;
@@ -68,8 +65,8 @@ export default class WatchedWordTest extends Component {
       let matches = [];
       this.args.model.watchedWord.compiledRegularExpression.forEach(
         (regexp) => {
-          const wordRegexp = createWatchedWordRegExp(toWatchedWord(regexp));
-          matches.push(...(this.value.match(wordRegexp) || []));
+          const regexpObj = createWatchedWordRegExp(regexp);
+          matches.push(...(this.value.match(regexpObj) || []));
         }
       );
 

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -1,9 +1,4 @@
 export function createWatchedWordRegExp(word) {
   const caseFlag = word.case_sensitive ? "" : "i";
-  return new RegExp(word.regexp, `${caseFlag}gu`);
-}
-
-export function toWatchedWord(regexp) {
-  const [[regexpString, options]] = Object.entries(regexp);
-  return { regexp: regexpString, ...options };
+  return new RegExp(word.full_regexp || word.regexp, `${caseFlag}gu`);
 }

--- a/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
@@ -1,8 +1,3 @@
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
-
 const MAX_MATCHES = 100;
 
 function isLinkOpen(str) {
@@ -16,13 +11,9 @@ function isLinkClose(str) {
 function findAllMatches(text, matchers) {
   const matches = [];
 
-  for (const { word, pattern, replacement, link } of matchers) {
-    if (matches.length >= MAX_MATCHES) {
-      break;
-    }
-
-    if (word.test(text)) {
-      for (const match of text.matchAll(pattern)) {
+  for (const { regexp, fullRegexp, replacement, link } of matchers) {
+    if (regexp.test(text)) {
+      for (const match of text.matchAll(fullRegexp)) {
         matches.push({
           index: match.index + match[0].indexOf(match[1]),
           text: match[1],
@@ -34,6 +25,10 @@ function findAllMatches(text, matchers) {
           break;
         }
       }
+    }
+
+    if (matches.length >= MAX_MATCHES) {
+      break;
     }
   }
 
@@ -53,37 +48,27 @@ export function setup(helper) {
   const opts = helper.getOptions();
 
   helper.registerPlugin((md) => {
-    const matchers = [];
+    const matchers = [
+      ...(md.options.discourse.watchedWordsReplace || []).map((word) => ({
+        regexp: new RegExp(word.regexp, word.case_sensitive ? "" : "i"),
+        fullRegexp: new RegExp(
+          word.full_regexp,
+          word.case_sensitive ? "gu" : "gui"
+        ),
+        replacement: word.replacement,
+        link: false,
+      })),
 
-    if (md.options.discourse.watchedWordsReplace) {
-      Object.entries(md.options.discourse.watchedWordsReplace).forEach(
-        ([regexpString, options]) => {
-          const word = toWatchedWord({ [regexpString]: options });
-
-          matchers.push({
-            word: new RegExp(options.word, options.case_sensitive ? "" : "i"),
-            pattern: createWatchedWordRegExp(word),
-            replacement: options.replacement,
-            link: false,
-          });
-        }
-      );
-    }
-
-    if (md.options.discourse.watchedWordsLink) {
-      Object.entries(md.options.discourse.watchedWordsLink).forEach(
-        ([regexpString, options]) => {
-          const word = toWatchedWord({ [regexpString]: options });
-
-          matchers.push({
-            word: new RegExp(options.word, options.case_sensitive ? "" : "i"),
-            pattern: createWatchedWordRegExp(word),
-            replacement: options.replacement,
-            link: true,
-          });
-        }
-      );
-    }
+      ...(md.options.discourse.watchedWordsLink || []).map((word) => ({
+        regexp: new RegExp(word.regexp, word.case_sensitive ? "" : "i"),
+        fullRegexp: new RegExp(
+          word.full_regexp,
+          word.case_sensitive ? "gu" : "gui"
+        ),
+        replacement: word.replacement,
+        link: true,
+      })),
+    ];
 
     if (matchers.length === 0) {
       return;

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -141,12 +141,13 @@ acceptance("Admin - Watched Words", function (needs) {
 acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.user();
   needs.site({
-    watched_words_replace: {
-      "(?:\\W|^)(betis)(?=\\W|$)": {
+    watched_words_replace: [
+      {
+        full_regexp: "(?:\\W|^)(betis)(?=\\W|$)",
         replacement: ":poop:",
         case_sensitive: false,
       },
-    },
+    ],
   });
 
   test("emoji renders successfully after replacement", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
@@ -27,11 +27,11 @@ export default {
     ],
     compiled_regular_expressions: {
       block: [
-        { '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)': { case_sensitive: false }, },
+        { full_regexp: '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)', case_sensitive: false },
       ],
       censor: [],
       require_approval: [
-        { "(?:\\W|^)(coupon)(?=\\W|$)": { case_sensitive: false }, },
+        { full_regexp: "(?:\\W|^)(coupon)(?=\\W|$)", case_sensitive: false },
       ],
       flag: [{ "(?:\\W|^)(pyramid|scheme)(?=\\W|$)": {case_sensitive: false }, },],
       replace: [{ "(?:\\W|^)(hi)(?=\\W|$)": { case_sensitive: false }},],

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1086,7 +1086,9 @@ eviltrout</p>
     assert.cookedOptions(
       "Pleased to meet you, but pleeeease call me later, xyz123",
       {
-        censoredRegexp: [{ "(xyz*|plee+ase)": { case_sensitive: false } }],
+        censoredRegexp: [
+          { full_regexp: "(xyz*|plee+ase)", case_sensitive: false },
+        ],
       },
       "<p>Pleased to meet you, but ■■■■■■■■■ call me later, ■■■123</p>",
       "supports censoring"
@@ -1611,13 +1613,14 @@ var bar = 'bar';
 
   test("watched words replace", function (assert) {
     const opts = {
-      watchedWordsReplace: {
-        "(?:\\W|^)(fun)(?=\\W|$)": {
+      watchedWordsReplace: [
+        {
           word: "fun",
+          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "times",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions("test fun funny", opts, "<p>test times funny</p>");
@@ -1626,13 +1629,14 @@ var bar = 'bar';
 
   test("watched words link", function (assert) {
     const opts = {
-      watchedWordsLink: {
-        "(?:\\W|^)(fun)(?=\\W|$)": {
+      watchedWordsLink: [
+        {
           word: "fun",
+          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "https://discourse.org",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions(
@@ -1645,13 +1649,14 @@ var bar = 'bar';
   test("watched words replace with bad regex", function (assert) {
     const opts = {
       siteSettings: { watched_words_regular_expressions: true },
-      watchedWordsReplace: {
-        "(\\bu?\\b)": {
+      watchedWordsReplace: [
+        {
           word: "(\\bu?\\b)",
+          full_regexp: "(\\bu?\\b)",
           replacement: "you",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions(

--- a/app/assets/javascripts/pretty-text/addon/censored-words.js
+++ b/app/assets/javascripts/pretty-text/addon/censored-words.js
@@ -1,13 +1,10 @@
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
+import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
 
 export function censorFn(regexpList, replacementLetter) {
   if (regexpList?.length) {
     replacementLetter = replacementLetter || "&#9632;";
     let censorRegexps = regexpList.map((regexp) => {
-      return createWatchedWordRegExp(toWatchedWord(regexp));
+      return createWatchedWordRegExp(regexp);
     });
 
     return function (text) {

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -191,9 +191,9 @@ class TopicCreator
     if watched_words.present?
       word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
       word_watcher_tags = topic.tags.map(&:name)
-      watched_words.each do |word, opts|
-        if word_watcher.word_matches?(word, case_sensitive: opts[:case_sensitive])
-          word_watcher_tags += opts[:replacement].split(",")
+      watched_words.each do |attrs|
+        if word_watcher.word_matches?(attrs[:word], case_sensitive: attrs[:case_sensitive])
+          word_watcher_tags += attrs[:replacement].split(",")
         end
       end
       DiscourseTagging.tag_topic_by_names(topic, Discourse.system_user.guardian, word_watcher_tags)

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -18,15 +18,9 @@ RSpec.describe WordWatcher do
       word2 =
         Fabricate(:watched_word, action: WatchedWord.actions[:block], case_sensitive: true).word
 
-      expect(described_class.words_for_action(:block)).to include(
-        word1 => {
-          case_sensitive: false,
-          word: word1,
-        },
-        word2 => {
-          case_sensitive: true,
-          word: word2,
-        },
+      expect(described_class.words_for_action(:block)).to contain_exactly(
+        { case_sensitive: false, word: word1, regexp: word1 },
+        { case_sensitive: true, word: word2, regexp: word2 },
       )
     end
 
@@ -38,17 +32,13 @@ RSpec.describe WordWatcher do
           replacement: "http://test.localhost/",
         ).word
 
-      expect(described_class.words_for_action(:link)).to include(
-        word => {
-          case_sensitive: false,
-          replacement: "http://test.localhost/",
-          word: word,
-        },
+      expect(described_class.words_for_action(:link)).to contain_exactly(
+        { case_sensitive: false, replacement: "http://test.localhost/", word: word, regexp: word },
       )
     end
 
     it "returns an empty hash when no words are present" do
-      expect(described_class.words_for_action(:tag)).to eq({})
+      expect(described_class.words_for_action(:tag)).to eq([])
     end
   end
 


### PR DESCRIPTION
Watched words used to be returned as a hash where the key was the word and the value was a hash with the other attributes. This data structure did not have any advantages and made processing more difficult.

This commit changes the data structure to be an array of hashes where each hash contains all the attributes of the watched word.

This commit also makes it more explicit that there is a short and fast regular expression (key "regexp") that is used to perform quick searches and does not match the whole word, and a long and complete regular expression (key "full_regexp") that can be used to perform Unicode matching and may include word boundaries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
