### PR TITLE
FIX: prevents audio container to overflow container

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-audio-upload.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-audio-upload.scss
@@ -1,0 +1,3 @@
+.chat-audio-upload {
+  max-width: 100%;
+}

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -66,3 +66,4 @@
 @import "chat-user-threads";
 @import "chat-navbar";
 @import "chat-thread-title";
+@import "chat-audio-upload";


### PR DESCRIPTION
Before:

![Screenshot 2023-12-22 at 09 14 48](https://github.com/discourse/discourse/assets/339945/bef21c30-4665-48d3-ade8-41824aa58b75)


After:

![Screenshot 2023-12-22 at 09 15 28](https://github.com/discourse/discourse/assets/339945/055caae3-0b6c-4a41-a54b-0ce4e772d499)
