### PR TITLE
FIX: Sort plugin list by name properly

### DIFF
--- a/app/controllers/admin/plugins_controller.rb
+++ b/app/controllers/admin/plugins_controller.rb
@@ -3,7 +3,7 @@
 class Admin::PluginsController < Admin::StaffController
   def index
     render_serialized(
-      Discourse.visible_plugins.sort_by { |p| p.name.downcase.gsub("discourse-", "") },
+      Discourse.visible_plugins.sort_by { |p| p.name.downcase.delete_prefix("discourse-") },
       AdminPluginSerializer,
       root: "plugins",
     )

--- a/app/controllers/admin/plugins_controller.rb
+++ b/app/controllers/admin/plugins_controller.rb
@@ -2,6 +2,10 @@
 
 class Admin::PluginsController < Admin::StaffController
   def index
-    render_serialized(Discourse.visible_plugins, AdminPluginSerializer, root: "plugins")
+    render_serialized(
+      Discourse.visible_plugins.sort_by { |p| p.name.downcase.gsub("discourse-", "") },
+      AdminPluginSerializer,
+      root: "plugins",
+    )
   end
 end


### PR DESCRIPTION
Some plugins have discourse- prefixed on their name
and some don't, so sorting in the list was inconsistent.
