### PR TITLE
DEV: Run system tests for official themes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,17 @@ jobs:
 
       matrix:
         build_type: [backend, frontend, system, annotations]
-        target: [core, plugins]
+        target: [core, plugins, themes]
         ruby: ["3.2"]
         exclude:
           - build_type: annotations
             target: plugins
+          - build_type: annotations
+            target: themes
+          - build_type: frontend
+            target: themes
+          - build_type: backend
+            target: themes
           - build_type: frontend
             target: core # Handled by core_frontend_tests job (below)
         include:
@@ -112,6 +118,10 @@ jobs:
       - name: Pull compatible versions of plugins
         if: matrix.target == 'plugins'
         run: bin/rake plugin:pull_compatible_all
+
+      - name: Checkout official themes
+        if: matrix.target == 'themes'
+        run: bin/rake themes:clone_all_official
 
       - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
         run: |
@@ -237,10 +247,17 @@ jobs:
           LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
         timeout-minutes: 30
-      
+
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system
+        timeout-minutes: 30
+
+      - name: Theme System Tests
+        if: matrix.build_type == 'system' && matrix.target == 'themes'
+        run: |
+          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --profile=50 --verbose --format documentation tmp/themes/*/spec/system
+        shell: bash
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -194,3 +194,26 @@ ensure
   db&.remove
   redis&.remove
 end
+
+desc "Clones all official themes."
+task "themes:clone_all_official" do |task, args|
+  require "theme_metadata"
+  FileUtils.rm_rf("tmp/themes")
+
+  official_themes =
+    ThemeMetadata::OFFICIAL_THEMES.each do |theme_name|
+      repo = "https://github.com/discourse/#{theme_name}"
+      path = File.expand_path("tmp/themes/#{theme_name}")
+
+      attempts = 0
+
+      begin
+        attempts += 1
+        system("git clone #{repo} #{path}", exception: true)
+      rescue StandardError
+        abort("Failed to clone #{repo}") if attempts >= 3
+        STDERR.puts "Failed to clone #{repo}... trying again..."
+        retry
+      end
+    end
+end

--- a/lib/theme_metadata.rb
+++ b/lib/theme_metadata.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ThemeMetadata
+  OFFICIAL_THEMES =
+    Set.new(
+      %w[
+        discourse-brand-header
+        discourse-category-banners
+        discourse-clickable-topic
+        discourse-color-scheme-toggle
+        discourse-custom-header-links
+        Discourse-easy-footer
+        discourse-gifs
+        discourse-topic-thumbnails
+        discourse-search-banner
+        discourse-unanswered-filter
+        discourse-versatile-banner
+        DiscoTOC
+        unformatted-code-detector
+      ],
+    ).to_a
+end


### PR DESCRIPTION
Why this change?

As the number of themes which the Discourse team supports officially
grows, we want to ensure that changes made to Discourse core do not
break the plugins. As such, we are adding a step to our Github actions
test job to run the system tests for all official themes.

What does this change do?

This change adds a step to our Github actions test job to run the system
tests for all official plugins. This is achieved by the introduction of
the `themes:install_all_official` Rake task which installs all the
themes that are officially supported by the Discourse team.