### PR TITLE
FIX: category-selector for top level categories

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -134,14 +134,10 @@ export default ComboBoxComponent.extend({
   ),
 
   async search(filter) {
-    const opts = {
-      parentCategoryId: this.options.parentCategory?.id || -1,
-      includeUncategorized: this.siteSettings.allow_uncategorized_topics,
-    };
-
     if (this.siteSettings.lazy_load_categories) {
       const results = await Category.asyncSearch(filter, {
-        ...opts,
+        parentCategoryId: this.options.parentCategory?.id || -1,
+        includeUncategorized: this.siteSettings.allow_uncategorized_topics,
         limit: 15,
       });
       return this.shortcuts.concat(
@@ -156,6 +152,10 @@ export default ComboBoxComponent.extend({
         })
       );
     }
+
+    const opts = {
+      parentCategoryId: this.options.parentCategory?.id,
+    };
 
     if (filter) {
       let results = Category.search(filter, opts);


### PR DESCRIPTION
The filter for top-level categories by using `parent_category_id = -1` is only implemented by the new search API.

Follow up to commit dbb8b66a378ec84a794510fcdcdc2ff9131c6aa3.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
