### PR TITLE
DEV: Simplify watched word data structures 

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
+++ b/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
@@ -1,9 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
+import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
 
 export default class WatchedWordTest extends Component {
   @tracked value;
@@ -68,8 +65,8 @@ export default class WatchedWordTest extends Component {
       let matches = [];
       this.args.model.watchedWord.compiledRegularExpression.forEach(
         (regexp) => {
-          const wordRegexp = createWatchedWordRegExp(toWatchedWord(regexp));
-          matches.push(...(this.value.match(wordRegexp) || []));
+          const regexpObj = createWatchedWordRegExp(regexp);
+          matches.push(...(this.value.match(regexpObj) || []));
         }
       );
 

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -1,4 +1,4 @@
 export function createWatchedWordRegExp(word) {
   const caseFlag = word.case_sensitive ? "" : "i";
-  return new RegExp(word.full_regexp || word.regexp, `${caseFlag}gu`);
+  return new RegExp(word.regexp, `${caseFlag}gu`);
 }

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -1,9 +1,4 @@
 export function createWatchedWordRegExp(word) {
   const caseFlag = word.case_sensitive ? "" : "i";
-  return new RegExp(word.regexp, `${caseFlag}gu`);
-}
-
-export function toWatchedWord(regexp) {
-  const [[regexpString, options]] = Object.entries(regexp);
-  return { ...options, regexp: regexpString };
+  return new RegExp(word.full_regexp || word.regexp, `${caseFlag}gu`);
 }

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -2,3 +2,15 @@ export function createWatchedWordRegExp(word) {
   const caseFlag = word.case_sensitive ? "" : "i";
   return new RegExp(word.regexp, `${caseFlag}gu`);
 }
+
+export function watchedWordMatcher(word, link = false) {
+  return {
+    partialRegexp: new RegExp(
+      word.partial_regexp,
+      word.case_sensitive ? "" : "i"
+    ),
+    regexp: createWatchedWordRegExp(word),
+    replacement: word.replacement,
+    link,
+  };
+}

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -3,7 +3,7 @@ export function createWatchedWordRegExp(word) {
   return new RegExp(word.regexp, `${caseFlag}gu`);
 }
 
-export function watchedWordMatcher(word, link = false) {
+export function buildWatchedWordMatcher(word, link = false) {
   return {
     partialRegexp: new RegExp(
       word.partial_regexp,

--- a/app/assets/javascripts/discourse-markdown-it/src/features/emoji.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/emoji.js
@@ -1,6 +1,6 @@
 import { buildEmojiUrl, isCustomEmoji } from "pretty-text/emoji";
 import { translations } from "pretty-text/emoji/data";
-import { watchedWordMatcher } from "discourse-common/utils/watched-words";
+import { buildWatchedWordMatcher } from "discourse-common/utils/watched-words";
 
 const MAX_NAME_LENGTH = 60;
 
@@ -363,7 +363,7 @@ export function setup(helper) {
           md.options.discourse.features.inlineEmoji,
           md.options.discourse.customEmojiTranslation,
           (md.options.discourse.watchedWordsReplace || []).map((word) =>
-            watchedWordMatcher(word)
+            buildWatchedWordMatcher(word)
           ),
           md.options.discourse.emojiDenyList
         )

--- a/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
@@ -1,4 +1,4 @@
-import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
+import { watchedWordMatcher } from "discourse-common/utils/watched-words";
 
 const MAX_MATCHES = 100;
 
@@ -51,25 +51,12 @@ export function setup(helper) {
 
   helper.registerPlugin((md) => {
     const matchers = [
-      ...(md.options.discourse.watchedWordsReplace || []).map((word) => ({
-        partialRegexp: new RegExp(
-          word.partial_regexp,
-          word.case_sensitive ? "" : "i"
-        ),
-        regexp: createWatchedWordRegExp(word),
-        replacement: word.replacement,
-        link: false,
-      })),
-
-      ...(md.options.discourse.watchedWordsLink || []).map((word) => ({
-        partialRegexp: new RegExp(
-          word.partial_regexp,
-          word.case_sensitive ? "" : "i"
-        ),
-        regexp: createWatchedWordRegExp(word),
-        replacement: word.replacement,
-        link: true,
-      })),
+      ...(md.options.discourse.watchedWordsReplace || []).map((word) =>
+        watchedWordMatcher(word)
+      ),
+      ...(md.options.discourse.watchedWordsLink || []).map((word) =>
+        watchedWordMatcher(word, true)
+      ),
     ];
 
     if (matchers.length === 0) {

--- a/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
@@ -1,3 +1,5 @@
+import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
+
 const MAX_MATCHES = 100;
 
 function isLinkOpen(str) {
@@ -11,9 +13,9 @@ function isLinkClose(str) {
 function findAllMatches(text, matchers) {
   const matches = [];
 
-  for (const { regexp, fullRegexp, replacement, link } of matchers) {
-    if (regexp.test(text)) {
-      for (const match of text.matchAll(fullRegexp)) {
+  for (const { partialRegexp, regexp, replacement, link } of matchers) {
+    if (partialRegexp.test(text)) {
+      for (const match of text.matchAll(regexp)) {
         matches.push({
           index: match.index + match[0].indexOf(match[1]),
           text: match[1],
@@ -50,21 +52,21 @@ export function setup(helper) {
   helper.registerPlugin((md) => {
     const matchers = [
       ...(md.options.discourse.watchedWordsReplace || []).map((word) => ({
-        regexp: new RegExp(word.regexp, word.case_sensitive ? "" : "i"),
-        fullRegexp: new RegExp(
-          word.full_regexp,
-          word.case_sensitive ? "gu" : "gui"
+        partialRegexp: new RegExp(
+          word.partial_regexp,
+          word.case_sensitive ? "" : "i"
         ),
+        regexp: createWatchedWordRegExp(word),
         replacement: word.replacement,
         link: false,
       })),
 
       ...(md.options.discourse.watchedWordsLink || []).map((word) => ({
-        regexp: new RegExp(word.regexp, word.case_sensitive ? "" : "i"),
-        fullRegexp: new RegExp(
-          word.full_regexp,
-          word.case_sensitive ? "gu" : "gui"
+        partialRegexp: new RegExp(
+          word.partial_regexp,
+          word.case_sensitive ? "" : "i"
         ),
+        regexp: createWatchedWordRegExp(word),
         replacement: word.replacement,
         link: true,
       })),

--- a/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
@@ -1,4 +1,4 @@
-import { watchedWordMatcher } from "discourse-common/utils/watched-words";
+import { buildWatchedWordMatcher } from "discourse-common/utils/watched-words";
 
 const MAX_MATCHES = 100;
 
@@ -52,10 +52,10 @@ export function setup(helper) {
   helper.registerPlugin((md) => {
     const matchers = [
       ...(md.options.discourse.watchedWordsReplace || []).map((word) =>
-        watchedWordMatcher(word)
+        buildWatchedWordMatcher(word)
       ),
       ...(md.options.discourse.watchedWordsLink || []).map((word) =>
-        watchedWordMatcher(word, true)
+        buildWatchedWordMatcher(word, true)
       ),
     ];
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -146,7 +146,7 @@ acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.site({
     watched_words_replace: [
       {
-        full_regexp: "(?:\\W|^)(betis)(?=\\W|$)",
+        regexp: "(?:\\W|^)(betis)(?=\\W|$)",
         replacement: ":poop:",
         case_sensitive: false,
       },

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -144,12 +144,13 @@ acceptance("Admin - Watched Words", function (needs) {
 acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.user();
   needs.site({
-    watched_words_replace: {
-      "(?:\\W|^)(betis)(?=\\W|$)": {
+    watched_words_replace: [
+      {
+        full_regexp: "(?:\\W|^)(betis)(?=\\W|$)",
         replacement: ":poop:",
         case_sensitive: false,
       },
-    },
+    ],
   });
 
   test("emoji renders successfully after replacement", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -146,7 +146,6 @@ acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.site({
     watched_words_replace: [
       {
-        word: "betis",
         partial_regexp: "betis",
         regexp: "(?:\\W|^)(betis)(?=\\W|$)",
         replacement: ":poop:",

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -146,6 +146,8 @@ acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.site({
     watched_words_replace: [
       {
+        word: "betis",
+        partial_regexp: "betis",
         regexp: "(?:\\W|^)(betis)(?=\\W|$)",
         replacement: ":poop:",
         case_sensitive: false,

--- a/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
@@ -27,11 +27,11 @@ export default {
     ],
     compiled_regular_expressions: {
       block: [
-        { full_regexp: '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)', case_sensitive: false },
+        { regexp: '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)', case_sensitive: false },
       ],
       censor: [],
       require_approval: [
-        { full_regexp: "(?:\\W|^)(coupon)(?=\\W|$)", case_sensitive: false },
+        { regexp: "(?:\\W|^)(coupon)(?=\\W|$)", case_sensitive: false },
       ],
       flag: [{ "(?:\\W|^)(pyramid|scheme)(?=\\W|$)": {case_sensitive: false }, },],
       replace: [{ "(?:\\W|^)(hi)(?=\\W|$)": { case_sensitive: false }},],

--- a/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
@@ -27,11 +27,11 @@ export default {
     ],
     compiled_regular_expressions: {
       block: [
-        { '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)': { case_sensitive: false }, },
+        { full_regexp: '(?:\\W|^)(liquorice|anise|<img\\ src="x">)(?=\\W|$)', case_sensitive: false },
       ],
       censor: [],
       require_approval: [
-        { "(?:\\W|^)(coupon)(?=\\W|$)": { case_sensitive: false }, },
+        { full_regexp: "(?:\\W|^)(coupon)(?=\\W|$)", case_sensitive: false },
       ],
       flag: [{ "(?:\\W|^)(pyramid|scheme)(?=\\W|$)": {case_sensitive: false }, },],
       replace: [{ "(?:\\W|^)(hi)(?=\\W|$)": { case_sensitive: false }},],

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1086,9 +1086,7 @@ eviltrout</p>
     assert.cookedOptions(
       "Pleased to meet you, but pleeeease call me later, xyz123",
       {
-        censoredRegexp: [
-          { full_regexp: "(xyz*|plee+ase)", case_sensitive: false },
-        ],
+        censoredRegexp: [{ regexp: "(xyz*|plee+ase)", case_sensitive: false }],
       },
       "<p>Pleased to meet you, but ■■■■■■■■■ call me later, ■■■123</p>",
       "supports censoring"
@@ -1616,7 +1614,7 @@ var bar = 'bar';
       watchedWordsReplace: [
         {
           word: "fun",
-          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
+          regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "times",
           case_sensitive: false,
         },
@@ -1632,7 +1630,7 @@ var bar = 'bar';
       watchedWordsLink: [
         {
           word: "fun",
-          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
+          regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "https://discourse.org",
           case_sensitive: false,
         },
@@ -1652,7 +1650,7 @@ var bar = 'bar';
       watchedWordsReplace: [
         {
           word: "(\\bu?\\b)",
-          full_regexp: "(\\bu?\\b)",
+          regexp: "(\\bu?\\b)",
           replacement: "you",
           case_sensitive: false,
         },

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1613,7 +1613,6 @@ var bar = 'bar';
     const opts = {
       watchedWordsReplace: [
         {
-          word: "fun",
           regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "times",
           case_sensitive: false,
@@ -1629,7 +1628,6 @@ var bar = 'bar';
     const opts = {
       watchedWordsLink: [
         {
-          word: "fun",
           regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "https://discourse.org",
           case_sensitive: false,
@@ -1649,7 +1647,6 @@ var bar = 'bar';
       siteSettings: { watched_words_regular_expressions: true },
       watchedWordsReplace: [
         {
-          word: "(\\bu?\\b)",
           regexp: "(\\bu?\\b)",
           replacement: "you",
           case_sensitive: false,

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1086,7 +1086,9 @@ eviltrout</p>
     assert.cookedOptions(
       "Pleased to meet you, but pleeeease call me later, xyz123",
       {
-        censoredRegexp: [{ "(xyz*|plee+ase)": { case_sensitive: false } }],
+        censoredRegexp: [
+          { full_regexp: "(xyz*|plee+ase)", case_sensitive: false },
+        ],
       },
       "<p>Pleased to meet you, but ■■■■■■■■■ call me later, ■■■123</p>",
       "supports censoring"
@@ -1611,13 +1613,14 @@ var bar = 'bar';
 
   test("watched words replace", function (assert) {
     const opts = {
-      watchedWordsReplace: {
-        "(?:\\W|^)(fun)(?=\\W|$)": {
+      watchedWordsReplace: [
+        {
           word: "fun",
+          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "times",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions("test fun funny", opts, "<p>test times funny</p>");
@@ -1626,13 +1629,14 @@ var bar = 'bar';
 
   test("watched words link", function (assert) {
     const opts = {
-      watchedWordsLink: {
-        "(?:\\W|^)(fun)(?=\\W|$)": {
+      watchedWordsLink: [
+        {
           word: "fun",
+          full_regexp: "(?:\\W|^)(fun)(?=\\W|$)",
           replacement: "https://discourse.org",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions(
@@ -1645,13 +1649,14 @@ var bar = 'bar';
   test("watched words replace with bad regex", function (assert) {
     const opts = {
       siteSettings: { watched_words_regular_expressions: true },
-      watchedWordsReplace: {
-        "(\\bu?\\b)": {
+      watchedWordsReplace: [
+        {
           word: "(\\bu?\\b)",
+          full_regexp: "(\\bu?\\b)",
           replacement: "you",
           case_sensitive: false,
         },
-      },
+      ],
     };
 
     assert.cookedOptions(

--- a/app/assets/javascripts/pretty-text/addon/censored-words.js
+++ b/app/assets/javascripts/pretty-text/addon/censored-words.js
@@ -1,13 +1,10 @@
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
+import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
 
 export function censorFn(regexpList, replacementLetter) {
   if (regexpList?.length) {
     replacementLetter = replacementLetter || "&#9632;";
     let censorRegexps = regexpList.map((regexp) => {
-      return createWatchedWordRegExp(toWatchedWord(regexp));
+      return createWatchedWordRegExp(regexp);
     });
 
     return function (text) {

--- a/app/assets/javascripts/pretty-text/addon/censored-words.js
+++ b/app/assets/javascripts/pretty-text/addon/censored-words.js
@@ -3,9 +3,7 @@ import { createWatchedWordRegExp } from "discourse-common/utils/watched-words";
 export function censorFn(regexpList, replacementLetter) {
   if (regexpList?.length) {
     replacementLetter = replacementLetter || "&#9632;";
-    let censorRegexps = regexpList.map((regexp) => {
-      return createWatchedWordRegExp(regexp);
-    });
+    const censorRegexps = regexpList.map(createWatchedWordRegExp);
 
     return function (text) {
       censorRegexps.forEach((censorRegexp) => {

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -432,7 +432,7 @@ class AdminDashboardData
   def watched_words_check
     WatchedWord.actions.keys.each do |action|
       begin
-        WordWatcher.compiled_regexps_for_action(action, raise_errors: true)
+        WordWatcher.words_for_action(action, raise_errors: true)
       rescue RegexpError => e
         translated_action = I18n.t("admin_js.admin.watched_words.actions.#{action}")
         I18n.t(

--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -16,10 +16,8 @@ class WatchedWordListSerializer < ApplicationSerializer
   end
 
   def compiled_regular_expressions
-    expressions = {}
-    actions.each do |action|
-      expressions[action] = WordWatcher.serialized_regexps_for_action(action, engine: :js)
+    actions.to_h do |action|
+      [action, WordWatcher.serialized_regexps_for_action(action, engine: :js)]
     end
-    expressions
   end
 end

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -2,7 +2,7 @@
 
 class WordWatcher
   REPLACEMENT_LETTER ||= CGI.unescape_html("&#9632;")
-  CACHE_VERSION ||= 3
+  CACHE_VERSION ||= 4
 
   def initialize(raw)
     @raw = raw
@@ -32,11 +32,21 @@ class WordWatcher
       .limit(WatchedWord::MAX_WORDS_PER_ACTION)
       .order(:id)
       .pluck(:word, :replacement, :case_sensitive)
+<<<<<<< HEAD
       .to_h do |w, r, c|
         [
           word_to_regexp(w, match_word: false),
           { word: w, replacement: r, case_sensitive: c }.compact,
         ]
+=======
+      .map do |w, r, c|
+        {
+          word: w,
+          regexp: word_to_regexp(w, match_word: false),
+          replacement: r,
+          case_sensitive: c,
+        }.compact
+>>>>>>> ce7b9da045 (DEV: Simplify watched word data structures)
       end
   end
 
@@ -55,8 +65,9 @@ class WordWatcher
   end
 
   def self.regexps_for_action(action, engine: :ruby)
-    cached_words_for_action(action)&.to_h do |_, attrs|
-      [word_to_regexp(attrs[:word], engine: engine), attrs]
+    cached_words_for_action(action)&.map do |attrs|
+      attrs[:full_regexp] = word_to_regexp(attrs[:word], engine: engine)
+      attrs
     end
   end
 
@@ -64,11 +75,7 @@ class WordWatcher
   # Make sure it is compatible with major browsers when changing
   # hint: non-chrome browsers do not support 'lookbehind'
   def self.compiled_regexps_for_action(action, engine: :ruby, raise_errors: false)
-    words = cached_words_for_action(action)
-    return [] if words.blank?
-
-    words
-      .values
+    (cached_words_for_action(action) || [])
       .group_by { |attrs| attrs[:case_sensitive] ? :case_sensitive : :case_insensitive }
       .map do |group_key, attrs_list|
         words = attrs_list.map { |attrs| attrs[:word] }
@@ -101,7 +108,7 @@ class WordWatcher
 
   def self.serialized_regexps_for_action(action, engine: :ruby)
     compiled_regexps_for_action(action, engine: engine).map do |r|
-      { r.source => { case_sensitive: !r.casefold? } }
+      { full_regexp: r.source, case_sensitive: !r.casefold? }
     end
   end
 
@@ -273,12 +280,10 @@ class WordWatcher
   private_class_method :match_word_regexp
 
   def self.replace(text, watch_word_type)
-    regexps_for_action(watch_word_type)
-      .to_a
-      .reduce(text) do |t, (word_regexp, attrs)|
-        case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE
-        replace_text_with_regexp(t, Regexp.new(word_regexp, case_flag), attrs[:replacement])
-      end
+    (regexps_for_action(watch_word_type) || []).reduce(text) do |t, attrs|
+      case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE
+      replace_text_with_regexp(t, Regexp.new(attrs[:full_regexp], case_flag), attrs[:replacement])
+    end
   end
 
   private_class_method :replace

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -8,7 +8,7 @@ class WordWatcher
     @raw = raw
   end
 
-  @cache_enabled = false
+  @cache_enabled = true
 
   def self.disable_cache
     @cache_enabled = false

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -192,9 +192,9 @@ class TopicCreator
     if watched_words.present?
       word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
       word_watcher_tags = topic.tags.map(&:name)
-      watched_words.each do |_, opts|
-        if word_watcher.word_matches?(opts[:word], case_sensitive: opts[:case_sensitive])
-          word_watcher_tags += opts[:replacement].split(",")
+      watched_words.each do |attrs|
+        if word_watcher.word_matches?(attrs[:word], case_sensitive: attrs[:case_sensitive])
+          word_watcher_tags += attrs[:replacement].split(",")
         end
       end
       DiscourseTagging.tag_topic_by_names(topic, Discourse.system_user.guardian, word_watcher_tags)

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -188,7 +188,7 @@ class TopicCreator
       end
     end
 
-    watched_words = WordWatcher.words_for_action(:tag)
+    watched_words = WordWatcher.cached_words_for_action(:tag)
     if watched_words.present?
       word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
       word_watcher_tags = topic.tags.map(&:name)

--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -2,17 +2,19 @@
 
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    words_regexps = WordWatcher.compiled_regexps_for_action(:censor)
-    if WordWatcher.words_for_action_exist?(:censor).present? && words_regexps.present?
-      censored_words = censor_words(value, words_regexps)
-      return if censored_words.blank?
+    return if !WordWatcher.words_for_action_exist?(:censor)
 
-      record.errors.add(
-        attribute,
-        :contains_censored_words,
-        censored_words: join_censored_words(censored_words),
-      )
-    end
+    words_regexps = WordWatcher.compiled_regexps_for_action(:censor)
+    return if words_regexps.blank?
+
+    censored_words = censor_words(value, words_regexps)
+    return if censored_words.blank?
+
+    record.errors.add(
+      attribute,
+      :contains_censored_words,
+      censored_words: join_censored_words(censored_words),
+    )
   end
 
   private

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -511,13 +511,13 @@
     },
     "watched_words_replace": {
       "type": [
-        "string",
+        "array",
         "null"
       ]
     },
     "watched_words_link": {
       "type": [
-        "string",
+        "array",
         "null"
       ]
     },

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -18,15 +18,9 @@ RSpec.describe WordWatcher do
       word2 =
         Fabricate(:watched_word, action: WatchedWord.actions[:block], case_sensitive: true).word
 
-      expect(described_class.words_for_action(:block)).to include(
-        word1 => {
-          case_sensitive: false,
-          word: word1,
-        },
-        word2 => {
-          case_sensitive: true,
-          word: word2,
-        },
+      expect(described_class.words_for_action(:block)).to contain_exactly(
+        { case_sensitive: false, word: word1, regexp: word1 },
+        { case_sensitive: true, word: word2, regexp: word2 },
       )
     end
 
@@ -38,17 +32,13 @@ RSpec.describe WordWatcher do
           replacement: "http://test.localhost/",
         ).word
 
-      expect(described_class.words_for_action(:link)).to include(
-        word => {
-          case_sensitive: false,
-          replacement: "http://test.localhost/",
-          word: word,
-        },
+      expect(described_class.words_for_action(:link)).to contain_exactly(
+        { case_sensitive: false, replacement: "http://test.localhost/", word: word, regexp: word },
       )
     end
 
     it "returns an empty hash when no words are present" do
-      expect(described_class.words_for_action(:tag)).to eq({})
+      expect(described_class.words_for_action(:tag)).to eq([])
     end
   end
 

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -53,8 +53,9 @@ RSpec.describe WordWatcher do
     end
 
     context "when watched_words_regular_expressions = true" do
+      before { SiteSetting.watched_words_regular_expressions = true }
+
       it "returns the proper regexp" do
-        SiteSetting.watched_words_regular_expressions = true
         regexps = described_class.compiled_regexps_for_action(:block)
 
         expect(regexps).to be_an(Array)
@@ -62,6 +63,22 @@ RSpec.describe WordWatcher do
           "/(#{word1})|(#{word2})/i",
           "/(#{word3})|(#{word4})/",
         )
+      end
+
+      it "validates regexp in Ruby" do
+        Fabricate(:watched_word, word: "*test", action: WatchedWord.actions[:block])
+
+        expect {
+          described_class.compiled_regexps_for_action(:block, raise_errors: true)
+        }.to raise_error(RegexpError)
+      end
+
+      it "validates regexp in JavaScript" do
+        Fabricate(:watched_word, word: "a\\-b", action: WatchedWord.actions[:block])
+
+        expect {
+          described_class.compiled_regexps_for_action(:block, raise_errors: true)
+        }.to raise_error(MiniRacer::RuntimeError)
       end
     end
 


### PR DESCRIPTION
Watched words used to be returned as a hash where the key was the
word and the value was a hash with the other attributes. This data
structure did not have any advantages and made processing more
difficult.

This commit changes the data structure to be an array of hashes
where each hash contains all the attributes of the watched word.

Watched words used to be validate using only Ruby, but this meant that
they could still be invalid in JavaScript and cause errors.

This commit also makes it more explicit that there is a short and fast
regular expression (key "regexp") that is used to perform quick
searches and does not match the whole word, and a long and complete
regular expression (key "full_regexp") that can be used to perform
Unicode matching and may include word boundaries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
