### PR TITLE
FIX: Add higher read & open timeouts for group SMTP emails

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -18,6 +18,8 @@ class GroupSmtpMailer < ActionMailer::Base
       authentication: GlobalSetting.smtp_authentication,
       enable_starttls_auto: from_group.smtp_ssl,
       return_response: true,
+      open_timeout: GlobalSetting.group_smtp_open_timeout,
+      read_timeout: GlobalSetting.group_smtp_read_timeout,
     }
 
     group_name = from_group.name_full_preferred

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -98,6 +98,14 @@ smtp_open_timeout = 5
 # Number of seconds to wait until timing-out a SMTP read(2) call
 smtp_read_timeout = 5
 
+# number of seconds to wait while attempting to open a SMTP connection only when
+# sending emails via group SMTP
+group_smtp_open_timeout = 30
+
+# Number of seconds to wait until timing-out a SMTP read(2) call only when sending
+# emails via group SMTP
+group_smtp_read_timeout = 60
+
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true
 

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe GroupSmtpMailer do
     expect(sent_mail.subject).to eq("Re: Hello from John")
   end
 
+  it "configures delivery options for SMTP correctly" do
+    mail = GroupSmtpMailer.send_mail(group, user.email, Fabricate(:post))
+    expect(mail.delivery_method.settings).to eq(
+      {
+        address: "smtp.gmail.com",
+        port: 587,
+        domain: "gmail.com",
+        user_name: "bugs@gmail.com",
+        password: "super$secret$password",
+        authentication: GlobalSetting.smtp_authentication,
+        enable_starttls_auto: true,
+        return_response: true,
+        open_timeout: GlobalSetting.group_smtp_open_timeout,
+        read_timeout: GlobalSetting.group_smtp_read_timeout,
+      },
+    )
+  end
+
   context "when the site has a reply by email address configured" do
     before do
       SiteSetting.manual_polling_enabled = true


### PR DESCRIPTION
When sending SMTP for group SMTP functionality, we
are running into timeouts for both read and open
when sending mail occassionally, which can cause issues
like the email only being sent to _some_ of the recipients
or to fail altogether.

The defaults of 5s are too low, so bumping them up to
the defaults of the `net-smtp` gem.
