### PR TITLE
REVERT: "FIX: Properly close search menu on click/touch outside (#25000)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu.js
@@ -67,17 +67,8 @@ export default class SearchMenu extends Component {
 
   @bind
   onDocumentPress(event) {
-    // If the search menu header button is clicked, we don't need to do anything and can
-    // let the header handle cleanup. Otherwise we mess with the toggling of the popup.
-    if (event.target.closest(".header-dropdown-toggle.search-dropdown")) {
-      return;
-    }
-
-    if (
-      this.menuPanelOpen &&
-      !event.target.closest(".search-menu .search-menu-container")
-    ) {
-      this.close();
+    if (!event.target.closest(".search-menu-container.menu-panel-results")) {
+      this.menuPanelOpen = false;
     }
   }
 
@@ -115,7 +106,7 @@ export default class SearchMenu extends Component {
 
     // We want to blur the active element (search input) when in stand-alone mode
     // so that when we focus on the search input again, the menu panel pops up
-    document.getElementById(SEARCH_INPUT_ID)?.blur();
+    document.activeElement.blur();
     this.menuPanelOpen = false;
   }
 


### PR DESCRIPTION
This reverts commit c91d053decdbe0739835a22f1fb7f3554e40398c.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
