### PR TITLE
UX: add missing button class to bulk-select

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header-column.hbr
@@ -6,7 +6,7 @@
     {{~#if bulkSelectEnabled}}
       <span class='bulk-select-topics'>
         {{~#if canDoBulkActions}}
-          <button class='btn btn-icon no-text bulk-select-actions'>{{d-icon "cog"}}&#8203;</button>
+          <button class='btn btn-default btn-icon no-text bulk-select-actions'>{{d-icon "cog"}}&#8203;</button>
         {{/if ~}}
         <button class='btn btn-default bulk-select-all'>{{i18n "topics.bulk.select_all"}}</button>
         <button class='btn btn-default bulk-clear-all'>{{i18n "topics.bulk.clear_all"}}</button>


### PR DESCRIPTION
Noticed in a theme that this was missing a class, there are no visual changes here for the default. 