### PR TITLE
DEV: Re-enable browser read timeout in specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -388,7 +388,7 @@ RSpec.configure do |config|
           options.add_preference("download.default_directory", Downloads::FOLDER)
         end
 
-    driver_options = { browser: :chrome }
+    driver_options = { browser: :chrome, timeout: BROWSER_READ_TIMEOUT }
 
     if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
       driver_options[:browser] = :remote


### PR DESCRIPTION
Turns out there's an easier (and properly working) way to do this!

See: https://github.com/teamcapybara/capybara/blob/52eaecea6d154b7d664b0032cd1cbcad4788fe65/lib/capybara/selenium/driver.rb#L68C42-L68C42

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
