### PR TITLE
DEV: Use staged user check instead

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -859,7 +859,7 @@ module Email
 
         user ||= stage_from_user
 
-        if user.groups.any? && !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map) &&
+        if !user.staged? && !user.in_any_groups?(SiteSetting.email_in_allowed_groups_map) &&
              !sent_to_mailinglist_mirror?
           raise InsufficientTrustLevelError
         end

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -92,12 +92,12 @@ class NewPostManager
       return :post_count
     end
 
-    if user.groups.any? && !user.in_any_groups?(SiteSetting.approve_unless_allowed_groups_map)
+    if !user.staged? && !user.in_any_groups?(SiteSetting.approve_unless_allowed_groups_map)
       return :group
     end
 
     if (
-         manager.args[:title].present? && user.groups.any? &&
+         manager.args[:title].present? && !user.staged? &&
            !user.in_any_groups?(SiteSetting.approve_new_topics_unless_allowed_groups_map)
        )
       return :new_topics_unless_allowed_groups

--- a/plugins/poll/spec/controllers/posts_controller_spec.rb
+++ b/plugins/poll/spec/controllers/posts_controller_spec.rb
@@ -3,13 +3,17 @@
 require "rails_helper"
 
 RSpec.describe PostsController do
-  let!(:user) { log_in }
+  let!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   let!(:title) { "Testing Poll Plugin" }
 
-  before { SiteSetting.min_first_post_typing_time = 0 }
+  before do
+    SiteSetting.min_first_post_typing_time = 0
+    log_in_user(user)
+  end
 
   describe "polls" do
     it "works" do
+      Group.refresh_automatic_groups!
       post :create, params: { title: title, raw: "[poll]\n- A\n- B\n[/poll]" }, format: :json
 
       expect(response.status).to eq(200)
@@ -375,7 +379,7 @@ RSpec.describe PostsController do
     before { SiteSetting.poll_minimum_trust_level_to_create = 2 }
 
     it "invalidates the post" do
-      log_in_user(Fabricate(:user, trust_level: 1))
+      log_in_user(Fabricate(:user, trust_level: 1, refresh_auto_groups: true))
 
       post :create, params: { title: title, raw: "[poll]\n- A\n- B\n[/poll]" }, format: :json
 
@@ -408,7 +412,7 @@ RSpec.describe PostsController do
     before { SiteSetting.poll_minimum_trust_level_to_create = 2 }
 
     it "validates the post" do
-      log_in_user(Fabricate(:user, trust_level: 2))
+      log_in_user(Fabricate(:user, trust_level: 2, refresh_auto_groups: true))
 
       post :create, params: { title: title, raw: "[poll]\n- A\n- B\n[/poll]" }, format: :json
 
@@ -423,7 +427,7 @@ RSpec.describe PostsController do
     before { SiteSetting.poll_minimum_trust_level_to_create = 2 }
 
     it "validates the post" do
-      log_in_user(Fabricate(:user, trust_level: 3))
+      log_in_user(Fabricate(:user, trust_level: 3, refresh_auto_groups: true))
 
       post :create, params: { title: title, raw: "[poll]\n- A\n- B\n[/poll]" }, format: :json
 
@@ -453,7 +457,7 @@ RSpec.describe PostsController do
     before { SiteSetting.poll_minimum_trust_level_to_create = 2 }
 
     it "validates the post" do
-      log_in_user(Fabricate(:user, trust_level: 1))
+      log_in_user(Fabricate(:user, trust_level: 1, refresh_auto_groups: true))
 
       post :create, params: { title: title, raw: title }, format: :json
 

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1704,6 +1704,7 @@ RSpec.describe Email::Receiver do
           :user,
           trust_level: SiteSetting.email_in_min_trust,
           user_emails: [Fabricate.build(:secondary_email, email: "existing@bar.com")],
+          refresh_auto_groups: true,
         )
 
       expect { process(:existing_user) }.to change(Topic, :count).by(1)
@@ -2079,7 +2080,7 @@ RSpec.describe Email::Receiver do
     end
 
     it "should skip validations for regular users" do
-      Fabricate(:user, email: "alice@foo.com")
+      Fabricate(:user, email: "alice@foo.com", refresh_auto_groups: true)
       expect { process(:mailinglist_short_message) }.to change { Topic.count }
     end
 
@@ -2088,8 +2089,8 @@ RSpec.describe Email::Receiver do
         category.set_permissions(everyone: :readonly)
         category.save!
 
-        Fabricate(:user, email: "alice@foo.com")
-        Fabricate(:user, email: "bob@bar.com")
+        Fabricate(:user, email: "alice@foo.com", refresh_auto_groups: true)
+        Fabricate(:user, email: "bob@bar.com", refresh_auto_groups: true)
       end
 
       it "should allow creating topic within read-only category" do
@@ -2106,7 +2107,7 @@ RSpec.describe Email::Receiver do
 
     it "ignores unsubscribe email" do
       SiteSetting.unsubscribe_via_email = true
-      Fabricate(:user, email: "alice@foo.com")
+      Fabricate(:user, email: "alice@foo.com", refresh_auto_groups: true)
 
       expect { process("mailinglist_unsubscribe") }.to_not change {
         ActionMailer::Base.deliveries.count


### PR DESCRIPTION
This change refactors the check `user.groups.any?` and instead uses
`user.staged?` to check if the user is staged or not.

Also fixes several tests to ensure the users have their auto trust level
groups created.

Follow up to:

- 8a45f84277e6e13bc48b8f4e40350a9cbd5cd2ee
- 447d9b210556e64c14f9ca9f8f9b52f54090cd41
- c89edd9e86870f97a770816210d71400f09181f2
