### PR TITLE
DEV: Include exception details for each test in flaky tests report

### DIFF
--- a/lib/turbo_tests/flaky/failed_example.rb
+++ b/lib/turbo_tests/flaky/failed_example.rb
@@ -34,6 +34,14 @@ module TurboTests
         @failed_example.location_rerun_argument
       end
 
+      def exception_name
+        @failed_example.execution_result.exception.class.name
+      end
+
+      def exception_message
+        @failed_example.execution_result.exception.message
+      end
+
       SCREENSHOT_PREFIX = "[Screenshot Image]: "
 
       # Unfortunately this has to be parsed from the output because `ActionDispatch` is just printing the path instead of
@@ -56,6 +64,8 @@ module TurboTests
         {
           message_lines:,
           description:,
+          exception_message:,
+          exception_name:,
           backtrace:,
           failure_screenshot_path:,
           location_rerun_argument:,

--- a/spec/lib/turbo_tests/flaky/manager_spec.rb
+++ b/spec/lib/turbo_tests/flaky/manager_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe TurboTests::Flaky::Manager do
               "message_lines" =>
                 "Failure/Error: Unable to infer file and line number from backtrace\n\nStandardError:\n  some error\n\n  [Screenshot Image]: /some/path/to/screenshot.png",
               "description" => "rspec example 1",
+              "exception_message" =>
+                "some error\n\n[Screenshot Image]: /some/path/to/screenshot.png",
+              "exception_name" => "StandardError",
               "backtrace" => ["some backtrace"],
               "failure_screenshot_path" => "/some/path/to/screenshot.png",
               "location_rerun_argument" => "./spec/lib/turbo_tests/flaky/manager_spec.rb:7",
@@ -88,6 +91,8 @@ RSpec.describe TurboTests::Flaky::Manager do
               "message_lines" =>
                 "Failure/Error: Unable to infer file and line number from backtrace\n\nStandardError:\n  some error",
               "description" => "rspec example 2",
+              "exception_message" => "some error",
+              "exception_name" => "StandardError",
               "backtrace" => ["some backtrace"],
               "failure_screenshot_path" => nil,
               "location_rerun_argument" => "./spec/lib/turbo_tests/flaky/manager_spec.rb:22",


### PR DESCRIPTION
Why this change?

The exception message and name is useful when analyzing why a test
failed.