### PR TITLE
FEATURE: Configure poll 'public' default via site setting

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.js
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import EmberObject, { action } from "@ember/object";
 import { gt, or } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
 import { observes } from "@ember-decorators/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
@@ -18,6 +19,8 @@ const CLOSED_POLL_RESULT = "on_close";
 const STAFF_POLL_RESULT = "staff_only";
 
 export default class PollUiBuilderModal extends Component {
+  @service siteSettings;
+
   showAdvanced = false;
   pollType = REGULAR_POLL_TYPE;
   pollTitle;
@@ -30,7 +33,7 @@ export default class PollUiBuilderModal extends Component {
   pollAutoClose;
   pollResult = ALWAYS_POLL_RESULT;
   chartType = BAR_CHART_TYPE;
-  publicPoll = true;
+  publicPoll = this.siteSettings.poll_default_public;
 
   @or("showAdvanced", "isNumber") showNumber;
   @gt("pollOptions.length", 1) canRemoveOption;

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -6,6 +6,7 @@ en:
     poll_minimum_trust_level_to_create: "Define the minimum trust level needed to create polls."
     poll_groupable_user_fields: "A set of user field names that can be used to group and filter poll results."
     poll_export_data_explorer_query_id: "ID of the Data Explorer Query to use for exporting poll results (0 to disable)."
+    poll_default_public: "When creating a new poll, enable the 'show who voted' option by default."
 
   poll:
     poll: "poll"

--- a/plugins/poll/config/settings.yml
+++ b/plugins/poll/config/settings.yml
@@ -22,3 +22,6 @@ plugins:
     default: -16
     min: -9999
     client: true
+  poll_default_public:
+    default: true
+    client: true

--- a/plugins/poll/test/javascripts/component/poll-ui-builder-test.js
+++ b/plugins/poll/test/javascripts/component/poll-ui-builder-test.js
@@ -211,4 +211,22 @@ module("Poll | Component | poll-ui-builder", function (hooks) {
     );
     await resultVisibility.collapse();
   });
+
+  test("default public value can be controlled with site setting", async function (assert) {
+    this.siteSettings.poll_default_public = false;
+
+    const results = await setupBuilder(this);
+
+    await fillIn(".poll-option-value input", "a");
+    await click(".poll-option-add");
+    await fillIn(".poll-option-value:nth-of-type(2) input", "b");
+
+    await click(".insert-poll");
+
+    assert.strictEqual(
+      results[results.length - 1],
+      "[poll type=regular results=always public=false chartType=bar]\n* a\n* b\n[/poll]\n",
+      "can be set to private boolean"
+    );
+  });
 });


### PR DESCRIPTION
Followup to 7e37e3e82409ffa59b9720c132e1bba7b02874a3

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
