### PR TITLE
FEATURE: Buffer file names of failed uploads when bulk uploading

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -4,6 +4,7 @@ import { sanitize as textSanitize } from "pretty-text/sanitizer";
 import deprecated from "discourse-common/lib/deprecated";
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 import { helperContext } from "discourse-common/lib/helpers";
+import I18n from "discourse-i18n";
 
 async function withEngine(name, ...args) {
   const engine = await import("discourse/static/markdown-it");
@@ -135,4 +136,19 @@ export function excerpt(cooked, length) {
   });
 
   return result;
+}
+
+export function humanizeList(listItems) {
+  const items = Array.from(listItems);
+  const last = items.pop();
+
+  if (items.length === 0) {
+    return last;
+  } else {
+    return [
+      items.join(I18n.t("word_connector.comma")),
+      I18n.t("word_connector.last_item"),
+      last,
+    ].join(" ");
+  }
 }

--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -1,3 +1,4 @@
+import { humanizeList } from "discourse/lib/text";
 import { isAppleDevice } from "discourse/lib/utilities";
 import deprecated from "discourse-common/lib/deprecated";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
@@ -300,6 +301,12 @@ export function getUploadMarkdown(upload) {
   } else {
     return attachmentMarkdown(upload);
   }
+}
+
+export function displayErrorForBulkUpload(errors) {
+  const fileNames = humanizeList(errors.mapBy("fileName"));
+
+  dialog.alert(I18n.t("post.errors.upload", { file_name: fileNames }));
 }
 
 export function displayErrorForUpload(data, siteSettings, fileName) {

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -11,6 +11,7 @@ import { cacheShortUploadUrl } from "pretty-text/upload-short-url";
 import { updateCsrfToken } from "discourse/lib/ajax";
 import {
   bindFileInputChangeListener,
+  displayErrorForBulkUpload,
   displayErrorForUpload,
   getUploadMarkdown,
   validateUploadedFile,
@@ -99,6 +100,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
 
   _bindUploadTarget() {
     this.set("inProgressUploads", []);
+    this.set("bufferedUploadErrors", []);
     this.placeholders = {};
     this._preProcessorStatus = {};
     this.editorEl = this.element.querySelector(this.editorClass);
@@ -352,6 +354,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
               this.appEvents.trigger(
                 `${this.composerEventPrefix}:all-uploads-complete`
               );
+              this._displayBufferedErrors();
               this._reset();
             }
           }
@@ -403,11 +406,11 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
     file.meta.error = error;
 
     if (!this.userCancelled) {
-      displayErrorForUpload(response || error, this.siteSettings, file.name);
+      this._bufferUploadError(response || error, file.name);
       this.appEvents.trigger(`${this.composerEventPrefix}:upload-error`, file);
     }
-
     if (this.inProgressUploads.length === 0) {
+      this._displayBufferedErrors();
       this._reset();
     }
   },
@@ -417,6 +420,24 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       "inProgressUploads",
       this.inProgressUploads.filter((upl) => upl.id !== fileId)
     );
+  },
+
+  _displayBufferedErrors() {
+    if (this.bufferedUploadErrors.length === 0) {
+      return;
+    } else if (this.bufferedUploadErrors.length === 1) {
+      displayErrorForUpload(
+        this.bufferedUploadErrors[0].data,
+        this.siteSettings,
+        this.bufferedUploadErrors[0].fileName
+      );
+    } else {
+      displayErrorForBulkUpload(this.bufferedUploadErrors);
+    }
+  },
+
+  _bufferUploadError(data, fileName) {
+    this.bufferedUploadErrors.push({ data, fileName });
   },
 
   _setupPreProcessors() {
@@ -561,6 +582,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       isProcessingUpload: false,
       isCancellable: false,
       inProgressUploads: [],
+      bufferedUploadErrors: [],
     });
     this._resetPreProcessors();
     this.fileInputEl.value = "";

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -163,6 +163,7 @@ en:
 
     word_connector:
       comma: ", "
+      last_item: "and"
 
     action_codes:
       public_topic: "Made this topic public %{when}"


### PR DESCRIPTION
### What is the problem?

Currently, when bulk uploading and multiple uploads fail, we show a number of dialogs in quick succession. This is of course a terrible user experience.

### How does this fix it?

With this change, we buffer the error messages until there are no more pending uploads. Then we combine the buffered errors and display a single dialog with a list of failed files.

<img width="819" alt="Screenshot 2023-12-29 at 12 30 26 PM" src="https://github.com/discourse/discourse/assets/5259935/697ff97b-0acd-4ea0-b70c-03d861ee01e9">

### How does it work?

Very simple. Just add an array as a buffer on the composer Uppy mixin. Instead of displaying a dialog on each error, we push to the buffer, and then flush it when there are no more uploads in progress.

### Not in this PR

This lays some groundwork for a nicer upload failure interface that we're discussing, but doesn't implement it.