### PR TITLE
FIX: Redirect to highlighted search result on `Enter`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
@@ -23,24 +23,33 @@ export default class Types extends Component {
 
   @action
   onClick(event) {
+    this.routeToSearchResult(event);
+  }
+
+  @action
+  onKeydown(event) {
+    if (event.key === "Escape") {
+      this.args.closeSearchMenu();
+      event.preventDefault();
+      return false;
+    } else if (event.key === "Enter") {
+      this.routeToSearchResult(event);
+      return false;
+    }
+
+    this.search.handleResultInsertion(event);
+    this.search.handleArrowUpOrDown(event);
+  }
+
+  @action
+  routeToSearchResult(event) {
     if (wantsNewWindow(event)) {
       return;
     }
 
     event.preventDefault();
-    DiscourseURL.routeTo(event.currentTarget.href);
+    event.stopPropagation();
+    DiscourseURL.routeTo(event.target.href);
     this.args.closeSearchMenu();
-  }
-
-  @action
-  onKeydown(e) {
-    if (e.key === "Escape") {
-      this.args.closeSearchMenu();
-      e.preventDefault();
-      return false;
-    }
-
-    this.search.handleResultInsertion(e);
-    this.search.handleArrowUpOrDown(e);
   }
 }


### PR DESCRIPTION
Raised in https://meta.discourse.org/t/keyboard-navigation-messes-up-the-search-menu/285405

We were incorrectly accessing the highlighted search result target's href which caused issues when navigating the topic list (eg /latest) with **j / k** and then immediately after accessing the search menu and navigating to and selecting a search result with the keyboard.  

### Current Behavior
Hitting enter on a search result redirects to the href of the topic in the topic list that was previously highlighted.

### Expected Behavior
Hitting enter on a search result redirects to the href of the highlighted search result.