### PR TITLE
UX: Adjust topic progress wrapper border radius

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -101,6 +101,16 @@ $topic-progress-height: 42px;
       position: relative;
     }
   }
+  #topic-progress-wrapper {
+    .topic-admin-menu-button .toggle-admin-menu {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    #topic-progress {
+      border-top-right-radius: var(--d-border-radius);
+      border-bottom-right-radius: var(--d-border-radius);
+    }
+  }
 }
 
 .progress-back-container {

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -104,10 +104,17 @@ $topic-progress-height: 42px;
   #topic-progress-wrapper {
     .topic-admin-menu-button .toggle-admin-menu {
       border-top-right-radius: 0;
+      border-bottom-left-radius: var(--d-border-radius);
       border-bottom-right-radius: 0;
     }
     #topic-progress {
+      border-radius: var(--d-border-radius);
+      overflow: hidden;
+    }
+    .topic-admin-menu-button-container + #topic-progress {
+      border-top-left-radius: 0;
       border-top-right-radius: var(--d-border-radius);
+      border-bottom-left-radius: 0;
       border-bottom-right-radius: var(--d-border-radius);
     }
   }

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -72,17 +72,6 @@
   }
 }
 
-#topic-progress-wrapper {
-  .topic-admin-menu-button .toggle-admin-menu {
-    border-top-right-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-  #topic-progress {
-    border-top-right-radius: var(--d-border-radius);
-    border-top-left-radius: var(--d-border-radius);
-  }
-}
-
 .topic-error {
   padding: 18px;
   width: 90%;


### PR DESCRIPTION
This PR adjusts how border radius affects the topic progress wrapper.

**Before**
<img width="274" alt="image" src="https://github.com/discourse/discourse/assets/30537603/0d03ddfa-90c7-4174-af8f-25f4023e1da1">

**After**
<img width="218" alt="image" src="https://github.com/discourse/discourse/assets/30537603/1fe4439f-520f-4e5f-a3ea-2ba028204fe0">
