### PR TITLE
FIX: improve structured data based on recent changes

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -36,6 +36,7 @@
   <%- if include_crawler_content? %>
     <div itemscope itemtype='http://schema.org/DiscussionForumPosting'>
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
+      <meta itemprop='url' content='<%= @topic_view.absolute_url %>'>
       <% if @topic_view.topic.category.present? %>
         <meta itemprop='articleSection' content='<%= @topic_view.topic.category.name %>'>
       <% end %>
@@ -66,7 +67,7 @@
                 <% end %>
               </span>
 
-              <link itemprop="mainEntityOfPage" href="<%= post.topic.url %>">
+              <link <%= post.is_first_post? ? "itemprop='mainEntityOfPage'" : "" %> href="<%= post.topic.url %>">
 
               <% if post.image_url %>
                 <link itemprop="image" href="<%= post.image_url %>">
@@ -84,7 +85,7 @@
               <span itemprop='position'><%= post.post_number %></span>
               </span>
             </div>
-            <div class='post' itemprop='<%= post.is_first_post? ? 'articleBody' : 'text'  %>'>
+            <div class='post' itemprop='text'>
               <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
             </div>
 


### PR DESCRIPTION
This commit makes some improvements to a topic's structured data based on the recommendation on meta topic: https://meta.discourse.org/t/google-structured-data-for-forums-and-profile-pages/286762/9
