### PR TITLE
DEV: Remove unused htmlbars-inline-precompile shim

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -16,12 +16,6 @@ define("I18n", [
   };
 });
 
-define("htmlbars-inline-precompile", ["exports"], function (exports) {
-  exports.default = function tag(strings) {
-    return Ember.Handlebars.compile(strings[0]);
-  };
-});
-
 define("ember-addons/ember-computed-decorators", [
   "discourse-common/utils/decorators",
   "discourse-common/lib/deprecated",


### PR DESCRIPTION
Since 4425e99bf937ec1dea5cc91a2a188c052d70d3a9, we no longer ship the template compiler to the client under any circumstances, so this shim doesn't work. Plus, even if it did work, it would trigger the ember-global deprecation and fail under Ember 4+.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
