### PR TITLE
DEV: Temporary fix for flaky system test

### DIFF
--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -19,10 +19,12 @@ describe "Flagging post", type: :system do
       topic_page.click_post_action_button(post_to_flag, :flag)
       flag_modal.choose_type(:off_topic)
       flag_modal.take_action(:agree_and_hide)
+
       expect(
         topic_page.post_by_number(post_to_flag).ancestor(".topic-post.post-hidden"),
       ).to be_present
-      expect(other_flag.reload.agreed_at).to be_present
+
+      try_until_success { expect(other_flag.reload.agreed_at).to be_present }
     end
   end
 end


### PR DESCRIPTION
Why this change?

Asserting against records of the database in system tests can be flaky
because those assertions can run against the database before the server
has actually saved the necessary changes to the database.

What does this change do?

While the assertion is not ideal, we are working around this as a
temporary fix by using `try_until_success` which will retry the
assertion up till the default capybara timeout.