### PR TITLE
UX: fix overlap obstructed anon topic reply

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -543,7 +543,7 @@
               @icon="reply"
               @action={{route-action "showLogin"}}
               @label="topic.reply.title"
-              class="btn-primary pull-right"
+              class="btn-primary"
             />
           </div>
         {{/if}}

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1500,8 +1500,10 @@ span.mention {
 }
 
 #topic-footer-buttons {
+  position: relative;
   margin: var(--below-topic-margin) 0;
   padding: 0;
+  z-index: z("base"); // places above proceeding relative parent
 
   .topic-footer-main-buttons {
     display: flex;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1499,11 +1499,14 @@ span.mention {
   }
 }
 
+html.anon #topic-footer-buttons {
+  display: flex;
+  justify-content: end;
+}
+
 #topic-footer-buttons {
-  position: relative;
   margin: var(--below-topic-margin) 0;
   padding: 0;
-  z-index: z("base"); // places above proceeding relative parent
 
   .topic-footer-main-buttons {
     display: flex;

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -53,10 +53,6 @@
         }
       }
     }
-
-    &-title {
-      display: inline-block;
-    }
   }
 
   // Target the .badge-category text, the bullet icon needs to maintain `display: block`

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -53,6 +53,10 @@
         }
       }
     }
+
+    &-title {
+      display: inline-block;
+    }
   }
 
   // Target the .badge-category text, the bullet icon needs to maintain `display: block`


### PR DESCRIPTION
This commit addresses the overlap between the anonymous reply button in a topic and the related or new and unread topics component.

Before (overlap):

![CleanShot 2023-12-15 at 16 02 24](https://github.com/discourse/discourse/assets/69276978/b307e05f-634c-47f3-bde1-1b556a4de6bb)

After:

![CleanShot 2023-12-15 at 16 01 18](https://github.com/discourse/discourse/assets/69276978/1c7420a2-e4cc-42c4-8b42-ff1931a7ae30)
