### PR TITLE
DEV: Remove assertion causing test to be flaky

### DIFF
--- a/plugins/chat/spec/system/user_status/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_status/sidebar_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "User status | sidebar", type: :system do
   context "when changing status" do
     it "updates status" do
       visit("/")
+
       current_user.set_status!("offline", "tooth")
 
-      expect(page).to have_css('.user-status-message .emoji[alt="tooth"]')
-      expect(find(".user-status-message .emoji")["src"]).to include("tooth")
+      expect(page).to have_css('.user-status-message img.emoji[alt="tooth"]')
     end
   end
 


### PR DESCRIPTION
Why this change?

The assertion does not make use of Capybara's waiting strategy and is
not really testing anything meaningful by asserting for the src of the
img element.