### PR TITLE
FIX: Invalid date when sending chat message in thread

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
@@ -63,7 +63,7 @@ export default class ChatThread {
     message.staged = true;
     message.processed = false;
     message.draft = false;
-    message.createdAt ??= moment.utc().format();
+    message.createdAt = new Date();
     message.thread = this;
 
     this.messagesManager.addMessages([message]);


### PR DESCRIPTION
Fixes a minor issue where "Invalid date" is shown briefly
when sending a message in a chat thread. Change to use
`new Date()` instead like the channel staged message which
does not have this issue.

![invalidthreaddate](https://github.com/discourse/discourse/assets/920448/ac4e8adb-41a3-4c42-896d-479f0effc3f0)

This is more noticeable on slower connections.
