### PR TITLE
DEV: Unhide lazy_load_categories site setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2493,6 +2493,7 @@ en:
 
     experimental_form_templates: "EXPERIMENTAL: Enable the form templates feature. <b>After enabled,</b> manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     enable_admin_sidebar_navigation: "EXPERIMENTAL: Enable sidebar navigation for the admin UI, which replaces the top-level admin navigation buttons."
+    lazy_load_categories: "EXPERIMENTAL: Load category information only when it is necessary to be displayed. This improves performance on sites with many categories."
 
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2300,7 +2300,6 @@ developer:
   lazy_load_categories:
     default: false
     client: true
-    hidden: true
 
 navigation:
   navigation_menu:


### PR DESCRIPTION
The new experimental site setting has been used to toggle functionality that allows categories to be loaded only when necessary (categories are no longer preloaded, category select kits perform search on the backend, enables infinite loading on categories page, etc).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
