### PR TITLE
DEV: Fix flaky tests report artifacts not using the right job_id

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
-    name: ${{ matrix.target }} ${{ matrix.build_type }} (Ember ${{ matrix.updated_ember && '5' || '3' }})
+    name: ${{ matrix.target }} ${{ matrix.build_type }} (Ember ${{ matrix.updated_ember && '5' || '3' }}) # Update fetch-job-id step if changing this
     runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || 'ubuntu-20.04-8core' }}
     container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}${{ (matrix.ruby == '3.1') && '-ruby-3.1.0' || '' }}
     timeout-minutes: 20
@@ -306,16 +306,23 @@ jobs:
           fi
         shell: bash
 
+      - name: Fetch Job ID
+        id: fetch-job-id
+        if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
+        run: |
+          job_id=$(ruby script/get_github_workflow_run_job_id.rb ${{ github.run_id }} ${{ github.run_attempt }} '${{ matrix.target }} ${{ matrix.build_type }} (Ember ${{ matrix.updated_ember && '5' || '3' }})')
+          echo "job_id=$job_id" >> $GITHUB_OUTPUT
+
       - name: Create flaky tests report artifact
         if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
-        run: cp tmp/turbo_rspec_flaky_tests.json tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.job }}.json
+        run: cp tmp/turbo_rspec_flaky_tests.json tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ steps.fetch-job-id.outputs.job_id }}.json
 
       - name: Upload flaky tests report
         uses: actions/upload-artifact@v3
         if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
         with:
           name: flaky-test-reports
-          path: tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ github.job }}.json
+          path: tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ steps.fetch-job-id.outputs.job_id }}.json
 
       - name: Check Annotations
         if: matrix.build_type == 'annotations'

--- a/script/get_github_workflow_run_job_id.rb
+++ b/script/get_github_workflow_run_job_id.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+workflow_run_id = ARGV[0]
+run_attempt = ARGV[1]
+job_name = ARGV[2]
+
+uri =
+  URI.parse(
+    "https://api.github.com/repos/discourse/discourse/actions/runs/#{workflow_run_id}/attempts/#{run_attempt}/jobs",
+  )
+
+request = Net::HTTP::Get.new(uri)
+request["Accept"] = "application/vnd.github+json"
+request["X-Github-Api-Version"] = "2022-11-28"
+
+response =
+  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.is_a?(URI::HTTPS)) do |http|
+    http.request(request)
+  end
+
+JSON.parse(response.body)["jobs"].each do |job|
+  if job["name"] == job_name
+    puts job["id"]
+    break
+  end
+end


### PR DESCRIPTION
### Why this change?

`github.job` returns the `job_id` per the docs but it doesn't actually
return the id of the job but instead returns the job's name strangely.

Per https://github.com/orgs/community/discussions/8945, there is no way
to get the `job_id` from the existing contexts in the actions run.
Therefore, we have to hit Github's API to fetch it. Not ideal but no
way around this.

### Reviewer notes

Not sure how to test this but it isn't critical to the application so I'm not spending much time on this.