### PR TITLE
FEATURE: increase tag description limit to 1000

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.hbs
@@ -10,13 +10,17 @@
             @input={{action (mut this.newTagName) value="target.value"}}
             @autofocus="true"
           />
-          <TextField
-            @id="edit-description"
+
+          <Textarea
+            id="edit-description"
             @value={{readonly this.tagInfo.description}}
-            @placeholder={{i18n "tagging.description"}}
-            @maxlength={{280}}
-            @input={{action (mut this.newTagDescription) value="target.value"}}
-            @autofocus="true"
+            placeholder={{i18n "tagging.description"}}
+            maxlength={{1000}}
+            {{on
+              "input"
+              (action (mut this.newTagDescription) value="target.value")
+            }}
+            autofocus="true"
           />
 
           <div class="edit-controls">

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -337,10 +337,10 @@ section.tag-info {
     flex-wrap: wrap;
     margin-bottom: 1em;
     #edit-name {
-      flex: 1 1 auto;
-      margin-right: 0.5em;
+      width: 100%;
     }
     #edit-description {
+      height: 120px;
       flex: 10 1 auto;
     }
     .edit-controls {

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,7 +19,7 @@ class Tag < ActiveRecord::Base
   validate :target_tag_validator,
            if: Proc.new { |t| t.new_record? || t.will_save_change_to_target_tag_id? }
   validate :name_validator
-  validates :description, length: { maximum: 280 }
+  validates :description, length: { maximum: 1000 }
 
   scope :where_name,
         ->(name) {
@@ -265,7 +265,7 @@ end
 #  updated_at         :datetime         not null
 #  pm_topic_count     :integer          default(0), not null
 #  target_tag_id      :integer
-#  description        :string
+#  description        :string(1000)
 #  public_topic_count :integer          default(0), not null
 #  staff_topic_count  :integer          default(0), not null
 #

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module TopicTagsMixin
+  DESCRIPTION_LIMIT = 80
+
   def self.included(klass)
     klass.attributes :tags
     klass.attributes :tags_descriptions
@@ -15,7 +17,10 @@ module TopicTagsMixin
   end
 
   def tags_descriptions
-    all_tags.each.with_object({}) { |tag, acc| acc[tag.name] = tag.description }.compact
+    all_tags
+      .each
+      .with_object({}) { |tag, acc| acc[tag.name] = tag.description&.truncate(DESCRIPTION_LIMIT) }
+      .compact
   end
 
   def topic

--- a/db/migrate/20231122043756_increase_size_of_tag_descriptions.rb
+++ b/db/migrate/20231122043756_increase_size_of_tag_descriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IncreaseSizeOfTagDescriptions < ActiveRecord::Migration[7.0]
+  def change
+    change_column :tags, :description, :string, limit: 1000
+  end
+end

--- a/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/spec/serializers/topic_list_item_serializer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe TopicListItemSerializer do
   describe "hidden tags" do
     let(:admin) { Fabricate(:admin) }
     let(:user) { Fabricate(:user) }
-    let(:hidden_tag) { Fabricate(:tag, name: "hidden") }
+    let(:hidden_tag) { Fabricate(:tag, name: "hidden", description: "a" * 1000) }
     let(:staff_tag_group) do
       Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
     end
@@ -59,6 +59,11 @@ RSpec.describe TopicListItemSerializer do
       json = TopicListItemSerializer.new(topic, scope: Guardian.new(admin), root: false).as_json
 
       expect(json[:tags]).to eq([hidden_tag.name])
+    end
+
+    it "trucates description" do
+      json = TopicListItemSerializer.new(topic, scope: Guardian.new(admin), root: false).as_json
+      expect(json[:tags_descriptions]).to eq({ "hidden" => "a" * 77 + "..." })
     end
 
     it "does not return hidden tag to non-staff" do


### PR DESCRIPTION
Admin can add tag description up to 1000 characters.

Full description is displayed on tag page, however on topic list it is truncated to 80 characters.

<img width="1423" alt="Screenshot 2023-11-27 at 3 15 31 pm" src="https://github.com/discourse/discourse/assets/72780/33bea731-d88f-4dfb-b10e-7f8b34e88846">

<img width="503" alt="Screenshot 2023-11-27 at 3 16 21 pm" src="https://github.com/discourse/discourse/assets/72780/a1ddd399-9e82-4751-a530-eeb90373c7ba">
