### PR TITLE
FIX: Allow the flags to be cleaned up

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -108,7 +108,7 @@ class ReviewableFlaggedPost < Reviewable
         label: "reviewables.actions.ignore.title",
       )
 
-    if !post.hidden?
+    if !post.hidden? || guardian.user.is_system_user?
       build_action(actions, :ignore_and_do_nothing, icon: "external-link-alt", bundle: ignore)
     end
     if guardian.can_delete_post_or_topic?(post)

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -99,6 +99,21 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
           expect(reviewable.actions_for(guardian).has?(:delete_user_block)).to be true
         end
       end
+
+      context "for ignore_and_do_nothing" do
+        it "does not return `ignore_and_do_nothing` when post is hidden" do
+          post.update(hidden: true)
+
+          expect(reviewable.actions_for(guardian).has?(:ignore_and_do_nothing)).to eq(false)
+        end
+
+        it "returns `ignore_and_do_nothing` if the acting user is system" do
+          post.update(hidden: true)
+          system_guardian = Guardian.new(Discourse.system_user)
+
+          expect(reviewable.actions_for(system_guardian).has?(:ignore_and_do_nothing)).to eq(true)
+        end
+      end
     end
 
     it "agree_and_keep agrees with the flags and keeps the post" do


### PR DESCRIPTION
Currently, the reviewable queue includes `ReviewableFlaggedPost` with posts that have already been hidden. This allows for such hidden posts to be cleared up by the auto-tool.