### PR TITLE
UX: Ensure wizard previews display at correct width

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -93,11 +93,8 @@ body.wizard {
     }
 
     &.styling {
-      max-width: 85%;
-
-      @include breakpoint("mobile-extra-large") {
-        max-width: 100%;
-      }
+      max-width: 100%;
+      width: auto;
     }
   }
 
@@ -161,16 +158,9 @@ body.wizard {
     display: block;
   }
 
-  &__field.component-styling-preview {
-    display: inline;
-    @media only screen and (max-device-width: 568px) {
-      display: none;
-    }
-  }
-
   &__field.text-governing-law,
   &__field.text-city-for-disputes {
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       display: none;
     }
   }
@@ -184,7 +174,7 @@ body.wizard {
     box-sizing: border-box;
     margin-right: 1em;
 
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 925px) {
       width: 80%;
       margin-left: auto;
       margin-right: auto;
@@ -193,11 +183,11 @@ body.wizard {
     + .wizard-container__fields {
       padding: 1em;
       background: var(--primary-very-low);
-      width: calc(100% - 170px);
+      width: auto;
       border-radius: 0.5em;
       margin-top: -1em;
 
-      @media only screen and (max-device-width: 568px) {
+      @media only screen and (max-width: 925px) {
         display: none;
       }
     }
@@ -229,7 +219,7 @@ body.wizard {
   .previews {
     position: relative;
     height: 320px;
-    width: 100%;
+    width: 628px;
     overflow: hidden;
     background: var(--secondary);
     border-radius: 10px;
@@ -285,7 +275,7 @@ body.wizard {
 
   &__step-form {
     flex: 1 0 50%;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       width: 100%;
     }
   }
@@ -323,7 +313,7 @@ body.wizard {
   &__step-text {
     display: inline;
     margin-right: 0.25em;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       display: none;
     }
   }
@@ -539,7 +529,7 @@ body.wizard {
       margin: 0;
     }
 
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       font-size: var(--font-0);
     }
   }
@@ -548,7 +538,7 @@ body.wizard {
     color: var(--primary-high);
     font-size: var(--font-up-1);
     margin: 0.25em 0 0.5em 3.5em;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       margin-left: 2em;
     }
   }
@@ -596,7 +586,7 @@ body.wizard {
     position: relative;
     vertical-align: middle;
     transition: background 0.25s;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       height: 20px;
       width: 35px;
     }
@@ -613,7 +603,7 @@ body.wizard {
     color: var(--secondary);
     top: 4px;
     left: 9px;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       top: 3px;
       left: 5px;
       font-size: var(--font-down-3);
@@ -628,7 +618,7 @@ body.wizard {
     top: 4px;
     left: 4px;
     transition: left 0.25s;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       height: 12px;
       width: 12px;
     }
@@ -644,7 +634,7 @@ body.wizard {
   }
   &__checkbox:checked + .wizard-container__checkbox-slider:before {
     left: 26px;
-    @media only screen and (max-device-width: 568px) {
+    @media only screen and (max-width: 568px) {
       left: 20px;
     }
   }


### PR DESCRIPTION
Also fixes breakpoints to use `max-width` instead of `max-device-width`. We should only care about the browser width, not the actual device's screen.

Before:

<img width="500" alt="SCR-20231208-qrms" src="https://github.com/discourse/discourse/assets/6270921/923b40fd-64e5-4ad2-be15-9cddc1a24488">

<img width="200" alt="SCR-20231208-qroe" src="https://github.com/discourse/discourse/assets/6270921/4d0757ae-4a7b-4392-9416-599bbced37c6">


After:

<img width="500" alt="SCR-20231208-qrjn" src="https://github.com/discourse/discourse/assets/6270921/c0e497ba-ffdc-4301-b25c-eead3cf756b7">

<img width="200" alt="SCR-20231208-qrkq" src="https://github.com/discourse/discourse/assets/6270921/04c3fbd8-4a6f-4372-a07c-2e28d68ed4d6">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
