### PR TITLE
DEV: Allow new_features URL to be configurable

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -218,6 +218,11 @@ module DiscourseUpdates
       )
     end
 
+    def new_features_endpoint
+      return "https://meta.discourse.org/new-features.json" if Rails.env.production?
+      ENV["DISCOURSE_NEW_FEATURES_ENDPOINT"] || "http://localhost:4200/new-features.json"
+    end
+
     private
 
     def last_installed_version_key
@@ -246,11 +251,6 @@ module DiscourseUpdates
 
     def missing_versions_key_prefix
       "missing_version"
-    end
-
-    def new_features_endpoint
-      return "https://meta.discourse.org/new-features.json" if Rails.env.production?
-      ENV["DISCOURSE_NEW_FEATURES_ENDPOINT"] || "http://localhost:4200/new-features.json"
     end
 
     def new_features_key

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -249,7 +249,8 @@ module DiscourseUpdates
     end
 
     def new_features_endpoint
-      "https://meta.discourse.org/new-features.json"
+      return "https://meta.discourse.org/new-features.json" if Rails.env.production?
+      ENV["DISCOURSE_NEW_FEATURES_ENDPOINT"] || "http://localhost:4200/new-features.json"
     end
 
     def new_features_key

--- a/spec/jobs/check_new_features_spec.rb
+++ b/spec/jobs/check_new_features_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Jobs::CheckNewFeatures do
     }
   end
 
-  def stub_meta_new_features_endpoint(*features)
-    stub_request(:get, "https://meta.discourse.org/new-features.json").to_return(
+  def stub_new_features_endpoint(*features)
+    stub_request(:get, DiscourseUpdates.new_features_endpoint).to_return(
       status: 200,
       body: JSON.dump(features),
       headers: {
@@ -43,7 +43,7 @@ RSpec.describe Jobs::CheckNewFeatures do
   before do
     DiscourseUpdates.stubs(:current_version).returns("2.8.1.beta13")
     freeze_time
-    stub_meta_new_features_endpoint(feature1, feature2, pending_feature)
+    stub_new_features_endpoint(feature1, feature2, pending_feature)
   end
 
   after { DiscourseUpdates.clean_state }


### PR DESCRIPTION
This is so the new features plugin can be tested
easier locally.
