### PR TITLE
DEV: Fix chat notifier deprecation warnings from job arguments

### DIFF
--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -358,7 +358,7 @@ module Chat
           chat_message_id: @chat_message.id,
           to_notify_ids_map: to_notify.as_json,
           already_notified_user_ids: already_notified_user_ids,
-          timestamp: @timestamp,
+          timestamp: @timestamp.to_s,
         },
       )
     end
@@ -366,7 +366,7 @@ module Chat
     def notify_watching_users(except: [])
       Jobs.enqueue(
         Jobs::Chat::NotifyWatching,
-        { chat_message_id: @chat_message.id, except_user_ids: except, timestamp: @timestamp },
+        { chat_message_id: @chat_message.id, except_user_ids: except, timestamp: @timestamp.to_s },
       )
     end
   end

--- a/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
@@ -58,7 +58,7 @@ describe Jobs::Chat::NotifyMentioned do
       .track_publish("/chat/notification-alert/#{user.id}") do
         job.execute(
           chat_message_id: message.id,
-          timestamp: message.created_at,
+          timestamp: message.created_at.to_s,
           to_notify_ids_map: to_notify_ids_map,
           already_notified_user_ids: already_notified_user_ids,
         )
@@ -69,7 +69,7 @@ describe Jobs::Chat::NotifyMentioned do
   def track_core_notification(user: user_2, message:, to_notify_ids_map:)
     job.execute(
       chat_message_id: message.id,
-      timestamp: message.created_at,
+      timestamp: message.created_at.to_s,
       to_notify_ids_map: to_notify_ids_map,
     )
 
@@ -186,7 +186,7 @@ describe Jobs::Chat::NotifyMentioned do
 
       job.execute(
         chat_message_id: message.id,
-        timestamp: message.created_at,
+        timestamp: message.created_at.to_s,
         to_notify_ids_map: to_notify_ids_map,
       )
     end
@@ -215,7 +215,7 @@ describe Jobs::Chat::NotifyMentioned do
 
       job.execute(
         chat_message_id: message.id,
-        timestamp: message.created_at,
+        timestamp: message.created_at.to_s,
         to_notify_ids_map: to_notify_ids_map,
       )
     end
@@ -259,7 +259,7 @@ describe Jobs::Chat::NotifyMentioned do
 
       job.execute(
         chat_message_id: message.id,
-        timestamp: message.created_at,
+        timestamp: message.created_at.to_s,
         to_notify_ids_map: to_notify_ids_map,
       )
     end


### PR DESCRIPTION
### What is this change?

We're seeing the following deprecation warnings in production:

```
Deprecation notice: Jobs::Chat::NotifyMentioned was enqueued with argument values which do not cleanly serialize to/from JSON ...
Deprecation notice: Jobs::Chat::NotifyWatching was enqueued with argument values which do not cleanly serialize to/from JSON ...
```

This is because we're passing a raw Ruby timestamp, which gets stringified implicitly when written to Redis. As per #15842, this conversion needs to be done explicitly.