### PR TITLE
UX: smaller new feature emoji

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -9,14 +9,14 @@ export default class DashboardNewFeatureItem extends Component {
     <div class="admin-new-feature-item">
       <div class="admin-new-feature-item__content">
         <div class="admin-new-feature-item__header">
-          <h3>
-            {{@item.title}}
-          </h3>
           {{#if (and @item.emoji (not @item.screenshot_url))}}
             <div
               class="admin-new-feature-item__new-feature-emoji"
             >{{@item.emoji}}</div>
           {{/if}}
+          <h3>
+            {{@item.title}}
+          </h3>
         </div>
         {{#if @item.screenshot_url}}
           <img

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -688,9 +688,6 @@
     padding-right: 0.5em;
     width: 100%;
   }
-  &__feature-description {
-    padding-top: 1em;
-  }
   &__header {
     display: flex;
     align-items: flex-start;

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -679,8 +679,9 @@
   padding: 1em;
 
   &__new-feature-emoji {
-    font-size: 3.5em;
-    padding-left: 0.5em;
+    font-size: 1.2em;
+    padding-left: 0;
+    padding-right: 0.5em;
   }
 
   &__content {
@@ -693,7 +694,6 @@
   &__header {
     display: flex;
     align-items: flex-start;
-    justify-content: space-between;
     font-size: var(--font-up-1);
     font-weight: bold;
     margin-bottom: 0.5em;

--- a/app/assets/stylesheets/mobile/dashboard.scss
+++ b/app/assets/stylesheets/mobile/dashboard.scss
@@ -5,6 +5,7 @@
   }
   .navigation a.navigation-link {
     padding: 0.5em;
+    font-size: var(--font-down-1);
   }
   .dashboard-new-features .section-body {
     grid-template-columns: none;


### PR DESCRIPTION
Moved the new feature emoji to the left of the title and made it smaller.

Demo:
<img width="1107" alt="Screenshot 2023-11-20 at 3 52 42 pm" src="https://github.com/discourse/discourse/assets/72780/63ef9adb-f57e-4f64-90d7-bb8aa71c06f9">

<img width="438" alt="Screenshot 2023-11-20 at 3 56 11 pm" src="https://github.com/discourse/discourse/assets/72780/f4249ed7-dd29-40ed-be67-c196518d181c">


