### PR TITLE
UX: fix button height/alignment of user-notifications-dropdown (mobile)

### DIFF
--- a/app/assets/stylesheets/mobile/user.scss
+++ b/app/assets/stylesheets/mobile/user.scss
@@ -222,6 +222,7 @@
           }
           .select-kit.dropdown-select-box.user-notifications-dropdown {
             width: 100%;
+            align-self: flex-start;
             li {
               flex: 1 1 100%;
               margin-left: 0;


### PR DESCRIPTION
Due to a [recent minor change in the select-kit-header,](https://github.com/discourse/discourse/pull/24649) there was a tiny regression with this button height. Bit of a convoluted crossroads of using select-kit + btn classes + flex.

<img width="379" alt="image" src="https://github.com/discourse/discourse/assets/101828855/8cce50cd-6ed7-46b5-a2b1-59df814cdb1c">

