### PR TITLE
UX: Ensure tag-info does not persist onto non-tag routes

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/discovery/list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/list.hbs
@@ -26,7 +26,7 @@
         @parentCategory={{this.model.subcategoryList.parentCategory}}
       />
     {{/if}}
-    {{#if this.showTagInfo}}
+    {{#if (and this.showTagInfo this.model.tag)}}
       <TagInfo @tag={{this.model.tag}} @list={{this.model.list}} />
     {{/if}}
   </:header>

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -475,6 +475,17 @@ acceptance("Tag info", function (needs) {
     );
   });
 
+  test("tag info hides when tag filter removed", async function (assert) {
+    await visit("/tag/happy-monkey");
+
+    await click("#show-tag-info");
+    assert.dom(".tag-info .tag-name").exists();
+
+    await visit("/latest");
+
+    assert.dom(".tag-info").doesNotExist("tag info is not shown on homepage");
+  });
+
   test("can filter tags page by category", async function (assert) {
     await visit("/tag/planters");
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
