### PR TITLE
FEATURE: change /invites.json api endpoint to optionally accept array of emails

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -38,6 +38,13 @@ class InvitesController < ApplicationController
   end
 
   def create
+    multiple_requests = (params[:email] and params[:email].kind_of?(Array))
+    multiple_requests ? create_many : create_one(params[:email])
+  end
+
+  def create_many
+    emails = params[:email]
+    # validate that topics and groups can accept invites.
     if params[:topic_id].present?
       topic = Topic.find_by(id: params[:topic_id])
       raise Discourse::InvalidParameters.new(:topic_id) if topic.blank?
@@ -49,7 +56,6 @@ class InvitesController < ApplicationController
     end
 
     guardian.ensure_can_invite_to_forum!(groups)
-
     if !groups_can_see_topic?(groups, topic)
       editable_topic_groups = topic.category.groups.filter { |g| guardian.can_edit_group?(g) }
       return(
@@ -58,38 +64,97 @@ class InvitesController < ApplicationController
         )
       )
     end
-
-    invite =
-      Invite.generate(
-        current_user,
-        email: params[:email],
-        domain: params[:domain],
-        skip_email: params[:skip_email],
-        invited_by: current_user,
-        custom_message: params[:custom_message],
-        max_redemptions_allowed: params[:max_redemptions_allowed],
-        topic_id: topic&.id,
-        group_ids: groups&.map(&:id),
-        expires_at: params[:expires_at],
-        invite_to_topic: params[:invite_to_topic],
-      )
-
-    if invite.present?
-      render_serialized(
-        invite,
-        InviteSerializer,
-        scope: guardian,
-        root: nil,
-        show_emails: params.has_key?(:email),
-        show_warnings: true,
-      )
-    else
-      render json: failed_json, status: 422
+    success = []
+    fail = []
+    emails.map do |email|
+      begin
+        invite =
+          Invite.generate(
+            current_user,
+            email: email,
+            domain: params[:domain],
+            skip_email: params[:skip_email],
+            invited_by: current_user,
+            custom_message: params["custom_message"],
+            max_redemptions_allowed: params[:max_redemptions_allowed],
+            topic_id: topic&.id,
+            group_ids: groups&.map(&:id),
+            expires_at: params[:expires_at],
+            invite_to_topic: params[:invite_to_topic],
+          )
+        success.push({ email: email, invite: invite }) if invite
+      rescue Invite::UserExists => e
+        fail.push({ email: email, error: e.message })
+      rescue ActiveRecord::RecordInvalid => e
+        fail.push({ email: email, error: e.record.errors.full_messages.first })
+      end
     end
-  rescue Invite::UserExists => e
-    render_json_error(e.message)
-  rescue ActiveRecord::RecordInvalid => e
-    render_json_error(e.record.errors.full_messages.first)
+
+    render json: {
+             num_successfully_created_invitations: success.length,
+             num_failed_invitations: fail.length,
+             failed_invitations: fail,
+             successful_invitations:
+               success.map do |s| InviteSerializer.new(s[:invite], scope: guardian) end,
+           }
+  end
+
+  def create_one(email)
+    begin
+      if params[:topic_id].present?
+        topic = Topic.find_by(id: params[:topic_id])
+        raise Discourse::InvalidParameters.new(:topic_id) if topic.blank?
+        guardian.ensure_can_invite_to!(topic)
+      end
+
+      if params[:group_ids].present? || params[:group_names].present?
+        groups =
+          Group.lookup_groups(group_ids: params[:group_ids], group_names: params[:group_names])
+      end
+
+      guardian.ensure_can_invite_to_forum!(groups)
+
+      if !groups_can_see_topic?(groups, topic)
+        editable_topic_groups = topic.category.groups.filter { |g| guardian.can_edit_group?(g) }
+        return(
+          render_json_error(
+            I18n.t("invite.requires_groups", groups: editable_topic_groups.pluck(:name).join(", ")),
+          )
+        )
+      end
+
+      invite =
+        Invite.generate(
+          current_user,
+          email: email,
+          domain: params[:domain],
+          skip_email: params[:skip_email],
+          invited_by: current_user,
+          custom_message: params[:custom_message],
+          max_redemptions_allowed: params[:max_redemptions_allowed],
+          topic_id: topic&.id,
+          group_ids: groups&.map(&:id),
+          expires_at: params[:expires_at],
+          invite_to_topic: params[:invite_to_topic],
+        )
+
+      if invite.present?
+        render_serialized(
+          invite,
+          InviteSerializer,
+          scope: guardian,
+          root: nil,
+          show_emails: params.has_key?(:email),
+          show_warnings: true,
+        )
+      else
+        render json: failed_json, status: 422
+      end
+    rescue Invite::UserExists => e
+      render_json_error(e.message)
+    rescue ActiveRecord::RecordInvalid => e
+      render_json_error(e.record.errors.full_messages.first)
+    end
   end
 
   def retrieve

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -37,12 +37,7 @@ class InvitesController < ApplicationController
     render layout: "no_ember"
   end
 
-  def create
-    multiple_requests = (params[:email] and params[:email].kind_of?(Array))
-    multiple_requests ? create_many : create_one(params[:email])
-  end
-
-  def create_many
+  def create_multiple
     emails = params[:email]
     # validate that topics and groups can accept invites.
     if params[:topic_id].present?
@@ -99,7 +94,7 @@ class InvitesController < ApplicationController
            }
   end
 
-  def create_one(email)
+  def create
     begin
       if params[:topic_id].present?
         topic = Topic.find_by(id: params[:topic_id])
@@ -126,7 +121,7 @@ class InvitesController < ApplicationController
       invite =
         Invite.generate(
           current_user,
-          email: email,
+          email: params[:email],
           domain: params[:domain],
           skip_email: params[:skip_email],
           invited_by: current_user,

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -38,6 +38,7 @@ class InvitesController < ApplicationController
   end
 
   def create_multiple
+    guardian.ensure_can_bulk_invite_to_forum!(current_user)
     emails = params[:email]
     # validate that topics and groups can accept invites.
     if params[:topic_id].present?

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -52,6 +52,7 @@ class InvitesController < ApplicationController
     end
 
     guardian.ensure_can_invite_to_forum!(groups)
+
     if !groups_can_see_topic?(groups, topic)
       editable_topic_groups = topic.category.groups.filter { |g| guardian.can_edit_group?(g) }
       return(
@@ -60,8 +61,19 @@ class InvitesController < ApplicationController
         )
       )
     end
+
+    if emails.size > SiteSetting.max_api_invites
+      return(
+        render_json_error(
+          I18n.t("invite.max_invite_emails_limit_exceeded", max: SiteSetting.max_api_invites),
+          422,
+        )
+      )
+    end
+
     success = []
     fail = []
+
     emails.map do |email|
       begin
         invite =

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -297,6 +297,7 @@ en:
       discourse_connect_enabled: "Invites are disabled because DiscourseConnect is enabled."
       invalid_access: "You are not permitted to view the requested resource."
     requires_groups: "Invite was not saved because the specified topic is inaccessible. Add one of the following groups: %{groups}."
+    max_invite_emails_limit_exceeded: "Request failed because number of emails exceeded the maximum (%{max})."
     domain_not_allowed: "Your email cannot be used to redeem this invite."
     max_redemptions_allowed_one: "for email invites should be 1."
     redemption_count_less_than_max: "should be less than %{max_redemptions_allowed}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1432,6 +1432,7 @@ Discourse::Application.routes.draw do
 
     resources :invites, only: %i[create update destroy]
     get "/invites/:id" => "invites#show", :constraints => { format: :html }
+    post "invites/create-multiple" => "invites#create_multiple", :constraints => { format: :json }
 
     post "invites/upload_csv" => "invites#upload_csv"
     post "invites/destroy-all-expired" => "invites#destroy_all_expired"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2706,7 +2706,7 @@ uncategorized:
     hidden: true
 
   max_api_invites:
-      default: 50000
+      default: 5000
       hidden: true
 
   overridden_robots_txt:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2706,7 +2706,7 @@ uncategorized:
     hidden: true
 
   max_api_invites:
-      default: 5000
+      default: 500
       hidden: true
 
   overridden_robots_txt:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2705,6 +2705,10 @@ uncategorized:
     default: 50000
     hidden: true
 
+  max_api_invites:
+      default: 50000
+      hidden: true
+
   overridden_robots_txt:
     default: ""
     hidden: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2706,7 +2706,7 @@ uncategorized:
     hidden: true
 
   max_api_invites:
-      default: 500
+      default: 200
       hidden: true
 
   overridden_robots_txt:

--- a/spec/requests/api/multiple_invites_spec.rb
+++ b/spec/requests/api/multiple_invites_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+require "swagger_helper"
+
+RSpec.describe "multiple invites" do
+  let(:"Api-Key") { Fabricate(:api_key).key }
+  let(:"Api-Username") { "system" }
+
+  path "/invites.json?" do
+    post "Create multiple invites" do
+      tags "Invites"
+      operationId "createMultipleInvites"
+      consumes "application/json"
+      parameter name: "Api-Key", in: :header, type: :string, required: true
+      parameter name: "Api-Username", in: :header, type: :string, required: true
+
+      parameter name: :request_body,
+                in: :body,
+                schema: {
+                  type: :object,
+                  properties: {
+                    email: {
+                      type: :string,
+                      example: %w[not-a-user-yet-1@example.com not-a-user-yet-2@example.com],
+                      description:
+                        "pass 1 email per invite to be generated. other properties will be shared by each invite.",
+                    },
+                    skip_email: {
+                      type: :boolean,
+                      default: false,
+                    },
+                    custom_message: {
+                      type: :string,
+                      description: "optional, for email invites",
+                    },
+                    max_redemptions_allowed: {
+                      type: :integer,
+                      example: 5,
+                      default: 1,
+                      description: "optional, for link invites",
+                    },
+                    topic_id: {
+                      type: :integer,
+                    },
+                    group_ids: {
+                      type: :string,
+                      description:
+                        "Optional, either this or `group_names`. Comma separated list for multiple ids.",
+                      example: "42,43",
+                    },
+                    group_names: {
+                      type: :string,
+                      description:
+                        "Optional, either this or `group_ids`. Comma separated list for multiple names.",
+                      example: "foo,bar",
+                    },
+                    expires_at: {
+                      type: :string,
+                      description:
+                        "optional, if not supplied, the invite_expiry_days site setting is used",
+                    },
+                  },
+                }
+
+      produces "application/json"
+      response "200", "success response" do
+        schema type: :object,
+               properties: {
+                 num_successfully_created_invitations: {
+                   type: :integer,
+                   example: 42,
+                 },
+                 num_failed_invitations: {
+                   type: :integer,
+                   example: 42,
+                 },
+                 failed_invitations: {
+                   type: :array,
+                   items: {
+                   },
+                   example: [],
+                 },
+                 successfully_created_invites: {
+                   type: :array,
+                   example: [
+                     {
+                       id: 42,
+                       link: "http://example.com/invites/9045fd767efe201ca60c6658bcf14158",
+                       email: "not-a-user-yet-1@example.com",
+                       emailed: true,
+                       custom_message: "Hello world!",
+                       topics: [],
+                       groups: [],
+                       created_at: "2021-01-01T12:00:00.000Z",
+                       updated_at: "2021-01-01T12:00:00.000Z",
+                       expires_at: "2021-02-01T12:00:00.000Z",
+                       expired: false,
+                     },
+                     {
+                       id: 42,
+                       link: "http://example.com/invites/c6658bcf141589045fd767efe201ca60",
+                       email: "not-a-user-yet-2@example.com",
+                       emailed: true,
+                       custom_message: "Hello world!",
+                       topics: [],
+                       groups: [],
+                       created_at: "2021-01-01T12:00:00.000Z",
+                       updated_at: "2021-01-01T12:00:00.000Z",
+                       expires_at: "2021-02-01T12:00:00.000Z",
+                       expired: false,
+                     },
+                   ],
+                 },
+               }
+
+        let(:request_body) do
+          { email: %w[not-a-user-yet-1@example.com not-a-user-yet-2@example.com] }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/multiple_invites_spec.rb
+++ b/spec/requests/api/multiple_invites_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "multiple invites" do
   let(:"Api-Key") { Fabricate(:api_key).key }
   let(:"Api-Username") { "system" }
 
-  path "/invites.json?" do
+  path "/invites/create-multiple.json?" do
     post "Create multiple invites" do
       tags "Invites"
       operationId "createMultipleInvites"

--- a/spec/requests/api/multiple_invites_spec.rb
+++ b/spec/requests/api/multiple_invites_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "multiple invites" do
   let(:"Api-Key") { Fabricate(:api_key).key }
   let(:"Api-Username") { "system" }
 
-  path "/invites/create-multiple.json?" do
+  path "/invites/create-multiple.json" do
     post "Create multiple invites" do
       tags "Invites"
       operationId "createMultipleInvites"

--- a/spec/requests/api/multiple_invites_spec.rb
+++ b/spec/requests/api/multiple_invites_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "multiple invites" do
                    },
                    example: [],
                  },
-                 successfully_created_invites: {
+                 successful_invitations: {
                    type: :array,
                    example: [
                      {

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -266,7 +266,10 @@ RSpec.describe InvitesController do
     it "creates multiple invites for multiple emails" do
       sign_in(user)
 
-      post "/invites.json", params: { email: %w[test@example.com test1@example.com bademail] }
+      post "/invites/create-multiple.json",
+           params: {
+             email: %w[test@example.com test1@example.com bademail],
+           }
       expect(response.status).to eq(200)
       json = JSON(response.body)
       expect(json["failed_invitations"].length).to eq(1)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -616,6 +616,25 @@ RSpec.describe InvitesController do
         end
       end
     end
+
+    it "fails if asked to generate too many invites at once" do
+      SiteSetting.max_api_invites = 3
+      sign_in(admin)
+      post "/invites/create-multiple.json",
+           params: {
+             email: %w[
+               mail1@mailinator.com
+               mail2@mailinator.com
+               mail3@mailinator.com
+               mail4@mailinator.com
+             ],
+           }
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body["errors"][0]).to eq(
+        I18n.t("invite.max_invite_emails_limit_exceeded", max: SiteSetting.max_api_invites),
+      )
+    end
   end
 
   describe "#retrieve" do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -527,17 +527,18 @@ RSpec.describe InvitesController do
       expect(json["successful_invitations"].length).to eq(2)
     end
 
-    it "creates 5000 invite codes with one request" do
+    it "creates many invite codes with one request" do #change to
       sign_in(admin)
+      num_emails = 5 # increase manually for load testing
       post "/invites/create-multiple.json",
            params: {
-             email: 1.upto(5000).map { |i| "test#{i}@example.com" },
+             email: 1.upto(num_emails).map { |i| "test#{i}@example.com" },
              #email: %w[test+1@example.com test1@example.com]
            }
       expect(response.status).to eq(200)
       json = JSON(response.body)
       expect(json["failed_invitations"].length).to eq(0)
-      expect(json["successful_invitations"].length).to eq(5000)
+      expect(json["successful_invitations"].length).to eq(num_emails)
     end
 
     context "with invite to topic" do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -263,6 +263,16 @@ RSpec.describe InvitesController do
       expect(response.status).to eq(403)
     end
 
+    it "creates multiple invites for multiple emails" do
+      sign_in(user)
+
+      post "/invites.json", params: { email: %w[test@example.com test1@example.com bademail] }
+      expect(response.status).to eq(200)
+      json = JSON(response.body)
+      expect(json["failed_invitations"].length).to eq(1)
+      expect(json["successful_invitations"].length).to eq(2)
+    end
+
     context "while logged in" do
       before { sign_in(user) }
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -527,6 +527,19 @@ RSpec.describe InvitesController do
       expect(json["successful_invitations"].length).to eq(2)
     end
 
+    it "creates 5000 invite codes with one request" do
+      sign_in(admin)
+      post "/invites/create-multiple.json",
+           params: {
+             email: 1.upto(5000).map { |i| "test#{i}@example.com" },
+             #email: %w[test+1@example.com test1@example.com]
+           }
+      expect(response.status).to eq(200)
+      json = JSON(response.body)
+      expect(json["failed_invitations"].length).to eq(0)
+      expect(json["successful_invitations"].length).to eq(5000)
+    end
+
     context "with invite to topic" do
       fab!(:topic)
 


### PR DESCRIPTION
for customer, who wants to generate many invite codes as part of an automated process, allow them to pass in multiple emails to this endpoint and get multiple invites back in one go.

https://meta.discourse.org/t/feature-request-sending-bulk-invitations-via-api/272423/18