### PR TITLE
UX: fix icon colour on signup CTA

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1450,6 +1450,11 @@ span.mention {
     .btn {
       margin-right: 0.5em;
       white-space: nowrap;
+
+      .d-icon {
+        color: inherit;
+      }
+
       &.btn-remind {
         background: var(--primary-very-low);
         margin-right: auto;


### PR DESCRIPTION
Icon is not appearing on signup button due to a hierarchy colour issue

<img width="637" alt="image" src="https://github.com/discourse/discourse/assets/101828855/e4235341-2f1e-4059-ba25-9299a3147f59">

