### PR TITLE
FIX: Post copy link not working

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -22,7 +22,10 @@ import RawHtml from "discourse/widgets/raw-html";
 import { applyDecorators, createWidget } from "discourse/widgets/widget";
 import { isTesting } from "discourse-common/config/environment";
 import { avatarUrl, translateSize } from "discourse-common/lib/avatar-utils";
-import getURL, { getURLWithCDN } from "discourse-common/lib/get-url";
+import getURL, {
+  getAbsoluteURL,
+  getURLWithCDN,
+} from "discourse-common/lib/get-url";
 import { iconNode } from "discourse-common/lib/icon-library";
 import I18n from "discourse-i18n";
 
@@ -653,7 +656,7 @@ createWidget("post-contents", {
     const post = this.findAncestorModel();
     const postId = post.id;
 
-    let actionCallback = () => clipboardCopy(post.shareUrl);
+    let actionCallback = () => clipboardCopy(getAbsoluteURL(post.shareUrl));
 
     // Can't use clipboard in JS tests.
     if (isTesting()) {
@@ -664,7 +667,7 @@ createWidget("post-contents", {
       postId,
       actionClass: "post-action-menu__copy-link",
       messageKey: "post.controls.link_copied",
-      actionCallback: () => actionCallback,
+      actionCallback,
       errorCallback: () => this.share(),
     });
   },

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -86,6 +86,8 @@ module PageObjects
           post_by_number(post).find(".post-controls .reply").click
         when :flag
           post_by_number(post).find(".post-controls .create-flag").click
+        when :copy_link
+          post_by_number(post).find(".post-controls .post-action-menu__copy-link").click
         end
       end
 

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "Post menu", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:post)
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before { sign_in(current_user) }
+
+  describe "copy link" do
+    let(:cdp) { PageObjects::CDP.new }
+
+    before { cdp.allow_clipboard }
+
+    xit "copies the absolute link to the post when clicked" do
+      topic_page.visit_topic(post.topic)
+      topic_page.click_post_action_button(post, :copy_link)
+      expect(cdp.read_clipboard).to eq(post.full_url + "?u=#{current_user.username}")
+    end
+  end
+end


### PR DESCRIPTION
Followup to c6cb3196718ba2dde8e799f5d9cdd999f3116d1f,
the actionCallback function was double-wrapped with () => {}
which meant that copyClipboard did not return a promise.
