### PR TITLE
DEV: Fix flaky fast edit keyboard shortcut QUnit test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -45,6 +45,9 @@ acceptance("Fast Edit", function (needs) {
     const textNode = query("#post_1 .cooked p").childNodes[0];
 
     await selectText(textNode, 9);
+
+    assert.dom(".quote-button").exists();
+
     await triggerKeyEvent(document, "keypress", "E");
 
     assert.dom("#fast-edit-input").exists();
@@ -60,7 +63,11 @@ acceptance("Fast Edit", function (needs) {
 
     // Closing
     await selectText(textNode, 9);
+
+    assert.dom(".quote-button").exists();
+
     await triggerKeyEvent(document, "keypress", "E");
+
     assert.dom("#fast-edit-input").exists();
 
     await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");


### PR DESCRIPTION
Why this change?

The test has been flaky on CI with the following assertion failing:

https://github.com/discourse/discourse/actions/runs/6897881042/job/18766867472?pr=24424

```
not ok 302 Firefox 115.0 - [899 ms] - Browser Id 5 - Acceptance: Fast Edit: Works with keyboard shortcut
    ---
        actual: >
            Element #fast-edit-input does not exist
        expected: >
            Element #fast-edit-input exists
```

The hypothesis here is that we are triggering the `E` keypress event
before the `.quote-button` menu has appeared. When that happens, we will
end up opening the composer instead of triggering the fast edit editor.