### PR TITLE
UX: Create polls with public=true by default

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.hbs
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.hbs
@@ -145,6 +145,15 @@
       {{/unless}}
     {{/unless}}
 
+    <div class="input-group poll-public">
+      <DToggleSwitch
+        @state={{this.publicPoll}}
+        @label="poll.ui_builder.poll_public.label"
+        class="poll-toggle-public"
+        {{on "click" this.togglePublic}}
+      />
+    </div>
+
     {{#if this.showAdvanced}}
       <div class="input-group poll-allowed-groups">
         <label class="input-group-label">{{i18n
@@ -211,19 +220,6 @@
             <label for="poll-chart-type-pie">{{d-icon "chart-pie"}}
               {{i18n "poll.ui_builder.poll_chart_type.pie"}}</label>
           </div>
-        </div>
-      {{/unless}}
-
-      {{#unless this.isPie}}
-        <div class="input-group poll-checkbox column">
-          <label>
-            <Input
-              @type="checkbox"
-              @checked={{this.publicPoll}}
-              class="poll-toggle-public"
-            />
-            {{i18n "poll.ui_builder.poll_public.label"}}
-          </label>
         </div>
       {{/unless}}
     {{/if}}

--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.js
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.js
@@ -30,7 +30,7 @@ export default class PollUiBuilderModal extends Component {
   pollAutoClose;
   pollResult = ALWAYS_POLL_RESULT;
   chartType = BAR_CHART_TYPE;
-  publicPoll = false;
+  publicPoll = true;
 
   @or("showAdvanced", "isNumber") showNumber;
   @gt("pollOptions.length", 1) canRemoveOption;
@@ -174,9 +174,7 @@ export default class PollUiBuilderModal extends Component {
     if (pollType === NUMBER_POLL_TYPE) {
       pollHeader += ` step=${step}`;
     }
-    if (publicPoll) {
-      pollHeader += ` public=true`;
-    }
+    pollHeader += ` public=${publicPoll ? "true" : "false"}`;
     if (chartType && pollType !== NUMBER_POLL_TYPE) {
       pollHeader += ` chartType=${chartType}`;
     }
@@ -380,5 +378,10 @@ export default class PollUiBuilderModal extends Component {
   updatePollType(pollType, event) {
     event?.preventDefault();
     this.set("pollType", pollType);
+  }
+
+  @action
+  togglePublic() {
+    this.set("publicPoll", !this.publicPoll);
   }
 }

--- a/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
+++ b/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
@@ -26,12 +26,14 @@
     .date-picker-wrapper {
       margin-right: 5px;
     }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
-  .poll-checkbox {
-    label {
-      width: unset;
-    }
+  .poll-public .d-toggle-switch--label {
+    margin-bottom: 0;
   }
 
   .radio-group {

--- a/plugins/poll/test/javascripts/component/poll-ui-builder-test.js
+++ b/plugins/poll/test/javascripts/component/poll-ui-builder-test.js
@@ -96,14 +96,14 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=number results=always min=1 max=20 step=1]\n[/poll]\n"
+      "[poll type=number results=always min=1 max=20 step=1 public=true]\n[/poll]\n"
     );
 
     await fillIn(".poll-options-step", "2");
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=number results=always min=1 max=20 step=2]\n[/poll]\n",
+      "[poll type=number results=always min=1 max=20 step=2 public=true]\n[/poll]\n",
       "includes step value"
     );
 
@@ -111,8 +111,8 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=number results=always min=1 max=20 step=2 public=true]\n[/poll]\n",
-      "includes public boolean"
+      "[poll type=number results=always min=1 max=20 step=2 public=false]\n[/poll]\n",
+      "can be set to private"
     );
 
     await fillIn(".poll-options-step", "0");
@@ -131,7 +131,7 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=regular results=always chartType=bar]\n* a\n* b\n[/poll]\n",
+      "[poll type=regular results=always public=true chartType=bar]\n* a\n* b\n[/poll]\n",
       "has correct output"
     );
 
@@ -142,8 +142,8 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=regular results=always public=true chartType=bar]\n* a\n* b\n[/poll]\n",
-      "has public boolean"
+      "[poll type=regular results=always public=false chartType=bar]\n* a\n* b\n[/poll]\n",
+      "can be set to private"
     );
 
     const groupChooser = selectKit(".group-chooser");
@@ -154,7 +154,7 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=regular results=always public=true chartType=bar groups=custom_group]\n* a\n* b\n[/poll]\n",
+      "[poll type=regular results=always public=false chartType=bar groups=custom_group]\n* a\n* b\n[/poll]\n",
       "has groups"
     );
   });
@@ -171,7 +171,7 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=multiple results=always min=1 max=2 chartType=bar]\n* a\n* b\n[/poll]\n",
+      "[poll type=multiple results=always min=1 max=2 public=true chartType=bar]\n* a\n* b\n[/poll]\n",
       "has correct output"
     );
 
@@ -182,8 +182,8 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     await click(".insert-poll");
     assert.strictEqual(
       results[results.length - 1],
-      "[poll type=multiple results=always min=1 max=2 public=true chartType=bar]\n* a\n* b\n[/poll]\n",
-      "has public boolean"
+      "[poll type=multiple results=always min=1 max=2 public=false chartType=bar]\n* a\n* b\n[/poll]\n",
+      "can be set to private boolean"
     );
   });
 


### PR DESCRIPTION
In the vast majority of cases, people want poll voters to be public. Previously, the checkbox for this was hidden behind the 'show advanced' settings in the poll builder UI.

This commit makes three changes to improve the experience:

1. Add `public=true|false` to poll markup (previously it would only be added when true

2. Bring the 'public' switch outside the 'show advanced' section for improved visibility

3. Change the default to 'true'

<img width="300" alt="SCR-20231110-nzvk" src="https://github.com/discourse/discourse/assets/6270921/33c5e562-dda4-4867-8dc2-137ed18cffa6">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
