### PR TITLE
FIX: Adjust border radius

### DIFF
--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -72,6 +72,17 @@
   }
 }
 
+#topic-progress-wrapper {
+  .topic-admin-menu-button .toggle-admin-menu {
+    border-top-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  #topic-progress {
+    border-top-right-radius: var(--d-border-radius);
+    border-top-left-radius: var(--d-border-radius);
+  }
+}
+
 .topic-error {
   padding: 18px;
   width: 90%;


### PR DESCRIPTION
This PR fixes some of the border radius issues in the topic progress bar on mobile.

**Before**
<img width="203" alt="image" src="https://github.com/discourse/discourse/assets/30537603/039aac76-cd5d-4d90-8a45-b07f0db714e7">


**After**
<img width="259" alt="image" src="https://github.com/discourse/discourse/assets/30537603/474353bd-579f-40cb-92d9-63997ca588b9">
