### PR TITLE
FIX: Handle missing git repo details in plugin list

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -519,8 +519,9 @@ class Plugin::Instance
   end
 
   def discourse_owned?
+    return false if commit_hash.blank?
     parsed_commit_url = UrlHelper.relaxed_parse(self.commit_url)
-    return false if !parsed_commit_url
+    return false if parsed_commit_url.blank?
     github_org = parsed_commit_url.path.split("/")[1]
     (github_org == "discourse" || github_org == "discourse-org") &&
       parsed_commit_url.host == "github.com"

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Plugin::Instance do
         plugin.git_repo.stubs(:url).returns("http://github.com/someguy/someguy-plugin")
         expect(plugin.discourse_owned?).to eq(false)
       end
+
+      it "returns false if the commit_url is missing because of git command issues" do
+        plugin = Plugin::Instance.find_all("#{Rails.root}/spec/fixtures/plugins")[3]
+        plugin.git_repo.stubs(:latest_local_commit).returns(nil)
+        expect(plugin.discourse_owned?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
Followup to e37fb3042d6f56a27a01614e57bc7029f472b0c9,
in some cases we cannot get git information for the
plugin folder (e.g. permission issues), so we need
to only try and get information about it if
commit_hash is present.
