### PR TITLE
FIX: Handle deprecations correctly in server-side pretty-text

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -52,7 +52,7 @@ export default function deprecated(msg, options = {}) {
   if (
     raiseError ||
     matchedWorkflow?.handler === "throw" ||
-    (!matchedWorkflow && deprecationWorkflow.throwOnUnhandled)
+    (!matchedWorkflow && deprecationWorkflow?.throwOnUnhandled)
   ) {
     throw msg;
   }

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2681,4 +2681,16 @@ HTML
 
     expect(cooked.strip).to eq(html.strip)
   end
+
+  it "handles deprecations correctly" do
+    Rails
+      .logger
+      .expects(:warn)
+      .once
+      .with("[PrettyText] Deprecation notice: Some deprecation message")
+
+    PrettyText.v8.eval <<~JS
+      require("discourse-common/lib/deprecated").default("Some deprecation message");
+    JS
+  end
 end


### PR DESCRIPTION
`window.deprecationWorkflow` does not exist in the server-side pretty-text environment. This commit fixes the check and adds a general spec for deprecations triggered inside pretty-text

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
