### PR TITLE
DEV: Throw error if `renderInOutlet` component has no template

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -31,6 +31,11 @@ export function extraConnectorComponent(outletName, klass) {
   if (!hasInternalComponentManager(klass)) {
     throw new Error("klass is not an Ember component");
   }
+  if (!getComponentTemplate(klass)) {
+    throw new Error(
+      "connector component has no associated template. Ensure the template is colocated or authored with gjs."
+    );
+  }
   if (outletName.includes("/")) {
     throw new Error("invalid outlet name");
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -466,6 +466,22 @@ module(
       await render(hbs`<PluginOutlet @name="test-name" />`);
       assert.dom(".gjs-test").hasText("Hello world from gjs");
     });
+
+    test("throws errors for invalid components", function (assert) {
+      assert.throws(() => {
+        extraConnectorComponent("test-name/blah", <template>
+          hello world
+        </template>);
+      }, /invalid outlet name/);
+
+      assert.throws(() => {
+        extraConnectorComponent("test-name", {});
+      }, /klass is not an Ember component/);
+
+      assert.throws(() => {
+        extraConnectorComponent("test-name", class extends Component {});
+      }, /connector component has no associated template/);
+    });
   }
 );
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
