### PR TITLE
UX: modal > remove obsolete wrapper class

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.hbs
@@ -17,84 +17,83 @@
     {{will-destroy this.cleanupListeners}}
     {{trap-tab preventScroll=false}}
   >
-    <div class="d-modal__wrapper">
-      <div class="d-modal__container">
-        {{yield to="aboveHeader"}}
 
-        {{#if
-          (and
-            (not @hideHeader)
-            (or
-              this.dismissable
-              @title
-              (has-block "headerBelowTitle")
-              (has-block "headerAboveTitle")
-            )
+    <div class="d-modal__container">
+      {{yield to="aboveHeader"}}
+
+      {{#if
+        (and
+          (not @hideHeader)
+          (or
+            this.dismissable
+            @title
+            (has-block "headerBelowTitle")
+            (has-block "headerAboveTitle")
           )
-        }}
-          <div class={{concat-class "d-modal__header" @headerClass}}>
+        )
+      }}
+        <div class={{concat-class "d-modal__header" @headerClass}}>
 
-            {{yield to="headerAboveTitle"}}
+          {{yield to="headerAboveTitle"}}
 
-            {{#if @title}}
-              <div class="d-modal__title">
-                <h3
-                  id="discourse-modal-title"
-                  class="d-modal__title-text"
-                >{{@title}}</h3>
+          {{#if @title}}
+            <div class="d-modal__title">
+              <h3
+                id="discourse-modal-title"
+                class="d-modal__title-text"
+              >{{@title}}</h3>
 
-                {{#if @subtitle}}
-                  <p class="d-modal__subtitle-text">{{@subtitle}}</p>
-                {{/if}}
+              {{#if @subtitle}}
+                <p class="d-modal__subtitle-text">{{@subtitle}}</p>
+              {{/if}}
 
-                {{yield to="belowModalTitle"}}
-              </div>
-            {{/if}}
-            {{yield to="headerBelowTitle"}}
+              {{yield to="belowModalTitle"}}
+            </div>
+          {{/if}}
+          {{yield to="headerBelowTitle"}}
 
-            {{#if this.dismissable}}
-              <DButton
-                @icon="times"
-                @action={{this.handleCloseButton}}
-                @title="modal.close"
-                class="btn-flat modal-close"
-              />
-            {{/if}}
-          </div>
-        {{/if}}
-
-        {{yield to="belowHeader"}}
-
-        {{this.validateFlashType @flashType}}
-        {{#if @flash}}
-          <div
-            id="modal-alert"
-            role="alert"
-            class={{concat-class
-              "alert"
-              (if @flashType (concat "alert-" @flashType))
-            }}
-          >
-            {{~@flash~}}
-          </div>
-        {{/if}}
-
-        <div class={{concat-class "d-modal__body" @bodyClass}} tabindex="-1">
-          {{#if (has-block "body")}}
-            {{yield to="body"}}
-          {{else}}
-            {{yield}}
+          {{#if this.dismissable}}
+            <DButton
+              @icon="times"
+              @action={{this.handleCloseButton}}
+              @title="modal.close"
+              class="btn-flat modal-close"
+            />
           {{/if}}
         </div>
+      {{/if}}
 
-        {{#if (has-block "footer")}}
-          <div class="d-modal__footer">
-            {{yield to="footer"}}
-          </div>
+      {{yield to="belowHeader"}}
+
+      {{this.validateFlashType @flashType}}
+      {{#if @flash}}
+        <div
+          id="modal-alert"
+          role="alert"
+          class={{concat-class
+            "alert"
+            (if @flashType (concat "alert-" @flashType))
+          }}
+        >
+          {{~@flash~}}
+        </div>
+      {{/if}}
+
+      <div class={{concat-class "d-modal__body" @bodyClass}} tabindex="-1">
+        {{#if (has-block "body")}}
+          {{yield to="body"}}
+        {{else}}
+          {{yield}}
         {{/if}}
-
-        {{yield to="belowFooter"}}
       </div>
+
+      {{#if (has-block "footer")}}
+        <div class="d-modal__footer">
+          {{yield to="footer"}}
+        </div>
+      {{/if}}
+
+      {{yield to="belowFooter"}}
     </div>
   </this.dynamicElement>
   {{#unless @inline}}

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -3,23 +3,21 @@
 .d-modal {
   pointer-events: none; // Allow clicks through wrappers so they hit the adjacent backdrop element
 
-  &__wrapper {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    z-index: z("modal", "content");
-    overflow: auto;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  z-index: z("modal", "content");
+  overflow: auto;
 
-    .-inline & {
-      position: relative;
-    }
+  &.-inline {
+    position: relative;
+  }
 
-    html.keyboard-visible body.ios-safari-composer-hacks & {
-      height: calc(var(--composer-vh, 1vh) * 100);
-    }
+  html.keyboard-visible body.ios-safari-composer-hacks & {
+    height: calc(var(--composer-vh, 1vh) * 100);
   }
 
   &__container {

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -266,9 +266,7 @@
 
 .d-modal.chat-modal-new-message {
   .d-modal {
-    &__wrapper {
-      align-items: flex-start;
-    }
+    align-items: flex-start;
     &__container {
       width: var(--modal-max-width);
       margin-top: 1rem;

--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -5,9 +5,6 @@
     width: 100%;
     max-width: 100%;
   }
-  .modal-inner-container {
-    width: 100%;
-  }
 }
 
 //legacy

--- a/spec/system/page_objects/modals/base.rb
+++ b/spec/system/page_objects/modals/base.rb
@@ -25,7 +25,7 @@ module PageObjects
       end
 
       def click_outside
-        find(".d-modal__wrapper").click(x: 0, y: 0)
+        find(".d-modal").click(x: 0, y: 0)
       end
 
       def click_primary_button


### PR DESCRIPTION
A superflous wrapper was interfering with the smoke tests so it had to go.