### PR TITLE
FIX: Wrong argument error being thrown in UrlHelper

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -69,7 +69,9 @@ class UrlHelper
   def self.normalized_encode(uri)
     url = uri.to_s
 
-    raise ArgumentError.new(:uri, "URL is too long") if url.length > MAX_URL_LENGTH
+    if url.length > MAX_URL_LENGTH
+      raise ArgumentError.new("URL starting with #{url[0..100]} is too long")
+    end
 
     # Ideally we will jump straight to `Addressable::URI.normalized_encode`. However,
     # that implementation has some edge-case issues like https://github.com/sporkmonger/addressable/issues/472.

--- a/spec/lib/url_helper_spec.rb
+++ b/spec/lib/url_helper_spec.rb
@@ -166,8 +166,10 @@ RSpec.describe UrlHelper do
     end
 
     it "raises error if too long" do
-      expect do UrlHelper.normalized_encode("https://#{"a" * 2_000}.com") end.to raise_error(
+      long_url = "https://#{"a" * 2_000}.com"
+      expect do UrlHelper.normalized_encode(long_url) end.to raise_error(
         ArgumentError,
+        "URL starting with #{long_url[0..100]} is too long",
       )
     end
   end


### PR DESCRIPTION
We were throwing ArgumentError in UrlHelper.normalised_encode,
but it was incorrect -- we were passing ArgumentError.new
2 arguments which is not supported. Fix this and have a hint
of which URL is causing the issue for debugging.
