### PR TITLE
DEV: Update before-header-panel outlet arguments

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/before-header-panel-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/before-header-panel-outlet.js
@@ -4,5 +4,5 @@ import { registerWidgetShim } from "discourse/widgets/render-glimmer";
 registerWidgetShim(
   "before-header-panel-outlet",
   "div.before-header-panel-outlet",
-  hbs`<PluginOutlet @name="before-header-panel" @outletArgs={{hash attrs=@data}} /> `
+  hbs`<PluginOutlet @name="before-header-panel" @outletArgs={{hash topic=@data.topic}} /> `
 );


### PR DESCRIPTION
Passing through `attrs` is problematic for a few reasons:

1. Connectors could mutate it and cause issues in the parent widget

2. It doesn't provide a clean API boundary. The connector can access all attrs of the widget. As we move towards refactoring the header away from widgets, this may change. Better to explicitly call out the things we expect plugins/themes to access

3. `attrs` is a reserved property for classic components. Passing an argument called `attrs` into a classic component raises a 'computed property override' deprecation error under Ember 3.28, and causes an error in Ember 4+.

Unfortunately this will be a breaking change to the outlet. Fortunately, it was introduced fairly recently and does not have too many users. We will make immediate updates to themes/plugins we are aware of.

Followup to 9cc2b5cc20c9dba826b9bb13dbbe742b691bdc15

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
