### PR TITLE
FIX: ensures side panel is closed

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-threads.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-threads.js
@@ -3,8 +3,10 @@ import DiscourseRoute from "discourse/routes/discourse";
 
 export default class ChatChannelThreads extends DiscourseRoute {
   @service chat;
+  @service chatStateManager;
 
   activate() {
     this.chat.activeChannel = null;
+    this.chatStateManager.closeSidePanel();
   }
 }


### PR DESCRIPTION
When navigating to /chat/threads we were not closing the side panel. It would not show as the route doesn't support it, but after if we would open a channel from the sidebar it would open the channel with an empty opened sidepanel .

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
