### PR TITLE
DEV: change header-topic-title-suffix-outlet to insert into span element

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -117,7 +117,7 @@ export default createWidget("header-topic-info", {
       heading.push(
         new RenderGlimmer(
           this,
-          "div",
+          "span.header-topic-title-suffix",
           hbs`<PluginOutlet @name="header-topic-title-suffix" @outletArgs={{@data.outletArgs}}/>`,
           {
             outletArgs: {


### PR DESCRIPTION
This change is more aligned with the intention of the outlet being a suffix to the topic title (and therefore inline) as opposed to a div that by its default block styling fits more with a `header-topic-title-below/after` type outlet.

Also enables simpler styling of suffix elements such as that in https://github.com/discourse/discourse-calendar/pull/474.