### PR TITLE
UX: move monospace font to variable

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -132,7 +132,7 @@
   }
 
   .markdown {
-    font-family: monospace;
+    font-family: var(--d-font-family--monospace);
     width: 100%;
     border-collapse: collapse;
     border-spacing: 0;

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -533,7 +533,7 @@
       width: 100%;
     }
     textarea {
-      font-family: monospace;
+      font-family: var(--d-font-family--monospace);
       resize: none;
       border-radius: 0;
       box-shadow: none;

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -514,8 +514,7 @@ pre.onebox code {
     white-space: pre-wrap;
     overflow-y: auto;
     word-break: break-word;
-    font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono",
-      "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace;
+    font-family: var(--d-font-family--monospace);
     box-sizing: border-box;
 
     .show-more {

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -855,7 +855,7 @@
     border: 0;
     cursor: auto;
     outline: none;
-    font-family: monospace;
+    font-family: var(--d-font-family--monospace);
     &:focus {
       box-shadow: none;
       border-color: var(--primary-low);

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -12,6 +12,9 @@
   --d-button-border-radius: var(--d-border-radius);
   --d-input-border-radius: var(--d-border-radius);
   --d-content-background: initial;
+  --d-font-family--monospace: Consolas, Menlo, Monaco, "Lucida Console",
+    "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono",
+    "Courier New", monospace;
 }
 
 // --------------------------------------------------

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -35,8 +35,7 @@ body.dragging {
 /***********************/
 code,
 pre {
-  font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono",
-    "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace;
+  font-family: var(--d-font-family--monospace);
 }
 
 // this removes the unwanted top margin on a paragraph under a heading


### PR DESCRIPTION
We were inconsistently using a specific font stack in a couple places, and `monospace` elsewhere... so this ties them to a single variable. 