### PR TITLE
DEV: Small tweaks for safe mode

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
@@ -9,21 +9,20 @@ export default {
     this.messageBus = owner.lookup("service:message-bus");
     this.session = owner.lookup("service:session");
 
-    // Preserve preview_theme_id=## and pp=async-flamegraph parameters across pages
+    const PRESERVED_QUERY_PARAMS = ["preview_theme_id", "pp", "safe_mode"];
     const params = new URLSearchParams(window.location.search);
-    const previewThemeId = params.get("preview_theme_id");
-    const flamegraph = params.get("pp") === "async-flamegraph";
-    if (flamegraph || previewThemeId !== null) {
+    const preservedParamValues = PRESERVED_QUERY_PARAMS.map((p) => [
+      p,
+      params.get(p),
+    ]).filter(([, v]) => v);
+    if (preservedParamValues.length) {
       ["replaceState", "pushState"].forEach((funcName) => {
         const originalFunc = window.history[funcName];
 
         window.history[funcName] = (stateObj, name, rawUrl) => {
           const url = new URL(rawUrl, window.location);
-          if (previewThemeId !== null) {
-            url.searchParams.set("preview_theme_id", previewThemeId);
-          }
-          if (flamegraph) {
-            url.searchParams.set("pp", "async-flamegraph");
+          for (const [param, value] of preservedParamValues) {
+            url.searchParams.set(param, value);
           }
 
           return originalFunc.call(window.history, stateObj, name, url.href);

--- a/app/views/safe_mode/index.html.erb
+++ b/app/views/safe_mode/index.html.erb
@@ -26,10 +26,7 @@
       <%= submit_tag t('safe_mode.enter'), class: 'btn btn-danger' %>
       <%- if flash[:must_select] %>
         <span class='safe-mode-warning'>
-          <svg xmlns="http://www.w3.org/2000/svg" width="14px" height="14px" viewBox="0 0 192 512">
-            <path d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"></path>
-          </svg>
-          <%= t 'safe_mode.must_select' %>
+          ⚠️ <%= t 'safe_mode.must_select' %>
         </span>
       <%- end %>
     </p>


### PR DESCRIPTION
- Preserve query param in URL when navigating around
- Replace inline warning svg with emoji, which works better across different color schemes

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
