### PR TITLE
DEV: Silence successful database migration output in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Restore database from cache
         if: steps.app-cache.outputs.cache-hit == 'true'
-        run: psql --quiet -o /dev/null -f tmp/app-cache/cache.sql postgres
+        run: script/silence_successful_output psql --quiet -o /dev/null -f tmp/app-cache/cache.sql postgres
 
       - name: Restore uploads from cache
         if: steps.app-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,7 @@ jobs:
           env.USES_PARALLEL_DATABASES == 'true' &&
           steps.app-cache.outputs.cache-hit != 'true'
         run: |
-          script/silence_successful_output bin/rake parallel:create
+          bin/rake parallel:create
           script/silence_successful_output bin/rake parallel:migrate
 
       - name: Dump database for cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,16 +150,16 @@ jobs:
       - name: Create and migrate database
         if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
-          bin/rake db:create
-          bin/rake db:migrate
+          script/silence_successful_output bin/rake db:create
+          script/silence_successful_output bin/rake db:migrate
 
       - name: Create and migrate parallel databases
         if: >-
           env.USES_PARALLEL_DATABASES == 'true' &&
           steps.app-cache.outputs.cache-hit != 'true'
         run: |
-          bin/rake parallel:create
-          bin/rake parallel:migrate
+          script/silence_successful_output bin/rake parallel:create
+          script/silence_successful_output bin/rake parallel:migrate
 
       - name: Dump database for cache
         if: steps.app-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Create and migrate database
         if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
-          script/silence_successful_output bin/rake db:create
+          bin/rake db:create
           script/silence_successful_output bin/rake db:migrate
 
       - name: Create and migrate parallel databases

--- a/script/silence_successful_output
+++ b/script/silence_successful_output
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run a command and write stdout/stderr to a temporary file. Print the output only if the command exits with a non-zero exit status
+
+tmp=$(mktemp)
+
+echo "[silence_successful_output] Running '$@' with output silenced..." >&2
+
+("$@") 2>&1 &> "$tmp"
+STATUS=$?
+
+if (( $STATUS )) ; then
+  echo "[silence_successful_output] '$@' failed! Output:" >&2
+  cat "$tmp" >&2
+else
+  echo "[silence_successful_output] '$@' succeeded!"
+fi
+
+rm "$tmp"
+
+exit $STATUS


### PR DESCRIPTION
The output of db:migrate for a new database is 20k+ lines. We only need the output when an error occurs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
