### PR TITLE
FIX: Recompile theme translations when fallback data changes

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 77
+  BASE_COMPILER_VERSION = 78
 
   class SettingsMigrationError < StandardError
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -664,6 +664,8 @@ class ThemeField < ActiveRecord::Base
           name: ThemeField.scss_fields + ThemeField.html_fields,
         )
       )
+    elsif translation_field?
+      return theme.theme_fields.where(target_id: Theme.targets[:translations])
     end
     ThemeField.none
   end


### PR DESCRIPTION
Previously we would only recompile a theme locale when its own data changes. However, the output also includes fallback data from other locales, so we need to invalidate all locales when fallback locale data is changed. Building a list of dependent locales is tricky, so let's just invalidate them all.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
