### PR TITLE
UX: create category doesn't always need a dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -22,10 +22,24 @@
   {{/if}}
 
   {{#if this.showCategoryAdmin}}
-    <CategoriesAdminDropdown
-      @onChange={{action "selectCategoryAdminDropdownAction"}}
-      @options={{hash triggerOnChangeOnTab=false}}
-    />
+    {{#if this.fixedCategoryPositions}}
+      <CategoriesAdminDropdown
+        @onChange={{action "selectCategoryAdminDropdownAction"}}
+        @options={{hash triggerOnChangeOnTab=false}}
+      />
+    {{else}}
+      <DButton
+        @action={{this.createCategory}}
+        @icon="plus"
+        @label={{if
+          this.site.mobileView
+          "categories.category"
+          "category.create"
+        }}
+        class="btn-default"
+        id="create-category"
+      />
+    {{/if}}
   {{/if}}
 
   {{#if (and this.category this.showCategoryEdit)}}

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { setting } from "discourse/lib/computed";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import NavItem from "discourse/models/nav-item";
@@ -14,6 +15,7 @@ export default Component.extend({
   dialog: service(),
   tagName: "",
   filterMode: tracked(),
+  fixedCategoryPositions: setting("fixed_category_positions"),
 
   @dependentKeyCompat
   get filterType() {

--- a/app/assets/javascripts/select-kit/addon/components/categories-admin-dropdown.js
+++ b/app/assets/javascripts/select-kit/addon/components/categories-admin-dropdown.js
@@ -1,12 +1,10 @@
 import { computed } from "@ember/object";
-import { setting } from "discourse/lib/computed";
 import I18n from "discourse-i18n";
 import DropdownSelectBoxComponent from "select-kit/components/dropdown-select-box";
 
 export default DropdownSelectBoxComponent.extend({
   pluginApiIdentifiers: ["categories-admin-dropdown"],
   classNames: ["categories-admin-dropdown"],
-  fixedCategoryPositions: setting("fixed_category_positions"),
 
   selectKitOptions: {
     icons: ["wrench", "caret-down"],
@@ -26,14 +24,12 @@ export default DropdownSelectBoxComponent.extend({
       },
     ];
 
-    if (this.fixedCategoryPositions) {
-      items.push({
-        id: "reorder",
-        name: I18n.t("categories.reorder.title"),
-        description: I18n.t("categories.reorder.title_long"),
-        icon: "random",
-      });
-    }
+    items.push({
+      id: "reorder",
+      name: I18n.t("categories.reorder.title"),
+      description: I18n.t("categories.reorder.title_long"),
+      icon: "random",
+    });
 
     return items;
   }),


### PR DESCRIPTION
This will show the `New Category` button outside of the dropdown when it's the only option present. When `fixed_category_positions` is enabled, the dropdown appears.  

Before:

![Screenshot 2023-11-28 at 1 17 08 PM](https://github.com/discourse/discourse/assets/1681963/459bf270-76bc-4722-836a-c665b2f2f354)

After:

![Screenshot 2023-11-28 at 12 30 43 PM](https://github.com/discourse/discourse/assets/1681963/74187f0f-67d6-4b88-8c55-a441821f76d3)

![Screenshot 2023-11-28 at 12 30 57 PM](https://github.com/discourse/discourse/assets/1681963/d841d92a-641d-48ce-83e1-a68c4611aaee)

On mobile "new" is dropped to save some space, 

![Screenshot 2023-11-28 at 12 52 47 PM](https://github.com/discourse/discourse/assets/1681963/be7e36ae-a1d6-40a3-b957-23043b5b1f2c)

I also considered dropping the "new" text from "new topic" on mobile, but that seems a little out of scope (and could have a broader impact on translation overrides). 