### PR TITLE
FIX: add gallery to lightbox for images within the same chat message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -159,6 +159,9 @@ export default {
         image: {
           verticalFit: true,
         },
+        gallery: {
+          enabled: true,
+        },
         callbacks: {
           elementParse: (item) => {
             item.src = item.el[0].dataset.largeSrc || item.el[0].src;


### PR DESCRIPTION
We use the lightbox gallery feature for photos within the topics that are part of the same post, but when multiple chat images are uploaded to a single message they don't use the gallery (each photo loads separately).

This small fix will correct that for our Magnific lightbox implementation within chat. It also aligns with the functionality that already exists in the experimental lightbox (which uses the gallery within chat messages).

No tests added as this is simply opting into the library gallery feature.