### PR TITLE
DEV: Add true_fields method for CustomFields

### DIFF
--- a/app/models/category_custom_field.rb
+++ b/app/models/category_custom_field.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CategoryCustomField < ActiveRecord::Base
+  include CustomField
+
   belongs_to :category
 end
 

--- a/app/models/concerns/custom_field.rb
+++ b/app/models/concerns/custom_field.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CustomField
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def true_fields
+      where(value: HasCustomFields::Helpers::CUSTOM_FIELD_TRUE)
+    end
+  end
+end

--- a/app/models/group_custom_field.rb
+++ b/app/models/group_custom_field.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GroupCustomField < ActiveRecord::Base
+  include CustomField
+
   belongs_to :group
 end
 

--- a/app/models/post_custom_field.rb
+++ b/app/models/post_custom_field.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostCustomField < ActiveRecord::Base
+  include CustomField
+
   belongs_to :post
 end
 

--- a/app/models/topic_custom_field.rb
+++ b/app/models/topic_custom_field.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TopicCustomField < ActiveRecord::Base
+  include CustomField
+
   belongs_to :topic
 end
 

--- a/app/models/user_custom_field.rb
+++ b/app/models/user_custom_field.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserCustomField < ActiveRecord::Base
+  include CustomField
+
   belongs_to :user
 
   scope :searchable,

--- a/spec/lib/concern/has_custom_fields_spec.rb
+++ b/spec/lib/concern/has_custom_fields_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe HasCustomFields do
       end
 
       class CustomFieldsTestItemCustomField < ActiveRecord::Base
+        include CustomField
+
         belongs_to :custom_fields_test_item
       end
     end
@@ -194,6 +196,30 @@ RSpec.describe HasCustomFields do
 
       db_item = CustomFieldsTestItem.find(test_item.id)
       expect(db_item.custom_fields).to eq("a" => %w[b 10 d])
+    end
+
+    it "that are true can be fetched" do
+      test_item = CustomFieldsTestItem.new
+      CustomFieldsTestItem.register_custom_field_type("bool", :boolean)
+
+      test_item.save!
+
+      expect(
+        CustomFieldsTestItemCustomField
+          .true_fields
+          .where(custom_fields_test_item_id: test_item.id)
+          .count,
+      ).to eq(0)
+
+      test_item.custom_fields["bool"] = true
+      test_item.save!
+
+      expect(
+        CustomFieldsTestItemCustomField
+          .true_fields
+          .where(custom_fields_test_item_id: test_item.id)
+          .count,
+      ).to eq(1)
     end
 
     it "supports type coercion" do


### PR DESCRIPTION
This is useful for plugins, that might otherwise rely on the CUSTOM_FIELD_TRUE constant.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
