### PR TITLE
FIX: Color of notification icons in user-notifications index

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -79,6 +79,9 @@
       a {
         align-items: center;
       }
+      .d-icon {
+        color: var(--primary-medium);
+      }
       .relative-date {
         margin-left: auto;
         padding-top: 0;


### PR DESCRIPTION
The heart icon is colored when it shouldn't be.

![Screenshot 2023-12-11 at 11 32 58 AM](https://github.com/discourse/discourse/assets/16214023/6139bc3e-be82-4da2-8a4a-5a4781a7c3fa)
