### PR TITLE
DEV: Validate that passed in groups exist in AtLeastOneGroupValidator

### DIFF
--- a/lib/validators/at_least_one_group_validator.rb
+++ b/lib/validators/at_least_one_group_validator.rb
@@ -3,13 +3,25 @@
 class AtLeastOneGroupValidator
   def initialize(opts = {})
     @opts = opts
+    @invalid_groups = []
   end
 
   def valid_value?(val)
-    val.present? && val != ""
+    @invalid_groups = []
+
+    return false if val.blank?
+
+    group_ids = val.to_s.split("|").map(&:to_i)
+
+    @invalid_groups = group_ids - Group.where(id: group_ids).pluck(:id)
+    @invalid_groups.empty?
   end
 
   def error_message
-    I18n.t("site_settings.errors.at_least_one_group_required")
+    if @invalid_groups.empty?
+      I18n.t("site_settings.errors.at_least_one_group_required")
+    else
+      I18n.t("site_settings.errors.invalid_group")
+    end
   end
 end

--- a/spec/lib/validators/at_least_one_group_validator_spec.rb
+++ b/spec/lib/validators/at_least_one_group_validator_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe AtLeastOneGroupValidator do
+  subject(:validator) { described_class.new }
+
+  describe "#valid_value?" do
+    context "when using a blank value" do
+      it { expect(validator.valid_value?(nil)).to eq(false) }
+    end
+
+    context "when one of the groups doesn't exist" do
+      it { expect(validator.valid_value?("10|1337")).to eq(false) }
+    end
+
+    context "when all the groups exist" do
+      it { expect(validator.valid_value?("10|11")).to eq(true) }
+    end
+  end
+
+  describe "#error_message" do
+    context "when using a blank value" do
+      before { validator.valid_value?(nil) }
+
+      it do
+        expect(validator.error_message).to eq(
+          "You must specify at least one group for this setting.",
+        )
+      end
+    end
+
+    context "when one of the groups doesn't exist" do
+      before { validator.valid_value?("10|1337") }
+
+      it { expect(validator.error_message).to eq("There's no group with that name.") }
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

This validator is used for site settings where one or more groups are to be input:

<img width="624" alt="Screenshot 2023-12-14 at 9 42 01 AM" src="https://github.com/discourse/discourse/assets/5259935/396b596a-f0bc-4100-a72a-d8f6d6afc2fa">

At the moment this validator just checks that the value isn't blank. This PR adds a validation for the existence of the groups passed in.