### PR TITLE
FIX: Ensure slugless topic URLs are correctly redirected

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -355,12 +355,8 @@ const TopicRoute = DiscourseRoute.extend({
 
   model(params, transition) {
     if (params.slug.match(ID_CONSTRAINT)) {
-      transition.abort();
-
-      DiscourseURL.routeTo(`/t/topic/${params.slug}/${params.id}`, {
-        replaceURL: true,
-      });
-
+      // URL with no slug - redirect to a URL with placeholder slug
+      this.router.transitionTo(`/t/-/${params.slug}/${params.id}`);
       return;
     }
 


### PR DESCRIPTION
Using `DiscourseURL.routeTo` with `replaceURL: true` wouldn't cause a true Ember redirect. That meant that the transition source would be be replaced in the browser's history stack, and the 'back' button wouldn't work as expected. Instead, we can use the router service to perform a proper redirect.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
