### PR TITLE
DEV: Support legacy precompiler paths in theme compiler

### DIFF
--- a/app/assets/javascripts/theme-transpiler/transpiler.js
+++ b/app/assets/javascripts/theme-transpiler/transpiler.js
@@ -89,7 +89,11 @@ function buildTemplateCompilerBabelPlugins({ extension, themeId }) {
       HTMLBarsInlinePrecompile,
       {
         compiler,
-        enableLegacyModules: ["ember-cli-htmlbars"],
+        enableLegacyModules: [
+          "ember-cli-htmlbars",
+          "ember-cli-htmlbars-inline-precompile",
+          "htmlbars-inline-precompile",
+        ],
       },
     ],
   ];


### PR DESCRIPTION
This updates the behaviour to match ember-cli-htmlbars, and should take care of the handful of themes which were relying on runtime compilation in tests (see 4425e99bf937ec1dea5cc91a2a188c052d70d3a9)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
