### PR TITLE
FIX: Multiple nested threads and duplicated messages in chat transcripts

### DIFF
--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -76,7 +76,7 @@ module Chat
           message = @message_data.first[:message]
           thread = Chat::Thread.find(thread_id)
 
-          if thread.present? && thread.replies.count > 1
+          if thread.present? && thread.replies_count > 0
             attrs << thread_id_attr
             attrs << thread_title_attr(message, thread)
           end
@@ -247,10 +247,16 @@ module Chat
           end
           rendered_thread_markdown << thread_bbcode_tag.render
         end
-        open_bbcode_tag.add_thread_markdown(
-          thread_id: message_group.first.thread_id,
-          markdown: rendered_thread_markdown.join("\n"),
-        )
+        thread_id = message_group.first.thread_id
+        if thread_id.present?
+          thread = Chat::Thread.find(thread_id)
+          if thread&.replies_count > 0
+            open_bbcode_tag.add_thread_markdown(
+              thread_id: thread_id,
+              markdown: rendered_thread_markdown.join("\n"),
+            )
+          end
+        end
       end
 
       # tie off the last open bbcode + render

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -73,8 +73,13 @@ module Chat
         attrs << reactions_attr if include_reactions
 
         if thread_id
-          attrs << thread_id_attr
-          attrs << thread_title_attr(@message_data.first[:message])
+          message = @message_data.first[:message]
+          thread = Chat::Thread.find(thread_id)
+
+          if thread.present? && thread.replies.count > 1
+            attrs << thread_id_attr
+            attrs << thread_title_attr(message, thread)
+          end
         end
 
         <<~MARKDOWN
@@ -134,8 +139,7 @@ module Chat
         "threadId=\"#{thread_id}\""
       end
 
-      def thread_title_attr(message)
-        thread = Chat::Thread.find(thread_id)
+      def thread_title_attr(message, thread)
         range = thread_ranges[message.id] if thread_ranges.has_key?(message.id)
 
         thread_title =

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -151,7 +151,7 @@ describe Chat::ChannelArchiveService do
         expect(@channel_archive.chat_channel.chat_messages.count).to eq(0)
       end
 
-      it "creates the correct posts for a channel with messages and threads" do
+      xit "creates the correct posts for a channel with messages and threads" do
         create_messages(2)
         create_threaded_messages(6, title: "a new thread")
         create_messages(7)

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -95,6 +95,7 @@ describe Chat::ChannelArchiveService do
       thread =
         Fabricate(:chat_thread, channel: channel, title: title, original_message: original_message)
       (num - 1).times { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
+      thread.update!(replies_count: num - 1)
     end
 
     def start_archive
@@ -150,7 +151,7 @@ describe Chat::ChannelArchiveService do
         expect(@channel_archive.chat_channel.chat_messages.count).to eq(0)
       end
 
-      xit "creates the correct posts for a channel with messages and threads" do
+      it "creates the correct posts for a channel with messages and threads" do
         create_messages(2)
         create_threaded_messages(6, title: "a new thread")
         create_messages(7)

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -257,7 +257,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  it "generates reaction data for threaded messages" do
+  xit "generates reaction data for threaded messages" do
     thread = Fabricate(:chat_thread, channel: channel)
     thread_om =
       Fabricate(
@@ -329,7 +329,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  it "generates a chat transcript for threaded messages" do
+  xit "generates a chat transcript for threaded messages" do
     thread = Fabricate(:chat_thread, channel: channel)
     thread_om =
       Fabricate(
@@ -367,7 +367,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  it "doesn't add thread info for threads with no replies" do
+  xit "doesn't add thread info for threads with no replies" do
     thread = Fabricate(:chat_thread, channel: channel)
     thread_om =
       Fabricate(
@@ -412,7 +412,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  it "generates the correct markdown for multiple threads" do
+  xit "generates the correct markdown for multiple threads" do
     channel_message_1 =
       Fabricate(:chat_message, user: user1, chat_channel: channel, message: "I need ideas")
     thread_1 = Fabricate(:chat_thread, channel: channel)

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -305,6 +305,7 @@ describe Chat::TranscriptService do
       emoji: "money_mouth_face",
     )
 
+    thread.update!(replies_count: 2)
     rendered =
       service(
         [thread_om.id, thread_reply_1.id, thread_reply_2.id],
@@ -328,7 +329,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  xit "generates a chat transcript for threaded messages" do
+  it "generates a chat transcript for threaded messages" do
     thread = Fabricate(:chat_thread, channel: channel)
     thread_om =
       Fabricate(
@@ -348,7 +349,7 @@ describe Chat::TranscriptService do
         thread: thread,
         message: "thanks",
       )
-
+    thread.update!(replies_count: 2)
     rendered = service([thread_om.id, thread_reply_1.id, thread_reply_2.id]).generate_markdown
     expect(rendered).to eq(<<~MARKDOWN)
     [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true" chained="true" threadId="#{thread.id}" threadTitle="#{I18n.t("chat.transcript.default_thread_title")}"]
@@ -366,7 +367,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  xit "doesn't add thread info for threads with no replies" do
+  it "doesn't add thread info for threads with no replies" do
     thread = Fabricate(:chat_thread, channel: channel)
     thread_om =
       Fabricate(
@@ -411,7 +412,7 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
-  xit "generates the correct markdown for multiple threads" do
+  it "generates the correct markdown for multiple threads" do
     channel_message_1 =
       Fabricate(:chat_message, user: user1, chat_channel: channel, message: "I need ideas")
     thread_1 = Fabricate(:chat_thread, channel: channel)
@@ -454,6 +455,8 @@ describe Chat::TranscriptService do
     thread_2_message_2 =
       Fabricate(:chat_message, chat_channel: channel, user: user2, thread: thread_2, message: "np")
 
+    thread_1.update!(replies_count: 1)
+    thread_2.update!(replies_count: 2)
     rendered =
       service(
         [

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -366,6 +366,25 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
+  xit "doesn't add thread info for threads with no replies" do
+    thread = Fabricate(:chat_thread, channel: channel)
+    thread_om =
+      Fabricate(
+        :chat_message,
+        chat_channel: channel,
+        user: user1,
+        thread: thread,
+        message: "no replies",
+      )
+
+    rendered = service([thread_om.id]).generate_markdown
+    expect(rendered).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{thread_om.id};#{thread_om.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}"]
+    no replies
+    [/chat]
+    MARKDOWN
+  end
+
   xit "generates the correct markdown for multiple threads" do
     channel_message_1 =
       Fabricate(:chat_message, user: user1, chat_channel: channel, message: "I need ideas")


### PR DESCRIPTION
This PR fixes an issue that occurs when archiving empty threads. Messages where someone clicked the reply button but never actually replied had the wrong thread info.

They would cause either duplicated thread replies or nested threads

![2023-12-04_12-24](https://github.com/discourse/discourse/assets/66427541/886a4c01-8df9-4705-815d-d63f3c721ef9)

![2023-12-04_12-18](https://github.com/discourse/discourse/assets/66427541/792036d8-722d-43ba-94cf-600778990790)

