### PR TITLE
DEV: Prepare jquery integration for Ember upgrade

### DIFF
--- a/app/assets/javascripts/discourse/app/global-compat.js
+++ b/app/assets/javascripts/discourse/app/global-compat.js
@@ -1,3 +1,4 @@
+import jQuery from "jquery";
 import virtualDom from "virtual-dom";
 import widgetHelpers from "discourse-widget-hbs/helpers";
 
@@ -5,3 +6,7 @@ window.__widget_helpers = widgetHelpers;
 
 // TODO: Eliminate this global
 window.virtualDom = virtualDom;
+
+if (!window.$) {
+  window.$ = window.jQuery = jQuery;
+}

--- a/app/assets/javascripts/discourse/config/optional-features.json
+++ b/app/assets/javascripts/discourse/config/optional-features.json
@@ -1,6 +1,0 @@
-{
-  "application-template-wrapper": false,
-  "default-async-observers": true,
-  "jquery-integration": true,
-  "template-only-glimmer-components": true
-}

--- a/app/assets/javascripts/discourse/config/optional-features.json.js
+++ b/app/assets/javascripts/discourse/config/optional-features.json.js
@@ -1,0 +1,11 @@
+const EMBER_MAJOR_VERSION = parseInt(
+  require("ember-source/package.json").version.split(".")[0],
+  10
+);
+
+module.exports = {
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": EMBER_MAJOR_VERSION < 4,
+  "template-only-glimmer-components": true,
+};

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -99,10 +99,12 @@ module.exports = function (defaults) {
     },
   });
 
-  // TODO: remove me
-  // Ember 3.28 still has some internal dependency on jQuery being a global,
-  // for the time being we will bring it in vendor.js
-  app.import("node_modules/jquery/dist/jquery.js", { prepend: true });
+  if (EMBER_MAJOR_VERSION < 4) {
+    // TODO: remove me
+    // Ember 3.28 still has some internal dependency on jQuery being a global,
+    // for the time being we will bring it in vendor.js
+    app.import("node_modules/jquery/dist/jquery.js", { prepend: true });
+  }
 
   // WARNING: We should only import scripts here if they are not in NPM.
   app.import(vendorJs + "bootbox.js");
@@ -177,7 +179,7 @@ module.exports = function (defaults) {
             if (
               !request.includes("-embroider-implicit") &&
               // TODO: delete special case for jquery when removing app.import() above
-              (request === "jquery" ||
+              ((EMBER_MAJOR_VERSION < 4 && request === "jquery") ||
                 request.startsWith("admin/") ||
                 request.startsWith("wizard/") ||
                 request.startsWith("discourse/plugins/") ||


### PR DESCRIPTION
- Update optional-features to tie the `jquery-integration` flag to the current ember version
- Wrap ember-4-specific logic in ember-cli-build with a version check
- Update global-compat.js to add the jquery global if it doesn't exist (i.e. if we're on a modern ember version)

Extracted from https://github.com/discourse/discourse/pull/21720. This is a no-op under our current Ember 3.28 version.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
