### PR TITLE
FIX: restore "categories and top topics" layout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import CategoriesAndLatestTopics from "discourse/components/categories-and-latest-topics";
+import CategoriesAndTopTopics from "discourse/components/categories-and-top-topics";
 import CategoriesBoxes from "discourse/components/categories-boxes";
 import CategoriesBoxesWithTopics from "discourse/components/categories-boxes-with-topics";
 import CategoriesOnly from "discourse/components/categories-only";
@@ -22,6 +23,7 @@ const subcategoryComponents = {
 const globalComponents = {
   categories_and_latest_topics_created_date: CategoriesAndLatestTopics,
   categories_and_latest_topics: CategoriesAndLatestTopics,
+  categories_and_top_topics: CategoriesAndTopTopics,
   categories_boxes_with_topics: CategoriesBoxesWithTopics,
   categories_boxes: CategoriesBoxes,
   categories_only: CategoriesOnly,
@@ -53,7 +55,6 @@ export default class CategoriesDisplay extends Component {
       style = mobileCompatibleViews[0];
     }
     const component = globalComponents[style];
-
     if (!component) {
       // eslint-disable-next-line no-console
       console.error("Unknown category list style: " + style);


### PR DESCRIPTION
Looks like this layout was accidentally omitted, this adds it back. I think this is a follow-up to 82d6d69