### PR TITLE
FIX: chat drawer routing fix for threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-threads.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-threads.gjs
@@ -45,7 +45,7 @@ export default class ChatDrawerRoutesChannelThreads extends Component {
         <navbar.BackButton
           @title={{this.backLinkTitle}}
           @route="chat.channel"
-          @routeModels={{this.chat.activeChannel?.routeModels}}
+          @routeModels={{this.chat.activeChannel.routeModels}}
         />
         <navbar.Title @title={{this.title}} @icon="discourse-threads" />
         <navbar.Actions as |action|>


### PR DESCRIPTION
This change fixes a minor regression in the chat back button navigation.

The navbar is wrapped in a conditional `if this.chat.activeChannel` so we don't need to do optional chaining of the `routeModels`, as it should always exist.