### PR TITLE
FIX: Remove old 'wizard' js script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,6 @@
 
     <%- if admin? %>
       <%= preload_script_url ExtraLocalesController.url("wizard") %>
-      <%= preload_script "wizard" %>
     <%- end %>
 
     <%- unless customization_disabled? %>


### PR DESCRIPTION
This was causing errors for admins. Followup to cbc28e8e337acc740487bc9cf5c263b3eaba6493

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
