### PR TITLE
DEV: Change default of `cross_origin_opener_policy_header`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -993,9 +993,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_cross_origin_opener_policy_header
-    if SiteSetting.cross_origin_opener_policy_header != "unsafe-none"
-      response.headers["Cross-Origin-Opener-Policy"] = SiteSetting.cross_origin_opener_policy_header
-    end
+    response.headers["Cross-Origin-Opener-Policy"] = SiteSetting.cross_origin_opener_policy_header
   end
 
   protected

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1967,7 +1967,7 @@ security:
   display_personal_messages_tag_counts:
     default: false
   cross_origin_opener_policy_header:
-    default: "unsafe-none"
+    default: "same-origin-allow-popups"
     type: enum
     choices:
       - "unsafe-none"

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe ApplicationController do
         get "/latest"
 
         expect(response.status).to eq(200)
-        expect(response.headers["Cross-Origin-Opener-Policy"]).to eq(nil)
+        expect(response.headers["Cross-Origin-Opener-Policy"]).to eq("unsafe-none")
       end
     end
   end


### PR DESCRIPTION
Why this change?

This is part of our efforts to harden the security of the Discourse
application. Setting the `CROSS_ORIGIN_OPENER_POLICY` header to `same-origin-allow-popups`
by default makes the application safer. We have opted to make this a
hidden site setting because most admins will never have to care about
this setting so we're are opting not to show it. If they do have to
change it, they can still do so by setting the
`DISCOURSE_CROSS_ORIGIN_OPENER_POLICY` env.