### PR TITLE
DEV: Stop exporting internal routeAction function

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/route-action.js
+++ b/app/assets/javascripts/discourse/app/helpers/route-action.js
@@ -27,7 +27,7 @@ function getRouteWithAction(router, actionName) {
   return { action, handler };
 }
 
-export function routeAction(actionName, router, ...params) {
+function routeAction(actionName, router, ...params) {
   assert("[ember-route-action-helper] Unable to lookup router", router);
 
   runInDebug(() => {


### PR DESCRIPTION
Consumers should use the default export. This function doesn't work directly (unless you manually construct its arguments) - the default export helper handles all that automatically.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
