### PR TITLE
DEV: Add "migrations-tooling" label to PRs for import scripts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,9 @@ chat:
   - changed_files:
       - any-glob-to-any-file: plugins/chat/**/*
 
-migration:
+migrations-tooling:
   - changed_files:
-      - any-glob-to-any-file: migrations/**/*
+      - any-glob-to-any-file:
+        - migrations/**/*
+        - script/bulk_import/**/*
+        - script/import_scripts/**/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 /migrations/ @discourse/migrations-tooling
+/script/bulk_import/ @discourse/migrations-tooling
+/script/import_scripts/ @discourse/migrations-tooling


### PR DESCRIPTION
Also, PRs for import scripts should automatically be assigned to the migrations-tooling group.