### PR TITLE
Feature: Add ability to hide modal header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -25,44 +25,45 @@
       <div class="modal-middle-container">
         <div class="modal-inner-container">
           {{yield to="aboveHeader"}}
-          {{#if this.showHeader}}
-            {{#if
+          {{#if
+          (and
+            (not @hideHeader)
               (or
                 this.dismissable
                 @title
                 (has-block "headerBelowTitle")
                 (has-block "headerAboveTitle")
               )
-            }}
-              <div class={{concat-class "modal-header" @headerClass}}>
-                {{#if this.dismissable}}
-                  <DButton
-                    @icon="times"
-                    @action={{this.handleCloseButton}}
-                    @title="modal.close"
-                    class="btn-flat modal-close close"
-                  />
+          )
+          }}
+            <div class={{concat-class "modal-header" @headerClass}}>
+              {{#if this.dismissable}}
+                <DButton
+                  @icon="times"
+                  @action={{this.handleCloseButton}}
+                  @title="modal.close"
+                  class="btn-flat modal-close close"
+                />
+              {{/if}}
+
+              {{yield to="headerAboveTitle"}}
+
+              <div class="modal-title-wrapper">
+                {{#if @title}}
+                  <div class="title">
+                    <h3 id="discourse-modal-title">{{@title}}</h3>
+
+                    {{#if @subtitle}}
+                      <p class="subtitle">{{@subtitle}}</p>
+                    {{/if}}
+                  </div>
                 {{/if}}
 
-                {{yield to="headerAboveTitle"}}
-
-                <div class="modal-title-wrapper">
-                  {{#if @title}}
-                    <div class="title">
-                      <h3 id="discourse-modal-title">{{@title}}</h3>
-
-                      {{#if @subtitle}}
-                        <p class="subtitle">{{@subtitle}}</p>
-                      {{/if}}
-                    </div>
-                  {{/if}}
-
-                  {{yield to="belowModalTitle"}}
-                </div>
-
-                {{yield to="headerBelowTitle"}}
+                {{yield to="belowModalTitle"}}
               </div>
-            {{/if}}
+
+              {{yield to="headerBelowTitle"}}
+            </div>
           {{/if}}
 
           {{yield to="belowHeader"}}

--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -25,43 +25,44 @@
       <div class="modal-middle-container">
         <div class="modal-inner-container">
           {{yield to="aboveHeader"}}
-
-          {{#if
-            (or
-              this.dismissable
-              @title
-              (has-block "headerBelowTitle")
-              (has-block "headerAboveTitle")
-            )
-          }}
-            <div class={{concat-class "modal-header" @headerClass}}>
-              {{#if this.dismissable}}
-                <DButton
-                  @icon="times"
-                  @action={{this.handleCloseButton}}
-                  @title="modal.close"
-                  class="btn-flat modal-close close"
-                />
-              {{/if}}
-
-              {{yield to="headerAboveTitle"}}
-
-              <div class="modal-title-wrapper">
-                {{#if @title}}
-                  <div class="title">
-                    <h3 id="discourse-modal-title">{{@title}}</h3>
-
-                    {{#if @subtitle}}
-                      <p class="subtitle">{{@subtitle}}</p>
-                    {{/if}}
-                  </div>
+          {{#if this.showHeader}}
+            {{#if
+              (or
+                this.dismissable
+                @title
+                (has-block "headerBelowTitle")
+                (has-block "headerAboveTitle")
+              )
+            }}
+              <div class={{concat-class "modal-header" @headerClass}}>
+                {{#if this.dismissable}}
+                  <DButton
+                    @icon="times"
+                    @action={{this.handleCloseButton}}
+                    @title="modal.close"
+                    class="btn-flat modal-close close"
+                  />
                 {{/if}}
 
-                {{yield to="belowModalTitle"}}
-              </div>
+                {{yield to="headerAboveTitle"}}
 
-              {{yield to="headerBelowTitle"}}
-            </div>
+                <div class="modal-title-wrapper">
+                  {{#if @title}}
+                    <div class="title">
+                      <h3 id="discourse-modal-title">{{@title}}</h3>
+
+                      {{#if @subtitle}}
+                        <p class="subtitle">{{@subtitle}}</p>
+                      {{/if}}
+                    </div>
+                  {{/if}}
+
+                  {{yield to="belowModalTitle"}}
+                </div>
+
+                {{yield to="headerBelowTitle"}}
+              </div>
+            {{/if}}
           {{/if}}
 
           {{yield to="belowHeader"}}

--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -26,15 +26,15 @@
         <div class="modal-inner-container">
           {{yield to="aboveHeader"}}
           {{#if
-          (and
-            (not @hideHeader)
+            (and
+              (not @hideHeader)
               (or
                 this.dismissable
                 @title
                 (has-block "headerBelowTitle")
                 (has-block "headerAboveTitle")
               )
-          )
+            )
           }}
             <div class={{concat-class "modal-header" @headerClass}}>
               {{#if this.dismissable}}

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -42,10 +42,6 @@ export default class DModal extends Component {
     }
   }
 
-  get showHeader() {
-    return !this.args.hideHeader;
-  }
-
   shouldTriggerClickOnEnter(event) {
     if (this.args.submitOnEnter === false) {
       return false;

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -42,6 +42,10 @@ export default class DModal extends Component {
     }
   }
 
+  get showHeader() {
+    return !this.args.hideHeader;
+  }
+
   shouldTriggerClickOnEnter(event) {
     if (this.args.submitOnEnter === false) {
       return false;

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.hbs
@@ -4,6 +4,7 @@
   <Styleguide::Component>
     <DModal
       @closeModal={{fn (mut this.inline) true}}
+      @hideHeader={{this.hideHeader}}
       @inline={{this.inline}}
       @title={{this.title}}
       @subtitle={{this.subtitle}}
@@ -23,6 +24,12 @@
   </Styleguide::Component>
 
   <Styleguide::Controls>
+    <Styleguide::Controls::Row @name="@hideHeader">
+      <DToggleSwitch
+        @state={{this.hideHeader}}
+        {{on "click" this.toggleHeader}}
+      />
+    </Styleguide::Controls::Row>
     <Styleguide::Controls::Row @name="@inline">
       <DToggleSwitch @state={{this.inline}} {{on "click" this.toggleInline}} />
     </Styleguide::Controls::Row>

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.js
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.js
@@ -5,6 +5,7 @@ import I18n from "discourse-i18n";
 
 export default class extends Component {
   @tracked inline = true;
+  @tracked hideHeader = false;
   @tracked dismissable = true;
   @tracked modalTagName = "div";
   @tracked title = I18n.t("styleguide.sections.modal.header");
@@ -17,12 +18,13 @@ export default class extends Component {
   modalTagNames = ["div", "form"];
 
   @action
+  toggleHeader() {
+    this.hideHeader = !this.hideHeader;
+  }
+
+  @action
   toggleInline() {
     this.inline = !this.inline;
-    if (!this.inline) {
-      // Make sure there is a way to dismiss the modal
-      this.dismissable = true;
-    }
   }
 
   @action

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.js
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.js
@@ -25,6 +25,10 @@ export default class extends Component {
   @action
   toggleInline() {
     this.inline = !this.inline;
+    if (!this.inline) {
+      // Make sure there is a way to dismiss the modal
+      this.dismissable = true;
+    }
   }
 
   @action


### PR DESCRIPTION
This adds the ability to hide the modal header using the `@hideHeader` argument when calling the `<DModal>` component.

One use case for this would the cmd+K modal used for creating new chat messages. It needs a title, but does not need the header to show, as this is a specially styled modal, not needing that aspect of the modal component.