### PR TITLE
DEV: Pass the user who requested the summary to the strategy.

### DIFF
--- a/app/services/topic_summarization.rb
+++ b/app/services/topic_summarization.rb
@@ -35,7 +35,7 @@ class TopicSummarization
       content[:contents] << { poster: username, id: pn, text: raw }
     end
 
-    summarization_result = strategy.summarize(content, &on_partial_blk)
+    summarization_result = strategy.summarize(content, user, &on_partial_blk)
 
     cache_summary(summarization_result, targets_data.map(&:first), topic)
   end

--- a/lib/summarization/base.rb
+++ b/lib/summarization/base.rb
@@ -75,6 +75,8 @@ module Summarization
     # @param &on_partial_blk { Block - Optional } - If the strategy supports it, the passed block
     # will get called with partial summarized text as its generated.
     #
+    # @param current_user { User } - User requesting the summary.
+    #
     # @returns { Hash } - The summarized content, plus chunks if the content couldn't be summarized in one pass. Example:
     #   {
     #     summary: "This is the final summary",
@@ -83,7 +85,7 @@ module Summarization
     #       { ids: [post_1.post_number, post_2.post_number], summary: "this is the second chunk" },
     #     ],
     #   }
-    def summarize(content)
+    def summarize(content, current_user)
       raise NotImplemented
     end
 

--- a/plugins/chat/app/controllers/chat/api/summaries_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/summaries_controller.rb
@@ -31,7 +31,7 @@ class Chat::Api::SummariesController < Chat::ApiController
         if content[:contents].empty?
           I18n.t("chat.summaries.no_targets")
         else
-          strategy.summarize(content).dig(:summary)
+          strategy.summarize(content, current_user).dig(:summary)
         end
 
       render json: { summary: summarized_text }

--- a/spec/support/dummy_custom_summarization.rb
+++ b/spec/support/dummy_custom_summarization.rb
@@ -21,7 +21,7 @@ class DummyCustomSummarization < Summarization::Base
     "dummy"
   end
 
-  def summarize(_content)
+  def summarize(_content, _user)
     @summarization_result.tap { |result| yield(result[:summary]) if block_given? }
   end
 end


### PR DESCRIPTION
This change allows the `discourse-ai` plugin to log the user who requested the summary in the `AiApiAuditLog`.

