### PR TITLE
UX: fix overlap of obstructed anon topic reply button

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1500,8 +1500,10 @@ span.mention {
 }
 
 #topic-footer-buttons {
+  position: relative;
   margin: var(--below-topic-margin) 0;
   padding: 0;
+  z-index: z("base"); // places above proceeding relative parent
 
   .topic-footer-main-buttons {
     display: flex;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -53,6 +53,10 @@
         }
       }
     }
+
+    &-title {
+      display: inline-block;
+    }
   }
 
   // Target the .badge-category text, the bullet icon needs to maintain `display: block`


### PR DESCRIPTION
This PR addresses the overlap between the anonymous reply button in a topic and the related or new and unread topics component.

Issue:

![CleanShot 2023-12-15 at 12 16 34](https://github.com/discourse/discourse/assets/69276978/1f20aa53-b42f-466c-958e-a2c0e0df0852)
