### PR TITLE
FIX: show leave channel notice only on group channels

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings.gjs
@@ -593,14 +593,13 @@ export default class ChatAboutScreen extends Component {
               />
             </:action>
           </section.row>
-          {{#unless @channel.isCategoryChannel}}
+          {{#if @channel.chatable.group}}
             <div class="chat-channel-settings__leave-info">
               {{icon "exclamation-triangle"}}
               {{i18n "chat.channel_settings.leave_groupchat_info"}}
             </div>
-          {{/unless}}
+          {{/if}}
         </form.section>
-
       </ChatForm>
     </div>
   </template>


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
