### PR TITLE
UX: Various improvements to JSON Schema editor

### DIFF
--- a/app/assets/stylesheets/common/base/json_schema.scss
+++ b/app/assets/stylesheets/common/base/json_schema.scss
@@ -171,6 +171,10 @@
       .je-tab--top {
         border: none;
         padding: 0;
+        color: var(--primary);
+        background: var(
+          --secondary
+        ) !important; // important is needed here to override inline styling on the element
       }
     }
 
@@ -242,6 +246,22 @@
           }
         }
       }
+    }
+
+    div[data-schematype="boolean"] {
+      label {
+        display: flex;
+        align-items: center;
+
+        input[type="checkbox"] {
+          margin-right: var(--space-1);
+        }
+      }
+    }
+
+    select option {
+      color: var(--primary);
+      background: var(--secondary);
     }
   }
 }


### PR DESCRIPTION
This PR makes a few improvements to the JSON Schema editor when using dark mode for the UI.

Before:

<img src="https://github.com/discourse/discourse/assets/17474474/af40ee42-e970-4502-9663-fa426247ecde" width=400>

After:

<img src="https://github.com/discourse/discourse/assets/17474474/e07d337d-ad13-46b6-b2a8-1b5bb74b05cb" width=400>
