### PR TITLE
DEV: Load svg icons in dev-environment qunit tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/index.html
+++ b/app/assets/javascripts/discourse/tests/index.html
@@ -42,6 +42,8 @@
     </style>
   </head>
   <body>
+    <discourse-assets-icons></discourse-assets-icons>
+
     {{content-for "body"}} {{content-for "test-body"}}
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -46,6 +46,7 @@ import { setDefaultOwner } from "discourse-common/lib/get-owner";
 import { setupS3CDN, setupURL } from "discourse-common/lib/get-url";
 import { buildResolver } from "discourse-common/resolver";
 import Application from "../app";
+import { loadSprites } from "../lib/svg-sprite-loader";
 
 const Plugin = $.fn.modal;
 const Modal = Plugin.Constructor;
@@ -398,6 +399,14 @@ export default function setupTests(config) {
   setupToolbar();
   reportMemoryUsageAfterTests();
   patchFailedAssertion();
+  if (!window.Testem) {
+    // Running in a dev server - svg sprites are available
+    // Using a fake 40-char version hash will redirect to the current one
+    loadSprites(
+      "/svg-sprite/localhost/svg--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js",
+      "fontawesome"
+    );
+  }
 
   if (!hasPluginJs && !hasThemeJs) {
     configureRaiseOnDeprecation();


### PR DESCRIPTION
Making the icons available generally in tests is tricky because they're generated dynamically by the rails server. However, if we restrict it to dev-mode (`/tests` in a browser) then it's possible to load them from the running rails server. This is purely a visual thing to make debugging easier - it should not affect test behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
