### PR TITLE
DEV: Cleanup unused markdownItUrl references

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/initializers/discourse-bootstrap.js
@@ -67,7 +67,6 @@ export default {
     session.serviceWorkerURL = setupData.serviceWorkerUrl;
     session.assetVersion = setupData.assetVersion;
     session.disableCustomCSS = setupData.disableCustomCss === "true";
-    session.markdownItURL = setupData.markdownItUrl;
 
     if (setupData.mbLastFileChangeId) {
       session.mbLastFileChangeId = parseInt(setupData.mbLastFileChangeId, 10);

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -312,10 +312,6 @@ export default function setupTests(config) {
     applyPretender(ctx.module, pretender, pretenderHelpers());
 
     Session.resetCurrent();
-    if (setupData) {
-      const session = Session.current();
-      session.markdownItURL = setupData.markdownItUrl;
-    }
     User.resetCurrent();
 
     PreloadStore.reset();


### PR DESCRIPTION
These are unused since 9a1695ccc1bcfb8bcbdc0512fff28a83500029e0

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
