### PR TITLE
FIX: correctly uses private_email site setting in chat

### DIFF
--- a/plugins/chat/app/views/user_notifications/chat_summary.html.erb
+++ b/plugins/chat/app/views/user_notifications/chat_summary.html.erb
@@ -26,37 +26,51 @@
       <tbody>
         <tr>
           <td colspan="100%">
-            <h5 style="margin:0.5em 0 0.5em 0;font-size:0.9em;"><%= chat_channel.title(@user) %></h5>
+            <h5 style="margin:0.5em 0 0.5em 0;font-size:0.9em;">
+              <%- if SiteSetting.private_email %>
+                <%= I18n.t("system_messages.private_channel_title", id: chat_channel.id) %>
+              <%- else %>
+                <%= chat_channel.title(@user) %>
+              <%- end %>
+            </h5>
           </td>
         </tr>
-        <%- messages.take(2).each do |chat_message| %>
-          <%- sender = chat_message.user %>
-          <%- sender_name = @display_usernames ? sender.username : sender.name %>
 
-          <tr class="message-row">
-            <td style="white-space:nowrap;vertical-align:top;padding:<%= rtl? ? '1em 2em 0 0' : '1em 0 0 2em' %>">
-              <img src="<%= sender.small_avatar_url -%>" style="height:20px;width:20px;margin:<%= rtl? ? '0 0 5px 0' : '0 5px 0 0' %>;border-radius:50%;clear:both;display:inline-block;outline:0;text-decoration:none;vertical-align:top;" alt="<%= sender_name -%>">
-              <span style="display:inline-block;color:#0a0a0a;vertical-align:top;font-weight:bold;">
-                <%= sender_name -%>
-              </span>
-              <span style="display:inline-block;color:#0a0a0a;font-size:0.8em;">
-                <%= I18n.l(@user_tz.to_local(chat_message.created_at), format: :long) -%>
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td style="width:99%;margin:0;padding:<%= rtl? ? '0 2em 0 0' : '0 0 0 2em' %>;vertical-align:top;">
-              <%= email_excerpt(chat_message.cooked_for_excerpt) %>
-            </td>
-          </tr>
+        <%- unless SiteSetting.private_email %>
+          <%- messages.take(2).each do |chat_message| %>
+            <%- sender = chat_message.user %>
+            <%- sender_name = @display_usernames ? sender.username : sender.name %>
+
+            <tr class="message-row">
+              <td style="white-space:nowrap;vertical-align:top;padding:<%= rtl? ? '1em 2em 0 0' : '1em 0 0 2em' %>">
+                <img src="<%= sender.small_avatar_url -%>" style="height:20px;width:20px;margin:<%= rtl? ? '0 0 5px 0' : '0 5px 0 0' %>;border-radius:50%;clear:both;display:inline-block;outline:0;text-decoration:none;vertical-align:top;" alt="<%= sender_name -%>">
+                <span style="display:inline-block;color:#0a0a0a;vertical-align:top;font-weight:bold;">
+                  <%= sender_name -%>
+                </span>
+                <span style="display:inline-block;color:#0a0a0a;font-size:0.8em;">
+                  <%= I18n.l(@user_tz.to_local(chat_message.created_at), format: :long) -%>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td style="width:99%;margin:0;padding:<%= rtl? ? '0 2em 0 0' : '0 0 0 2em' %>;vertical-align:top;">
+                <%= email_excerpt(chat_message.cooked_for_excerpt) %>
+              </td>
+            </tr>
+          <%- end %>
         <%- end %>
+
         <tr>
           <td colspan="100%" style="padding:<%= rtl? ? '2em 2em 0 0' : '2em 0 0 2em' %>">
             <a class="more-messages-link" href="<%= messages.first.full_url %>">
-              <%- if other_messages_count <= 0 %>
+              <%- if SiteSetting.private_email %>
                 <%= I18n.t("user_notifications.chat_summary.view_messages", count: messages.size)%>
               <%- else %>
-                <%= I18n.t("user_notifications.chat_summary.view_more", count: other_messages_count)%>
+                <%- if other_messages_count <= 0 %>
+                  <%= I18n.t("user_notifications.chat_summary.view_messages", count: messages.size)%>
+                <%- else %>
+                  <%= I18n.t("user_notifications.chat_summary.view_more", count: other_messages_count)%>
+                <%- end %>
               <%- end %>
             </a>
           </td>

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -30,6 +30,7 @@ en:
       direct_message_enabled_groups_invalid: "You must specify at least one group for this setting. If you do not want anyone except staff to send direct messages, choose the staff group."
       chat_upload_not_allowed_secure_uploads: "Chat uploads are not allowed when secure uploads site setting is enabled."
   system_messages:
+    private_channel_title: "Channel %{id}"
     chat_channel_archive_complete:
       title: "Chat Channel Archive Complete"
       subject_template: "Chat channel archive completed successfully"
@@ -233,6 +234,7 @@ en:
         other: "You have new chat messages"
       from: "%{site_name}"
       subject:
+        private_message: "[%{email_prefix}] New message"
         direct_message_from_1: "[%{email_prefix}] New message from %{username}"
         direct_message_from_2: "[%{email_prefix}] New message from %{username1} and %{username2}"
         direct_message_from_more:

--- a/plugins/chat/lib/chat/user_notifications_extension.rb
+++ b/plugins/chat/lib/chat/user_notifications_extension.rb
@@ -53,6 +53,15 @@ module Chat
     end
 
     def summary_subject(user, grouped_messages)
+      if SiteSetting.private_email
+        return(
+          I18n.t(
+            "user_notifications.chat_summary.subject.private_message",
+            email_prefix: @email_prefix,
+          )
+        )
+      end
+
       all_channels = grouped_messages.keys
       grouped_channels = all_channels.partition { |c| !c.direct_message_channel? }
       channels = grouped_channels.first


### PR DESCRIPTION
Chat will now check for the state of `SiteSetting.private_email` when sending the summary, when enabled, the mail will not display user information, channel information other than the ID and no message information, only the count of messages.

Private enabled:

![Screenshot 2023-11-23 at 13 00 21](https://github.com/discourse/discourse/assets/339945/8ba37741-6f2b-4c4b-997b-dbb87854f945)

Private disabled:

![Screenshot 2023-11-23 at 13 00 10](https://github.com/discourse/discourse/assets/339945/651cae92-4b3e-40e7-ac29-0a93f55eae76)

