### PR TITLE
DEV: Partially revert 5b91dc184418000adaabf0dfe64eebbd8233d6ec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -388,8 +388,7 @@ RSpec.configure do |config|
           options.add_preference("download.default_directory", Downloads::FOLDER)
         end
 
-    client = Selenium::WebDriver::Remote::Http::Default.new(read_timeout: BROWSER_READ_TIMEOUT)
-    driver_options = { browser: :chrome, http_client: client }
+    driver_options = { browser: :chrome }
 
     if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
       driver_options[:browser] = :remote


### PR DESCRIPTION
Why this change?

The code changes introduced in 5b91dc184418000adaabf0dfe64eebbd8233d6ec
resulted in errors being raised when `session.quit` is called when using
multiple sessions. From my debugging, this seems to be attributed to the
fact that the change introduced resulted in multiple sessions sharing
the same instance of `Selenium::WebDriver::Remote::Http::Default`. While
sharing the same instance in theory should be fine, but the problem is
that [`Selenium::WebDriver::Driver` will mutate the `server_url`](https://github.com/SeleniumHQ/selenium/blob/82f7cf7a3a47db1497badd964d7f918d11e4e11a/rb/lib/selenium/webdriver/remote/bridge.rb#L43-L44) of the
client in `Selenium::WebDriver::Remote::Bridge`. This is problematic
because each session created by capybara relies on a different server
URL and this mutation causes all sorts of weird errors to occur.

To reproduce the problem, run `LOAD_PLUGINS=1 rspec plugins/chat/spec/system/send_message_spec.rb:76`
locally while excluding the changes in this commit.