### PR TITLE
UX: select kit name > flex

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -113,7 +113,8 @@
       }
 
       .name {
-        display: inline-block;
+        display: inline-flex;
+        gap: 0.5em;
         > .d-icon {
           margin-left: 0.5em;
           margin-right: 0;


### PR DESCRIPTION
Fixes spacing within select-kits to avoid:

![image](https://github.com/discourse/discourse/assets/101828855/04dc380c-292c-46ba-89b0-d58e9cc9469f)
