### PR TITLE
DEV: Update login-required-test modal-close selector

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -27,7 +27,7 @@ acceptance("Login Required", function (needs) {
     await click("header .login-button");
     assert.ok(exists(".login-modal"), "they can still access the login modal");
 
-    await click(".modal-header .close");
+    await click(".d-modal__header .modal-close");
     assert.ok(invisible(".login-modal"), "it closes the login modal");
   });
 });


### PR DESCRIPTION
This was accidentally selecting the close button on `<DModalLegacy />`, which is present in the DOM with `display: none`. The close button logic would close any active modal, so the test would pass. However, it will stop passing when we remove the legacy modal system.

(extracted from https://github.com/discourse/discourse/pull/21720)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
