### PR TITLE
FIX: do not set X-Discourse-Username on cached requests

### DIFF
--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -13,11 +13,18 @@ RSpec.describe StaticController do
 
     context "with local store" do
       it "returns the default favicon if favicon has not been configured" do
+        sign_in(Fabricate(:user))
+
         get "/favicon/proxied"
 
         expect(response.status).to eq(200)
         expect(response.media_type).to eq("image/png")
         expect(response.body.bytesize).to eq(SiteIconManager.favicon.filesize)
+
+        # should be cached
+        expect(response["Expires"]).to be_present
+        # we cache headers, so don't include usernames
+        expect(response["X-Discourse-Username"]).to eq(nil)
       end
 
       it "returns the configured favicon" do


### PR DESCRIPTION
Any cached requests should avoid adding X-Discourse-Username so
subsequent calls don't include incorrect username

This avoids leaking username who cached between requests on configs where
the header is not stripped
