### PR TITLE
FEATURE: Allow `/filter` route to be accessible by anon users

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -46,6 +46,7 @@ class ListController < ApplicationController
                   TopTopic.periods.map { |p| :"category_top_#{p}" },
                   TopTopic.periods.map { |p| :"category_none_top_#{p}" },
                   :group_topics,
+                  :filter,
                 ].flatten
 
   # Create our filters

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1160,10 +1160,14 @@ RSpec.describe ListController do
       ).to contain_exactly(topic.id)
     end
 
-    it "should respond with 403 response code for an anonymous user" do
+    it "should not return topics that an anon user is not allowed to view" do
       get "/filter.json"
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(200)
+
+      expect(
+        response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] },
+      ).to contain_exactly(topic.id)
     end
 
     it "should respond with 404 response code when `experimental_topics_filter` site setting has not been enabled" do


### PR DESCRIPTION
Why this change?

There is no reason for us to exclude anon users from viewing this route
so we're making a product decision to change this.