### PR TITLE
FIX: Add more specificity to outline

### DIFF
--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -158,7 +158,7 @@ $hpad: 0.65em;
 
 @mixin default-focus() {
   border-color: var(--tertiary);
-  outline: 1px solid var(--tertiary);
+  outline: 2px solid var(--tertiary);
   outline-offset: -2px;
 }
 


### PR DESCRIPTION
This prevents a double outline / border on zoom sizes that are not the standard.