### PR TITLE
UX: pointer cursor on custom sidebar link icon

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -5,10 +5,6 @@
   .sidebar-section-header {
     display: flex;
   }
-
-  .sidebar-section-link-prefix.icon {
-    cursor: move;
-  }
   .sidebar-section[data-section-name="community"]
     .sidebar-section-link-prefix.icon {
     cursor: pointer;


### PR DESCRIPTION
Recently, we disabled the option to reorder links directly from the sidebar. Instead, user has to go to edit modal.

https://github.com/discourse/discourse/pull/24188

However, move cursor was left, which is misleading.
