### PR TITLE
DEV: funnel *.hbr for discourse-hbr

### DIFF
--- a/app/assets/javascripts/discourse-hbr/index.js
+++ b/app/assets/javascripts/discourse-hbr/index.js
@@ -1,11 +1,16 @@
 "use strict";
 
+const Funnel = require("broccoli-funnel");
 const rawHandlebarsCompiler = require("./raw-handlebars-compiler");
 
 module.exports = {
   name: require("./package").name,
 
   treeForApp() {
-    return rawHandlebarsCompiler(this.app.trees.app);
+    const hbr = new Funnel(this.app.trees.app, {
+      include: ["**/*.hbr"],
+    });
+
+    return rawHandlebarsCompiler(hbr);
   },
 };


### PR DESCRIPTION
Previosuly, rawHandlebarsCompiler get the entire app tree as its input. While it is configured to only act on `.hbr` extensions, it still have to process and the files, and more importantly, copy or symlink all of the app files, including those it didn't touch, into its output tree.

<img width="326" alt="Screen_Shot_2023-11-14_at_1 05 54_PM" src="https://github.com/discourse/discourse/assets/55829/2fa8ca9e-d5ad-451b-acef-4f7d58fa0d57">

This seems to cause a great deal of confusion for Embroider in the upcoming release (#24352), which may or may not be a bug, but we really shouldn't be doing that to begin with, and it risks other issues like the copied version of the file stomping over the same file processed by something else.

![Screen_Shot_2023-11-14_at_12 51 16_PM](https://github.com/discourse/discourse/assets/55829/a4227915-ee6c-43dd-bcc4-fdd86b5417d0)

![Screen_Shot_2023-11-14_at_12 56 37_PM](https://github.com/discourse/discourse/assets/55829/d9f7794d-d9e6-4d1f-8a3b-827076f45f26)

![Screen_Shot_2023-11-14_at_12 56 59_PM](https://github.com/discourse/discourse/assets/55829/60b16069-538c-45cc-b07e-2a02f7c95fa0)

This commit funnels down the input tree to just *.hbr files before passing it into the raw handlebars compiler.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
