### PR TITLE
DEV: Prepare plugin-outlet for ember upgrade

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -145,7 +145,11 @@ class PluginOutletWithTagNameWrapper extends ClassicComponent {
   // Overridden parentView to make this wrapper 'transparent'
   // Calling this will trigger the deprecation notice in PluginOutletComponent
   get parentView() {
-    return this._parentView.parentView;
+    // init() of CoreView calls `this.parentView`. That would trigger the deprecation notice,
+    // so skip it until this component is initialized.
+    if (this._state) {
+      return this._parentView.parentView;
+    }
   }
   set parentView(value) {
     this._parentView = value;


### PR DESCRIPTION
In modern versions of Ember, `this.parentView` is called internally during component init. We don't want our deprecation message to be triggered by that internal call, so we need an additional check.

Extracted from https://github.com/discourse/discourse/pull/21720

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
