### PR TITLE
FIX: Show only top categories in first category-drop

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -135,12 +135,15 @@ export default ComboBoxComponent.extend({
 
   async search(filter) {
     const opts = {
-      parentCategoryId: this.options.parentCategory?.id,
+      parentCategoryId: this.options.parentCategory?.id || -1,
       includeUncategorized: this.siteSettings.allow_uncategorized_topics,
     };
 
     if (this.siteSettings.lazy_load_categories) {
-      const results = await Category.asyncSearch(filter, { ...opts, limit: 5 });
+      const results = await Category.asyncSearch(filter, {
+        ...opts,
+        limit: 15,
+      });
       return this.shortcuts.concat(
         results.sort((a, b) => {
           if (a.parent_category_id && !b.parent_category_id) {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -353,7 +353,13 @@ class CategoriesController < ApplicationController
         ) if term.present?
 
     categories =
-      categories.where(parent_category_id: parent_category_id) if parent_category_id.present?
+      (
+        if parent_category_id != -1
+          categories.where(parent_category_id: parent_category_id)
+        else
+          categories.where(parent_category_id: nil)
+        end
+      ) if parent_category_id.present?
 
     categories =
       categories.where.not(id: SiteSetting.uncategorized_category_id) if !include_uncategorized

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1096,6 +1096,17 @@ RSpec.describe CategoriesController do
           "Foobar",
         )
       end
+
+      it "can return only top-level categories" do
+        get "/categories/search.json", params: { parent_category_id: -1 }
+
+        expect(response.parsed_body["categories"].size).to eq(3)
+        expect(response.parsed_body["categories"].map { |c| c["name"] }).to contain_exactly(
+          "Uncategorized",
+          "Foo",
+          "Notfoo",
+        )
+      end
     end
 
     context "with include_uncategorized" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
