### PR TITLE
DEV: Update gh workflow check-branches.yml

### DIFF
--- a/.github/workflows/check-branches.yml
+++ b/.github/workflows/check-branches.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - name: Check branches
         run: |
-          if [ ${{ github.base_ref }} == "tests-passed" ]; then
+          BASE_REF=${{ github.base_ref }}
+          if [ "$BASE_REF" == "tests-passed" ]; then
             echo "PR requests to tests-passed branch are not allowed. Please use main."
             exit 1
           fi


### PR DESCRIPTION
Without this change the resulting comparison looks like

```
if [ tests-passed == "tests-passed" ]; then
```

and so it was always failing. This way the resulting base branch name will also be in quotes for the comparison.

Follow up to: #24273
