### PR TITLE
DEV: Drop chat_mention.notification_id column

### DIFF
--- a/plugins/chat/app/models/chat/mention.rb
+++ b/plugins/chat/app/models/chat/mention.rb
@@ -20,7 +20,6 @@ end
 #  id              :bigint           not null, primary key
 #  chat_message_id :integer          not null
 #  user_id         :integer
-#  notification_id :integer          not null
 #  target_id       :integer
 #  type            :integer          not null
 #  created_at      :datetime         not null

--- a/plugins/chat/db/post_migrate/20240408140000_drop_notification_id_from_chat_mentions.rb
+++ b/plugins/chat/db/post_migrate/20240408140000_drop_notification_id_from_chat_mentions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropNotificationIdFromChatMentions < ActiveRecord::Migration[7.0]
+  DROPPED_COLUMNS ||= { chat_mentions: %i[notification_id] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We ignore this column since fbd24fa6.
