### PR TITLE
FIX: Use subfolder-safe url for category in html view

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -8,7 +8,7 @@
       <div class="topic-category" itemscope itemtype="http://schema.org/BreadcrumbList">
         <% @breadcrumbs.each_with_index do |c, i| %>
           <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="<%= Discourse.base_url %><%= c[:url] %>" class="badge-wrapper bullet" itemprop="item">
+            <a href="<%= @topic_view.topic.category.url %>" class="badge-wrapper bullet" itemprop="item">
               <span class='badge-category-bg' style='background-color: #<%= c[:color] %>'></span>
               <span class='badge-category clear-badge'>
                 <span class='category-name' itemprop='name'><%= c[:name] %></span>

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe "topics/show.html.erb" do
-  fab!(:category) { Fabricate(:category) }
+  fab!(:category)
   fab!(:topic) { Fabricate(:topic, category: category) }
 
   it "uses subfolder-safe category url" do

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -4,7 +4,22 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe "topics/show.html.erb" do
-  fab!(:topic)
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+
+  it "uses subfolder-safe category url" do
+    set_subfolder "/subpath"
+    topic_view = OpenStruct.new(topic: topic, posts: [])
+    topic_view.stubs(:summary).returns("")
+    view.stubs(:crawler_layout?).returns(false)
+    assign(:topic_view, topic_view)
+    assign(:breadcrumbs, [{ name: category.name, color: category.color }])
+    assign(:tags, [])
+
+    render template: "topics/show", formats: [:html]
+
+    assert_select "a[href='/subpath/c/#{category.slug}/#{category.id}']"
+  end
 
   it "add nofollow to RSS alternate link for topic" do
     topic_view = OpenStruct.new(topic: topic, posts: [])


### PR DESCRIPTION
On /subfolder/t/:id, the view rendered had mis-jointed subfolder URL. This PR fixes that.

Before:
```
<a href="http://localhost:3000/forum/forum/c/site-feedback/2"
```

After:
```
<a href="/forum/c/site-feedback/2"
```