### PR TITLE
FIX: Request html when fetching inline onebox data

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -86,6 +86,7 @@ class FinalDestination
         end
       )
     @stop_at_blocked_pages = @opts[:stop_at_blocked_pages]
+    @extra_headers = @opts[:headers]
   end
 
   def self.connection_timeout
@@ -120,6 +121,7 @@ class FinalDestination
       "Host" => @uri.hostname + (@include_port_in_host_header ? ":#{@uri.port}" : ""),
     }
 
+    result.merge!(@extra_headers) if @extra_headers
     result["Cookie"] = @cookie if @cookie
 
     result

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -78,6 +78,9 @@ module RetrieveTitle
         stop_at_blocked_pages: true,
         max_redirects: max_redirects,
         initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit,
+        headers: {
+          Accept: "text/html,*/*",
+        },
       )
 
     current = nil


### PR DESCRIPTION
We do expect to retrieve html so…

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
