### PR TITLE
UX: make summary 100% height

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -72,6 +72,7 @@
     cursor: pointer;
     display: flex;
     align-items: stretch;
+    height: 100%;
     &:not(.btn) {
       border-radius: var(--d-input-border-radius);
       padding-left: 0.5em;


### PR DESCRIPTION
Fixing this possible issue in the select-kit, where the summary tag doesn't take the full height of the parent detail tag

![image](https://github.com/discourse/discourse/assets/101828855/b2fa16d6-6f43-406a-ad6b-dcdd9b3fb509)

Missing a few mm:
<img width="325" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c3e4e26c-abd0-4d43-8f95-8efb61c53e05">

I've seen the height:100% applied on a lot of scoped instances already, and I think it shouldn't cause any global issues. (Famous last words)

