### PR TITLE
UX: properly align close button icon on composer messages

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -128,8 +128,8 @@
     flex-direction: row-reverse;
     align-items: center;
     position: absolute;
-    right: 0.67em;
-    top: 0.67em;
+    right: 0;
+    top: 0;
     color: var(--primary-medium);
     font-size: var(--font-0);
     .d-icon {


### PR DESCRIPTION
Before:

<img width="610" alt="Screenshot 2023-11-29 at 7 46 59 PM" src="https://github.com/discourse/discourse/assets/11170663/0019e88d-1b06-4156-b1b8-54d1fc464dc5">

After:

<img width="609" alt="Screenshot 2023-11-29 at 7 53 21 PM" src="https://github.com/discourse/discourse/assets/11170663/bc7f2084-772d-43d7-9068-28e4b05922db">
