### PR TITLE
FIX: pass args in chat header to logo widget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
@@ -4,5 +4,5 @@ import { registerWidgetShim } from "discourse/widgets/render-glimmer";
 registerWidgetShim(
   "home-logo-wrapper-outlet",
   "div.home-logo-wrapper-outlet",
-  hbs`<PluginOutlet @name="home-logo-wrapper"><MountWidget @widget="home-logo" @attrs={{@data}} @args={{hash minimized=@data.topic}} /></PluginOutlet>`
+  hbs`<PluginOutlet @name="home-logo-wrapper"><MountWidget @widget="home-logo" @args={{@data}} /></PluginOutlet>`
 );


### PR DESCRIPTION
This change passes down all params to the home logo widget (rather than explicitly setting `minimized`). This will allow for flexible logo sizing in the Discourse full width theme component.