### PR TITLE
FIX: Allow quoting thread's original message

### DIFF
--- a/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
+++ b/plugins/chat/assets/javascripts/lib/discourse-markdown/chat-transcript.js
@@ -30,6 +30,7 @@ const chatTranscriptRule = {
       return;
     }
 
+    const isThread = threadId && content.includes("[chat");
     let wrapperDivToken = state.push("div_chat_transcript_wrap", "div", 1);
 
     if (channelName && multiQuote) {
@@ -53,7 +54,7 @@ const chatTranscriptRule = {
       state.push("div_chat_transcript_meta", "div", -1);
     }
 
-    if (threadId) {
+    if (isThread) {
       state.push("details_chat_transcript_wrap_open", "details", 1);
       state.push("summary_chat_transcript_open", "summary", 1);
 
@@ -227,7 +228,7 @@ const chatTranscriptRule = {
     let messagesToken = state.push("div_chat_transcript_messages", "div", 1);
     messagesToken.attrs = [["class", "chat-transcript-messages"]];
 
-    if (threadId) {
+    if (isThread) {
       const regex = /\[chat/i;
       const match = regex.exec(content);
 

--- a/plugins/chat/spec/lib/chat/pretty_text_spec.rb
+++ b/plugins/chat/spec/lib/chat/pretty_text_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe PrettyText do
+  it "allows quoting chained messages" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="jan;101;2023-12-01T21:10:53Z" channel="Tech Talks" channelId="5" multiQuote="true" chained="true"]
+    message 1
+    [/chat]
+    
+    [chat quote="Kai;102;2023-12-01T21:10:53Z" chained="true"]
+    message 2
+    
+    message 3
+    [/chat]
+    MD
+
+    expect(cooked).to include('class="chat-transcript chat-transcript-chained"')
+    expect(cooked).to include('data-channel-name="Tech Talks"')
+    expect(cooked).to include('data-channel-id="5"')
+  end
+
+  it "allows quoting non-chained messages" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="jan;101;2023-12-01T21:10:53Z" channel="Tech Talks" channelId="5"]
+    message 1
+    [/chat]
+    
+    [chat quote="Kai;102;2023-12-01T21:10:53Z"]
+    message 2
+    
+    message 3
+    [/chat]
+    MD
+
+    expect(cooked).to include('class="chat-transcript"')
+    expect(cooked).to include('data-channel-name="Tech Talks"')
+    expect(cooked).to include('data-channel-id="5"')
+    expect(cooked).not_to include("chat-transcript-chained")
+  end
+
+  it "includes channel metadata" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="alice;103;2023-12-02T10:20:30Z" channel="Game Grove" channelId="5" multiQuote="true"]
+    message
+    [/chat]
+    MD
+
+    expect(cooked).to include(
+      "<div class=\"chat-transcript-meta\">\nOriginally sent in <a href=\"/chat/c/-/5\">Game Grove</a></div>",
+    )
+  end
+
+  it "includes message reactions" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="alice;103;2023-12-02T10:20:30Z" reactions="smile:alice,bob;heart:carol"]
+    This is a test message with reactions
+    [/chat]
+    MD
+
+    expect(cooked).to include(
+      "<div class=\"chat-transcript-reaction\">\n<img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/heart.png?v=#{Emoji::EMOJI_VERSION}\" title=\"heart\" loading=\"lazy\" alt=\"heart\" class=\"emoji\"> 1</div>",
+    )
+    expect(cooked).to include(
+      "<div class=\"chat-transcript-reaction\">\n<img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/smile.png?v=#{Emoji::EMOJI_VERSION}\" title=\"smile\" loading=\"lazy\" alt=\"smile\" class=\"emoji\"> 2</div>",
+    )
+  end
+
+  it "allows quoting threads" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="jan;274;2023-12-06T04:15:00Z" channelId="2" threadId="140"]
+    original message
+    
+    [chat quote="kai;274;2023-12-06T04:30:04Z" chained="true"]
+    thread reply 1
+    [/chat]
+    
+    [chat quote="jan;274;2023-12-06T05:00:00Z" chained="true"]
+    thread reply 2
+    [/chat]
+    
+    [/chat]
+    MD
+    expect(cooked).to include('class="chat-transcript-thread"')
+    expect(cooked).to include("details")
+    expect(cooked).to include("summary")
+  end
+
+  it "renders a thread as a normal message if there are no nested messages" do
+    cooked = PrettyText.cook <<~MD
+    [chat quote="jan;274;2023-12-06T04:15:00Z" channelId="2" threadId="140" threadTitle="NatureNotes"]
+    original message
+    [/chat]
+    MD
+
+    expect(cooked).not_to include('class="chat-transcript-thread"')
+    expect(cooked).to include(
+      "<div class=\"chat-transcript-messages\">\n<p>original message</p></div>",
+    )
+  end
+end


### PR DESCRIPTION
This change makes it so the transcribed message only shows as a thread if the message has nested messages, even if the message has a `threadId`. This allows for quoting thread messages, since currently, when quoting a thread in a post, only the original message is shown.

```
[chat quote="jan2;274;2023-12-06T04:07:04Z" channelId="2" threadId="140" threadTitle="Thread"]
original message content
[/chat]
```
### Before
![2023-12-07_12-09](https://github.com/discourse/discourse/assets/66427541/9751e055-3470-4ec5-b3d2-b2f8a4a54c5a)
### After
![2023-12-07_12-08](https://github.com/discourse/discourse/assets/66427541/8b4114d5-b6bf-4d00-aae5-cc39d9be9c5c)
