### PR TITLE
UX: use same colour for thread icon as for indicator when unread

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -44,7 +44,7 @@
 
     &.has-unreads {
       .d-icon-discourse-threads {
-        color: var(--tertiary);
+        color: var(--tertiary-med-or-tertiary);
       }
     }
   }


### PR DESCRIPTION
### Before

<img width="352" alt="image" src="https://github.com/discourse/discourse/assets/101828855/67f21abb-7615-485d-a5bc-315e969f2641">

### After
<img width="407" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c7f1b5d1-227a-44c5-94e2-68dbda38278a">


