### PR TITLE
DEV: fix broken grant badge utils test

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/grant-badge-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/grant-badge-utils.js
@@ -24,7 +24,7 @@ export function grantableBadges(allBadges, userBadges) {
 }
 
 export function isBadgeGrantable(badgeId, availableBadges) {
-  return (
+  return !!(
     availableBadges && availableBadges.some((b) => b.get("id") === badgeId)
   );
 }

--- a/app/assets/javascripts/discourse/tests/unit/lib/grant-badge-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/grant-badge-utils-test.js
@@ -1,50 +1,53 @@
+import { getOwner } from "@ember/application";
+import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import {
   grantableBadges,
   isBadgeGrantable,
 } from "discourse/lib/grant-badge-utils";
-import Badge from "discourse/models/badge";
 module("Unit | Utility | Grant Badge", function (hooks) {
-  hooks.beforeEach(() => {
-    const firstBadge = Badge.create({
+  setupTest(hooks);
+
+  test("grantableBadges", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const firstBadge = store.createRecord("badge", {
       id: 3,
       name: "A Badge",
       enabled: true,
       manually_grantable: true,
     });
-    const middleBadge = Badge.create({
+    const middleBadge = store.createRecord("badge", {
       id: 1,
       name: "My Badge",
       enabled: true,
       manually_grantable: true,
     });
-    const lastBadge = Badge.create({
+    const lastBadge = store.createRecord("badge", {
       id: 2,
       name: "Zoo Badge",
       enabled: true,
       manually_grantable: true,
       multiple_grant: true,
     });
-    const grantedBadge = Badge.create({
+    const grantedBadge = store.createRecord("badge", {
       id: 6,
       name: "Grant Badge",
       enabled: true,
       manually_grantable: true,
       multiple_grant: false,
     });
-    const disabledBadge = Badge.create({
+    const disabledBadge = store.createRecord("badge", {
       id: 4,
       name: "Disabled Badge",
       enabled: false,
       manually_grantable: true,
     });
-    const automaticBadge = Badge.create({
+    const automaticBadge = store.createRecord("badge", {
       id: 5,
       name: "Automatic Badge",
       enabled: true,
       manually_grantable: false,
     });
-
     const allBadges = [
       lastBadge,
       firstBadge,
@@ -53,44 +56,70 @@ module("Unit | Utility | Grant Badge", function (hooks) {
       disabledBadge,
       automaticBadge,
     ];
-    const userBadges = [lastBadge, grantedBadge];
 
-    test("grantableBadges", function (assert) {
-      const sortedNames = [firstBadge.name, middleBadge.name, lastBadge.name];
-
-      const result = grantableBadges(allBadges, userBadges);
-      const badgeNames = result.map((b) => b.name);
-
-      assert.deepEqual(badgeNames, sortedNames, "sorts badges by name");
-      assert.notOk(
-        badgeNames.includes(grantedBadge.name),
-        "excludes already granted badges"
-      );
-      assert.notOk(
-        badgeNames.includes(disabledBadge.name),
-        "excludes disabled badges"
-      );
-      assert.notOk(
-        badgeNames.includes(automaticBadge.name),
-        "excludes automatic badges"
-      );
-      assert.ok(
-        badgeNames.includes(lastBadge.name),
-        "includes granted badges that can be granted multiple times"
-      );
+    const userBadges = [lastBadge, grantedBadge].map((badge) => {
+      return store.createRecord("user-badge", {
+        badge_id: badge.id,
+      });
     });
+    const sortedNames = [firstBadge.name, middleBadge.name, lastBadge.name];
 
-    test("isBadgeGrantable", function (assert) {
-      const badges = [firstBadge, lastBadge];
-      assert.ok(isBadgeGrantable(firstBadge.id, badges));
-      assert.notOk(
-        isBadgeGrantable(disabledBadge.id, badges),
-        "returns false when badgeId is not that of any badge in availableBadges"
-      );
-      assert.notOk(
-        isBadgeGrantable(firstBadge.id),
-        "returns false if no availableBadges is defined"
-      );
+    const result = grantableBadges(allBadges, userBadges);
+    const badgeNames = result.map((b) => b.name);
+
+    assert.deepEqual(badgeNames, sortedNames, "sorts badges by name");
+    assert.false(
+      badgeNames.includes(grantedBadge.name),
+      "excludes already granted badges"
+    );
+    assert.false(
+      badgeNames.includes(disabledBadge.name),
+      "excludes disabled badges"
+    );
+    assert.false(
+      badgeNames.includes(automaticBadge.name),
+      "excludes automatic badges"
+    );
+    assert.true(
+      badgeNames.includes(lastBadge.name),
+      "includes granted badges that can be granted multiple times"
+    );
+  });
+
+  test("isBadgeGrantable", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const grantable_once_badge = store.createRecord("badge", {
+      id: 3,
+      name: "A Badge",
+      enabled: true,
+      manually_grantable: true,
     });
+    const other_grantable_badge = store.createRecord("badge", {
+      id: 2,
+      name: "Zoo Badge",
+      enabled: true,
+      manually_grantable: true,
+      multiple_grant: true,
+    });
+    const disabledBadge = store.createRecord("badge", {
+      id: 4,
+      name: "Disabled Badge",
+      enabled: false,
+      manually_grantable: true,
+    });
+    const badges = [grantable_once_badge, other_grantable_badge];
+    assert.true(isBadgeGrantable(grantable_once_badge.id, badges));
+    assert.false(
+      isBadgeGrantable(disabledBadge.id, badges),
+      "returns false when badgeId is not that of any badge in availableBadges"
+    );
+    assert.false(
+      isBadgeGrantable(grantable_once_badge.id, []),
+      "returns false if empty array availableBadges is passed in"
+    );
+    assert.false(
+      isBadgeGrantable(grantable_once_badge.id, null),
+      "returns false if no availableBadges is defined"
+    );
   });
 });


### PR DESCRIPTION
This test suite was previously mistakenly left inside the before hooks call. This PR fixes that test suite, and ensures that isBadgeGrantable returns a boolean type (`null && <boolean>` returns null).
