### PR TITLE
FIX: Reload page after adding 2FA when it is enforced

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/second-factor-add-security-key.js
+++ b/app/assets/javascripts/discourse/app/components/modal/second-factor-add-security-key.js
@@ -130,6 +130,9 @@ export default class SecondFactorAddSecurityKey extends Component {
               this.args.model.markDirty();
               this.errorMessage = null;
               this.args.closeModal();
+              if (this.args.model.enforcedSecondFactor) {
+                window.location.reload();
+              }
             })
             .catch((error) => this.args.model.onError(error))
             .finally(() => (this.loading = false));

--- a/app/assets/javascripts/discourse/app/components/modal/second-factor-add-totp.js
+++ b/app/assets/javascripts/discourse/app/components/modal/second-factor-add-totp.js
@@ -61,6 +61,9 @@ export default class SecondFactorAddTotp extends Component {
         this.args.model.markDirty();
         this.errorMessage = null;
         this.args.closeModal();
+        if (this.args.model.enforcedSecondFactor) {
+          window.location.reload();
+        }
       })
       .catch((error) => this.args.model.onError(error))
       .finally(() => (this.loading = false));

--- a/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
@@ -53,6 +53,7 @@ export default Controller.extend(CanCheckEmails, {
       await this.modal.show(SecondFactorAddTotp, {
         model: {
           secondFactor: this.model,
+          enforcedSecondFactor: this.currentUser.enforcedSecondFactor,
           markDirty: () => this.markDirty(),
           onError: (e) => this.handleError(e),
         },
@@ -68,6 +69,7 @@ export default Controller.extend(CanCheckEmails, {
       await this.modal.show(SecondFactorAddSecurityKey, {
         model: {
           secondFactor: this.model,
+          enforcedSecondFactor: this.currentUser.enforcedSecondFactor,
           markDirty: this.markDirty,
           onError: this.handleError,
         },


### PR DESCRIPTION
When 2FA is enforced and the user has no key or TOTP on their account, we block navigating away from the page until they have added one. However, we don't reload the page after they have added one, so the user is left with a page that still says they need to add 2FA.