### PR TITLE
DEV: Move menu-item-end PluginOutlet outside <a> tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.hbs
@@ -25,10 +25,9 @@
       {{/if}}
     </div>
 
-    <PluginOutlet @name="menu-item-end" @outletArgs={{hash item=this}}>
-      {{#if this.endComponent}}
-        <this.endComponent />
-      {{/if}}
-    </PluginOutlet>
+    {{#if this.endComponent}}
+      <this.endComponent />
+    {{/if}}
   </a>
+  <PluginOutlet @name="menu-item-end" @outletArgs={{this.endOutletArgs}} />
 </li>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
@@ -61,6 +61,10 @@ export default class UserMenuItem extends Component {
     return this.#item.endComponent;
   }
 
+  get endOutletArgs() {
+    return this.#item.endOutletArgs;
+  }
+
   get #item() {
     return this.args.item;
   }

--- a/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
@@ -70,6 +70,12 @@ export default class UserMenuNotificationItem extends UserMenuBaseItem {
     return this.notification.acting_user_avatar_template;
   }
 
+  get endOutletArgs() {
+    return {
+      notification: this.notification,
+    };
+  }
+
   get #notificationName() {
     return this.site.notificationLookup[this.notification.notification_type];
   }


### PR DESCRIPTION
This moves the plugin outlet so it no longer wraps the date, and is outside the `<a>` tag so you can cleanly put interactive elements inside the outlet without worrying about nested interactions.

As well as passing some actual data into the pluginOutlet rather than just the rendering component.