### PR TITLE
DEV: Don't use the deprecated `createEvent()`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/expanding-text-area.js
+++ b/app/assets/javascripts/discourse/app/components/expanding-text-area.js
@@ -16,9 +16,11 @@ export default TextArea.extend({
   @observes("value")
   _updateAutosize() {
     this.element.value = this.value;
-    const evt = document.createEvent("Event");
-    evt.initEvent("autosize:update", true, false);
-    this.element.dispatchEvent(evt);
+    const event = new Event("autosize:update", {
+      bubbles: true,
+      cancelable: false,
+    });
+    this.element.dispatchEvent(event);
   },
 
   @on("willDestroyElement")

--- a/app/assets/javascripts/discourse/app/lib/autosize.js
+++ b/app/assets/javascripts/discourse/app/lib/autosize.js
@@ -119,9 +119,11 @@ function assign(ta, { setOverflowX = true, setOverflowY = true } = {}) {
     }
 
     if (startHeight !== ta.style.height) {
-      const evt = document.createEvent("Event");
-      evt.initEvent("autosize:resized", true, false);
-      ta.dispatchEvent(evt);
+      const event = new Event("autosize:resized", {
+        bubbles: true,
+        cancelable: false,
+      });
+      ta.dispatchEvent(event);
     }
   }
 
@@ -170,18 +172,24 @@ function exportDestroy(ta) {
   if (!(ta && ta.nodeName && ta.nodeName === "TEXTAREA")) {
     return;
   }
-  const evt = document.createEvent("Event");
-  evt.initEvent("autosize:destroy", true, false);
-  ta.dispatchEvent(evt);
+
+  const event = new Event("autosize:destroy", {
+    bubbles: true,
+    cancelable: false,
+  });
+  ta.dispatchEvent(event);
 }
 
 function exportUpdate(ta) {
   if (!(ta && ta.nodeName && ta.nodeName === "TEXTAREA")) {
     return;
   }
-  const evt = document.createEvent("Event");
-  evt.initEvent("autosize:update", true, false);
-  ta.dispatchEvent(evt);
+
+  const event = new Event("autosize:update", {
+    bubbles: true,
+    cancelable: false,
+  });
+  ta.dispatchEvent(event);
 }
 
 let autosize = (el, options) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -16,11 +16,13 @@ async function openFlagModal() {
 }
 
 async function pressEnter(element, modifier) {
-  const event = document.createEvent("Event");
-  event.initEvent("keydown", true, true);
-  event.key = "Enter";
-  event.keyCode = 13;
-  event[modifier] = true;
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "Enter",
+    keyCode: 13,
+    [modifier]: true,
+  });
   element.dispatchEvent(event);
   await settled();
 }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
