### PR TITLE
FIX: CLS jumpiness in post-stream when ?page=N

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -194,16 +194,28 @@ export default MountWidget.extend({
               return;
             }
 
-            const position = domUtils.position(refreshedElem);
-            const top = position.top - distToElement;
-            document.documentElement.scroll({ top, left: 0 });
+            // The getOffsetTop function calculates the total offset distance of
+            // an element from the top of the document. Unlike element.offsetTop
+            // which only returns the offset relative to its nearest positioned
+            // ancestor, this function recursively accumulates the offsetTop
+            // of an element and all of its offset parents (ancestors).
+            // This ensures the total distance is measured from the very top of
+            // the document, accounting for any nested elements and their
+            // respective offsets.
+            const getOffsetTop = (element) => {
+              if (!element) return 0;
+              return element.offsetTop + getOffsetTop(element.offsetParent);
+            };
+
+            const top = getOffsetTop(refreshedElem) - offsetCalculator();
+            window.scrollTo({ top: top });
 
             // This seems weird, but somewhat infrequently a rerender
             // will cause the browser to scroll to the top of the document
             // in Chrome. This makes sure the scroll works correctly if that
             // happens.
             schedule("afterRender", () => {
-              document.documentElement.scroll({ top, left: 0 });
+              window.scrollTo({ top: top });
             });
           });
         };

--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -1,13 +1,13 @@
 import { schedule, scheduleOnce } from "@ember/runloop";
 import { inject as service } from "@ember/service";
-import discourseDebounce from "discourse-common/lib/debounce";
-import { bind } from "discourse-common/utils/decorators";
-import domUtils from "discourse-common/utils/dom-utils";
 import MountWidget from "discourse/components/mount-widget";
 import offsetCalculator from "discourse/lib/offset-calculator";
 import { isWorkaroundActive } from "discourse/lib/safari-hacks";
 import DiscourseURL from "discourse/lib/url";
 import { cloak, uncloak } from "discourse/widgets/post-stream";
+import discourseDebounce from "discourse-common/lib/debounce";
+import { bind } from "discourse-common/utils/decorators";
+import domUtils from "discourse-common/utils/dom-utils";
 
 const DEBOUNCE_DELAY = 50;
 
@@ -200,19 +200,21 @@ export default MountWidget.extend({
             // the document, accounting for any nested elements and their
             // respective offsets.
             const getOffsetTop = (element) => {
-              if (!element) return 0;
+              if (!element) {
+                return 0;
+              }
               return element.offsetTop + getOffsetTop(element.offsetParent);
             };
 
             const top = getOffsetTop(refreshedElem) - offsetCalculator();
-            window.scrollTo({ top: top });
+            window.scrollTo({ top });
 
             // This seems weird, but somewhat infrequently a rerender
             // will cause the browser to scroll to the top of the document
             // in Chrome. This makes sure the scroll works correctly if that
             // happens.
             schedule("afterRender", () => {
-              window.scrollTo({ top: top });
+              window.scrollTo({ top });
             });
           });
         };

--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -1,13 +1,13 @@
 import { schedule, scheduleOnce } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import discourseDebounce from "discourse-common/lib/debounce";
+import { bind } from "discourse-common/utils/decorators";
+import domUtils from "discourse-common/utils/dom-utils";
 import MountWidget from "discourse/components/mount-widget";
 import offsetCalculator from "discourse/lib/offset-calculator";
 import { isWorkaroundActive } from "discourse/lib/safari-hacks";
 import DiscourseURL from "discourse/lib/url";
 import { cloak, uncloak } from "discourse/widgets/post-stream";
-import discourseDebounce from "discourse-common/lib/debounce";
-import { bind } from "discourse-common/utils/decorators";
-import domUtils from "discourse-common/utils/dom-utils";
 
 const DEBOUNCE_DELAY = 50;
 
@@ -181,10 +181,7 @@ export default MountWidget.extend({
       const first = posts.objectAt(onscreen[0]);
       if (this._topVisible !== first) {
         this._topVisible = first;
-        const elem = postsNodes.item(onscreen[0]);
-        const elemId = elem.id;
-        const elemPos = domUtils.position(elem);
-        const distToElement = elemPos?.top || 0;
+        const elemId = postsNodes.item(onscreen[0]).id;
 
         const topRefresh = () => {
           refresh(() => {


### PR DESCRIPTION
Currently, some users have shared that there is CLS when accessing /t/:id?page=2: https://meta.discourse.org/t/page-n-urls-have-high-cls-hence-bad-seo/249554

With certain conditions, this issue does not show up. The easiest way to reproduce this is probably to do either of this
- Use a 3G slow connection or;
- Add a breakpoint to `scrolling-post-stream.topRefresh (anon)`
- (and optionally `lock-on.lock`)

This took me a while as it was hard to determine what else was causing the shift when `?page=2` (or more). Ultimately, replacing the dom's scroll methods helped find all the scrolly (hah, get it?) places. 

This issue is happening because there are multiple areas that set scroll location in the post stream when loading a topic. In our case, sometimes `lock-on` is triggering and scrolling to post_1, before ?page=2's post_21 is being scrolled to, due to posts above post_21 can finishing loading at different times. This causes some calculations to not add up, as being in the middle of a post stream has different calculations than being at the top of the post stream.

Below are four videos, the first two are what it looks like before the fix, the last two are what it looks like after the fix.

Unfixed, without breakpoints, no visible issue:

https://github.com/discourse/discourse/assets/1555215/0c22a3ad-e6d6-40c7-a6ac-4cd630493c58

Unfixed, with breakpoints, obvious CLS issue:

https://github.com/discourse/discourse/assets/1555215/127b6116-0775-483b-b2e0-66c8632800ad

Fixed, without breakpoints - how a user typically sees the page:

https://github.com/discourse/discourse/assets/1555215/6c8b0a7e-5064-435a-9da9-8aa799367948

Fixed, with breakpoints, CLS issue fixed! ✅ 

https://github.com/discourse/discourse/assets/1555215/790ef1e6-8536-41d4-8f7a-c2e44d28725c


