### PR TITLE
Fix: Handle failing to update parent category

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -97,6 +97,7 @@ export default Controller.extend({
       );
 
       this.set("saving", true);
+      const previousParentCategory = model.get("parentCategory");
       model.set("parentCategory", parentCategory);
 
       model
@@ -118,6 +119,8 @@ export default Controller.extend({
         .catch((error) => {
           popupAjaxError(error);
           this.set("saving", false);
+          model.set("parent_category_id", undefined);
+          model.set("parentCategory", previousParentCategory);
         });
     },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -180,6 +180,36 @@ acceptance("Category Edit", function (needs) {
     assert.ok(!visible(".dialog-body"));
   });
 
+  test("Nested subcategory error when saving", async function (assert) {
+    await visit("/c/bug/edit");
+
+    const categoryChooser = selectKit(".category-chooser.single-select");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(1002);
+
+    await click("#save-category");
+
+    assert.strictEqual(
+      query(".dialog-body").textContent.trim(),
+      I18n.t("generic_error_with_reason", {
+        error: "subcategory nested under another subcategory",
+      })
+    );
+
+    await click(".dialog-footer .btn-primary");
+    assert.ok(!visible(".dialog-body"));
+
+    assert.ok(
+      !visible(".category-breadcrumb .category-drop-header[data-value='1002']"),
+      "it doesn't show the nested subcategory in the breadcrumb"
+    );
+
+    assert.ok(
+      !visible(".category-breadcrumb .single-select-header[data-value='1002']"),
+      "it clears the category chooser"
+    );
+  });
+
   test("Subcategory list settings", async function (assert) {
     await visit("/c/bug/edit/settings");
 

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -462,6 +462,12 @@ export function applyDefaultHandlers(pretender) {
       return response(422, { errors: ["duplicate email"] });
     }
 
+    if (category.parent_category_id === 1002) {
+      return response(422, {
+        errors: ["subcategory nested under another subcategory"],
+      });
+    }
+
     return response({ category });
   });
 


### PR DESCRIPTION
Fix  https://meta.discourse.org/t/category-selectors-shouldnt-be-updated-when-selecting-and-failing-to-set-a-parent-category/274324/4