### PR TITLE
DEV: Prepare lib/ember-events for Ember upgrade

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ember-events.js
+++ b/app/assets/javascripts/discourse/app/lib/ember-events.js
@@ -3,6 +3,7 @@ import Component from "@ember/component";
 import EmberObject from "@ember/object";
 import Ember from "ember";
 import { actionModifier } from "./ember-action-modifier";
+import { EMBER_MAJOR_VERSION } from "./ember-version";
 
 /**
  * Classic Ember components (i.e. "@ember/component") rely upon "event
@@ -126,13 +127,16 @@ function rewireClassicComponentEvents(app) {
     allEventMethods[methodName] = event;
   }
 
+  const triggerOverrideMethod =
+    EMBER_MAJOR_VERSION < 4 ? "trigger" : "_trigger";
+
   // Avoid Component.reopen to stop `ember.component.reopen` deprecation warning
   EmberObject.reopen.call(Component, {
     /**
      * @param {string | typeof INTERNAL} name
      * @param {unknown[]} args
      */
-    trigger(name, ...args) {
+    [triggerOverrideMethod](name, ...args) {
       if (name === INTERNAL) {
         if (this.element) {
           return this._super.call(this, ...args);


### PR DESCRIPTION
Extracted from https://github.com/discourse/discourse/pull/21720. This is a no-op under our current Ember 3.28 version.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
