### PR TITLE
UI: chat header style improvements

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-header.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-header.scss
@@ -14,12 +14,11 @@
     align-items: center;
 
     .back-to-forum {
-      color: var(--primary-medium);
+      color: var(--primary);
       font-size: var(--font-up-1);
-      font-weight: var(--font-bold);
-      padding: 0.8rem;
+      padding: 0.5rem 0.8rem;
 
-      &:focus {
+      .d-icon {
         color: var(--primary);
       }
     }
@@ -27,9 +26,9 @@
     .c-heading {
       color: var(--primary);
       font-size: var(--font-up-2);
-      font-weight: var(--font-bold);
+      font-weight: bold;
       margin: 0 auto;
-      padding: 0.6rem;
+      padding: 0.4rem 0.8rem;
     }
   }
 }


### PR DESCRIPTION
Small visual improvements for chat header:

- makes the Back to Forum target size slightly narrower
- makes the text color consistent between header and back button (and d-icon)
- makes the chat heading bold

Before:
<img width="389" alt="Screenshot 2023-12-28 at 1 54 18 PM" src="https://github.com/discourse/discourse/assets/2257978/fc271bb3-912d-4d47-b69b-856a432ffe5f">

After:
<img width="390" alt="Screenshot 2023-12-28 at 1 46 40 PM" src="https://github.com/discourse/discourse/assets/2257978/6bc30de7-68b8-4869-86e8-302f6db164e5">

/t/-/112520