### PR TITLE
UX: header avatar > change to aria-label

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -176,7 +176,9 @@ createWidget(
               "aria-haspopup": true,
               "aria-expanded": attrs.active,
               href: attrs.user.path,
-              title: attrs.user.name || attrs.user.username,
+              "aria-label":
+                (attrs.user.name || attrs.user.username) +
+                I18n.t("user.account_possessive"),
               "data-auto-route": true,
             },
           },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1089,6 +1089,7 @@ en:
       said: "%{username}:"
       profile: "Profile"
       profile_possessive: "%{username}'s profile"
+      account_possessive: "'s account"
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive:


### PR DESCRIPTION
For the 2023 A11Y assessment:

* Add “account” after the user’s name to provide the full purpose of the button.
* Use aria-label instead of title