### PR TITLE
FIX: disables tooltip on desktop message menu’s reaction

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.gjs
@@ -142,6 +142,7 @@ export default class ChatMessageActionsDesktop extends Component {
                 @onReaction={{this.messageInteractor.react}}
                 @message={{this.message}}
                 @showCount={{false}}
+                @disableTooltip={{true}}
               />
             {{/each}}
           {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
@@ -19,7 +19,7 @@ export default class ChatMessageReaction extends Component {
   @tracked isActive = false;
 
   registerTooltip = modifier((element) => {
-    if (!this.popoverContent?.length) {
+    if (this.disableTooltip || !this.popoverContent?.length) {
       return;
     }
 
@@ -36,6 +36,10 @@ export default class ChatMessageReaction extends Component {
       instance?.destroy();
     };
   });
+
+  get disableTooltip() {
+    return this.args.disableTooltip ?? false;
+  }
 
   get showCount() {
     return this.args.showCount ?? true;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
