### PR TITLE
DEV: maxmind license checking failing tests

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1078,7 +1078,7 @@ en:
       confirm_delete_other_accounts: "Are you sure you want to delete these accounts?"
       powered_by: "using <a href='https://maxmind.com'>MaxMindDB</a>"
       copied: "copied"
-      no_license: "Configure MaxMind to enable GeoIP information"
+      no_license: "You must configure MaxMind to enable GeoIP information. This is configured using DISCOURSE_MAXMIND_LICENSE_KEY in your container config. If you are on a hosted Discourse service, contact your service provider."
 
     user_fields:
       none: "(select an option)"

--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -11,10 +11,8 @@ class DiscourseIpInfo
   end
 
   def open_db(path)
-    unless GlobalSetting.maxmind_license_key.blank?
-      @loc_mmdb = mmdb_load(File.join(path, "GeoLite2-City.mmdb"))
-      @asn_mmdb = mmdb_load(File.join(path, "GeoLite2-ASN.mmdb"))
-    end
+    @loc_mmdb = mmdb_load(File.join(path, "GeoLite2-City.mmdb"))
+    @asn_mmdb = mmdb_load(File.join(path, "GeoLite2-ASN.mmdb"))
     @cache = LruRedux::ThreadSafeCache.new(2000)
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1153,8 +1153,6 @@ RSpec.describe Report do
         freeze_time DateTime.parse("2017-03-01 12:00")
 
         ip = [81, 2, 69, 142]
-        # Assign a dummy MaxMind license key, which is now checked in open_db
-        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1680,8 +1680,6 @@ RSpec.describe Admin::UsersController do
     shared_examples "IP info retrieval possible" do
       it "retrieves IP info" do
         ip = "81.2.69.142"
-        # Assign a dummy MaxMind license key, which is now checked in open_db
-        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS.any_instance.stubs(:getname).with(ip).returns("ip-81-2-69-142.example.com")
@@ -1719,8 +1717,6 @@ RSpec.describe Admin::UsersController do
 
       it "prevents retrieval of IP info with a 404 response" do
         ip = "81.2.69.142"
-        # Assign a dummy MaxMind license key, which is now checked in open_db
-        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS.any_instance.stubs(:getname).with(ip).returns("ip-81-2-69-142.example.com")

--- a/spec/serializers/user_auth_token_serializer_spec.rb
+++ b/spec/serializers/user_auth_token_serializer_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe UserAuthTokenSerializer do
   fab!(:user) { Fabricate(:moderator) }
   let(:token) { UserAuthToken.generate!(user_id: user.id, client_ip: "2a02:ea00::", staff: true) }
   # Assign a dummy MaxMind license key, which is now checked in open_db
-  global_setting "maxmind_license_key", "dummy"
 
   before(:each) { DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb")) }
 


### PR DESCRIPTION
This improves the implementation of #18993

1. Error message displayed to user is clearer
2. open_db will also be called, even if license key is blank, as it was previously
3. This in turn means no need to keep stubbing 'maxmind_license_key'
