### PR TITLE
UX: improve poll vote count text wrap

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -65,6 +65,7 @@ div.poll {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
+      width: 100%;
       gap: 0.25em 0;
 
       @include breakpoint("mobile-extra-large", min-width) {
@@ -101,15 +102,24 @@ div.poll {
           display: flex;
           flex-direction: column;
           align-items: center;
+          .info-label,
+          .info-number {
+            margin: 0;
+          }
           + .poll-info_counts-count {
-            margin-top: 0.5em;
-            display: block;
-            .info-number {
-              margin-right: 0.33em;
-            }
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            justify-content: center;
+            min-width: 0;
+            gap: 0 0.33em;
+            margin: 0.5em;
             .info-number,
             .info-label {
               font-size: var(--font-up-1);
+              min-width: 0;
+              white-space: normal;
+              line-height: var(--line-height-medium);
             }
           }
         }


### PR DESCRIPTION
This improves text wrapping for more verbose translations 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/469dd978-247b-4f0d-9b6d-d70709f5839d)

After: 
![Screenshot 2023-12-05 at 6 06 25 PM](https://github.com/discourse/discourse/assets/1681963/e6de9f87-97e1-46e8-aed8-45fd4e9c1970)


Shorter text will still display in a single line: 
![Screenshot 2023-12-05 at 6 04 28 PM](https://github.com/discourse/discourse/assets/1681963/a106d757-9777-446c-b83a-e0670637e79c)