### PR TITLE
FIX: TL3 can convert their post to a wiki

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -330,7 +330,7 @@ module PostGuardian
 
   def can_wiki?(post)
     return false unless authenticated?
-    return true if is_staff? || @user.in_any_groups?(SiteSetting.edit_wiki_post_allowed_groups_map)
+    return true if is_staff? || @user.has_trust_level?(TrustLevel[4])
 
     if @user.has_trust_level?(SiteSetting.min_trust_to_allow_self_wiki) && is_my_own?(post)
       return false if post.hidden?

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3639,8 +3639,6 @@ RSpec.describe Guardian do
   describe "can_wiki?" do
     let(:post) { Fabricate(:post, created_at: 1.minute.ago) }
 
-    before { SiteSetting.edit_wiki_post_allowed_groups = "14" }
-
     it "returns false for regular user" do
       expect(Guardian.new(coding_horror).can_wiki?(post)).to be_falsey
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -709,7 +709,6 @@ RSpec.describe PostsController do
       end
 
       it "raises an error if the user doesn't have permission to wiki the post" do
-        SiteSetting.edit_wiki_post_allowed_groups = "14"
         put "/posts/#{post.id}/wiki.json", params: { wiki: "true" }
         expect(response).to be_forbidden
       end


### PR DESCRIPTION
A bug that allowed TL1 to convert other's posts to wiki.

The issue was introduced in this PR: https://github.com/discourse/discourse/pull/24999/files

The wiki can be created if a user is TL3 and it is their own post - default 3 for setting `min_trust_to_allow_self_wiki`

In addition, a wiki can be created by staff and TL4 users for any post.
