### PR TITLE
DEV: Refactor `/my/*` redirect handling

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/url-redirects.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/url-redirects.js
@@ -10,8 +10,16 @@ export default {
     DiscourseURL.rewrite(/^\/groups$/, "/g");
     DiscourseURL.rewrite(/^\/groups\//, "/g/");
 
-    // Initialize default homepage
+    const currentUser = owner.lookup("service:current-user");
     let siteSettings = owner.lookup("service:site-settings");
+
+    // Setup `/my` redirects
+    if (currentUser) {
+      DiscourseURL.rewrite(/^\/my\//, `/u/${currentUser.username_lower}/`);
+    } else {
+      DiscourseURL.rewrite(/^\/my\/.*/, "/login-preferences");
+    }
+
     initializeDefaultHomepage(siteSettings);
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -8,7 +8,6 @@ import offsetCalculator from "discourse/lib/offset-calculator";
 import { defaultHomepage } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Session from "discourse/models/session";
-import User from "discourse/models/user";
 import { isTesting } from "discourse-common/config/environment";
 import getURL, { withoutPrefix } from "discourse-common/lib/get-url";
 
@@ -226,21 +225,6 @@ const DiscourseURL = EmberObject.extend({
     const oldPath = this.router.currentURL;
 
     path = path.replace(/(https?\:)?\/\/[^\/]+/, "");
-
-    // Rewrite /my/* urls
-    let myPath = getURL("/my/");
-    const fullPath = getURL(path);
-    if (fullPath.startsWith(myPath)) {
-      const currentUser = User.current();
-      if (currentUser) {
-        path = fullPath.replace(
-          myPath,
-          `${userPath(currentUser.get("username_lower"))}/`
-        );
-      } else {
-        return this.redirectTo("/login-preferences");
-      }
-    }
 
     // handle prefixes
     if (path.startsWith("/")) {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
@@ -146,6 +146,9 @@ acceptance("Group Members", function (needs) {
   });
 });
 
+/**
+ * Workaround for https://github.com/tildeio/router.js/pull/335
+ */
 async function visitWithRedirects(url) {
   try {
     await visit(url);
@@ -154,6 +157,7 @@ async function visitWithRedirects(url) {
     if (message !== "TransitionAborted") {
       throw error;
     }
+    await settled();
   }
 }
 


### PR DESCRIPTION
This change means that the `/my` redirects will be handled by the ember 'unknown' route, and will therefore function correctly when using pure-ember transition methods like `router.transitionTo`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
