### PR TITLE
DEV: Remove extra calls to `reset_sessions!` and `use_default_driver`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -585,8 +585,6 @@ RSpec.configure do |config|
     page.execute_script("if (typeof MessageBus !== 'undefined') { MessageBus.stop(); }")
     MessageBus.backend_instance.reset! # Clears all existing backlog from memory backend
     Scheduler::Defer.do_all_work # Process everything that was added to the defer queue when running the test
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
     Discourse.redis.flushdb
   end
 


### PR DESCRIPTION
Why this change?

Capybara is already calling those two methods: https://github.com/teamcapybara/capybara/blob/52eaecea6d154b7d664b0032cd1cbcad4788fe65/lib/capybara/rspec.rb#L20-L21