### PR TITLE
DEV: Always run bundle and yarn install while running `d/boot_dev`

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -107,12 +107,6 @@ docker run -d \
     discourse/discourse_dev:release /sbin/boot
 
 if [ "${initialize}" = "initialize" ]; then
-    echo "Installing gems..."
-    "${SCRIPTPATH}/bundle" install
-
-    echo "Yarn install..."
-    "${SCRIPTPATH}/exec" yarn install --cwd app/assets/javascripts/discourse
-
     echo "Migrating database..."
     "${SCRIPTPATH}/rake" db:migrate
     RAILS_ENV=test "${SCRIPTPATH}/rake" db:migrate
@@ -120,3 +114,10 @@ if [ "${initialize}" = "initialize" ]; then
     echo "Creating admin user..."
     "${SCRIPTPATH}/rake" admin:create
 fi
+
+echo "Installing gems..."
+"${SCRIPTPATH}/bundle" install
+
+echo "Yarn install..."
+"${SCRIPTPATH}/exec" yarn install --cwd app/assets/javascripts/discourse
+


### PR DESCRIPTION
Why this change?

Before this change, running `d/boot_dev` does not run `bundle install`
and `yarn install` unless the `--init` option is specified. However,
this does not make sense because the user will end up having to run
`d/bundle install` and `d/yarn install` manually after if the `--init`
option is not used. We can simplify this by just always running `bundle
install` and `yarn install` whenever `d/boot_dev` is used.

What does this change do?

This change changes the `d/boot_dev` script to always run `bundle
install` and `yarn install`.