### PR TITLE
FIX: Hide old min_trust_level_for_here_mention setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -960,6 +960,7 @@ posting:
   min_trust_level_for_here_mention:
     default: "2"
     enum: "TrustLevelAndStaffSetting"
+    hidden: true
   here_mention_allowed_groups:
     default: "12" # auto group trust_level_2
     type: group_list


### PR DESCRIPTION
Followup to 67ac4c5616b459cfa216c3e25b52997f064799f4
