### PR TITLE
DEV: patch @ember/test-helpers

### DIFF
--- a/app/assets/javascripts/patches/@ember+test-helpers+2.9.4.patch
+++ b/app/assets/javascripts/patches/@ember+test-helpers+2.9.4.patch
@@ -1,0 +1,80 @@
+diff --git a/node_modules/@ember/test-helpers/addon-test-support/@ember/test-helpers/setup-rendering-context.js b/node_modules/@ember/test-helpers/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+index 4079777..b3a3cc2 100644
+--- a/node_modules/@ember/test-helpers/addon-test-support/@ember/test-helpers/setup-rendering-context.js
++++ b/node_modules/@ember/test-helpers/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+@@ -54,7 +54,7 @@ let templateId = 0;
+   Renders the provided template and appends it to the DOM.
+ 
+   @public
+-  @param {Template|Component} templateOrComponent the component (or template) to render
++  @param {Template|Component} templateFactoryOrComponent the component (or template) to render
+   @param {RenderOptions} options options hash containing engine owner ({ owner: engineOwner })
+   @returns {Promise<void>} resolves when settled
+ 
+@@ -64,9 +64,9 @@ let templateId = 0;
+   </caption>
+   await render(hbs`<div class="container"></div>`);
+ */
+-export function render(templateOrComponent, options) {
++export function render(templateFactoryOrComponent, options) {
+   let context = getContext();
+-  if (!templateOrComponent) {
++  if (!templateFactoryOrComponent) {
+     throw new Error('you must pass a template to `render()`');
+   }
+   return Promise.resolve().then(() => runHooks('render', 'start')).then(() => {
+@@ -88,16 +88,12 @@ export function render(templateOrComponent, options) {
+     if (macroCondition(dependencySatisfies('ember-source', '<3.24.0'))) {
+       // Pre 3.24, we just don't support rendering components at all, so we error
+       // if we find anything that isn't a template.
+-      const isTemplate = '__id' in templateOrComponent && '__meta' in templateOrComponent || 'id' in templateOrComponent && 'meta' in templateOrComponent;
++      const isTemplate = '__id' in templateFactoryOrComponent && '__meta' in templateFactoryOrComponent || 'id' in templateFactoryOrComponent && 'meta' in templateFactoryOrComponent;
+       if (!isTemplate) {
+         throw new Error(`Using \`render\` with something other than a pre-compiled template is not supported until Ember 3.24 (you are on ${Ember.VERSION}).`);
+       }
+-      templateId += 1;
+-      let templateFullName = `template:-undertest-${templateId}`;
+-      ownerToRenderFrom.register(templateFullName, templateOrComponent);
+-      templateOrComponent = lookupTemplate(ownerToRenderFrom, templateFullName);
+     } else {
+-      if (isComponent(templateOrComponent, owner)) {
++      if (isComponent(templateFactoryOrComponent, owner)) {
+         // We use this to track when `render` is used with a component so that we can throw an
+         // assertion if `this.{set,setProperty} is used in the same test
+         ComponentRenderMap.set(context, true);
+@@ -105,18 +101,18 @@ export function render(templateOrComponent, options) {
+         if (setCalls !== undefined) {
+           assert(`You cannot call \`this.set\` or \`this.setProperties\` when passing a component to \`render\`, but they were called for the following properties:\n${setCalls.map(key => `  - ${key}`).join('\n')}`);
+         }
+-        let ProvidedComponent = ensureSafeComponent(templateOrComponent, context);
+         context = {
+-          ProvidedComponent
++          ProvidedComponent: templateFactoryOrComponent,
+         };
+-        templateOrComponent = INVOKE_PROVIDED_COMPONENT;
+-      } else {
+-        templateId += 1;
+-        let templateFullName = `template:-undertest-${templateId}`;
+-        ownerToRenderFrom.register(templateFullName, templateOrComponent);
+-        templateOrComponent = lookupTemplate(ownerToRenderFrom, templateFullName);
++        templateFactoryOrComponent = INVOKE_PROVIDED_COMPONENT;
+       }
+     }
++
++    templateId += 1;
++    let templateFullName = `template:-undertest-${templateId}`;
++    ownerToRenderFrom.register(templateFullName, templateFactoryOrComponent);
++    let template = lookupTemplate(ownerToRenderFrom, templateFullName);
++
+     let outletState = {
+       render: {
+         owner,
+@@ -138,7 +134,7 @@ export function render(templateOrComponent, options) {
+             name: 'index',
+             controller: context,
+             ViewClass: undefined,
+-            template: templateOrComponent,
++            template,
+             outlets: {}
+           },
+           outlets: {}


### PR DESCRIPTION
Mainly we are after https://github.com/emberjs/ember-test-helpers/pull/1445 so the Ember 5 test suite doesn't fail on canary, but also took some code from https://github.com/emberjs/ember-test-helpers/pull/1378 as needed to make the code make sense.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
