### PR TITLE
FIX: prevents input to reset at wrong moment

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -518,7 +518,6 @@ export default class ChatChannel extends Component {
       popupAjaxError(e);
     } finally {
       message.editing = false;
-      this.resetComposerMessage();
       this.pane.sending = false;
     }
   }
@@ -553,7 +552,6 @@ export default class ChatChannel extends Component {
     } catch (error) {
       this._onSendError(message.id, error);
     } finally {
-      this.resetComposerMessage();
       this.pane.sending = false;
     }
   }


### PR DESCRIPTION
Before this fix we would reset the input two times:

- right before sending message
- and after it's been sent

The second one is actually not necessary, and more over with the server delay the user could have started typing a new message and that would clear it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
