### PR TITLE
FIX: Allow setting an array custom field to a singleton value

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -20,14 +20,7 @@ module HasCustomFields
     def validate(obj, name, value)
       return if value.nil?
 
-      size =
-        if Array === type || (type != :json && Array === value)
-          value.map { |v| serialize(v).bytesize }.max || 0
-        else
-          serialize(value).bytesize
-        end
-
-      if size > max_length
+      if serialize(value).bytesize > max_length
         obj.errors.add(
           :base,
           I18n.t("custom_fields.validations.max_value_length", max_value_length: max_length),
@@ -279,7 +272,7 @@ module HasCustomFields
           field_type = descriptor.type
 
           if Array === field_type || (field_type != :json && Array === value)
-            value = value || []
+            value = Array(value || [])
             value.compact!
             sub_type = field_type[0]
 

--- a/spec/lib/concern/has_custom_fields_spec.rb
+++ b/spec/lib/concern/has_custom_fields_spec.rb
@@ -134,6 +134,13 @@ RSpec.describe HasCustomFields do
       expect(db_item.custom_fields).to eq("a" => "b", "c" => "d")
     end
 
+    it "handles assigning singleton values to array fields" do
+      CustomFieldsTestItem.register_custom_field_type "array", [:integer]
+      test_item = CustomFieldsTestItem.new
+      test_item.custom_fields = { "array" => "1" }
+      test_item.save
+    end
+
     it "handles arrays properly" do
       CustomFieldsTestItem.register_custom_field_type "array", [:integer]
       test_item = CustomFieldsTestItem.new


### PR DESCRIPTION
Also, validation happens per item in an array field.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
