### PR TITLE
FIX: Table builder spec

### DIFF
--- a/spec/system/table_builder_spec.rb
+++ b/spec/system/table_builder_spec.rb
@@ -99,11 +99,13 @@ describe "Table Builder", type: :system do
       |Make | Model | Year|
       |--- | --- | ---|
       |Toyota | Supra | 1998|
-      |Nissan | Skyline | 1999|
+      |Nissan | Skyline GTR | 1999|
       |Honda | S2000 | 2001|
       RAW
 
-      expect(normalize_value(post1.reload.raw)).to eq(normalize_value(updated_post))
+      try_until_success do
+        expect(normalize_value(post1.reload.raw)).to eq(normalize_value(updated_post))
+      end
     end
 
     context "when adding an edit reason" do


### PR DESCRIPTION
This PR updates the `table_builder_spec`:
- Fixes regression: updated post needs to include the updated value appended to the original value ("GTR")
- `try_until_success` added because of flakiness with `post1` not consistently having updated content.