### PR TITLE
DEV: Convert min_trust_to_send_email_messages to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1979,6 +1979,7 @@ en:
 
     min_trust_to_send_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages."
     min_trust_to_send_email_messages: "The minimum trust level required to send personal messages via email."
+    send_email_messages_allowed_groups: "Groups that are allowed to send personal messages via email."
     min_trust_to_flag_posts: "The minimum trust level required to flag posts"
     flag_post_allowed_groups: "Groups that are allowed to flag posts."
     min_trust_to_post_links: "The minimum trust level required to include links in posts"
@@ -2580,6 +2581,7 @@ en:
       ignore_allowed_groups: "min_trust_level_to_allow_ignore"
       self_wiki_allowed_groups: "min_trust_to_allow_self_wiki"
       create_tag_allowed_groups: "min_trust_to_create_tag"
+      send_email_messages_allowed_groups: "min_trust_to_send_email_messages"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1727,6 +1727,13 @@ trust:
   min_trust_to_send_email_messages:
     default: "4"
     enum: "TrustLevelAndStaffSetting"
+    hidden: true
+  send_email_messages_allowed_groups:
+    default: "1|3|14"
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   min_trust_to_flag_posts:
     default: 1
     enum: "TrustLevelSetting"

--- a/db/migrate/20231218081901_fill_send_email_messages_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231218081901_fill_send_email_messages_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class FillSendEmailMessagesAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    configured_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_to_send_email_messages' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL4, we only need to do anything if it's been changed in the DB.
+    if configured_trust_level.present?
+      corresponding_group =
+        case configured_trust_level
+        when "admin"
+          "1"
+        when "staff"
+          "1|3"
+          # Matches Group::AUTO_GROUPS to the trust levels.
+        else
+          "1|3|1#{configured_trust_level}"
+        end
+
+      # Data_type 20 is group_list.
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('send_email_messages_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: corresponding_group,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -526,7 +526,7 @@ class Guardian
     return false if !authenticated?
     # User is trusted enough
     @user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map) &&
-      @user.has_trust_level_or_staff?(SiteSetting.min_trust_to_send_email_messages)
+      @user.in_any_groups?(SiteSetting.send_email_messages_allowed_groups_map)
   end
 
   def can_export_entity?(entity)

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -35,6 +35,7 @@ module SiteSettings::DeprecatedSettings
     ["min_trust_level_to_allow_ignore", "ignore_allowed_groups", false, "3.3"],
     ["min_trust_to_allow_self_wiki", "self_wiki_allowed_groups", false, "3.3"],
     ["min_trust_to_create_tag", "create_tag_allowed_groups", false, "3.3"],
+    ["min_trust_to_send_email_messages", "send_email_messages_allowed_groups", false, "3.3"],
   ]
 
   OVERRIDE_TL_GROUP_SETTINGS = %w[
@@ -54,6 +55,7 @@ module SiteSettings::DeprecatedSettings
     min_trust_level_to_allow_invite
     min_trust_level_to_allow_ignore
     min_trust_to_create_tag
+    min_trust_to_send_email_messages
   ]
 
   def group_to_tl(old_setting, new_setting)
@@ -111,13 +113,7 @@ module SiteSettings::DeprecatedSettings
 
   def setup_deprecated_methods
     SETTINGS.each do |old_setting, new_setting, override, version|
-      if !override
-        SiteSetting.singleton_class.public_send(
-          :alias_method,
-          :"_#{old_setting}",
-          :"#{old_setting}",
-        )
-      end
+      SiteSetting.singleton_class.alias_method(:"_#{old_setting}", :"#{old_setting}") if !override
 
       if OVERRIDE_TL_GROUP_SETTINGS.include?(old_setting)
         define_singleton_method "_group_to_tl_#{old_setting}" do |warn: true|
@@ -140,13 +136,7 @@ module SiteSettings::DeprecatedSettings
         end
       end
 
-      if !override
-        SiteSetting.singleton_class.public_send(
-          :alias_method,
-          :"_#{old_setting}?",
-          :"#{old_setting}?",
-        )
-      end
+      SiteSetting.singleton_class.alias_method(:"_#{old_setting}?", :"#{old_setting}?") if !override
 
       define_singleton_method "#{old_setting}?" do |warn: true|
         if warn
@@ -159,13 +149,7 @@ module SiteSettings::DeprecatedSettings
         self.public_send("#{override ? new_setting : "_" + old_setting}?")
       end
 
-      if !override
-        SiteSetting.singleton_class.public_send(
-          :alias_method,
-          :"_#{old_setting}=",
-          :"#{old_setting}=",
-        )
-      end
+      SiteSetting.singleton_class.alias_method(:"_#{old_setting}=", :"#{old_setting}=") if !override
 
       define_singleton_method "#{old_setting}=" do |val, warn: true|
         if warn


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/283408)

### What is this change?

We're changing the implementation of trust levels to use groups. Part of this is to have site settings that reference trust levels use groups instead. It converts the `min_trust_to_send_email_messages` site setting to `send_email_messages_allowed_groups`.
