### PR TITLE
FIX: relies on mention mixin for size

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -67,14 +67,10 @@
     }
 
     .mention {
-      padding: 0 0em 0.07em;
-      display: inline-block;
-      font-size: 0.93em;
+      @include mention;
 
       &.highlighted {
-        @include mention;
         background: var(--tertiary-low);
-        color: var(--primary);
       }
     }
 


### PR DESCRIPTION
This commit fixes a regression where non highlighted mentions have an incorrect size.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
