### PR TITLE
DEV: Remove unused searchTags param

### DIFF
--- a/app/assets/javascripts/select-kit/addon/mixins/tags.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/tags.js
@@ -9,11 +9,7 @@ import I18n from "discourse-i18n";
 
 export default Mixin.create({
   searchTags(url, data, callback) {
-    return ajax(getURL(url), {
-      quietMillis: 200,
-      dataType: "json",
-      data,
-    })
+    return ajax(getURL(url), { data })
       .then((json) => callback(this, json))
       .catch(popupAjaxError);
   },


### PR DESCRIPTION
that doesn't exist in the codebase anymore

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
