### PR TITLE
DEV: Convert min_trust_level_to_allow_user_card_background to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1979,6 +1979,7 @@ en:
     min_trust_to_post_embedded_media: "The minimum trust level required to embed media items in a post"
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"
     min_trust_level_to_allow_user_card_background: "The minimum trust level required to upload a user card background"
+    user_card_background_allowed_groups: "Groups that are allowed to upload a user card background."
     min_trust_level_to_allow_invite: "The minimum trust level required to invite users"
     min_trust_level_to_allow_ignore: "The minimum trust level required to ignore users"
     allowed_link_domains: "Domains that users may link to even if they don't have the appropriate trust level to post links"
@@ -2563,7 +2564,8 @@ en:
       create_topic_allowed_groups: "min_trust_to_create_topic"
       edit_post_allowed_groups: "min_trust_to_edit_post"
       flag_post_allowed_groups: "min_trust_to_flag_posts"
-      tl4_delete_posts_and_topics: "delete_all_posts_and_topics_allowed_groups"
+      delete_all_posts_and_topics_allowed_groups: "tl4_delete_posts_and_topics"
+      user_card_background_allowed_groups: "min_trust_level_to_allow_user_card_background"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1740,6 +1740,12 @@ trust:
     default: 0
     client: true
     enum: "TrustLevelSetting"
+  user_card_background_allowed_groups:
+    default: "10"
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   min_trust_level_to_allow_invite:
     default: 2
     enum: "TrustLevelSetting"

--- a/db/migrate/20231214020814_fill_user_card_background_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231214020814_fill_user_card_background_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FillUserCardBackgroundAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    configured_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_level_to_allow_user_card_background' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL0, we only need to do anything if it's been changed in the DB.
+    if configured_trust_level.present?
+      # Matches Group::AUTO_GROUPS to the trust levels.
+      corresponding_group = "1#{configured_trust_level}"
+
+      # Data_type 20 is group_list.
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('user_card_background_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: corresponding_group,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -188,10 +188,8 @@ module UserGuardian
   end
 
   def can_upload_user_card_background?(user)
-    (
-      is_me?(user) &&
-        user.has_trust_level?(SiteSetting.min_trust_level_to_allow_user_card_background.to_i)
-    ) || is_staff?
+    (is_me?(user) && user.in_any_groups?(SiteSetting.user_card_background_allowed_groups_map)) ||
+      is_staff?
   end
 
   def can_upload_external?

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -25,6 +25,12 @@ module SiteSettings::DeprecatedSettings
     ["min_trust_to_edit_post", "edit_post_allowed_groups", false, "3.3"],
     ["min_trust_to_flag_posts", "flag_post_allowed_groups", false, "3.3"],
     ["tl4_delete_posts_and_topics", "delete_all_posts_and_topics_allowed_groups", false, "3.3"],
+    [
+      "min_trust_level_to_allow_user_card_background",
+      "user_card_background_allowed_groups",
+      false,
+      "3.3",
+    ],
   ]
 
   def setup_deprecated_methods

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe UserGuardian do
 
   let(:moderator_upload) { Upload.new(user_id: moderator.id, id: 4) }
 
-  let(:trust_level_1) { build(:user, trust_level: 1) }
-  let(:trust_level_2) { build(:user, trust_level: 2) }
+  fab!(:trust_level_1) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
+  fab!(:trust_level_2) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
 
   describe "#can_pick_avatar?" do
     let :guardian do
@@ -450,13 +450,13 @@ RSpec.describe UserGuardian do
 
     it "returns true if the trust level of user matches site setting" do
       guardian = Guardian.new(trust_level_2)
-      SiteSetting.min_trust_level_to_allow_user_card_background = 2
+      SiteSetting.user_card_background_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       expect(guardian.can_upload_user_card_background?(trust_level_2)).to eq(true)
     end
 
     it "returns false if the trust level of user does not matches site setting" do
       guardian = Guardian.new(trust_level_1)
-      SiteSetting.min_trust_level_to_allow_user_card_background = 2
+      SiteSetting.user_card_background_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       expect(guardian.can_upload_user_card_background?(trust_level_1)).to eq(false)
     end
   end

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe UserUpdater do
     end
 
     it "allows user to update user card background when the user has required trust level" do
-      user = Fabricate(:user, trust_level: 2)
+      user = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
       updater = UserUpdater.new(user, user)
       upload = Fabricate(:upload)
       SiteSetting.min_trust_level_to_allow_user_card_background = 2


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/283408)

### What is this change?

We're changing the implementation of trust levels to use groups. Part of this is to have site settings that reference trust levels use groups instead. It converts the `min_trust_level_to_allow_user_card_background` site setting to `user_card_background_allowed_groups`.

Nothing of note here. This is used in exactly one place, and there's no fallout.