### PR TITLE
UX: Change direction of focus outline

### DIFF
--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -159,7 +159,7 @@ $hpad: 0.65em;
 @mixin default-focus() {
   border-color: var(--tertiary);
   outline: 1px solid var(--tertiary);
-  outline-offset: 0;
+  outline-offset: -2px;
 }
 
 @mixin fa-rotate($degrees, $rotation) {

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -69,7 +69,6 @@
     @include form-item-sizing;
     font-weight: 500;
     overflow: hidden;
-    transition: all 0.25s;
     cursor: pointer;
     display: flex;
     align-items: stretch;


### PR DESCRIPTION
The outline added around inputs on focus sometimes is cut off due to `overflow: hidden` on some elements. This PR inverts the outlines to be 1px inside of the input, thereby not having the outline cutoff. It also inadvertently helps drop down menus be aligned with their input container. Thanks to @chapoi for the suggestion.

**Before**
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/79aecda7-8667-416d-b5ac-b78dda842b88">
 ---
<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/74f4ba6f-6e28-4271-b2ab-4a329f92855e">

**After**
<img width="400" alt="image" src="https://github.com/discourse/discourse/assets/30537603/2ffb3a7a-dc53-4ef7-be84-9c1dbd42efa4">
---
<img width="250" alt="image" src="https://github.com/discourse/discourse/assets/30537603/3943e44c-6a06-4968-81ba-a1f55e130641">
