### PR TITLE
DEV: Convert min_trust_to_flag_posts setting to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1972,6 +1972,7 @@ en:
     min_trust_to_send_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages."
     min_trust_to_send_email_messages: "The minimum trust level required to send personal messages via email."
     min_trust_to_flag_posts: "The minimum trust level required to flag posts"
+    flag_post_allowed_groups: "Groups that are allowed to flag posts."
     min_trust_to_post_links: "The minimum trust level required to include links in posts"
     min_trust_to_post_embedded_media: "The minimum trust level required to embed media items in a post"
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"
@@ -2559,6 +2560,7 @@ en:
       uploaded_avatars_allowed_groups: "allow_uploaded_avatars"
       create_topic_allowed_groups: "min_trust_to_create_topic"
       edit_post_allowed_groups: "min_trust_to_edit_post"
+      flag_post_allowed_groups: "min_trust_to_flag_posts"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1715,6 +1715,12 @@ trust:
   min_trust_to_flag_posts:
     default: 1
     enum: "TrustLevelSetting"
+  flag_post_allowed_groups:
+    default: "11"
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   min_trust_to_post_links:
     default: 0
     enum: "TrustLevelSetting"

--- a/db/migrate/20231213060822_fill_flag_post_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231213060822_fill_flag_post_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FillFlagPostAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    configured_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_to_flag_posts' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL1, we only need to do anything if it's been changed in the DB.
+    if configured_trust_level.present?
+      # Matches Group::AUTO_GROUPS to the trust levels.
+      corresponding_group = "1#{configured_trust_level}"
+
+      # Data_type 20 is group_list.
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('flag_post_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: corresponding_group,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -78,7 +78,7 @@ module PostGuardian
         (
           is_flag && not(already_did_flagging) &&
             (
-              @user.has_trust_level?(TrustLevel[SiteSetting.min_trust_to_flag_posts]) ||
+              @user.in_any_groups?(SiteSetting.flag_post_allowed_groups_map) ||
                 post.topic.private_message?
             )
         ) ||

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -23,6 +23,7 @@ module SiteSettings::DeprecatedSettings
     ["allow_uploaded_avatars", "uploaded_avatars_allowed_groups", false, "3.3"],
     ["min_trust_to_create_topic", "create_topic_allowed_groups", false, "3.3"],
     ["min_trust_to_edit_post", "edit_post_allowed_groups", false, "3.3"],
+    ["min_trust_to_flag_posts", "flag_post_allowed_groups", false, "3.3"],
   ]
 
   def setup_deprecated_methods

--- a/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
@@ -2,7 +2,7 @@
 
 describe "Local dates", type: :system do
   fab!(:topic)
-  fab!(:current_user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
   let(:year) { Time.zone.now.year + 1 }
   let(:month) { Time.zone.now.month }
   let(:bookmark_modal) { PageObjects::Modals::Bookmark.new }

--- a/spec/integration/flags_spec.rb
+++ b/spec/integration/flags_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe PostAction do
   it "triggers the 'flag_reviewed' event when there was at least one flag" do
-    admin = Fabricate(:admin)
+    admin = Fabricate(:admin, refresh_auto_groups: true)
 
     post = Fabricate(:post)
     events = DiscourseEvent.track_events { PostDestroyer.new(admin, post).destroy }

--- a/spec/integration/spam_rules_spec.rb
+++ b/spec/integration/spam_rules_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "spam rules for users" do
   describe "auto-silence users based on flagging" do
     fab!(:admin) # needed to send a system message
     fab!(:moderator)
-    fab!(:user1) { Fabricate(:user) }
-    fab!(:user2) { Fabricate(:user) }
+    fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:user2) { Fabricate(:user, refresh_auto_groups: true) }
 
     before do
       SiteSetting.hide_post_sensitivity = Reviewable.sensitivities[:disabled]

--- a/spec/jobs/auto_queue_handler_spec.rb
+++ b/spec/jobs/auto_queue_handler_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Jobs::AutoQueueHandler do
   describe "old flagged post" do
     fab!(:spam_result) do
       PostActionCreator.new(
-        Fabricate(:user),
+        Fabricate(:user, refresh_auto_groups: true),
         Fabricate(:post),
         PostActionType.types[:spam],
         message: "this is the initial message",

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -3,7 +3,7 @@
 require "csv"
 
 RSpec.describe Jobs::ExportUserArchive do
-  fab!(:user) { Fabricate(:user, username: "john_doe") }
+  fab!(:user) { Fabricate(:user, username: "john_doe", refresh_auto_groups: true) }
   fab!(:user2) { Fabricate(:user) }
   let(:extra) { {} }
   let(:job) do

--- a/spec/jobs/pending_reviewables_reminder_spec.rb
+++ b/spec/jobs/pending_reviewables_reminder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Jobs::PendingReviewablesReminder do
 
   def create_flag(created_at)
     PostActionCreator.create(
-      Fabricate(:user),
+      Fabricate(:user, refresh_auto_groups: true),
       Fabricate(:post),
       :spam,
       created_at: created_at,

--- a/spec/jobs/truncate_user_flag_stats_spec.rb
+++ b/spec/jobs/truncate_user_flag_stats_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::TruncateUserFlagStats do
-  fab!(:user)
-  fab!(:other_user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:other_user) { Fabricate(:user, refresh_auto_groups: true) }
 
   before do
     # We might make this a site setting eventually

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Guardian do
   end
 
   describe "#post_can_act?" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:post)
 
     describe "an anonymous user" do
@@ -233,19 +233,18 @@ RSpec.describe Guardian do
     end
 
     describe "trust levels" do
+      before { user.change_trust_level!(TrustLevel[0]) }
+
       it "returns true for a new user liking something" do
-        user.trust_level = TrustLevel[0]
         expect(Guardian.new(user).post_can_act?(post, :like)).to be_truthy
       end
 
       it "returns false for a new user flagging as spam" do
-        user.trust_level = TrustLevel[0]
         expect(Guardian.new(user).post_can_act?(post, :spam)).to be_falsey
       end
 
       it "returns true for a new user flagging as spam if enabled" do
-        SiteSetting.min_trust_to_flag_posts = 0
-        user.trust_level = TrustLevel[0]
+        SiteSetting.flag_post_allowed_groups = 0
         expect(Guardian.new(user).post_can_act?(post, :spam)).to be_truthy
       end
 

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe PostActionCreator do
   fab!(:admin)
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post)
   let(:like_type_id) { PostActionType.types[:like] }
 
@@ -202,7 +202,11 @@ RSpec.describe PostActionCreator do
 
     context "with existing reviewable" do
       let!(:reviewable) do
-        PostActionCreator.create(Fabricate(:user), post, :inappropriate).reviewable
+        PostActionCreator.create(
+          Fabricate(:user, refresh_auto_groups: true),
+          post,
+          :inappropriate,
+        ).reviewable
       end
 
       it "appends to an existing reviewable if exists" do
@@ -273,19 +277,31 @@ RSpec.describe PostActionCreator do
   describe "take_action" do
     it "will hide the post" do
       PostActionCreator
-        .new(Fabricate(:moderator), post, PostActionType.types[:spam], take_action: true)
+        .new(
+          Fabricate(:moderator, refresh_auto_groups: true),
+          post,
+          PostActionType.types[:spam],
+          take_action: true,
+        )
         .perform
         .reviewable
       expect(post.reload).to be_hidden
     end
 
     context "when there is another reviewable on the post" do
-      before { PostActionCreator.create(Fabricate(:user), post, :inappropriate) }
+      before do
+        PostActionCreator.create(Fabricate(:user, refresh_auto_groups: true), post, :inappropriate)
+      end
 
       it "will agree with the old reviewable" do
         reviewable =
           PostActionCreator
-            .new(Fabricate(:moderator), post, PostActionType.types[:spam], take_action: true)
+            .new(
+              Fabricate(:moderator, refresh_auto_groups: true),
+              post,
+              PostActionType.types[:spam],
+              take_action: true,
+            )
             .perform
             .reviewable
         expect(reviewable.reload).to be_approved
@@ -298,7 +314,12 @@ RSpec.describe PostActionCreator do
 
       it "still hides the post without considering the score" do
         PostActionCreator
-          .new(Fabricate(:moderator), post, PostActionType.types[:spam], take_action: true)
+          .new(
+            Fabricate(:moderator, refresh_auto_groups: true),
+            post,
+            PostActionType.types[:spam],
+            take_action: true,
+          )
           .perform
           .reviewable
         expect(post.reload).to be_hidden

--- a/spec/lib/post_action_destroyer_spec.rb
+++ b/spec/lib/post_action_destroyer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe PostActionDestroyer do
   fab!(:admin)
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post)
 
   describe "#perform" do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Category do
     fab!(:category) { Fabricate(:category_with_definition, reviewable_by_group: group) }
     fab!(:topic) { Fabricate(:topic, category: category) }
     fab!(:post) { Fabricate(:post, topic: topic) }
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
     it "will add the group to the reviewable" do
       SiteSetting.enable_category_group_moderation = true

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Post do
-  fab!(:coding_horror)
+  fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
 
   let(:upload_path) { Discourse.store.upload_path }
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Report do
           freeze_time DateTime.parse("2017-03-01 12:00")
 
           if arg == :flag
-            user = Fabricate(:user)
+            user = Fabricate(:user, refresh_auto_groups: true)
             topic = Fabricate(:topic, user: user)
             builder = ->(dt) do
               PostActionCreator.create(
@@ -462,7 +462,7 @@ RSpec.describe Report do
       before do
         3.times { Fabricate(:user, admin: true) }
         2.times { Fabricate(:user, moderator: true) }
-        UserSilencer.silence(Fabricate(:user), Fabricate.build(:admin))
+        UserSilencer.silence(Fabricate(:user, refresh_auto_groups: true), Fabricate.build(:admin))
         Fabricate(:user, suspended_till: 1.week.from_now, suspended_at: 1.day.ago)
       end
 
@@ -590,7 +590,7 @@ RSpec.describe Report do
     include_examples "no data"
 
     context "with flags" do
-      let(:flagger) { Fabricate(:user) }
+      let(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
       let(:post) { Fabricate(:post, user: flagger) }
 
       before { freeze_time }
@@ -689,7 +689,7 @@ RSpec.describe Report do
 
     let(:sam) { Fabricate(:user, moderator: true, username: "sam") }
 
-    let(:jeff) { Fabricate(:user, moderator: true, username: "jeff") }
+    let(:jeff) { Fabricate(:user, moderator: true, username: "jeff", refresh_auto_groups: true) }
 
     include_examples "no data"
 
@@ -848,7 +848,7 @@ RSpec.describe Report do
       include_examples "with data x/y"
 
       before(:each) do
-        user = Fabricate(:user)
+        user = Fabricate(:user, refresh_auto_groups: true)
         topic = Fabricate(:topic, user: user)
         post0 = Fabricate(:post, topic: topic, user: user)
         post1 = Fabricate(:post, topic: Fabricate(:topic, category: c1, user: user), user: user)
@@ -1078,8 +1078,8 @@ RSpec.describe Report do
   end
 
   describe "user_flagging_ratio" do
-    let(:joffrey) { Fabricate(:user, username: "joffrey") }
-    let(:robin) { Fabricate(:user, username: "robin") }
+    let(:joffrey) { Fabricate(:user, username: "joffrey", refresh_auto_groups: true) }
+    let(:robin) { Fabricate(:user, username: "robin", refresh_auto_groups: true) }
     let(:moderator) { Fabricate(:moderator) }
     let(:user) { Fabricate(:user) }
 

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     ReviewableFlaggedPost.default_visible.pending.count
   end
 
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post)
-  fab!(:moderator)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
 
   it "sets `potential_spam` when a spam flag is added" do
     reviewable = PostActionCreator.off_topic(user, post).reviewable
     expect(reviewable.potential_spam?).to eq(false)
-    PostActionCreator.spam(Fabricate(:user), post)
+    PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
     expect(reviewable.reload.potential_spam?).to eq(true)
   end
 

--- a/spec/models/reviewable_history_spec.rb
+++ b/spec/models/reviewable_history_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ReviewableHistory, type: :model do
 
   it "won't log a transition to the same state" do
     p0 = Fabricate(:post)
-    reviewable = PostActionCreator.spam(Fabricate(:user), p0).reviewable
+    reviewable = PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), p0).reviewable
     expect(reviewable.reviewable_histories.size).to eq(1)
     PostActionCreator.inappropriate(Fabricate(:user), p0)
     expect(reviewable.reload.reviewable_histories.size).to eq(1)

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ReviewableQueuedPost, type: :model do
   fab!(:category)
-  fab!(:moderator)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
 
   describe "creating a post" do
     let!(:topic) { Fabricate(:topic, category: category) }

--- a/spec/models/reviewable_score_spec.rb
+++ b/spec/models/reviewable_score_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ReviewableScore, type: :model do
   describe "transitions" do
-    fab!(:user) { Fabricate(:user, trust_level: 3) }
+    fab!(:user) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
     fab!(:post)
     fab!(:moderator)
 
@@ -46,10 +46,10 @@ RSpec.describe ReviewableScore, type: :model do
   end
 
   describe "overall score" do
-    fab!(:user0) { Fabricate(:user, trust_level: 1) }
-    fab!(:user1) { Fabricate(:user, trust_level: 2) }
-    fab!(:user2) { Fabricate(:user, trust_level: 3) }
-    fab!(:moderator)
+    fab!(:user0) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
+    fab!(:user1) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
+    fab!(:user2) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
+    fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
     fab!(:post)
     let(:topic) { post.topic }
 

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Reviewable, type: :model do
 
     it "will update the category if the topic category changes" do
       post = Fabricate(:post)
-      moderator = Fabricate(:moderator)
+      moderator = Fabricate(:moderator, refresh_auto_groups: true)
       reviewable = PostActionCreator.spam(moderator, post).reviewable
       expect(reviewable.category).to eq(post.topic.category)
       new_cat = Fabricate(:category)
@@ -350,7 +350,7 @@ RSpec.describe Reviewable, type: :model do
   end
 
   describe "message bus notifications" do
-    fab!(:moderator)
+    fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
     let(:post) { Fabricate(:post) }
 
     it "triggers a notification on create" do
@@ -364,9 +364,11 @@ RSpec.describe Reviewable, type: :model do
       reviewable = PostActionCreator.create(moderator, post, :inappropriate).reviewable
       reviewable.perform(moderator, :disagree)
 
-      expect { PostActionCreator.spam(Fabricate(:user), post) }.to change {
-        reviewable.reload.status
-      }.from("rejected").to("pending").and change { Jobs::NotifyReviewable.jobs.size }.by(1)
+      expect {
+        PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
+      }.to change { reviewable.reload.status }.from("rejected").to("pending").and change {
+              Jobs::NotifyReviewable.jobs.size
+            }.by(1)
     end
 
     it "triggers a notification on pending -> approve" do
@@ -424,7 +426,7 @@ RSpec.describe Reviewable, type: :model do
   end
 
   describe "flag_stats" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:post)
     let(:reviewable) { PostActionCreator.spam(user, post).reviewable }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1925,7 +1925,7 @@ RSpec.describe User do
   end
 
   describe "staff info" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:moderator)
 
     describe "#number_of_flags_given" do

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe PostActionUsersController do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   let(:post) { Fabricate(:post, user: sign_in(user)) }
 
   describe "index" do

--- a/spec/requests/post_actions_controller_spec.rb
+++ b/spec/requests/post_actions_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe PostActionsController do
       end
 
       it "doesn't pass take_action through if the user isn't staff" do
-        sign_in(Fabricate(:user))
+        sign_in(Fabricate(:user, refresh_auto_groups: true))
 
         post "/post_actions.json",
              params: {

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -81,7 +81,7 @@ end
 
 RSpec.describe PostsController do
   fab!(:admin)
-  fab!(:moderator)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user_trust_level_0) { Fabricate(:trust_level_0, refresh_auto_groups: true) }
   fab!(:user_trust_level_1) { Fabricate(:trust_level_1, refresh_auto_groups: true) }

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe ReviewablesController do
 
       context "with conversation" do
         fab!(:post)
-        fab!(:user)
+        fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
         fab!(:admin)
         let(:result) { PostActionCreator.notify_moderators(user, post, "this is the first post") }
         let(:reviewable) { result.reviewable }
@@ -565,8 +565,8 @@ RSpec.describe ReviewablesController do
       fab!(:post0) { Fabricate(:post) }
       fab!(:post1) { Fabricate(:post, topic: post0.topic) }
       fab!(:post2) { Fabricate(:post) }
-      fab!(:user0) { Fabricate(:user) }
-      fab!(:user1) { Fabricate(:user) }
+      fab!(:user0) { Fabricate(:user, refresh_auto_groups: true) }
+      fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
 
       it "returns empty json for no reviewables" do
         get "/review/topics.json"

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe PostSerializer do
   end
 
   context "with a post with reviewable content" do
-    let!(:reviewable) { PostActionCreator.spam(Fabricate(:user), post).reviewable }
+    let!(:reviewable) do
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post).reviewable
+    end
 
     it "includes the reviewable data" do
       json =

--- a/spec/serializers/reviewable_flagged_post_serializer_spec.rb
+++ b/spec/serializers/reviewable_flagged_post_serializer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ReviewableFlaggedPostSerializer do
 
   it "includes the user fields for review" do
     p0 = Fabricate(:post)
-    reviewable = PostActionCreator.spam(Fabricate(:user), p0).reviewable
+    reviewable = PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), p0).reviewable
     json =
       ReviewableFlaggedPostSerializer.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
     expect(json[:cooked]).to eq(p0.cooked)

--- a/spec/serializers/topic_view_details_serializer_spec.rb
+++ b/spec/serializers/topic_view_details_serializer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe TopicViewDetailsSerializer do
     before { SiteSetting.can_permanently_delete = true }
 
     it "is true for admins" do
-      admin = Fabricate(:admin)
+      admin = Fabricate(:admin, refresh_auto_groups: true)
 
       serializer = described_class.new(TopicView.new(post.topic, admin), scope: Guardian.new(admin))
       expect(serializer.as_json.dig(:topic_view_details, :can_permanently_delete)).to eq(true)

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe TopicViewSerializer do
   use_redis_snapshotting
 
   fab!(:topic)
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user_2) { Fabricate(:user) }
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
   describe "#featured_link and #featured_link_root_domain" do
     fab!(:featured_link) { "http://meta.discourse.org" }
@@ -329,11 +329,13 @@ RSpec.describe TopicViewSerializer do
   context "with flags" do
     fab!(:post) { Fabricate(:post, topic: topic) }
     fab!(:other_post) { Fabricate(:post, topic: topic) }
+    fab!(:flagger_1) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:flagger_2) { Fabricate(:user, refresh_auto_groups: true) }
 
     it "will return reviewable counts on posts" do
-      r = PostActionCreator.inappropriate(Fabricate(:user), post).reviewable
+      r = PostActionCreator.inappropriate(flagger_1, post).reviewable
       r.perform(admin, :agree_and_keep)
-      PostActionCreator.spam(Fabricate(:user), post)
+      PostActionCreator.spam(flagger_2, post)
 
       json = serialize_topic(topic, admin)
       p0 = json[:post_stream][:posts][0]

--- a/spec/services/auto_silence_spec.rb
+++ b/spec/services/auto_silence_spec.rb
@@ -46,14 +46,17 @@ RSpec.describe SpamRule::AutoSilence do
     end
 
     it "returns the score when there are two flags with spam as the reason" do
-      PostActionCreator.spam(Fabricate(:user), post)
-      PostActionCreator.spam(Fabricate(:user), post)
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
       expect(score).to eq(4.0)
     end
 
     it "returns the score when there are two spam flags, each on a different post" do
-      PostActionCreator.spam(Fabricate(:user), post)
-      PostActionCreator.spam(Fabricate(:user), Fabricate(:post, user: post.user))
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
+      PostActionCreator.spam(
+        Fabricate(:user, refresh_auto_groups: true),
+        Fabricate(:post, user: post.user),
+      )
       expect(score).to eq(4.0)
     end
   end
@@ -74,18 +77,18 @@ RSpec.describe SpamRule::AutoSilence do
     end
 
     it "returns 1 when there is one spam flag" do
-      PostActionCreator.spam(Fabricate(:user), post)
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
       expect(count).to eq(1)
     end
 
     it "returns 2 when there are two spam flags from 2 users" do
-      PostActionCreator.spam(Fabricate(:user), post)
-      PostActionCreator.spam(Fabricate(:user), post)
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
+      PostActionCreator.spam(Fabricate(:user, refresh_auto_groups: true), post)
       expect(count).to eq(2)
     end
 
     it "returns 1 when there are two spam flags on two different posts from 1 user" do
-      flagger = Fabricate(:user)
+      flagger = Fabricate(:user, refresh_auto_groups: true)
       PostActionCreator.spam(flagger, post)
       PostActionCreator.spam(flagger, Fabricate(:post, user: post.user))
       expect(count).to eq(1)
@@ -135,8 +138,8 @@ RSpec.describe SpamRule::AutoSilence do
 
   describe "autosilenced?" do
     let(:user) { Fabricate(:newuser) }
-    let(:flagger) { Fabricate(:user) }
-    let(:flagger2) { Fabricate(:user) }
+    let(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+    let(:flagger2) { Fabricate(:user, refresh_auto_groups: true) }
     let(:post) { Fabricate(:post, user: user) }
     let(:post2) { Fabricate(:post, user: user) }
 

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe UserDestroyer do
   fab!(:user) { Fabricate(:user_with_secondary_email) }
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
   describe ".new" do
     it "raises an error when user is nil" do

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -2,7 +2,7 @@
 
 describe "Bookmarking posts and topics", type: :system do
   fab!(:topic)
-  fab!(:current_user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post) { Fabricate(:post, topic: topic, raw: "This is some post to bookmark") }
   fab!(:post_2) { Fabricate(:post, topic: topic, raw: "Some interesting post content") }
 

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Flagging post", type: :system do
-  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:current_user) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:first_post) { Fabricate(:post) }
   fab!(:post_to_flag) { Fabricate(:post, topic: first_post.topic) }
 


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/283408)

### What is this change?

We're changing the implementation of trust levels to use groups. Part of this is to have site settings that reference trust levels use groups instead. It converts the `min_trust_to_flag_posts` site setting to `flag_post_allowed_groups`.

**Note:** In the original setting, "posts" is plural. I have changed this to "post" singular in the new setting to match others.