### PR TITLE
FIX: Add checkbox-label to notification bulk actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-actions/notification-level.hbs
+++ b/app/assets/javascripts/discourse/app/components/bulk-actions/notification-level.hbs
@@ -1,7 +1,7 @@
 <div class="bulk-notification-list">
   {{#each this.notificationLevels as |level|}}
     <div class="controls">
-      <label class="radio notification-level-radio">
+      <label class="radio notification-level-radio checkbox-label">
         <RadioButton
           @value={{level.id}}
           @name="notification_level"


### PR DESCRIPTION
Followup to c80b5b718c2e3dee70b7ad70c32b22b078080efe

Before

![image](https://github.com/discourse/discourse/assets/920448/407a45f6-7ea6-4d6b-af5e-b22165e2c78d)

After

![image](https://github.com/discourse/discourse/assets/920448/04d94c2c-0769-4d53-b0c6-2d977d55cfed)
