### PR TITLE
UX: fix disabled input styles

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -296,11 +296,7 @@ textarea {
   &:focus:required:invalid {
     color: var(--danger);
     border-color: var(--danger);
-  }
-
-  &:focus:required:invalid:focus {
-    border-color: var(--danger);
-    box-shadow: var(--shadow-focus-danger);
+    outline: 1px solid var(--danger);
   }
 }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -3,6 +3,15 @@
 // BEWARE: changing these styles implies they take effect anywhere they are seen
 // throughout the Discourse application
 
+:root {
+  --d-input-bg-color: var(--secondary);
+  --d-input-text-color: var(--primary);
+  --d-input-border: 1px solid var(--primary-400);
+  --d-input-bg-color--disabled: var(--primary-low);
+  --d-input-text-color--disabled: var(--primary);
+  --d-input-border--disabled: 1px solid var(--primary-low);
+}
+
 // Animation Keyframes
 @keyframes ping {
   0% {
@@ -180,35 +189,6 @@ input {
   }
 }
 
-input,
-select,
-textarea {
-  color: var(--primary);
-  caret-color: currentColor;
-
-  &[class*="span"] {
-    float: none;
-    margin-left: 0;
-  }
-
-  &[disabled],
-  &[readonly] {
-    cursor: not-allowed;
-    background-color: var(--primary-low);
-    border-color: var(--primary-low);
-  }
-
-  &:focus:required:invalid {
-    color: var(--danger);
-    border-color: var(--danger);
-  }
-
-  &:focus:required:invalid:focus {
-    border-color: var(--danger);
-    box-shadow: var(--shadow-focus-danger);
-  }
-}
-
 input {
   &[type="text"],
   &[type="password"],
@@ -228,9 +208,9 @@ input {
     @include form-item-sizing;
     display: inline-block;
     margin-bottom: 9px;
-    color: var(--primary);
-    background-color: var(--secondary);
-    border: 1px solid var(--primary-400);
+    color: var(--d-input-text-color);
+    background-color: var(--d-input-bg-color);
+    border: var(--d-input-border);
     border-radius: var(--d-input-border-radius);
     &:focus {
       @include default-focus;
@@ -292,6 +272,35 @@ table {
     color: var(--primary-medium);
     text-align: left;
     padding: 0.5em;
+  }
+}
+
+input,
+select,
+textarea {
+  color: var(--d-input-bg-color--disabled);
+  caret-color: currentColor;
+
+  &[class*="span"] {
+    float: none;
+    margin-left: 0;
+  }
+
+  &[disabled],
+  &[readonly] {
+    cursor: not-allowed;
+    background-color: var(--d-input-bg-color--disabled);
+    border: var(--d-input-border--disabled);
+  }
+
+  &:focus:required:invalid {
+    color: var(--danger);
+    border-color: var(--danger);
+  }
+
+  &:focus:required:invalid:focus {
+    border-color: var(--danger);
+    box-shadow: var(--shadow-focus-danger);
   }
 }
 


### PR DESCRIPTION
The disabled styles weren't taking effect here because they were earlier in the cascade and being overridden by styles within the block

```css
input {
  &[type="text"],
  &[type="password"],
```

So I moved the disabled styles to after this in the cascade so they'll work again. 

I've also added some CSS variables for these, this will allow a theme to edit the input styles like 

```css
input[type="text"]  {
 --d-input-bg-color: red;
}
```

the nice thing about doing 👆🏻 instead of 👇🏻 

```css
input[type="text"] {
  background: red; 
}
```

is that redefining the variable won't override the `disabled` styles... when setting the color directly using `background` on the class, the theme would also need to re-add the disabled styles for them to work properly.


Before (disabled, but no visual effect):


![Screenshot 2023-11-28 at 11 38 17 AM](https://github.com/discourse/discourse/assets/1681963/a7bca7e2-60fa-47b7-8e59-48be6ec47eb6)

After: 

![Screenshot 2023-11-28 at 11 38 25 AM](https://github.com/discourse/discourse/assets/1681963/0d38caac-2d02-470e-aedd-0039d2981196)
