### PR TITLE
UX: align navbar and composer uploads

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer-uploads.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer-uploads.scss
@@ -2,7 +2,7 @@
   max-width: 100%;
 
   .chat-composer-uploads-container {
-    padding: 0.5rem 0.25rem;
+    padding: 0.5rem 1rem;
     display: flex;
     white-space: nowrap;
     overflow-x: auto;

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -5,7 +5,6 @@
   gap: 0.25rem;
 
   &-container {
-    padding-inline: 0.5rem;
     border-bottom: 1px solid var(--primary-low);
     background: var(--secondary);
     height: var(--chat-header-offset);
@@ -13,6 +12,13 @@
     box-sizing: border-box;
     display: flex;
     z-index: z("composer", "content") - 1;
+
+    .full-page & {
+      padding-inline: 1rem;
+    }
+    .chat-drawer & {
+      padding-inline: 0.25rem;
+    }
 
     &.-clickable {
       cursor: pointer;


### PR DESCRIPTION
Made some improvements for misalignments that have been here a while:
* make sure the new header is aligned with the content and composer
* align the uploads with everything too

### Before/After Desktop
<img width="307" alt="image" src="https://github.com/discourse/discourse/assets/101828855/a52cd7d8-6903-499d-9f51-66ecd00d4d59">

### Drawer
<img width="387" alt="image" src="https://github.com/discourse/discourse/assets/101828855/210d72f0-e4e9-41b4-bae2-31b6fb9358b3">

### Mobile
<img width="305" alt="image" src="https://github.com/discourse/discourse/assets/101828855/1cb8b8a0-744b-4a49-b841-0df56da87561">


