### PR TITLE
FIX: Move the `search-menu-results-top` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
@@ -2,6 +2,10 @@
   <SearchMenu::BrowserSearchTip />
 {{else}}
   <div class="results">
+    <PluginOutlet
+      @name="search-menu-results-top"
+      @outletArgs={{hash closeSearchMenu=@closeSearchMenu}}
+    />
     {{#if @suggestionKeyword}}
       <SearchMenu::Results::Assistant
         @suggestionKeyword={{@suggestionKeyword}}
@@ -26,11 +30,6 @@
           @searchTermChanged={{@searchTermChanged}}
         />
       {{/if}}
-
-      <PluginOutlet
-        @name="search-menu-results-top"
-        @outletArgs={{hash closeSearchMenu=@closeSearchMenu}}
-      />
 
       {{#if (and @searchTopics this.resultTypesWithComponent)}}
         {{! render results after a search has been performed }}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
@@ -4,7 +4,12 @@
   <div class="results">
     <PluginOutlet
       @name="search-menu-results-top"
-      @outletArgs={{hash closeSearchMenu=@closeSearchMenu}}
+      @outletArgs={{hash
+        closeSearchMenu=@closeSearchMenu
+        searchTerm=this.search.activeGlobalSearchTerm
+        inTopicContext=this.search.inTopicContext
+        searchTopics=@searchTopics
+      }}
     />
     {{#if @suggestionKeyword}}
       <SearchMenu::Results::Assistant


### PR DESCRIPTION
The `search-menu-results-top` plugin outlet was not positioned at the top of `results` as expected. Additionally, the expected outlet arguments that existed in the "widget implementation" were not available on the glimmer search menu. 