### PR TITLE
FIX: update tag description field placeholder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.hbs
@@ -13,7 +13,7 @@
 
           <Textarea
             id="edit-description"
-            @value={{readonly this.tagInfo.description}}
+            @value={{readonly this.tagInfo.descriptionWithNewLines}}
             placeholder={{i18n "tagging.description"}}
             maxlength={{1000}}
             {{on

--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -80,6 +80,10 @@ export default Component.extend({
   @action
   edit(event) {
     event?.preventDefault();
+    this.tagInfo.set(
+      "descriptionWithNewLines",
+      this.tagInfo.description?.replaceAll("<br>", "\n")
+    );
     this.setProperties({
       editing: true,
       newTagName: this.tag.id,
@@ -127,6 +131,7 @@ export default Component.extend({
   @action
   finishedEditing() {
     const oldTagName = this.tag.id;
+    this.newTagDescription = this.newTagDescription.replaceAll("\n", "<br>");
     this.tag
       .update({ id: this.newTagName, description: this.newTagDescription })
       .then((result) => {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4308,7 +4308,7 @@ en:
         one: "Its synonym will also be deleted."
         other: "Its %{count} synonyms will also be deleted."
       edit_tag: "Edit tag name and description"
-      description: "Description"
+      description: "Description (max 1000 characters)"
       sort_by: "Sort by:"
       sort_by_count: "count"
       sort_by_name: "name"


### PR DESCRIPTION
Improvements after  https://github.com/discourse/discourse/pull/24561

1. Make placeholder more descriptive
2. Respect new line breaks in description


