### PR TITLE
FIX: Update position on model when re-positioning record

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -196,8 +196,8 @@ class CategoriesController < ApplicationController
       category_params.delete(:custom_fields)
 
       # properly null the value so the database constraint doesn't catch us
-      category_params[:email_in] = nil if category_params[:email_in]&.blank?
-      category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags]&.blank?
+      category_params[:email_in] = nil if category_params[:email_in].blank?
+      category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags].blank?
 
       old_permissions = cat.permissions_params
       old_permissions = { "everyone" => 1 } if old_permissions.empty?

--- a/app/models/concerns/positionable.rb
+++ b/app/models/concerns/positionable.rb
@@ -33,5 +33,7 @@ module Positionable
     WHERE id = :id",
             id: id,
             position: position
+
+    self.position = position
   end
 end


### PR DESCRIPTION
### What is happening?

When updating the position of a category, the server correctly updates the position in the database, but the response sent back to the client still contains the old position, causing it to "flip back" in the UI when saving. Only reloading the page will reveal the new, correct value.

### Why is it happening?

The `Positionable` concern correctly positions the record and updates the database, but we don't assign the new position to the already instantiated model.

### How does this fix it?

EZPZ, just assign `self.position` after the database update. 😎 
