### PR TITLE
DEV: Prefer Ember's RSVP over native Promise

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -80,30 +80,35 @@ export default class DiscoveryCategoriesRoute extends DiscourseRoute {
   }
 
   async _findCategoriesAndTopics(filter) {
-    let result = await hash({
+    return hash({
       categoriesList: PreloadStore.getAndRemove("categories_list"),
       topicsList: PreloadStore.getAndRemove("topic_list"),
-    });
+    })
+      .then((result) => {
+        if (
+          result.categoriesList?.category_list &&
+          result.topicsList?.topic_list
+        ) {
+          return { ...result.categoriesList, ...result.topicsList };
+        } else {
+          // Otherwise, return the ajax result
+          return ajax(`/categories_and_${filter}`);
+        }
+      })
+      .then((result) => {
+        if (result.topic_list?.top_tags) {
+          this.site.set("top_tags", result.topic_list.top_tags);
+        }
 
-    if (result.categoriesList?.category_list && result.topicsList?.topic_list) {
-      result = { ...result.categoriesList, ...result.topicsList };
-    } else {
-      // Otherwise, return the ajax result
-      result = await ajax(`/categories_and_${filter}`);
-    }
-
-    if (result.topic_list?.top_tags) {
-      this.site.set("top_tags", result.topic_list.top_tags);
-    }
-
-    return CategoryList.create({
-      store: this.store,
-      categories: CategoryList.categoriesFrom(this.store, result),
-      topics: TopicList.topicsFrom(this.store, result),
-      can_create_category: result.category_list.can_create_category,
-      can_create_topic: result.category_list.can_create_topic,
-      loadBefore: this._loadBefore(this.store),
-    });
+        return CategoryList.create({
+          store: this.store,
+          categories: CategoryList.categoriesFrom(this.store, result),
+          topics: TopicList.topicsFrom(this.store, result),
+          can_create_category: result.category_list.can_create_category,
+          can_create_topic: result.category_list.can_create_topic,
+          loadBefore: this._loadBefore(this.store),
+        });
+      });
   }
 
   titleToken() {


### PR DESCRIPTION
This causes an incompatibility in some plugins that are patching the discovery-categories route, such as discourse-global-filter.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
