### PR TITLE
PERF: Switch `plugin:install_all_official` to clone plugins concurrently

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -42,7 +42,6 @@ task "plugin:install_all_official" do
       attempts += 1
       retry
     end
-    end
   end
 
   Concurrent::Promise.zip(*promises).value!

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -28,7 +28,7 @@ task "plugin:install_all_official" do
       repo += ".git"
     end
 
-    Concurrent::Promise.execute do
+    promises << Concurrent::Promise.execute do
       attempts ||= 1
       STDOUT.puts("Cloning '#{repo}' to '#{path}'...")
       system("git clone --quiet #{repo} #{path}", exception: true)

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -29,20 +29,19 @@ task "plugin:install_all_official" do
     end
 
     Concurrent::Promise.execute do
-      attempts = 0
-      begin
-        attempts += 1
-        STDOUT.puts("Cloning '#{repo}' to '#{path}'...")
-        system("git clone --quiet #{repo} #{path}", exception: true)
-      rescue StandardError
-        if attempts >= 3
-          failures << repo
-          abort
-        end
-
-        STDOUT.puts "Failed to clone #{repo}... trying again..."
-        retry
+      attempts ||= 1
+      STDOUT.puts("Cloning '#{repo}' to '#{path}'...")
+      system("git clone --quiet #{repo} #{path}", exception: true)
+    rescue StandardError
+      if attempts == 3
+        failures << repo
+        abort
       end
+
+      STDOUT.puts "Failed to clone #{repo}... trying again..."
+      attempts += 1
+      retry
+    end
     end
   end
 


### PR DESCRIPTION
Why this change?

`plugin:install_all_official` is quite slow at the moment taking roughly
1 minute and 51 seconds on my machine. Since most of the time is spent
waiting on the network, we can actually speed up the Rake task
significantly by executing the cloning concurrently. With a 8 cores
machine, cloning all plugins will only take 15 seconds.

What does this change do?

This change wraps the `git clone` operation in the
`plugin:install_all_official` Rake task in a `Concurrent::Promise` which
basically runs the `git clone` operation in a Thread. The `--quiet`
option has also been added to `git clone` since running stuff
concurrently messes up the output. That could be fixed but it has been
determined to be not worth it since the output from `git clone` is
meaningless to us.