### PR TITLE
DEV: Remove unnecessary method call in system tests teardown

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -563,7 +563,6 @@ RSpec.configure do |config|
 
     page.execute_script("if (typeof MessageBus !== 'undefined') { MessageBus.stop(); }")
     MessageBus.backend_instance.reset! # Clears all existing backlog from memory backend
-    Scheduler::Defer.do_all_work # Process everything that was added to the defer queue when running the test
     Discourse.redis.flushdb
   end
 


### PR DESCRIPTION
Why this change?

`Scheduler::Deferrable` runs in the async mode in the test environment
so there is no queue we need to flush.