### PR TITLE
DEV: Unskip flaky editing sidebar nav menu categories on mobile test

### DIFF
--- a/spec/system/editing_sidebar_categories_navigation_spec.rb
+++ b/spec/system/editing_sidebar_categories_navigation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
   before { sign_in(user) }
 
   shared_examples "a user can edit the sidebar categories navigation" do |mobile|
-    xit "allows a user to edit the sidebar categories navigation", mobile: mobile do
+    it "allows a user to edit the sidebar categories navigation", mobile: mobile do
       visit "/latest"
 
       sidebar.open_on_mobile if mobile

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -6,7 +6,7 @@ module PageObjects
       class Sidebar < Base
         def open_on_mobile
           click_button("toggle-hamburger-menu")
-          page.has_no_css?("div.menu-panel.animating")
+          wait_for_animation(find("div.menu-panel"))
         end
 
         def visible?


### PR DESCRIPTION
Why this change?

The test became flaky due to d208396c5c495301cf301426a4166006ffb1d285.
In that commit, we introduced `page.has_no_css?("div.menu-panel.animating")` to `PageObjects::Components::NavigationMenu::Sidebar#open_on_mobile` but
it did not work as intended because `page.has_no_css?("div.menu-panel.animating")` can return `true` immediately as the `animating` class has not been added
to the element.

What does this change do?

Switch to the `wait_for_animation` system helper to ensure that all
animations have ended on the element.