### PR TITLE
Fix server.zh_CN.yml translation

### DIFF
--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -189,7 +189,7 @@ zh_CN:
       too_long:
         other: 过长（最多 %{count} 个字符）
       too_short:
-        other: 过短（最多 %{count} 个字符）
+        other: 过短（最少 %{count} 个字符）
       wrong_length:
         other: 长度错误（应为 %{count} 个字符）
       other_than: "必须不为 %{count}"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

`过短` and `最多` are a pair of antonyms，the correct usage should be '过短（最少 %{count} 个字符）'
