### PR TITLE
FIX: chat navbar follow-ups

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
@@ -15,7 +15,7 @@ export default class ChatRoutesChannelInfo extends Component {
 
   membersLabel = I18n.t("chat.channel_info.tabs.members");
   settingsLabel = I18n.t("chat.channel_info.tabs.settings");
-  backToChannelLabel = I18n.t("chat.channel_info.back_to_all_channel");
+  backToChannelLabel = I18n.t("chat.channel_info.back_to_all_channels");
   backToAllChannelsLabel = I18n.t("chat.channel_info.back_to_channel");
 
   get showTabs() {

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -3,19 +3,22 @@
   // 46px is the height of the navbar
   height: calc(
     var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-      var(--composer-height, 0px) - var(--chat-header-offset)
+      var(--composer-height, 0px) - var(--chat-header-offset, 0px)
   );
 
   // mobile with keyboard opened
   .keyboard-visible & {
-    height: calc(var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px));
+    height: calc(
+      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+        var(--chat-header-offset, 0px)
+    );
   }
 
   // ipad
   .footer-nav-ipad & {
     height: calc(
       var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--composer-height, 0px)
+        var(--chat-header-offset, 0px) - var(--composer-height, 0px)
     );
   }
 }


### PR DESCRIPTION
- correctly accounts for navbar height on ipad and when keyboard is open
- fixes an incorrect I18n key

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
