### PR TITLE
UX: have svg icons inherit colour

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -117,6 +117,10 @@ img {
   vertical-align: middle;
 }
 
+.svg-icon {
+  color: inherit;
+}
+
 // Forms
 // --------------------------------------------------
 


### PR DESCRIPTION
To avoid having to manually set or overrule svg icons, this commit sets a `color:inherit` in the base css for all `.svg-icon` classes.
