### PR TITLE
FIX: don't apply extraClassName to all popup menus

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -773,6 +773,7 @@ export default createWidget("post-menu", {
     this.menu.show(event.target, {
       identifier: "admin-post-menu",
       component: AdminPostMenu,
+      extraClassName: "popup-menu",
       data: {
         scheduleRerender: this.scheduleRerender.bind(this),
         transformedPost: this.attrs,

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -61,7 +61,7 @@ export const MENU = {
     fallbackPlacements: FLOAT_UI_PLACEMENTS,
     autoUpdate: true,
     trapTab: true,
-    extraClassName: "popup-menu",
+    extraClassName: null,
   },
   portalOutletId: "d-menu-portal-outlet",
 };


### PR DESCRIPTION
follow-up to 56795f5, the "popup-menu" class shouldn't apply to *all* of these menus 