### PR TITLE
DEV: Attempt to fix flaky test by using `click_button` instead of `click`

### DIFF
--- a/spec/system/page_objects/modals/insert_table.rb
+++ b/spec/system/page_objects/modals/insert_table.rb
@@ -11,7 +11,7 @@ module PageObjects
       end
 
       def cancel
-        find("#{MODAL_SELECTOR} .d-modal-cancel").click
+        click_button(I18n.t("js.cancel"))
       end
 
       def click_edit_reason


### PR DESCRIPTION
Why this change?

Some of the tests in `spec/system/table_builder_spec.rb` are flaky when
we are asserting that clicking the cancel button will close the modal.
This change attempts to fix it by using the `click_button` method
instead of `find` then `click` which is more reliable.