### PR TITLE
UX: Vertically align the svg in checkbox slider component

### DIFF
--- a/app/assets/stylesheets/common/components/d-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/d-toggle-switch.scss
@@ -83,7 +83,7 @@
       font-size: var(--font-down-1);
       color: var(--secondary);
       left: 7px;
-      top: 7px;
+      top: 6px;
       position: absolute;
     }
   }


### PR DESCRIPTION
The svg in the slider is slightly too low.

Before:
![Screenshot 2023-11-21 at 2 32 18 PM](https://github.com/discourse/discourse/assets/1555215/6f37267d-4530-44a6-a1da-48060917eb63)

After:
![Screenshot 2023-11-21 at 2 32 58 PM](https://github.com/discourse/discourse/assets/1555215/c21bc8f2-e213-4871-a1b0-7bf69f3f79f9)
