### PR TITLE
DEV: remove wrapping `span` from discovery-above

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/layout.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery/layout.hbs
@@ -22,9 +22,7 @@
   </div>
 </div>
 
-<span>
-  <PluginOutlet @name="discovery-above" @connectorTagName="div" />
-</span>
+<PluginOutlet @name="discovery-above" @connectorTagName="div" />
 
 <div class="container list-container">
   <div class="row">


### PR DESCRIPTION
The previous addition of the `span` here, in combination with the refactor in 82d6d69, is causing an issue with a customer theme. We want to gradually remove these spans surrounding `PluginOutlets` anyway... so this will fix their theme while also progressing towards that goal. 