### PR TITLE
FIX: Unable to move pm to public topic

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -154,7 +154,9 @@ class PostRevisor
   end
 
   def self.create_small_action_for_category_change(topic:, user:, old_category:, new_category:)
-    return if !SiteSetting.create_post_for_category_and_tag_changes
+    if !old_category || !new_category || !SiteSetting.create_post_for_category_and_tag_changes
+      return
+    end
 
     topic.add_moderator_post(
       user,

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -291,6 +291,17 @@ RSpec.describe PostRevisor do
           ),
         )
       end
+
+      describe "with PMs" do
+        fab!(:pm) { Fabricate(:private_message_topic) }
+        let(:first_post) { create_post(user: admin, topic: pm, allow_uncategorized_topics: false) }
+        fab!(:category) { Fabricate(:category, topic_count: 1) }
+        it "Does not create a category change small_action post when converting to a topic" do
+          expect do
+            TopicConverter.new(first_post.topic, admin).convert_to_public_topic(category.id)
+          end.to change { category.reload.topic_count }.by(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This change allows sites with `create_post_for_category_and_tag_changes` enabled to still be able to convert PMs to topics.