### PR TITLE
FIX: Prevent error when poster isn't present in message notification

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/messages-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/messages-list.js
@@ -83,7 +83,7 @@ export default class UserMenuMessagesList extends UserMenuNotificationsList {
       topics.forEach((t) => {
         t.last_poster_avatar_template = usersById.get(
           t.lastPoster.user_id
-        ).avatar_template;
+        )?.avatar_template;
       });
     }
 


### PR DESCRIPTION
There was occasionally a JS error when the user wasn't serialized to the client -- we want to avoid a hard JS error in this cvase.