### PR TITLE
DEV: Remove unnecessary method_missing from GuardianUser

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -35,10 +35,6 @@ class GuardianUser
       true
     end
   end
-
-  def method_missing(method, *args, &block)
-    @user_alike.public_send(method, *args, &block)
-  end
 end
 
 # The guardian is responsible for confirming access to various site resources and operations


### PR DESCRIPTION
Followup to 77b6a038bae010c9e9e630a137f9ccd570f60784, this
was a mistake and should have been removed before merge.
