### PR TITLE
DEV: Stringify settledState debug info

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -417,7 +417,7 @@ function patchFailedAssertion() {
       // eslint-disable-next-line no-console
       console.warn(
         "ℹ️ Hint: when the assertion failed, the Ember runloop was not in a settled state. Maybe you missed an `await` further up the test? Or maybe you need to manually add `await settled()` before your assertion?",
-        getSettledState()
+        JSON.stringify(getSettledState())
       );
     }
 


### PR DESCRIPTION
So it actually shows up in CI (in a form other than `[object Object]`)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
