### PR TITLE
DEV: Restore ember-global deprecation in production

### DIFF
--- a/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
+++ b/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
@@ -33,6 +33,29 @@ define("discourse/lib/deprecate-shim", ["exports"], function (exports) {
         console.warn(`DEPRECATION: ${updatedMessage}`);
       }
     );
+
+    // Patch ember-global deprecation
+    Object.defineProperty(window, "Ember", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        require("@ember/debug").deprecate(
+          "Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead.",
+          false,
+          {
+            id: "ember-global",
+            until: "4.0.0",
+            url: "https://deprecations.emberjs.com/v3.x/#toc_ember-global",
+            for: "ember-source",
+            since: {
+              enabled: "3.27.0",
+            },
+          }
+        );
+
+        return require("ember").default;
+      },
+    });
   };
 });
 


### PR DESCRIPTION
Even with our patch to the deprecate() macro, this is optimized out of the production build because it's wrapped in an `if(DEBUG)` statement. (https://github.com/davidtaylorhq/ember.js/blob/14c02f53b8/packages/%40ember/-internals/bootstrap/index.ts#L19-L19)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
