### PR TITLE
UX: fix new group chat cancel i18n label

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/message-creator/new-group.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message-creator/new-group.gjs
@@ -18,7 +18,6 @@ export default class NewGroup extends Component {
   @tracked newGroupTitle = "";
 
   placeholder = I18n.t("chat.direct_message_creator.group_name");
-  cancelLabel = I18n.t("cancel");
 
   get membersCount() {
     return this.args.members?.length;
@@ -79,7 +78,7 @@ export default class NewGroup extends Component {
             <div class="chat-message-creator__new-group-footer">
               <DButton
                 class="btn-primary btn-flat"
-                @label={{this.cancelLabel}}
+                @label="cancel"
                 @action={{@cancel}}
               />
               <DButton


### PR DESCRIPTION
`@label` expects the I18n key and we were passing the translated value instead.

![image](https://github.com/discourse/discourse/assets/3530/a01611e8-f5e6-4817-8b71-f12d0dcea53a)
