### PR TITLE
DEV: Remove flaky setting deprecation logging specs

### DIFF
--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -832,54 +832,6 @@ RSpec.describe SiteSettingExtension do
 
       expect(client_settings["with_html"]).to eq("<script></script>rest")
     end
-
-    context "for deprecated settings" do
-      let(:fake_logger) { FakeLogger.new }
-
-      before do
-        @orig_logger = Rails.logger
-        Rails.logger = fake_logger
-      end
-
-      after { Rails.logger = @orig_logger }
-
-      it "does not log deprecation warnings" do
-        stub_const(
-          SiteSettings::DeprecatedSettings,
-          "SETTINGS",
-          [["use_https", "force_https", true, "0.0.1"]],
-        ) do
-          SiteSetting.setup_deprecated_methods
-          SiteSetting.client_settings_json_uncached
-          expect(fake_logger.warnings).to eq([])
-        end
-      end
-    end
-  end
-
-  describe ".settings_hash" do
-    context "for deprecated settings" do
-      let(:fake_logger) { FakeLogger.new }
-
-      before do
-        @orig_logger = Rails.logger
-        Rails.logger = fake_logger
-      end
-
-      after { Rails.logger = @orig_logger }
-
-      it "does not log deprecation warnings" do
-        stub_const(
-          SiteSettings::DeprecatedSettings,
-          "SETTINGS",
-          [["use_https", "force_https", true, "0.0.1"]],
-        ) do
-          SiteSetting.setup_deprecated_methods
-          SiteSetting.settings_hash
-          expect(fake_logger.warnings).to eq([])
-        end
-      end
-    end
   end
 
   describe ".setup_methods" do


### PR DESCRIPTION
Followup to baeac8f105cff8bbe70db67789bc96883cb185bc,
I tried to fix this in 6bf66ccd1a05f45fdcc6a074e9ec1c0fc4f66def
but it is still not reliable, just removing since they are
too unreliable for value provided
