### PR TITLE
FIX: Don't refresh on topic search result click

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
@@ -48,7 +48,8 @@ export default class Types extends Component {
 
   @action
   routeToSearchResult(event) {
-    DiscourseURL.routeTo(event.target.href);
+    event.preventDefault();
+    DiscourseURL.routeTo(event.currentTarget.href);
     this.args.closeSearchMenu();
   }
 }

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.js
@@ -26,7 +26,9 @@ export default class Types extends Component {
     if (wantsNewWindow(event)) {
       return;
     }
-    this.routeToSearchResult(event);
+
+    event.preventDefault();
+    this.routeToSearchResult(event.currentTarget.href);
   }
 
   @action
@@ -38,7 +40,7 @@ export default class Types extends Component {
     } else if (event.key === "Enter") {
       event.preventDefault();
       event.stopPropagation();
-      this.routeToSearchResult(event);
+      this.routeToSearchResult(event.target.href);
       return false;
     }
 
@@ -47,9 +49,8 @@ export default class Types extends Component {
   }
 
   @action
-  routeToSearchResult(event) {
-    event.preventDefault();
-    DiscourseURL.routeTo(event.currentTarget.href);
+  routeToSearchResult(href) {
+    DiscourseURL.routeTo(href);
     this.args.closeSearchMenu();
   }
 }


### PR DESCRIPTION
Fixes an issue where when selecting a topic search result we were refreshing the page rather than letting `DiscourseURL` redirect us to the given topic. This was because we were leaning on a `a` tag and it's href to handle the redirect
    
https://github.com/discourse/discourse/blob/3aeff56fafd1bbd924a493c9f696ead0421db57a/app/assets/javascripts/discourse/app/components/search-menu/results/types.hbs#L15-L16

rather than `preventDefault`'ing the redirect