### PR TITLE
DEV: Update auth-complete to use public router service

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
@@ -37,8 +37,8 @@ export default {
     }
 
     if (lastAuthResult) {
-      const router = owner.lookup("router:main");
-      router.one("didTransition", () => {
+      const router = owner.lookup("service:router");
+      router.one("routeDidChange", () => {
         next(() => {
           const options = JSON.parse(lastAuthResult);
 
@@ -46,7 +46,7 @@ export default {
             return;
           }
 
-          if (router.currentPath === "invites.show") {
+          if (router.currentRouteName === "invites.show") {
             owner
               .lookup("controller:invites-show")
               .authenticationComplete(options);


### PR DESCRIPTION
`router:main` is private and has an unstable API (e.g. the `didTransition` event does not fire in Ember 5)

(extracted from #21720)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
