### PR TITLE
A11Y: allow tab titles to use default translation

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
@@ -36,12 +36,8 @@ export default class UserMenuTab {
     } else {
       key = `user_menu.tabs.${id}`;
     }
-    // the lookup method returns undefined if the key doesn't exist.
-    // this ensures that don't use the "missing translation" string as the
-    // title for tabs that don't define title in the yml files.
-    if (I18n.lookup(key)) {
-      return I18n.t(key, { count });
-    }
+
+    return I18n.t(key, { count });
   }
 
   /**


### PR DESCRIPTION
A customer reported that a blind user has a hard time using the user notification tabs in the site header, because they were just being read as "tab 1 of 8" by NVDA (they don't hear "all notifications", "likes", etc)

This was because their site uses a locale which does not have translations for the tab titles defined, so `I18n.lookup(key)` returns undefined and there's no fallback. 

Removing this allows missing translations to fallback to English. In the case of tabs added with missing titles (like a tab added for a plugin for example), I think it's probably better to show the missing translation string anyway... this will hopefully make it more apparent that a string needs to be added. 