### PR TITLE
UX: improve btn-transparent styling

### DIFF
--- a/app/assets/javascripts/discourse/app/components/admin-post-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/admin-post-menu.gjs
@@ -54,7 +54,7 @@ export default class AdminPostMenu extends Component {
           <DButton
             @label="review.moderation_history"
             @icon="list"
-            class="btn btn-transparent moderation-history"
+            class="btn popup-menu-btn moderation-history"
             @href={{this.reviewUrl}}
           />
         </li>
@@ -70,7 +70,7 @@ export default class AdminPostMenu extends Component {
             }}
             @icon="shield-alt"
             class={{concatClass
-              "btn btn-transparent toggle-post-type"
+              "btn popup-menu-btn toggle-post-type"
               (if @data.transformedPost.isModeratorAction "btn-success")
             }}
             @action={{fn this.topicAction "togglePostType"}}
@@ -89,7 +89,7 @@ export default class AdminPostMenu extends Component {
             }}
             title="post.controls.unhide"
             class={{concatClass
-              "btn btn-transparent"
+              "btn popup-menu-btn"
               (if @data.transformedPost.notice "change-notice" "add-notice")
               (if @data.transformedPost.notice "btn-success")
             }}
@@ -103,7 +103,7 @@ export default class AdminPostMenu extends Component {
           <DButton
             @label="post.controls.unhide"
             @icon="far-eye"
-            class="btn btn-transparent unhide-post"
+            class="btn popup-menu-btn unhide-post"
             @action={{fn this.topicAction "unhidePost"}}
           />
         </li>
@@ -123,7 +123,7 @@ export default class AdminPostMenu extends Component {
             @label="post.controls.change_owner"
             @icon="user"
             title="post.controls.lock_post_description"
-            class="btn btn-transparent change-owner"
+            class="btn popup-menu-btn change-owner"
             @action={{fn this.topicAction "changePostOwner"}}
           />
         </li>
@@ -135,7 +135,7 @@ export default class AdminPostMenu extends Component {
             <DButton
               @label="post.controls.grant_badge"
               @icon="certificate"
-              class="btn btn-transparent grant-badge"
+              class="btn popup-menu-btn grant-badge"
               @action={{fn this.topicAction "grantBadge"}}
             />
           </li>
@@ -148,7 +148,7 @@ export default class AdminPostMenu extends Component {
               @icon="unlock"
               title="post.controls.unlock_post_description"
               class={{concatClass
-                "btn btn-transparent unlock-post"
+                "btn popup-menu-btn unlock-post"
                 (if @data.post.locked "btn-success")
               }}
               @action={{fn this.topicAction "unlockPost"}}
@@ -160,7 +160,7 @@ export default class AdminPostMenu extends Component {
               @label="post.controls.lock_post"
               @icon="lock"
               title="post.controls.lock_post_description"
-              class="btn btn-transparent lock-post"
+              class="btn popup-menu-btn lock-post"
               @action={{fn this.topicAction "lockPost"}}
             />
           </li>
@@ -172,7 +172,7 @@ export default class AdminPostMenu extends Component {
           <DButton
             @label="post.controls.permanently_delete"
             @icon="trash-alt"
-            class="btn btn-transparent permanently-delete"
+            class="btn popup-menu-btn permanently-delete"
             @action={{fn this.topicAction "permanentlyDeletePost"}}
           />
         </li>
@@ -185,7 +185,7 @@ export default class AdminPostMenu extends Component {
               @label="post.controls.unwiki"
               @icon="far-edit"
               class={{concatClass
-                "btn btn-transparent wiki wikied"
+                "btn popup-menu-btn wiki wikied"
                 (if @data.transformedPost.wiki "btn-success")
               }}
               @action={{fn this.topicAction "toggleWiki"}}
@@ -196,7 +196,7 @@ export default class AdminPostMenu extends Component {
             <DButton
               @label="post.controls.wiki"
               @icon="far-edit"
-              class="btn btn-transparent wiki"
+              class="btn popup-menu-btn wiki"
               @action={{fn this.topicAction "toggleWiki"}}
             />
           </li>
@@ -208,7 +208,7 @@ export default class AdminPostMenu extends Component {
           <DButton
             @label="post.controls.publish_page"
             @icon="file"
-            class="btn btn-transparent publish-page"
+            class="btn popup-menu-btn publish-page"
             @action={{fn this.topicAction "showPagePublish"}}
           />
         </li>
@@ -219,7 +219,7 @@ export default class AdminPostMenu extends Component {
           <DButton
             @label="post.controls.rebake"
             @icon="sync-alt"
-            class="btn btn-transparent rebuild-html"
+            class="btn popup-menu-btn rebuild-html"
             @action={{fn this.topicAction "rebakePost"}}
           />
         </li>
@@ -231,7 +231,7 @@ export default class AdminPostMenu extends Component {
             @label={{button.label}}
             @translatedLabel={{button.translatedLabel}}
             @icon={{button.icon}}
-            class={{concatClass "btn btn-transparent" button.className}}
+            class={{concatClass "btn popup-menu-btn" button.className}}
             @action={{fn this.extraAction button}}
           />
         </li>

--- a/app/assets/javascripts/discourse/app/components/discourse-banner.hbs
+++ b/app/assets/javascripts/discourse/app/components/discourse-banner.hbs
@@ -3,7 +3,7 @@
     <div id="banner" class={{this.overlay}}>
       <div class="floated-buttons">
         {{#if this.currentUser.staff}}
-          <a href={{this.banner.url}} class="btn btn-flat edit-banner">
+          <a href={{this.banner.url}} class="btn btn-transparent edit-banner">
             {{d-icon "pencil-alt"}}
             {{#unless this.site.mobileView}}
               {{html-safe (i18n "banner.edit")}}
@@ -15,7 +15,7 @@
           @icon="times"
           @action={{this.dismiss}}
           @title="banner.close"
-          class="btn-flat close"
+          class="btn-transparent close"
         />
       </div>
       <div id="banner-content">

--- a/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
@@ -55,6 +55,7 @@ export default class DFloatBody extends Component {
           @mainClass
           (if this.options.animated "-animated")
           (if @instance.expanded "-expanded")
+          this.options.extraClassName
         }}
         data-identifier={{this.options.identifier}}
         data-content

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -61,6 +61,7 @@ export const MENU = {
     fallbackPlacements: FLOAT_UI_PLACEMENTS,
     autoUpdate: true,
     trapTab: true,
+    extraClassName: "popup-menu",
   },
   portalOutletId: "d-menu-portal-outlet",
 };

--- a/app/assets/stylesheets/common/base/popup-menu.scss
+++ b/app/assets/stylesheets/common/base/popup-menu.scss
@@ -23,13 +23,15 @@
     text-align: left;
     background: none;
     width: 100%;
-    padding: 0.75em;
+    padding: 0.5em;
     border-radius: 0;
     margin: 0;
 
     .d-icon {
       color: var(--primary-medium);
       align-self: flex-start;
+      margin-right: 0.75em;
+      margin-top: 0.1em; // vertical alignment
     }
 
     &:focus,

--- a/app/assets/stylesheets/common/base/topic-admin-menu.scss
+++ b/app/assets/stylesheets/common/base/topic-admin-menu.scss
@@ -32,7 +32,7 @@
     .d-icon {
       font-size: var(--font-down-1);
       margin-top: 2px; // vertical alignment
-      margin-right: 1rem;
+      margin-right: 0.75em;
     }
   }
 

--- a/app/assets/stylesheets/common/components/admin-post-menu.scss
+++ b/app/assets/stylesheets/common/components/admin-post-menu.scss
@@ -11,6 +11,7 @@
 
     li {
       margin-bottom: 2px;
+      border: none;
 
       &:last-child {
         margin-bottom: 0;

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -397,57 +397,55 @@
   }
 }
 
-.btn-transparent {
-  background: none;
-  border: 0;
-  color: var(--primary);
-
-  &.btn-primary,
-  &.btn-primary:focus,
-  &.btn-primary:hover {
-    .d-icon {
-      color: var(--tertiary) !important;
-    }
+@mixin btn-colors($btn-color) {
+  color: var(--#{$btn-color});
+  .d-icon {
+    color: currentColor;
   }
-  &.btn-danger,
-  &.btn-danger:focus,
-  &.btn-danger:hover {
-    .d-icon {
-      color: var(--danger) !important;
-    }
+  &:focus,
+  &:focus-visible {
+    color: var(--#{$btn-color}-hover);
   }
-  &.btn-success,
-  &.btn-success:focus,
-  &.btn-success:hover {
-    .d-icon {
-      color: var(--success) !important;
-    }
-  }
-
   .discourse-no-touch & {
     &:hover {
-      color: var(--primary);
-      background: var(--d-hover);
+      color: var(--#{$btn-color}-hover);
+    }
+  }
+}
+
+.btn-transparent {
+  &,
+  &.btn-default {
+    background: transparent !important;
+    border: 0;
+    color: var(--primary);
+    .d-icon {
+      color: var(--primary-high);
+    }
+    &:focus,
+    &:focus-visible {
+      color: var(--tertiary-hover);
       .d-icon {
-        color: var(--primary);
+        color: currentColor;
+      }
+    }
+    .discourse-no-touch & {
+      &:hover {
+        color: var(--tertiary-hover);
+        .d-icon {
+          color: currentColor;
+        }
       }
     }
   }
-
-  &:focus {
-    color: var(--primary);
-    background: var(--d-hover);
-    .d-icon {
-      color: var(--primary);
-    }
+  &.btn-primary {
+    @include btn-colors("tertiary");
   }
-
-  &:focus-visible {
-    color: var(--primary);
-    background: var(--d-hover);
-    .d-icon {
-      color: var(--primary);
-    }
+  &.btn-danger {
+    @include btn-colors("danger");
+  }
+  &.btn-success {
+    @include btn-colors("success");
   }
 }
 


### PR DESCRIPTION
This makes some adjustments to the existing `btn-transparent` class so that it's always transparent and can inherit colors from other button classes (while retaining transparency). 

Adding `.btn-transparent` to a button will ensure the button will always be transparent. The text and icon color will change on hover and focus. 


![Screenshot 2023-12-01 at 9 37 55 AM](https://github.com/discourse/discourse/assets/1681963/dbc7171d-2f0d-44a7-8528-5e0233257cc4)
![Screenshot 2023-12-01 at 9 37 45 AM](https://github.com/discourse/discourse/assets/1681963/9553c9e1-c081-4cd9-996c-1bc28a9b82ee)

![Screenshot 2023-12-01 at 9 38 36 AM](https://github.com/discourse/discourse/assets/1681963/87ec9f7f-229c-4198-8a4c-558f6a5028ac)
![Screenshot 2023-12-01 at 9 38 57 AM](https://github.com/discourse/discourse/assets/1681963/aa72bf7e-9513-4057-869a-85b81267265b)

![Screenshot 2023-12-01 at 9 39 43 AM](https://github.com/discourse/discourse/assets/1681963/1121dcfa-df23-47a0-bf54-3fb3d5b945c8)
![Screenshot 2023-12-01 at 9 39 25 AM](https://github.com/discourse/discourse/assets/1681963/8cb74761-090c-4db3-8af6-c97249d31074)

There will be some follow-up work to transition `btn-flat` to new usage of `btn-transparent` where appropriate. `btn-flat` is similar, but will be used in cases where a background color is appropriate on hover and focus. 

This also updated the existing use of `.btn-transparent` which was solely used in the post admin popup menu. I transitioned that menu to use `.popup-menu-btn` to be more consistent with the topic admin menu. 

To start, I've updated `btn-flat` to `btn-transparent` within `discourse-banner` because this was a known issue:

before (edit button focused):
![Screenshot 2023-12-01 at 9 44 36 AM](https://github.com/discourse/discourse/assets/1681963/65138c7e-a679-4e64-bd41-73422f0ed373)

after (edit button focused): 
![Screenshot 2023-12-01 at 9 44 13 AM](https://github.com/discourse/discourse/assets/1681963/094781c5-1362-4533-9089-c18cfc5458dc)
