### PR TITLE
FIX: relocate `above-discovery-categories` outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
 import { inject as service } from "@ember/service";
 import CategoriesAndLatestTopics from "discourse/components/categories-and-latest-topics";
 import CategoriesAndTopTopics from "discourse/components/categories-and-top-topics";
@@ -6,6 +7,7 @@ import CategoriesBoxes from "discourse/components/categories-boxes";
 import CategoriesBoxesWithTopics from "discourse/components/categories-boxes-with-topics";
 import CategoriesOnly from "discourse/components/categories-only";
 import CategoriesWithFeaturedTopics from "discourse/components/categories-with-featured-topics";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import SubcategoriesWithFeaturedTopics from "discourse/components/subcategories-with-featured-topics";
 
 const mobileCompatibleViews = [
@@ -73,6 +75,11 @@ export default class CategoriesDisplay extends Component {
   }
 
   <template>
+    <PluginOutlet
+      @name="above-discovery-categories"
+      @connectorTagName="div"
+      @outletArgs={{hash categories=@categories topics=@topics}}
+    />
     <this.categoriesComponent @categories={{@categories}} @topics={{@topics}} />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -8,14 +8,6 @@
     />
   </:navigation>
   <:list>
-    <PluginOutlet
-      @name="above-discovery-categories"
-      @connectorTagName="div"
-      @outletArgs={{hash
-        categories=this.model.categories
-        topics=this.model.topics
-      }}
-    />
 
     {{body-class "categories-list"}}
 


### PR DESCRIPTION
This outlet previously displayed above /categories, *and* above subcategories on a category topic list (i.e. /c/4) when `Show subcategory list above topics in this category` is enabled. 

This regressed in 82d6d69, so this moves the outlet to restore this behavior. 
