### PR TITLE
UX: adjust bootstrap mode tooltip color

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -416,14 +416,21 @@ $mobile-avatar-height: 1.532em;
   }
 }
 
-.d-header-mode .bootstrap-mode {
-  color: var(--primary-medium);
-  font-size: var(--font-down-1);
-  margin-left: 1em;
-  padding: 0.15em 0.5em;
+.d-header-mode {
+  .bootstrap-mode {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+    margin-left: 1em;
+    padding: 0.15em 0.5em;
 
-  &:focus {
-    background-color: var(--primary-medium);
-    color: var(--secondary);
+    &:focus {
+      background-color: var(--primary-medium);
+      color: var(--secondary);
+    }
+  }
+
+  .fk-d-button-tooltip .fk-d-tooltip__trigger {
+    color: var(--header_primary-high);
+    background: transparent;
   }
 }


### PR DESCRIPTION
There's a very light background that looks misplaced, and the icon color is too bold relative to other header icons. 

Before:
![Screenshot 2023-12-21 at 1 09 51 PM](https://github.com/discourse/discourse/assets/1681963/203909c9-9f3c-49a2-b2f1-940c321c01d4)

After:
![Screenshot 2023-12-21 at 1 10 34 PM](https://github.com/discourse/discourse/assets/1681963/92317eb2-f224-4a74-bd17-a658b75da1c0)
