### PR TITLE
DEV: Pin rbtrace gem to 0.4.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -196,7 +196,12 @@ gem "rack-mini-profiler", require: ["enable_rails_patches"]
 
 gem "unicorn", require: false, platform: :ruby
 gem "puma", require: false
-gem "rbtrace", require: false, platform: :mri
+
+# Pin to 0.4.14 for now because 0.5.0 is broken.
+# It has been fixed in https://github.com/tmm1/rbtrace/commit/1c674885694c6f2cb935eeccb0591feeb67679cf but we are waiting
+# for a new release to be published.
+gem "rbtrace", "0.4.14", require: false, platform: :mri
+
 gem "gc_tracer", require: false, platform: :mri
 
 # required for feed importing and embedding

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbtrace (0.5.0)
+    rbtrace (0.4.14)
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)
       optimist (>= 3.0.0)
@@ -627,7 +627,7 @@ DEPENDENCIES
   railties
   rake
   rb-fsevent
-  rbtrace
+  rbtrace (= 0.4.14)
   rchardet
   redcarpet
   redis


### PR DESCRIPTION
Why this change?

rbtrace 0.5.0 has a bug which is preventing the rbtrace CLI from
working. The bug has been fixed in https://github.com/tmm1/rbtrace/commit/1c674885694c6f2cb935eeccb0591feeb67679cf
but we are waiting for a new version to be released with the fix.