### PR TITLE
FIX: Introduce Guardian::BasicUser for oneboxing checks

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -873,6 +873,10 @@ module Discourse
     @system_users[current_db] ||= User.find_by(id: SYSTEM_USER_ID)
   end
 
+  def self.basic_user
+    Guardian.basic_user
+  end
+
   def self.store
     if SiteSetting.Upload.enable_s3_uploads
       @s3_store_loaded ||= require "file_store/s3_store"

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -78,11 +78,77 @@ class Guardian
     end
   end
 
+  # In some cases, we want a user that is not totally anonymous, but has
+  # the absolute baseline of access to the forum, acting like a TL0 user
+  # that is logged in. This represents someone who cannot access any secure
+  # categories or PMs but can read public topics.
+  class BasicUser
+    def blank?
+      false
+    end
+    def admin?
+      false
+    end
+    def staff?
+      false
+    end
+    def moderator?
+      false
+    end
+    def anonymous?
+      false
+    end
+    def approved?
+      true
+    end
+    def staged?
+      false
+    end
+    def silenced?
+      false
+    end
+    def is_system_user?
+      false
+    end
+    def bot?
+      false
+    end
+    def secure_category_ids
+      []
+    end
+    def groups
+      @groups ||= Group.where(id: Group::AUTO_GROUPS[:trust_level_0])
+    end
+    def has_trust_level?(level)
+      level == TrustLevel[0]
+    end
+    def has_trust_level_or_staff?(level)
+      has_trust_level?(level)
+    end
+    def email
+      nil
+    end
+    def whisperer?
+      false
+    end
+    def in_any_groups?(group_ids)
+      group_ids.include?(Group::AUTO_GROUPS[:everyone]) || (group_ids & groups.map(&:id)).any?
+    end
+  end
+
   attr_reader :request
 
   def initialize(user = nil, request = nil)
     @user = user.presence || AnonymousUser.new
     @request = request
+  end
+
+  def self.anon_user(request: nil)
+    new(AnonymousUser.new, request)
+  end
+
+  def self.basic_user(request: nil)
+    new(BasicUser.new, request)
   end
 
   def user


### PR DESCRIPTION
Through internal discussion, it has become clear that
we need a conceptual Guardian user that bridges the
gap between anon users and a logged in forum user with
an absolute baseline level of access to public topics,
which can be used in cases where:

1. Automated systems are running which shouldn't see any
   private data
1. A baseline level of user access is needed

In this case we are fixing the latter; when oneboxing a local
topic, and we are linking to a topic in another category from
the current one, we need to operate off a baseline level of
access, since not all users have access to the same categories,
and we don't want e.g. editing a post with an internal link to
expose sensitive internal information.