### PR TITLE
DEV: Catch errors in theme/plugin onPageChange handlers

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -799,7 +799,8 @@ class PluginApi {
    ```
    **/
   onPageChange(fn) {
-    this.onAppEvent("page:changed", (data) => fn(data.url, data.title));
+    const callback = wrapWithErrorHandler(fn, "broken_page_change_alert");
+    this.onAppEvent("page:changed", (data) => callback(data.url, data.title));
   }
 
   /**

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -220,6 +220,7 @@ en:
       only_admins: "(this message is only shown to site administrators)"
 
     broken_decorator_alert: "Posts may not display correctly because one of the post content decorators on your site raised an error."
+    broken_page_change_alert: "An onPageChange handler raised an error. Check the browser developer tools for more information."
 
     broken_plugin_alert: "Caused by plugin '%{name}'"
 


### PR DESCRIPTION
This makes the errors easier for admins to identify/resolve, and also prevents failures from affecting core functionality.

<img width="1157" alt="SCR-20231207-uhsi" src="https://github.com/discourse/discourse/assets/6270921/b9dcb2b2-713e-4e82-b1f8-9062160af952">

<img width="469" alt="SCR-20231207-uhqi" src="https://github.com/discourse/discourse/assets/6270921/b9523a46-9177-43e4-878e-8d367456c3f5">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
