### PR TITLE
DEV: Only enable minio for core system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,7 @@ jobs:
         run: bin/rake themes:clone_all_official
 
       - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
+        if: matrix.build_type == 'system' && matrix.target == 'core'
         run: |
           echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
           echo "127.0.0.1 discoursetest.minio.local" | sudo tee -a /etc/hosts
@@ -241,8 +242,8 @@ jobs:
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build
 
-      - name: Ensure latest minio binary installed for System Tests
-        if: matrix.build_type == 'system'
+      - name: Ensure latest minio binary installed for Core System Tests
+        if: matrix.build_type == 'system' && matrix.target == 'core'
         run: bundle exec ruby script/install_minio_binaries.rb
 
       - name: Core System Tests


### PR DESCRIPTION
Why this change?

Let's us not run stuff when we don't need it.