### PR TITLE
FIX: Use labels for bold & italic in composer when language doesn't match english

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -63,22 +63,26 @@ class Toolbar {
       { group: "extras", buttons: [] },
     ];
 
+    const boldLabel = getButtonLabel("composer.bold_label", "B");
+    const boldIcon = boldLabel ? null : "bold";
     this.addButton({
       id: "bold",
       group: "fontStyles",
-      icon: "bold",
-      label: getButtonLabel("composer.bold_label", "B"),
+      icon: boldIcon,
+      label: boldLabel,
       shortcut: "B",
       preventFocus: true,
       trimLeading: true,
       perform: (e) => e.applySurround("**", "**", "bold_text"),
     });
 
+    const italicLabel = getButtonLabel("composer.italic_label", "I");
+    const italicIcon = italicLabel ? null : "italic";
     this.addButton({
       id: "italic",
       group: "fontStyles",
-      icon: "italic",
-      label: getButtonLabel("composer.italic_label", "I"),
+      icon: italicIcon,
+      label: italicLabel,
       shortcut: "I",
       preventFocus: true,
       trimLeading: true,
@@ -88,6 +92,7 @@ class Toolbar {
     if (opts.showLink) {
       this.addButton({
         id: "link",
+        icon: "link",
         group: "insertions",
         shortcut: "K",
         preventFocus: true,
@@ -114,6 +119,7 @@ class Toolbar {
         id: "code",
         group: "insertions",
         shortcut: "E",
+        icon: "code",
         preventFocus: true,
         trimLeading: true,
         action: (...args) => this.context.send("formatCode", args),
@@ -170,7 +176,7 @@ class Toolbar {
       tabindex: button.tabindex || "-1",
       className: button.className || button.id,
       label: button.label,
-      icon: button.icon || button.id,
+      icon: button.icon,
       action: button.action || ((a) => this.context.send("toolbarButton", a)),
       perform: button.perform || function () {},
       trimLeading: button.trimLeading,


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
