### PR TITLE
DEV: Remove unnecessary `js: true` options from specs

### DIFF
--- a/plugins/chat/spec/system/chat/composer/channel_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat | composer | channel", type: :system, js: true do
+RSpec.describe "Chat | composer | channel", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
   fab!(:current_user) { Fabricate(:admin) }

--- a/plugins/chat/spec/system/chat/composer/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/thread_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat | composer | thread", type: :system, js: true do
+RSpec.describe "Chat | composer | thread", type: :system do
   fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:message_1) do

--- a/plugins/chat/spec/system/chat_summarization_spec.rb
+++ b/plugins/chat/spec/system/chat_summarization_spec.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe "Summarize a channel since your last visit", type: :system, js: true do
+RSpec.describe "Summarize a channel since your last visit", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:group)
-  let(:plugin) { Plugin::Instance.new }
-
   fab!(:channel) { Fabricate(:chat_channel) }
-
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel) }
-
   let(:chat) { PageObjects::Pages::Chat.new }
-
+  let(:plugin) { Plugin::Instance.new }
   let(:summarization_result) { { summary: "This is a summary", chunks: [] } }
 
   before do

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-describe "Viewing top topics on categories page", type: :system, js: true do
+describe "Viewing top topics on categories page", type: :system do
   fab!(:user)
-  let(:category_list) { PageObjects::Components::CategoryList.new }
-  let(:topic_view) { PageObjects::Components::TopicView.new }
   fab!(:category)
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:post) { Fabricate(:post, topic: topic) }
+  let(:category_list) { PageObjects::Components::CategoryList.new }
+  let(:topic_view) { PageObjects::Components::TopicView.new }
 
   it "displays and updates new counter" do
     skip(<<~TEXT)

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Composer Post Validations", type: :system, js: true do
+describe "Composer Post Validations", type: :system do
   fab!(:tl0_user) { Fabricate(:user, trust_level: 0) }
   fab!(:tl1_user) { Fabricate(:user, trust_level: 1) }
   fab!(:tl2_user) { Fabricate(:user, trust_level: 2) }

--- a/spec/system/composer/template_validation_spec.rb
+++ b/spec/system/composer/template_validation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Composer Form Template Validations", type: :system, js: true do
+describe "Composer Form Template Validations", type: :system do
   fab!(:user)
   fab!(:form_template) do
     Fabricate(

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Uploading files in the composer", type: :system, js: true do
+describe "Uploading files in the composer", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:modal) { PageObjects::Modals::Base.new }

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Flagging post", type: :system, js: true do
+describe "Flagging post", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   fab!(:first_post) { Fabricate(:post) }
   fab!(:post_to_flag) { Fabricate(:post, topic: first_post.topic) }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
