### PR TITLE
FIX: Flashing when loading glimmer `SearchMenu` results

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
@@ -1,6 +1,6 @@
 {{#if (and this.search.inTopicContext (not @searchTopics))}}
   <SearchMenu::BrowserSearchTip />
-{{else if (not @loading)}}
+{{else}}
   <div class="results">
     {{#if @suggestionKeyword}}
       <SearchMenu::Results::Assistant


### PR DESCRIPTION
# Before

https://github.com/discourse/discourse/assets/50783505/6f3161f1-ebf2-4647-8d6f-c03a7e440b2a



# After

https://github.com/discourse/discourse/assets/50783505/c70d4084-d881-4b6c-8689-c598183e9dd2

