### PR TITLE
UX: chat navbar > alignments part 2

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/threads.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/threads.gjs
@@ -15,7 +15,7 @@ export default class ChatDrawerRoutesThreads extends Component {
     <Navbar @onClick={{this.chat.toggleDrawer}} as |navbar|>
       <navbar.BackButton @title={{this.backButtonTitle}} />
       <navbar.Title
-        @title={{i18n "chat.threads.list"}}
+        @title={{i18n "chat.my_threads.title"}}
         @icon="discourse-threads"
         as |title|
       >

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/threads.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/threads.gjs
@@ -1,13 +1,18 @@
 import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 import i18n from "discourse-common/helpers/i18n";
 import Navbar from "discourse/plugins/chat/discourse/components/chat/navbar";
 import UserThreads from "discourse/plugins/chat/discourse/components/user-threads";
 
 export default class ChatRoutesThreads extends Component {
+  @service site;
+
   <template>
     <div class="c-routes-threads">
       <Navbar as |navbar|>
-        <navbar.BackButton />
+        {{#if this.site.mobileView}}
+          <navbar.BackButton />
+        {{/if}}
         <navbar.Title
           @title={{i18n "chat.my_threads.title"}}
           @icon="discourse-threads"

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/header.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread-list/header.gjs
@@ -24,11 +24,13 @@ export default class ChatThreadListHeader extends Component {
 
   <template>
     <Navbar as |navbar|>
-      <navbar.BackButton
-        @route="chat.channel"
-        @routeModels={{@channel.routeModels}}
-        @title={{i18n "chat.return_to_channel"}}
-      />
+      {{#if this.site.mobileView}}
+        <navbar.BackButton
+          @route="chat.channel"
+          @routeModels={{@channel.routeModels}}
+          @title={{i18n "chat.return_to_channel"}}
+        />
+      {{/if}}
 
       <navbar.Title @title={{this.title}} @icon="discourse-threads" />
 

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -12,12 +12,13 @@
     box-sizing: border-box;
     display: flex;
     z-index: z("composer", "content") - 1;
+    padding-inline: 1rem;
 
-    .full-page & {
-      padding-inline: 1rem;
-    }
     .chat-drawer & {
       padding-inline: 0.25rem;
+    }
+    .c-routes-channel-thread & {
+      padding-inline: 0;
     }
 
     &.-clickable {
@@ -37,7 +38,18 @@
   .c-navbar__title {
     @include ellipsis();
     font-weight: 700;
-    padding-left: 0.75rem;
+
+    .c-routes-channel-threads & {
+      padding-left: 0;
+    }
+
+    .chat-drawer & {
+      padding-left: 0.75rem;
+    }
+  }
+
+  .c-navbar__back-button ~ .c-navbar__title {
+    padding-left: 0;
   }
 
   .c-navbar__sub-title {

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -15,7 +15,8 @@
     padding-inline: 1rem;
 
     .chat-drawer &,
-    .c-routes-channel-thread & {
+    .c-routes-channel-thread &,
+    .c-routes-channel-info & {
       padding-inline: 0;
     }
 

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -14,9 +14,7 @@
     z-index: z("composer", "content") - 1;
     padding-inline: 1rem;
 
-    .chat-drawer & {
-      padding-inline: 0.25rem;
-    }
+    .chat-drawer &,
     .c-routes-channel-thread & {
       padding-inline: 0;
     }
@@ -44,7 +42,7 @@
     }
 
     .chat-drawer & {
-      padding-left: 0.75rem;
+      padding-left: 1rem;
     }
   }
 

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -1,5 +1,5 @@
 .c-navbar {
   &-container {
-    padding-inline: 0;
+    padding-inline: 0.25rem;
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -1,0 +1,5 @@
+.c-navbar {
+  &-container {
+    padding-inline: 0;
+  }
+}

--- a/plugins/chat/assets/stylesheets/mobile/index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/index.scss
@@ -17,5 +17,6 @@
 @import "chat-channel-settings";
 @import "chat-form";
 @import "chat-modal-new-message";
+@import "chat-navbar";
 @import "chat-thread-list-header";
 @import "chat-user-threads";


### PR DESCRIPTION
* Added some more finnicky CSS for all the different scenarios with navbar having an arrow-back or not.
* Changed copy to consistently say "My threads"
* Removed 2 arrow-backs that shouldn't be there:

1. Desktop thread index
<img width="1133" alt="image" src="https://github.com/discourse/discourse/assets/101828855/5d3d37dd-f509-4da4-9a79-cbe26070e3f7">

2. Desktop user thread index 

<img width="1160" alt="image" src="https://github.com/discourse/discourse/assets/101828855/722801b4-fc8c-4e7e-8b21-3ae0954fd974">
