### PR TITLE
UX: chat leave info

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -583,9 +583,11 @@ export default class ChatAboutScreen extends Component {
               />
             </:action>
           </section.row>
-          <div class="chat-channel-settings__leave-info">
-            {{icon "exclamation-triangle"}}
-            {{I18n.t "chat.channel_settings.leave_groupchat_info"}}</div>
+          {{#unless @channel.isCategoryChannel}}
+            <div class="chat-channel-settings__leave-info">
+              {{icon "exclamation-triangle"}}
+              {{I18n.t "chat.channel_settings.leave_groupchat_info"}}</div>
+          {{/unless}}
         </form.section>
 
       </ChatForm>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -10,6 +10,7 @@ import categoryBadge from "discourse/helpers/category-badge";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
 import I18n from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 import ChatForm from "discourse/plugins/chat/discourse/components/chat/form";

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -9,6 +9,7 @@ import DToggleSwitch from "discourse/components/d-toggle-switch";
 import categoryBadge from "discourse/helpers/category-badge";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import icon from "discourse-common/helpers/d-icon";
 import I18n from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 import ChatForm from "discourse/plugins/chat/discourse/components/chat/form";
@@ -582,7 +583,11 @@ export default class ChatAboutScreen extends Component {
               />
             </:action>
           </section.row>
+          <div class="chat-channel-settings__leave-info">
+            {{icon "exclamation-triangle"}}
+            {{I18n.t "chat.channel_settings.leave_groupchat_info"}}</div>
         </form.section>
+
       </ChatForm>
     </div>
   </template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -586,7 +586,8 @@ export default class ChatAboutScreen extends Component {
           {{#unless @channel.isCategoryChannel}}
             <div class="chat-channel-settings__leave-info">
               {{icon "exclamation-triangle"}}
-              {{I18n.t "chat.channel_settings.leave_groupchat_info"}}</div>
+              {{i18n "chat.channel_settings.leave_groupchat_info"}}
+            </div>
           {{/unless}}
         </form.section>
 

--- a/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
@@ -18,4 +18,8 @@
       color: var(--danger);
     }
   }
+
+  .chat-form__section-content:has(.chat-channel-settings__leave-info) {
+    gap: 0.25rem;
+  }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
@@ -9,4 +9,13 @@
   .chat-retention-reminder-text {
     color: var(--primary-medium);
   }
+
+  &__leave-info {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-medium);
+
+    .d-icon {
+      color: var(--danger);
+    }
+  }
 }

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -62,6 +62,7 @@ en:
         delete_channel: "Delete channel"
         join_channel: "Join channel"
         leave_channel: "Leave channel"
+        leave_groupchat_info: "By leaving this group chat, you will no longer have access to it and won’t receive notifications related to it. To rejoin, you will need to be re-invited by a member of the group chat."
         join: "Join"
         leave: "Leave"
         save_label:


### PR DESCRIPTION
Adding extra copy to clarify the consequences of leaving a group chat

<img width="599" alt="image" src="https://github.com/discourse/discourse/assets/101828855/0fd4e16a-a234-4426-ad45-d43dbd17bf98">

