### PR TITLE
FIX: Improve group mention copy for small groups

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -859,7 +859,12 @@ export default class ComposerService extends Service {
         group_link: groupLink,
       });
     } else if (userCount > 0) {
-      body = I18n.t("composer.group_mentioned", {
+      // Louder warning for a larger group.
+      const translationKey =
+        userCount >= 5
+          ? "composer.larger_group_mentioned"
+          : "composer.group_mentioned";
+      body = I18n.t(translationKey, {
         group: `@${name}`,
         count: userCount,
         group_link: groupLink,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2395,8 +2395,9 @@ en:
         one: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} user. Nobody will be notified."
         other: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} users. Nobody will be notified."
       group_mentioned:
-        one: "By mentioning %{group}, you are about to notify <a href='%{group_link}'>%{count} person</a> – are you sure?"
-        other: "By mentioning %{group}, you are about to notify <a href='%{group_link}'>%{count} people</a> – are you sure?"
+        one: "Mentioning %{group} will notify <a href='%{group_link}'>%{count} person</a>."
+        other: "Mentioning %{group} will notify <a href='%{group_link}'>%{count} people</a>."
+      larger_group_mentioned: "Mentioning %{group} will notify <a href='%{group_link}'>%{count} people</a>. Are you sure?"
       cannot_see_mention:
         category: "You mentioned @%{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
         private: "You mentioned @%{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this personal message."


### PR DESCRIPTION
If a group is < 5 members, the mention warning doesn't need to
be so harsh. This commit changes the copy for the existing warning
and adds a new one for groups that are >= 5 members.

Larger groups:

![image](https://github.com/discourse/discourse/assets/920448/60964b5f-dc88-4bbd-89b5-27fcb9eb402a)

And for smaller groups:

![image](https://github.com/discourse/discourse/assets/920448/8a137326-a6d7-4eb1-bade-f7c13e99a91d)

