### PR TITLE
FIX: Position Float Kit elements correctly in RTL mode

### DIFF
--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -12,7 +12,6 @@
   width: max-content;
   position: absolute;
   top: 0;
-  left: 0;
   max-width: 600px;
   display: flex;
   padding: 0;
@@ -87,9 +86,5 @@
       rotate: 90deg;
       right: -9px;
     }
-  }
-
-  html.rtl & {
-    left: unset;
   }
 }

--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -88,4 +88,8 @@
       right: -9px;
     }
   }
+
+  html.rtl & {
+    left: unset;
+  }
 }

--- a/app/assets/stylesheets/common/float-kit/d-tooltip.scss
+++ b/app/assets/stylesheets/common/float-kit/d-tooltip.scss
@@ -89,4 +89,8 @@
       right: -9px;
     }
   }
+
+  html.rtl & {
+    left: unset;
+  }
 }

--- a/app/assets/stylesheets/common/float-kit/d-tooltip.scss
+++ b/app/assets/stylesheets/common/float-kit/d-tooltip.scss
@@ -17,7 +17,6 @@
   width: max-content;
   position: absolute;
   top: 0;
-  left: 0;
   display: flex !important;
   padding: 0;
 
@@ -88,9 +87,5 @@
       rotate: 90deg;
       right: -9px;
     }
-  }
-
-  html.rtl & {
-    left: unset;
   }
 }


### PR DESCRIPTION
Float-kit elements (menus/tooltips) are positioned where they should be by setting an inline `left` property in JavaScript when they're rendered. We also, for some reasons, set `left: 0` on float-kit elements here:

https://github.com/discourse/discourse/blob/25d9927785b07697132504fca77b8156600966ff/app/assets/stylesheets/common/float-kit/d-menu.scss#L11-L15

This property is overridden by the inline property that the library sets in JavaScript. However, in RTL mode, all of our scss files are flipped where everything left becomes right and vice versa. In this case, the `left: 0` property in the scss file above becomes `right: 0`.

This results in a conflict specific to RTL mode where both the `left` and `right` properties are defined on the same absolute-positioned element; the `right` property will always be set to 0 because it comes from the (flipped) scss file above, and the inline `left` property will be set to some px amount determined in JavaScript.

The `right` property will take precedence over the inline `left` property [due to the page being right-to-left](https://developer.mozilla.org/en-US/docs/Web/CSS/right#description) and this causes float-kit elements to incorrectly always stick to the right.

This PR adds `left: unset` property, which becomes `right: unset` after the file is flipped, that only takes effect in RTL mode to give precedence back to the inline `left` property that positions the element where it should be.

Another solution here could be to remove the `left: 0` property entirely from the scss file, but I don't know why it's there in the first place (git blame doesn't help) so I can't say for sure that removing it would not have bad implications.

Meta topic: https://meta.discourse.org/t/positioning-issues-with-rtl-locales-after-recent-updates/280220?u=osama

Before:

<img width=400 src="https://github.com/discourse/discourse/assets/17474474/5a6f87c8-04f0-4512-bcc2-1b132a703f50">

![image](https://github.com/discourse/discourse/assets/17474474/ff0be0db-0a56-40fe-aba7-8c04f1ea1fab)


After:

<img width=300 src="https://github.com/discourse/discourse/assets/17474474/187a3ca5-ffb5-4824-bbbd-dba8a82455d4">

![image](https://github.com/discourse/discourse/assets/17474474/8f977fce-b597-4a16-afd6-2a1960ba0b65)
