### PR TITLE
DEV: Cache plugin gems when running plugin test jobs in Github CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,12 @@ jobs:
         if: matrix.target == 'plugins'
         run: bin/rake plugin:pull_compatible_all
 
+      - name: Plugin gems cache
+        uses: actions/cache@v3
+        with:
+          path: plugins/*/gems
+          key: ${{ runner.os }}-plugin-gems-${{matrix.ruby}}-${{ hashFiles('plugins/*/plugin.rb') }}
+
       - name: Checkout official themes
         if: matrix.target == 'themes' && matrix.build_type == 'system'
         run: bin/rake themes:clone_all_official


### PR DESCRIPTION
### Why this change?

Plugin gems for official plugins are being installed over and over again
each time we run RSpec and QUnit tests for plugins. In particular, the
rugged gem installed by the discourse-code-review plugin takes
approximately 50-60 seconds to install because it is compiling libgit2.

### What does this change do?

This commit introduces a Github action cache where we cache the `plugins/*/gems` directories and burst the cache when `plugins/*/plugin.rb` changes.

### Outcome of this change

`plugins backend` job is reduced from 8m to 6m on cache hit. 
`plugins frontend` job is reduced from 6m to 5m on cache  hit.