### PR TITLE
UX: html-safe dialog.message, clarify poll error

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/components/dialog-holder.hbs
+++ b/app/assets/javascripts/dialog-holder/addon/components/dialog-holder.hbs
@@ -27,7 +27,7 @@
               @model={{this.dialog.bodyComponentModel}}
             />
           {{else if this.dialog.message}}
-            <p>{{this.dialog.message}}</p>
+            <p>{{html-safe this.dialog.message}}</p>
           {{/if}}
         </div>
       {{/if}}

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -12,7 +12,7 @@ en:
     poll: "poll"
     invalid_argument: "Invalid value '%{value}' for argument '%{argument}'."
 
-    multiple_polls_without_name: "There are multiple polls without a name. Use the '<code>name</code>' attribute to uniquely identify your polls."
+    multiple_polls_without_name: "When creating multiple polls, include unique names by adding <code>name=example</code> to your <code>[poll]</code> tags."
     multiple_polls_with_same_name: "There are multiple polls with the same name: <strong>%{name}</strong>. Use the '<code>name</code>' attribute to uniquely identify your polls."
 
     default_poll_must_have_at_least_1_option: "Poll must have at least 1 option."


### PR DESCRIPTION
Before:
![Screenshot 2023-11-15 at 11 14 56 AM](https://github.com/discourse/discourse/assets/1681963/bc591572-cbeb-4148-96ca-87a5a4f7692d)


After:
![Screenshot 2023-11-15 at 11 14 20 AM](https://github.com/discourse/discourse/assets/1681963/f22710cf-3bdc-44b0-823f-e13aac3a4ad2)


Reported here: https://meta.discourse.org/t/multiple-polls-misleading-unique-name-error/285581