### PR TITLE
FIX: correct online indicator for non interactive

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-user-avatar.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-user-avatar.gjs
@@ -56,7 +56,9 @@ export default class ChatUserAvatar extends Component {
           {{this.avatar}}
         </a>
       {{else}}
-        {{this.avatar}}
+        <span class="chat-user-avatar__container">
+          {{this.avatar}}
+        </span>
       {{/if}}
     </div>
   </template>

--- a/plugins/chat/spec/plugin_helper.rb
+++ b/plugins/chat/spec/plugin_helper.rb
@@ -42,7 +42,7 @@ module ChatSystemHelpers
           in_reply_to_id: in_reply_to,
           thread_id: thread_id,
           guardian: last_user.guardian,
-          message: Faker::Lorem.words(number: 5).join(" "),
+          message: Faker::Alphanumeric.alpha(number: SiteSetting.chat_minimum_message_length),
         )
 
       raise "#{creator.inspect_steps.inspect}\n\n#{creator.inspect_steps.error}" if creator.failure?


### PR DESCRIPTION
When introducing non interactive user avatar, the `chat-user-avatar__container` div has been omitted, which prevented the css to correctly apply.


Before:
![Screenshot 2023-11-14 at 11 27 22](https://github.com/discourse/discourse/assets/339945/19312595-f56e-47eb-956c-e0709ade3e2b)

After:
![Screenshot 2023-11-14 at 11 27 01](https://github.com/discourse/discourse/assets/339945/42d477f7-968a-407a-8ad2-494e1605cef2)
