### PR TITLE
DEV: adds a chat-join-channel-button outlet

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
@@ -108,7 +108,7 @@ export default class ToggleChannelMembershipButton extends Component {
         @name="chat-join-channel-button"
         @outletArgs={{hash
           onJoinChannel=this.onJoinChannel
-          channel=this.args.channel
+          channel=@channel
           icon=this.options.joinIcon
           title=this.options.joinTitle
           label=this.label


### PR DESCRIPTION
This outlet allows to redefine the button displayed when asking the user to join a channel.

The following outletArgs are sent to the outlet:

```
onJoinChannel
channel
icon
title
label
disabled
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
