### PR TITLE
DEV: Redirect on trailing slash for category and tag pages

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -416,6 +416,7 @@ class ListController < ApplicationController
 
       return redirect_to path(url), status: 301
     end
+    return redirect_to path(request.fullpath), status: 301 if request.original_url.end_with? "/"
 
     @description_meta =
       if @category.uncategorized?

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -142,6 +142,10 @@ class TagsController < ::ApplicationController
 
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
+      if request.original_url.end_with? "/"
+        redirect_to(request.fullpath, status: :moved_permanently)
+        return
+      end
       @tag_id = params[:tag_id].force_encoding("UTF-8")
       @additional_tags =
         params[:additional_tag_ids].to_s.split("/").map { |t| t.force_encoding("UTF-8") }

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1082,6 +1082,15 @@ RSpec.describe ListController do
         )
       end
     end
+
+    context "with trailing slash" do
+      it "redirects to URL without trailing slash" do
+        get "/c/#{category.slug}/#{category.id}/"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/c/#{category.slug}/#{category.id}")
+      end
+    end
   end
 
   describe "shared drafts" do

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1087,7 +1087,7 @@ RSpec.describe ListController do
       it "redirects to URL without trailing slash" do
         get "/c/#{category.slug}/#{category.id}/"
 
-        expect(response).to have_http_status(301)
+        expect(response).to have_http_status :moved_permanently
         expect(response).to redirect_to("/c/#{category.slug}/#{category.id}")
       end
     end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -900,7 +900,7 @@ RSpec.describe TagsController do
       it "redirects to URL without trailing slash" do
         get "/tag/#{tag.name}/"
 
-        expect(response).to have_http_status(301)
+        expect(response).to have_http_status :moved_permanently
         expect(response).to redirect_to("/tag/#{tag.name}")
       end
     end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -895,6 +895,15 @@ RSpec.describe TagsController do
         end
       end
     end
+
+    context "with trailing slash" do
+      it "redirects to URL without trailing slash" do
+        get "/tag/#{tag.name}/"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/tag/#{tag.name}")
+      end
+    end
   end
 
   describe "#show_top" do


### PR DESCRIPTION
Both https://meta.discourse.org/c/bug/1/ and https://meta.discourse.org/c/bug/1 work.

This gives our SEO friends some headaches.

This PR redirects 
- https://meta.discourse.org/c/bug/1/ to https://meta.discourse.org/c/bug/1, and 
- https://meta.discourse.org/tag/email/ to https://meta.discourse.org/tag/email.