### PR TITLE
DEV: Set `Capybara.default_max_wait_time` to `4` as default

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -304,6 +304,8 @@ RSpec.configure do |config|
 
     if ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].present?
       Capybara.default_max_wait_time = ENV["CAPYBARA_DEFAULT_MAX_WAIT_TIME"].to_i
+    else
+      Capybara.default_max_wait_time = 4
     end
 
     Capybara.threadsafe = true


### PR DESCRIPTION
Why this change?

By default, `Capybara.default_max_wait_time` is set to `2`. However,
this is not a high enough default for Discourse as certain requests like
creating a post can take upwards of 2 seconds even on a high end desktop
CPU like the Ryzen 5950x. Therefore, we have decided to double the default max wait time.