### PR TITLE
UX: resize pm composer inputs for narrow screens

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -18,12 +18,19 @@
   &.private-message {
     .with-tags {
       .title-and-category {
-        flex-wrap: nowrap; // force title and tags on same line for PMs
+        flex-wrap: nowrap;
+        gap: 0.5em;
         .mini-tag-chooser {
+          max-width: 50%;
           margin-bottom: 8px; // match title input margin
-          flex: 0 0 auto;
-          margin-left: 8px; // matches margin between category and tag input
-          width: 39%;
+          flex: 1 1 auto;
+        }
+      }
+      .title-input {
+        max-width: 50%;
+        min-width: 0;
+        input {
+          min-width: 0;
         }
       }
     }


### PR DESCRIPTION
Makes this layout a little more flexible so the tag input doesn't overflow when it's enabled

Before: 
![Screenshot 2023-12-22 at 2 57 20 PM](https://github.com/discourse/discourse/assets/1681963/aeb9b142-b0b8-4959-89f1-c83564d7c2d0)

After:
![Screenshot 2023-12-22 at 2 58 38 PM](https://github.com/discourse/discourse/assets/1681963/8a399845-daaf-4aa9-ab15-1d23a93f11ad)
