### PR TITLE
FEATURE: Allow sorting group members by custom field via API

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -99,7 +99,7 @@
 
           <PluginOutlet
             @name="group-index-table-header-after-username"
-            @outletArgs={{hash group=this.model}}
+            @outletArgs={{hash group=this.model asc=this.asc order=this.order}}
           />
 
           <TableHeaderToggle

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -282,10 +282,20 @@ class GroupsController < ApplicationController
       )
     end
 
+    include_custom_fields = params[:include_custom_fields] == "true"
+
+    allowed_fields =
+      User.allowed_user_custom_fields(guardian) +
+        UserField.all.pluck(:id).map { |fid| "#{User::USER_FIELD_PREFIX}#{fid}" }
+
     if params[:order] && %w[last_posted_at last_seen_at].include?(params[:order])
       order = "#{params[:order]} #{dir} NULLS LAST"
     elsif params[:order] == "added_at"
       order = "group_users.created_at #{dir}"
+    elsif include_custom_fields && params[:order] == "custom_field" &&
+          allowed_fields.include?(params[:order_field])
+      order =
+        "(SELECT value FROM user_custom_fields ucf WHERE ucf.user_id = users.id AND ucf.name = '#{params[:order_field]}') #{dir} NULLS LAST"
     end
 
     users = group.users.human_users
@@ -313,7 +323,7 @@ class GroupsController < ApplicationController
     owners = users.where("group_users.owner")
 
     group_members_serializer =
-      params[:include_custom_fields] ? GroupUserWithCustomFieldsSerializer : GroupUserSerializer
+      include_custom_fields ? GroupUserWithCustomFieldsSerializer : GroupUserSerializer
 
     render json: {
              members: serialize_data(members, group_members_serializer),


### PR DESCRIPTION
If `include_custom_fields` is passed to the group member directory endpoint, `order` accepts a `custom_field` value with a new `order_field` query param to set which allowed custom field should be used for sorting. Example: `/groups/group-name/members.json?include_custom_fields=true&order=custom_field&order_field=user_field_1`.

Additionally, `asc` and `order` were added to the `group-index-table-header-after-username` plugin outlet for further use in customizations.