### PR TITLE
PERF: Only invalidate other translations when en changes

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -664,8 +664,8 @@ class ThemeField < ActiveRecord::Base
           name: ThemeField.scss_fields + ThemeField.html_fields,
         )
       )
-    elsif translation_field?
-      return theme.theme_fields.where(target_id: Theme.targets[:translations])
+    elsif translation_field? && name == "en" # en is fallback for all other locales
+      return theme.theme_fields.where(target_id: Theme.targets[:translations]).where.not(name: "en")
     end
     ThemeField.none
   end


### PR DESCRIPTION
en is the only fallback locale we use, so there's no need to invalidate everything when other languages change. Limiting this also helps to prevent circular dependent_field relations which could cause issues in some situations.

Followup to eda79186eefaf97fe916d97c256c3e7b807d2237

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
