### PR TITLE
FIX: whitelist uploads before creating thumbnail variants

### DIFF
--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -26,7 +26,7 @@ module Chat
       return if !SiteSetting.create_thumbnails
 
       @model.uploads.each do |upload|
-        next if !upload.present? || !IMG_FILETYPES.include?(upload.extension.downcase)
+        next if upload.blank? || IMG_FILETYPES.exclude?(upload.extension.downcase)
 
         if upload.width <= SiteSetting.max_image_width &&
              upload.height <= SiteSetting.max_image_height


### PR DESCRIPTION
Since upload types can include many formats based on the site setting allowed_extensions, there can be many non image formats (such as audio or video) we should whitelist image only formats and only attempt to create thumbnails for whitelisted upload extensions.