### PR TITLE
DEV: Remove development-only `DiscourseURL` global

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
@@ -1,5 +1,3 @@
-import DiscourseURL from "discourse/lib/url";
-import { isDevelopment } from "discourse-common/config/environment";
 import discourseLater from "discourse-common/lib/later";
 import { bind } from "discourse-common/utils/decorators";
 
@@ -28,11 +26,6 @@ export default {
           return originalFunc.call(window.history, stateObj, name, url.href);
         };
       });
-    }
-
-    // Useful to export this for debugging purposes
-    if (isDevelopment()) {
-      window.DiscourseURL = DiscourseURL;
     }
 
     // Observe file changes


### PR DESCRIPTION
I don't think anyone is actually using this, and the change won't affect production because it was only happening in development/test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
