### PR TITLE
DEV: Improve error message when test fails

### DIFF
--- a/spec/requests/finish_installation_controller_spec.rb
+++ b/spec/requests/finish_installation_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FinishInstallationController do
 
       it "doesn't allow access" do
         get "/finish-installation"
-        expect(response).to be_forbidden
+        expect(response.status).to eq(403)
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe FinishInstallationController do
 
       it "doesn't allow access" do
         get "/finish-installation/register"
-        expect(response).to be_forbidden
+        expect(response.status).to eq(403)
       end
     end
 


### PR DESCRIPTION
Why this change?

The two tests being updated in question has been flaky on CI. However,
when using `be_forbidden`, the error message does not indicate what the
actual response code was making it hard for us to debug.

What does this change do?

Assert for the exact response status code we are expecting.