### PR TITLE
DEV: Bump rswag-specs from 2.11.0 to 2.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,9 +150,7 @@ group :test, :development do
   gem "rubocop-discourse", require: false
   gem "parallel_tests"
 
-  # Depreciation warnings that we can't act on is being printed out in the test output.
-  # See https://github.com/rswag/rswag/issues/703
-  gem "rswag-specs", "2.11.0"
+  gem "rswag-specs"
 
   gem "annotate"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     in_threads (1.6.0)
     jmespath (1.6.2)
     json (2.7.1)
-    json-schema (3.0.0)
+    json-schema (4.1.1)
       addressable (>= 2.8)
     json_schemer (2.1.1)
       hana (~> 1.3)
@@ -407,9 +407,9 @@ GEM
     rspec-support (3.12.1)
     rss (0.3.0)
       rexml
-    rswag-specs (2.11.0)
+    rswag-specs (2.13.0)
       activesupport (>= 3.1, < 7.2)
-      json-schema (>= 2.2, < 4.0)
+      json-schema (>= 2.2, < 5.0)
       railties (>= 3.1, < 7.2)
       rspec-core (>= 2.14)
     rtlcss (0.2.1)
@@ -638,7 +638,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rss
-  rswag-specs (= 2.11.0)
+  rswag-specs
   rtlcss
   rubocop-discourse
   ruby-prof

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -89,15 +89,15 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join("openapi").to_s
+  config.openapi_root = Rails.root.join("openapi").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
-  # document below. You can override this behavior by adding a swagger_doc tag to the
-  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
     "openapi.yaml" => {
       openapi: "3.1.0",
       info: {
@@ -135,5 +135,5 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end


### PR DESCRIPTION
Issues described in https://github.com/rswag/rswag/issues/703 were resolved and released in new version of rswag.

This PR takes back changes done in revert https://github.com/discourse/discourse/pull/24560 and resolves the dependency warnings.