### PR TITLE
DEV: Add support for limit in notifications index w/o recent param

### DIFF
--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -90,10 +90,32 @@ RSpec.describe NotificationsController do
         describe "when limit params is invalid" do
           include_examples "invalid limit params",
                            "/notifications.json",
-                           described_class::INDEX_LIMIT,
+                           described_class::INDEX_LIMIT + 1,
                            params: {
                              recent: true,
                            }
+        end
+
+        it "respects limit param and properly bumps offset for load_more_notifications URL" do
+          7.times { notification = Fabricate(:notification, user: user) }
+
+          get "/notifications.json", params: { filter: :all, username: user.username, limit: 2 }
+          expect(response.parsed_body["notifications"].count).to eq(2)
+          expect(response.parsed_body["load_more_notifications"]).to eq(
+            "/notifications?filter=all&limit=2&offset=2&username=#{user.username}",
+          )
+
+          # Same as response above but we need .json added before query params.
+          get "/notifications.json?filter=all&limit=2&offset=2&username=#{user.username}"
+          expect(response.parsed_body["load_more_notifications"]).to eq(
+            "/notifications?filter=all&limit=2&offset=4&username=#{user.username}",
+          )
+
+          # We are seeing that the offset is increasing properly and limit is staying the same
+          get "/notifications.json?filter=all&limit=2&offset=4&username=#{user.username}"
+          expect(response.parsed_body["load_more_notifications"]).to eq(
+            "/notifications?filter=all&limit=2&offset=6&username=#{user.username}",
+          )
         end
 
         it "get notifications with all filters" do

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -99,22 +99,22 @@ RSpec.describe NotificationsController do
         it "respects limit param and properly bumps offset for load_more_notifications URL" do
           7.times { notification = Fabricate(:notification, user: user) }
 
-          get "/notifications.json", params: { filter: :all, username: user.username, limit: 2 }
+          get "/notifications.json", params: { username: user.username, limit: 2 }
           expect(response.parsed_body["notifications"].count).to eq(2)
           expect(response.parsed_body["load_more_notifications"]).to eq(
-            "/notifications?filter=all&limit=2&offset=2&username=#{user.username}",
+            "/notifications?limit=2&offset=2&username=#{user.username}",
           )
 
           # Same as response above but we need .json added before query params.
-          get "/notifications.json?filter=all&limit=2&offset=2&username=#{user.username}"
+          get "/notifications.json?limit=2&offset=2&username=#{user.username}"
           expect(response.parsed_body["load_more_notifications"]).to eq(
-            "/notifications?filter=all&limit=2&offset=4&username=#{user.username}",
+            "/notifications?limit=2&offset=4&username=#{user.username}",
           )
 
           # We are seeing that the offset is increasing properly and limit is staying the same
-          get "/notifications.json?filter=all&limit=2&offset=4&username=#{user.username}"
+          get "/notifications.json?limit=2&offset=4&username=#{user.username}"
           expect(response.parsed_body["load_more_notifications"]).to eq(
-            "/notifications?filter=all&limit=2&offset=6&username=#{user.username}",
+            "/notifications?limit=2&offset=6&username=#{user.username}",
           )
         end
 


### PR DESCRIPTION
Currently to use a `limit` in the notifications index, you have to _also_ pass `recent: true` as a param.

This PR:
* Adds optional limit param to be used in the notifications query, regardless of the presence of `recent`
* Raises the max limit of the response with `recent` present from `50` -> `60`. It is super weird we have a hard-limit of 50 before with `recent` param, and 60 without the param.

Don't @ me or something 