### PR TITLE
DEV: Remove sidebar homepage workaround

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -1,6 +1,5 @@
 import { tracked } from "@glimmer/tracking";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
-import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class SectionLink {
   @tracked linkDragCss;
@@ -23,12 +22,7 @@ export default class SectionLink {
     if (!this.externalOrFullReload) {
       const routeInfoHelper = new RouteInfoHelper(router, value);
 
-      if (routeInfoHelper.route === "discovery.index") {
-        this.route = `discovery.${defaultHomepage()}`;
-      } else {
-        this.route = routeInfoHelper.route;
-      }
-
+      this.route = routeInfoHelper.route;
       this.models = routeInfoHelper.models;
       this.query = routeInfoHelper.query;
     }


### PR DESCRIPTION
In the past, routing to the homepage using Ember was problematic. Following 575c2c8573, Ember can now route to the homepage successfully, and so these sidebar workarounds are no longer required.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
