### PR TITLE
FIX: Run bundle install before migration in `d/boot_dev`

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -106,6 +106,12 @@ docker run -d \
     --restart=always \
     discourse/discourse_dev:release /sbin/boot
 
+echo "Installing gems..."
+"${SCRIPTPATH}/bundle" install
+
+echo "Yarn install..."
+"${SCRIPTPATH}/exec" yarn install --cwd app/assets/javascripts/discourse
+
 if [ "${initialize}" = "initialize" ]; then
     echo "Migrating database..."
     "${SCRIPTPATH}/rake" db:migrate
@@ -114,10 +120,4 @@ if [ "${initialize}" = "initialize" ]; then
     echo "Creating admin user..."
     "${SCRIPTPATH}/rake" admin:create
 fi
-
-echo "Installing gems..."
-"${SCRIPTPATH}/bundle" install
-
-echo "Yarn install..."
-"${SCRIPTPATH}/exec" yarn install --cwd app/assets/javascripts/discourse
 


### PR DESCRIPTION
48c0cd5b2aae16830149c3982b525eb75e03e8dc broke `d/boot_dev` when used
with `--init` because `rake db:migrate` will fail as it requires `bundle
install` to run first