### PR TITLE
DEV: Use a single registry for preloaded category custom fields

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -6,9 +6,6 @@ class CategoryList
   cattr_accessor :preloaded_topic_custom_fields
   self.preloaded_topic_custom_fields = Set.new
 
-  cattr_accessor :preloaded_category_custom_fields
-  self.preloaded_category_custom_fields = Set.new
-
   attr_accessor :categories, :uncategorized
 
   def self.register_included_association(association)
@@ -142,8 +139,8 @@ class CategoryList
 
     @categories = query.to_a
 
-    if preloaded_category_custom_fields.any?
-      Category.preload_custom_fields(@categories, preloaded_category_custom_fields)
+    if Site.preloaded_category_custom_fields.any?
+      Category.preload_custom_fields(@categories, Site.preloaded_category_custom_fields)
     end
 
     include_subcategories = @options[:include_subcategories] == true

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -292,9 +292,9 @@ class Plugin::Instance
 
   # Registers a category custom field to be loaded when rendering a category list
   # Example usage:
-  #   register_category_list_preloaded_category_custom_fields("custom_field")
-  def register_category_list_preloaded_category_custom_fields(field)
-    CategoryList.preloaded_category_custom_fields << field
+  #   register_preloaded_category_custom_fields("custom_field")
+  def register_preloaded_category_custom_fields(field)
+    Site.preloaded_category_custom_fields << field
   end
 
   def custom_avatar_column(column)

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -362,10 +362,10 @@ RSpec.describe CategoryList do
     fab!(:category) { Fabricate(:category, user: admin) }
 
     before { category.upsert_custom_fields("bob" => "marley") }
-    after { CategoryList.preloaded_category_custom_fields = Set.new }
+    after { Site.reset_preloaded_category_custom_fields }
 
     it "can preloads custom fields" do
-      CategoryList.preloaded_category_custom_fields << "bob"
+      Site.preloaded_category_custom_fields << "bob"
 
       expect(category_list.categories[-1].custom_field_preloaded?("bob")).to eq(true)
     end


### PR DESCRIPTION
There was a registry for preloaded site categories and a new one has been introduced recently for categories serialized through a CategoryList.

Having two registries created a lot of fraction for developers and this commit merges them into a single one, providing a unified API.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
