### PR TITLE
UX: Add 'edit' link to theme colour palette selector

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -447,4 +447,9 @@ export default class AdminCustomizeThemesShowController extends Controller {
       .saveChanges("enabled")
       .catch(() => this.model.set("enabled", true));
   }
+
+  @action
+  editColorScheme() {
+    this.router.transitionTo("adminCustomize.colors.show", this.colorSchemeId);
+  }
 }

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -282,12 +282,21 @@
           </div>
 
           <div class="setting-value">
-            <ColorPalettes
-              @content={{this.colorSchemes}}
-              @value={{this.colorSchemeId}}
-              @icon="paint-brush"
-              @options={{hash filterable=true}}
-            />
+            <div class="color-palette-input-group">
+              <ColorPalettes
+                @content={{this.colorSchemes}}
+                @value={{this.colorSchemeId}}
+                @icon="paint-brush"
+                @options={{hash filterable=true}}
+              />
+              {{#if this.colorSchemeId}}
+                <DButton
+                  @icon="pen"
+                  @action={{this.editColorScheme}}
+                  @title="admin.customize.theme.edit_color_scheme"
+                />
+              {{/if}}
+            </div>
 
             <div class="desc">{{i18n
                 "admin.customize.theme.color_scheme_select"

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -450,6 +450,11 @@
     .setting {
       padding-bottom: 0;
     }
+
+    .color-palette-input-group {
+      display: flex;
+      gap: 0.5rem;
+    }
   }
 
   .editor-information {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5314,6 +5314,7 @@ en:
           color_scheme_user_selectable: "Color scheme can be selected by users"
           auto_update: "Auto update when Discourse is updated"
           color_scheme: "Color Palette"
+          edit_color_scheme: "Edit Color Palette"
           default_light_scheme: "Light (default)"
           color_scheme_select: "Select colors to be used by theme"
           custom_sections: "Custom sections:"


### PR DESCRIPTION
<img width="656" alt="SCR-20231229-ppad-2" src="https://github.com/discourse/discourse/assets/6270921/c70ef241-b225-4dbf-bc43-6514338d4985">
