### PR TITLE
DEV: Align S3 transfer acceleration global settings

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -158,6 +158,14 @@ class SiteSetting < ActiveRecord::Base
       SiteSetting.enable_s3_uploads ? SiteSetting.s3_endpoint : GlobalSetting.s3_endpoint
     end
 
+    def self.enable_s3_transfer_acceleration
+      if SiteSetting.enable_s3_uploads
+        SiteSetting.enable_s3_transfer_acceleration
+      else
+        GlobalSetting.enable_s3_transfer_acceleration
+      end
+    end
+
     def self.enable_s3_uploads
       SiteSetting.enable_s3_uploads || GlobalSetting.use_s3?
     end

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -225,7 +225,7 @@ s3_cdn_url =
 s3_endpoint =
 s3_http_continue_timeout =
 s3_install_cors_rule =
-s3_enable_transfer_acceleration =
+enable_s3_transfer_acceleration =
 
 # Optionally, specify a separate CDN to be used for static JS assets stored on S3
 s3_asset_cdn_url =

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -25,7 +25,7 @@ module FileStore
         S3Helper.new(
           s3_bucket,
           Rails.configuration.multisite ? multisite_tombstone_prefix : TOMBSTONE_PREFIX,
-          use_accelerate_endpoint: SiteSetting.enable_s3_transfer_acceleration,
+          use_accelerate_endpoint: SiteSetting.Upload.enable_s3_transfer_acceleration,
         )
     end
 

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -47,15 +47,8 @@ class S3Helper
     setting_klass = use_db_s3_config ? SiteSetting : GlobalSetting
     options = S3Helper.s3_options(setting_klass)
     options[:client] = s3_client if s3_client.present?
-    use_accelerate_endpoint =
-      (
-        if use_db_s3_config
-          SiteSetting.enable_s3_transfer_acceleration
-        else
-          GlobalSetting.s3_enable_transfer_acceleration
-        end
-      )
-    options[:use_accelerate_endpoint] = !for_backup && use_accelerate_endpoint
+    options[:use_accelerate_endpoint] = !for_backup &&
+      SiteSetting.Upload.enable_s3_transfer_acceleration
 
     bucket =
       if for_backup


### PR DESCRIPTION
Followup to fe05fdae244d98e2e569f6553b6f6a04bc09c74d

For consistency with other S3 settings, make the global setting
the same name as the site setting and use SiteSetting.Upload
too so it reads from the correct place.
