### PR TITLE
FIX: nullifies target message id when not readable

### DIFF
--- a/plugins/chat/app/services/chat/list_channel_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_messages.rb
@@ -84,11 +84,18 @@ module Chat
 
     def target_message_exists(channel:, guardian:, **)
       return true if context.target_message_id.blank?
+
       target_message =
         Chat::Message.with_deleted.find_by(id: context.target_message_id, chat_channel: channel)
       return false if target_message.blank?
+
       return true if !target_message.trashed?
-      target_message.user_id == guardian.user.id || guardian.is_staff?
+      if target_message.trashed? && target_message.user_id == guardian.user.id || guardian.is_staff?
+        return true
+      end
+
+      context.target_message_id = nil
+      true
     end
 
     def fetch_messages(channel:, contract:, guardian:, enabled_threads:, **)

--- a/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe Chat::ListChannelMessages do
       before { target_message.trash! }
 
       context "when user is regular" do
-        it { is_expected.to fail_a_policy(:target_message_exists) }
+        it "nullifies target_message_id" do
+          expect(result.target_message_id).to be_blank
+        end
       end
 
       context "when user is the message creator" do


### PR DESCRIPTION
This bug was very reproducible when your last read was a message you didn't read and an admin would delete it. When coming back to the channel you would get a not found, in this case we will now nullify the provided `target_message_id` and present you the latest message of the channel.

We could be more fancy and  try to detect the next readable message but that would be more code and complexity for such a rare case.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
