### PR TITLE
FIX: correctly show "chat with" and not "chat in" for users

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -273,9 +273,15 @@ export default {
             }
 
             get title() {
-              return I18n.t("chat.placeholder_channel", {
-                channelName: this.channel.escapedTitle,
-              });
+              if (this.channel.chatable.group) {
+                return I18n.t("chat.placeholder_channel", {
+                  channelName: this.channel.escapedTitle,
+                });
+              } else {
+                return I18n.t("chat.placeholder_users", {
+                  commaSeparatedNames: this.channel.chatable.users[0].username,
+                });
+              }
             }
 
             get text() {


### PR DESCRIPTION
Prior to this fix direct message would always show "Chat in ..." when hovering the channel even if you were hovering a direct message channel with another user (or yourself).

We will now correctly show:

- `Chat in ...` for group channels
- `Chat with ...` for direct message channels

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
