### PR TITLE
FEATURE: Add threads support to chat archives

### DIFF
--- a/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
+++ b/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
@@ -57,14 +57,35 @@ const chatTranscriptRule = {
       state.push("details_chat_transcript_wrap_open", "details", 1);
       state.push("summary_chat_transcript_open", "summary", 1);
 
-      let threadTitleSpanToken = state.push(
+      const threadToken = state.push("div_thread_open", "div", 1);
+      threadToken.attrs = [["class", "chat-transcript-thread"]];
+
+      const threadHeaderToken = state.push("div_thread_header_open", "div", 1);
+      threadHeaderToken.attrs = [["class", "chat-transcript-thread-header"]];
+
+      const thread_svg = state.push("svg_thread_header_open", "svg", 1);
+      thread_svg.block = false;
+      thread_svg.attrs = [
+        ["class", "fa d-icon d-icon-discourse-threads svg-icon svg-node"],
+      ];
+      state.push(thread_svg);
+      let thread_use = state.push("use_svg_thread_open", "use", 1);
+      thread_use.block = false;
+      thread_use.attrs = [["href", "#discourse-threads"]];
+      state.push(thread_use);
+      state.push(state.push("use_svg_thread_close", "use", -1));
+      state.push(state.push("svg_thread_header_close", "svg", -1));
+
+      const threadTitleContainerToken = state.push(
         "span_thread_title_open",
         "span",
         1
       );
-      threadTitleSpanToken.attrs = [["class", "chat-transcript-thread-title"]];
-      const threadToken = state.push("html_inline", "", 0);
+      threadTitleContainerToken.attrs = [
+        ["class", "chat-transcript-thread-header__title"],
+      ];
 
+      const threadTitleToken = state.push("html_inline", "", 0);
       const unescapedThreadTitle = performEmojiUnescape(threadTitle, {
         getURL: options.getURL,
         emojiSet: options.emojiSet,
@@ -73,11 +94,13 @@ const chatTranscriptRule = {
         inlineEmoji: options.inlineEmoji,
         lazy: true,
       });
-
-      threadToken.content = unescapedThreadTitle
+      threadTitleToken.content = unescapedThreadTitle
         ? unescapedThreadTitle
         : I18n.t("chat.quote.default_thread_title");
+
       state.push("span_thread_title_close", "span", -1);
+
+      state.push("div_thread_header_close", "div", -1);
     }
 
     let wrapperClasses = ["chat-transcript"];
@@ -215,6 +238,7 @@ const chatTranscriptRule = {
           content.substring(0, match.index)
         );
         state.push("html_raw", "", -1);
+        state.push("div_thread_close", "div", -1);
         state.push("summary_chat_transcript_close", "summary", -1);
         const token = state.push("html_raw", "", 1);
 
@@ -273,6 +297,8 @@ const chatTranscriptRule = {
 
 export function setup(helper) {
   helper.allowList([
+    "svg[class=fa d-icon d-icon-discourse-threads svg-icon svg-node]",
+    "use[href=#discourse-threads]",
     "div[class=chat-transcript]",
     "details[class=chat-transcript]",
     "div[class=chat-transcript chat-transcript-chained]",
@@ -292,7 +318,9 @@ export function setup(helper) {
     "div[data-username]",
     "div[data-datetime]",
     "a.chat-transcript-channel",
-    "span.chat-transcript-thread-title",
+    "div.chat-transcript-thread",
+    "div.chat-transcript-thread-header",
+    "span.chat-transcript-thread-header__title",
   ]);
 
   helper.registerOptions((opts, siteSettings) => {

--- a/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
+++ b/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
@@ -220,6 +220,7 @@ const chatTranscriptRule = {
 
         token.content = customMarkdownCookFn(content.substring(match.index));
         state.push("html_raw", "", -1);
+        state.push("details_chat_transcript_wrap_close", "details", -1);
       }
     } else {
       // rendering chat message content with limited markdown rule subset
@@ -265,9 +266,6 @@ const chatTranscriptRule = {
     }
 
     state.push("div_chat_transcript_messages", "div", -1);
-    if (threadId) {
-      state.push("details_chat_transcript_wrap_close", "details", -1);
-    }
     state.push("div_chat_transcript_wrap", "div", -1);
     return true;
   },

--- a/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
+++ b/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
@@ -36,8 +36,18 @@ const chatTranscriptRule = {
       let metaDivToken = state.push("div_chat_transcript_meta", "div", 1);
       metaDivToken.attrs = [["class", "chat-transcript-meta"]];
       const channelToken = state.push("html_inline", "", 0);
+
+      const unescapedChannelName = performEmojiUnescape(channelName, {
+        getURL: options.getURL,
+        emojiSet: options.emojiSet,
+        emojiCDNUrl: options.emojiCDNUrl,
+        enableEmojiShortcuts: options.enableEmojiShortcuts,
+        inlineEmoji: options.inlineEmoji,
+        lazy: true,
+      });
+
       channelToken.content = I18n.t("chat.quote.original_channel", {
-        channel: channelName,
+        channel: unescapedChannelName,
         channelLink,
       });
       state.push("div_chat_transcript_meta", "div", -1);
@@ -55,8 +65,17 @@ const chatTranscriptRule = {
       threadTitleSpanToken.attrs = [["class", "chat-transcript-thread-title"]];
       const threadToken = state.push("html_inline", "", 0);
 
-      threadToken.content = threadTitle
-        ? threadTitle
+      const unescapedThreadTitle = performEmojiUnescape(threadTitle, {
+        getURL: options.getURL,
+        emojiSet: options.emojiSet,
+        emojiCDNUrl: options.emojiCDNUrl,
+        enableEmojiShortcuts: options.enableEmojiShortcuts,
+        inlineEmoji: options.inlineEmoji,
+        lazy: true,
+      });
+
+      threadToken.content = unescapedThreadTitle
+        ? unescapedThreadTitle
         : I18n.t("chat.quote.default_thread_title");
       state.push("span_thread_title_close", "span", -1);
     }

--- a/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
+++ b/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
@@ -138,7 +138,7 @@ const chatTranscriptRule = {
       spanToken.attrs = [["title", messageTimeStart]];
 
       spanToken.block = false;
-      if (channelName) {
+      if (channelName && !multiQuote) {
         let channelLinkToken = state.push("link_open", "a", 1);
         channelLinkToken.attrs = [
           ["class", "chat-transcript-channel"],

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -94,6 +94,8 @@
 
     .chat-transcript-reaction {
       @include chat-reaction;
+
+      pointer-events: none;
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -70,6 +70,12 @@
       padding: 0.5rem;
 
       > summary {
+        display: flex;
+
+        &::before {
+          line-height: 1;
+        }
+
         .chat-transcript-thread {
           &-header {
             margin-bottom: 0.5rem;

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -27,6 +27,11 @@
     border-bottom: 1px solid var(--primary-low);
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
+
+    img.emoji {
+      height: 1.1em;
+      width: 1.1em;
+    }
   }
 
   .chat-transcript-channel,

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -34,11 +34,6 @@
     }
   }
 
-  .chat-transcript-channel,
-  .chat-transcript-thread {
-    font-size: var(--font-down-1-rem);
-  }
-
   .chat-transcript-separator {
     font-size: var(--font-down-3-rem);
     color: var(--primary-high);
@@ -70,8 +65,18 @@
     }
   }
 
-  summary > .chat-transcript-user {
-    margin-top: 0.5rem;
+  .topic-body .cooked & {
+    > details {
+      padding: 0.5rem;
+
+      > summary {
+        .chat-transcript-thread {
+          &-header {
+            margin-bottom: 0.5rem;
+          }
+        }
+      }
+    }
   }
 
   .chat-transcript-user-avatar .avatar {

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -17,6 +17,10 @@
     border-bottom: 0;
   }
 
+  details > .chat-transcript-chained:first-of-type {
+    margin-top: 0.5rem;
+  }
+
   .chat-transcript-meta {
     color: var(--primary-high);
     font-size: var(--font-down-2-rem);
@@ -59,6 +63,10 @@
     p:last-of-type {
       margin-bottom: 0;
     }
+  }
+
+  summary > .chat-transcript-user {
+    margin-top: 0.5rem;
   }
 
   .chat-transcript-user-avatar .avatar {

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -433,6 +433,7 @@ en:
       quote:
         original_channel: 'Originally sent in <a href="%{channelLink}">%{channel}</a>'
         copy_success: "Chat quote copied to clipboard"
+        default_thread_title: "Thread"
 
       notification_levels:
         never: "Never"

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -192,6 +192,10 @@ en:
     summaries:
       no_targets: "There were no messages during the selected period."
 
+    transcript:
+      default_thread_title: "Thread"
+      split_thread_range: "messages %{start} to %{end} of %{total}"
+
   discourse_push_notifications:
     popup:
       chat_mention:

--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -149,14 +149,13 @@ module Chat
                 thread_size = thread.size - 1
                 last_thread_index = 0
 
-                (messages_chunk.size / ARCHIVED_MESSAGES_PER_POST + 1).times do |index|
+                (messages_chunk.size.to_f / (ARCHIVED_MESSAGES_PER_POST - 1)).ceil.times do |index|
                   if last_thread_index != thread_size
                     if index == 0
                       thread_index = thread.index(post_last_message)
                     else
                       next_post_last_message =
-                        messages_chunk[(ARCHIVED_MESSAGES_PER_POST * (index + 1)) - 1]
-
+                        messages_chunk[(ARCHIVED_MESSAGES_PER_POST * (index + 1)) - index]
                       if next_post_last_message.present? &&
                            next_post_last_message.thread_id.present? &&
                            next_post_last_message.thread_id == post_last_message.thread_id

--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -141,7 +141,7 @@ module Chat
 
             buffer.clear
 
-            if message_chunk.size > ARCHIVED_MESSAGES_PER_POST
+            if message_chunk.size > ARCHIVED_MESSAGES_PER_POST && !threads.empty?
               post_last_message = message_chunk[ARCHIVED_MESSAGES_PER_POST - 1]
 
               thread = threads.select { |msg| msg.thread_id == post_last_message.thread_id }

--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -146,9 +146,10 @@ module Chat
               post_last_message = messages_chunk[ARCHIVED_MESSAGES_PER_POST - 1]
 
               thread = threads.select { |msg| msg.thread_id == post_last_message.thread_id }
-              thread_size = thread.size - 1
               thread_om = thread.first
+              next if thread_om.nil?
 
+              thread_size = thread.size - 1
               last_thread_index = 0
 
               (messages_chunk.size / ARCHIVED_MESSAGES_PER_POST + 1).times do |index|
@@ -186,8 +187,9 @@ module Chat
 
             messages_chunk.each do |message|
               # We duplicate the original message when it spans across multiple posts
-              if messages_chunk.size > ARCHIVED_MESSAGES_PER_POST && !message.thread_id.nil? &&
-                   message.thread_id == thread_om.thread_id && batch.empty? && message != thread_om
+              if messages_chunk.size > ARCHIVED_MESSAGES_PER_POST && thread_om.present? &&
+                   !message.thread_id.nil? && message.thread_id == thread_om.thread_id &&
+                   batch.empty? && message != thread_om
                 batch << thread_om
 
                 thread_ranges[thread_om.id] = split_thread_ranges[message.thread_id].first

--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -85,6 +85,7 @@ module Chat
       @chat_channel_archive = chat_channel_archive
       @chat_channel = chat_channel_archive.chat_channel
       @chat_channel_title = chat_channel.title(chat_channel_archive.archived_by)
+      @archived_messages_ids = []
     end
 
     def execute
@@ -323,9 +324,8 @@ module Chat
           deleted_by_id: chat_channel_archive.archived_by.id,
         )
 
-        chat_channel_archive.update!(
-          archived_messages: chat_channel_archive.archived_messages + message_ids.length,
-        )
+        @archived_messages_ids = (@archived_messages_ids + message_ids).uniq
+        chat_channel_archive.update!(archived_messages: @archived_messages_ids.length)
       end
 
       Rails.logger.info(

--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -200,10 +200,9 @@ module Chat
 
     private
 
+    # It's used to call the TranscriptService, which will
+    # generate the markdown for a given set of messages.
     def create_post_from_batch(chat_messages, batch_thread_ranges)
-      # It's used to call the TranscriptService, which will
-      # generate the markdown for a given set of messages.
-
       create_post(
         Chat::TranscriptService.new(
           chat_channel,
@@ -218,11 +217,10 @@ module Chat
       ) { delete_message_batch(chat_messages.map(&:id)) }
     end
 
+    # Message batches can be greater than the maximum number of messages
+    # per post if we also include threads. This is used to calculate all
+    # the ranges when we split the threads that are included in the batch.
     def calculate_thread_ranges(message_chunk, thread, thread_om, post_last_message)
-      # Message batches can be greater than the maximum number of messages
-      # per post if we also include threads. This is used to calculate all
-      # the ranges when we split the threads that are included in the batch.
-
       ranges = {}
       thread_size = thread.size - 1
       last_thread_index = 0

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -251,7 +251,6 @@ module Chat
 
       # tie off the last open bbcode + render
       rendered_markdown << open_bbcode_tag.render
-      puts rendered_markdown.join("\n")
       rendered_markdown.join("\n")
     end
 

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -27,7 +27,7 @@ module Chat
                   :no_link,
                   :include_reactions,
                   :thread_id,
-                  :split_thread_ranges
+                  :thread_ranges
 
       def initialize(
         channel: nil,
@@ -37,7 +37,7 @@ module Chat
         no_link: false,
         include_reactions: false,
         thread_id: nil,
-        split_thread_ranges: {}
+        thread_ranges: {}
       )
         @channel = channel
         @acting_user = acting_user
@@ -45,7 +45,7 @@ module Chat
         @chained = chained
         @no_link = no_link
         @include_reactions = include_reactions
-        @split_thread_ranges = split_thread_ranges
+        @thread_ranges = thread_ranges
         @message_data = []
         @threads_markdown = {}
         @thread_id = thread_id
@@ -94,7 +94,7 @@ module Chat
             if msg_data[:message].thread_id.present?
               thread_data = @threads_markdown[msg_data[:message].thread_id]
 
-              if !thread_data.nil?
+              if thread_data.present?
                 rendered_message + "\n\n" + thread_data
               else
                 rendered_message
@@ -136,16 +136,16 @@ module Chat
 
       def thread_title_attr(message)
         thread = Chat::Thread.find(thread_id)
-        split_range = split_thread_ranges[message.id] if split_thread_ranges.has_key?(message.id)
+        range = thread_ranges[message.id] if thread_ranges.has_key?(message.id)
 
         thread_title =
           thread.title.present? ? thread.title : I18n.t("chat.transcript.default_thread_title")
-        thread_title += " (#{split_range})" if split_range.present?
+        thread_title += " (#{range})" if range.present?
         "threadTitle=\"#{thread_title}\""
       end
     end
 
-    def initialize(channel, acting_user, messages_or_ids: [], split_thread_ranges: {}, opts: {})
+    def initialize(channel, acting_user, messages_or_ids: [], thread_ranges: {}, opts: {})
       @channel = channel
       @acting_user = acting_user
 
@@ -155,7 +155,7 @@ module Chat
         @messages = messages_or_ids
       end
       @opts = opts
-      @split_thread_ranges = split_thread_ranges
+      @thread_ranges = thread_ranges
     end
 
     def generate_markdown
@@ -172,7 +172,7 @@ module Chat
           chained: !all_messages_same_user,
           no_link: @opts[:no_link],
           thread_id: messages.first.thread_id,
-          split_thread_ranges: @split_thread_ranges,
+          thread_ranges: @thread_ranges,
           include_reactions: @opts[:include_reactions],
         )
 
@@ -192,7 +192,7 @@ module Chat
               chained: !all_messages_same_user,
               no_link: @opts[:no_link],
               thread_id: message.thread_id,
-              split_thread_ranges: @split_thread_ranges,
+              thread_ranges: @thread_ranges,
               include_reactions: @opts[:include_reactions],
             )
         end

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -63,7 +63,11 @@ module Chat
         attrs << CHAINED_ATTR if chained
         attrs << NO_LINK_ATTR if no_link
         attrs << reactions_attr if include_reactions
-        attrs << thread_id_attr if thread_id
+
+        if thread_id
+          attrs << thread_id_attr
+          attrs << thread_title_attr
+        end
 
         <<~MARKDOWN
       [chat #{attrs.compact.join(" ")}]
@@ -120,6 +124,12 @@ module Chat
 
       def thread_id_attr
         "threadId=\"#{thread_id}\""
+      end
+
+      def thread_title_attr
+        thread = Chat::Thread.find(thread_id)
+        return if thread.title.blank?
+        "threadTitle=\"#{thread.title}\""
       end
     end
 

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -187,7 +187,7 @@ module Chat
           thread_bbcode_tag =
             TranscriptBBCode.new(
               acting_user: @acting_user,
-              chained: true,
+              chained: !all_messages_same_user,
               no_link: @opts[:no_link],
               include_reactions: @opts[:include_reactions],
             )

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -40,7 +40,6 @@ module Chat
         @include_reactions = include_reactions
         @message_data = []
         @threads_markdown = {}
-        @attrs = {}
         @thread_id = thread_id
       end
 
@@ -52,24 +51,22 @@ module Chat
         @threads_markdown[thread_id] = markdown
       end
 
-      def set_attrs(message)
-        @attrs = [quote_attr(message)]
-      end
-
       def render
+        attrs = [quote_attr(@message_data.first[:message])]
+
         if channel
-          @attrs << channel_attr
-          @attrs << channel_id_attr
+          attrs << channel_attr
+          attrs << channel_id_attr
         end
 
-        @attrs << MULTIQUOTE_ATTR if multiquote
-        @attrs << CHAINED_ATTR if chained
-        @attrs << NO_LINK_ATTR if no_link
-        @attrs << reactions_attr if include_reactions
-        @attrs << thread_id_attr if thread_id
+        attrs << MULTIQUOTE_ATTR if multiquote
+        attrs << CHAINED_ATTR if chained
+        attrs << NO_LINK_ATTR if no_link
+        attrs << reactions_attr if include_reactions
+        attrs << thread_id_attr if thread_id
 
         <<~MARKDOWN
-      [chat #{@attrs.compact.join(" ")}]
+      [chat #{attrs.compact.join(" ")}]
       #{render_messages}
       [/chat]
       MARKDOWN
@@ -180,7 +177,7 @@ module Chat
         else
           open_bbcode_tag.add(message: message)
         end
-        open_bbcode_tag.set_attrs(message)
+
         previous_message = message
 
         if message_group.length > 1
@@ -217,7 +214,6 @@ module Chat
             else
               thread_bbcode_tag.add(message: thread_message)
             end
-            thread_bbcode_tag.set_attrs(thread_message)
             previous_thread_message = thread_message
           end
           rendered_thread_markdown << thread_bbcode_tag.render

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -86,7 +86,7 @@ module Chat
               thread_data = @threads_markdown[msg_data[:message].thread_id]
 
               if !thread_data.nil?
-                rendered_message + "\n" + thread_data
+                rendered_message + "\n\n" + thread_data
               else
                 rendered_message
               end
@@ -185,6 +185,7 @@ module Chat
 
         if message_group.length > 1
           previous_thread_message = nil
+          rendered_thread_markdown.clear
 
           thread_bbcode_tag =
             TranscriptBBCode.new(

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -88,6 +88,19 @@ describe Chat::ChannelArchiveService do
   describe "#execute" do
     def create_messages(num)
       num.times { Fabricate(:chat_message, chat_channel: channel) }
+
+      # num.times { |i| Fabricate(:chat_message, chat_channel: channel, message: "message #{i + 1}") }
+    end
+
+    def create_threaded_messages(num, title: nil)
+      original_message = Fabricate(:chat_message, chat_channel: channel)
+      thread =
+        Fabricate(:chat_thread, channel: channel, title: title, original_message: original_message)
+      (num - 1).times { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
+
+      # (num - 1).times do |i|
+      #   Fabricate(:chat_message, chat_channel: channel, thread: thread, message: "thread #{i + 1}")
+      # end
     end
 
     def start_archive
@@ -139,6 +152,61 @@ describe Chat::ChannelArchiveService do
         expect(topic.archived).to eq(true)
 
         expect(@channel_archive.archived_messages).to eq(50)
+        expect(@channel_archive.chat_channel.status).to eq("archived")
+        expect(@channel_archive.chat_channel.chat_messages.count).to eq(0)
+      end
+
+      it "creates the correct posts for a channel with messages and threads" do
+        create_messages(2)
+        create_threaded_messages(6, title: "a new thread")
+        create_messages(7)
+        create_threaded_messages(3)
+        create_threaded_messages(27, title: "another long thread")
+        create_messages(10)
+
+        start_archive
+
+        stub_const(Chat::ChannelArchiveService, "ARCHIVED_MESSAGES_PER_POST", 5) do
+          described_class.new(@channel_archive).execute
+        end
+
+        @channel_archive.reload
+        topic = @channel_archive.destination_topic
+        expect(topic.posts.count).to eq(14)
+
+        topic
+          .posts
+          .where.not(post_number: 1)
+          .each do |post|
+            case post.post_number
+            when 2
+              expect(post.raw).to include("a new thread")
+              expect(post.raw).to include(
+                I18n.t("chat.transcript.split_thread_range", start: 1, end: 2, total: 5),
+              )
+            when 3
+              expect(post.raw).to include("a new thread")
+              expect(post.raw).to include(
+                I18n.t("chat.transcript.split_thread_range", start: 3, end: 5, total: 5),
+              )
+            when 5
+              expect(post.raw).to include(
+                "threadTitle=\"#{I18n.t("chat.transcript.default_thread_title")}\"",
+              )
+            when 10
+              expect(post.raw).to include("another long thread")
+              expect(post.raw).to include(
+                I18n.t("chat.transcript.split_thread_range", start: 17, end: 20, total: 26),
+              )
+            end
+
+            expect(post.raw).to include("[chat")
+            expect(post.raw).to include("noLink=\"true\"")
+            expect(post.user).to eq(Discourse.system_user)
+          end
+        expect(topic.archived).to eq(true)
+
+        expect(@channel_archive.archived_messages).to eq(55)
         expect(@channel_archive.chat_channel.status).to eq("archived")
         expect(@channel_archive.chat_channel.chat_messages.count).to eq(0)
       end

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -88,8 +88,6 @@ describe Chat::ChannelArchiveService do
   describe "#execute" do
     def create_messages(num)
       num.times { Fabricate(:chat_message, chat_channel: channel) }
-
-      # num.times { |i| Fabricate(:chat_message, chat_channel: channel, message: "message #{i + 1}") }
     end
 
     def create_threaded_messages(num, title: nil)
@@ -97,10 +95,6 @@ describe Chat::ChannelArchiveService do
       thread =
         Fabricate(:chat_thread, channel: channel, title: title, original_message: original_message)
       (num - 1).times { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
-
-      # (num - 1).times do |i|
-      #   Fabricate(:chat_message, chat_channel: channel, thread: thread, message: "thread #{i + 1}")
-      # end
     end
 
     def start_archive

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -313,7 +313,7 @@ describe Chat::TranscriptService do
         },
       ).generate_markdown
     expect(rendered).to eq(<<~MARKDOWN)
-    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" reactions="heart:bjorn" threadId="#{thread.id}"]
+    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" reactions="heart:bjorn" threadId="#{thread.id}" threadTitle="#{I18n.t("chat.transcript.default_thread_title")}"]
     an extremely insightful response :)
 
     [chat quote="brucechat;#{thread_reply_1.id};#{thread_reply_1.created_at.iso8601}" chained="true" reactions="+1:hvitserk;heart:sigurd"]
@@ -351,7 +351,7 @@ describe Chat::TranscriptService do
 
     rendered = service([thread_om.id, thread_reply_1.id, thread_reply_2.id]).generate_markdown
     expect(rendered).to eq(<<~MARKDOWN)
-    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" threadId="#{thread.id}"]
+    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" threadId="#{thread.id}" threadTitle="#{I18n.t("chat.transcript.default_thread_title")}"]
     reply to me!
 
     [chat quote="brucechat;#{thread_reply_1.id};#{thread_reply_1.created_at.iso8601}" chained="true"]
@@ -389,7 +389,7 @@ describe Chat::TranscriptService do
 
     channel_message_2 =
       Fabricate(:chat_message, user: user2, chat_channel: channel, message: "more?")
-    thread_2 = Fabricate(:chat_thread, channel: channel)
+    thread_2 = Fabricate(:chat_thread, channel: channel, title: "the second idea")
     thread_2_om =
       Fabricate(
         :chat_message,
@@ -426,7 +426,7 @@ describe Chat::TranscriptService do
     I need ideas
     [/chat]
 
-    [chat quote="brucechat;#{thread_1_om.id};#{thread_1_om.created_at.iso8601}" chained="true" threadId="#{thread_1.id}"]
+    [chat quote="brucechat;#{thread_1_om.id};#{thread_1_om.created_at.iso8601}" chained="true" threadId="#{thread_1.id}" threadTitle="#{I18n.t("chat.transcript.default_thread_title")}"]
     this is my idea
 
     [chat quote="martinchat;#{thread_1_message.id};#{thread_1_message.created_at.iso8601}" chained="true"]
@@ -439,7 +439,7 @@ describe Chat::TranscriptService do
     more?
     [/chat]
 
-    [chat quote="brucechat;#{thread_2_om.id};#{thread_2_om.created_at.iso8601}" chained="true" threadId="#{thread_2.id}"]
+    [chat quote="brucechat;#{thread_2_om.id};#{thread_2_om.created_at.iso8601}" chained="true" threadId="#{thread_2.id}" threadTitle="the second idea"]
     another one
 
     [chat quote="martinchat;#{thread_2_message_1.id};#{thread_2_message_1.created_at.iso8601}" chained="true"]

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -6,7 +6,9 @@ describe Chat::TranscriptService do
   let(:acting_user) { Fabricate(:user) }
   let(:user1) { Fabricate(:user, username: "martinchat") }
   let(:user2) { Fabricate(:user, username: "brucechat") }
-  let(:channel) { Fabricate(:category_channel, name: "The Beam Discussions") }
+  let(:channel) do
+    Fabricate(:category_channel, name: "The Beam Discussions", threading_enabled: true)
+  end
 
   def service(message_ids, opts: {})
     described_class.new(channel, acting_user, messages_or_ids: Array.wrap(message_ids), opts: opts)
@@ -251,6 +253,203 @@ describe Chat::TranscriptService do
 
     [chat quote="brucechat;#{message3.id};#{message3.created_at.iso8601}" chained="true" reactions="sob:ivar"]
     a new perspective
+    [/chat]
+    MARKDOWN
+  end
+
+  it "generates reaction data for threaded messages" do
+    thread = Fabricate(:chat_thread, channel: channel)
+    thread_om =
+      Fabricate(
+        :chat_message,
+        user: user1,
+        chat_channel: channel,
+        thread: thread,
+        message: "an extremely insightful response :)",
+      )
+    thread_reply_1 =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user2,
+        thread: thread,
+        message: "wow so tru",
+      )
+    thread_reply_2 =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread,
+        message: "a new perspective",
+      )
+
+    Chat::MessageReaction.create!(
+      chat_message: thread_om,
+      user: Fabricate(:user, username: "bjorn"),
+      emoji: "heart",
+    )
+    Chat::MessageReaction.create!(
+      chat_message: thread_reply_1,
+      user: Fabricate(:user, username: "sigurd"),
+      emoji: "heart",
+    )
+    Chat::MessageReaction.create!(
+      chat_message: thread_reply_1,
+      user: Fabricate(:user, username: "hvitserk"),
+      emoji: "+1",
+    )
+    Chat::MessageReaction.create!(
+      chat_message: thread_reply_2,
+      user: Fabricate(:user, username: "ubbe"),
+      emoji: "money_mouth_face",
+    )
+
+    rendered =
+      service(
+        [thread_om.id, thread_reply_1.id, thread_reply_2.id],
+        opts: {
+          include_reactions: true,
+        },
+      ).generate_markdown
+    expect(rendered).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" reactions="heart:bjorn" threadId="#{thread.id}"]
+    an extremely insightful response :)
+
+    [chat quote="brucechat;#{thread_reply_1.id};#{thread_reply_1.created_at.iso8601}" chained="true" reactions="+1:hvitserk;heart:sigurd"]
+    wow so tru
+    [/chat]
+
+    [chat quote="martinchat;#{thread_reply_2.id};#{thread_reply_2.created_at.iso8601}" chained="true" reactions="money_mouth_face:ubbe"]
+    a new perspective
+    [/chat]
+
+    [/chat]
+    MARKDOWN
+  end
+
+  it "generates a chat transcript for threaded messages" do
+    thread = Fabricate(:chat_thread, channel: channel)
+    thread_om =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread,
+        message: "reply to me!",
+      )
+    thread_reply_1 =
+      Fabricate(:chat_message, chat_channel: channel, user: user2, thread: thread, message: "done")
+    thread_reply_2 =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread,
+        message: "thanks",
+      )
+
+    rendered = service([thread_om.id, thread_reply_1.id, thread_reply_2.id]).generate_markdown
+    expect(rendered).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" threadId="#{thread.id}"]
+    reply to me!
+
+    [chat quote="brucechat;#{thread_reply_1.id};#{thread_reply_1.created_at.iso8601}" chained="true"]
+    done
+    [/chat]
+
+    [chat quote="martinchat;#{thread_reply_2.id};#{thread_reply_2.created_at.iso8601}" chained="true"]
+    thanks
+    [/chat]
+
+    [/chat]
+    MARKDOWN
+  end
+
+  it "generates the correct markdown for multiple threads" do
+    channel_message_1 =
+      Fabricate(:chat_message, user: user1, chat_channel: channel, message: "I need ideas")
+    thread_1 = Fabricate(:chat_thread, channel: channel)
+    thread_1_om =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user2,
+        thread: thread_1,
+        message: "this is my idea",
+      )
+    thread_1_message =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread_1,
+        message: "cool",
+      )
+
+    channel_message_2 =
+      Fabricate(:chat_message, user: user2, chat_channel: channel, message: "more?")
+    thread_2 = Fabricate(:chat_thread, channel: channel)
+    thread_2_om =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user2,
+        thread: thread_2,
+        message: "another one",
+      )
+    thread_2_message_1 =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread_2,
+        message: "thanks",
+      )
+    thread_2_message_2 =
+      Fabricate(:chat_message, chat_channel: channel, user: user2, thread: thread_2, message: "np")
+
+    rendered =
+      service(
+        [
+          channel_message_1.id,
+          thread_1_om.id,
+          thread_1_message.id,
+          channel_message_2.id,
+          thread_2_om.id,
+          thread_2_message_1.id,
+          thread_2_message_2.id,
+        ],
+      ).generate_markdown
+    expect(rendered).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{channel_message_1.id};#{channel_message_1.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true"]
+    I need ideas
+    [/chat]
+
+    [chat quote="brucechat;#{thread_1_om.id};#{thread_1_om.created_at.iso8601}" chained="true" threadId="#{thread_1.id}"]
+    this is my idea
+
+    [chat quote="martinchat;#{thread_1_message.id};#{thread_1_message.created_at.iso8601}" chained="true"]
+    cool
+    [/chat]
+
+    [/chat]
+
+    [chat quote="brucechat;#{channel_message_2.id};#{channel_message_2.created_at.iso8601}" chained="true"]
+    more?
+    [/chat]
+
+    [chat quote="brucechat;#{thread_2_om.id};#{thread_2_om.created_at.iso8601}" chained="true" threadId="#{thread_2.id}"]
+    another one
+
+    [chat quote="martinchat;#{thread_2_message_1.id};#{thread_2_message_1.created_at.iso8601}" chained="true"]
+    thanks
+    [/chat]
+
+    [chat quote="brucechat;#{thread_2_message_2.id};#{thread_2_message_2.created_at.iso8601}" chained="true"]
+    np
+    [/chat]
+
     [/chat]
     MARKDOWN
   end


### PR DESCRIPTION
This PR introduces thread support for channel archives. Now, threaded messages are rendered inside a `details` HTML tag in posts.

The transcript markdown rules now support two new attributes: `threadId` and `threadTitle`.

- If `threadId` is present, all nested `chat` tags are rendered inside the first one.
- `threadTitle` (optional) defines the summary content.

```
[chat threadId=19 ... ]
thread OM

  [chat ... ]
  thread reply
  [/chat]

[/chat]
```

If threads are split across multiple posts when archiving, the range of messages in each part will be displayed alongside the thread title. For example: `(message 1 to 16 of 20)` and `(message 17 to 20 of 20)`




