### PR TITLE
DEV: ensures we have error message before message check

### DIFF
--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Message errors", type: :system do
 
       channel_page.send_message("atoolongmessage" + "a" * max_length)
 
-      expect(page).to have_no_content("atoolongmessage")
       expect(page).to have_content(I18n.t("chat.errors.message_too_long", count: max_length))
+      expect(page).to have_no_content("atoolongmessage")
     end
   end
 end


### PR DESCRIPTION
Previously the spec could be flakey as the long message could show on the screen while we await for processing. Now we will first check to have the error message on screen, at this point the erroneous message should never be visible.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
