### PR TITLE
DEV: Print version info to console on boot

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -10,6 +10,7 @@ import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-inje
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { isTesting } from "discourse-common/config/environment";
 import { buildResolver } from "discourse-common/resolver";
+import { VERSION } from "@ember/version";
 
 const _pluginCallbacks = [];
 let _unhandledThemeErrors = [];
@@ -27,6 +28,8 @@ const Discourse = Application.extend({
 
   // Start up the Discourse application by running all the initializers we've defined.
   start() {
+    printDebugInfo();
+
     document.querySelector("noscript")?.remove();
 
     // Rewire event handling to eliminate event delegation for better compat
@@ -209,6 +212,30 @@ function resolveDiscourseInitializer(moduleName, themeId) {
   };
 
   return initializer;
+}
+
+let printedDebugInfo = false;
+function printDebugInfo() {
+  if (printedDebugInfo) {
+    return;
+  }
+
+  let str = "ℹ️ ";
+
+  const generator = document.querySelector("meta[name=generator]")?.content;
+  const parts = generator?.split(" ");
+  if (parts) {
+    const discourseVersion = parts[1];
+    const gitVersion = parts[5]?.substr(0, 10);
+    str += `Discourse v${discourseVersion} — https://github.com/discourse/discourse/commits/${gitVersion} — `;
+  }
+
+  str += `Ember v${VERSION}`;
+
+  // eslint-disable-next-line no-console
+  console.log(str);
+
+  printedDebugInfo = true;
 }
 
 export default Discourse;


### PR DESCRIPTION
Discourse already includes version information in a `<meta` tag on the page. This commit surfaces it to the console on boot for easier access, and also adds the Ember version (which will be particularly useful as we start rolling out the upgrade to Ember 5)

<img width="774" alt="SCR-20231118-libg" src="https://github.com/discourse/discourse/assets/6270921/6c4fc12e-b979-492b-8541-55ddaff74eb5">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
