### PR TITLE
FIX: Handle 404 correctly when transition has no path

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/unknown.js
+++ b/app/assets/javascripts/discourse/app/routes/unknown.js
@@ -13,7 +13,7 @@ export default class UnknownRoute extends DiscourseRoute {
       return;
     }
 
-    const rewrittenPath = rewritePath(path);
+    const rewrittenPath = path && rewritePath(path);
     if (rewrittenPath !== path) {
       this.router.transitionTo(rewrittenPath);
       return;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
