### PR TITLE
FIX: Ensure bulk select toggle appears for non-admin on new/unread

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -43,7 +43,9 @@ export default Component.extend(LoadMore, {
   },
 
   get toggleInTitle() {
-    return !this.bulkSelectHelper?.bulkSelectEnabled && this.canBulkSelect;
+    return (
+      !this.bulkSelectHelper?.bulkSelectEnabled && this.get("canBulkSelect")
+    );
   },
 
   @discourseComputed


### PR DESCRIPTION
TopicList is a classic component, so we need to use `.get()` for the argument to be autotracked in a native getter 😢

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
