### PR TITLE
DEV: Don't depend on assets path to determine layout that is rendered

### DIFF
--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe InvitesController do
       it "shows unobfuscated email" do
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
-        expect(response.body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+        expect(response.body).to_not have_tag(:body, with: { class: "no-ember" })
         expect(response.body).to include(invite.email)
         expect(response.body).not_to include("i*****g@a***********e.ooo")
       end
@@ -94,7 +94,7 @@ RSpec.describe InvitesController do
 
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
-        expect(response.body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+        expect(response.body).to_not have_tag(:body, with: { class: "no-ember" })
         expect(response.body).not_to include(
           I18n.t(
             "invite.not_found_template",
@@ -119,7 +119,7 @@ RSpec.describe InvitesController do
 
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
-        expect(response.body).to have_tag(:script, with: { src: "/assets/discourse.js" })
+        expect(response.body).to_not have_tag(:body, with: { class: "no-ember" })
         expect(response.body).not_to include(
           I18n.t(
             "invite.not_found_template",
@@ -204,7 +204,8 @@ RSpec.describe InvitesController do
     it "fails if invite does not exist" do
       get "/invites/missing"
       expect(response.status).to eq(200)
-      expect(response.body).to_not have_tag(:script, with: { src: "/assets/application.js" })
+
+      expect(response.body).to have_tag(:body, with: { class: "no-ember" })
       expect(response.body).to include(I18n.t("invite.not_found", base_url: Discourse.base_url))
     end
 
@@ -213,7 +214,8 @@ RSpec.describe InvitesController do
 
       get "/invites/#{invite.invite_key}"
       expect(response.status).to eq(200)
-      expect(response.body).to_not have_tag(:script, with: { src: "/assets/application.js" })
+
+      expect(response.body).to have_tag(:body, with: { class: "no-ember" })
       expect(response.body).to include(I18n.t("invite.expired", base_url: Discourse.base_url))
     end
 
@@ -229,7 +231,8 @@ RSpec.describe InvitesController do
 
       get "/invites/#{invite.invite_key}"
       expect(response.status).to eq(200)
-      expect(response.body).to_not have_tag(:script, with: { src: "/assets/application.js" })
+
+      expect(response.body).to have_tag(:body, with: { class: "no-ember" })
       expect(response.body).to include(
         I18n.t(
           "invite.not_found_template",
@@ -242,7 +245,8 @@ RSpec.describe InvitesController do
 
       get "/invites/#{invite.invite_key}"
       expect(response.status).to eq(200)
-      expect(response.body).to_not have_tag(:script, with: { src: "/assets/application.js" })
+
+      expect(response.body).to have_tag(:body, with: { class: "no-ember" })
       expect(response.body).to include(
         I18n.t(
           "invite.not_found_template_link",


### PR DESCRIPTION
Why this change?

In the `invites_controller_spec.rb` file, we had several tests that were
checking for assets path in the response's body to determine which
layout has been rendered. However, those test fails if `bin/ember-cli
--build` has been run locally.

What does this change do?

Instead of checking for asset paths to determine the layout that has
been rendered, this change relies on the fact that the `no_ember` layout
has a `no-ember` class on the `body` element. This is more deterministic
as compared to relying on the different asset paths that are rendered in
the response.