### PR TITLE
UX: improve mobile user card button display

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
@@ -171,13 +171,11 @@
               />
             </li>
           {{/if}}
-          <li>
-            <PluginOutlet
-              @name="user-card-additional-buttons"
-              @connectorTagName="div"
-              @outletArgs={{hash user=this.user close=(action "close")}}
-            />
-          </li>
+          <PluginOutlet
+            @name="user-card-additional-buttons"
+            @connectorTagName="li"
+            @outletArgs={{hash user=this.user close=(action "close")}}
+          />
         </ul>
         <PluginOutlet
           @name="user-card-additional-controls"

--- a/app/assets/stylesheets/mobile/components/user-card.scss
+++ b/app/assets/stylesheets/mobile/components/user-card.scss
@@ -21,20 +21,21 @@
     }
     .usercard-controls {
       width: 100%; // always wraps to next line
-      --usercard-control-margin: 0.25em;
       display: flex;
       flex-wrap: wrap;
-      margin: 1em calc(var(--usercard-control-margin) * -1) 0;
+      margin-top: 1em;
+      gap: 0.5em;
       li {
-        flex: 1 0 calc(50% - (var(--usercard-control-margin) * 2));
-        min-width: 0;
-        margin: 0 var(--usercard-control-margin);
+        flex: 1 0 45%;
+        min-width: 8em;
         &:empty {
           display: none;
         }
         button {
-          @include ellipsis;
-          margin-bottom: calc(var(--usercard-control-margin) * 2);
+          margin: 0;
+          .d-button-label {
+            @include ellipsis;
+          }
         }
       }
     }


### PR DESCRIPTION
This improves some wrapping, and ensures that text truncates when it needs to. 

I've also updated the `user-card-additional-buttons` outlet, so the connector tag is a `li` and we aren't including an empty `li` when it's not in use. 

<img width="388" alt="Screenshot 2023-11-09 at 4 34 11 PM" src="https://github.com/discourse/discourse/assets/1681963/cfb392a6-8db8-4bc0-9d7b-e43a817ddd3b">
<img width="508" alt="Screenshot 2023-11-09 at 4 34 35 PM" src="https://github.com/discourse/discourse/assets/1681963/65c41aae-dd39-4b13-bb1e-086c5cbc6da4">



previously, a long translation would simply overflow: 

![image](https://github.com/discourse/discourse/assets/1681963/b9005583-43df-4e36-9a34-383ad58ab017)