### PR TITLE
FIX: Account activation under ember-5 build

### DIFF
--- a/app/assets/javascripts/discourse/scripts/activate-account.js
+++ b/app/assets/javascripts/discourse/scripts/activate-account.js
@@ -1,18 +1,27 @@
-/* eslint-disable ember/no-global-jquery */
 (function () {
-  const $activateButton = $("#activate-account-button");
-  $activateButton.on("click", function () {
-    $activateButton.prop("disabled", true);
+  const activateButton = document.querySelector("#activate-account-button");
+  activateButton.addEventListener("click", async function () {
+    activateButton.setAttribute("disabled", true);
     const hpPath = document.getElementById("data-activate-account").dataset
       .path;
-    $.ajax(hpPath)
-      .then(function (hp) {
-        $("#password_confirmation").val(hp.value);
-        $("#challenge").val(hp.challenge.split("").reverse().join(""));
-        $("#activate-account-form").submit();
-      })
-      .fail(function () {
-        $activateButton.prop("disabled", false);
+
+    try {
+      const response = await fetch(hpPath, {
+        headers: {
+          Accept: "application/json",
+        },
       });
+      const hp = await response.json();
+
+      document.querySelector("#password_confirmation").value = hp.value;
+      document.querySelector("#challenge").value = hp.challenge
+        .split("")
+        .reverse()
+        .join("");
+      document.querySelector("#activate-account-form").submit();
+    } catch (e) {
+      activateButton.removeAttribute("disabled");
+      throw e;
+    }
   });
 })();

--- a/app/views/users/activate_account.html.erb
+++ b/app/views/users/activate_account.html.erb
@@ -12,7 +12,6 @@
 </div>
 
 <%- content_for(:no_ember_head) do %>
-  <%= preload_script "vendor" %>
   <%= render_google_universal_analytics_code %>
   <%= tag.meta id: 'data-activate-account', data: { path: path('/session/hp') } %>
 <%- end %>


### PR DESCRIPTION
We were previously relying on Ember's 'vendor' bundle to make the jquery global available on the activate_account route. That no longer happens under our Ember 5 build.

This commit updates our activate-account script to remove the need for jquery, so that it works under both Ember 3 and Ember 5 builds.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
