### PR TITLE
DEV: Remove GitHub gjs highlighting workaround

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,7 +27,3 @@
 *.PDF  diff=astextplain
 *.rtf  diff=astextplain
 *.RTF  diff=astextplain
-
-# Ember App
-*.gjs linguist-language=js linguist-detectable
-*.gts linguist-language=ts linguist-detectable


### PR DESCRIPTION
Native gjs highlighting just landed, so this override shouldn't be needed any more.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
