### PR TITLE
FIX: Prevent invalid tos and privacy URLs in cache

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -606,15 +606,18 @@ module Discourse
     if SiteSetting.tos_url.present?
       SiteSetting.tos_url
     else
-      urls_cache["tos"] ||= (
+      return urls_cache["tos"] if urls_cache["tos"].present?
+
+      tos_url =
         if SiteSetting.tos_topic_id > 0 && Topic.exists?(id: SiteSetting.tos_topic_id)
           "#{Discourse.base_path}/tos"
-        else
-          :nil
         end
-      )
 
-      urls_cache["tos"] != :nil ? urls_cache["tos"] : nil
+      if tos_url
+        urls_cache["tos"] = tos_url
+      else
+        urls_cache.delete("tos")
+      end
     end
   end
 
@@ -622,15 +625,18 @@ module Discourse
     if SiteSetting.privacy_policy_url.present?
       SiteSetting.privacy_policy_url
     else
-      urls_cache["privacy_policy"] ||= (
+      return urls_cache["privacy_policy"] if urls_cache["privacy_policy"].present?
+
+      privacy_policy_url =
         if SiteSetting.privacy_topic_id > 0 && Topic.exists?(id: SiteSetting.privacy_topic_id)
           "#{Discourse.base_path}/privacy"
-        else
-          :nil
         end
-      )
 
-      urls_cache["privacy_policy"] != :nil ? urls_cache["privacy_policy"] : nil
+      if privacy_policy_url
+        urls_cache["privacy_policy"] = privacy_policy_url
+      else
+        urls_cache.delete("privacy_policy")
+      end
     end
   end
 


### PR DESCRIPTION
There are certain cases where the tos_url and privacy_policy_url
can end up with a "nil" value in the Discourse.urls_cache.

The cause of this is unclear, but it seems to behave differently
between doing this caching in the rails console and the running
server.

To avoid this we can just not store anything that looks like nil
in the cache; we can delete the cache keys entirely if we don't
need them anymore.
