### PR TITLE
FIX: Sorting toggles on topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/components/discovery/topics.js
@@ -24,7 +24,7 @@ export default class DiscoveryTopics extends Component {
   }
 
   get ascending() {
-    return this.args.model.get("params.ascending");
+    return this.args.model.get("params.ascending") === "true";
   }
 
   get hasTopics() {

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -101,6 +101,16 @@ export default class DiscoveryListController extends Controller {
     return this.model.category && !this.createTopicTargetCategory;
   }
 
+  get resolvedAscending() {
+    return (
+      (this.ascending ?? this.model.list.get("params.ascending")) === "true"
+    );
+  }
+
+  get resolvedOrder() {
+    return this.order ?? this.model.list.get("params.order") ?? "activity";
+  }
+
   @action
   createTopic() {
     this.composer.openNewTopic({
@@ -120,14 +130,12 @@ export default class DiscoveryListController extends Controller {
 
   @action
   changeSort(sortBy) {
-    if (sortBy === this.order) {
-      this.ascending = !this.ascending;
-      this.model.list.updateSortParams(sortBy, this.ascending);
+    if (sortBy === this.resolvedOrder) {
+      this.ascending = !this.resolvedAscending;
     } else {
-      this.order = sortBy;
       this.ascending = false;
-      this.model.list.updateSortParams(sortBy, false);
     }
+    this.order = sortBy;
   }
 
   @action

--- a/spec/system/discovery_list_spec.rb
+++ b/spec/system/discovery_list_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe "Topic list focus", type: :system do
+  fab!(:topics) { Fabricate.times(10, :post).map(&:topic) }
+  fab!(:reply) { Fabricate(:post, topic: topics.first) }
+
+  let(:discovery) { PageObjects::Pages::Discovery.new }
+
+  def nth_topic_id(n)
+    discovery.topic_list.find(".topic-list-item:nth-of-type(#{n})")["data-topic-id"]
+  end
+
+  it "can sort a topic list by activity" do
+    visit "/latest"
+    expect(discovery.topic_list).to have_topics(count: 10)
+    newest_topic_id = nth_topic_id(1)
+
+    find("th[data-sort-order='activity']").click
+
+    expect(page).to have_css("th[data-sort-order='activity'][aria-sort=ascending]")
+    expect(nth_topic_id(10)).to eq(newest_topic_id)
+
+    find("th[data-sort-order='activity']").click
+    expect(page).to have_css("th[data-sort-order='activity'][aria-sort=descending]")
+    expect(nth_topic_id(1)).to eq(newest_topic_id)
+  end
+
+  it "can sort a topic list by replies" do
+    visit "/latest"
+    expect(discovery.topic_list).to have_topics(count: 10)
+
+    find("th[data-sort-order='posts']").click
+
+    expect(page).to have_css("th[data-sort-order='posts'][aria-sort=descending]")
+    expect(nth_topic_id(1)).to eq(reply.topic_id.to_s)
+
+    find("th[data-sort-order='posts']").click
+    expect(page).to have_css("th[data-sort-order='posts'][aria-sort=ascending]")
+    expect(nth_topic_id(10)).to eq(reply.topic_id.to_s)
+  end
+end


### PR DESCRIPTION
- Correctly interpret string queryParams
- On first click of a new column, use "descending". Otherwise, toggle.
- Add system specs for behavior

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
