### PR TITLE
UX: login modal sizing fixes

### DIFF
--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -10,6 +10,7 @@
   .d-modal {
     &__container {
       position: relative;
+      width: max-content;
     }
     &__header {
       border-bottom: none;
@@ -41,6 +42,7 @@
   }
 
   .login-left-side {
+    width: 100%;
     padding: 3rem;
     overflow: auto;
   }
@@ -75,6 +77,7 @@
     justify-content: center;
     gap: 1rem;
     height: 100%;
+    white-space: nowrap;
   }
 
   #login-form {

--- a/app/assets/stylesheets/mobile/login-modal.scss
+++ b/app/assets/stylesheets/mobile/login-modal.scss
@@ -2,6 +2,9 @@
   .d-modal.login-modal,
   .d-modal.create-account {
     .d-modal {
+      &__container {
+        width: 100%;
+      }
       &__body {
         flex-direction: column;
         gap: unset;


### PR DESCRIPTION
The login modal was wrongly sized when there are no social logins present. No idea how these bugs slipped through the refactor but should be fixed now.

## before:
![image](https://github.com/discourse/discourse/assets/101828855/90c033b6-a668-4bb0-a5e2-66a90a9857af)

## After:
### with social logins
<img width="1032" alt="image" src="https://github.com/discourse/discourse/assets/101828855/7136f48b-0944-471c-ba91-1eeb9ba661e9">
<img width="1018" alt="image" src="https://github.com/discourse/discourse/assets/101828855/fbf6a2b6-6aff-4b68-85f9-e99c7a04da7a">


### without social logins
<img width="1015" alt="image" src="https://github.com/discourse/discourse/assets/101828855/80b67fa7-9901-4c76-bec5-5c1ff256f0bd">
<img width="1022" alt="image" src="https://github.com/discourse/discourse/assets/101828855/61b79f77-0ebd-4542-926a-217159e07cfe">

