### PR TITLE
FIX: Don't use `:true`/`:false` symbols

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -886,8 +886,8 @@ class Category < ActiveRecord::Base
   end
 
   def has_children?
-    @has_children ||= (id && Category.where(parent_category_id: id).exists?) ? :true : :false
-    @has_children == :true
+    return @has_children if defined?(@has_children)
+    @has_children = (id && Category.where(parent_category_id: id).exists?)
   end
 
   def uncategorized?


### PR DESCRIPTION
on line 252 `has_children` is set to true/false (actual booleans) which means `has_children?` was in some cases returning incorrect value

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
