### PR TITLE
DEV: Add outlets and actions to move topic modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
@@ -166,23 +166,55 @@
                 "topic.split_topic.instructions" count=@model.selectedPostsCount
               )
             }}</p>
-          <form>
-            <label>{{i18n "topic.split_topic.topic_name"}}</label>
-            <TextField
-              @value={{this.topicName}}
-              @placeholderKey="composer.title_placeholder"
-              id="split-topic-name"
-            />
+          <form class="split-new-topic-form">
+            <div class="control-group">
+              <label>{{i18n "topic.split_topic.topic_name"}}</label>
+              <TextField
+                @value={{this.topicName}}
+                @placeholderKey="composer.title_placeholder"
+                id="split-topic-name"
+              />
+              <PluginOutlet
+                @name="split-new-topic-title-after"
+                @outletArgs={{hash
+                  selectedPosts=@model.selectedPosts
+                  updateTopicName=this.updateTopicName
+                }}
+              />
+            </div>
 
-            <label>{{i18n "categories.category"}}</label>
-            <CategoryChooser
-              @value={{this.categoryId}}
-              class="small"
-              @onChange={{action (mut this.categoryId)}}
-            />
+            <div class="control-group">
+              <label>{{i18n "categories.category"}}</label>
+              <CategoryChooser
+                @value={{this.categoryId}}
+                class="small"
+                @onChange={{action (mut this.categoryId)}}
+              />
+              <PluginOutlet
+                @name="split-new-topic-category-after"
+                @outletArgs={{hash
+                  selectedPosts=@model.selectedPosts
+                  updateCategoryId=this.updateCategoryId
+                }}
+              />
+            </div>
+
             {{#if this.canAddTags}}
-              <label>{{i18n "tagging.tags"}}</label>
-              <TagChooser @tags={{this.tags}} @categoryId={{this.categoryId}} />
+              <div class="control-group">
+                <label>{{i18n "tagging.tags"}}</label>
+                <TagChooser
+                  @tags={{this.tags}}
+                  @categoryId={{this.categoryId}}
+                />
+                <PluginOutlet
+                  @name="split-new-topic-tag-after"
+                  @outletArgs={{hash
+                    selectedPosts=@model.selectedPosts
+                    updateTags=this.updateTags
+                    tags=this.tags
+                  }}
+                />
+              </div>
             {{/if}}
           </form>
         {{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.js
@@ -162,4 +162,19 @@ export default class MoveToTopic extends Component {
       this.saving = false;
     }
   }
+
+  @action
+  updateTopicName(newName) {
+    this.topicName = newName;
+  }
+
+  @action
+  updateCategoryId(newId) {
+    this.categoryId = newId;
+  }
+
+  @action
+  updateTags(newTags) {
+    this.tags = newTags;
+  }
 }


### PR DESCRIPTION
**For usage by Discourse AI in (https://github.com/discourse/discourse-ai/pull/360), this PR:**
- adds plugin outlets:
   - `split-new-topic-title-after`
   - `split-new-topic-category-after`
   -  `split-new-topic-tag-after`
- adds actions that are passed into the outlets for updating attributes:
   - `updateTopicName`
   - `updateCategoryId`
   - `updateTags`
- wraps input groups in `<div class="control-group">`
