### PR TITLE
DEV: Add outlet and changes to support AI proofread

### DIFF
--- a/app/assets/javascripts/discourse/app/components/fast-edit.gjs
+++ b/app/assets/javascripts/discourse/app/components/fast-edit.gjs
@@ -1,8 +1,10 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import { fixQuotes } from "discourse/components/post-text-selection";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -11,8 +13,8 @@ import autoFocus from "discourse/modifiers/auto-focus";
 import I18n from "discourse-i18n";
 
 export default class FastEdit extends Component {
-  @tracked value = this.args.initialValue;
   @tracked isSaving = false;
+  @tracked value = this.args.newValue || this.args.initialValue;
 
   buttonTitle = I18n.t("composer.title", {
     modifier: translateModKey("Meta+"),
@@ -37,6 +39,11 @@ export default class FastEdit extends Component {
   updateValue(event) {
     event.preventDefault();
     this.value = event.target.value;
+  }
+
+  @action
+  updateValueProperty(value) {
+    this.value = value;
   }
 
   @action
@@ -67,17 +74,29 @@ export default class FastEdit extends Component {
         {{on "input" this.updateValue}}
         id="fast-edit-input"
         {{autoFocus}}
-      >{{@initialValue}}</textarea>
+      >{{this.value}}</textarea>
 
-      <DButton
-        class="btn-small btn-primary save-fast-edit"
-        @action={{this.save}}
-        @icon="pencil-alt"
-        @label="composer.save_edit"
-        @translatedTitle={{this.buttonTitle}}
-        @isLoading={{this.isSaving}}
-        @disabled={{this.disabled}}
-      />
+      <div class="fast-edit-container__footer">
+        <DButton
+          class="btn-small btn-primary save-fast-edit"
+          @action={{this.save}}
+          @icon="pencil-alt"
+          @label="composer.save_edit"
+          @translatedTitle={{this.buttonTitle}}
+          @isLoading={{this.isSaving}}
+          @disabled={{this.disabled}}
+        />
+
+        <PluginOutlet
+          @name="fast-edit-footer-after"
+          @defaultGlimmer={{true}}
+          @outletArgs={{hash
+            initialValue=this.args.initialValue
+            newValue=this.args.newValue
+            updateValue=this.updateValueProperty
+          }}
+        />
+      </div>
     </div>
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/fast-edit.gjs
+++ b/app/assets/javascripts/discourse/app/components/fast-edit.gjs
@@ -91,8 +91,8 @@ export default class FastEdit extends Component {
           @name="fast-edit-footer-after"
           @defaultGlimmer={{true}}
           @outletArgs={{hash
-            initialValue=this.args.initialValue
-            newValue=this.args.newValue
+            initialValue=@initialValue
+            newValue=@newValue
             updateValue=this.updateValueProperty
           }}
         />

--- a/app/assets/javascripts/discourse/app/components/modal/fast-edit.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/fast-edit.hbs
@@ -1,5 +1,6 @@
 <DModal @title={{i18n "post.quote_edit"}} @closeModal={{@closeModal}}>
   <FastEdit
+    @newValue={{@model.newValue}}
     @initialValue={{@model.initialValue}}
     @post={{@model.post}}
     @close={{@closeModal}}

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -190,7 +190,7 @@ export default class PostTextSelectionToolbar extends Component {
         <PluginOutlet
           @name="post-text-buttons"
           @defaultGlimmer={{true}}
-          @outletArgs={{hash data=@data}}
+          @outletArgs={{hash data=@data post=this.post}}
         >
           {{#if this.embedQuoteButton}}
             <DButton


### PR DESCRIPTION
**This PR adds some changes to the `<FastEdit />` component:**
- adds a plugin outlet (`fast-edit-footer-after`)
- adds a new optional argument `newValue` so that a new value can be preset when invoking the component
- adds an `@action` called `updateValueProperty()` so components inside the plugin outlet can call the action to update the textarea's value.

These minor changes have been added to support creating the AI feature: "adding proofread to post AI helper" for the Discourse AI plugin (PR: https://github.com/discourse/discourse-ai/pull/359)