### PR TITLE
DEV: Correct deprecation id for discovery-controller-shims

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/discovery-controller-shims.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/discovery-controller-shims.js
@@ -11,7 +11,7 @@ function ControllerShim(resolverName, deprecationId) {
       deprecated(
         `${resolverName} no longer exists, and this shim will eventually be removed. To fetch information about the current discovery route, use the discovery service instead.`,
         {
-          deprecationId,
+          id: deprecationId,
         }
       );
     }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
