### PR TITLE
FIX: buildQuoteMarkdown fn was not passed down properly

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -457,18 +457,6 @@ export default Controller.extend(bufferedProperty("model"), {
       });
     },
 
-    buildQuoteMarkdown() {
-      const { postId, buffer, opts } = this.quoteState;
-      const loadedPost = this.get("model.postStream").findLoadedPost(postId);
-      const promise = loadedPost
-        ? Promise.resolve(loadedPost)
-        : this.get("model.postStream").loadPost(postId);
-
-      return promise.then((post) => {
-        return buildQuote(post, buffer, opts);
-      });
-    },
-
     fillGapBefore(args) {
       return this.get("model.postStream").fillGapBefore(args.post, args.gap);
     },
@@ -1560,6 +1548,19 @@ export default Controller.extend(bufferedProperty("model"), {
   @action
   recoverTopic() {
     this.model.recover();
+  },
+
+  @action
+  buildQuoteMarkdown() {
+    const { postId, buffer, opts } = this.quoteState;
+    const loadedPost = this.get("model.postStream").findLoadedPost(postId);
+    const promise = loadedPost
+      ? Promise.resolve(loadedPost)
+      : this.get("model.postStream").loadPost(postId);
+
+    return promise.then((post) => {
+      return buildQuote(post, buffer, opts);
+    });
   },
 
   deleteTopic(opts = {}) {


### PR DESCRIPTION
Followup to d128dc0e6141e3a813971742f366337432ca9b31,
I swear I tried this locally and it worked, but it turns
out it didn't. Need to keep the `action "function"` syntax
here.
