### PR TITLE
DEV: Introduce plugin API for getting stats

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -75,7 +75,7 @@ class Plugin::Instance
   end
 
   # This method returns Core stats + stats registered by plugins
-  def self.get_stats
+  def self.stats
     Stat.all_stats
   end
 

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -74,6 +74,11 @@ class Plugin::Instance
     @seed_fu_filter = filter
   end
 
+  # This method returns Core stats + stats registered by plugins
+  def self.get_stats
+    Stat.all_stats
+  end
+
   def self.find_all(parent_path)
     [].tap do |plugins|
       # also follows symlinks - http://stackoverflow.com/q/357754

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -28,6 +28,54 @@ RSpec.describe Plugin::Instance do
     end
   end
 
+  describe "get_stats" do
+    after { DiscoursePluginRegistry.reset! }
+
+    it "returns core stats" do
+      stats = Plugin::Instance.get_stats
+      expect(stats.keys).to contain_exactly(
+        :topics_last_day,
+        :topics_7_days,
+        :topics_30_days,
+        :topics_count,
+        :posts_last_day,
+        :posts_7_days,
+        :posts_30_days,
+        :posts_count,
+        :users_last_day,
+        :users_7_days,
+        :users_30_days,
+        :users_count,
+        :active_users_last_day,
+        :active_users_7_days,
+        :active_users_30_days,
+        :likes_last_day,
+        :likes_7_days,
+        :likes_30_days,
+        :likes_count,
+      )
+    end
+
+    it "returns stats registered by plugins" do
+      plugin = Plugin::Instance.new
+      stats_name = "plugin_stats"
+      plugin.register_stat(stats_name) do
+        { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
+      end
+
+      stats = Plugin::Instance.get_stats
+
+      expect(stats.with_indifferent_access).to match(
+        hash_including(
+          "#{stats_name}_last_day": 1,
+          "#{stats_name}_7_days": 10,
+          "#{stats_name}_30_days": 100,
+          "#{stats_name}_count": 1000,
+        ),
+      )
+    end
+  end
+
   describe "git repo details" do
     describe ".discourse_owned?" do
       it "returns true if the plugin is on github in discourse-org or discourse orgs" do

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe Plugin::Instance do
     end
   end
 
-  describe "get_stats" do
+  describe "stats" do
     after { DiscoursePluginRegistry.reset! }
 
     it "returns core stats" do
-      stats = Plugin::Instance.get_stats
+      stats = Plugin::Instance.stats
       expect(stats.keys).to contain_exactly(
         :topics_last_day,
         :topics_7_days,
@@ -63,7 +63,7 @@ RSpec.describe Plugin::Instance do
         { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
       end
 
-      stats = Plugin::Instance.get_stats
+      stats = Plugin::Instance.stats
 
       expect(stats.with_indifferent_access).to match(
         hash_including(


### PR DESCRIPTION
Before, when needed to get stats in a plugin, we called Core classes directly. Introducing plugin API will decouple plugins from Core and give as more freedom in refactoring stats in Core. Without this API, I wasn't able to do all refactorings I wanted when working on d91456fd.