### PR TITLE
UX: small alignment tweaks for chat thread list header

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-thread-header.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-header.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  padding-inline: 1rem 0.5rem;
+  padding-inline: 0.5rem;
 
   .touch & {
     &__label {

--- a/plugins/chat/assets/stylesheets/mobile/chat-thread-list-header.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-thread-list-header.scss
@@ -1,0 +1,12 @@
+.chat-thread-list-header {
+  padding-inline: 0 0.5rem;
+  align-items: flex-start;
+
+  &__label {
+    padding-top: 0.35em;
+  }
+
+  &__label-channel {
+    line-height: var(--line-height-small);
+  }
+}

--- a/plugins/chat/assets/stylesheets/mobile/index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/index.scss
@@ -17,3 +17,4 @@
 @import "chat-channel-settings";
 @import "chat-form";
 @import "chat-modal-new-message";
+@import "chat-thread-list-header";


### PR DESCRIPTION
Before:
<img width="411" alt="image" src="https://github.com/discourse/discourse/assets/101828855/86bf4594-94bf-4497-a115-a01bdf91acb7">

After:
<img width="356" alt="image" src="https://github.com/discourse/discourse/assets/101828855/b49c777e-ef0a-457b-b183-cc5baf9c3123">


