### PR TITLE
PERF: Only apply terser to production assets

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -141,16 +141,20 @@ module.exports = function (defaults) {
     parsePluginClientSettings(discourseRoot, vendorJs, app),
     funnel(`${discourseRoot}/public/javascripts`, { destDir: "javascripts" }),
     generateWorkboxTree(),
-    concat(adminTree, {
-      inputFiles: ["**/*.js"],
-      outputFile: `assets/admin.js`,
-    }),
-    concat(wizardTree, {
-      inputFiles: ["**/*.js"],
-      outputFile: `assets/wizard.js`,
-    }),
-    generateScriptsTree(app),
-    discoursePluginsTree,
+    applyTerser(
+      concat(adminTree, {
+        inputFiles: ["**/*.js"],
+        outputFile: `assets/admin.js`,
+      })
+    ),
+    applyTerser(
+      concat(wizardTree, {
+        inputFiles: ["**/*.js"],
+        outputFile: `assets/wizard.js`,
+      })
+    ),
+    applyTerser(generateScriptsTree(app)),
+    applyTerser(discoursePluginsTree),
     testStylesheetTree,
   ];
 
@@ -261,5 +265,5 @@ module.exports = function (defaults) {
     },
   });
 
-  return mergeTrees([appTree, applyTerser(mergeTrees(extraPublicTrees))]);
+  return mergeTrees([appTree, mergeTrees(extraPublicTrees)]);
 };


### PR DESCRIPTION
We funnel vendored javascript through ember-cli, but that's only used for the testem environment. Therefore, there's no need to minify it in production builds. In my tests, this reduces peak RSS of a production build from 3.53GB to 3.15GB.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
