### PR TITLE
FIX: failing spec in sidebar tags

### DIFF
--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     Tag.delete_all
 
     tags =
-      (TagsController::LIST_LIMIT + 20).times.map.with_index do |index|
+      (TagsController::LIST_LIMIT + 50).times.map.with_index do |index|
         Fabricate(:tag, name: "Tag #{sprintf("%03d", index)}")
       end
 

--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     Tag.delete_all
 
     tags =
-      (TagsController::LIST_LIMIT + 1).times.map.with_index do |index|
+      (TagsController::LIST_LIMIT + 20).times.map.with_index do |index|
         Fabricate(:tag, name: "Tag #{sprintf("%03d", index)}")
       end
 


### PR DESCRIPTION
The modal is now larger and more tags will be shown by default, we need more tags to correctly test the scroll behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
