### PR TITLE
DEV: Add stale PR workflow

### DIFF
--- a/.github/workflows/stale-pr-closer.yml
+++ b/.github/workflows/stale-pr-closer.yml
@@ -1,0 +1,20 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has been open for 60 days with no activity. To keep it open, remove the stale tag, push code, or add a comment. Otherwise, it will be closed in 14 days.'
+          exempt-pr-labels: dependencies
+          operations-per-run: 1 # for testing


### PR DESCRIPTION
- Mark stale after 60 days
- Close 14 days later

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
