### PR TITLE
FIX: allow to click on thread indicator

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-thread-indicator.gjs
@@ -27,10 +27,6 @@ export default class ChatMessageThreadIndicator extends Component {
     return this.args.interactiveUser ?? true;
   }
 
-  get interactiveThread() {
-    return this.args.interactiveThread ?? true;
-  }
-
   @action
   setup(element) {
     this.element = element;
@@ -46,15 +42,13 @@ export default class ChatMessageThreadIndicator extends Component {
       this.element.addEventListener("touchCancel", this.cancelTouch);
     }
 
-    if (this.interactiveThread) {
-      this.element.addEventListener("mousedown", this.openThread, {
-        passive: true,
-      });
+    this.element.addEventListener("mousedown", this.openThread, {
+      passive: true,
+    });
 
-      this.element.addEventListener("keydown", this.openThread, {
-        passive: true,
-      });
-    }
+    this.element.addEventListener("keydown", this.openThread, {
+      passive: true,
+    });
   }
 
   @action
@@ -70,15 +64,13 @@ export default class ChatMessageThreadIndicator extends Component {
       this.element.removeEventListener("touchCancel", this.cancelTouch);
     }
 
-    if (this.interactiveThread) {
-      this.element.removeEventListener("mousedown", this.openThread, {
-        passive: true,
-      });
+    this.element.removeEventListener("mousedown", this.openThread, {
+      passive: true,
+    });
 
-      this.element.removeEventListener("keydown", this.openThread, {
-        passive: true,
-      });
-    }
+    this.element.removeEventListener("keydown", this.openThread, {
+      passive: true,
+    });
   }
 
   @bind
@@ -142,7 +134,8 @@ export default class ChatMessageThreadIndicator extends Component {
       {{willDestroy this.teardown}}
       role="button"
       title={{i18n "chat.threads.open"}}
-      tabindex={{if this.interactiveThread "0" "-1"}}
+      tabindex="0"
+      ...attributes
     >
 
       <div class="chat-message-thread-indicator__last-reply-avatar">

--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -89,6 +89,7 @@ export default class UserThreads extends Component {
                   @message={{thread.originalMessage}}
                   @interactiveUser={{false}}
                   @interactiveThread={{false}}
+                  tabindex="-1"
                 />
               </div>
             </div>


### PR DESCRIPTION
We can also now control tabindex, and other html attributes, which allows to lick on the thread indicator but not tab to it for example.

By default the tabindex will be 0.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
