### PR TITLE
FEATURE: Add API scope for /logs route

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -234,6 +234,11 @@ class ApiKeyScope < ActiveRecord::Base
             actions: %w[users#create groups#index],
           },
         },
+        logs: {
+          messages: {
+            actions: [Logster::Web],
+          },
+        },
       }
 
       parse_resources!(mappings)
@@ -290,6 +295,11 @@ class ApiKeyScope < ActiveRecord::Base
 
             if actions.include?(action) && api_supported_path && !excluded_paths.include?(path)
               urls << "#{engine_mount_path}#{path} (#{route.verb})"
+            end
+
+            if actions.include?(Logster::Web)
+              urls << "/logs/messages.json (POST)"
+              urls << "/logs/show/:id.json (GET)"
             end
           end
         end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5017,6 +5017,8 @@ en:
               commenting: Necessary for the WP Discourse plugin commenting features.
               discourse_connect: Necessary for the WP Discourse plugin DiscourseConnect features.
               utilities: Necessary if you use WP Discourse plugin Utilities.
+            logs:
+              messages: List messages from /logs or get a specific log message.
 
       web_hooks:
         title: "Webhooks"

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -440,6 +440,7 @@ RSpec.describe Admin::ApiController do
           "search",
           "invites",
           "wordpress",
+          "logs",
         )
 
         topic_routes = [
@@ -479,6 +480,10 @@ RSpec.describe Admin::ApiController do
           "/u/:username/feature-topic (PUT)",
           "/u/:username/clear-featured-topic (PUT)",
         )
+
+        expect(
+          scopes["logs"].any? { |h| h["urls"].include?("/logs/messages.json (POST)") },
+        ).to be_truthy
       end
     end
 


### PR DESCRIPTION
Adds an API scope for accessing Logster's routes. This one is a bit
different than routes from core because it is mounted like

```
mount Logster::Web => "/logs"
```

and doesn't have all the route info a traditional rails app/engine does.
