### PR TITLE
DEV: Respect `SKIP_TEST_DATABASE` when running `rake db:create`

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -20,7 +20,8 @@ module MultisiteTestHelpers
   end
 
   def self.create_multisite?
-    (ENV["RAILS_ENV"] == "test" || !ENV["RAILS_ENV"]) && !ENV["RAILS_DB"] && !ENV["SKIP_MULTISITE"]
+    (ENV["RAILS_ENV"] == "test" || !ENV["RAILS_ENV"]) && !ENV["RAILS_DB"] &&
+      !ENV["SKIP_MULTISITE"] && !ENV["SKIP_TEST_DATABASE"]
   end
 end
 


### PR DESCRIPTION
Why this change?

By default the `db:create` Rake task in activerecord creates the
databases for both the development and test environment. This while
seemingly odd is by design from Rails. In order to avoid creating the
test database, Rails supports the `SKIP_TEST_DATABASE` environment
variable which we should respect when creating the multisite test
database.

See [https://github.com/rails/rails/issues/27299](https://github.com/rails/rails/issues/27299#issuecomment-1214684427) for the discussion.