### PR TITLE
FIX: correctly update replies_count on chat_threads

### DIFF
--- a/plugins/chat/app/models/chat/thread.rb
+++ b/plugins/chat/app/models/chat/thread.rb
@@ -127,16 +127,16 @@ module Chat
       # future we may want to update this more frequently.
       updated_thread_ids = DB.query_single <<~SQL
         WITH updated_threads AS (
-            UPDATE chat_threads ct
-            SET replies_count = COALESCE(subquery.new_count, 0)
-            FROM (
-                SELECT cm.thread_id, COUNT(cm.*) - 1 AS new_count
-                FROM chat_threads
-                LEFT JOIN chat_messages cm ON cm.thread_id = chat_threads.id AND cm.deleted_at IS NULL
-                GROUP BY cm.thread_id
-            ) AS subquery
-            WHERE ct.id = subquery.thread_id AND ct.replies_count IS DISTINCT FROM COALESCE(subquery.new_count, 0)
-            RETURNING ct.id AS thread_id
+          UPDATE chat_threads ct
+          SET replies_count = COALESCE(subquery.new_count, 0)
+          FROM (
+            SELECT cm.thread_id, COUNT(cm.*) - 1 AS new_count
+            FROM chat_threads
+            LEFT JOIN chat_messages cm ON cm.thread_id = chat_threads.id AND cm.deleted_at IS NULL
+            GROUP BY cm.thread_id
+          ) AS subquery
+          WHERE ct.id = subquery.thread_id AND ct.replies_count IS DISTINCT FROM COALESCE(subquery.new_count, 0)
+          RETURNING ct.id AS thread_id
         )
         SELECT thread_id
         FROM updated_threads;

--- a/plugins/chat/app/models/chat/thread.rb
+++ b/plugins/chat/app/models/chat/thread.rb
@@ -126,20 +126,16 @@ module Chat
       # It is updated eventually via Jobs::Chat::PeriodicalUpdates. In
       # future we may want to update this more frequently.
       updated_thread_ids = DB.query_single <<~SQL
-        WITH updated_threads AS (
-          UPDATE chat_threads ct
-          SET replies_count = COALESCE(subquery.new_count, 0)
-          FROM (
-            SELECT cm.thread_id, COUNT(cm.*) - 1 AS new_count
-            FROM chat_threads
-            LEFT JOIN chat_messages cm ON cm.thread_id = chat_threads.id AND cm.deleted_at IS NULL
-            GROUP BY cm.thread_id
-          ) AS subquery
-          WHERE ct.id = subquery.thread_id AND ct.replies_count IS DISTINCT FROM COALESCE(subquery.new_count, 0)
-          RETURNING ct.id AS thread_id
-        )
-        SELECT thread_id
-        FROM updated_threads;
+        UPDATE chat_threads ct
+        SET replies_count = COALESCE(subquery.new_count, 0)
+        FROM (
+          SELECT cm.thread_id, COUNT(cm.*) - 1 AS new_count
+          FROM chat_threads
+          LEFT JOIN chat_messages cm ON cm.thread_id = chat_threads.id AND cm.deleted_at IS NULL
+          GROUP BY cm.thread_id
+        ) AS subquery
+        WHERE ct.id = subquery.thread_id AND ct.replies_count IS DISTINCT FROM COALESCE(subquery.new_count, 0)
+        RETURNING ct.id AS thread_id
       SQL
       return if updated_thread_ids.empty?
       self.clear_caches!(updated_thread_ids)

--- a/plugins/chat/app/models/chat/thread.rb
+++ b/plugins/chat/app/models/chat/thread.rb
@@ -126,17 +126,20 @@ module Chat
       # It is updated eventually via Jobs::Chat::PeriodicalUpdates. In
       # future we may want to update this more frequently.
       updated_thread_ids = DB.query_single <<~SQL
-        UPDATE chat_threads threads
-        SET replies_count = subquery.replies_count
-        FROM (
-          SELECT COUNT(*) - 1 AS replies_count, thread_id
-          FROM chat_messages
-          WHERE chat_messages.deleted_at IS NULL AND thread_id IS NOT NULL
-          GROUP BY thread_id
-        ) subquery
-        WHERE threads.id = subquery.thread_id
-        AND subquery.replies_count != threads.replies_count
-        RETURNING threads.id AS thread_id;
+        WITH updated_threads AS (
+            UPDATE chat_threads ct
+            SET replies_count = COALESCE(subquery.new_count, 0)
+            FROM (
+                SELECT cm.thread_id, COUNT(cm.*) - 1 AS new_count
+                FROM chat_threads
+                LEFT JOIN chat_messages cm ON cm.thread_id = chat_threads.id AND cm.deleted_at IS NULL
+                GROUP BY cm.thread_id
+            ) AS subquery
+            WHERE ct.id = subquery.thread_id AND ct.replies_count IS DISTINCT FROM COALESCE(subquery.new_count, 0)
+            RETURNING ct.id AS thread_id
+        )
+        SELECT thread_id
+        FROM updated_threads;
       SQL
       return if updated_thread_ids.empty?
       self.clear_caches!(updated_thread_ids)


### PR DESCRIPTION
The previous query would look at the existing messages, count them, and update the associated thread.

But, if for some reason messages were **ALL** deleted without updating the `replies_count`, then the query wouldn't find any message, and wouldn't update any thread's `replies_count`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
