### PR TITLE
DEV: Make DTooltipInstance destroy synchronous

### DIFF
--- a/app/assets/javascripts/float-kit/addon/lib/d-tooltip-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-tooltip-instance.js
@@ -56,8 +56,8 @@ export default class DTooltipInstance extends FloatKitInstance {
   }
 
   @action
-  async destroy() {
-    await this.close();
+  destroy() {
+    this.close();
     this.tearDownListeners();
   }
 }

--- a/app/assets/javascripts/float-kit/addon/lib/float-kit-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/float-kit-instance.js
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import { cancel, next } from "@ember/runloop";
+import { cancel } from "@ember/runloop";
 import { makeArray } from "discourse-common/lib/helpers";
 import discourseLater from "discourse-common/lib/later";
 import { bind } from "discourse-common/utils/decorators";
@@ -20,17 +20,13 @@ export default class FloatKitInstance {
   content = null;
 
   @action
-  async show() {
+  show() {
     this.expanded = true;
-
-    await new Promise((resolve) => next(resolve));
   }
 
   @action
-  async close() {
+  close() {
     this.expanded = false;
-
-    await new Promise((resolve) => next(resolve));
   }
 
   @action


### PR DESCRIPTION
Having async cleanup on a modifier is problematic because it means it might persist beyond the end of a test, leading to flaky 'Test is not isolated' errors.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
