### PR TITLE
FIX: Guardian initialize for basic user

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -115,6 +115,11 @@ class Guardian
   # that is logged in. This represents someone who cannot access any secure
   # categories or PMs but can read public topics.
   class BasicUser
+    # There are many guardian checks that expect an authenticated user
+    # to have an ID; let's make sure it's one that will never exist.
+    def id
+      -9_999_999
+    end
     def blank?
       true
     end
@@ -174,10 +179,10 @@ class Guardian
     end
   end
 
-  attr_reader :request
+  attr_reader :request, :guardian_user
 
   def initialize(user = nil, request = nil)
-    @guardian_user = GuardianUser.new(user.presence || AnonymousUser.new)
+    @guardian_user = GuardianUser.new(user.nil? ? AnonymousUser.new : user)
     @user = @guardian_user.actual
     @request = request
   end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -40,6 +40,44 @@ RSpec.describe Guardian do
     expect { Guardian.new(user) }.not_to raise_error
   end
 
+  it "can make a basic_user which is a fake user with minimal permissions" do
+    expect(Guardian.basic_user.guardian_user.actual).to be_a(Guardian::BasicUser)
+  end
+
+  it "can make an anonymous_user which is a fake user representing someone not logged in" do
+    expect(Guardian.anon_user.guardian_user.actual).to be_a(Guardian::AnonymousUser)
+  end
+
+  describe "authenticated?" do
+    it "returns true for basic_user" do
+      expect(Guardian.basic_user.authenticated?).to eq(true)
+    end
+
+    it "returns true for an actual user" do
+      expect(Guardian.new(user).authenticated?).to eq(true)
+    end
+
+    it "returns false for anon_user" do
+      expect(Guardian.anon_user.authenticated?).to eq(false)
+      expect(Guardian.new.authenticated?).to eq(false)
+    end
+  end
+
+  describe "user" do
+    it "returns nil for basic_user" do
+      expect(Guardian.basic_user.user).to eq(nil)
+    end
+
+    it "returns the user record for an actual user" do
+      expect(Guardian.new(user).user).to eq(user)
+    end
+
+    it "returns nil for anon_user" do
+      expect(Guardian.anon_user.user).to eq(nil)
+      expect(Guardian.new.user).to eq(nil)
+    end
+  end
+
   describe "link_posting_access" do
     it "is none for anonymous users" do
       expect(Guardian.new.link_posting_access).to eq("none")

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -956,6 +956,14 @@ RSpec.describe Oneboxer do
       it "returns topic if basic user can see the topic" do
         expect(Oneboxer.local_topic(url, route, opts)).to eq(topic)
       end
+
+      context "for login_required" do
+        before { SiteSetting.login_required = true }
+
+        it "returns topic if basic user can see the topic" do
+          expect(Oneboxer.local_topic(url, route, opts)).to eq(topic)
+        end
+      end
     end
 
     context "when user_id is provided" do


### PR DESCRIPTION
Followup to de983796e1b66aa2ab039a4fb6e32cec8a65a098,
I did not realise this issue because conditions are
different in production, this does the correct thing
and adds more tests.
