### PR TITLE
DEV: Patch `deprecated-run-loop-and-computed-dot-access` in production

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,6 +19,7 @@ plugins/**/lib/javascripts/locale
 public/
 !/app/assets/javascripts/discourse/public
 vendor/
+!app/assets/javascripts/ember-production-deprecations/vendor/
 app/assets/javascripts/discourse/tests/fixtures
 spec/
 node_modules/

--- a/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
+++ b/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
@@ -34,13 +34,15 @@ define("discourse/lib/deprecate-shim", ["exports"], function (exports) {
       }
     );
 
+    const deprecate = require("@ember/debug").deprecate;
+
     // Patch ember-global deprecation
     if (window.hasOwnProperty("Ember")) {
       Object.defineProperty(window, "Ember", {
         enumerable: true,
         configurable: true,
         get() {
-          require("@ember/debug").deprecate(
+          deprecate(
             "Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead.",
             false,
             {
@@ -57,6 +59,113 @@ define("discourse/lib/deprecate-shim", ["exports"], function (exports) {
           return require("ember").default;
         },
       });
+    }
+
+    // Patch run.blah deprecations
+    // https://github.com/emberjs/ember.js/blob/007fc9eba1/packages/%40ember/runloop/index.js#L748-L808
+    const deprecatedRunloopFunctions = [
+      "backburner",
+      "begin",
+      "bind",
+      "cancel",
+      "debounce",
+      "end",
+      "hasScheduledTimers",
+      "join",
+      "later",
+      "next",
+      "once",
+      "schedule",
+      "scheduleOnce",
+      "throttle",
+      "cancelTimers",
+    ];
+
+    const run = require("@ember/runloop").run;
+    for (const name of deprecatedRunloopFunctions) {
+      const currentDescriptor = Object.getOwnPropertyDescriptor(run, name);
+      if (currentDescriptor?.value) {
+        Object.defineProperty(run, name, {
+          get() {
+            deprecate(
+              `Using \`run.${name}\` has been deprecated. Instead, import the value directly.`,
+              false,
+              {
+                id: "deprecated-run-loop-and-computed-dot-access",
+                until: "4.0.0",
+                for: "ember-source",
+                since: {
+                  enabled: "3.27.0",
+                },
+                url: "https://deprecations.emberjs.com/v3.x/#toc_deprecated-run-loop-and-computed-dot-access",
+              }
+            );
+            return currentDescriptor.value;
+          },
+        });
+      }
+    }
+
+    // Patch computed.blah deprecations
+    // https://github.com/emberjs/ember.js/blob/v3.28.12/packages/%40ember/object/index.js#L60-L118
+    const deprecatedComputedFunctions = [
+      "alias",
+      "and",
+      "bool",
+      "collect",
+      "deprecatingAlias",
+      "empty",
+      "equal",
+      "filterBy",
+      "filter",
+      "gte",
+      "gt",
+      "intersect",
+      "lte",
+      "lt",
+      "mapBy",
+      "map",
+      "match",
+      "max",
+      "min",
+      "none",
+      "notEmpty",
+      "not",
+      "oneWay",
+      "reads",
+      "or",
+      "readOnly",
+      "setDiff",
+      "sort",
+      "sum",
+      "union",
+      "uniqBy",
+      "uniq",
+    ];
+
+    const computed = require("@ember/object").computed;
+    for (const name of deprecatedComputedFunctions) {
+      const currentDescriptor = Object.getOwnPropertyDescriptor(computed, name);
+      if (currentDescriptor?.value) {
+        Object.defineProperty(computed, name, {
+          get() {
+            deprecate(
+              `Using \`computed.${name}\` has been deprecated. Instead, import the value directly.`,
+              false,
+              {
+                id: "deprecated-run-loop-and-computed-dot-access",
+                until: "4.0.0",
+                for: "ember-source",
+                since: {
+                  enabled: "3.27.0",
+                },
+                url: "https://deprecations.emberjs.com/v3.x/#toc_deprecated-run-loop-and-computed-dot-access",
+              }
+            );
+            return currentDescriptor.value;
+          },
+        });
+      }
     }
   };
 });


### PR DESCRIPTION
In Ember, these deprecations are wrapped in an `if(DEBUG)` check, so they are optimized out of the production build. We prefer to keep deprecations in production so that we can collect telemetry and warn theme authors who do not use local development environments.

This commit restores the deprecations as part of our ember-production-deprecations addon.

These will be removed once we finalise the upgrade to Ember 5.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
