### PR TITLE
DEV: Set `Capybara.default_max_wait_time` to `4` as default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,16 +306,19 @@ jobs:
           fi
         shell: bash
 
+      - name: Echo
+        run: echo "${{github.run_id}}"
+
       - name: Create flaky tests report artifact
         if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
-        run: cp tmp/turbo_rspec_flaky_tests.json tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.job }}.json
+        run: cp tmp/turbo_rspec_flaky_tests.json tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.run_id }}.json
 
       - name: Upload flaky tests report
         uses: actions/upload-artifact@v3
         if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
         with:
           name: flaky-test-reports
-          path: tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.job }}.json
+          path: tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.run_id }}.json
 
       - name: Check Annotations
         if: matrix.build_type == 'annotations'


### PR DESCRIPTION
Why this change?

By default, `Capybara.default_max_wait_time` is set to `2`. However,
this is not a high enough default for Discourse as certain requests like
creating a post can take upwards of 2 seconds even on a high end desktop
CPU like the Ryzen 5950x. Therefore, we have decided to double the default max wait time.