### PR TITLE
FIX: Resolve computed property override when inviting to PM

### DIFF
--- a/app/assets/javascripts/discourse/app/components/invite-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-panel.js
@@ -267,8 +267,11 @@ export default Component.extend({
     }
   },
 
-  @discourseComputed("isPM")
-  errorMessage(isPM) {
+  @discourseComputed("isPM", "ajaxError")
+  errorMessage(isPM, ajaxError) {
+    if (ajaxError) {
+      return ajaxError;
+    }
     return isPM
       ? I18n.t("topic.invite_private.error")
       : I18n.t("topic.invite_reply.error");
@@ -326,14 +329,9 @@ export default Component.extend({
 
     const onerror = (e) => {
       if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
-        this.set("errorMessage", e.jqXHR.responseJSON.errors[0]);
+        this.set("ajaxError", e.jqXHR.responseJSON.errors[0]);
       } else {
-        this.set(
-          "errorMessage",
-          this.isPM
-            ? I18n.t("topic.invite_private.error")
-            : I18n.t("topic.invite_reply.error")
-        );
+        this.set("ajaxError", null);
       }
       model.setProperties({ saving: false, error: true });
     };
@@ -397,14 +395,9 @@ export default Component.extend({
       })
       .catch((e) => {
         if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
-          this.set("errorMessage", e.jqXHR.responseJSON.errors[0]);
+          this.set("ajaxError", e.jqXHR.responseJSON.errors[0]);
         } else {
-          this.set(
-            "errorMessage",
-            this.isPM
-              ? I18n.t("topic.invite_private.error")
-              : I18n.t("topic.invite_reply.error")
-          );
+          this.set("ajaxError", null);
         }
         model.setProperties({ saving: false, error: true });
       });

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -13,6 +13,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "discourse-i18n";
+import selectKit from "../helpers/select-kit-helper";
 
 acceptance("Personal Message", function (needs) {
   needs.user();
@@ -75,8 +76,19 @@ acceptance("Personal Message (regular user)", function (needs) {
 
 acceptance("Personal Message - invite", function (needs) {
   needs.user();
+  needs.pretender((server, helper) => {
+    server.get("/u/search/users", () =>
+      helper.response({ users: [{ username: "example" }] })
+    );
 
-  test("suggested messages", async function (assert) {
+    server.post("/t/12/invite", () =>
+      helper.response(422, {
+        errors: ["Some validation error"],
+      })
+    );
+  });
+
+  test("can open invite modal", async function (assert) {
     await visit("/t/pm-for-testing/12");
     await click(".add-remove-participant-btn");
     await click(".private-message-map .controls .add-participant-btn");
@@ -84,5 +96,24 @@ acceptance("Personal Message - invite", function (needs) {
     assert
       .dom(".d-modal.add-pm-participants .invite-user-control")
       .exists("invite modal is displayed");
+  });
+
+  test("shows errors correctly", async function (assert) {
+    await visit("/t/pm-for-testing/12");
+    await click(".add-remove-participant-btn");
+    await click(".private-message-map .controls .add-participant-btn");
+
+    assert
+      .dom(".d-modal.add-pm-participants .invite-user-control")
+      .exists("invite modal is displayed");
+
+    const input = selectKit(".invite-user-input");
+    await input.expand();
+    await input.fillInFilter("example");
+    await input.selectRowByValue("example");
+
+    await click(".send-invite");
+
+    assert.dom(".d-modal.add-pm-participants .alert-error").exists();
   });
 });


### PR DESCRIPTION
When inviting failed, a deprecation was being raised under Ember 3, and an error under Ember 4+

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
