### PR TITLE
FIX: Ensure file size restriction types are ints

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -35,7 +35,7 @@ class Admin::SiteSettingsController < Admin::AdminController
     when :integer
       value = value.tr("^-0-9", "")
     when :file_size_restriction
-      value = value.tr("^-0-9", "")
+      value = value.tr("^0-9", "").to_i
     when :uploaded_image_list
       value = Upload.get_from_urls(value.split("|")).to_a
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -59,7 +59,7 @@ class Topic < ActiveRecord::Base
 
   def thumbnail_info(enqueue_if_missing: false, extra_sizes: [])
     return nil unless original = image_upload
-    return nil if original.filesize >= SiteSetting.max_image_size_kb.kilobytes
+    return nil if original.filesize >= SiteSetting.max_image_size_kb.to_i.kilobytes
     return nil unless original.read_attribute(:width) && original.read_attribute(:height)
 
     infos = []

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -276,6 +276,13 @@ RSpec.describe Admin::SiteSettingsController do
         expect(SiteSetting.suggested_topics).to eq(1000)
       end
 
+      it "sanitizes file_size_restriction values" do
+        put "/admin/site_settings/max_image_size_kb.json", params: { max_image_size_kb: "4096" }
+
+        expect(response.status).to eq(200)
+        expect(SiteSetting.max_image_size_kb).to eq(4096)
+      end
+
       it "sanitizes negative integer values correctly" do
         put "/admin/site_settings/pending_users_reminder_delay_minutes.json",
             params: {


### PR DESCRIPTION
Settings that are using the new `file_size_restriction` types like the
`max_image_size_kb` setting need to have their values saved as integers.
This was a recent regression in 00209f03e6bc55c6dd776dbe828b8bb53cd935f4
that caused these values to be saved as strings.

This change also removes negatives from the validation regex because
file sizes can't be negative anyways.

Bug report: https://meta.discourse.org/t/289037
