### PR TITLE
UX: fix icon-lock size on email-login page

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -119,12 +119,14 @@ body.invite-page {
   padding: 20px;
   margin: 0 auto;
   .content-wrapper {
-    box-shadow: 0 1px 10px 1px rgba(var(--primary-low-rgb), 1.25);
-    border-radius: 10px;
     padding: 1em 2.5em 1em 2.5em;
     .image-wrapper {
       text-align: center;
       padding-bottom: 1em;
+
+      img {
+        max-width: 200px;
+      }
     }
     .email-login-form {
       text-align: center;


### PR DESCRIPTION
Fixing some regression due to either the modal changes or due to signup/login being full width
<img width="1149" alt="image" src="https://github.com/discourse/discourse/assets/101828855/78025182-a204-4e56-87b0-c27d6c259d95">

* scaling icon
* removing modal-like borders

<img width="1155" alt="image" src="https://github.com/discourse/discourse/assets/101828855/d14f9dc9-76e5-4bdd-bfb3-c68307b96f64">

<img width="445" alt="image" src="https://github.com/discourse/discourse/assets/101828855/e0370c96-f54c-455d-a4f7-5bd9ca7e0a70">
