### PR TITLE
FIX: Updating array custom fields should be order independent

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -259,7 +259,8 @@ module HasCustomFields
 
         # let's iterate through our arrays and compare them
         array_fields.each do |field_name, fields|
-          if fields.length == dup[field_name].length && fields.map(&:value) == dup[field_name]
+          if fields.length == dup[field_name].length &&
+               fields.map(&:value).to_set == dup[field_name].to_set
             dup.delete(field_name)
           else
             fields.each(&:destroy!)

--- a/spec/lib/concern/has_custom_fields_spec.rb
+++ b/spec/lib/concern/has_custom_fields_spec.rb
@@ -347,6 +347,17 @@ RSpec.describe HasCustomFields do
       expect(item_with_json.custom_fields_clean?).to eq(true)
     end
 
+    it "doesn't update array fields when the items are the same, but appear in different orders" do
+      CustomFieldsTestItem.register_custom_field_type("array_field", :array)
+      test_item = CustomFieldsTestItem.create
+      test_item.custom_fields["array_field"] = %w[foo bar]
+      test_item.save_custom_fields
+      test_item.custom_fields["array_field"] = %w[bar foo]
+      expect { test_item.save_custom_fields }.not_to change {
+        CustomFieldsTestItemCustomField.last.id
+      }
+    end
+
     describe "create_singular" do
       it "creates new records" do
         item = CustomFieldsTestItem.create!


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
