### PR TITLE
FIX: escape category description text

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -103,7 +103,7 @@ function buildTopicCount(count) {
 }
 
 export function defaultCategoryLinkRenderer(category, opts) {
-  let descriptionText = get(category, "description_text");
+  let descriptionText = escapeExpression(get(category, "description_text"));
   let restricted = get(category, "read_restricted");
   let url = opts.url
     ? opts.url


### PR DESCRIPTION
This is a follow-up to 797da58. 

The description for the "uncategorized" category (set by `category.uncategorized_description`) can break the layout if it contains HTML. (Normal category descriptions already have HTML stripped at this point.)

Before:
![Screenshot 2023-12-05 at 1 11 39 PM](https://github.com/discourse/discourse/assets/1681963/6b1c25f1-107a-4e0a-b722-744bdfbb3eca)

After:
![Screenshot 2023-12-05 at 1 11 30 PM](https://github.com/discourse/discourse/assets/1681963/0707acf6-ba8c-4abf-a04d-f72c3244ce0b)
