### PR TITLE
DEV: Update when / how we display of full name on `search-item-user`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.hbs
@@ -62,6 +62,7 @@
             @resultTypes={{this.resultTypesWithComponent}}
             @closeSearchMenu={{@closeSearchMenu}}
             @searchTermChanged={{@searchTermChanged}}
+            @displayNameWithUser={{true}}
           />
         {{/if}}
       {{/if}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/user.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/user.hbs
@@ -5,7 +5,7 @@
   username=@result.username
 }}
 <div class="user-titles">
-  {{#if @result.name}}
+  {{#if (and @displayNameWithUser @result.name)}}
     <span class="name">{{@result.name}}</span>
   {{/if}}
   <span class="username">

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.hbs
@@ -17,7 +17,10 @@
             {{on "click" this.onClick}}
             class="search-link"
           >
-            <resultType.component @result={{result}} />
+            <resultType.component
+              @result={{result}}
+              @displayNameWithUser={{@displayNameWithUser}}
+            />
           </a>
         </li>
       {{/each}}

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
@@ -1136,9 +1136,6 @@ acceptance("Search - Glimmer - assistant", function (needs) {
     const username = firstUser.querySelector(".username").innerText.trim();
     assert.strictEqual(username, "TeaMoe");
 
-    const name = firstUser.querySelector(".name").innerText.trim();
-    assert.strictEqual(name, "TeaMoe Full");
-
     await click(firstUser);
     assert.strictEqual(query("#search-term").value, `@${username}`);
   });

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -389,7 +389,10 @@ $search-pad-horizontal: 0.5em;
   .search-item-user {
     display: flex;
     align-self: center;
-    gap: 0.33em;
+
+    .username {
+      margin-right: 0.33em;
+    }
   }
 
   .search-result-user {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -387,13 +387,9 @@ $search-pad-horizontal: 0.5em;
   }
 
   .search-item-user {
-    .username {
-      margin-right: 0.33rem;
-    }
-
-    img.avatar {
-      margin-right: 0 !important;
-    }
+    display: flex;
+    align-self: center;
+    gap: 0.33em;
   }
 
   .search-result-user {


### PR DESCRIPTION
- Full name should only be displayed within `initial options`
- Keep results on a single line unless full name is included

# Initial Options
<img width="416" alt="Screenshot 2024-01-02 at 9 58 07 AM" src="https://github.com/discourse/discourse/assets/50783505/a9f6880a-86e0-4683-978a-c0391a90c78e">

# Other
<img width="432" alt="Screenshot 2024-01-02 at 9 58 43 AM" src="https://github.com/discourse/discourse/assets/50783505/83b508b0-c501-4fb7-89f7-8e66dc88979f">
<img width="424" alt="Screenshot 2024-01-02 at 9 58 18 AM" src="https://github.com/discourse/discourse/assets/50783505/b98223d7-f92c-4803-87bf-0470e6ce05ed">
