### PR TITLE
FEATURE: Delete backups based on time window

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1804,6 +1804,7 @@ en:
     enable_backups: "Allow administrators to create backups of the forum"
     allow_restore: "Allow restore, which can replace ALL site data! Leave disabled unless you plan to restore a backup"
     maximum_backups: "The maximum amount of backups to keep. Older backups are automatically deleted"
+    remove_older_backups: "Remove backups older than the specified number of days. Leave blank to disable."
     automatic_backups_enabled: "Run automatic backups as defined in backup frequency"
     backup_frequency: "The number of days between backups."
     s3_backup_bucket: "The remote bucket to hold backups. WARNING: Make sure it is a private bucket."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2241,6 +2241,9 @@ backups:
   maximum_backups:
     client: true
     default: 5
+  remove_older_backups:
+    client: true
+    default: ""
   automatic_backups_enabled:
     default: true
   backup_frequency:

--- a/lib/backup_restore/backup_store.rb
+++ b/lib/backup_restore/backup_store.rb
@@ -42,6 +42,25 @@ module BackupRestore
       reset_cache
     end
 
+    def delete_prior_to_n_days
+      window = SiteSetting.remove_older_backups.to_i
+      puts "window: #{window} days"
+      return unless window && window.is_a?(Numeric) && window > 0
+      return unless cleanup_allowed?
+
+      store = BackupRestore::BackupStore.create
+      puts Time.now.ago(window.days)
+      files.each { |file|
+        puts file.filename
+        puts file.last_modified
+        if file.last_modified < Time.now.ago(window.days)
+          puts "deleting #{file.filename}"
+          store.delete_file(file.filename)
+        end
+      }
+      # reset_cache
+    end
+
     def remote?
       fail NotImplementedError
     end

--- a/lib/backup_restore/backup_store.rb
+++ b/lib/backup_restore/backup_store.rb
@@ -44,21 +44,12 @@ module BackupRestore
 
     def delete_prior_to_n_days
       window = SiteSetting.remove_older_backups.to_i
-      puts "window: #{window} days"
       return unless window && window.is_a?(Numeric) && window > 0
       return unless cleanup_allowed?
-
-      store = BackupRestore::BackupStore.create
-      puts Time.now.ago(window.days)
-      files.each { |file|
-        puts file.filename
-        puts file.last_modified
-        if file.last_modified < Time.now.ago(window.days)
-          puts "deleting #{file.filename}"
-          store.delete_file(file.filename)
-        end
-      }
-      # reset_cache
+      files.each do |file|
+        delete_file(file.filename) if file.last_modified < Time.now.ago(window.days)
+      end
+      reset_cache
     end
 
     def remote?

--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -51,6 +51,7 @@ module BackupRestore
       @backup_filename
     ensure
       delete_old
+      delete_prior_to_n_days
       clean_up
       notify_user
       log "Finished!"
@@ -356,6 +357,15 @@ module BackupRestore
       store.delete_old
     rescue => ex
       log "Something went wrong while deleting old backups.", ex
+    end
+
+    def delete_prior_to_n_days
+      return if Rails.env.development?
+
+      log "Deleting backups prior to n days..."
+      store.delete_prior_to_n_days
+    rescue => ex
+      log "Something went wrong while deleting backups prior to n days....", ex
     end
 
     def notify_user

--- a/lib/backup_restore/local_backup_store.rb
+++ b/lib/backup_restore/local_backup_store.rb
@@ -35,7 +35,7 @@ module BackupRestore
 
     def delete_file(filename)
       path = path_from_filename(filename)
-
+      puts "delete_file: #{path}"
       if File.exist?(path)
         File.delete(path)
         reset_cache

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe BackupRestore::Backuper do
     context "when the result isn't successful" do
       let(:success) { false }
 
-      it "doesn't refresh disk stats" do
+      it "refresh disk stats" do
         store.expects(:reset_cache).never
         run
       end
@@ -94,9 +94,16 @@ RSpec.describe BackupRestore::Backuper do
       let(:success) { true }
 
       it "refreshes disk stats" do
-        store.expects(:reset_cache)
+        store.expects(:reset_cache).times(3)
         run
       end
     end
+
+    # context "whether successful or not" do
+    #   it "deletes old backups" do
+    #     store.expects(:delete_prior_to_n_days)
+    #     run
+    #   end
+    # end
   end
 end

--- a/spec/lib/backup_restore/local_backup_store_spec.rb
+++ b/spec/lib/backup_restore/local_backup_store_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BackupRestore::LocalBackupStore do
     @root_directory = Dir.mktmpdir
     @paths = []
     SiteSetting.backup_location = BackupLocationSiteSetting::LOCAL
+
   end
 
   after { FileUtils.remove_dir(@root_directory, true) }

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -148,6 +148,29 @@ RSpec.shared_examples "backup store" do
       end
     end
 
+    include ActiveSupport::Testing::TimeHelpers
+    describe "#delete_prior_to_n_days" do
+      it "does nothing if the number of days blank or <1" do
+        SiteSetting.remove_older_backups = ""
+
+        store.delete_prior_to_n_days
+        expect(store.files).to eq([backup1, backup2, backup3])
+      end
+
+      it "removes the two backups that are older than 7 days" do
+        travel_to Time.new(2018, 9, 19, 0, 0, 00)
+
+          # 7 days-1 minute later than backup1,
+          # which has last_modified= "2018-09-13T15:10:00Z"
+
+        SiteSetting.remove_older_backups = "7"
+
+          #expect(store.files).to eq([backup1, backup2, backup3])
+        store.delete_prior_to_n_days
+        expect(store.files).to eq([backup1])
+      end
+    end
+
     describe "#file" do
       it "returns information about the file when the file exists" do
         expect(store.file(backup1.filename)).to eq(backup1)

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -159,13 +159,13 @@ RSpec.shared_examples "backup store" do
 
       it "removes the two backups that are older than 7 days" do
         travel_to Time.new(2018, 9, 19, 0, 0, 00)
-
-          # 7 days-1 minute later than backup1,
-          # which has last_modified= "2018-09-13T15:10:00Z"
-
         SiteSetting.remove_older_backups = "7"
 
-          #expect(store.files).to eq([backup1, backup2, backup3])
+        # 7 days before 9/19 is 9/12. that's earlier than date
+        # of backup1 (9/13, last_modified= "2018-09-13T15:10:00Z").
+        # Hence backup1 should be retained because it's within the last 7 days.
+        # and backup2 & backup3, which are older, should be deleted
+
         store.delete_prior_to_n_days
         expect(store.files).to eq([backup1])
       end


### PR DESCRIPTION
for compliance purposes, epic has asked for a site setting to specify a max age for any backups.

this pr adds the site setting and makes changes to the backup job to make sure there are no backup files older than the specified number of jobs.

meta: https://meta.discourse.org/t/just-looking-for-a-confirmation-that-no-backups-are-kept-past-30-days/280424/20

