### PR TITLE
FIX: remove trailing slashes and query params on meta-tag-updater's canonical url

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/meta-tag-updater.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/meta-tag-updater.js
@@ -1,3 +1,4 @@
+import { getCanonicalUrl } from "discourse/lib/url";
 import { getAbsoluteURL } from "discourse-common/lib/get-url";
 
 export default {
@@ -21,7 +22,7 @@ export default {
       twitterTitle?.setAttribute("content", title);
       twitterUrl?.setAttribute("content", absoluteUrl);
 
-      canonicalUrl?.setAttribute("href", absoluteUrl);
+      canonicalUrl?.setAttribute("href", getCanonicalUrl(absoluteUrl));
     });
   },
 };

--- a/app/assets/javascripts/discourse/app/instance-initializers/meta-tag-updater.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/meta-tag-updater.js
@@ -22,7 +22,9 @@ export default {
       twitterTitle?.setAttribute("content", title);
       twitterUrl?.setAttribute("content", absoluteUrl);
 
-      canonicalUrl?.setAttribute("href", getCanonicalUrl(absoluteUrl));
+      if (canonicalUrl) {
+        canonicalUrl.setAttribute("href", getCanonicalUrl(absoluteUrl));
+      }
     });
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -40,6 +40,8 @@ const SERVER_SIDE_ONLY = [
 // scrolling to "suggested topics".
 const JUMP_END_BUFFER = 250;
 
+const ALLOWED_CANONICAL_PARAMS = ["page"];
+
 export function rewritePath(path) {
   const params = path.split("?");
 
@@ -541,6 +543,21 @@ export function getEditCategoryUrl(category, subcategories, tab) {
     url += `/${tab}`;
   }
   return getURL(url);
+}
+
+export function getCanonicalUrl(absoluteUrl) {
+  const canonicalUrl = new URL(absoluteUrl);
+  canonicalUrl.pathname = canonicalUrl.pathname.replace(/\/$/, "");
+
+  const allowedSearchParams = new URLSearchParams();
+  for (const [key, value] of canonicalUrl.searchParams) {
+    if (ALLOWED_CANONICAL_PARAMS.includes(key)) {
+      allowedSearchParams.append(key, value);
+    }
+  }
+  canonicalUrl.search = allowedSearchParams.toString();
+
+  return canonicalUrl.toString();
 }
 
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -553,15 +553,13 @@ export function getCanonicalUrl(absoluteUrl) {
     ""
   );
 
-  if (canonicalUrl.searchParams.size > 0) {
-    const allowedSearchParams = new URLSearchParams();
-    for (const [key, value] of canonicalUrl.searchParams) {
-      if (ALLOWED_CANONICAL_PARAMS.includes(key)) {
-        allowedSearchParams.append(key, value);
-      }
+  const allowedSearchParams = new URLSearchParams();
+  for (const [key, value] of canonicalUrl.searchParams) {
+    if (ALLOWED_CANONICAL_PARAMS.includes(key)) {
+      allowedSearchParams.append(key, value);
     }
-    canonicalUrl.search = allowedSearchParams.toString();
   }
+  canonicalUrl.search = allowedSearchParams.toString();
 
   return canonicalUrl.toString();
 }

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -41,6 +41,7 @@ const SERVER_SIDE_ONLY = [
 const JUMP_END_BUFFER = 250;
 
 const ALLOWED_CANONICAL_PARAMS = ["page"];
+const TRAILING_SLASH_REGEX = /\/$/;
 
 export function rewritePath(path) {
   const params = path.split("?");
@@ -547,15 +548,20 @@ export function getEditCategoryUrl(category, subcategories, tab) {
 
 export function getCanonicalUrl(absoluteUrl) {
   const canonicalUrl = new URL(absoluteUrl);
-  canonicalUrl.pathname = canonicalUrl.pathname.replace(/\/$/, "");
+  canonicalUrl.pathname = canonicalUrl.pathname.replace(
+    TRAILING_SLASH_REGEX,
+    ""
+  );
 
-  const allowedSearchParams = new URLSearchParams();
-  for (const [key, value] of canonicalUrl.searchParams) {
-    if (ALLOWED_CANONICAL_PARAMS.includes(key)) {
-      allowedSearchParams.append(key, value);
+  if (canonicalUrl.searchParams.size > 0) {
+    const allowedSearchParams = new URLSearchParams();
+    for (const [key, value] of canonicalUrl.searchParams) {
+      if (ALLOWED_CANONICAL_PARAMS.includes(key)) {
+        allowedSearchParams.append(key, value);
+      }
     }
+    canonicalUrl.search = allowedSearchParams.toString();
   }
-  canonicalUrl.search = allowedSearchParams.toString();
 
   return canonicalUrl.toString();
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -148,7 +148,7 @@ acceptance("Admin - Site Settings", function (needs) {
   });
 
   test("category name is preserved", async function (assert) {
-    await visit("admin/site_settings/category/basic?filter=menu");
+    await visit("/admin/site_settings/category/basic?filter=menu");
     assert.strictEqual(
       currentURL(),
       "/admin/site_settings/category/basic?filter=menu"
@@ -156,7 +156,7 @@ acceptance("Admin - Site Settings", function (needs) {
   });
 
   test("shows all_results if current category has none", async function (assert) {
-    await visit("admin/site_settings");
+    await visit("/admin/site_settings");
 
     await click(".admin-nav .basic a");
     assert.strictEqual(currentURL(), "/admin/site_settings/category/basic");

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -2,6 +2,7 @@ import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import DiscourseURL, {
+  getCanonicalUrl,
   getCategoryAndTagUrl,
   prefixProtocol,
   userPath,
@@ -179,6 +180,40 @@ module("Unit | Utility | url", function (hooks) {
     assert.ok(
       DiscourseURL.replaceState.calledWith("#heading1"),
       "in-page anchors call replaceState with the url fragment"
+    );
+  });
+
+  test("getCanonicalUrl", function (assert) {
+    assert.strictEqual(
+      getCanonicalUrl("http://eviltrout.com/t/this-is-a-test/1/"),
+      "http://eviltrout.com/t/this-is-a-test/1",
+      "trailing slashes are removed"
+    );
+
+    assert.strictEqual(
+      getCanonicalUrl(
+        "http://eviltrout.com/t/this-is-a-test/1/?page=2&u=john&not_allowed=true"
+      ),
+      "http://eviltrout.com/t/this-is-a-test/1?page=2",
+      "disallowed query params are removed"
+    );
+
+    assert.strictEqual(
+      getCanonicalUrl("http://eviltrout.com/t/this-is-a-test/2"),
+      "http://eviltrout.com/t/this-is-a-test/2",
+      "canonical urls are not modified"
+    );
+
+    assert.strictEqual(
+      getCanonicalUrl("http://eviltrout.com/t/this-is-a-test/2/?"),
+      "http://eviltrout.com/t/this-is-a-test/2",
+      "trailing /? are removed"
+    );
+
+    assert.strictEqual(
+      getCanonicalUrl("http://eviltrout.com/t/this-is-a-test/2?"),
+      "http://eviltrout.com/t/this-is-a-test/2",
+      "trailing ? are removed"
     );
   });
 });


### PR DESCRIPTION
This uses the same strategy from the [server-side canonical URL generation](https://github.com/discourse/discourse/blob/04a58a6e64b39c567b1fda6618f20e7b72a546ec/lib/canonical_url.rb#L16-L26) to avoid inconsistencies.