### PR TITLE
DEV: Only add ember-global deprecation for Ember 3

### DIFF
--- a/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
+++ b/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
@@ -35,27 +35,29 @@ define("discourse/lib/deprecate-shim", ["exports"], function (exports) {
     );
 
     // Patch ember-global deprecation
-    Object.defineProperty(window, "Ember", {
-      enumerable: true,
-      configurable: true,
-      get() {
-        require("@ember/debug").deprecate(
-          "Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead.",
-          false,
-          {
-            id: "ember-global",
-            until: "4.0.0",
-            url: "https://deprecations.emberjs.com/v3.x/#toc_ember-global",
-            for: "ember-source",
-            since: {
-              enabled: "3.27.0",
-            },
-          }
-        );
+    if (window.hasOwnProperty("Ember")) {
+      Object.defineProperty(window, "Ember", {
+        enumerable: true,
+        configurable: true,
+        get() {
+          require("@ember/debug").deprecate(
+            "Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead.",
+            false,
+            {
+              id: "ember-global",
+              until: "4.0.0",
+              url: "https://deprecations.emberjs.com/v3.x/#toc_ember-global",
+              for: "ember-source",
+              since: {
+                enabled: "3.27.0",
+              },
+            }
+          );
 
-        return require("ember").default;
-      },
-    });
+          return require("ember").default;
+        },
+      });
+    }
   };
 });
 


### PR DESCRIPTION
(otherwise, we're accidentally extending support for the global into Ember 5!)

Followup to 106c1c317f70c80f968038f0c770ac1d9d480927

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
