### PR TITLE
FIX: Rendering a single item in a grid

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/columns.js
+++ b/app/assets/javascripts/discourse/app/lib/columns.js
@@ -85,7 +85,7 @@ export default class Columns {
 
     const wrapper = document.createElement("span");
     wrapper.classList.add("image-wrapper");
-    wrapper.append(item);
+    wrapper.appendChild(item.cloneNode());
     return wrapper;
   }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/columns-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/columns-test.js
@@ -154,4 +154,34 @@ module("Unit | Columns", function (hooks) {
       "one element in column 3"
     );
   });
+
+  test("renders a single item in a P tag", function (assert) {
+    document.getElementById(
+      "qunit-fixture"
+    ).innerHTML = `<div class="d-image-grid">
+<p><img src="/images/avatar.png" alt role="presentation"></p>
+</div>`;
+
+    const grid = document.querySelector(".d-image-grid");
+    const cols = new Columns(grid);
+    assert.strictEqual(cols.items.length, 1);
+
+    assert.strictEqual(
+      grid.dataset.disabled,
+      "true",
+      "disabled attribute is added"
+    );
+
+    assert.strictEqual(
+      document.querySelectorAll(".d-image-grid > .d-image-grid-column").length,
+      0,
+      "no column elements are rendered"
+    );
+
+    assert.strictEqual(
+      document.querySelectorAll(".d-image-grid > p > img").length,
+      1,
+      "an image element is rendered"
+    );
+  });
 });


### PR DESCRIPTION
Should fix https://meta.discourse.org/t/-/285768.

Appending without cloning was causing the item to be removed from the DOM but on a 1-item grid we skip the rest of the grid's rendering, hence the item was never re-inserted. Cloning ensures we don't remove the item during processing (it does get removed later on when rendering the grid's columns).
