### PR TITLE
DEV: Convert min_trust_level_to_allow_ignore to groups

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/users.js
@@ -8,9 +8,12 @@ import discourseComputed from "discourse-common/utils/decorators";
 export default Controller.extend({
   ignoredUsernames: alias("model.ignored_usernames"),
 
-  @discourseComputed("model.trust_level")
+  @discourseComputed("model.trust_level", "model.groups")
   userCanIgnore(trustLevel) {
-    return trustLevel >= this.siteSettings.min_trust_level_to_allow_ignore;
+    return (
+      trustLevel >= this.siteSettings.min_trust_level_to_allow_ignore ||
+      this.currentUser.isInAnyGroups(this.siteSettings.ignore_allowed_groups)
+    );
   },
 
   @discourseComputed("userCanIgnore", "model.staff")

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -175,11 +175,23 @@ acceptance(
 
 acceptance("Ignored users", function (needs) {
   needs.user();
-  needs.settings({ min_trust_level_to_allow_ignore: 1 });
+  needs.settings({ ignore_allowed_groups: "11" });
 
   test("when trust level < min level to ignore", async function (assert) {
     await visit(`/u/eviltrout/preferences/users`);
-    updateCurrentUser({ trust_level: 0, moderator: false, admin: false });
+    updateCurrentUser({
+      trust_level: 0,
+      moderator: false,
+      admin: false,
+      groups: [
+        {
+          id: 10,
+          name: "trust_level_0",
+          display_name: "trust_level_0",
+          automatic: true,
+        },
+      ],
+    });
 
     assert.ok(
       !exists(".user-ignore"),

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1983,6 +1983,7 @@ en:
     min_trust_level_to_allow_invite: "The minimum trust level required to invite users"
     invite_allowed_groups: "Groups that are allowed to invite users."
     min_trust_level_to_allow_ignore: "The minimum trust level required to ignore users"
+    ignore_allowed_groups: "Groups that are allowed to ignore other users."
     allowed_link_domains: "Domains that users may link to even if they don't have the appropriate trust level to post links"
 
     newuser_max_links: "How many links a new user can add to a post."
@@ -2569,6 +2570,7 @@ en:
       delete_all_posts_and_topics_allowed_groups: "tl4_delete_posts_and_topics"
       user_card_background_allowed_groups: "min_trust_level_to_allow_user_card_background"
       invite_allowed_groups: "min_trust_level_to_allow_invite"
+      ignore_allowed_groups: "min_trust_level_to_allow_ignore"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1760,6 +1760,13 @@ trust:
     default: 2
     enum: "TrustLevelSetting"
     client: true
+  ignore_allowed_groups:
+    default: "12"
+    type: group_list
+    client: true
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   allow_flagging_staff: true
   send_tl1_welcome_message: true
   send_tl2_promotion_message: true

--- a/db/migrate/20231214031754_fill_ignore_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231214031754_fill_ignore_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FillIgnoreAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    configured_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_level_to_allow_ignore' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL2, we only need to do anything if it's been changed in the DB.
+    if configured_trust_level.present?
+      # Matches Group::AUTO_GROUPS to the trust levels.
+      corresponding_group = "1#{configured_trust_level}"
+
+      # Data_type 20 is group_list.
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('ignore_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: corresponding_group,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -557,7 +557,8 @@ class Guardian
 
   def can_ignore_users?
     return false if anonymous?
-    @user.staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_allow_ignore.to_i)
+    @user.staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_allow_ignore.to_i) ||
+      @user.in_any_groups?(SiteSetting.ignore_allowed_groups_map)
   end
 
   def allowed_theme_repo_import?(repo)

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -32,6 +32,7 @@ module SiteSettings::DeprecatedSettings
       "3.3",
     ],
     ["min_trust_level_to_allow_invite", "invite_allowed_groups", false, "3.3"],
+    ["min_trust_level_to_allow_ignore", "ignore_allowed_groups", false, "3.3"],
   ]
 
   def setup_deprecated_methods

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3467,7 +3467,7 @@ RSpec.describe Guardian do
   end
 
   describe "#can_ignore_user?" do
-    before { SiteSetting.min_trust_level_to_allow_ignore = 1 }
+    before { SiteSetting.ignore_allowed_groups = Group::AUTO_GROUPS[:trust_level_1] }
 
     let(:guardian) { Guardian.new(trust_level_2) }
 
@@ -3498,21 +3498,21 @@ RSpec.describe Guardian do
       end
     end
 
-    context "when ignorer's trust level is below min_trust_level_to_allow_ignore" do
+    context "when ignorer is not in requred trust level group" do
       let(:guardian) { Guardian.new(trust_level_0) }
       it "does not allow ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(false)
       end
     end
 
-    context "when ignorer's trust level is equal to min_trust_level_to_allow_ignore site setting" do
+    context "when ignorer is in the required trust level group" do
       let(:guardian) { Guardian.new(trust_level_1) }
       it "allows ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
     end
 
-    context "when ignorer's trust level is above min_trust_level_to_allow_ignore site setting" do
+    context "when ignorer is in a higher than required trust level group" do
       let(:guardian) { Guardian.new(trust_level_3) }
       it "allows ignoring user" do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/283408)

### What is this change?

We're changing the implementation of trust levels to use groups. Part of this is to have site settings that reference trust levels use groups instead. It converts the `min_trust_level_to_allow_ignore ` site setting to `ignore_allowed_groups`.

This PR maintains backwards compatibility until we can update plugins and themes using this.