### PR TITLE
FIX: correct typo minmin_trust_to_edit_wiki_post

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2562,7 +2562,7 @@ en:
       approve_unless_allowed_groups: "approve_unless_trust_level"
       approve_new_topics_unless_allowed_groups: "approve_new_topics_unless_trust_level"
       email_in_allowed_groups: "email_in_min_trust"
-      edit_wiki_post_allowed_groups: "minmin_trust_to_edit_wiki_post"
+      edit_wiki_post_allowed_groups: "min_trust_to_edit_wiki_post"
       uploaded_avatars_allowed_groups: "allow_uploaded_avatars"
       create_topic_allowed_groups: "min_trust_to_create_topic"
       edit_post_allowed_groups: "min_trust_to_edit_post"

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -330,7 +330,7 @@ module PostGuardian
 
   def can_wiki?(post)
     return false unless authenticated?
-    return true if is_staff? || @user.has_trust_level?(TrustLevel[4])
+    return true if is_staff? || @user.in_any_groups?(SiteSetting.edit_wiki_post_allowed_groups_map)
 
     if @user.has_trust_level?(SiteSetting.min_trust_to_allow_self_wiki) && is_my_own?(post)
       return false if post.hidden?

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3639,6 +3639,8 @@ RSpec.describe Guardian do
   describe "can_wiki?" do
     let(:post) { Fabricate(:post, created_at: 1.minute.ago) }
 
+    before { SiteSetting.edit_wiki_post_allowed_groups = "14" }
+
     it "returns false for regular user" do
       expect(Guardian.new(coding_horror).can_wiki?(post)).to be_falsey
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -709,6 +709,7 @@ RSpec.describe PostsController do
       end
 
       it "raises an error if the user doesn't have permission to wiki the post" do
+        SiteSetting.edit_wiki_post_allowed_groups = "14"
         put "/posts/#{post.id}/wiki.json", params: { wiki: "true" }
         expect(response).to be_forbidden
       end


### PR DESCRIPTION
Typo introduced here https://github.com/discourse/discourse/pull/24766#pullrequestreview-1792187422

In addition, use setting instead of hard-coded `@user.has_trust_level?(TrustLevel[4])`
