### PR TITLE
DEV: Add `safe_mode=deprecation_errors` mode

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -1,7 +1,7 @@
 const handlers = [];
 const disabledDeprecations = new Set();
-const emberCliDeprecationWorkflows =
-  window.deprecationWorkflow?.config?.workflow;
+const deprecationWorkflow = window.deprecationWorkflow;
+const workflows = deprecationWorkflow?.config?.workflow;
 
 let emberDeprecationSilencer;
 
@@ -47,13 +47,15 @@ export default function deprecated(msg, options = {}) {
 
   handlers.forEach((h) => h(msg, options));
 
-  if (raiseError) {
+  const matchedWorkflow = workflows?.find((w) => w.matchId === id);
+
+  if (
+    raiseError ||
+    matchedWorkflow?.handler === "throw" ||
+    (!matchedWorkflow && deprecationWorkflow.throwOnUnhandled)
+  ) {
     throw msg;
   }
-
-  const matchedWorkflow = emberCliDeprecationWorkflows?.find(
-    (w) => w.matchId === id
-  );
 
   if (matchedWorkflow?.handler !== "silence") {
     console.warn(...[consolePrefix, msg].filter(Boolean)); //eslint-disable-line no-console

--- a/app/assets/javascripts/discourse/app/initializers/deprecation-error-mode.js
+++ b/app/assets/javascripts/discourse/app/initializers/deprecation-error-mode.js
@@ -1,0 +1,9 @@
+export default {
+  initialize() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("safe_mode")?.split(",").includes("deprecation_errors")) {
+      window.deprecationWorkflow.throwOnUnhandled = true;
+      return;
+    }
+  },
+};

--- a/app/controllers/safe_mode_controller.rb
+++ b/app/controllers/safe_mode_controller.rb
@@ -19,6 +19,8 @@ class SafeModeController < ApplicationController
       safe_mode << "no_plugins"
     elsif params["no_unofficial_plugins"] == "true"
       safe_mode << "no_unofficial_plugins"
+    elsif params["deprecation_errors"] == "true"
+      safe_mode << "deprecation_errors"
     end
 
     if safe_mode.length > 0

--- a/app/views/safe_mode/index.html.erb
+++ b/app/views/safe_mode/index.html.erb
@@ -22,6 +22,17 @@
     <%= t 'safe_mode.no_plugins' %>
     </label>
     </p>
+
+    <p>
+      <%= t 'safe_mode.deprecation_error_description' %>  
+    </p>
+    <p>
+    <label>
+    <%= check_box_tag 'deprecation_errors', true, false %>
+    <%= t 'safe_mode.deprecation_error_label' %>
+    </label>
+    </p>
+
     <p>
       <%= submit_tag t('safe_mode.enter'), class: 'btn btn-danger' %>
       <%- if flash[:must_select] %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5073,6 +5073,8 @@ en:
     no_themes: "Disable themes and theme components"
     no_unofficial_plugins: "Disable unofficial client-side plugin customizations"
     no_plugins: "Disable all client-side plugin customizations"
+    deprecation_error_description: "To check for compatibility with upcoming Discourse updates, you can make Javascript deprecations raise an error:"
+    deprecation_error_label: Make Javascript deprecations raise an error
     enter: "Enter Safe Mode"
     must_select: "You must select at least one option to enter safe mode."
   wizard:


### PR DESCRIPTION
This commit adds an additional toggle to our safe-mode system. When enabled, it will cause all deprecation messages to become exceptions. This gives admins a way to test their themes/plugins against upcoming Discourse changes without needing to use the browser developer tools.

<img width="1098" alt="SCR-20231213-mibn" src="https://github.com/discourse/discourse/assets/6270921/f456cf26-60c1-4f8b-84c9-540fe4974e37">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
