### PR TITLE
UX: make sidebar title static

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
+++ b/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
@@ -7,9 +7,7 @@ export default createWidget("sidebar-toggle", {
     const attrs = this.attrs;
     return [
       this.attach("button", {
-        title: attrs.showSidebar
-          ? "sidebar.hide_sidebar"
-          : "sidebar.show_sidebar",
+        title: "sidebar.title",
         icon: "bars",
         action: this.site.narrowDesktopView
           ? "toggleHamburger"

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
@@ -218,7 +218,7 @@ acceptance(
 
       assert.strictEqual(
         query(".btn-sidebar-toggle").title,
-        I18n.t("sidebar.hide_sidebar"),
+        I18n.t("sidebar.title"),
         "has the right title attribute when sidebar is expanded"
       );
 
@@ -233,7 +233,7 @@ acceptance(
 
       assert.strictEqual(
         query(".btn-sidebar-toggle").title,
-        I18n.t("sidebar.show_sidebar"),
+        I18n.t("sidebar.title"),
         "has the right title attribute when sidebar is collapsed"
       );
     });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4474,8 +4474,7 @@ en:
       redirect_after_success: "Second factor authentication is successful. Redirecting to the previous page…"
 
     sidebar:
-      show_sidebar: "Show sidebar"
-      hide_sidebar: "Hide sidebar"
+      title: "Sidebar"
       unread_count:
         one: "%{count} unread"
         other: "%{count} unread"


### PR DESCRIPTION
The toggle sidebar disclosure button changes the accessible name between “Hide sidebar” and “Show sidebar”, but also uses the aria-expanded state. This results in it being announced as, “Hide sidebar expanded” and “Show sidebar collapsed”, which is confusing. 
This commit changes the accessible name to “Sidebar”, allowing the expanded collapsed state to be announced by the aria-expanded attribute. This will result in the button being announced as, “Sidebar expanded” or “Sidebar collapsed”.