### PR TITLE
UX: align topic notification button + text vertically

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -237,9 +237,13 @@ a.reply-to-tab {
     align-items: center;
 
     .reason {
+      display: flex;
+      flex-direction: column;
       align-items: flex-start;
-      .select-kit {
-        max-width: 40%;
+
+      .text {
+        margin-left: 0;
+        margin-top: 0.25rem;
       }
     }
     @include breakpoint(mobile-medium) {


### PR DESCRIPTION
To avoid the button sometimes being too narrow for the label:
![image](https://github.com/discourse/discourse/assets/101828855/620e580a-6e9d-4f6b-800a-1210f17c50d3)

I'm removing the max-width on select kit and stacking the elements vertically instead (mobile only)

<img width="353" alt="image" src="https://github.com/discourse/discourse/assets/101828855/236121ec-25ae-4407-af91-ebfe2b45294b">


