### PR TITLE
FIX: Excessive video data downloading from service worker

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -121,6 +121,11 @@ workbox.routing.registerRoute(
       return false;
     }
 
+    // Exclude videos from service worker
+    if (args.event.request.headers.has('range')) {
+      return false;
+    }
+
     var matching = cdnUrls.filter(
       function(url) {
         return args.url.href.startsWith(url);


### PR DESCRIPTION
This bug appears to only be on Chrome due to the service worker fetching
the video content on page load instead of on play. For some reason
though the service worker would fetch around 4x more than the size of
the video resulting in excessive data being downloaded especially for
larger videos.

meta https://meta.discourse.org/t/287817
internal /t/111387/52
