### PR TITLE
DEV: Remove `category-macro`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/category-macro.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/category-macro.js
@@ -1,8 +1,0 @@
-import { computed, get } from "@ember/object";
-import Category from "discourse/models/category";
-
-export default function categoryFromId(property) {
-  return computed(property, function () {
-    return Category.findById(get(this, property));
-  });
-}

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -10,9 +10,9 @@ import RestModel from "discourse/models/rest";
 import Topic from "discourse/models/topic";
 import User from "discourse/models/user";
 import getURL from "discourse-common/lib/get-url";
-import categoryFromId from "discourse-common/utils/category-macro";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
+import Category from "./category";
 
 export const AUTO_DELETE_PREFERENCES = {
   NEVER: 0,
@@ -125,7 +125,10 @@ const Bookmark = RestModel.extend({
     return newTags;
   },
 
-  category: categoryFromId("category_id"),
+  @computed("category_id")
+  get category() {
+    return Category.findById(this.category_id);
+  },
 
   @discourseComputed("reminder_at", "currentUser")
   formattedReminder(bookmarkReminderAt, currentUser) {

--- a/app/assets/javascripts/discourse/app/models/pending-post.js
+++ b/app/assets/javascripts/discourse/app/models/pending-post.js
@@ -2,8 +2,8 @@ import { reads } from "@ember/object/computed";
 import { cook } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
 import RestModel from "discourse/models/rest";
-import categoryFromId from "discourse-common/utils/category-macro";
 import discourseComputed from "discourse-common/utils/decorators";
+import Category from "./category";
 
 const PendingPost = RestModel.extend({
   expandedExcerpt: null,
@@ -22,7 +22,10 @@ const PendingPost = RestModel.extend({
     return userPath(username.toLowerCase());
   },
 
-  category: categoryFromId("category_id"),
+  @discourseComputed("category_id")
+  category() {
+    return Category.findById(this.category_id);
+  },
 });
 
 export default PendingPost;

--- a/app/assets/javascripts/discourse/app/models/reviewable.js
+++ b/app/assets/javascripts/discourse/app/models/reviewable.js
@@ -2,9 +2,9 @@ import { dasherize, underscore } from "@ember/string";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import RestModel from "discourse/models/rest";
-import categoryFromId from "discourse-common/utils/category-macro";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
+import Category from "./category";
 
 export const PENDING = 0;
 export const APPROVED = 1;
@@ -68,7 +68,10 @@ const Reviewable = RestModel.extend({
     });
   },
 
-  category: categoryFromId("category_id"),
+  @discourseComputed("category_id")
+  category() {
+    return Category.findById(this.category_id);
+  },
 
   update(updates) {
     // If no changes, do nothing

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -20,9 +20,9 @@ import { flushMap } from "discourse/services/store";
 import deprecated from "discourse-common/lib/deprecated";
 import getURL from "discourse-common/lib/get-url";
 import { deepMerge } from "discourse-common/lib/object";
-import categoryFromId from "discourse-common/utils/category-macro";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
+import Category from "./category";
 
 export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);
@@ -213,7 +213,10 @@ const Topic = RestModel.extend({
     return { type: "topic", id };
   },
 
-  category: categoryFromId("category_id"),
+  @discourseComputed("category_id")
+  category() {
+    return Category.findById(this.category_id);
+  },
 
   @discourseComputed("url")
   shareUrl(url) {

--- a/app/assets/javascripts/discourse/app/models/user-action.js
+++ b/app/assets/javascripts/discourse/app/models/user-action.js
@@ -4,8 +4,8 @@ import { postUrl } from "discourse/lib/utilities";
 import RestModel from "discourse/models/rest";
 import User from "discourse/models/user";
 import UserActionGroup from "discourse/models/user-action-group";
-import categoryFromId from "discourse-common/utils/category-macro";
 import discourseComputed from "discourse-common/utils/decorators";
+import Category from "./category";
 
 const UserActionTypes = {
   likes_given: 1,
@@ -27,7 +27,10 @@ Object.keys(UserActionTypes).forEach(
 );
 
 const UserAction = RestModel.extend({
-  category: categoryFromId("category_id"),
+  @discourseComputed("category_id")
+  category() {
+    return Category.findById(this.category_id);
+  },
 
   @discourseComputed("action_type")
   descriptionKey(action) {


### PR DESCRIPTION
This discourse-common decorator was dependent on the core app, hence creating a circular reference that was breaking the embroider upgrade. (see: #24391)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
