### PR TITLE
FEATURE: move inflector so plugins can lean on it

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,28 @@ require_relative "../lib/plugin_gem"
 
 # Global config
 require_relative "../app/models/global_setting"
+
+# This custom inflector is needed because of our jobs directory structure.
+# Ideally, we should not prefix our jobs with a `Jobs` namespace but instead
+# have a `Job` suffix to follow the Rails conventions on naming.
+#
+# Based on:
+# https://github.com/rails/rails/blob/75e6c0ac/railties/lib/rails/autoloaders/inflector.rb#L7-L19
+# Additonally this allows plugins to override the inflections cause it is defined prior to plugin init
+module DiscourseInflector
+  @overrides = {}
+
+  def self.camelize(basename, abspath)
+    return basename.camelize if abspath.ends_with?("onceoff.rb")
+    return "Jobs" if abspath.ends_with?("jobs/base.rb")
+    @overrides[basename] || basename.camelize
+  end
+
+  def self.inflect(overrides)
+    @overrides.merge!(overrides)
+  end
+end
+
 GlobalSetting.configure!
 if GlobalSetting.load_plugins?
   # Support for plugins to register custom setting providers. They can do this

--- a/config/initializers/000-zeitwerk.rb
+++ b/config/initializers/000-zeitwerk.rb
@@ -1,25 +1,5 @@
 # frozen_string_literal: true
 
-# This custom inflector is needed because of our jobs directory structure.
-# Ideally, we should not prefix our jobs with a `Jobs` namespace but instead
-# have a `Job` suffix to follow the Rails conventions on naming.
-#
-# Based on:
-# https://github.com/rails/rails/blob/75e6c0ac/railties/lib/rails/autoloaders/inflector.rb#L7-L19
-module DiscourseInflector
-  @overrides = {}
-
-  def self.camelize(basename, abspath)
-    return basename.camelize if abspath.ends_with?("onceoff.rb")
-    return "Jobs" if abspath.ends_with?("jobs/base.rb")
-    @overrides[basename] || basename.camelize
-  end
-
-  def self.inflect(overrides)
-    @overrides.merge!(overrides)
-  end
-end
-
 Rails.autoloaders.each do |autoloader|
   autoloader.inflector = DiscourseInflector
 


### PR DESCRIPTION
Prior to this I don't think plugins had any way to register custom inflections
safely.

On eval ... intializers have not been run yet
after_initialize is already too late
