### PR TITLE
FIX: Have file size restriction type return integers

### DIFF
--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -143,6 +143,8 @@ class SiteSettings::TypeSupervisor
       value.to_f
     when self.class.types[:integer]
       value.to_i
+    when self.class.types[:file_size_restriction]
+      value.to_i
     when self.class.types[:bool]
       value == true || value == "t" || value == "true"
     when self.class.types[:null]

--- a/spec/lib/site_settings/type_supervisor_spec.rb
+++ b/spec/lib/site_settings/type_supervisor_spec.rb
@@ -96,6 +96,9 @@ RSpec.describe SiteSettings::TypeSupervisor do
       it "'tag_group_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:tag_group_list]).to eq(26)
       end
+      it "'file_size_restriction' should be at the right position" do
+        expect(SiteSettings::TypeSupervisor.types[:file_size_restriction]).to eq(27)
+      end
     end
   end
 
@@ -331,6 +334,16 @@ RSpec.describe SiteSettings::TypeSupervisor do
         expect(
           settings.type_supervisor.to_rb_value(:type_null, "1", SiteSetting.types[:integer]),
         ).to eq(1)
+      end
+
+      it "returns an integer for file_size_restriction type" do
+        expect(
+          settings.type_supervisor.to_rb_value(
+            :type_file_size_restriction,
+            "1024",
+            SiteSetting.types[:file_size_restriction],
+          ),
+        ).to eq 1024
       end
 
       it "returns nil value" do


### PR DESCRIPTION
This adds a proper conversion for all file_size_restriction site
settings and converts them to integers instead of strings. This way
methods like `.kilobytes` won't fail because it's assumed all of these
types are integers already.

Follow up to: 00209f03e6bc55c6dd776dbe828b8bb53cd935f4 and

Bug report: https://meta.discourse.org/t/289291
