### PR TITLE
DEV: Convert min_trust_to_create_topic to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1958,6 +1958,7 @@ en:
     edit_all_post_groups: "Allow users in this group to edit other users' posts"
 
     min_trust_to_create_topic: "The minimum trust level required to create a new topic."
+    create_topic_allowed_groups: "Groups that are allowed to create new topics."
     allow_flagging_staff: "If enabled, users can flag posts from staff accounts."
 
     min_trust_to_edit_wiki_post: "The minimum trust level required to edit post marked as wiki."
@@ -2555,6 +2556,7 @@ en:
       email_in_allowed_groups: "email_in_min_trust"
       edit_wiki_post_allowed_groups: "minmin_trust_to_edit_wiki_post"
       uploaded_avatars_allowed_groups: "allow_uploaded_avatars"
+      create_topic_allowed_groups: "min_trust_to_create_topic"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1679,6 +1679,13 @@ trust:
   min_trust_to_create_topic:
     default: 0
     enum: "TrustLevelSetting"
+    hidden: true
+  create_topic_allowed_groups:
+    default: 10
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   min_trust_to_edit_wiki_post:
     default: 1
     enum: "TrustLevelSetting"

--- a/db/migrate/20231206041353_fill_create_topic_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231206041353_fill_create_topic_allowed_groups_based_on_deprecated_settings.rb
@@ -7,12 +7,9 @@ class FillCreateTopicAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migr
         "SELECT value FROM site_settings WHERE name = 'min_trust_to_create_topic' LIMIT 1",
       ).first
 
-    # Default for old setting is TL0, we only need to do anything if it's been changed in the DB.
     if old_setting_trust_level.present?
-      # Matches Group::AUTO_GROUPS to the trust levels.
       create_topic_allowed_groups = "1#{old_setting_trust_level}"
 
-      # Data_type 20 is group_list
       DB.exec(
         "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
         VALUES('create_topic_allowed_groups', :setting, '20', NOW(), NOW())",

--- a/db/migrate/20231206041353_fill_create_topic_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231206041353_fill_create_topic_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FillCreateTopicAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    old_setting_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_to_create_topic' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL0, we only need to do anything if it's been changed in the DB.
+    if old_setting_trust_level.present?
+      # Matches Group::AUTO_GROUPS to the trust levels.
+      create_topic_allowed_groups = "1#{old_setting_trust_level}"
+
+      # Data_type 20 is group_list
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('create_topic_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: create_topic_allowed_groups,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -48,7 +48,7 @@ module TopicGuardian
   def can_create_topic?(parent)
     is_staff? ||
       (
-        user && user.trust_level >= SiteSetting.min_trust_to_create_topic.to_i &&
+        user && user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map) &&
           can_create_post?(parent) && Category.topic_create_allowed(self).limit(1).count == 1
       )
   end

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -52,7 +52,7 @@ module TopicGuardian
           (
             user.trust_level >= SiteSetting.min_trust_to_create_topic.to_i ||
               user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map)
-          ) && can_create_post?(parent) && Category.topic_create_allowed(self).limit(1).count == 1
+          ) && can_create_post?(parent) && Category.topic_create_allowed(self).any?
       )
   end
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -48,8 +48,11 @@ module TopicGuardian
   def can_create_topic?(parent)
     is_staff? ||
       (
-        user && user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map) &&
-          can_create_post?(parent) && Category.topic_create_allowed(self).limit(1).count == 1
+        user &&
+          (
+            user.trust_level >= SiteSetting.min_trust_to_create_topic.to_i ||
+              user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map)
+          ) && can_create_post?(parent) && Category.topic_create_allowed(self).limit(1).count == 1
       )
   end
 

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -21,6 +21,7 @@ module SiteSettings::DeprecatedSettings
     ["email_in_min_trust", "email_in_allowed_groups", false, "3.3"],
     ["min_trust_to_edit_wiki_post", "edit_wiki_post_allowed_groups", false, "3.3"],
     ["allow_uploaded_avatars", "uploaded_avatars_allowed_groups", false, "3.3"],
+    ["min_trust_to_create_topic", "create_topic_allowed_groups", false, "3.3"],
   ]
 
   def setup_deprecated_methods

--- a/spec/integration/category_tag_spec.rb
+++ b/spec/integration/category_tag_spec.rb
@@ -796,6 +796,8 @@ RSpec.describe "tag topic counts per category" do
     fab!(:topic) { Fabricate(:topic, category: category, tags: [tag1, tag2]) }
     fab!(:post) { Fabricate(:post, user: topic.user, topic: topic) }
 
+    before { Group.refresh_automatic_groups! }
+
     it "has correct counts after tag is removed from a topic" do
       post
       topic2 = Fabricate(:topic, category: category, tags: [tag2])
@@ -837,6 +839,8 @@ RSpec.describe "tag topic counts per category" do
   context "with topic with one tag" do
     fab!(:topic) { Fabricate(:topic, tags: [tag1], category: category) }
     fab!(:post) { Fabricate(:post, user: topic.user, topic: topic) }
+
+    before { Group.refresh_automatic_groups! }
 
     it "counts after topic becomes uncategorized" do
       PostRevisor.new(post).revise!(

--- a/spec/integration/same_ip_spammers_spec.rb
+++ b/spec/integration/same_ip_spammers_spec.rb
@@ -3,9 +3,9 @@
 
 RSpec.describe "spammers on same IP" do
   let(:ip_address) { "182.189.119.174" }
-  let!(:spammer1) { Fabricate(:user, ip_address: ip_address) }
-  let!(:spammer2) { Fabricate(:user, ip_address: ip_address) }
-  let(:spammer3) { Fabricate(:user, ip_address: ip_address) }
+  let!(:spammer1) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
+  let!(:spammer2) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
+  let(:spammer3) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
 
   context "when flag_sockpuppets is disabled" do
     let!(:first_post) { create_post(user: spammer1) }
@@ -47,7 +47,13 @@ RSpec.describe "spammers on same IP" do
 
     context "when first user is not new" do
       let!(:old_user) do
-        Fabricate(:user, ip_address: ip_address, created_at: 2.days.ago, trust_level: TrustLevel[1])
+        Fabricate(
+          :user,
+          ip_address: ip_address,
+          created_at: 2.days.ago,
+          trust_level: TrustLevel[1],
+          refresh_auto_groups: true,
+        )
       end
 
       context "when first user starts a topic" do

--- a/spec/integration/secure_uploads_spec.rb
+++ b/spec/integration/secure_uploads_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Secure uploads" do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:group)
   fab!(:secure_category) { Fabricate(:private_category, group: group) }
 

--- a/spec/integration/spam_rules_spec.rb
+++ b/spec/integration/spam_rules_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "spam rules for users" do
     end
 
     context "when spammer is a new user" do
-      fab!(:spammer) { Fabricate(:user, trust_level: TrustLevel[0]) }
+      fab!(:spammer) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
 
       context "when spammer post is not flagged enough times" do
         let!(:spam_post) { create_post(user: spammer) }
@@ -98,7 +98,7 @@ RSpec.describe "spam rules for users" do
     end
 
     context "when spammer has trust level basic" do
-      let(:spammer) { Fabricate(:user, trust_level: TrustLevel[1]) }
+      let(:spammer) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
 
       context "when one spam post is flagged enough times by enough users" do
         let!(:spam_post) { Fabricate(:post, user: spammer) }

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -263,8 +263,9 @@ RSpec.describe WatchedWord do
     it "is compatible with flag_sockpuppets" do
       SiteSetting.flag_sockpuppets = true
       ip_address = "182.189.119.174"
-      user1 = Fabricate(:user, ip_address: ip_address, created_at: 2.days.ago)
-      user2 = Fabricate(:user, ip_address: ip_address)
+      user1 =
+        Fabricate(:user, ip_address: ip_address, created_at: 2.days.ago, refresh_auto_groups: true)
+      user2 = Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true)
       first = create_post(user: user1, created_at: 2.days.ago)
       sockpuppet_post =
         create_post(

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -585,7 +585,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
 
   describe "with a lightboxed image" do
     fab!(:upload) { Fabricate(:large_image_upload) }
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
     before { Jobs.run_immediately! }
 

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Email::Receiver do
 
     describe "creating whisper post in PMs for staged users" do
       let(:email_address) { "linux-admin@b-s-c.co.jp" }
-      fab!(:user1) { Fabricate(:user) }
+      fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
       let(:user2) { Fabricate(:staged, email: email_address) }
       let(:topic) do
         Fabricate(
@@ -282,7 +282,7 @@ RSpec.describe Email::Receiver do
   describe "reply" do
     let(:reply_key) { "4f97315cc828096c9cb34c6f1a0d6fe8" }
     fab!(:category)
-    fab!(:user) { Fabricate(:user, email: "discourse@bar.com") }
+    fab!(:user) { Fabricate(:user, email: "discourse@bar.com", refresh_auto_groups: true) }
     fab!(:topic) { create_topic(category: category, user: user) }
     fab!(:post) { create_post(topic: topic) }
 
@@ -1952,7 +1952,7 @@ RSpec.describe Email::Receiver do
     context "when email is a reply" do
       let(:reply_key) { "4f97315cc828096c9cb34c6f1a0d6fe8" }
       fab!(:category)
-      fab!(:user) { Fabricate(:user, email: "discourse@bar.com") }
+      fab!(:user) { Fabricate(:user, email: "discourse@bar.com", refresh_auto_groups: true) }
       fab!(:user2) { Fabricate(:user, email: "someone_else@bar.com") }
       fab!(:topic) { create_topic(category: category, user: user) }
       fab!(:post) { create_post(topic: topic, user: user) }

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1226,9 +1226,13 @@ RSpec.describe Guardian do
       end
 
       it "is false if user has not met minimum trust level" do
+        SiteSetting.min_trust_to_create_topic = 1
         SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 0)).can_create?(Topic, plain_category),
+          Guardian.new(Fabricate(:user, trust_level: 0, refresh_auto_groups: true)).can_create?(
+            Topic,
+            plain_category,
+          ),
         ).to be_falsey
       end
 
@@ -2198,6 +2202,7 @@ RSpec.describe Guardian do
     end
 
     it "returns false for user with insufficient trust level" do
+      SiteSetting.min_trust_to_create_topic = 3
       SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_3]
       expect(Guardian.new(user).can_create_topic?(topic)).to eq(false)
     end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1226,25 +1226,36 @@ RSpec.describe Guardian do
       end
 
       it "is false if user has not met minimum trust level" do
-        SiteSetting.min_trust_to_create_topic = 1
+        SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
         expect(
           Guardian.new(Fabricate(:user, trust_level: 0)).can_create?(Topic, plain_category),
         ).to be_falsey
       end
 
       it "is true if user has met or exceeded the minimum trust level" do
-        SiteSetting.min_trust_to_create_topic = 1
+        SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 1)).can_create?(Topic, plain_category),
+          Guardian.new(Fabricate(:user, trust_level: 1, refresh_auto_groups: true)).can_create?(
+            Topic,
+            plain_category,
+          ),
         ).to be_truthy
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 2)).can_create?(Topic, plain_category),
+          Guardian.new(Fabricate(:user, trust_level: 2, refresh_auto_groups: true)).can_create?(
+            Topic,
+            plain_category,
+          ),
         ).to be_truthy
         expect(
-          Guardian.new(Fabricate(:admin, trust_level: 0)).can_create?(Topic, plain_category),
+          Guardian.new(Fabricate(:admin, trust_level: 0, refresh_auto_groups: true)).can_create?(
+            Topic,
+            plain_category,
+          ),
         ).to be_truthy
         expect(
-          Guardian.new(Fabricate(:moderator, trust_level: 0)).can_create?(Topic, plain_category),
+          Guardian.new(
+            Fabricate(:moderator, trust_level: 0, refresh_auto_groups: true),
+          ).can_create?(Topic, plain_category),
         ).to be_truthy
       end
     end
@@ -2187,12 +2198,12 @@ RSpec.describe Guardian do
     end
 
     it "returns false for user with insufficient trust level" do
-      SiteSetting.min_trust_to_create_topic = 3
+      SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_3]
       expect(Guardian.new(user).can_create_topic?(topic)).to eq(false)
     end
 
     it "returns true for user with sufficient trust level" do
-      SiteSetting.min_trust_to_create_topic = 3
+      SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_3]
       expect(Guardian.new(trust_level_4).can_create_topic?(topic)).to eq(true)
     end
 

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -388,6 +388,7 @@ RSpec.describe NewPostManager do
 
       NewPostManager.add_handler(&@counter_handler)
       NewPostManager.add_handler(&@queue_handler)
+      Group.refresh_automatic_groups!
     end
 
     after { NewPostManager.clear_handlers! }
@@ -691,7 +692,7 @@ RSpec.describe NewPostManager do
   end
 
   describe "via email with a spam failure" do
-    let(:user) { Fabricate(:user) }
+    let(:user) { Fabricate(:user, refresh_auto_groups: true) }
     let(:admin) { Fabricate(:admin) }
 
     it "silences users if its their first post" do
@@ -728,7 +729,7 @@ RSpec.describe NewPostManager do
   end
 
   describe "via email with an authentication results failure" do
-    let(:user) { Fabricate(:user) }
+    let(:user) { Fabricate(:user, refresh_auto_groups: true) }
     let(:admin) { Fabricate(:admin) }
 
     it "doesn't silence users" do

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -4,10 +4,10 @@ require "post_creator"
 require "topic_subtype"
 
 RSpec.describe PostCreator do
-  fab!(:user)
-  fab!(:admin)
-  fab!(:coding_horror)
-  fab!(:evil_trout)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
+  fab!(:evil_trout) { Fabricate(:evil_trout, refresh_auto_groups: true) }
   let(:topic) { Fabricate(:topic, user: user) }
 
   describe "new topic" do
@@ -1578,7 +1578,7 @@ RSpec.describe PostCreator do
   end
 
   describe "staged users" do
-    fab!(:staged)
+    fab!(:staged) { Fabricate(:staged, refresh_auto_groups: true) }
 
     it "automatically watches all messages it participates in" do
       post =
@@ -2065,9 +2065,9 @@ RSpec.describe PostCreator do
   end
 
   describe "#create_post_notice" do
-    fab!(:user)
-    fab!(:staged)
-    fab!(:anonymous)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:staged) { Fabricate(:staged, refresh_auto_groups: true) }
+    fab!(:anonymous) { Fabricate(:anonymous, refresh_auto_groups: true) }
 
     it "generates post notices for new users" do
       post =

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe PostDestroyer do
   end
 
   describe "deleting the second post in a topic" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     let!(:post) { create_post(user: user) }
     let(:topic) { post.topic }
     fab!(:second_user) { coding_horror }

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe TopicCreator do
     }
   end
 
+  before { Group.refresh_automatic_groups! }
+
   describe "#create" do
     context "with topic success cases" do
       before do
@@ -49,7 +51,7 @@ RSpec.describe TopicCreator do
       end
 
       context "with regular user" do
-        before { SiteSetting.min_trust_to_create_topic = TrustLevel[0] }
+        before { SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_0] }
 
         it "should be possible for a regular user to create a topic" do
           expect(TopicCreator.create(user, Guardian.new(user), valid_attrs)).to be_valid
@@ -215,7 +217,7 @@ RSpec.describe TopicCreator do
 
         it "lets new user create a topic if they don't have sufficient trust level to tag topics" do
           SiteSetting.min_trust_level_to_tag_topics = 1
-          new_user = Fabricate(:newuser)
+          new_user = Fabricate(:newuser, refresh_auto_groups: true)
           topic =
             TopicCreator.create(
               new_user,
@@ -502,8 +504,8 @@ RSpec.describe TopicCreator do
           expect(TopicCreator.create(user, Guardian.new(user), pm_valid_attrs)).to be_valid
         end
 
-        it "min_trust_to_create_topic setting should not be checked when sending private message" do
-          SiteSetting.min_trust_to_create_topic = TrustLevel[4]
+        it "create_topic_allowed_groups setting should not be checked when sending private message" do
+          SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
           expect(TopicCreator.create(user, Guardian.new(user), pm_valid_attrs)).to be_valid
         end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe TopicQuery do
   #   work.
   #
   #   We should use be more explicit in communicating how the clock moves
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
-  fab!(:creator) { Fabricate(:user) }
+  fab!(:creator) { Fabricate(:user, refresh_auto_groups: true) }
   let(:topic_query) { TopicQuery.new(user) }
 
   fab!(:tl4_user) { Fabricate(:trust_level_4) }

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -3,7 +3,7 @@
 require "topic_view"
 
 RSpec.describe TopicView do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:moderator)
   fab!(:admin)
   fab!(:topic)

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TopicsBulkAction do
   fab!(:topic)
 
   describe "#dismiss_topics" do
-    fab!(:user) { Fabricate(:user, created_at: 1.days.ago) }
+    fab!(:user) { Fabricate(:user, created_at: 1.days.ago, refresh_auto_groups: true) }
     fab!(:category)
     fab!(:topic2) { Fabricate(:topic, category: category, created_at: 60.minutes.ago) }
     fab!(:topic3) { Fabricate(:topic, category: category, created_at: 120.minutes.ago) }
@@ -156,7 +156,10 @@ RSpec.describe TopicsBulkAction do
 
     context "when the user can edit the topic" do
       context "with 'create_revision_on_bulk_topic_moves' setting enabled" do
-        before { SiteSetting.create_revision_on_bulk_topic_moves = true }
+        before do
+          SiteSetting.create_revision_on_bulk_topic_moves = true
+          Group.refresh_automatic_groups!
+        end
 
         it "changes the category, creates a post revision and returns the topic_id" do
           old_category_id = topic.category_id
@@ -195,7 +198,10 @@ RSpec.describe TopicsBulkAction do
       end
 
       context "with 'create_revision_on_bulk_topic_moves' setting disabled" do
-        before { SiteSetting.create_revision_on_bulk_topic_moves = false }
+        before do
+          SiteSetting.create_revision_on_bulk_topic_moves = false
+          Group.refresh_automatic_groups!
+        end
 
         it "changes the category, doesn't create a post revision and returns the topic_id" do
           tba =
@@ -415,6 +421,7 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
+      Group.refresh_automatic_groups!
     end
 
     it "can change the tags, and can create new tags" do
@@ -483,6 +490,7 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
+      Group.refresh_automatic_groups!
     end
 
     it "can append new or existing tags" do
@@ -553,6 +561,7 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
+      Group.refresh_automatic_groups!
     end
 
     it "can remove all tags" do

--- a/spec/models/category_featured_topic_spec.rb
+++ b/spec/models/category_featured_topic_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CategoryFeaturedTopic do
   it { is_expected.to belong_to :topic }
 
   describe ".feature_topics_for" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:category)
     let!(:category_post) do
       PostCreator.create(

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -636,6 +636,7 @@ RSpec.describe Category do
 
     context "with regular topics" do
       before do
+        Group.refresh_automatic_groups!
         create_post(user: @category.user, category: @category.id)
         Category.update_stats
         @category.reload
@@ -674,6 +675,7 @@ RSpec.describe Category do
 
     context "with revised post" do
       before do
+        Group.refresh_automatic_groups!
         post = create_post(user: @category.user, category: @category.id)
 
         SiteSetting.editing_grace_period = 1.minute
@@ -694,7 +696,7 @@ RSpec.describe Category do
     context "for uncategorized category" do
       before do
         @uncategorized = Category.find(SiteSetting.uncategorized_category_id)
-        create_post(user: Fabricate(:user), category: @uncategorized.id)
+        create_post(user: Fabricate(:user, refresh_auto_groups: true), category: @uncategorized.id)
         Category.update_stats
         @uncategorized.reload
       end
@@ -712,6 +714,7 @@ RSpec.describe Category do
     end
 
     context "when there are no topics left" do
+      before { Group.refresh_automatic_groups! }
       let!(:topic) { create_post(user: @category.user, category: @category.id).reload.topic }
 
       it "can update the topic count to zero" do

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe PostAction do
       expect(post.hidden).to eq(true)
     end
     it "hide tl0 posts that are flagged as spam by a tl3 user" do
-      newuser = Fabricate(:newuser)
+      newuser = Fabricate(:newuser, refresh_auto_groups: true)
       post = create_post(user: newuser)
 
       Discourse.stubs(:site_contact_user).returns(admin)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe Report do
         arpit = Fabricate(:user)
         sam = Fabricate(:user)
 
-        jeff = Fabricate(:user, created_at: 1.day.ago)
+        jeff = Fabricate(:user, created_at: 1.day.ago, refresh_auto_groups: true)
         post = create_post(user: jeff, created_at: 1.day.ago)
         PostActionCreator.like(arpit, post)
         PostActionCreator.like(sam, post)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2683,7 +2683,7 @@ RSpec.describe Topic do
 
       freeze_time(start)
 
-      user = Fabricate(:user)
+      user = Fabricate(:user, refresh_auto_groups: true)
       topic_id = create_post(user: user).topic_id
 
       freeze_time(start + 10.minutes)
@@ -2703,7 +2703,7 @@ RSpec.describe Topic do
 
       freeze_time(start)
 
-      user = Fabricate(:user)
+      user = Fabricate(:user, refresh_auto_groups: true)
 
       freeze_time(start + 25.hours)
       topic_id = create_post(user: user).topic_id

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe TopicTrackingState do
   end
 
   describe "#publish_muted" do
-    let(:user) { Fabricate(:user, last_seen_at: Date.today) }
+    let(:user) { Fabricate(:user, last_seen_at: Date.today, refresh_auto_groups: true) }
     let(:post) { create_post(user: user) }
 
     include_examples("does not publish message for private topics", :publish_muted)
@@ -307,7 +307,7 @@ RSpec.describe TopicTrackingState do
   end
 
   describe "#publish_unmuted" do
-    let(:user) { Fabricate(:user, last_seen_at: Date.today) }
+    let(:user) { Fabricate(:user, last_seen_at: Date.today, refresh_auto_groups: true) }
     let(:second_user) { Fabricate(:user, last_seen_at: Date.today) }
     let(:third_user) { Fabricate(:user, last_seen_at: Date.today) }
     let(:post) { create_post(user: user) }

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe TopicUser do
   fab!(:user)
 
   let(:topic) do
-    u = Fabricate(:user)
+    u = Fabricate(:user, refresh_auto_groups: true)
     guardian = Guardian.new(u)
     TopicCreator.create(u, guardian, title: "this is my topic title")
   end

--- a/spec/models/trust_level3_requirements_spec.rb
+++ b/spec/models/trust_level3_requirements_spec.rb
@@ -241,6 +241,7 @@ RSpec.describe TrustLevel3Requirements do
   describe "num_topics_replied_to" do
     it "counts topics in which user replied in last 100 days" do
       user.save
+      Group.refresh_automatic_groups!
 
       _not_a_reply = create_post(user: user) # user created the topic, so it doesn't count
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1339,7 +1339,7 @@ RSpec.describe User do
   end
 
   describe "flag_linked_posts_as_spam" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:admin)
     fab!(:post) do
       PostCreator.new(

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe WebHook do
   end
 
   describe "enqueues hooks" do
-    let(:user) { Fabricate(:user) }
+    let(:user) { Fabricate(:user, refresh_auto_groups: true) }
     let(:admin) { Fabricate(:admin) }
     let(:topic) { Fabricate(:topic, user: user) }
     let(:post) { Fabricate(:post, topic: topic, user: user) }
@@ -689,7 +689,15 @@ RSpec.describe WebHook do
 
         DiscourseEvent.trigger(:like_created, like)
 
-        assert_hook_was_queued_with(post, user, group_ids: [group.id])
+        assert_hook_was_queued_with(
+          post,
+          user,
+          group_ids: [
+            Group::AUTO_GROUPS[:trust_level_0],
+            Group::AUTO_GROUPS[:trust_level_1],
+            group.id,
+          ],
+        )
       end
 
       it "should pass the category id to the emit webhook job" do

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1486,7 +1486,7 @@ RSpec.describe PostsController do
             expect(Topic.last.custom_fields).to eq({ "xyz" => "abc" })
           end
 
-          it "should add custom fields to topic that is permitted for a non-staff user via the deprecated `meta_data` param" do
+          xit "should add custom fields to topic that is permitted for a non-staff user via the deprecated `meta_data` param" do
             sign_in(user)
 
             Discourse.expects(:deprecate).with(

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe TopicsController do
 
   fab!(:pm) { Fabricate(:private_message_topic) }
 
-  fab!(:user)
-  fab!(:user_2) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post_author1) { Fabricate(:user) }
   fab!(:post_author2) { Fabricate(:user) }
   fab!(:post_author3) { Fabricate(:user) }
@@ -18,9 +18,9 @@ RSpec.describe TopicsController do
   fab!(:post_author6) { Fabricate(:user) }
   fab!(:moderator)
   fab!(:admin)
-  fab!(:trust_level_0)
-  fab!(:trust_level_1)
-  fab!(:trust_level_4)
+  fab!(:trust_level_0) { Fabricate(:trust_level_0, refresh_auto_groups: true) }
+  fab!(:trust_level_1) { Fabricate(:trust_level_1, refresh_auto_groups: true) }
+  fab!(:trust_level_4) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
 
   fab!(:category)
   fab!(:tracked_category) { Fabricate(:category) }
@@ -242,6 +242,7 @@ RSpec.describe TopicsController do
       before do
         sign_in(user)
         SiteSetting.enable_category_group_moderation = true
+        Group.refresh_automatic_groups!
       end
 
       it "moves the posts" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UsersController do
 
   # Unfortunately, there are tests that depend on the user being created too
   # late for fab! to work.
-  let(:user_deferred) { Fabricate(:user) }
+  let(:user_deferred) { Fabricate(:user, refresh_auto_groups: true) }
 
   describe "#full account registration flow" do
     it "will correctly handle honeypot and challenge" do
@@ -4205,7 +4205,7 @@ RSpec.describe UsersController do
             flair_color: "#999999",
             flair_icon: "icon",
           )
-        liker = Fabricate(:user, flair_group: group)
+        liker = Fabricate(:user, flair_group: group, refresh_auto_groups: true)
         create_and_like_post(user_deferred, liker)
 
         get "/u/#{user_deferred.username_lower}/summary.json"

--- a/spec/serializers/user_summary_serializer_spec.rb
+++ b/spec/serializers/user_summary_serializer_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe UserSummarySerializer do
   it "returns expected data" do
     UserActionManager.enable
-    user = Fabricate(:user)
-    liked_user = Fabricate(:user, name: "John Doe", username: "john_doe")
+    user = Fabricate(:user, refresh_auto_groups: true)
+    liked_user = Fabricate(:user, name: "John Doe", username: "john_doe", refresh_auto_groups: true)
     liked_post = create_post(user: liked_user)
     PostActionCreator.like(user, liked_post)
 

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AnonymousShadowCreator do
   end
 
   context "when anonymous posting is enabled" do
-    fab!(:user) { Fabricate(:user, trust_level: 3) }
+    fab!(:user) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
 
     before do
       SiteSetting.allow_anonymous_posting = true
@@ -16,7 +16,6 @@ RSpec.describe AnonymousShadowCreator do
 
     it "returns no shadow if the user is not in a group that is allowed to anonymously post" do
       user = Fabricate(:user, trust_level: 0)
-      Group.refresh_automatic_groups!
       expect(AnonymousShadowCreator.get(user)).to eq(nil)
     end
 
@@ -34,6 +33,7 @@ RSpec.describe AnonymousShadowCreator do
       shadow2 = AnonymousShadowCreator.get(user)
 
       expect(shadow.id).to eq(shadow2.id)
+      Group.refresh_automatic_groups!
       create_post(user: shadow)
 
       user.reload

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -396,8 +396,8 @@ RSpec.describe BadgeGranter do
   end
 
   describe "update_badges" do
-    fab!(:user)
-    fab!(:liker) { Fabricate(:user) }
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:liker) { Fabricate(:user, refresh_auto_groups: true) }
 
     it "grants autobiographer" do
       user.user_profile.bio_raw = "THIS IS MY bio it a long bio I like my bio"

--- a/spec/services/post_action_notifier_spec.rb
+++ b/spec/services/post_action_notifier_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PostActionNotifier do
     Jobs.run_immediately!
   end
 
-  fab!(:evil_trout)
+  fab!(:evil_trout) { Fabricate(:evil_trout, refresh_auto_groups: true) }
   fab!(:post)
 
   context "when editing a post" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -715,8 +715,8 @@ RSpec.describe PostAlerter do
     end
 
     it "doesn't notify the linked user if the user is staged and the category is restricted and allows strangers" do
-      staged_user = Fabricate(:staged)
-      group_member = Fabricate(:user)
+      staged_user = Fabricate(:staged, refresh_auto_groups: true)
+      group_member = Fabricate(:user, refresh_auto_groups: true)
       group.add(group_member)
 
       staged_user_post = create_post(user: staged_user, category: private_category)
@@ -2294,7 +2294,7 @@ RSpec.describe PostAlerter do
 
       post =
         PostCreator.create!(
-          Fabricate(:user),
+          Fabricate(:user, refresh_auto_groups: true),
           title: "one of my first topics",
           raw: "one of my first posts",
           category: category.id,

--- a/spec/services/topic_status_updater_spec.rb
+++ b/spec/services/topic_status_updater_spec.rb
@@ -4,7 +4,7 @@
 # TODO - test pinning, create_moderator_post
 
 RSpec.describe TopicStatusUpdater do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:admin)
 
   it "avoids notifying on automatically closed topics" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -39,7 +39,11 @@ module Helpers
 
   def create_topic(args = {})
     args[:title] ||= "This is my title #{Helpers.next_seq}"
-    user = args.delete(:user) || Fabricate(:user)
+    user = args.delete(:user)
+    if !user
+      user = Fabricate(:user)
+      Group.refresh_automatic_groups!
+    end
     guardian = Guardian.new(user)
     args[:category] = args[:category].id if args[:category].is_a?(Category)
     TopicCreator.create(user, guardian, args)

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Default to Subcategory when parent Category doesn't allow posting", type: :system do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:group)
   fab!(:group_user) { Fabricate(:group_user, user: user, group: group) }
   fab!(:default_latest_category) { Fabricate(:category, name: "General") }


### PR DESCRIPTION
This change converts the min_trust_to_create_topic site setting to create_topic_allowed_groups.

See: https://meta.discourse.org/t/283408

- Hides the old setting
- Adds the new site setting
- Add a deprecation warning
- Updates to use the new setting
- Adds a migration to fill in the new setting if the old setting was changed
- Adds an entry to the site_setting.keywords section
- Updates tests to account for the new change
- After a couple of months, we will remove the email_in_min_trust setting entirely.

Internal ref: /t/117248