### PR TITLE
FIX: target chat-message-text only on secondary action

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -32,7 +32,7 @@ module PageObjects
 
         def secondary_action(action)
           if page.has_css?("html.mobile-view", wait: 0)
-            component.click(delay: 0.6)
+            component.find(".chat-message-text").click(delay: 0.6)
             page.find(".chat-message-actions [data-id=\"#{action}\"]").click
           else
             open_more_menu
@@ -61,10 +61,7 @@ module PageObjects
           text = I18n.t("js.chat.deleted", count: args[:deleted]) if args[:deleted]
 
           @component =
-            page.find(
-              "#{context} #{selector} .chat-message-text",
-              text: text ? /#{Regexp.escape(text)}/ : nil,
-            )
+            page.find("#{context} #{selector}", text: text ? /#{Regexp.escape(text)}/ : nil)
 
           self
         end

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
 
     context "when quoting a single message into a topic" do
       fab!(:post_1) { Fabricate(:post) }
-      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
       it "quotes the message" do
         chat_page.visit_channel(chat_channel_1)
@@ -62,8 +62,8 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
 
     context "when quoting multiple messages into a topic" do
       fab!(:post_1) { Fabricate(:post) }
-      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
-      fab!(:message_2) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
+      fab!(:message_2) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
       it "quotes the messages" do
         chat_page.visit_channel(chat_channel_1)
@@ -71,8 +71,8 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
         clip_text = copy_messages_to_clipboard([message_1, message_2])
         topic_page.visit_topic_and_open_composer(post_1.topic)
         topic_page.fill_in_composer("This is a new post!\n\n" + clip_text)
-
         within(".d-editor-preview") { expect(page).to have_css(".chat-transcript", count: 2) }
+
         expect(page).to have_content("Originally sent in #{chat_channel_1.name}")
 
         topic_page.send_reply
@@ -85,7 +85,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
 
     context "when quoting a message containing a onebox" do
       fab!(:post_1) { Fabricate(:post) }
-      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
       before do
         Oneboxer.stubs(:preview).returns(
@@ -109,7 +109,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
     end
 
     context "when quoting a message in another message" do
-      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
       it "quotes the message" do
         chat_page.visit_channel(chat_channel_1)
@@ -125,7 +125,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
   end
 
   context "when quoting into a topic directly" do
-    fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1, use_service: true) }
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
     let(:topic_title) { "Some topic title for testing" }
 
     it "opens the topic composer with correct state" do


### PR DESCRIPTION
This is not necessary for other cases and was breaking specs. This commit also avoids using chat service when not necessary.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
