### PR TITLE
UX: prevent chat count from getting squished

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
@@ -79,6 +79,7 @@
       padding: 0;
       font-size: var(--font-up-1);
       justify-content: center;
+      flex-shrink: 0;
     }
 
     &__avatar {


### PR DESCRIPTION
Reported on meta
https://meta.discourse.org/t/long-dm-group-titles-cause-squished-icons/288031

Needed a flex-shrink to prevent this.
