### PR TITLE
PERF: avoid table scan while performing a very large update

### DIFF
--- a/db/post_migrate/20231120190818_trigger_post_rebake_category_style_quotes.rb
+++ b/db/post_migrate/20231120190818_trigger_post_rebake_category_style_quotes.rb
@@ -1,12 +1,31 @@
 # frozen_string_literal: true
 
 class TriggerPostRebakeCategoryStyleQuotes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def up
-    DB.exec(<<~SQL)
-      UPDATE posts
-      SET baked_version = NULL
-      WHERE cooked LIKE '%blockquote%'
+    max_id = DB.query_single(<<~SQL).first.to_i
+      SELECT MAX(id)
+      FROM posts
     SQL
+
+    chunk_size = 100_000
+    while max_id > 0
+      ids = DB.query_single(<<~SQL, from: max_id, to: max_id - chunk_size)
+        SELECT id
+        FROM posts
+        WHERE cooked LIKE '%blockquote%'
+        AND id < :from and id >= :to
+      SQL
+
+      DB.exec(<<~SQL, ids: ids) if ids && ids.length > 0
+          UPDATE posts
+          SET baked_version = NULL
+          WHERE id IN (:ids)
+        SQL
+
+      max_id -= chunk_size
+    end
   end
 
   def down

--- a/db/post_migrate/20231120190818_trigger_post_rebake_category_style_quotes.rb
+++ b/db/post_migrate/20231120190818_trigger_post_rebake_category_style_quotes.rb
@@ -11,11 +11,11 @@ class TriggerPostRebakeCategoryStyleQuotes < ActiveRecord::Migration[7.0]
 
     chunk_size = 100_000
     while max_id > 0
-      ids = DB.query_single(<<~SQL, from: max_id, to: max_id - chunk_size)
+      ids = DB.query_single(<<~SQL, start: max_id - chunk_size, finish: max_id)
         SELECT id
         FROM posts
         WHERE cooked LIKE '%blockquote%'
-        AND id < :from and id >= :to
+        AND id >= :start AND id <= :finish
       SQL
 
       DB.exec(<<~SQL, ids: ids) if ids && ids.length > 0


### PR DESCRIPTION
We were seeing lots of deadlocks deploying this migration. This improves
the situation in 2 ways.

1. ddl transaction is avoided, so we hold locks for far shorter times
2. we operate in chunks of a maximum of 100_000 posts (though it is heavily filtered down)
