### PR TITLE
FIX: category selectors for lazy loaded categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
@@ -10,9 +10,7 @@
     {{/if}}
     <CategorySelector
       @categoryIds={{@model.watched_category_ids}}
-      @categories={{@model.watchedCategories}}
       @blockedCategoryIds={{@selectedCategoryIds}}
-      @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.watchedCategories)}}
     />
   </div>
@@ -29,9 +27,7 @@
     {{/if}}
     <CategorySelector
       @categoryIds={{@model.tracked_category_ids}}
-      @categories={{@model.trackedCategories}}
       @blockedCategoryIds={{@selectedCategoryIds}}
-      @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.trackedCategories)}}
     />
   </div>
@@ -46,9 +42,7 @@
       {{i18n "user.watched_first_post_categories"}}</label>
     <CategorySelector
       @categoryIds={{@model.watched_first_post_category_ids}}
-      @categories={{@model.watchedFirstPostCategories}}
       @blockedCategoryIds={{@selectedCategoryIds}}
-      @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.watchedFirstPostCategories)}}
     />
   </div>
@@ -63,9 +57,7 @@
       <label>{{d-icon "d-regular"}} {{i18n "user.regular_categories"}}</label>
       <CategorySelector
         @categoryIds={{@model.regular_category_ids}}
-        @categories={{@model.regularCategories}}
         @blockedCategoryIds={{@selectedCategoryIds}}
-        @blockedCategories={{@selectedCategories}}
         @onChange={{action (mut @model.regularCategories)}}
       />
     </div>
@@ -84,9 +76,7 @@
 
       <CategorySelector
         @categoryIds={{@model.muted_category_ids}}
-        @categories={{@model.mutedCategories}}
         @blockedCategoryIds={{@selectedCategoryIds}}
-        @blockedCategories={{@selectedCategories}}
         @onChange={{action (mut @model.mutedCategories)}}
       />
     </div>

--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
@@ -9,7 +9,9 @@
         }}</a>
     {{/if}}
     <CategorySelector
+      @categoryIds={{@model.watched_category_ids}}
       @categories={{@model.watchedCategories}}
+      @blockedCategoryIds={{@selectedCategoryIds}}
       @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.watchedCategories)}}
     />
@@ -26,7 +28,9 @@
         }}</a>
     {{/if}}
     <CategorySelector
+      @categoryIds={{@model.tracked_category_ids}}
       @categories={{@model.trackedCategories}}
+      @blockedCategoryIds={{@selectedCategoryIds}}
       @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.trackedCategories)}}
     />
@@ -41,7 +45,9 @@
     <label>{{d-icon "d-watching-first"}}
       {{i18n "user.watched_first_post_categories"}}</label>
     <CategorySelector
+      @categoryIds={{@model.watched_first_post_category_ids}}
       @categories={{@model.watchedFirstPostCategories}}
+      @blockedCategoryIds={{@selectedCategoryIds}}
       @blockedCategories={{@selectedCategories}}
       @onChange={{action (mut @model.watchedFirstPostCategories)}}
     />
@@ -56,7 +62,9 @@
     >
       <label>{{d-icon "d-regular"}} {{i18n "user.regular_categories"}}</label>
       <CategorySelector
+        @categoryIds={{@model.regular_category_ids}}
         @categories={{@model.regularCategories}}
+        @blockedCategoryIds={{@selectedCategoryIds}}
         @blockedCategories={{@selectedCategories}}
         @onChange={{action (mut @model.regularCategories)}}
       />
@@ -75,7 +83,9 @@
       {{/if}}
 
       <CategorySelector
+        @categoryIds={{@model.muted_category_ids}}
         @categories={{@model.mutedCategories}}
+        @blockedCategoryIds={{@selectedCategoryIds}}
         @blockedCategories={{@selectedCategories}}
         @onChange={{action (mut @model.mutedCategories)}}
       />

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
@@ -14,4 +14,17 @@ export default Controller.extend({
       .concat(watching, watchingFirst, tracking, regular, muted)
       .filter((t) => t);
   },
+
+  @discourseComputed(
+    "model.watching_category_ids.[]",
+    "model.watching_first_post_category_ids.[]",
+    "model.tracking_category_ids.[]",
+    "model.regular_category_ids.[]",
+    "model.muted_category_ids.[]"
+  )
+  selectedCategoryIds(watching, watchingFirst, tracking, regular, muted) {
+    return []
+      .concat(watching, watchingFirst, tracking, regular, muted)
+      .filter((t) => t);
+  },
 });

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
@@ -3,19 +3,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend({
   @discourseComputed(
-    "model.watchingCategories.[]",
-    "model.watchingFirstPostCategories.[]",
-    "model.trackingCategories.[]",
-    "model.regularCategories.[]",
-    "model.mutedCategories.[]"
-  )
-  selectedCategories(watching, watchingFirst, tracking, regular, muted) {
-    return []
-      .concat(watching, watchingFirst, tracking, regular, muted)
-      .filter((t) => t);
-  },
-
-  @discourseComputed(
     "model.watching_category_ids.[]",
     "model.watching_first_post_category_ids.[]",
     "model.tracking_category_ids.[]",

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
@@ -23,8 +23,6 @@ export default Controller.extend({
     "model.muted_category_ids.[]"
   )
   selectedCategoryIds(watching, watchingFirst, tracking, regular, muted) {
-    return []
-      .concat(watching, watchingFirst, tracking, regular, muted)
-      .filter((t) => t);
+    return [].concat(watching, watchingFirst, tracking, regular, muted);
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
@@ -17,28 +17,27 @@ export default Controller.extend({
   },
 
   @discourseComputed(
-    "siteSettings.mute_all_categories_by_default",
-    "model.watchedCategories",
-    "model.watchedFirstPostCategories",
-    "model.trackedCategories",
-    "model.mutedCategories",
-    "model.regularCategories"
+    "model.watched_categoriy_ids",
+    "model.watched_first_post_categoriy_ids",
+    "model.tracked_categoriy_ids",
+    "model.muted_categoriy_ids",
+    "model.regular_category_ids",
+    "siteSettings.mute_all_categories_by_default"
   )
-  selectedCategories(
-    muteAllCategoriesByDefault,
+  selectedCategoryIds(
     watched,
     watchedFirst,
     tracked,
     muted,
-    regular
+    regular,
+    muteAllCategoriesByDefault
   ) {
-    let categories = [].concat(watched, watchedFirst, tracked);
-
-    categories = categories.concat(
+    return [].concat(
+      watched,
+      watchedFirst,
+      tracked,
       muteAllCategoriesByDefault ? regular : muted
     );
-
-    return categories.filter((t) => t);
   },
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
@@ -151,16 +151,14 @@ export default class extends Controller {
     "siteSettings.mute_all_categories_by_default"
   )
   get selectedCategoryIds() {
-    return []
-      .concat(
-        this.model.watched_category_ids,
-        this.model.watched_first_post_category_ids,
-        this.model.tracked_category_ids,
-        this.siteSettings.mute_all_categories_by_default
-          ? this.model.regular_category_ids
-          : this.model.muted_category_ids
-      )
-      .filter((t) => t);
+    return [].concat(
+      this.model.watched_category_ids,
+      this.model.watched_first_post_category_ids,
+      this.model.tracked_category_ids,
+      this.siteSettings.mute_all_categories_by_default
+        ? this.model.regular_category_ids
+        : this.model.muted_category_ids
+    );
   }
 
   @computed("siteSettings.remove_muted_tags_from_latest")

--- a/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
@@ -122,27 +122,6 @@ export default class extends Controller {
   }
 
   @computed(
-    "model.watchedCategories",
-    "model.watchedFirstPostCategories",
-    "model.trackedCategories",
-    "model.mutedCategories",
-    "model.regularCategories",
-    "siteSettings.mute_all_categories_by_default"
-  )
-  get selectedCategories() {
-    return []
-      .concat(
-        this.model.watchedCategories,
-        this.model.watchedFirstPostCategories,
-        this.model.trackedCategories,
-        this.siteSettings.mute_all_categories_by_default
-          ? this.model.regularCategories
-          : this.model.mutedCategories
-      )
-      .filter((t) => t);
-  }
-
-  @computed(
     "model.watched_category_ids",
     "model.watched_first_post_category_ids",
     "model.tracked_category_ids",

--- a/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
@@ -142,6 +142,27 @@ export default class extends Controller {
       .filter((t) => t);
   }
 
+  @computed(
+    "model.watched_category_ids",
+    "model.watched_first_post_category_ids",
+    "model.tracked_category_ids",
+    "model.muted_category_ids",
+    "model.regular_category_ids",
+    "siteSettings.mute_all_categories_by_default"
+  )
+  get selectedCategoryIds() {
+    return []
+      .concat(
+        this.model.watched_category_ids,
+        this.model.watched_first_post_category_ids,
+        this.model.tracked_category_ids,
+        this.siteSettings.mute_all_categories_by_default
+          ? this.model.regular_category_ids
+          : this.model.muted_category_ids
+      )
+      .filter((t) => t);
+  }
+
   @computed("siteSettings.remove_muted_tags_from_latest")
   get hideMutedTags() {
     return this.siteSettings.remove_muted_tags_from_latest !== "never";

--- a/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
@@ -12,8 +12,6 @@
 
     <CategorySelector
       @categoryIds={{this.model.watching_category_ids}}
-      @categories={{this.model.watchingCategories}}
-      @blockedCategories={{this.selectedCategories}}
       @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.watchingCategories)}}
     />
@@ -29,8 +27,6 @@
 
     <CategorySelector
       @categoryIds={{this.model.tracking_category_ids}}
-      @categories={{this.model.trackingCategories}}
-      @blockedCategories={{this.selectedCategories}}
       @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.trackingCategories)}}
     />
@@ -46,8 +42,6 @@
 
     <CategorySelector
       @categoryIds={{this.model.watching_first_post_category_ids}}
-      @categories={{this.model.watchingFirstPostCategories}}
-      @blockedCategories={{this.selectedCategories}}
       @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.watchingFirstPostCategories)}}
     />
@@ -65,8 +59,6 @@
 
     <CategorySelector
       @categoryIds={{this.model.regular_category_ids}}
-      @categories={{this.model.regularCategories}}
-      @blockedCategories={{this.selectedCategories}}
       @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.regularCategories)}}
     />
@@ -82,8 +74,6 @@
 
     <CategorySelector
       @categoryIds={{this.model.muted_category_ids}}
-      @categories={{this.model.mutedCategories}}
-      @blockedCategories={{this.selectedCategories}}
       @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.mutedCategories)}}
     />

--- a/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
@@ -11,8 +11,10 @@
       {{i18n "groups.notifications.watching.title"}}</label>
 
     <CategorySelector
+      @categoryIds={{this.model.watching_category_ids}}
       @categories={{this.model.watchingCategories}}
       @blockedCategories={{this.selectedCategories}}
+      @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.watchingCategories)}}
     />
 
@@ -26,8 +28,10 @@
       {{i18n "groups.notifications.tracking.title"}}</label>
 
     <CategorySelector
+      @categoryIds={{this.model.tracking_category_ids}}
       @categories={{this.model.trackingCategories}}
       @blockedCategories={{this.selectedCategories}}
+      @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.trackingCategories)}}
     />
 
@@ -41,8 +45,10 @@
       {{i18n "groups.notifications.watching_first_post.title"}}</label>
 
     <CategorySelector
+      @categoryIds={{this.model.watching_first_post_category_ids}}
       @categories={{this.model.watchingFirstPostCategories}}
       @blockedCategories={{this.selectedCategories}}
+      @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.watchingFirstPostCategories)}}
     />
 
@@ -58,8 +64,10 @@
       {{i18n "groups.notifications.regular.title"}}</label>
 
     <CategorySelector
+      @categoryIds={{this.model.regular_category_ids}}
       @categories={{this.model.regularCategories}}
       @blockedCategories={{this.selectedCategories}}
+      @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.regularCategories)}}
     />
 
@@ -73,8 +81,10 @@
       {{i18n "groups.notifications.muted.title"}}</label>
 
     <CategorySelector
+      @categoryIds={{this.model.muted_category_ids}}
       @categories={{this.model.mutedCategories}}
       @blockedCategories={{this.selectedCategories}}
+      @blockedCategoryIds={{this.selectedCategoryIds}}
       @onChange={{action (mut this.model.mutedCategories)}}
     />
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/categories.hbs
@@ -1,7 +1,7 @@
 <UserPreferences::Categories
   @canSee={{this.canSee}}
   @model={{this.model}}
-  @selectedCategories={{this.selectedCategories}}
+  @selectedCategoryIds={{this.selectedCategoryIds}}
   @hideMutedTags={{this.hideMutedTags}}
   @save={{action "save"}}
   @siteSettings={{this.siteSettings}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
@@ -57,7 +57,6 @@
     <UserPreferences::Categories
       @canSee={{this.canSee}}
       @model={{this.model}}
-      @selectedCategories={{this.selectedCategories}}
       @selectedCategoryIds={{this.selectedCategoryIds}}
       @hideMutedTags={{this.hideMutedTags}}
       @siteSettings={{this.siteSettings}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
@@ -58,6 +58,7 @@
       @canSee={{this.canSee}}
       @model={{this.model}}
       @selectedCategories={{this.selectedCategories}}
+      @selectedCategoryIds={{this.selectedCategoryIds}}
       @hideMutedTags={{this.hideMutedTags}}
       @siteSettings={{this.siteSettings}}
     />

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -24,6 +24,19 @@ export default ComboBoxComponent.extend({
     prioritizedCategoryId: null,
   },
 
+  init() {
+    this._super(...arguments);
+
+    if (
+      this.siteSettings.lazy_load_categories &&
+      !Category.hasAsyncFoundAll([this.value])
+    ) {
+      Category.asyncFindByIds([this.value]).then(() => {
+        this.notifyPropertyChange("value");
+      });
+    }
+  },
+
   modifyComponentForRow() {
     return "category-row";
   },

--- a/app/assets/javascripts/select-kit/addon/components/category-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-selector.js
@@ -38,6 +38,8 @@ export default MultiSelectComponent.extend({
           return this.blockedCategories.map((c) => c.id);
         })
       );
+    } else if (!this.blockedCategoryIds) {
+      this.set("blockedCategoryIds", []);
     }
 
     if (this.siteSettings.lazy_load_categories) {

--- a/app/assets/javascripts/select-kit/addon/components/category-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-selector.js
@@ -28,8 +28,6 @@ export default MultiSelectComponent.extend({
           return this.categories.map((c) => c.id);
         })
       );
-    } else if (!this.categoryIds) {
-      this.set("categoryIds", []);
     }
 
     if (this.blockedCategories && !this.blockedCategoryIds) {
@@ -40,8 +38,6 @@ export default MultiSelectComponent.extend({
           return this.blockedCategories.map((c) => c.id);
         })
       );
-    } else if (!this.blockedCategoryIds) {
-      this.set("blockedCategoryIds", []);
     }
 
     if (this.siteSettings.lazy_load_categories) {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -316,7 +316,9 @@ class CategoriesController < ApplicationController
 
     raise Discourse::NotFound if categories.blank?
 
-    render_serialized(categories, SiteCategorySerializer, root: :categories)
+    Category.preload_user_fields!(guardian, categories)
+
+    render_serialized(categories, SiteCategorySerializer, root: :categories, scope: guardian)
   end
 
   def search
@@ -383,7 +385,9 @@ class CategoriesController < ApplicationController
 
     categories = categories.order(:id)
 
-    render json: categories, each_serializer: SiteCategorySerializer
+    Category.preload_user_fields!(guardian, categories)
+
+    render_serialized(categories, SiteCategorySerializer, root: :categories, scope: guardian)
   end
 
   private

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -226,6 +226,8 @@ class Category < ActiveRecord::Base
   attr_accessor :skip_category_definition
 
   def self.preload_user_fields!(guardian, categories)
+    category_ids = categories.map(&:id)
+
     # Load notification levels
     notification_levels = CategoryUser.notification_levels_for(guardian.user)
     notification_levels.default = CategoryUser.default_notification_level
@@ -233,12 +235,12 @@ class Category < ActiveRecord::Base
     # Load permissions
     allowed_topic_create_ids =
       if !guardian.is_admin? && !guardian.is_anonymous?
-        Category.topic_create_allowed(guardian).where(id: categories.map(&:id)).pluck(:id).to_set
+        Category.topic_create_allowed(guardian).where(id: category_ids).pluck(:id).to_set
       end
 
     # Categories with children
     with_children =
-      Category.where(parent_category_id: categories.map(&:id)).pluck(:parent_category_id).to_set
+      Category.where(parent_category_id: category_ids).pluck(:parent_category_id).to_set
 
     # Update category attributes
     categories.each do |category|

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -19,7 +19,7 @@ class BasicCategorySerializer < ApplicationSerializer
              :notification_level,
              :can_edit,
              :topic_template,
-             :has_children?,
+             :has_children,
              :sort_order,
              :sort_ascending,
              :show_subcategory_list,

--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -36,4 +36,19 @@ class SiteCategorySerializer < BasicCategorySerializer
   def include_required_tag_groups?
     SiteSetting.tagging_enabled
   end
+
+  def notification_level
+    return if !scope || scope.anonymous?
+
+    CategoryUser.where(user_id: scope.user.id, category_id: object.id).pick(:notification_level) ||
+      CategoryUser.default_notification_level
+  end
+
+  def permission
+    return if !scope || scope.anonymous?
+
+    if scope.is_admin? || Category.topic_create_allowed(scope).include?(object.id)
+      CategoryGroup.permission_types[:full]
+    end
+  end
 end

--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -36,19 +36,4 @@ class SiteCategorySerializer < BasicCategorySerializer
   def include_required_tag_groups?
     SiteSetting.tagging_enabled
   end
-
-  def notification_level
-    return if !scope || scope.anonymous?
-
-    CategoryUser.where(user_id: scope.user.id, category_id: object.id).pick(:notification_level) ||
-      CategoryUser.default_notification_level
-  end
-
-  def permission
-    return if !scope || scope.anonymous?
-
-    if scope.is_admin? || Category.topic_create_allowed(scope).include?(object.id)
-      CategoryGroup.permission_types[:full]
-    end
-  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1298,8 +1298,6 @@ RSpec.describe Category do
     let(:guardian) { Guardian.new(admin) }
     fab!(:category)
 
-    before { Category.clear_parent_ids }
-
     describe "when category is uncategorized" do
       it "should return the reason" do
         category = Category.find(SiteSetting.uncategorized_category_id)

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -79,7 +79,10 @@
           "items": {}
         },
         "has_children": {
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "sort_order": {
           "type": [

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -61,7 +61,7 @@
         },
         "permission": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },
@@ -82,7 +82,10 @@
           "items": {}
         },
         "has_children": {
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "sort_order": {
           "type": [

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1092,6 +1092,17 @@ RSpec.describe CategoriesController do
         expect(response.status).to eq(403)
       end
     end
+
+    it "returns user fields" do
+      sign_in(admin)
+
+      get "/categories/find.json", params: { slug_path_with_id: "#{category.slug}/#{category.id}" }
+
+      category = response.parsed_body["categories"].first
+      expect(category["notification_level"]).to eq(NotificationLevels.all[:regular])
+      expect(category["permission"]).to eq(CategoryGroup.permission_types[:full])
+      expect(category["has_children"]).to eq(true)
+    end
   end
 
   describe "#search" do
@@ -1225,6 +1236,17 @@ RSpec.describe CategoriesController do
 
         expect(response.parsed_body["categories"].size).to eq(2)
       end
+    end
+
+    it "returns user fields" do
+      sign_in(admin)
+
+      get "/categories/search.json", params: { select_category_ids: [category.id] }
+
+      category = response.parsed_body["categories"].first
+      expect(category["notification_level"]).to eq(NotificationLevels.all[:regular])
+      expect(category["permission"]).to eq(CategoryGroup.permission_types[:full])
+      expect(category["has_children"]).to eq(true)
     end
   end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1044,24 +1044,34 @@ RSpec.describe CategoriesController do
     fab!(:category) { Fabricate(:category, name: "Foo") }
     fab!(:subcategory) { Fabricate(:category, name: "Foobar", parent_category: category) }
 
-    it "returns the category" do
-      get "/categories/find.json",
-          params: {
-            category_slug_path_with_id: "#{category.slug}/#{category.id}",
-          }
+    context "with ids" do
+      it "returns the categories" do
+        get "/categories/find.json", params: { ids: [subcategory.id] }
 
-      expect(response.parsed_body["category"]["id"]).to eq(category.id)
-      expect(response.parsed_body["ancestors"]).to eq([])
+        expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq([subcategory.id])
+      end
     end
 
-    it "returns the subcategory and ancestors" do
-      get "/categories/find.json",
-          params: {
-            category_slug_path_with_id: "#{subcategory.slug}/#{subcategory.id}",
-          }
+    context "with slug path" do
+      it "returns the category" do
+        get "/categories/find.json",
+            params: {
+              slug_path_with_id: "#{category.slug}/#{category.id}",
+            }
 
-      expect(response.parsed_body["category"]["id"]).to eq(subcategory.id)
-      expect(response.parsed_body["ancestors"].map { |c| c["id"] }).to eq([category.id])
+        expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq([category.id])
+      end
+
+      it "returns the subcategory and ancestors" do
+        get "/categories/find.json",
+            params: {
+              slug_path_with_id: "#{subcategory.slug}/#{subcategory.id}",
+            }
+
+        expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq(
+          [category.id, subcategory.id],
+        )
+      end
     end
   end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1072,6 +1072,17 @@ RSpec.describe CategoriesController do
           [category.id, subcategory.id],
         )
       end
+
+      it "does not return hidden category" do
+        category.update!(read_restricted: true)
+
+        get "/categories/find.json",
+            params: {
+              slug_path_with_id: "#{category.slug}/#{category.id}",
+            }
+
+        expect(response.status).to eq(403)
+      end
     end
   end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1050,6 +1050,14 @@ RSpec.describe CategoriesController do
 
         expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq([subcategory.id])
       end
+
+      it "does not return hidden category" do
+        category.update!(read_restricted: true)
+
+        get "/categories/find.json", params: { ids: [123_456_789] }
+
+        expect(response.status).to eq(404)
+      end
     end
 
     context "with slug path" do


### PR DESCRIPTION
A lot of work has been put in the select kits used for selecting
categories: CategorySelector, CategoryChooser, CategoryDrop, however
they still do not work as expected when these selectors already have
values set, because the category were still looked up in the list of
categories stored on the client-side `Categrories.list()`.

This PR fixes that by looking up the categories when the selector is
initialized. This required altering the `/categories/find.json` endpoint
to accept a list of IDs that need to be looked up. The API is called
using `Category.asyncFindByIds` on the client-side.

CategorySelector was also updated to receive a list of category IDs as
attribute, instead of the list of categories, because the list of
categories may have not been loaded.

During this development, I noticed that `SiteCategorySerializer` did not
serializer all fields (such as `permission` and `notification_level`)
which are not a property of category, but a property of the relationship
between users and categories. To make this more efficient, the
`preload_user_fields!` method was implemented that can be used to
preload these attributes for a user and a list of categories.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
