### PR TITLE
FIX: only show passkeys button in login modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/login-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.hbs
@@ -16,7 +16,7 @@
   </button>
 {{/each}}
 
-{{#if this.canUsePasskeys}}
+{{#if this.showPasskeysButton}}
   <PasskeyLoginButton @passkeyLogin={{this.passkeyLogin}} />
 {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/login-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.js
@@ -10,10 +10,10 @@ export default Component.extend({
   @discourseComputed(
     "buttons.length",
     "showLoginWithEmailLink",
-    "canUsePasskeys"
+    "showPasskeysButton"
   )
-  hidden(buttonsCount, showLoginWithEmailLink, canUsePasskeys) {
-    return buttonsCount === 0 && !showLoginWithEmailLink && !canUsePasskeys;
+  hidden(buttonsCount, showLoginWithEmailLink, showPasskeysButton) {
+    return buttonsCount === 0 && !showLoginWithEmailLink && !showPasskeysButton;
   },
 
   @discourseComputed
@@ -22,10 +22,11 @@ export default Component.extend({
   },
 
   @discourseComputed
-  canUsePasskeys() {
+  showPasskeysButton() {
     return (
       this.siteSettings.enable_local_logins &&
       this.siteSettings.enable_passkeys &&
+      this.context === "login" &&
       isWebauthnSupported()
     );
   },

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -279,7 +279,10 @@
 
       {{#if this.showExternalLoginButtons}}
         <div class="create-account-login-buttons">
-          <LoginButtons @externalLogin={{this.externalLogin}} />
+          <LoginButtons
+            @externalLogin={{this.externalLogin}}
+            @context="create-account"
+          />
         </div>
       {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/login.hbs
@@ -18,6 +18,7 @@
         <LoginButtons
           @externalLogin={{this.externalLoginAction}}
           @passkeyLogin={{this.passkeyLogin}}
+          @context="login"
         />
       {{/if}}
     {{/if}}
@@ -75,6 +76,7 @@
         <LoginButtons
           @externalLogin={{this.externalLoginAction}}
           @passkeyLogin={{this.passkeyLogin}}
+          @context="login"
         />
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -50,7 +50,10 @@
                   />
                 {{/unless}}
               {{else}}
-                <LoginButtons @externalLogin={{action "externalLogin"}} />
+                <LoginButtons
+                  @externalLogin={{action "externalLogin"}}
+                  @context="invite"
+                />
               {{/if}}
             {{/if}}
 

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-test.js
@@ -114,3 +114,19 @@ acceptance("Create Account - full_name_required", function (needs) {
     assert.verifySteps(["request"]);
   });
 });
+
+acceptance("Create Account - passkeys enabled", function (needs) {
+  needs.settings({ enable_passkeys: true });
+
+  test("does not show passkeys button", async function (assert) {
+    await visit("/");
+    await click("header .sign-up-button");
+
+    assert
+      .dom(".create-account-form .btn-primary")
+      .exists("create account button exists");
+
+    assert.dom(".create-account-form .btn-primary").exists();
+    assert.dom(".passkey-login-button").doesNotExist();
+  });
+});


### PR DESCRIPTION
We show the rest of the external login buttons in the create account modal as well, but "login with a passkey" is not relevant in that context.
