### PR TITLE
UX: Add class to text select menu when fast-editing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,6 @@ PLATFORMS
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-darwin-20
-  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,6 +528,7 @@ PLATFORMS
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -183,7 +183,7 @@ export default class PostTextSelectionToolbar extends Component {
     <div
       {{on "mousedown" this.trapEvents}}
       {{on "mouseup" this.trapEvents}}
-      class={{concatClass "quote-button" "visible"}}
+      class={{concatClass "quote-button" "visible" (if this.isFastEditing "fast-editing")}}
       {{this.appEventsListeners}}
     >
       <div class="buttons">

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -183,7 +183,11 @@ export default class PostTextSelectionToolbar extends Component {
     <div
       {{on "mousedown" this.trapEvents}}
       {{on "mouseup" this.trapEvents}}
-      class={{concatClass "quote-button" "visible" (if this.isFastEditing "fast-editing")}}
+      class={{concatClass
+        "quote-button"
+        "visible"
+        (if this.isFastEditing "fast-editing")
+      }}
       {{this.appEventsListeners}}
     >
       <div class="buttons">


### PR DESCRIPTION
This PR adds a class to the text select pop-up menu when fast editing.