### PR TITLE
DEV: Update specs to avoid dependence on ember-cli build

### DIFF
--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe InvitesController do
     it "shows the accept invite page" do
       get "/invites/#{invite.invite_key}"
       expect(response.status).to eq(200)
-      expect(response.body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+      expect(response.body).to have_tag(
+        :script,
+        with: {
+          "data-discourse-entrypoint" => "discourse",
+        },
+      )
       expect(response.body).not_to include(invite.email)
       expect(response.body).to_not include(
         I18n.t(

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2714,7 +2714,7 @@ RSpec.describe TopicsController do
 
         body = response.body
 
-        expect(body).to have_tag(:script, src: "/assets/discourse.js")
+        expect(body).to have_tag(:script, with: { "data-discourse-entrypoint" => "discourse" })
         expect(body).to have_tag(:meta, with: { name: "fragment" })
       end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3116,7 +3116,7 @@ RSpec.describe TopicsController do
           body = response.body
 
           expect(response.status).to eq(200)
-          expect(body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+          expect(body).to have_tag(:script, with: { "data-discourse-entrypoint" => "discourse" })
           expect(body).to_not have_tag(:meta, with: { name: "fragment" })
         end
       end
@@ -3129,7 +3129,7 @@ RSpec.describe TopicsController do
 
           body = response.body
 
-          expect(body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+          expect(body).to have_tag(:script, with: { "data-discourse-entrypoint" => "discourse" })
           expect(body).to have_tag(:meta, with: { name: "fragment" })
         end
 
@@ -5162,7 +5162,7 @@ RSpec.describe TopicsController do
 
         body = response.body
 
-        expect(body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+        expect(body).to have_tag(:script, with: { "data-discourse-entrypoint" => "discourse" })
         expect(body).to have_tag(:meta, with: { name: "fragment" })
       end
     end


### PR DESCRIPTION
The `src` of js files is now dependent on the ember-cli/webpack build, so it's not a good thing to check in specs. In CI it passes because the ember-cli build is not run. But locally it would fail if you had a build in `app/assets/javascripts/discourse/dist`.

This commit updates the specs to check for the presence of a stable data attribute instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
