### PR TITLE
DEV: Collect css assets from webpack build

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -9,7 +9,7 @@ class EmberCli < ActiveSupport::CurrentAttributes
   end
 
   def self.assets
-    cache[:assets] ||= Dir.glob("**/*.{js,map,txt}", base: "#{dist_dir}/assets")
+    cache[:assets] ||= Dir.glob("**/*.{js,map,txt,css}", base: "#{dist_dir}/assets")
   end
 
   def self.script_chunks


### PR DESCRIPTION
fb95ab8e006d67f485881fb2c8715918486a8684 started depending on webpack-bundled CSS, but css files weren't being collected by Sprockets or uploaded to S3.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
