### PR TITLE
DEV: Fix assertion in embedding test

### DIFF
--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe EmbedController do
                 embed_url: embed_url,
               },
               headers: {
-                "REFERER" => "http://eviltrout.com/wat/1-2-3.html",
+                "REFERER" => "https://discourse.org/blog-entry-1",
               }
 
           expect(response.status).to eq(200)


### PR DESCRIPTION
The modified test used to be the same as the test above. The bad test
was introduced in commit https://github.com/discourse/discourse/commit/77d4c4d8dc00491b99aa15dfd78eb22a47ffe663,
during a refactoring.

This was not a serious problem because the same behavior was still
tested partially by the other tests below.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
