### PR TITLE
DEV: Deprecate array custom fields

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -86,6 +86,13 @@ module HasCustomFields
     end
 
     def register_custom_field_type(name, type)
+      if Array === type
+        Discourse.deprecate(
+          "Array types for custom fields are deprecated, use type :json instead",
+          drop_from: "3.3.0",
+        )
+      end
+
       @custom_field_types ||= {}
       @custom_field_types[name] = type
     end


### PR DESCRIPTION
Array custom fields use separate rows for each value, but whenever we update an array, we have always destroy the existing rows and create new ones. Therefore, there's no benefit over using the json type.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
