### PR TITLE
DEV: Convert email_in_min_trust to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2140,6 +2140,8 @@ en:
     log_mail_processing_failures: "Log all email processing failures to <a href='%{base_path}/logs' target='_blank'>/logs</a>"
     email_in: "Allow users to post new topics via email. After enabling this setting, you will be able to configure incoming email addresses for groups and categories."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."
+    email_in_allowed_groups: "Groups that are allowed to post new topics via email."
+
     email_in_authserv_id: "The identifier of the service doing authentication checks on incoming emails. See <a href='https://meta.discourse.org/t/134358'>https://meta.discourse.org/t/134358</a> for instructions on how to configure this."
     email_in_spam_header: "The email header to detect spam."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2549,6 +2549,7 @@ en:
       shared_drafts_allowed_groups: "shared_drafts_min_trust_level"
       approve_unless_allowed_groups: "approve_unless_trust_level"
       approve_new_topics_unless_allowed_groups: "approve_new_topics_unless_trust_level"
+      email_in_allowed_groups: "email_in_min_trust"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1254,6 +1254,13 @@ email:
   email_in_min_trust:
     default: 2
     enum: "TrustLevelSetting"
+    hidden: true
+  email_in_allowed_groups:
+    default: 12
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   email_in_authserv_id:
     default: ""
   email_in_spam_header:

--- a/db/migrate/20231122212122_fill_email_in_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231122212122_fill_email_in_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FillEmailInAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    email_in_min_trust_raw =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'email_in_min_trust' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL0, we only need to do anything if it's been changed in the DB.
+    if email_in_min_trust_raw.present?
+      # Matches Group::AUTO_GROUPS to the trust levels.
+      email_in_allowed_groups = "1#{email_in_min_trust_raw}"
+
+      # Data_type 20 is group_list
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('email_in_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: email_in_allowed_groups,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -859,7 +859,8 @@ module Email
 
         user ||= stage_from_user
 
-        if !user.has_trust_level?(SiteSetting.email_in_min_trust) && !sent_to_mailinglist_mirror?
+        if user.groups.any? && !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map) &&
+             !sent_to_mailinglist_mirror?
           raise InsufficientTrustLevelError
         end
 
@@ -1067,7 +1068,7 @@ module Email
         )
       elsif destination.is_a?(Category)
         return false if user.staged? && !destination.email_in_allow_strangers
-        return false if !user.has_trust_level?(SiteSetting.email_in_min_trust)
+        return false if !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map)
 
         topic_user = embedded_user&.call || user
         create_topic(

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -1068,7 +1068,9 @@ module Email
         )
       elsif destination.is_a?(Category)
         return false if user.staged? && !destination.email_in_allow_strangers
-        return false if !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map)
+        if user.groups.any? && !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map)
+          return false
+        end
 
         topic_user = embedded_user&.call || user
         create_topic(

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -18,6 +18,7 @@ module SiteSettings::DeprecatedSettings
       false,
       "3.3",
     ],
+    ["email_in_min_trust", "email_in_allowed_groups", false, "3.3"],
   ]
 
   def setup_deprecated_methods


### PR DESCRIPTION
This change converts the `email_in_min_trust` site setting to
`email_in_allowed_groups`.

See: https://meta.discourse.org/t/283408

- Hides the old setting
- Adds the new site setting
- Add a deprecation warning
- Updates to use the new setting
- Adds a migration to fill in the new setting if the old setting was
  changed
- Adds an entry to the site_setting.keywords section
- Updates tests to account for the new change

After a couple of months we will remove the
`email_in_min_trust` setting entirely.

Internal ref: /t/115696
