### PR TITLE
UX: Place login button text in span tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/login-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.hbs
@@ -12,7 +12,7 @@
     {{else}}
       {{d-icon "sign-in-alt"}}
     {{/if}}
-    {{b.title}}
+    <span class="btn-social-title">{{b.title}}</span>
   </button>
 {{/each}}
 


### PR DESCRIPTION
This will allow us to hide text on login buttons at smaller screen widths.