### PR TITLE
FIX: disable browser `history.scrollRestoration` feature

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -44,6 +44,10 @@ const Discourse = Application.extend({
       Error.stackTraceLimit = Infinity;
     }
 
+    // Our scroll-manager service takes care of storing and restoring scroll position.
+    // Disable browser handling:
+    window.history.scrollRestoration = "manual";
+
     loadInitializers(this);
   },
 


### PR DESCRIPTION
When going 'back', default browser behavior is to restore the scroll position. Unfortunately sites are given no control over the timing of this restoration, which means it can happen halfway through an Ember transition. Therefore we disable it, and re-implement the functionality in our scroll-manager service.

We inadvertently dropped this configuration in 7c9cf666da8f9480315fb2641d5436360aff63c4, which led to issues like https://meta.discourse.org/t/286463 because a scroll event was emitted halfway through a transition.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
