### PR TITLE
FIX: Word wrap for quote buttons

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -610,6 +610,10 @@ aside.quote {
         color: var(--tertiary);
       }
     }
+
+    .d-button-label {
+      white-space: nowrap;
+    }
   }
 
   .quote-sharing {


### PR DESCRIPTION
The button text was becoming multiline unnecessarily

Before

![image](https://github.com/discourse/discourse/assets/920448/c6d7add2-72e0-48e6-9727-e12db77acfdf)

After

![image](https://github.com/discourse/discourse/assets/920448/bba66173-08bf-4359-99db-0fed64fb2955)
