### PR TITLE
UX: prevent header buttons from wrapping text

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -101,6 +101,7 @@
     display: flex;
     align-items: center;
     margin-top: 0.2em;
+    white-space: nowrap;
   }
 
   .login-button,


### PR DESCRIPTION
Preventing this
https://meta.discourse.org/t/login-signup-button-change-shape-when-sidebar-hidden/286420?u=chapoi

