### PR TITLE
DEV: Fix `nil` exception when reporting server failures

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -582,7 +582,7 @@ RSpec.configure do |config|
 
   config.after :each do |example|
     if example.exception && RspecErrorTracker.exceptions.present?
-      lines = RSpec.current_example.metadata[:extra_failure_lines]
+      lines = (RSpec.current_example.metadata[:extra_failure_lines] ||= "")
 
       lines << "~~~~~~~ SERVER EXCEPTIONS ~~~~~~~"
 


### PR DESCRIPTION
Follow-up to f5ca96528ddc6cc14e5c86cf2172418ab863e845

Why this change?

`RSpec.current_example.metadata[:extra_failure_lines]` can be `nil` and
calling `<<` on `nil` is not a good idea.

What does this change do?

Set `RSpec.current_example.metadata[:extra_failure_lines]` to `""` as
long as there are exceptions.