### PR TITLE
UX: update post background highlight

### DIFF
--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -14,12 +14,11 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .topic-body.topic-body.highlighted .cooked {
-      animation: unset;
-    }
-
-    .topic-body.highlighted .regular.contents {
-      animation: background-fade-highlight 2.5s ease-out;
+    .topic-body.highlighted {
+      animation: none;
+      .regular.contents {
+        animation: background-fade-highlight 2.5s ease-out;
+      }
     }
   }
 
@@ -155,24 +154,16 @@
   // special post type colors
 
   .current-user-post {
-    &:not(.moderator):not(.whisper.current-user-post) {
-      .regular.contents {
-        background: var(--tertiary-very-low);
-        border-color: var(--tertiary-very-low);
-      }
+    .regular.contents {
+      background: var(--tertiary-very-low);
+      border-color: var(--tertiary-very-low);
+    }
+    @media (prefers-reduced-motion: no-preference) {
       .topic-body.highlighted {
-        @media (prefers-reduced-motion: no-preference) {
-          .cooked {
-            animation: unset;
-          }
-          .regular.contents {
-            animation: current-user-background-fade-highlight 2.5s ease-out;
-          }
+        .regular.contents {
+          animation: current-user-background-fade-highlight 2.5s ease-out;
         }
       }
-    }
-    .topic-body .cooked {
-      border: 1px solid transparent;
     }
     .embedded-posts {
       .topic-body .cooked {
@@ -182,26 +173,18 @@
   }
 
   .moderator {
+    .topic-body.highlighted {
+      .regular.contents {
+        animation: none;
+      }
+    }
+
     .regular.contents {
       background: var(--highlight-low);
       border-color: var(--highlight-low);
-    }
-    .regular.contents .cooked {
-      background: transparent;
-      border: 1px solid transparent;
-    }
-  }
-
-  .deleted {
-    .regular.contents {
-      background: var(--danger-low);
-      border-color: var(--danger-low);
-    }
-    .topic-body .regular .cooked {
-      background: transparent;
-    }
-    .topic-body.highlighted .regular.contents {
-      animation: unset;
+      .cooked {
+        background: transparent;
+      }
     }
   }
 
@@ -215,6 +198,21 @@
       border: 2px dashed var(--tertiary-low);
       @media (prefers-reduced-motion: no-preference) {
         animation: background-fade-highlight 2.5s ease-out;
+      }
+    }
+  }
+
+  .deleted {
+    .topic-body .regular.contents {
+      background: var(--danger-low);
+      border-color: transparent;
+      .cooked {
+        background: transparent;
+      }
+    }
+    &.whisper {
+      .topic-body .regular.contents {
+        border-color: var(--danger-low-mid);
       }
     }
   }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -945,12 +945,12 @@ aside.quote {
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .topic-body.highlighted .cooked,
+  .topic-body.highlighted,
   .small-action-desc.highlighted {
     animation: background-fade-highlight 2.5s ease-out;
   }
   // Disable animation so deleted status is visible immediately
-  .deleted .topic-body.highlighted .cooked {
+  .deleted .topic-body.highlighted {
     animation: none;
   }
 }


### PR DESCRIPTION
This updates the post highlight background (when entering a topic) to be on `.contents` rather than `.cooked`, as was the case before https://github.com/discourse/discourse/pull/24825

Before:
![Screenshot 2024-01-02 at 2 57 03 PM](https://github.com/discourse/discourse/assets/1681963/74b39d0a-3f64-47fb-88a1-a2ec9b039200)

After:
![Screenshot 2024-01-02 at 2 56 40 PM](https://github.com/discourse/discourse/assets/1681963/947bb7a0-8205-4de1-aefe-c7f06b5c471e)

This also updates PM highlighting to reflect this change, as the styles there are different. 

/t/117647


