### PR TITLE
DEV: Add parent_id column to notifications and allow chat_mentions to have several notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -411,6 +411,7 @@ end
 #  post_number       :integer
 #  post_action_id    :integer
 #  high_priority     :boolean          default(FALSE), not null
+#  parent_id         :integer
 #
 # Indexes
 #
@@ -421,4 +422,5 @@ end
 #  index_notifications_on_user_id_and_topic_id_and_post_number  (user_id,topic_id,post_number)
 #  index_notifications_read_or_not_high_priority                (user_id,id DESC,read,topic_id) WHERE (read OR (high_priority = false))
 #  index_notifications_unique_unread_high_priority              (user_id,id) UNIQUE WHERE ((NOT read) AND (high_priority = true))
+#  index_notifications_on_parent_id                             (parent_id)
 #

--- a/db/migrate/20231208080000_add_parent_id_to_notifications.rb
+++ b/db/migrate/20231208080000_add_parent_id_to_notifications.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddParentIdToNotifications < ActiveRecord::Migration[7.0]
+  def up
+    add_column :notifications, :parent_id, :integer, null: true
+
+    DB.exec <<~SQL
+      UPDATE notifications n
+      SET parent_id = cm.id
+      FROM chat_mentions cm
+      WHERE n.id = cm.notification_id;
+    SQL
+
+    add_index :notifications, :parent_id
+  end
+
+  def down
+    remove_index :notifications, :parent_id
+    remove_column :notifications, :parent_id
+  end
+end

--- a/plugins/chat/app/jobs/regular/chat/notify_mentioned.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_mentioned.rb
@@ -122,7 +122,7 @@ module Jobs
             read: is_read,
           )
 
-        mention.update!(notification: notification)
+        mention.notifications << notification
       end
 
       def send_notifications(membership, mention_type)

--- a/plugins/chat/app/models/chat/mention.rb
+++ b/plugins/chat/app/models/chat/mention.rb
@@ -3,6 +3,7 @@
 module Chat
   class Mention < ActiveRecord::Base
     self.table_name = "chat_mentions"
+    self.ignored_columns = ["notification_id"]
 
     belongs_to :user
     belongs_to :chat_message, class_name: "Chat::Message"

--- a/plugins/chat/app/models/chat/mention.rb
+++ b/plugins/chat/app/models/chat/mention.rb
@@ -6,7 +6,10 @@ module Chat
 
     belongs_to :user
     belongs_to :chat_message, class_name: "Chat::Message"
-    belongs_to :notification, dependent: :destroy
+    has_many :notifications,
+             -> { where notification_type: Notification.types[:chat_mention] },
+             foreign_key: :parent_id,
+             dependent: :destroy
   end
 end
 

--- a/plugins/chat/app/services/chat/action/mark_mentions_read.rb
+++ b/plugins/chat/app/services/chat/action/mark_mentions_read.rb
@@ -17,7 +17,7 @@ module Chat
           .where(notification_type: Notification.types[:chat_mention])
           .where(user: user)
           .where(read: false)
-          .joins("INNER JOIN chat_mentions ON chat_mentions.notification_id = notifications.id")
+          .joins("INNER JOIN chat_mentions ON chat_mentions.id = notifications.parent_id")
           .joins("INNER JOIN chat_messages ON chat_mentions.chat_message_id = chat_messages.id")
           .where("chat_messages.chat_channel_id IN (?)", channel_ids)
           .then do |notifications|

--- a/plugins/chat/app/services/chat/trash_message.rb
+++ b/plugins/chat/app/services/chat/trash_message.rb
@@ -55,9 +55,9 @@ module Chat
     end
 
     def destroy_notifications(message:, **)
-      ids = Chat::Mention.where(chat_message: message).pluck(:notification_id)
+      ids =
+        Chat::Mention.where(chat_message: message).joins(:notifications).pluck("notifications.id")
       Notification.where(id: ids).destroy_all
-      Chat::Mention.where(chat_message: message).update_all(notification_id: nil)
     end
 
     def update_tracking_state(message:, **)

--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -85,7 +85,8 @@ module Chat
       already_notified_user_ids =
         Chat::Mention
           .where(chat_message: @chat_message)
-          .where.not(notification: nil)
+          .left_outer_joins(:notifications)
+          .where.not(notifications: { id: nil })
           .pluck(:user_id)
 
       to_notify, inaccessible, all_mentioned_user_ids = list_users_to_notify

--- a/plugins/chat/lib/chat/user_notifications_extension.rb
+++ b/plugins/chat/lib/chat/user_notifications_extension.rb
@@ -11,9 +11,8 @@ module Chat
           .joins(:user, :chat_channel)
           .where.not(user: user)
           .where("chat_messages.created_at > ?", 1.week.ago)
-          .joins(
-            "LEFT OUTER JOIN chat_mentions cm ON cm.chat_message_id = chat_messages.id AND cm.notification_id IS NOT NULL",
-          )
+          .joins("LEFT OUTER JOIN chat_mentions cm ON cm.chat_message_id = chat_messages.id")
+          .joins("LEFT OUTER JOIN notifications n ON n.parent_id = cm.id")
           .joins(
             "INNER JOIN user_chat_channel_memberships uccm ON uccm.chat_channel_id = chat_channels.id",
           )
@@ -22,7 +21,7 @@ module Chat
           (uccm.last_read_message_id IS NULL OR chat_messages.id > uccm.last_read_message_id) AND
           (uccm.last_unread_mention_when_emailed_id IS NULL OR chat_messages.id > uccm.last_unread_mention_when_emailed_id) AND
           (
-            (cm.user_id = :user_id AND uccm.following IS true AND chat_channels.chatable_type = 'Category') OR
+            (cm.user_id = :user_id AND n.id IS NOT NULL AND uccm.following IS true AND chat_channels.chatable_type = 'Category') OR
             (chat_channels.chatable_type = 'DirectMessage')
           )
         SQL

--- a/plugins/chat/spec/jobs/regular/chat/channel_delete_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/channel_delete_spec.rb
@@ -26,7 +26,7 @@ describe Jobs::Chat::ChannelDelete do
     Chat::Mention.create(
       user: user2,
       chat_message: messages.sample,
-      notification: Fabricate(:notification),
+      notifications: [Fabricate(:notification)],
     )
 
     @incoming_chat_webhook_id = Fabricate(:incoming_chat_webhook, chat_channel: chat_channel)

--- a/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
@@ -283,8 +283,7 @@ describe Jobs::Chat::NotifyMentioned do
       expect(data_hash[:chat_channel_title]).to eq(expected_channel_title)
       expect(data_hash[:chat_channel_slug]).to eq(public_channel.slug)
 
-      chat_mention =
-        Chat::Mention.where(notification: created_notification, user: user_2, chat_message: message)
+      chat_mention = Chat::Mention.find(created_notification.parent_id)
       expect(chat_mention).to be_present
     end
   end

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -257,7 +257,7 @@ describe UserNotifications do
               :chat_mention,
               user: user,
               chat_message: chat_message,
-              notification: notification,
+              notifications: [notification],
             )
           end
 
@@ -310,7 +310,7 @@ describe UserNotifications do
               :chat_mention,
               user: user,
               chat_message: another_chat_message,
-              notification: notification,
+              notifications: [notification],
             )
             another_chat_channel.update!(last_message: another_chat_message)
 
@@ -350,7 +350,7 @@ describe UserNotifications do
                 :chat_mention,
                 user: user,
                 chat_message: another_chat_message,
-                notification: notification,
+                notifications: [notification],
               )
               another_chat_channel.update!(last_message: another_chat_message)
             end
@@ -379,7 +379,7 @@ describe UserNotifications do
               :chat_mention,
               user: user,
               chat_message: chat_message,
-              notification: notification,
+              notifications: [notification],
             )
           end
 
@@ -406,7 +406,7 @@ describe UserNotifications do
             :chat_mention,
             user: user,
             chat_message: chat_message,
-            notification: notification,
+            notifications: [notification],
           )
         end
 
@@ -513,7 +513,7 @@ describe UserNotifications do
               :chat_mention,
               user: user,
               chat_message: new_message,
-              notification: notification,
+              notifications: [notification],
             )
 
             email = described_class.chat_summary(user, {})
@@ -642,7 +642,12 @@ describe UserNotifications do
               2.times do
                 msg = Fabricate(:chat_message, user: sender, chat_channel: channel)
                 notification = Fabricate(:notification)
-                Fabricate(:chat_mention, user: user, chat_message: msg, notification: notification)
+                Fabricate(
+                  :chat_mention,
+                  user: user,
+                  chat_message: msg,
+                  notifications: [notification],
+                )
               end
 
               email = described_class.chat_summary(user, {})
@@ -668,7 +673,7 @@ describe UserNotifications do
                     :chat_mention,
                     user: user,
                     chat_message: msg,
-                    notification: notification,
+                    notifications: [notification],
                   )
                 end
 
@@ -695,7 +700,7 @@ describe UserNotifications do
               :chat_mention,
               user: user,
               chat_message: new_message,
-              notification: notification,
+              notifications: [notification],
             )
 
             email = described_class.chat_summary(user, {})

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -449,8 +449,8 @@ describe Chat::Message do
 
     it "destroys chat_mention" do
       message_1 = Fabricate(:chat_message)
-      notification = Fabricate(:notification)
-      mention_1 = Fabricate(:chat_mention, chat_message: message_1, notification: notification)
+      notification = Fabricate(:notification, notification_type: Notification.types[:chat_mention])
+      mention_1 = Fabricate(:chat_mention, chat_message: message_1, notifications: [notification])
 
       message_1.reload.destroy!
 

--- a/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
@@ -128,7 +128,11 @@ describe Chat::ChannelUnreadsQuery do
           user_id: current_user.id,
           data: { chat_message_id: message.id, chat_channel_id: channel.id }.to_json,
         )
-      Chat::Mention.create!(notification: notification, user: current_user, chat_message: message)
+      Chat::Mention.create!(
+        notifications: [notification],
+        user: current_user,
+        chat_message: message,
+      )
     end
 
     it "returns a correct unread mention" do

--- a/plugins/chat/spec/requests/chat/api/reads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/reads_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Chat::Api::ReadsController do
         }.to_json,
       )
       .tap do |notification|
-        Chat::Mention.create!(user: user, chat_message: msg, notification: notification)
+        Chat::Mention.create!(user: user, chat_message: msg, notifications: [notification])
       end
   end
 end

--- a/plugins/chat/spec/requests/chat/api/thread_reads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/thread_reads_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Chat::Api::ThreadReadsController do
         }.to_json,
       )
       .tap do |notification|
-        Chat::Mention.create!(user: user, chat_message: msg, notification: notification)
+        Chat::Mention.create!(user: user, chat_message: msg, notifications: [notification])
       end
   end
 end

--- a/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
+++ b/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
 
       before do
         Chat::Mention.create!(
-          notification: notification_1,
+          notifications: [notification_1],
           user: current_user,
           chat_message: message_1,
         )
         Chat::Mention.create!(
-          notification: notification_2,
+          notifications: [notification_2],
           user: current_user,
           chat_message: message_3,
         )

--- a/plugins/chat/spec/services/chat/trash_message_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_message_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe Chat::TrashMessage do
 
         it "destroys notifications for mentions" do
           notification = Fabricate(:notification)
-          mention = Fabricate(:chat_mention, chat_message: message, notification: notification)
+          mention = Fabricate(:chat_mention, chat_message: message, notifications: [notification])
 
           result
 
           mention = Chat::Mention.find_by(id: mention.id)
           expect(mention).to be_present
-          expect(mention.notification_id).to be_nil
+          expect(mention.notifications).to be_empty
         end
 
         it "publishes associated Discourse and MessageBus events" do

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Chat::UpdateMessage do
         )
 
         mention = user3.chat_mentions.where(chat_message: message.id).first
-        expect(mention.notification).to be_present
+        expect(mention.notifications.length).to be(1)
       end
 
       it "doesn't create mentions for already mentioned users" do
@@ -215,7 +215,7 @@ RSpec.describe Chat::UpdateMessage do
         )
 
         mention = user_without_memberships.chat_mentions.where(chat_message: chat_message).first
-        expect(mention.notification).to be_nil
+        expect(mention.notifications).to be_empty
       end
 
       it "destroys mentions that should be removed" do
@@ -271,7 +271,7 @@ RSpec.describe Chat::UpdateMessage do
         )
 
         mention = admin1.chat_mentions.where(chat_message_id: message.id).first
-        expect(mention.notification).to be_nil
+        expect(mention.notifications).to be_empty
       end
 
       it "creates a chat_mention record without notification when self mentioning" do
@@ -282,7 +282,7 @@ RSpec.describe Chat::UpdateMessage do
 
         mention = user1.chat_mentions.where(chat_message: chat_message).first
         expect(mention).to be_present
-        expect(mention.notification).to be_nil
+        expect(mention.notifications).to be_empty
       end
 
       it "adds mentioned user and their status to the message bus message" do

--- a/plugins/chat/spec/services/chat/update_user_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_last_read_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Chat::UpdateUserLastRead do
         before do
           Jobs.run_immediately!
           Chat::Mention.create!(
-            notification: notification,
+            notifications: [notification],
             user: current_user,
             chat_message: message_1,
           )

--- a/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe Chat::UpdateUserThreadLastRead do
         before do
           Jobs.run_immediately!
           Chat::Mention.create!(
-            notification: notification_1,
+            notifications: [notification_1],
             user: current_user,
             chat_message: Fabricate(:chat_message, chat_channel: channel, thread: thread),
           )
           Chat::Mention.create!(
-            notification: notification_2,
+            notifications: [notification_2],
             user: current_user,
             chat_message: Fabricate(:chat_message, chat_channel: channel, thread: thread),
           )


### PR DESCRIPTION
In chat, we need the ability to have several notifications per chat mention. Currently, we have `one_to_one` relation between `chat_mentions` and `notifications`:

https://github.com/discourse/discourse/blob/4adbcf3f2a351c9cd1d78ce390987203a45fd198/plugins/chat/app/models/chat/mention.rb#L9

We want to have `one_to_many` relationship. The main motivation for that is that we want to solve some performance problems with mentions that we're having now (for example, when someone mentions @ all on a chat channel we have to create a `chat_mention` record per user, while with `one_to_many` relationship we will be able to create only one `chat_mention` record in such cases). And apart from solving performance problems, this will make the code design better.

Just adding a `chat_mention_id` column to the notifications table wouldn't be a good solution, because we shouldn't mention chat related stuff in Core as chat is a plugin.

So in this PR, I implemented a general solution by adding the `parent_id` column to the `notifications` table. Now an object, not necessary a `chat_mention`, may have several notifications referenced via this column. And I migrated the `chat_mentions` related code to using this column. In this PR I only made it possible to have several notifications per mention, further refactoring of chat mentions will be in subsequent PRs.

Note that I've already marked the old `chat_mention.notification_id` column as ignored, but I'm not deleting it in this PR. I want to delete it later in https://github.com/discourse/discourse/pull/24800.


