### PR TITLE
DEV: Set a browser read timeout in capybara

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -177,6 +177,7 @@ end
 RSpec.configure { |config| config.extend Prefabrication }
 
 PER_SPEC_TIMEOUT_SECONDS = 30
+BROWSER_READ_TIMEOUT = 20
 
 RSpec.configure do |config|
   config.fail_fast = ENV["RSPEC_FAIL_FAST"] == "1"
@@ -388,7 +389,10 @@ RSpec.configure do |config|
           options.add_preference("download.default_directory", Downloads::FOLDER)
         end
 
-    driver_options = { browser: :chrome }
+    client = Selenium::WebDriver::Remote::Http::Default.new
+    client.read_timeout = BROWSER_READ_TIMEOUT
+
+    driver_options = { browser: :chrome, http_client: client }
 
     if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
       driver_options[:browser] = :remote


### PR DESCRIPTION
Hopefully will catch some stalling specs (I think they currently time out in ~5 minutes?)