### PR TITLE
DEV: Add extension points to `Admin User Fields`

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -55,6 +55,17 @@
       <span>{{i18n "admin.user_fields.searchable.title"}}</span>
     </AdminFormRow>
 
+    <PluginOutlet
+      @name="after-admin-user-fields"
+      @outletArgs={{hash
+        userField=this.userField
+        buffered=this.buffered
+        fieldTypes=this.fieldTypes
+        save=this.save
+        cancel=this.cancel
+      }}
+    />
+
     <AdminFormRow>
       <DButton
         @action={{this.save}}

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -57,13 +57,7 @@
 
     <PluginOutlet
       @name="after-admin-user-fields"
-      @outletArgs={{hash
-        userField=this.userField
-        buffered=this.buffered
-        fieldTypes=this.fieldTypes
-        save=this.save
-        cancel=this.cancel
-      }}
+      @outletArgs={{hash buffered=this.buffered}}
     />
 
     <AdminFormRow>

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { schedule } from "@ember/runloop";
+import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n, propertyEqual } from "discourse/lib/computed";
@@ -10,6 +11,8 @@ import I18n from "discourse-i18n";
 import UserField from "admin/models/user-field";
 
 export default Component.extend(bufferedProperty("userField"), {
+  adminCustomUserFields: service(),
+
   tagName: "",
   isEditing: false,
 
@@ -75,7 +78,8 @@ export default Component.extend(bufferedProperty("userField"), {
       "show_on_profile",
       "show_on_user_card",
       "searchable",
-      "options"
+      "options",
+      ...this.adminCustomUserFields.additionalProperties
     );
 
     return this.userField

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -144,7 +144,7 @@ import { modifySelectKit } from "select-kit/mixins/plugin-api";
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.20.0";
+export const PLUGIN_API_VERSION = "1.21.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -2610,6 +2610,24 @@ class PluginApi {
    */
   addBulkActionButton(opts) {
     _addBulkButton(opts);
+  }
+
+  /**
+   * Include the passed user field properties in the user field save request.
+   * This is useful for plugins that are adding additional columns to the user field model and want
+   * to save the new property values alongside the default user field properties (all under the same save call)
+   *
+   * The `userFieldProperties` param can be passed as a single string or an array of strings.
+   *
+   * ```
+   * api.includeUserFieldPropertiesOnSave(["property_one", "property_two"]);
+   * ```
+   *
+   */
+  includeUserFieldPropertiesOnSave(userFieldProperties) {
+    this.container
+      .lookup("service:admin-custom-user-fields")
+      .addProperties(userFieldProperties);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -2613,21 +2613,21 @@ class PluginApi {
   }
 
   /**
-   * Include the passed user field properties in the user field save request.
+   * Include the passed user field property in the Admin User Field save request.
    * This is useful for plugins that are adding additional columns to the user field model and want
    * to save the new property values alongside the default user field properties (all under the same save call)
    *
-   * The `userFieldProperties` param can be passed as a single string or an array of strings.
    *
    * ```
-   * api.includeUserFieldPropertiesOnSave(["property_one", "property_two"]);
+   * api.includeUserFieldPropertyOnSave("property_one");
+   * api.includeUserFieldPropertyOnSave("property_two");
    * ```
    *
    */
-  includeUserFieldPropertiesOnSave(userFieldProperties) {
+  includeUserFieldPropertyOnSave(userFieldProperty) {
     this.container
       .lookup("service:admin-custom-user-fields")
-      .addProperties(userFieldProperties);
+      .addProperty(userFieldProperty);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/services/admin-custom-user-fields.js
+++ b/app/assets/javascripts/discourse/app/services/admin-custom-user-fields.js
@@ -4,10 +4,7 @@ import Service from "@ember/service";
 export default class AdminCustomUserFields extends Service {
   @tracked additionalProperties = [];
 
-  addProperties(properties) {
-    if (typeof properties === "string") {
-      properties = [properties];
-    }
-    this.additionalProperties.push(...properties);
+  addProperty(property) {
+    this.additionalProperties.push(property);
   }
 }

--- a/app/assets/javascripts/discourse/app/services/admin-custom-user-fields.js
+++ b/app/assets/javascripts/discourse/app/services/admin-custom-user-fields.js
@@ -1,0 +1,13 @@
+import { tracked } from "@glimmer/tracking";
+import Service from "@ember/service";
+
+export default class AdminCustomUserFields extends Service {
+  @tracked additionalProperties = [];
+
+  addProperties(properties) {
+    if (typeof properties === "string") {
+      properties = [properties];
+    }
+    this.additionalProperties.push(...properties);
+  }
+}

--- a/app/controllers/admin/user_fields_controller.rb
+++ b/app/controllers/admin/user_fields_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::UserFieldsController < Admin::AdminController
   def self.columns
-    %i[
+    columns = %i[
       name
       field_type
       editable
@@ -13,6 +13,7 @@ class Admin::UserFieldsController < Admin::AdminController
       position
       searchable
     ]
+    DiscoursePluginRegistry.apply_modifier(:admin_user_fields_columns, columns)
   end
 
   def create

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,13 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2023-12-22
+
+### Added
+
+- Added `includeUserFieldPropertiesOnSave` function, which includes the passed user field properties in the user field save request. This is useful for plugins that are adding additional columns to the user field model and want to save the new property values alongside the default user field properties (all under the same save call).
+
+
 ## [1.20.0] - 2023-12-20
 
 ### Added


### PR DESCRIPTION
- Add plugin outlet to `AdminUserFieldItem`
- Add ability to include custom fields when saving `AdminUserFieldItem` 
- Update plugin API with `includeUserFieldPropertiesOnSave` per ☝️ 
- Add `DiscoursePluginRegistry` to `UserFieldsController` to add custom columns
