### PR TITLE
FIX: render page title on tag routes

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -170,26 +170,26 @@ export default class TagShowRoute extends DiscourseRoute {
     const filterText = I18n.t(
       `filters.${this.navMode.replace("/", ".")}.title`
     );
-    const controller = this.controllerFor(this.controllerName);
+    const model = this.currentModel;
 
-    if (controller.tag?.id) {
-      if (controller.category) {
+    if (model?.tag?.id) {
+      if (model.category) {
         return I18n.t("tagging.filters.with_category", {
           filter: filterText,
-          tag: controller.tag.id,
-          category: controller.category.name,
+          tag: model.tag.id,
+          category: model.category.name,
         });
       } else {
         return I18n.t("tagging.filters.without_category", {
           filter: filterText,
-          tag: controller.tag.id,
+          tag: model.tag.id,
         });
       }
     } else {
-      if (controller.category) {
+      if (model.category) {
         return I18n.t("tagging.filters.untagged_with_category", {
           filter: filterText,
-          category: controller.category.name,
+          category: model.category.name,
         });
       } else {
         return I18n.t("tagging.filters.untagged_without_category", {


### PR DESCRIPTION
I think this is a follow-up to 82d6d69, but didn't investigate 

Reported here: https://meta.discourse.org/t/title-of-tag-xxx/286130

Before:
![Screenshot 2023-11-20 at 6 19 44 PM](https://github.com/discourse/discourse/assets/1681963/f0c7f84f-2358-4ff2-bbd2-2efc56285d65)

After:
![Screenshot 2023-11-20 at 6 19 30 PM](https://github.com/discourse/discourse/assets/1681963/fa6dc7aa-fb5f-40fd-95a5-709a0465785c)

