### PR TITLE
UX: fix info text color on custom field for login

### DIFF
--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -88,6 +88,13 @@
     }
   }
 
+  .more-info,
+  .instructions {
+    color: var(--primary-medium);
+    min-height: 1.4em;
+    overflow-wrap: anywhere;
+  }
+
   .caps-lock-warning {
     color: var(--danger);
     font-size: var(--font-down-1);


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse/assets/101828855/c1ebb5a4-0e32-41db-88bc-7b5bf720bfcf)

After
<img width="380" alt="image" src="https://github.com/discourse/discourse/assets/101828855/b8fa1cd7-0078-45f2-a61c-ab8b0d230d05">


