### PR TITLE
DEV: Identify errors/deprecations triggered by browser extensions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/source-identifier.js
+++ b/app/assets/javascripts/discourse/app/lib/source-identifier.js
@@ -2,6 +2,12 @@ import DEBUG from "@glimmer/env";
 import PreloadStore from "discourse/lib/preload-store";
 import getURL from "discourse-common/lib/get-url";
 
+const BROWSER_EXTENSION_PROTOCOLS = [
+  "moz-extension://",
+  "chrome-extension://",
+  "webkit-masked-url://",
+];
+
 export default function identifySource(error) {
   if (!error || !error.stack) {
     try {
@@ -21,6 +27,12 @@ export default function identifySource(error) {
     /^.*discourse-deprecation-collector.*$/gm,
     ""
   );
+
+  if (BROWSER_EXTENSION_PROTOCOLS.any((p) => stack.includes(p))) {
+    return {
+      type: "browser-extension",
+    };
+  }
 
   const themeMatches = stack.match(/\/theme-javascripts\/[\w-]+\.js/g) || [];
 
@@ -72,6 +84,8 @@ export function consolePrefix(error, source) {
     return `[THEME ${source.id} '${source.name}']`;
   } else if (source && source.type === "plugin") {
     return `[PLUGIN ${source.name}]`;
+  } else if (source && source.type === "browser-extension") {
+    return "[BROWSER EXTENSION]";
   }
 
   return "";


### PR DESCRIPTION
It's possible for browser extensions to trigger JS errors and deprecation warnings. That can lead to significant confusion and noise in our logs/metrics. One recent example we've identified is the 'Wappalyzer' extension triggering the `ember-global` deprecation.

This commit will clearly identify these errors/deprecations with a `[BROWSER EXTENSION]` prefix in the console.

<img width="943" alt="SCR-20231211-mimt" src="https://github.com/discourse/discourse/assets/6270921/ba8be903-3a30-4fee-8130-2f5a0168803c">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
