### PR TITLE
Unfinished RenderComponent widgets exploration

### DIFF
--- a/app/assets/javascripts/chat-lite/src/widgets/header-icons/chat-lite.gjs
+++ b/app/assets/javascripts/chat-lite/src/widgets/header-icons/chat-lite.gjs
@@ -1,0 +1,18 @@
+import { icon } from "discourse-plugin/helper";
+import { service } from "discourse-plugin/service";
+import Widget from "discourse-plugin/widget";
+import ChatService from "../../services/chat";
+
+export default class ChatLiteHeaderIcon extends Widget {
+  @service(ChatService) chat;
+
+  get isActive() {
+    return this.chat.userCanChat;
+  }
+
+  <template>
+    <li class="header-dropdown-toggle chat-header-icon">
+      {{icon "birthday-cake"}}
+    </li>
+  </template>
+}

--- a/app/assets/javascripts/discourse-plugin/src/widget/index.js
+++ b/app/assets/javascripts/discourse-plugin/src/widget/index.js
@@ -1,0 +1,54 @@
+import { setOwner } from "@ember/application";
+import {
+  capabilities,
+  getComponentTemplate,
+  setComponentManager,
+  setComponentTemplate,
+} from "@ember/component";
+import { assert } from "@ember/debug";
+
+export default class Widget {
+  static {
+    const WidgetComponentManager = {
+      capabilities: capabilities("3.13", {
+        asyncLifecycleCallbacks: false,
+        destructor: false,
+        updateHook: false,
+      }),
+
+      createComponent(widget) {
+        assert("Must not be null", widget !== null);
+        assert("Must be an object", typeof widget === "object");
+        assert("Must be an instance of Widget", #widget in widget);
+        return widget;
+      },
+
+      getContext(widget) {
+        assert("Must not be null", widget !== null);
+        assert("Must be an object", typeof widget === "object");
+        assert("Must be an instance of Widget", #widget in widget);
+        return widget;
+      },
+    };
+
+    setComponentManager(() => WidgetComponentManager, this.prototype);
+  }
+
+  #widget = true;
+
+  constructor(owner) {
+    setOwner(this, owner);
+
+    if (getComponentTemplate(this) === undefined) {
+      const Template = getComponentTemplate(this.constructor);
+
+      if (Template) {
+        setComponentTemplate(Template, this.constructor.prototype);
+      }
+    }
+  }
+
+  get isActive() {
+    return true;
+  }
+}

--- a/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
+++ b/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
@@ -6,6 +6,117 @@ import { createWidgetFrom } from "discourse/widgets/widget";
 
 const INITIAL_CLASSES = Symbol("RENDER_GLIMMER_INITIAL_CLASSES");
 
+export class RenderComponent {
+  /**
+   * Create a RenderComponent instance
+   * @param widget - the widget instance which is rendering this content
+   * @param renderInto - a string describing a new wrapper element (e.g. `div.my-class`),
+   *  or an existing HTML element to append content into.
+   * @param component - a component to render
+   * @param data - will be made available at `@data` in your template
+   */
+  constructor(widget, renderInto, component, data) {
+    this.renderInto = renderInto;
+    if (widget) {
+      this.widget = widget;
+    }
+    this.component = component;
+    this.data = data;
+  }
+
+  init() {
+    if (this.renderInto instanceof Element) {
+      this.element = this.renderInto;
+    } else {
+      const [type, ...classNames] = this.renderInto.split(".");
+      this.element = document.createElement(type);
+      this.element.classList.add(...classNames);
+      this.element[INITIAL_CLASSES] = classNames;
+    }
+    this.connectComponent();
+    return this.element;
+  }
+
+  destroy() {
+    if (this._componentInfo) {
+      this.parentMountWidgetComponent.unmountChildComponent(
+        this._componentInfo
+      );
+    }
+  }
+
+  update(prev) {
+    if (
+      prev.component !== this.component ||
+      prev.renderInto !== this.renderInto
+    ) {
+      // Totally different component, but the widget framework guessed it was the
+      // same widget. Destroy old component and re-init the new one.
+      prev.destroy();
+      return this.init();
+    }
+
+    this._componentInfo = prev._componentInfo;
+    if (prev.data !== this.data) {
+      this._componentInfo.data = this.data;
+    }
+
+    return null;
+  }
+
+  connectComponent() {
+    const { element, component } = this;
+
+    this._componentInfo = {
+      element,
+      component,
+      @tracked data: this.data,
+      setWrapperElementAttrs: (attrs) =>
+        this.updateElementAttrs(element, attrs),
+    };
+
+    this.parentMountWidgetComponent.mountChildComponent(this._componentInfo);
+  }
+
+  updateElementAttrs(element, attrs) {
+    for (let [key, value] of Object.entries(attrs)) {
+      if (key === "class") {
+        value = [element[INITIAL_CLASSES], value].filter(Boolean).join(" ");
+      }
+
+      if ([null, undefined].includes(value)) {
+        element.removeAttribute(key);
+      } else {
+        element.setAttribute(key, value);
+      }
+    }
+  }
+
+  get parentMountWidgetComponent() {
+    return this.widget?._findView() || this._emberView;
+  }
+}
+
+RenderComponent.prototype.type = "Widget";
+
+export function registerComponentWidgetShim(name, tagName, component) {
+  const RenderComponentShim = class MyClass extends RenderComponent {
+    constructor(attrs) {
+      super(null, tagName, component, attrs);
+      return this;
+    }
+
+    get widget() {
+      return this.parentWidget;
+    }
+
+    didRenderWidget() {}
+    willRerenderWidget() {}
+  };
+
+  createWidgetFrom(RenderComponentShim, name, {});
+}
+
 /*
 
 This class allows you to render arbitrary Glimmer templates inside widgets.
@@ -82,8 +193,7 @@ hbs`{{@setWrapperElementAttrs class="some class value" title="title value"}}`
 If you prefer, you can pass this function down into your own components, and call it from there. Invoked as a helper, this can
 be passed (auto-)tracked values, and will update the wrapper element attributes whenever the inputs.
 */
-
-export default class RenderGlimmer {
+export default class RenderGlimmer extends RenderComponent {
   /**
    * Create a RenderGlimmer instance
    * @param widget - the widget instance which is rendering this content
@@ -97,92 +207,14 @@ export default class RenderGlimmer {
       "`template` should be a template compiled via `ember-cli-htmlbars`",
       template.name === "factory"
     );
-    this.renderInto = renderInto;
-    if (widget) {
-      this.widget = widget;
-    }
-    this.template = template;
-    this.data = data;
-  }
-
-  init() {
-    if (this.renderInto instanceof Element) {
-      this.element = this.renderInto;
-    } else {
-      const [type, ...classNames] = this.renderInto.split(".");
-      this.element = document.createElement(type);
-      this.element.classList.add(...classNames);
-      this.element[INITIAL_CLASSES] = classNames;
-    }
-    this.connectComponent();
-    return this.element;
-  }
-
-  destroy() {
-    if (this._componentInfo) {
-      this.parentMountWidgetComponent.unmountChildComponent(
-        this._componentInfo
-      );
-    }
-  }
-
-  update(prev) {
-    if (
-      prev.template.__id !== this.template.__id ||
-      prev.renderInto !== this.renderInto
-    ) {
-      // Totally different component, but the widget framework guessed it was the
-      // same widget. Destroy old component and re-init the new one.
-      prev.destroy();
-      return this.init();
-    }
-
-    this._componentInfo = prev._componentInfo;
-    if (prev.data !== this.data) {
-      this._componentInfo.data = this.data;
-    }
-
-    return null;
-  }
-
-  connectComponent() {
-    const { element, template } = this;
 
     const component = templateOnly();
     component.name = "Widgets/RenderGlimmer";
     setComponentTemplate(template, component);
 
-    this._componentInfo = {
-      element,
-      component,
-      @tracked data: this.data,
-      setWrapperElementAttrs: (attrs) =>
-        this.updateElementAttrs(element, attrs),
-    };
-
-    this.parentMountWidgetComponent.mountChildComponent(this._componentInfo);
-  }
-
-  updateElementAttrs(element, attrs) {
-    for (let [key, value] of Object.entries(attrs)) {
-      if (key === "class") {
-        value = [element[INITIAL_CLASSES], value].filter(Boolean).join(" ");
-      }
-
-      if ([null, undefined].includes(value)) {
-        element.removeAttribute(key);
-      } else {
-        element.setAttribute(key, value);
-      }
-    }
-  }
-
-  get parentMountWidgetComponent() {
-    return this.widget?._findView() || this._emberView;
+    super(widget, renderInto, component, data);
   }
 }
-
-RenderGlimmer.prototype.type = "Widget";
 
 /**
  * Define a widget shim which renders a Glimmer template. Designed for incrementally migrating


### PR DESCRIPTION
Unfinihsed attempt in allowing widgets to render components, which could, in the simple case, allow `<template>...</template>` in place of hbs`...`, but also in the more complex cases allow rendering a full class based component with its own `@tracked` and everything taken care of. As far as I can tell it's pretty much already set up for it.

The other side (not directly related to or necessary for the ability to render components in general) of the exploration is to allow for us to pre-instantiate a component, or in other words, rendere an already instantiated component `{{this.component}}`, where `this.component` is an instance, not a class. This is sometimes needed when we have additional JS APIs that we want to call on the object before deciding whether to render or not, because, e.g. the widget can opt out-of being rendered, but if it had just disabled itself with `{{#if}}...{{/if}}` it would have left behind an empty wrapper and/or event handling infrastructure, etc aroud it.

That stuff is in the unfinished Widget base class and is basically copied from my work in `ember-polaris-routing`, where the route wants to be a component, but the router wants to instantiate it in JS land well before rendering has a chance to happen.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
