### PR TITLE
FIX: correctly highlights message on reply click

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.hbs
@@ -11,6 +11,7 @@
   {{did-insert this.didUpdateChannel}}
   {{did-insert this.addAutoFocusEventListener}}
   {{will-destroy this.removeAutoFocusEventListener}}
+  {{did-update this.loadMessages @targetMessageId}}
   data-id={{@channel.id}}
 >
   <ChatFullPageHeader

--- a/plugins/chat/spec/system/chat/composer/channel_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/channel_spec.rb
@@ -99,4 +99,19 @@ RSpec.describe "Chat | composer | channel", type: :system, js: true do
       end
     end
   end
+
+  context "when click on reply indicator" do
+    before do
+      Fabricate(:chat_message, chat_channel: channel_1)
+      Fabricate(:chat_message, chat_channel: channel_1, in_reply_to: message_1)
+    end
+
+    it "highlights the message" do
+      chat_page.visit_channel(channel_1)
+
+      page.find(".chat-reply").click
+
+      expect(channel_page.messages).to have_message(id: message_1.id, highlighted: true)
+    end
+  end
 end

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -104,6 +104,7 @@ module PageObjects
           selector += ".-persisted" if args[:persisted]
           selector += ".-staged" if args[:staged]
           selector += ".-deleted" if args[:deleted]
+          selector += ".-highlighted" if args[:highlighted]
           selector
         end
       end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
