### PR TITLE
DEV: Reorder custom ember-cli middleware to restore error page

### DIFF
--- a/app/assets/javascripts/bootstrap-json/package.json
+++ b/app/assets/javascripts/bootstrap-json/package.json
@@ -9,9 +9,11 @@
   ],
   "ember-addon": {
     "before": [
-      "serve-files-middleware",
-      "history-support-middleware",
+      "broccoli-serve-files",
       "proxy-server-middleware"
+    ],
+    "after": [
+      "broccoli-watcher"
     ]
   },
   "devDependencies": {

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -70,6 +70,8 @@ module.exports = function (defaults) {
       backburner:
         "node_modules/@discourse/backburner.js/dist/named-amd/backburner.js",
     },
+
+    historySupportMiddleware: false,
   });
 
   // TODO: remove me


### PR DESCRIPTION
Ember-cli has built-in error pages when there is a build error. Previously these were not being used in Discourse because our custom proxy middleware was too early in the stack. This commit reorders things  so that the "broccoli-watcher" middleware runs before our custom proxy. It also disables the `historySupportMiddleware`, which doesn't make sense in our 'always proxy' setup.

<img width="1180" alt="SCR-20231115-lnlg" src="https://github.com/discourse/discourse/assets/6270921/cb703da0-9662-4f9e-afee-9172cd43e9d7">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
