### PR TITLE
UX: composer category dropdown height, truncation

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -270,22 +270,20 @@ html.composer-open {
         max-width: 450px;
       }
 
-      // below needed for text-overflow: ellipsis;
       .selected-name {
         max-width: 100%;
         overflow: hidden;
         .name {
-          max-width: 100%;
-          overflow: hidden;
           display: flex;
+          font-size: var(--font-up-1);
+          max-width: 100%;
           gap: 0 0.5em;
-          .badge-category__wrapper {
+          .badge-category {
             overflow: hidden;
           }
           // This prevents the first category from being too-truncated at the expense of a long subcategory
-          .badge-category__wrapper:first-of-type:not(:last-of-type) {
-            flex: 1 0 auto;
-            max-width: 50%;
+          > span:last-of-type:not(:first-of-type) {
+            flex-shrink: 10;
           }
         }
       }


### PR DESCRIPTION
Follow-up to 797da58

This fixes the dropdown height, as well as the category truncation when names are too long: 

Before:
![Screenshot 2023-11-16 at 3 55 45 PM](https://github.com/discourse/discourse/assets/1681963/1627b78f-b0d0-4144-b793-ede3aa064987)


After:
![Screenshot 2023-11-16 at 3 24 16 PM](https://github.com/discourse/discourse/assets/1681963/1221e75e-fef3-47fb-b8ca-ae3f980e890a)
