### PR TITLE
FIX: `plugin:install_all_gems` Rake task not installing plugin gem

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -170,18 +170,8 @@ end
 
 desc "install all plugin gems"
 task "plugin:install_all_gems" do |t|
-  # Left intentionally blank.
-  # When the app is being loaded, all missing gems are installed
-  # See: lib/plugin_gem.rb
-  puts "Done"
-end
-
-desc "install plugin gems"
-task "plugin:install_gems", :plugin do |t, args|
-  # Left intentionally blank.
-  # When the app is being loaded, all missing gems are installed
-  # See: lib/plugin_gem.rb
-  puts "Done"
+  ENV["LOAD_PLUGINS"] = "1"
+  Rake::Task["environment"].invoke
 end
 
 def spec(plugin, parallel: false, argv: nil)


### PR DESCRIPTION
### Why this change?

This regressed in dec68d780c58ef0954865b786d04b653c20e26fa where the
commit assumes that plugin gems are always installed when the
`plugin:install_all_gems` Rake task is ran as it would run the our Rails
initializers which activates plugins and install the gems. However, this
assumption only holds true when the `LOAD_PLUGINS` env variable is present and set to
`1`.

### What does this change do?

This commit changes the `plugin:install_all_gems` to load the Rails
environment with the `LOAD_PLUGINS` env variable set to `1` such that the plugin gems
will be installed as part of our initialization process for the app.

The commit also removes the `plugin:install_gems` Rake task which is
currently a noop and does not seem to be used anywhere.