### PR TITLE
DEV: Prepare modal implementation for Ember upgrade

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-legacy.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-modal-legacy.hbs
@@ -76,7 +76,7 @@
           {{~this.flash.text~}}
         </div>
 
-        {{yield}}
+        {{outlet "modalBody"}}
 
         {{#each this.errors as |error|}}
           <div class="alert alert-error">

--- a/app/assets/javascripts/discourse/app/components/modal-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal-container.hbs
@@ -11,26 +11,24 @@
   {{/each}}
 {{/if}}
 
-{{! Legacy modals depend on this wrapper being in the DOM at all times. Eventually this will be dropped.
-For now, we mitigate the potential impact on things like tests by removing the `modal` and `d-modal` classes when inactive }}
-<DModalLegacy
-  @modalClass={{if
-    this.modal.isLegacy
-    (concat-class
-      "modal"
-      "d-modal"
-      this.modal.modalClass
-      (if this.modal.opts.panels "has-tabs")
-    )
-  }}
-  @title={{this.modal.title}}
-  @titleAriaElementId={{this.modal.opts.titleAriaElementId}}
-  @panels={{this.modal.opts.panels}}
-  @selectedPanel={{this.modal.selectedPanel}}
-  @onSelectPanel={{this.modal.onSelectPanel}}
-  @hidden={{this.modal.hidden}}
-  @errors={{this.modal.errors}}
-  @closeModal={{this.closeModal}}
->
-  {{outlet "modalBody"}}
-</DModalLegacy>
+{{#if this.renderLegacy}}
+  <DModalLegacy
+    @modalClass={{if
+      this.modal.isLegacy
+      (concat-class
+        "modal"
+        "d-modal"
+        this.modal.modalClass
+        (if this.modal.opts.panels "has-tabs")
+      )
+    }}
+    @title={{this.modal.title}}
+    @titleAriaElementId={{this.modal.opts.titleAriaElementId}}
+    @panels={{this.modal.opts.panels}}
+    @selectedPanel={{this.modal.selectedPanel}}
+    @onSelectPanel={{this.modal.onSelectPanel}}
+    @hidden={{this.modal.hidden}}
+    @errors={{this.modal.errors}}
+    @closeModal={{this.closeModal}}
+  />
+{{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal-container.js
+++ b/app/assets/javascripts/discourse/app/components/modal-container.js
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { EMBER_MAJOR_VERSION } from "discourse/lib/ember-version";
 
 export default class ModalContainer extends Component {
   @service modal;
@@ -8,5 +9,9 @@ export default class ModalContainer extends Component {
   @action
   closeModal(data) {
     this.modal.close(data);
+  }
+
+  get renderLegacy() {
+    return EMBER_MAJOR_VERSION < 4;
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/ember-version.js
+++ b/app/assets/javascripts/discourse/app/lib/ember-version.js
@@ -1,0 +1,5 @@
+import { VERSION } from "@ember/version";
+
+const parts = VERSION.split(".");
+
+export const EMBER_MAJOR_VERSION = parseInt(parts[0], 10);

--- a/app/assets/javascripts/discourse/app/services/modal.js
+++ b/app/assets/javascripts/discourse/app/services/modal.js
@@ -5,6 +5,7 @@ import Service, { inject as service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import $ from "jquery";
 import { CLOSE_INITIATED_BY_MODAL_SHOW } from "discourse/components/d-modal";
+import { EMBER_MAJOR_VERSION } from "discourse/lib/ember-version";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import deprecated, {
   withSilencedDeprecations,
@@ -23,6 +24,8 @@ const LEGACY_OPTS = new Set([
 
 @disableImplicitInjections
 class ModalService extends Service {
+  @service dialog;
+
   @tracked activeModal;
   @tracked opts = {};
 
@@ -43,6 +46,23 @@ class ModalService extends Service {
    * @returns {Promise} A promise that resolves when the modal is closed, with any data passed to closeModal
    */
   show(modal, opts) {
+    if (typeof modal === "string") {
+      this.dialog.alert(
+        `Error: the '${modal}' modal needs updating to work with the latest version of Discourse. See https://meta.discourse.org/t/268057.`
+      );
+      deprecated(
+        `Defining modals using a controller is no longer supported. Use the component-based API instead. (modal: ${modal})`,
+        {
+          id: "discourse.modal-controllers",
+          since: "3.1",
+          dropFrom: "3.2",
+          url: "https://meta.discourse.org/t/268057",
+          raiseError: true,
+        }
+      );
+      return;
+    }
+
     this.close({ initiatedBy: CLOSE_INITIATED_BY_MODAL_SHOW });
 
     let resolveShowPromise;
@@ -50,7 +70,7 @@ class ModalService extends Service {
       resolveShowPromise = resolve;
     });
 
-    this.opts = opts || {};
+    this.opts = opts ??= {};
     this.activeModal = { component: modal, opts, resolveShowPromise };
 
     const unsupportedOpts = Object.keys(opts).filter((key) =>
@@ -75,7 +95,7 @@ class ModalService extends Service {
 }
 
 // Remove all logic below when legacy modals are dropped (deprecation: discourse.modal-controllers)
-export default class ModalServiceWithLegacySupport extends ModalService {
+class ModalServiceWithLegacySupport extends ModalService {
   @service appEvents;
 
   @tracked name;
@@ -261,3 +281,7 @@ export default class ModalServiceWithLegacySupport extends ModalService {
     return this.name && !this.activeModal;
   }
 }
+
+export default EMBER_MAJOR_VERSION >= 4
+  ? ModalService
+  : ModalServiceWithLegacySupport;


### PR DESCRIPTION
- Skip rendering DModalLegacy when running Ember 5
- Move named outlet inside the DModalLegacy component file
- Exclude that DModalLegacy template from the build when running Ember 5
- Skip LegacySupport version of modal service when running Ember 5
- Add error popup for legacy modals when running Ember 5

Extracted from https://github.com/discourse/discourse/pull/21720. This is a no-op under our current Ember 3.28 version.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
