### PR TITLE
FIX: shortcut typo

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3437,7 +3437,7 @@ en:
     post:
       confirm_delete: "Are you sure you want to delete this post?"
       quote_reply: "Quote"
-      quote_reply_shortcut: "Quote (or press e)"
+      quote_reply_shortcut: "Quote (or press q)"
       quote_edit: "Edit"
       quote_edit_shortcut: "Edit (or press e)"
       quote_share: "Share"


### PR DESCRIPTION
Fixes a typo from bdecb23