### PR TITLE
UX: Disable dropdown when filtering in edit nav menu tags modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.hbs
@@ -15,7 +15,7 @@
   @filterSelected={{this.filterSelected}}
   @filterUnselected={{this.filterUnselected}}
   @closeModal={{@closeModal}}
-  @loading={{this.tagsLoading}}
+  @loading={{(or this.tagsLoading this.disableFiltering)}}
   class="sidebar__edit-navigation-menu__tags-modal"
 >
   {{#if this.tagsLoading}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.js
@@ -16,6 +16,7 @@ export default class extends Component {
   @tracked onlyUnSelected = false;
   @tracked tags = [];
   @tracked tagsLoading;
+  @tracked disableFiltering;
   @tracked selectedTags = [...this.currentUser.sidebarTagNames];
 
   constructor() {
@@ -50,6 +51,7 @@ export default class extends Component {
       })
       .finally(() => {
         this.tagsLoading = false;
+        this.disableFiltering = false;
       });
   }
 
@@ -110,6 +112,7 @@ export default class extends Component {
 
   @action
   onFilterInput(filter) {
+    this.disableFiltering = true;
     discourseDebounce(this, this.#performFiltering, filter, INPUT_DELAY);
   }
 


### PR DESCRIPTION
Why this change?

The `Editing sidebar tags navigation allows a user to filter the tag in the modal by selection` system test was flaky
when we were doing `modal.filter("").filter_by_unselected`. The
hypothesis here is that since the filtering is debounced and the  
dropdown is only disabled in the debounced function, there is a chance that when
`modal.filter_by_unselected` runs, it is selecting a row against a
disabled dropdown which results in a noop.

What does this change do?

When filtering using the input in the modal, we will now disabled the
dropdown until the filtering completes which will then re-enable the
dropdown.