### PR TITLE
FIX: Form template form error visiblity

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -363,4 +363,5 @@
   padding: 1rem;
   border: 1px solid var(--primary-medium);
   margin-bottom: 0;
+  height: 100%;
 }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -361,7 +361,7 @@
   overflow: auto;
   background: var(--primary-very-low);
   padding: 1rem;
-  border: 1px solid var(--primary-medium);
+  border: 1px solid var(--primary-400);
   margin-bottom: 0;
   height: 100%;
 }

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -181,7 +181,7 @@ module PageObjects
       end
 
       def has_form_template_field_error?(error)
-        page.has_css?(".form-template-field__error", text: error, visible: all)
+        page.has_css?(".form-template-field__error", text: error, visible: :all)
       end
 
       def has_form_template_field_label?(label)

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -181,7 +181,7 @@ module PageObjects
       end
 
       def has_form_template_field_error?(error)
-        page.has_css?(".form-template-field__error", text: error)
+        page.has_css?(".form-template-field__error", text: error, visible: all)
       end
 
       def has_form_template_field_label?(label)


### PR DESCRIPTION
This PR attempts to fix flaky spec with form template forms. It does so by ensuring `form_template_field_error` is `visible: :all` and also by ensuring the form's height is filled even when there is less fields used.

This PR also updates the border colour of the form template's form to match the borders of other inputs in the composer (since the recent changes https://github.com/discourse/discourse/pull/24060).

## Before
![Screenshot 2023-12-07 at 11 38 36](https://github.com/discourse/discourse/assets/30090424/e65698a9-eda3-4938-983b-7c7b0f6a8c78)


## After
![Screenshot 2023-12-07 at 11 44 38](https://github.com/discourse/discourse/assets/30090424/4b2c7157-6979-4cad-92e1-a2a94bd7faf6)

