### PR TITLE
FIX: Updating presence status in readonly mode should fail gracefully

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,15 @@ Discourse/NoResetColumnInformationInMigrations:
 Lint/Debugger:
   Exclude:
     - script/**/*
+
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - for
+    - while
+    - if
+    - as
+    - after
+    - in

--- a/app/controllers/presence_controller.rb
+++ b/app/controllers/presence_controller.rb
@@ -42,6 +42,8 @@ class PresenceController < ApplicationController
   end
 
   def update
+    raise Discourse::ReadOnly if @readonly_mode
+
     client_id = params[:client_id]
     if !client_id.is_a?(String) || client_id.blank?
       raise Discourse::InvalidParameters.new(:client_id)

--- a/spec/requests/presence_controller_spec.rb
+++ b/spec/requests/presence_controller_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe PresenceController do
   end
 
   describe "#update" do
+    context "in readonly mode" do
+      use_redis_snapshotting
+
+      before { Discourse.enable_readonly_mode }
+
+      it "produces 503" do
+        sign_in(user)
+        client_id = SecureRandom.hex
+
+        post "/presence/update.json",
+             params: {
+               client_id: client_id,
+               present_channels: [ch1.name, ch2.name],
+             }
+
+        expect(response.status).to eq(503)
+      end
+    end
+
     it "works" do
       sign_in(user)
       client_id = SecureRandom.hex


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
