### PR TITLE
DEV: Remove most Ember 3 jobs from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
-    name: ${{ matrix.target }} ${{ matrix.build_type }}${{ matrix.updated_ember && ' (Ember 5)' || '' }}
+    name: ${{ matrix.target }} ${{ matrix.build_type }} (Ember ${{ matrix.updated_ember && '5' || '3' }})
     runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || 'ubuntu-20.04-8core' }}
     container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}${{ (matrix.ruby == '3.1') && '-ruby-3.1.0' || '' }}
     timeout-minutes: 20
@@ -44,7 +44,7 @@ jobs:
         build_type: [backend, frontend, system, annotations]
         target: [core, plugins, themes]
         ruby: ["3.2"]
-        updated_ember: [false]
+        updated_ember: [true]
         exclude:
           - build_type: annotations
             target: plugins
@@ -54,21 +54,6 @@ jobs:
             target: themes
           - build_type: frontend
             target: core # Handled by core_frontend_tests job (below)
-        include:
-          - build_type: system
-            target: chat
-          - build_type: system
-            target: chat
-            updated_ember: true
-          - build_type: system
-            target: core
-            updated_ember: true
-          - build_type: frontend
-            target: plugins
-            updated_ember: true
-          - build_type: frontend
-            target: themes
-            updated_ember: true
 
     steps:
       - name: Set working directory owner
@@ -346,7 +331,7 @@ jobs:
 
   core_frontend_tests:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
-    name: core frontend (${{ matrix.browser }})${{ matrix.updated_ember && ' (Ember 5)' || '' }}
+    name: core frontend (${{ matrix.browser }}) (Ember ${{ matrix.updated_ember && '5' || '3' }})
     runs-on: ubuntu-20.04-8core
     container:
       image: discourse/discourse_test:slim-browsers
@@ -358,10 +343,10 @@ jobs:
       fail-fast: false
       matrix:
         browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
-        updated_ember: [false]
+        updated_ember: [true]
         include:
           - browser: Chrome
-            updated_ember: true
+            updated_ember: false
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}


### PR DESCRIPTION
It's very unlikely that something will be introduced which works under Ember 5 and not Ember 3. To reduce GitHub actions costs, flakiness, and visual noise, let's cut down the matrix so we're only using Ember 3 for the 'core frontend' job. All others can run under Ember 5.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
