### PR TITLE
DEV: Remove usage of `min_trust_to_create_topic` SiteSetting 

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -48,11 +48,8 @@ module TopicGuardian
   def can_create_topic?(parent)
     is_staff? ||
       (
-        user &&
-          (
-            user.trust_level >= SiteSetting.min_trust_to_create_topic.to_i ||
-              user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map)
-          ) && can_create_post?(parent) && Category.topic_create_allowed(self).any?
+        user && user.in_any_groups?(SiteSetting.create_topic_allowed_groups_map) &&
+          can_create_post?(parent) && Category.topic_create_allowed(self).any?
       )
   end
 

--- a/plugins/poll/spec/lib/new_post_manager_spec.rb
+++ b/plugins/poll/spec/lib/new_post_manager_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe NewPostManager do
-  let(:user) { Fabricate(:newuser) }
-  let(:admin) { Fabricate(:admin) }
+  let(:user) { Fabricate(:newuser, refresh_auto_groups: true) }
+  let(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
   describe "when new post containing a poll is queued for approval" do
     before { SiteSetting.poll_minimum_trust_level_to_create = 0 }

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe PostAction do
       expect(post.hidden).to eq(true)
     end
     it "hide tl0 posts that are flagged as spam by a tl3 user" do
-      newuser = Fabricate(:newuser)
+      newuser = Fabricate(:newuser, refresh_auto_groups: true)
       post = create_post(user: newuser)
 
       Discourse.stubs(:site_contact_user).returns(admin)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1483,7 +1483,7 @@ RSpec.describe PostsController do
             expect(Topic.last.custom_fields).to eq({ "xyz" => "abc" })
           end
 
-          xit "should add custom fields to topic that is permitted for a non-staff user via the deprecated `meta_data` param" do
+          it "should add custom fields to topic that is permitted for a non-staff user via the deprecated `meta_data` param" do
             sign_in(user)
 
             post "/posts.json",

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 describe "Composer Post Validations", type: :system do
-  fab!(:tl0_user) { Fabricate(:user, trust_level: 0) }
-  fab!(:tl1_user) { Fabricate(:user, trust_level: 1) }
-  fab!(:tl2_user) { Fabricate(:user, trust_level: 2) }
+  fab!(:tl0_user) { Fabricate(:user, trust_level: 0, refresh_auto_groups: true) }
+  fab!(:tl1_user) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
+  fab!(:tl2_user) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
   fab!(:topic)
   fab!(:post) { Fabricate(:post, topic: topic) }
 

--- a/spec/system/composer/preview_spec.rb
+++ b/spec/system/composer/preview_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Composer Preview", type: :system do
-  fab!(:user) { Fabricate(:user, username: "bob") }
+  fab!(:user) { Fabricate(:user, username: "bob", refresh_auto_groups: true) }
   let(:composer) { PageObjects::Components::Composer.new }
 
   before { sign_in user }

--- a/spec/system/composer/template_validation_spec.rb
+++ b/spec/system/composer/template_validation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Composer Form Template Validations", type: :system do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:form_template) do
     Fabricate(
       :form_template,

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Uploading files in the composer", type: :system do
-  fab!(:current_user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
 
   let(:modal) { PageObjects::Modals::Base.new }
   let(:composer) { PageObjects::Components::Composer.new }

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Dismissing New", type: :system do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
   let(:discovery) { PageObjects::Pages::Discovery.new }
   let(:topic_list_controls) { PageObjects::Components::TopicListControls.new }


### PR DESCRIPTION
Using `min_trust_to_create_topic` and `create_topic_allowed_groups`  together was part of https://github.com/discourse/discourse/pull/24740

Now, when plugins specs are fixed, we can safely remove that part of logic.
