### PR TITLE
DEV: Fix bookmark flaky

### DIFF
--- a/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
@@ -35,6 +35,8 @@ describe UsersController do
       sign_in(current_user)
     end
 
+    after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }
+
     it "does not return any unread notifications for chat bookmarks that the user no longer has access to" do
       bookmark_with_reminder =
         Fabricate(:bookmark, user: current_user, bookmarkable: bookmark_message)


### PR DESCRIPTION
Fixes this problem that happens sometimes in specs:

> Mocha::StubbingError:
> #<Mock:0x135150> was instantiated in one test but it is receiving
invocations within another test. This can lead to unintended
interactions between tests and hence unexpected test failures. Ensure
that every test correctly cleans up any state that it introduces.
