### PR TITLE
DEV: Improve browser-update compatibility

### DIFF
--- a/app/assets/javascripts/discourse/scripts/browser-update.js
+++ b/app/assets/javascripts/discourse/scripts/browser-update.js
@@ -45,8 +45,8 @@
     }
 
     // retrieve localized browser upgrade text
-    var t = I18n.t("browser_update"); // eslint-disable-line no-undef
-    if (t.indexOf(".browser_update]") !== -1) {
+    var t = window.I18n && I18n.t("browser_update"); // eslint-disable-line no-undef
+    if (!t || t.indexOf(".browser_update]") !== -1) {
       // very old browsers might fail to load even translations
       t =
         'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is unsupported</a>. Please <a href="https://browsehappy.com">switch to a supported browser</a> to view rich content, log in and reply.';


### PR DESCRIPTION
Now that we're using native `import()`, our main JS bundles might not even be parse-able by older browsers. In that case, `I18n` will never be defined, and so we need to account for that situation in the browser-update code.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
