### PR TITLE
FIX: discourse remap: fix output to avoid UX issue

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -42,8 +42,8 @@ class DiscourseCLI < Thor
     else
       puts "Rewriting all occurrences of #{from} to #{to}"
     end
-    puts "THIS TASK WILL REWRITE DATA, ARE YOU SURE (type YES)"
     puts "WILL RUN ON ALL #{RailsMultisite::ConnectionManagement.all_dbs.length} DBS" if options[:global]
+    puts "THIS TASK WILL REWRITE DATA, ARE YOU SURE (type YES)"
     text = STDIN.gets
     if text.strip.upcase != "YES"
       puts "aborting."


### PR DESCRIPTION
Before this commit, this output is possible:

```
Rewriting all occurrences of STRING1 to STRING2

THIS TASK WILL REWRITE DATA, ARE YOU SURE (type YES)
WILL RUN ON ALL 1 DBS
```

Which, when run from a script, might lead one to believe that YES was automatically inserted into STDIN and the script is continuing.

Turns out this isn't the case so the obvious expectation is broken.

This commit swaps the order of those last lines to make it clear that the script is blocked on input.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
