### PR TITLE
DEV: Improve Guardian devex

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -84,7 +84,7 @@ class Guardian
   # categories or PMs but can read public topics.
   class BasicUser
     def blank?
-      false
+      true
     end
     def admin?
       false
@@ -141,6 +141,8 @@ class Guardian
   def initialize(user = nil, request = nil)
     @user = user.presence || AnonymousUser.new
     @request = request
+    @fake = @user.is_a?(AnonymousUser) || @user.is_a?(BasicUser)
+    @authenticated = !@user.is_a?(AnonymousUser)
   end
 
   def self.anon_user(request: nil)
@@ -152,7 +154,7 @@ class Guardian
   end
 
   def user
-    @user.presence
+    @fake ? nil : @user
   end
   alias current_user user
 
@@ -161,7 +163,7 @@ class Guardian
   end
 
   def authenticated?
-    @user.present?
+    @authenticated
   end
 
   def is_admin?


### PR DESCRIPTION
It's quite confusing for blank? to be overridden
on AnonymousUser and BasicUser to represent
whether the fake user is authenticated or not.

While we can't remove `blank? -> false` because
it is used in tons of places in other guardians,
we can achieve authenticated? check and also
return nil on the user method more clearly with
some instance variables on init.
