### PR TITLE
Revert "Build(deps-dev): Bump rswag-specs from 2.11.0 to 2.12.0 (#24555)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,9 @@ group :test, :development do
   gem "rubocop-discourse", require: false
   gem "parallel_tests"
 
-  gem "rswag-specs"
+  # Depreciation warnings that we can't act on is being printed out in the test output.
+  # See https://github.com/rswag/rswag/issues/703
+  gem "rswag-specs", "2.11.0"
 
   gem "annotate"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     in_threads (1.6.0)
     jmespath (1.6.2)
     json (2.6.3)
-    json-schema (4.1.1)
+    json-schema (3.0.0)
       addressable (>= 2.8)
     json_schemer (2.1.0)
       hana (~> 1.3)
@@ -407,9 +407,9 @@ GEM
     rspec-support (3.12.1)
     rss (0.3.0)
       rexml
-    rswag-specs (2.12.0)
+    rswag-specs (2.11.0)
       activesupport (>= 3.1, < 7.2)
-      json-schema (>= 2.2, < 5.0)
+      json-schema (>= 2.2, < 4.0)
       railties (>= 3.1, < 7.2)
       rspec-core (>= 2.14)
     rtlcss (0.2.1)
@@ -638,7 +638,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rss
-  rswag-specs
+  rswag-specs (= 2.11.0)
   rtlcss
   rubocop-discourse
   ruby-prof


### PR DESCRIPTION
This reverts commit fd5d5954122919aaff882421bbd9758dc0aa31e1.

See https://github.com/rswag/rswag/issues/703