### PR TITLE
DEV: Convert min_trust_to_allow_self_wiki to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1970,6 +1970,7 @@ en:
     edit_post_allowed_groups: "Groups that are allowed to edit posts."
 
     min_trust_to_allow_self_wiki: "The minimum trust level required to make user's own post wiki."
+    self_wiki_allowed_groups: "Groups where users can make their own post wiki."
 
     min_trust_to_send_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages."
     min_trust_to_send_email_messages: "The minimum trust level required to send personal messages via email."
@@ -2571,6 +2572,7 @@ en:
       user_card_background_allowed_groups: "min_trust_level_to_allow_user_card_background"
       invite_allowed_groups: "min_trust_level_to_allow_invite"
       ignore_allowed_groups: "min_trust_level_to_allow_ignore"
+      self_wiki_allowed_groups: "min_trust_to_allow_self_wiki"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1714,6 +1714,13 @@ trust:
   min_trust_to_allow_self_wiki:
     default: 3
     enum: "TrustLevelSetting"
+    hidden: true
+  self_wiki_allowed_groups:
+    default: "13"
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   min_trust_to_send_email_messages:
     default: "4"
     enum: "TrustLevelAndStaffSetting"

--- a/db/migrate/20231222030024_fill_self_wiki_allowed_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20231222030024_fill_self_wiki_allowed_groups_based_on_deprecated_settings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class FillSelfWikiAllowedGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
+  def up
+    configured_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_trust_to_allow_self_wiki' LIMIT 1",
+      ).first
+
+    # Default for old setting is TL3, we only need to do anything if it's been changed in the DB.
+    if configured_trust_level.present?
+      corresponding_group = "1#{configured_trust_level}"
+
+      # Data_type 20 is group_list.
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('self_wiki_allowed_groups', :setting, '20', NOW(), NOW())",
+        setting: corresponding_group,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -332,7 +332,7 @@ module PostGuardian
     return false unless authenticated?
     return true if is_staff? || @user.has_trust_level?(TrustLevel[4])
 
-    if @user.has_trust_level?(SiteSetting.min_trust_to_allow_self_wiki) && is_my_own?(post)
+    if @user.in_any_groups?(SiteSetting.self_wiki_allowed_groups_map) && is_my_own?(post)
       return false if post.hidden?
       return !post.edit_time_limit_expired?(@user)
     end

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -33,6 +33,7 @@ module SiteSettings::DeprecatedSettings
     ],
     ["min_trust_level_to_allow_invite", "invite_allowed_groups", false, "3.3"],
     ["min_trust_level_to_allow_ignore", "ignore_allowed_groups", false, "3.3"],
+    ["min_trust_to_allow_self_wiki", "self_wiki_allowed_groups", false, "3.3"],
   ]
 
   OVERRIDE_TL_GROUP_SETTINGS = %w[

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3649,12 +3649,12 @@ RSpec.describe Guardian do
     end
 
     it "returns false when user satisfies trust level but tries to wiki someone else's post" do
-      SiteSetting.min_trust_to_allow_self_wiki = 2
+      SiteSetting.self_wiki_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       expect(Guardian.new(trust_level_2).can_wiki?(post)).to be_falsey
     end
 
     it "returns true when user satisfies trust level and owns the post" do
-      SiteSetting.min_trust_to_allow_self_wiki = 2
+      SiteSetting.self_wiki_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       own_post = Fabricate(:post, user: trust_level_2)
       expect(Guardian.new(trust_level_2).can_wiki?(own_post)).to be_truthy
     end


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/283408)

### What is this change?

We're changing the implementation of trust levels to use groups. Part of this is to have site settings that reference trust levels use groups instead. It converts the `min_trust_to_allow_self_wiki` site setting to `self_wiki_allowed_groups`.

Nothing of note here. This is used in exactly one place, and there's no fallout.
