### PR TITLE
DEV: Half-revert search-menu flicker fix

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
@@ -2,76 +2,78 @@
   <SearchMenu::BrowserSearchTip />
 {{else}}
   <div class="results">
-    <PluginOutlet
-      @name="search-menu-results-top"
-      @outletArgs={{hash
-        closeSearchMenu=@closeSearchMenu
-        searchTerm=this.search.activeGlobalSearchTerm
-        inTopicContext=this.search.inTopicContext
-        searchTopics=@searchTopics
-      }}
-    />
-    {{#if @suggestionKeyword}}
-      <SearchMenu::Results::Assistant
-        @suggestionKeyword={{@suggestionKeyword}}
-        @results={{@suggestionResults}}
-        @closeSearchMenu={{@closeSearchMenu}}
-        @searchTermChanged={{@searchTermChanged}}
+    {{#unless @loading}}
+      <PluginOutlet
+        @name="search-menu-results-top"
+        @outletArgs={{hash
+          closeSearchMenu=@closeSearchMenu
+          searchTerm=this.search.activeGlobalSearchTerm
+          inTopicContext=this.search.inTopicContext
+          searchTopics=@searchTopics
+        }}
       />
-    {{else if this.termTooShort}}
-      <div class="no-results">{{i18n "search.too_short"}}</div>
-    {{else if this.noTopicResults}}
-      <div class="no-results">{{i18n "search.no_results"}}</div>
-    {{else if this.renderInitialOptions}}
-      <SearchMenu::Results::InitialOptions
-        @closeSearchMenu={{@closeSearchMenu}}
-        @searchTermChanged={{@searchTermChanged}}
-      />
-    {{else}}
-      {{#if (and (not @searchTopics) (not @inPMInboxContext))}}
-        {{! render the first couple suggestions before a search has been performed}}
+      {{#if @suggestionKeyword}}
+        <SearchMenu::Results::Assistant
+          @suggestionKeyword={{@suggestionKeyword}}
+          @results={{@suggestionResults}}
+          @closeSearchMenu={{@closeSearchMenu}}
+          @searchTermChanged={{@searchTermChanged}}
+        />
+      {{else if this.termTooShort}}
+        <div class="no-results">{{i18n "search.too_short"}}</div>
+      {{else if this.noTopicResults}}
+        <div class="no-results">{{i18n "search.no_results"}}</div>
+      {{else if this.renderInitialOptions}}
         <SearchMenu::Results::InitialOptions
           @closeSearchMenu={{@closeSearchMenu}}
           @searchTermChanged={{@searchTermChanged}}
         />
-      {{/if}}
+      {{else}}
+        {{#if (and (not @searchTopics) (not @inPMInboxContext))}}
+          {{! render the first couple suggestions before a search has been performed}}
+          <SearchMenu::Results::InitialOptions
+            @closeSearchMenu={{@closeSearchMenu}}
+            @searchTermChanged={{@searchTermChanged}}
+          />
+        {{/if}}
 
-      {{#if (and @searchTopics this.resultTypesWithComponent)}}
-        {{! render results after a search has been performed }}
-        <SearchMenu::Results::Types
-          @resultTypes={{this.resultTypesWithComponent}}
-          @topicResultsOnly={{true}}
-          @closeSearchMenu={{@closeSearchMenu}}
-        />
-        <SearchMenu::Results::MoreLink
-          @updateTypeFilter={{@updateTypeFilter}}
-          @triggerSearch={{@triggerSearch}}
-          @resultTypes={{this.resultTypesWithComponent}}
-          @closeSearchMenu={{@closeSearchMenu}}
-          @searchTermChanged={{@searchTermChanged}}
-        />
-      {{else if
-        (and
-          (not @inPMInboxContext)
-          (not @searchTopics)
-          this.resultTypesWithComponent
-        )
-      }}
-        <SearchMenu::Results::Types
-          @resultTypes={{this.resultTypesWithComponent}}
-          @closeSearchMenu={{@closeSearchMenu}}
-          @searchTermChanged={{@searchTermChanged}}
-        />
+        {{#if (and @searchTopics this.resultTypesWithComponent)}}
+          {{! render results after a search has been performed }}
+          <SearchMenu::Results::Types
+            @resultTypes={{this.resultTypesWithComponent}}
+            @topicResultsOnly={{true}}
+            @closeSearchMenu={{@closeSearchMenu}}
+          />
+          <SearchMenu::Results::MoreLink
+            @updateTypeFilter={{@updateTypeFilter}}
+            @triggerSearch={{@triggerSearch}}
+            @resultTypes={{this.resultTypesWithComponent}}
+            @closeSearchMenu={{@closeSearchMenu}}
+            @searchTermChanged={{@searchTermChanged}}
+          />
+        {{else if
+          (and
+            (not @inPMInboxContext)
+            (not @searchTopics)
+            this.resultTypesWithComponent
+          )
+        }}
+          <SearchMenu::Results::Types
+            @resultTypes={{this.resultTypesWithComponent}}
+            @closeSearchMenu={{@closeSearchMenu}}
+            @searchTermChanged={{@searchTermChanged}}
+          />
+        {{/if}}
       {{/if}}
-    {{/if}}
-    <PluginOutlet
-      @name="search-menu-results-bottom"
-      @outletArgs={{hash
-        inTopicContext=this.search.inTopicContext
-        searchTermChanged=@searchTermChanged
-        searchTopics=@searchTopics
-        closeSearchMenu=@closeSearchMenu
-      }}
-    />
+      <PluginOutlet
+        @name="search-menu-results-bottom"
+        @outletArgs={{hash
+          inTopicContext=this.search.inTopicContext
+          searchTermChanged=@searchTermChanged
+          searchTopics=@searchTopics
+          closeSearchMenu=@closeSearchMenu
+        }}
+      />
+    {{/unless}}
   </div>
 {{/if}}


### PR DESCRIPTION
https://github.com/discourse/discourse/commit/aadc104817bb0306856b4718f5c50fb481e77c16 removed the loading conditional here so there was no flicker. This adds back the conditional, as we have customizations that rely on the re-initialization of components due to the change in the `loading` value.