### PR TITLE
FIX: with_secure_uploads? could return nil in some cases

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -186,6 +186,17 @@ RSpec.describe Post do
           expect(post.with_secure_uploads?).to eq(true)
         end
 
+        context "when the topic is deleted" do
+          before do
+            topic.trash!
+            post.reload
+          end
+
+          it "returns true" do
+            expect(post.with_secure_uploads?).to eq(true)
+          end
+        end
+
         context "if secure_uploads_pm_only" do
           before { SiteSetting.secure_uploads_pm_only = true }
 
@@ -200,6 +211,14 @@ RSpec.describe Post do
 
         it "returns true" do
           expect(post.with_secure_uploads?).to eq(true)
+        end
+
+        context "when the topic is deleted" do
+          before { topic.trash! }
+
+          it "returns true" do
+            expect(post.with_secure_uploads?).to eq(true)
+          end
         end
 
         context "if secure_uploads_pm_only" do


### PR DESCRIPTION
When we check upload security, one of the checks is to
run `access_control_post.with_secure_uploads?`. The problem
here is that the `topic` for the post could be deleted,
which would make the check return `nil` sometimes instead
of false because of safe navigation. We just need to be
more explicit.
