### PR TITLE
UX: add height to non-highlighted mention

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -66,10 +66,16 @@
       width: 100%;
     }
 
-    .mention.highlighted {
-      @include mention;
-      background: var(--tertiary-low);
-      color: var(--primary);
+    .mention {
+      padding: 0 0em 0.07em;
+      display: inline-block;
+      font-size: 0.93em;
+
+      &.highlighted {
+        @include mention;
+        background: var(--tertiary-low);
+        color: var(--primary);
+      }
     }
 
     // Automatic aspect-ratio mapping https://developer.mozilla.org/en-US/docs/Web/Media/images/aspect_ratio_mapping


### PR DESCRIPTION
Should make a non-highlighted mention just as high as a highlighted one, preventing the jump when the highlighted class is added.
