### PR TITLE
DEV: Add quote-share-buttons-before plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -212,6 +212,12 @@ export default class PostTextSelectionToolbar extends Component {
             />
           {{/if}}
 
+          <PluginOutlet
+            @name="quote-share-buttons-before"
+            @connectorTagName="span"
+            @outletArgs={{hash data=@data}}
+          />
+
           {{#if this.quoteSharingEnabled}}
             <span class="quote-sharing">
               {{#if this.quoteSharingShowLabel}}


### PR DESCRIPTION
This is so additional buttons can be rendered inbetween
the quote/edit buttons and the share buttons for post quotes
