### PR TITLE
UX: Fix edit navigation tags modal height too long on desktop

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -243,9 +243,7 @@
     }
   }
 
-  &:not(.bookmark-reminder-modal):not(.history-modal):not(
-      .sidebar__edit-navigation-menu__modal
-    ) {
+  &:not(.bookmark-reminder-modal):not(.history-modal) {
     .modal-body:not(.reorder-categories):not(.poll-ui-builder):not(
         .poll-breakdown
       ) {

--- a/app/assets/stylesheets/desktop/components/_index.scss
+++ b/app/assets/stylesheets/desktop/components/_index.scss
@@ -1,4 +1,5 @@
 @import "more-topics";
+@import "sidebar/edit-navigation-menu/tags-modal";
 @import "user-card";
 @import "user-info";
 @import "user-stream-item";

--- a/app/assets/stylesheets/desktop/components/sidebar/edit-navigation-menu/tags-modal.scss
+++ b/app/assets/stylesheets/desktop/components/sidebar/edit-navigation-menu/tags-modal.scss
@@ -1,0 +1,5 @@
+.sidebar__edit-navigation-menu__tags-modal {
+  .d-modal__body {
+    max-height: 30vh;
+  }
+}

--- a/spec/system/editing_sidebar_tags_navigation_spec.rb
+++ b/spec/system/editing_sidebar_tags_navigation_spec.rb
@@ -177,11 +177,11 @@ RSpec.describe "Editing sidebar tags navigation", type: :system do
     expect(modal).to have_tag_checkboxes([tag1, tag2, tag3, tag4])
   end
 
-  xit "loads more tags when the user scrolls views the last tag in the modal and there is more tags to load" do
+  it "loads more tags when the user scrolls views the last tag in the modal and there is more tags to load" do
     Tag.delete_all
 
     tags =
-      (TagsController::LIST_LIMIT + 50).times.map do |index|
+      (TagsController::LIST_LIMIT + 1).times.map do |index|
         Fabricate(:tag, name: "Tag #{sprintf("%03d", index)}")
       end
 


### PR DESCRIPTION
### Why this change?

The tags modal loads more tags via infinite loading based on when the last tag in the
given page appears in the viewport for the user. When it comes into
view, a request is then triggered to fetch additional tags. To ensure
that we are only loading a single page of tags each time the modal is
opened, we previously set a max height on the modal's body to ensure
that the last tag which appears in the modal will be outside of the view
port in the initial load. However, this has regressed recently due to
unknown reasons and resulted in multiple pages of tags being loaded
immediately from the server as the modal's height was not restricted.
This regression was caught by an existing test but was unfortunately
determined as flaky.

### What does this change do?

This change restores the max height on the edit navigation menu tags
modal on dekstop.

### Recordings

#### Before

![Peek 2023-12-07 09-30](https://github.com/discourse/discourse/assets/4335742/abaf4009-d36f-448f-be5b-258cc3665350)


#### After

![Peek 2023-12-07 09-31](https://github.com/discourse/discourse/assets/4335742/6d2d7fb2-9c09-4843-9631-bdcd08003e1f)

