### PR TITLE
DEV: Allow 'emails disabled' notices to be temporarily dismissed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -121,6 +121,10 @@ export default class GlobalNotice extends Component {
         Notice.create({
           text: I18n.t("emails_are_disabled"),
           id: "alert-emails-disabled",
+          options: {
+            dismissable: true,
+            persistentDismiss: false,
+          },
         })
       );
     } else if (this.siteSettings.disable_emails === "non-staff") {
@@ -128,6 +132,10 @@ export default class GlobalNotice extends Component {
         Notice.create({
           text: I18n.t("emails_are_disabled_non_staff"),
           id: "alert-emails-disabled",
+          options: {
+            dismissable: true,
+            persistentDismiss: false,
+          },
         })
       );
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
@@ -3,7 +3,6 @@ import { test } from "qunit";
 import {
   acceptance,
   exists,
-  query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "discourse-i18n";
@@ -27,11 +26,9 @@ acceptance("Email Disabled Banner", function (needs) {
       exists(".alert-emails-disabled"),
       "alert is displayed when email disabled"
     );
-    assert.strictEqual(
-      query(".alert-emails-disabled").innerText,
-      I18n.t("emails_are_disabled"),
-      "alert uses the correct text"
-    );
+    assert
+      .dom(".alert-emails-disabled .text")
+      .hasText(I18n.t("emails_are_disabled"), "alert uses the correct text");
   });
 
   test("when non-staff", async function (assert) {
@@ -41,11 +38,12 @@ acceptance("Email Disabled Banner", function (needs) {
       exists(".alert-emails-disabled"),
       "alert is displayed when email disabled for non-staff"
     );
-    assert.strictEqual(
-      query(".alert-emails-disabled").innerText,
-      I18n.t("emails_are_disabled_non_staff"),
-      "alert uses the correct text"
-    );
+    assert
+      .dom(".alert-emails-disabled .text")
+      .hasText(
+        I18n.t("emails_are_disabled_non_staff"),
+        "alert uses the correct text"
+      );
 
     updateCurrentUser({ moderator: true });
     await visit("/");
@@ -53,10 +51,11 @@ acceptance("Email Disabled Banner", function (needs) {
       exists(".alert-emails-disabled"),
       "alert is displayed to staff when email disabled for non-staff"
     );
-    assert.strictEqual(
-      query(".alert-emails-disabled").innerText,
-      I18n.t("emails_are_disabled_non_staff"),
-      "alert uses the correct text"
-    );
+    assert
+      .dom(".alert-emails-disabled .text")
+      .hasText(
+        I18n.t("emails_are_disabled_non_staff"),
+        "alert uses the correct text"
+      );
   });
 });


### PR DESCRIPTION
This makes it much easier to see what a production site will look like before launch. The notices return on the next pageload, so there is minimal risk of this affecting visibility of an email configuration problem.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
