### PR TITLE
FIX: Vietnamese language native name

### DIFF
--- a/config/locales/names.yml
+++ b/config/locales/names.yml
@@ -529,7 +529,7 @@ ve:
   nativeName: Tshivenḓa
 vi:
   name: Vietnamese
-  nativeName: Việt Nam
+  nativeName: tiếng Việt
 vo:
   name: Volapük
   nativeName: Volapük


### PR DESCRIPTION
It was wrongly set to the Vietnamese name of the Vietnam country, instead of the Vietnamese name of the Vietnamese language.

Source: https://www.wikidata.org/wiki/Q9199

No test included for this trivial change.
