### PR TITLE
DEV: remove undefined `categoryPageStyle`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -13,7 +13,6 @@
       @connectorTagName="div"
       @outletArgs={{hash
         categories=this.model.categories
-        categoryPageStyle=this.categoryPageStyle
         topics=this.model.topics
       }}
     />
@@ -51,7 +50,6 @@
       @connectorTagName="div"
       @outletArgs={{hash
         categories=this.model.categories
-        categoryPageStyle=this.categoryPageStyle
         topics=this.model.topics
       }}
     />


### PR DESCRIPTION
It looks like this computed value was removed from the controller in https://github.com/discourse/discourse/commit/82d6d691eec9e97c88d67182bcbc583461e3e0dc

It could be added back, but I don't see many themes that rely on it (only one in the discourse github org, which I have a PR open to fix) and this data is available using the `siteSettings` service. 