### PR TITLE
DEV: uses `in: {}` with lambda to work with `eager_load`

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Discourse::Application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = true
+  config.eager_load = ENV["CI"].present?
 
   # Configure static asset server for tests with Cache-Control for performance
   config.public_file_server.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Discourse::Application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = true
 
   # Configure static asset server for tests with Cache-Control for performance
   config.public_file_server.enabled = true

--- a/plugins/chat/app/services/chat/flag_message.rb
+++ b/plugins/chat/app/services/chat/flag_message.rb
@@ -40,7 +40,7 @@ module Chat
       validates :channel_id, presence: true
 
       attribute :flag_type_id, :integer
-      validates :flag_type_id, inclusion: { in: ::ReviewableScore.types.values }
+      validates :flag_type_id, inclusion: { in: ->(_reviewable) { ::ReviewableScore.types.values } }
 
       attribute :message, :string
       attribute :is_warning, :boolean

--- a/plugins/chat/app/services/chat/flag_message.rb
+++ b/plugins/chat/app/services/chat/flag_message.rb
@@ -40,7 +40,7 @@ module Chat
       validates :channel_id, presence: true
 
       attribute :flag_type_id, :integer
-      validates :flag_type_id, inclusion: { in: ->(_reviewable) { ::ReviewableScore.types.values } }
+      validates :flag_type_id, inclusion: { in: ->(_flag_type) { ::ReviewableScore.types.values } }
 
       attribute :message, :string
       attribute :is_warning, :boolean

--- a/plugins/chat/spec/services/chat/flag_message_spec.rb
+++ b/plugins/chat/spec/services/chat/flag_message_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Chat::FlagMessage do
     it { is_expected.to validate_presence_of(:message_id) }
 
     it do
-      skip("TODO: This does not work in CI when eager load is set to true") if ENV["CI"]
       is_expected.to validate_inclusion_of(:flag_type_id).in_array(ReviewableScore.types.values)
     end
   end


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/bf3e121323ce6442266da0f36df5cfcc4f2c7d14 this spec had been skipped as it was not working with `eager_load`.

When validating with a dynamic set of values, especially one that might change during runtime, we should use a lambda or a proc to ensure that the validation uses the most up-to-date set of values. This is particularly important when using `config.eager_load = true`, which can cause some elements to be loaded only once at startup, thus not reflecting changes made at runtime.

This was the root cause of the issues here, as we were adding more ReviewableScore types after initial load through: `register_reviewable_type Chat::ReviewableMessage`
