### PR TITLE
DEV: Introduce `FlakySpec::Retry`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       EMBER_VERSION: ${{ (matrix.updated_ember && '5') || '3' }}
+      DISCOURSE_RETRY_AND_REPORT_FLAKY_SPECS: ${{ matrix.build_type == 'system' }}
 
     strategy:
       fail-fast: false
@@ -282,12 +283,41 @@ jobs:
         shell: bash
         timeout-minutes: 30
 
+      - name: Check for failed system test screenshots
+        id: check-failed-system-test-screenshots
+        if: matrix.build_type == 'system'
+        run: |
+          if [ -f tmp/capybara/*.png ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Upload failed system test screenshots
         uses: actions/upload-artifact@v3
-        if: matrix.build_type == 'system' && failure()
+        if: matrix.build_type == 'system' && steps.check-failed-system-test-screenshots.outputs.exists == 'true'
         with:
           name: failed-system-test-screenshots
           path: tmp/capybara/*.png
+
+      - name: Check for flaky test report
+        id: check-flaky-spec-report
+        if: matrix.build_type == 'system'
+        run: |
+          if [ -f tmp/flaky_spec_report_*.json ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Upload flaky test report
+        uses: actions/upload-artifact@v3
+        if: matrix.build_type == 'system' && steps.check-flaky-spec-report.outputs.exists == 'true'
+        with:
+          name: flaky-test-report
+          path: tmp/flaky_spec_report_*.json
 
       - name: Check Annotations
         if: matrix.build_type == 'annotations'

--- a/lib/flaky_spec/failed_example.rb
+++ b/lib/flaky_spec/failed_example.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module FlakySpec
+  class FailedExample
+    # @param [RSpec::Core::Example] rspec_example
+    def initialize(rspec_example)
+      # The exception has not been set on the `execution_result` at this point, so we have to set it manually for
+      # `RSpec::Core::Notifications::FailedExampleNotification` to work properly.
+      rspec_example.execution_result.exception = rspec_example.exception
+
+      @rspec_failed_notification =
+        RSpec::Core::Notifications::FailedExampleNotification.new(rspec_example)
+    end
+
+    # See https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FNotifications%2FFailedExampleNotification:message_lines
+    def message_lines
+      lines = @rspec_failed_notification.message_lines.join("\n")
+
+      # Strip ANSI color codes from the message lines as we are likely running in a terminal where `RSpec.color` is enabled
+      lines = lines.gsub!(/\e\[[0-9;]*m/, "").strip
+
+      lines
+    end
+
+    # See https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FNotifications%2FFailedExampleNotification:description
+    def description
+      @rspec_failed_notification.description
+    end
+
+    # See https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FNotifications%2FFailedExampleNotification:formatted_backtrace
+    def backtrace
+      @rspec_failed_notification.formatted_backtrace
+    end
+
+    SCREENSHOT_PREFIX = "[Screenshot Image]: "
+
+    # Unfortunately this has to be parsed from the output because `ActionDispatch` is just printing the path instead of
+    # properly adding the screenshot to the test metadata.
+    def failure_screenshot_path
+      @rspec_failed_notification.message_lines.each do |message_line|
+        if message_line.start_with?(SCREENSHOT_PREFIX)
+          return message_line.split(SCREENSHOT_PREFIX).last.chomp
+        end
+      end
+
+      nil
+    end
+
+    def to_h
+      { message_lines:, description:, backtrace:, failure_screenshot_path: }
+    end
+  end
+end

--- a/lib/flaky_spec/flaky_example.rb
+++ b/lib/flaky_spec/flaky_example.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module FlakySpec
+  class FlakyExample
+    # @param [RSpec::Core::Notifications::ExampleNotification] rspec_notification
+    def initialize(rspec_notification)
+      @rspec_notification = rspec_notification
+      @rspec_example = rspec_notification.example
+    end
+
+    def uid
+      Digest::MD5.hexdigest(
+        "#{@rspec_example.id}-#{@rspec_example.full_description}-#{@rspec_example.location}",
+      )
+    end
+
+    def attempts
+      @rspec_example.metadata.dig(:flaky_spec, :retry_attempts) || 0
+    end
+
+    # See https://www.rubydoc.info/gems/rspec-core/RSpec%2FCore%2FExample:location_rerun_argument
+    def location_rerun_argument
+      @rspec_example.location_rerun_argument
+    end
+
+    def failed_examples
+      @rspec_example.metadata[:flaky_spec][:failed_examples]
+    end
+
+    def to_h
+      { uid:, location_rerun_argument:, failed_examples: }
+    end
+  end
+end

--- a/lib/flaky_spec/listener.rb
+++ b/lib/flaky_spec/listener.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module FlakySpec
+  class Listener
+    OUTPUT_PATH = Rails.root.join("tmp/flaky_spec_report_#{Process.pid}.json")
+
+    def initialize
+      @flaky_examples = []
+    end
+
+    def seed(notification)
+      @seed = notification.seed
+    end
+
+    def example_passed(notification)
+      example = FlakyExample.new(notification)
+
+      return if example.attempts == 0
+
+      @flaky_examples << example
+    end
+
+    # @returns [String, nil] the path to the output file if there are flaky examples, otherwise nil.
+    def stop(_notification)
+      return if @flaky_examples.blank?
+
+      # write to json file
+      File.open(OUTPUT_PATH, "w") do |f|
+        f.write(JSON.pretty_generate({ seed: @seed, flaky_examples: @flaky_examples.map(&:to_h) }))
+      end
+    end
+  end
+end

--- a/lib/flaky_spec/retry.rb
+++ b/lib/flaky_spec/retry.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module FlakySpec
+  class Retry
+    # @param [RSpec::Core::Example::Procsy] rspec_example_procsy
+    # @param [Integer] retry_count The number of times to retry the example when it fails.
+    def self.run(rspec_example_procsy, retry_count: 1)
+      new(rspec_example_procsy, retry_count:).run_with_retry
+    end
+
+    # @private
+    def initialize(rspec_example_procsy, retry_count:)
+      @rspec_example_procsy = rspec_example_procsy
+      @rspec_example = rspec_example_procsy.example
+      self.retry_count = retry_count
+    end
+
+    # @private
+    def metadata
+      @rspec_example.metadata[:flaky_spec] ||= {}
+    end
+
+    # @private
+    def attempts
+      metadata[:retry_attempts] || 0
+    end
+
+    # @private
+    def increment_attempts
+      metadata[:retry_attempts] ||= 0
+      metadata[:retry_attempts] += 1
+    end
+
+    # @private
+    def retry_count
+      metadata[:retry_count]
+    end
+
+    # @private
+    def retry_count=(count)
+      metadata[:retry_count] = count
+    end
+
+    # @private
+    def failed_examples
+      metadata[:failed_examples] ||= []
+    end
+
+    # @private
+    def store_failed_example(example)
+      failed_examples << FailedExample.new(example).to_h
+    end
+
+    # @private
+    def run_with_retry
+      loop do
+        # Clear the exception so that the example can be re-run.
+        @rspec_example.display_exception = nil
+
+        # HACK: Clear this first because failing assertions are somehow being treated as a Capybara synchronize timeout
+        # exception?
+        @rspec_example.metadata[:_capybara_timeout_exception] = nil
+        @rspec_example_procsy.run
+
+        break if @rspec_example.exception.nil?
+
+        store_failed_example(@rspec_example)
+
+        increment_attempts
+        break if attempts > retry_count
+      end
+
+      @rspec_example
+    end
+  end
+end

--- a/spec/lib/flaky_spec/listener_spec.rb
+++ b/spec/lib/flaky_spec/listener_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe FlakySpec::Listener do
+  describe "#stop" do
+    it "does not write any output file to disk when there are no flaky examples" do
+      FlakySpec::Listener.new.stop(nil)
+
+      expect(File.exist?(FlakySpec::Listener::OUTPUT_PATH)).to eq(false)
+    end
+
+    it "correctly writes an output file to disk when there are flaky examples" do
+      listener = FlakySpec::Listener.new
+      listener.seed(RSpec::Core::Notifications::SeedNotification.new(1234))
+
+      normal_example = RSpec::Core::ExampleGroup.describe.example
+
+      flaky_example = RSpec::Core::ExampleGroup.describe.example
+
+      flaky_example.metadata[:flaky_spec] = {
+        retry_attempts: 2,
+        failed_examples: [
+          {
+            message_lines: "message lines 1",
+            description: "description 1",
+            backtrace: "backtrace 1",
+            failure_screenshot_path: "/failures/screenshot/path/1.png",
+          },
+          {
+            message_lines: "message lines 2",
+            description: "description 2",
+            backtrace: "backtrace 2",
+            failure_screenshot_path: "/failures/screenshot/path/2.png",
+          },
+        ],
+      }
+
+      flaky_example_2 = RSpec::Core::ExampleGroup.describe.example
+
+      flaky_example_2.metadata[:flaky_spec] = {
+        retry_attempts: 1,
+        failed_examples: [
+          {
+            message_lines: "message lines 3",
+            description: "description 3",
+            backtrace: "backtrace 3",
+            failure_screenshot_path: "/failures/screenshot/path/3.png",
+          },
+        ],
+      }
+
+      [normal_example, flaky_example, flaky_example_2].each do |example|
+        listener.example_passed(RSpec::Core::Notifications::ExampleNotification.for(example))
+      end
+
+      listener.stop(nil)
+
+      expect(File.read(FlakySpec::Listener::OUTPUT_PATH)).to eq(<<~OUTPUT.chomp)
+      {
+        "seed": 1234,
+        "flaky_examples": [
+          {
+            "uid": "e3e83a7a0501d439867edf28f3246785",
+            "location_rerun_argument": "./spec/lib/flaky_spec/listener_spec.rb:17",
+            "failed_examples": [
+              {
+                "message_lines": "message lines 1",
+                "description": "description 1",
+                "backtrace": "backtrace 1",
+                "failure_screenshot_path": "/failures/screenshot/path/1.png"
+              },
+              {
+                "message_lines": "message lines 2",
+                "description": "description 2",
+                "backtrace": "backtrace 2",
+                "failure_screenshot_path": "/failures/screenshot/path/2.png"
+              }
+            ]
+          },
+          {
+            "uid": "aa8c60324803ab6d24a9ee88fe823637",
+            "location_rerun_argument": "./spec/lib/flaky_spec/listener_spec.rb:37",
+            "failed_examples": [
+              {
+                "message_lines": "message lines 3",
+                "description": "description 3",
+                "backtrace": "backtrace 3",
+                "failure_screenshot_path": "/failures/screenshot/path/3.png"
+              }
+            ]
+          }
+        ]
+      }
+      OUTPUT
+    ensure
+      File.delete(FlakySpec::Listener::OUTPUT_PATH) if File.exist?(FlakySpec::Listener::OUTPUT_PATH)
+    end
+  end
+end

--- a/spec/lib/flaky_spec/retry_spec.rb
+++ b/spec/lib/flaky_spec/retry_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+# rubocop:disable RSpec/BeforeAfterAll
+# rubocop:disable RSpec/ExpectActual
+
+RSpec.describe FlakySpec::Retry, flaky_spec_retry: true do
+  def set_expectations(expectations)
+    @expectations = expectations
+  end
+
+  def shift_expectation
+    @expectations.shift
+  end
+
+  def reset_expectations
+    @expectations = nil
+  end
+
+  def count
+    @count ||= 0
+  end
+
+  def count_up
+    @count ||= 0
+    @count += 1
+  end
+
+  def reset_count
+    @count = 0
+  end
+
+  context "when test fails 2 times before passing on third try" do
+    before(:all) { set_expectations([false, false, true]) }
+
+    before { count_up }
+
+    after(:all) do
+      reset_expectations
+      reset_count
+    end
+
+    it "should retry the example 2 times" do
+      expect(true).to eq(shift_expectation)
+      expect(count).to eq(3)
+
+      current_example = RSpec.current_example
+
+      expect(current_example.metadata[:flaky_spec][:retry_attempts]).to eq(2)
+      expect(current_example.metadata[:flaky_spec][:failed_examples].size).to eq(2)
+
+      first_failed_example = current_example.metadata[:flaky_spec][:failed_examples].first
+
+      current_example.metadata[:flaky_spec][:failed_examples].each do |failed_example|
+        expect(failed_example[:message_lines]).to eq(<<~OUTPUT.chomp)
+        Failure/Error: expect(true).to eq(shift_expectation)
+
+          expected: false
+               got: true
+
+          (compared using ==)
+
+          Diff:
+          @@ -1 +1 @@
+          -false
+          +true
+        OUTPUT
+
+        expect(failed_example[:description]).to eq(
+          "FlakySpec::Retry when test fails 2 times before passing on third try should retry the example 2 times",
+        )
+
+        expect(failed_example[:backtrace]).to be_present
+        expect(failed_example[:failure_screenshot_path]).to eq(nil)
+      end
+    end
+  end
+
+  context "when test fails 1 time before passing on second try" do
+    before(:all) { set_expectations([false, true]) }
+
+    before { count_up }
+
+    after(:all) do
+      reset_expectations
+      reset_count
+    end
+
+    it "should retry the example 1 time" do
+      expect(true).to eq(shift_expectation)
+      expect(count).to eq(2)
+
+      current_example = RSpec.current_example
+
+      expect(current_example.metadata[:flaky_spec][:retry_attempts]).to eq(1)
+      expect(current_example.metadata[:flaky_spec][:failed_examples].size).to eq(1)
+
+      failed_example = current_example.metadata[:flaky_spec][:failed_examples].first
+
+      expect(failed_example[:message_lines]).to eq(<<~OUTPUT.chomp)
+      Failure/Error: expect(true).to eq(shift_expectation)
+
+        expected: false
+             got: true
+
+        (compared using ==)
+
+        Diff:
+        @@ -1 +1 @@
+        -false
+        +true
+      OUTPUT
+
+      expect(failed_example[:description]).to eq(
+        "FlakySpec::Retry when test fails 1 time before passing on second try should retry the example 1 time",
+      )
+
+      expect(failed_example[:backtrace]).to be_present
+      expect(failed_example[:failure_screenshot_path]).to eq(nil)
+    end
+  end
+
+  context "when test does not fail on first run" do
+    before(:all) { set_expectations([true]) }
+
+    before { count_up }
+
+    after(:all) do
+      reset_expectations
+      reset_count
+    end
+
+    it "should not retry the example" do
+      expect(true).to eq(shift_expectation)
+      expect(count).to eq(1)
+
+      current_example = RSpec.current_example
+
+      expect(current_example.metadata[:flaky_spec][:retry_attempts]).to eq(nil)
+      expect(current_example.metadata[:flaky_spec][:failed_examples]).to eq(nil)
+    end
+  end
+end

--- a/spec/system/flaky_spec/retry_spec.rb
+++ b/spec/system/flaky_spec/retry_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+# rubocop:disable RSpec/BeforeAfterAll
+
+RSpec.describe "Testing FlakySpec::Retry on system tests" do
+  def set_expectations(expectations)
+    @expectations = expectations
+  end
+
+  def shift_expectation
+    @expectations.shift
+  end
+
+  def reset_expectations
+    @expectations = nil
+  end
+
+  def count
+    @count ||= 0
+  end
+
+  def count_up
+    @count ||= 0
+    @count += 1
+  end
+
+  def reset_count
+    @count = 0
+  end
+
+  _previous_example = nil
+
+  context "when test fails 2 times before passing on third try", order: :defined do
+    before(:all) { set_expectations(["not ok", "not ok", "ok"]) }
+
+    before { count_up }
+
+    after(:all) do
+      reset_expectations
+      reset_count
+      _previous_example = nil
+    end
+
+    it "should retry the example 2 times", type: :system, flaky_spec_retry: true do
+      visit("/srv/status")
+
+      expect(page).to have_content(shift_expectation)
+      expect(count).to eq(3)
+
+      _previous_example = RSpec.current_example
+    end
+
+    it "should store the right failure details in metadata of the flaky example" do
+      expect(_previous_example.metadata[:flaky_spec][:retry_attempts]).to eq(2)
+      expect(_previous_example.metadata[:flaky_spec][:failed_examples].size).to eq(2)
+
+      _previous_example.metadata[:flaky_spec][:failed_examples].each do |failed_example|
+        expect(failed_example[:message_lines]).to include(<<~OUTPUT.chomp)
+        Failure/Error: expect(page).to have_content(shift_expectation)
+          expected to find text "not ok" in "ok"
+        OUTPUT
+
+        expect(failed_example[:description]).to eq(
+          "Testing FlakySpec::Retry on system tests when test fails 2 times before passing on third try should retry the example 2 times",
+        )
+
+        expect(failed_example[:backtrace]).to be_present
+
+        expect(failed_example[:failure_screenshot_path]).to match(
+          %r{tmp/capybara/failures_r_spec_example_groups_testing_flaky_spec_retry_on_system_tests_when_test_fails2_times_before_passing_on_third_try_should_retry_the_example_2_times_(\d+).png},
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What motivated this change?

Our builds on Github actions have been extremely flaky mostly due to system tests. This has led to a drop in confidence
in our test suite where our developers tend to assume that a failed job is due to a flaky system test. As a result, we
have had instances where changes that resulted in legit test failures are merged into the `main` branch because developers
assumed it was a flaky test when it wasn't.

### What does this change do?

This change seeks to reduce the flakiness of our builds on Github Actions by automatically re-running system tests when
they fail. At the time of writing, we have configured system tests to automatically re-run for up to 2 times. Since
automatically re-running the tests is sweeping the problem under the rug temporarily, this change introduces the
`FlakySpec::Listener` class which will log the flaky tests to a file on disk which is then stored as an artifact for the
Github run. While we understand that automatic re-runs may lead to lower accuracy of our system tests, we accept this as
an acceptable trade-offs since a fragile build has a much greater impact on our developers' time.

### How is the change implemented?

Firstly, a `FlakySpec::Retry` class is introduced and it is mostly inspired by the https://github.com/NoRedInk/rspec-retry
gem which at the time of writing has entered maintenance mode. The gem also did not completely fit our use case so I
decided to just port the core logic instead of relying on the gem.

The `FlakySpec::Retry` class is quite simple and basically does the
following:

1. Exposes a `.run` API which accepts an instance of `RSpec::Core::Example::Procsy` and a kwarg `retry_count`. This allows
   us to hook into each example run like so:

   ```
   config.around(:each, type: :system) do |example|
     FlakySpec::Retry.run(example, retry_count: flaky_spec_retry_count)
   end
   ```

2. In the `FlakySpec::Retry#run` method, we basically run the example and  if it fails, we re-run it up to configured
   `retry_count` times. Each time the example fails, we store details about the failures in the `metadata` of the example.
   See `FlakySpec::FailedExample#to_h` for the details of the metadata that is stored.

Secondly, we register the `FlakySpec::Listener` as a custom RSpec listener. The listener mainly listens to
the `example_passed` event and checks if the passed example has had multiple re-run attempts given by the `retry_attempts`
metadata that is stored. If the passed example has had multiple re-run attempts, that test is considered flaky and the
failure details that has been stored in the example's metadata is logged to disk.

Once stuff has been logged to disk, it is uploaded as an artifact on Github as part of the workflow run. We intend to build
an external service which will fetch those artifacts from Github and analyze them in the near future.