### PR TITLE
DEV: Add current menu-panel tab ID as data attribute to panel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
@@ -1,5 +1,6 @@
 <div
   class={{this.classNames}}
+  data-tab-id={{this.currentTabId}}
   data-max-width="320"
   {{did-insert this.triggerRenderedAppEvent}}
 >

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -197,7 +197,13 @@ export default class UserMenu extends Component {
   @tracked currentNotificationTypes;
 
   get classNames() {
-    let classes = ["user-menu", "revamped", "menu-panel", "drop-down"];
+    let classes = [
+      "user-menu",
+      "revamped",
+      "menu-panel",
+      "drop-down",
+      `current-tab__${this.currentTabId}`,
+    ];
     if (this.siteSettings.show_user_menu_avatars) {
       classes.push("show-avatars");
     }

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -197,13 +197,7 @@ export default class UserMenu extends Component {
   @tracked currentNotificationTypes;
 
   get classNames() {
-    let classes = [
-      "user-menu",
-      "revamped",
-      "menu-panel",
-      "drop-down",
-      `current-tab__${this.currentTabId}`,
-    ];
+    let classes = ["user-menu", "revamped", "menu-panel", "drop-down"];
     if (this.siteSettings.show_user_menu_avatars) {
       classes.push("show-avatars");
     }


### PR DESCRIPTION
This is a very simple change, to add data-tab-id to the user-menu panel with the current tab ID. We have a customer who has customizations breaking up the user menu into different panels, rather than having the tabbed approach. Currently there is no clean way to differentiate between these panels, but being able to style based on the current tab is perfect!
