### PR TITLE
DEV: uses alphanumeric to avoid flakey specs

### DIFF
--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -67,7 +67,7 @@ end
 Fabricator(:chat_message_without_service, class_name: "Chat::Message") do
   user
   chat_channel
-  message { Faker::Lorem.words(number: 5).join(" ") }
+  message { Faker::Alphanumeric.alpha(number: SiteSetting.chat_minimum_message_length) }
 
   after_build { |message, attrs| message.cook }
   after_create { |message, attrs| message.upsert_mentions }
@@ -94,7 +94,9 @@ Fabricator(:chat_message_with_service, class_name: "Chat::CreateMessage") do
       resolved_class.call(
         chat_channel_id: channel.id,
         guardian: user.guardian,
-        message: transients[:message] || Faker::Lorem.words(number: 5).join(" "),
+        message:
+          transients[:message] ||
+            Faker::Alphanumeric.alpha(number: SiteSetting.chat_minimum_message_length),
         thread_id: transients[:thread]&.id,
         in_reply_to_id: transients[:in_reply_to]&.id,
         upload_ids: transients[:upload_ids],


### PR DESCRIPTION
Faker text with quotes or thread dots for example would cause issues in tests due to cooking.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
