### PR TITLE
DEV: Remove RAILS_MASTER flag from Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,17 @@ updates:
         versions:
           - "> 1.2.0"
           - "< 2"
+    groups:
+      rails:
+        patterns:
+          - "actionmailer"
+          - "actionpack"
+          - "actionview"
+          - "actionmodel"
+          - "activerecord"
+          - "activesupport"
+          - "railties"
+          - "sprockets-rails"
   - package-ecosystem: "npm"
     directory: "/app/assets/javascripts/"
     schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -6,28 +6,14 @@ source "https://rubygems.org"
 
 gem "bootsnap", require: false, platform: :mri
 
-def rails_master?
-  ENV["RAILS_MASTER"] == "1"
-end
-
-if rails_master?
-  gem "arel", git: "https://github.com/rails/arel.git"
-  gem "rails", git: "https://github.com/rails/rails.git"
-else
-  # NOTE: Until rubygems gives us optional dependencies we are stuck with this needing to be explicit
-  # this allows us to include the bits of rails we use without pieces we do not.
-  #
-  # To issue a rails update bump the version number here
-  rails_version = "7.0.7"
-  gem "actionmailer", rails_version
-  gem "actionpack", rails_version
-  gem "actionview", rails_version
-  gem "activemodel", rails_version
-  gem "activerecord", rails_version
-  gem "activesupport", rails_version
-  gem "railties", rails_version
-  gem "sprockets-rails"
-end
+gem "actionmailer"
+gem "actionpack"
+gem "actionview"
+gem "activemodel"
+gem "activerecord"
+gem "activesupport"
+gem "railties"
+gem "sprockets-rails"
 
 gem "json"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,14 +530,14 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionmailer (= 7.0.7)
-  actionpack (= 7.0.7)
-  actionview (= 7.0.7)
+  actionmailer
+  actionpack
+  actionview
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 7.0.7)
-  activerecord (= 7.0.7)
-  activesupport (= 7.0.7)
+  activemodel
+  activerecord
+  activesupport
   addressable
   annotate
   aws-sdk-s3
@@ -624,7 +624,7 @@ DEPENDENCIES
   rails-dom-testing
   rails_failover
   rails_multisite
-  railties (= 7.0.7)
+  railties
   rake
   rb-fsevent
   rbtrace


### PR DESCRIPTION
We don't use this flag, and it prevents Dependabot from being able to automatically create PRs for Rails gem updates

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
