### PR TITLE
Revert "FIX: `plugin:install_all_gems` Rake task not installing plugin gem (#24522)"

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -170,8 +170,18 @@ end
 
 desc "install all plugin gems"
 task "plugin:install_all_gems" do |t|
-  ENV["LOAD_PLUGINS"] = "1"
-  Rake::Task["environment"].invoke
+  # Left intentionally blank.
+  # When the app is being loaded, all missing gems are installed
+  # See: lib/plugin_gem.rb
+  puts "Done"
+end
+
+desc "install plugin gems"
+task "plugin:install_gems", :plugin do |t, args|
+  # Left intentionally blank.
+  # When the app is being loaded, all missing gems are installed
+  # See: lib/plugin_gem.rb
+  puts "Done"
 end
 
 def spec(plugin, parallel: false, argv: nil)


### PR DESCRIPTION
This breaks the `plugin:install_all_gems` Rake task when used before
Redis is running. Need to go back to the drawing board.

This reverts commit 189aa5fa4e489cbca323c25e4a6f9417547aa1a9.