### PR TITLE
FIX: Properly close search menu on click/touch outside

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu.js
@@ -68,7 +68,7 @@ export default class SearchMenu extends Component {
   @bind
   onDocumentPress(event) {
     if (!event.target.closest(".search-menu-container.menu-panel-results")) {
-      this.menuPanelOpen = false;
+      this.close();
     }
   }
 

--- a/app/assets/javascripts/discourse/app/components/search-menu.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu.js
@@ -67,7 +67,16 @@ export default class SearchMenu extends Component {
 
   @bind
   onDocumentPress(event) {
-    if (!event.target.closest(".search-menu-container.menu-panel-results")) {
+    // If the search menu header button is clicked, we don't need to do anything and can
+    // let the header handle cleanup. Otherwise we mess with the toggling of the popup.
+    if (event.target.closest(".header-dropdown-toggle.search-dropdown")) {
+      return;
+    }
+
+    if (
+      this.menuPanelOpen &&
+      !event.target.closest(".search-menu .search-menu-container")
+    ) {
       this.close();
     }
   }
@@ -106,7 +115,7 @@ export default class SearchMenu extends Component {
 
     // We want to blur the active element (search input) when in stand-alone mode
     // so that when we focus on the search input again, the menu panel pops up
-    document.activeElement.blur();
+    document.getElementById(SEARCH_INPUT_ID)?.blur();
     this.menuPanelOpen = false;
   }
 


### PR DESCRIPTION
This is a very easy change -- we have a function for _properly_ closing the search menu, but we weren't calling it. The close function also blurs the search term input which gets us back to the proper state where clicking the search menu brings it back up rather than leaving us a in a broken state.