### PR TITLE
DEV: Improve QUnit acceptance assertion for flaky test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -80,19 +80,30 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
     `;
 
     await triggerKeyEvent(document, "keypress", "J");
+
     assert
-      .dom(".post-stream .topic-post.selected #post_1")
-      .exists("first post is selected");
+      .dom(".post-stream .topic-post.selected article")
+      .hasAttribute("id", "post_1", "first post is selected");
 
     await triggerKeyEvent(document, "keypress", "J");
+
     assert
-      .dom(".post-stream .topic-post.selected #post_4")
-      .exists("pressing j moves selection to next visible post");
+      .dom(".post-stream .topic-post.selected article")
+      .hasAttribute(
+        "id",
+        "post_4",
+        "pressing j moves selection to next visible post"
+      );
 
     await triggerKeyEvent(document, "keypress", "K");
+
     assert
-      .dom(".post-stream .topic-post.selected #post_1")
-      .exists("pressing k moves selection to previous visible post");
+      .dom(".post-stream .topic-post.selected article")
+      .hasAttribute(
+        "id",
+        "post_1",
+        "pressing k moves selection to previous visible post"
+      );
   });
 });
 


### PR DESCRIPTION
Why this change?

This test has been flaky on CI: https://github.com/discourse/discourse/actions/runs/6880353258/job/18714366795
However, the way the current assertions are written does not really
allow us to easily figure out what went wrong since we only know that
`#post_4` was not selected. It will be useful to know what was selected
instead of `#post_4` when the test fails.

What does this change do?

This change updates the assertion of the flaky test to reveal which post
was selected should the test fail.