### PR TITLE
DEV: Fix can't modify frozen string error when reporting server errors

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -582,7 +582,7 @@ RSpec.configure do |config|
 
   config.after :each do |example|
     if example.exception && RspecErrorTracker.exceptions.present?
-      lines = (RSpec.current_example.metadata[:extra_failure_lines] ||= "")
+      lines = (RSpec.current_example.metadata[:extra_failure_lines] ||= +"")
 
       lines << "~~~~~~~ SERVER EXCEPTIONS ~~~~~~~"
 


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/commit/9d658591d67122286f2b4aa484bd1697f183f965