### PR TITLE
DEV: correctly uses link to message endpoint in spec

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -279,7 +279,7 @@ export default {
                 });
               } else {
                 return I18n.t("chat.placeholder_users", {
-                  commaSeparatedNames: this.channel.chatable.users[0].username,
+                  commaSeparatedNames: this.channel.escapedTitle,
                 });
               }
             }

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Chat channel", type: :system do
 
     it "jumps to the bottom of the channel" do
       unloaded_message = Fabricate(:chat_message, chat_channel: channel_1)
-      visit("/chat/message/#{message_1.id}")
+      visit("/chat/c/-/#{channel_1.id}/#{message_1.id}")
 
       expect(channel_page).to have_no_loading_skeleton
       expect(page).to have_no_css("[data-id='#{unloaded_message.id}']")
@@ -168,7 +168,7 @@ RSpec.describe "Chat channel", type: :system do
     end
 
     xit "doesn’t scroll the pane" do
-      visit("/chat/message/#{message_1.id}")
+      visit("/chat/c/-/#{channel_1.id}/#{message_1.id}")
 
       new_message = Fabricate(:chat_message, chat_channel: channel_1)
 

--- a/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
+++ b/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Sidebar navigation menu", type: :system do
         visit("/")
 
         expect(sidebar_page.dms_section.find(".channel-#{dm_channel_1.id}")["title"]).to eq(
-          "Chat in @&lt;script&gt;alert(&#x27;hello&#x27;)&lt;/script&gt;",
+          "Chat with @&lt;script&gt;alert(&#x27;hello&#x27;)&lt;/script&gt;",
         )
       end
     end


### PR DESCRIPTION
- correctly uses link to message endpoint in spec
- correctly uses "chat with"