### PR TITLE
FIX: Correct urls to account for subfolder setup

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -350,7 +350,7 @@
       </div>
       <div class="controls">
         <DButton
-          @href={{get-url "/admin/api/keys"}}
+          @href="/admin/api/keys"
           @label="admin.api.manage_keys"
           class="btn-default"
         />

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -350,7 +350,7 @@
       </div>
       <div class="controls">
         <DButton
-          @href="/admin/api/keys"
+          @href={{get-url "/admin/api/keys"}}
           @label="admin.api.manage_keys"
           class="btn-default"
         />

--- a/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
@@ -1,4 +1,4 @@
-<a href="/tags">
+<a class="tag-groups--back" href={{get-url "/tags"}}>
   {{d-icon "chevron-left"}}
   <span>{{i18n "tagging.groups.back_btn"}}</span>
 </a>

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,4 +1,5 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
+import { setPrefix } from "discourse-common/lib/get-url";
 import { test } from "qunit";
 import {
   acceptance,
@@ -11,17 +12,21 @@ acceptance("Tag Groups", function (needs) {
   needs.user();
   needs.settings({ tagging_enabled: true });
   needs.pretender((server, helper) => {
+    const tagGroups = {
+      tag_group: {
+        id: 42,
+        name: "test tag group",
+        tag_names: ["monkey"],
+        parent_tag_name: [],
+        one_per_topic: false,
+        permissions: { everyone: 1 },
+      },
+    };
     server.post("/tag_groups", () => {
-      return helper.response({
-        tag_group: {
-          id: 42,
-          name: "test tag group",
-          tag_names: ["monkey"],
-          parent_tag_name: [],
-          one_per_topic: false,
-          permissions: { everyone: 1 },
-        },
-      });
+      return helper.response(tagGroups);
+    });
+    server.get("/forum/tag_groups", () => {
+      return helper.response(tagGroups);
     });
 
     server.get("/groups/search.json", () => {
@@ -81,5 +86,14 @@ acceptance("Tag Groups", function (needs) {
       exists("#visible-permission:checked"),
       "selected permission does not change after saving"
     );
+  });
+
+  test("going back to tags supports subfolder", async function (assert) {
+    setPrefix("/forum");
+
+    await visit("/tag_groups");
+    assert
+      .dom("a.tag-groups--back")
+      .hasAttribute("href", "/forum/tags", "supports subfolder");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,5 +1,4 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
-import { setPrefix } from "discourse-common/lib/get-url";
 import { test } from "qunit";
 import {
   acceptance,
@@ -7,6 +6,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { setPrefix } from "discourse-common/lib/get-url";
 
 acceptance("Tag Groups", function (needs) {
   needs.user();


### PR DESCRIPTION
https://meta.discourse.org/t/back-to-all-tags-link-broken-on-manage-tag-groups-page/288825

We forgot to `get-url` :sadpikachu:
