### PR TITLE
FIX: pt-BR translations

### DIFF
--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1512,7 +1512,7 @@ pt_BR:
         browser_active: '%{browser} | <span class="active">ativar agora</span>'
         browser_last_seen: "%{browser}|%{date}"
       last_posted: "Última postagem"
-      last_seen: "Vistos"
+      last_seen: "Visto por último"
       created: "Ingressou"
       log_out: "Sair"
       location: "Localização"
@@ -3085,7 +3085,7 @@ pt_BR:
         other: "ver %{count} respostas ocultas"
       sr_reply_to: "Resposta à postagem %{post_number} por %{username}"
       notice:
-        new_user: "Esta é a primeira vez que o %{user} postou. Vamos dar boas-vindas à nossa comunidade"
+        new_user: "Esta é a primeira vez que %{user} postou. Vamos dar boas-vindas à nossa comunidade"
         returning_user: "Faz tempo que não vemos %{user}. Sua última postagem foi em %{time}."
       unread: "A postagem não foi lida"
       has_replies:


### PR DESCRIPTION
Fixes inaccurate translation of "last seen" (line 1515) Makes new user message gender neutral (line 3088)

For line 1515
The current last_seen text is an inaccurate translation and doesn't convey the meaning of "last seen". Proposed translation makes it accurate.

For line 3088
The "o" before the username is an article that implies it's a male user. The absence of the article is grammatically correct and makes it gender-neutral.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
