### PR TITLE
FIX: saving tag changes without description

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -131,7 +131,7 @@ export default Component.extend({
   @action
   finishedEditing() {
     const oldTagName = this.tag.id;
-    this.newTagDescription = this.newTagDescription.replaceAll("\n", "<br>");
+    this.newTagDescription = this.newTagDescription?.replaceAll("\n", "<br>");
     this.tag
       .update({ id: this.newTagName, description: this.newTagDescription })
       .then((result) => {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/cant-edit-tag-names/287750

If there's no tag description, we get a `Uncaught TypeError: this.newTagDescription is null` here