### PR TITLE
FIX: Flaky table builder spec

### DIFF
--- a/spec/system/table_builder_spec.rb
+++ b/spec/system/table_builder_spec.rb
@@ -7,7 +7,7 @@ describe "Table Builder", type: :system do
   fab!(:topic) { Fabricate(:topic, user: user) }
   fab!(:post1) { create_post(user: user, topic: topic, raw: <<~RAW) }
         |Make   | Model   | Year|
-        |-------| ------- | ----|
+        |--- | --- | ---|
         |Toyota | Supra   | 1998|
         |Nissan | Skyline | 1999|
         |Honda  | S2000  | 2001|
@@ -97,7 +97,7 @@ describe "Table Builder", type: :system do
 
       updated_post = <<~RAW
       |Make | Model | Year|
-      |-------| ------- | ----|
+      |--- | --- | ---|
       |Toyota | Supra | 1998|
       |Nissan | Skyline | 1999|
       |Honda | S2000 | 2001|


### PR DESCRIPTION
This PR fixes a flaky spec in `table_builder_spec.rb`

Previously we initialized the post with a table divider like `|-------| ------- | ----|` but the default table divider is `|--- | --- | ---|` (only 3 hyphens between each pipe). So, when the table gets edited, it is overridden with the default table divider, causing flakiness when the spec compares the table for changes.

In this PR we opt for using the default table dividers for all instances of markdown tables in the spec.