### PR TITLE
DEV: add `btn-default` class ro review action buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.gjs
@@ -61,7 +61,7 @@ export default class ReviewableBundledAction extends Component {
         @translatedLabel={{this.first.label}}
         @disabled={{@reviewableUpdating}}
         class={{concatClass
-          "reviewable-action"
+          "btn-default reviewable-action"
           (dasherize this.first.id)
           this.first.button_class
         }}

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
@@ -122,7 +122,7 @@
               @icon="pencil-alt"
               @action={{action "edit"}}
               @label="review.edit"
-              class="reviewable-action edit"
+              class="reviewable-action btn-default edit"
             />
           {{/if}}
         {{/if}}


### PR DESCRIPTION
These buttons in the review queue didn't have the `btn-default` class, which is often used as a generic button target in themes. This adds it (and causes no visual changes). 

![Screenshot 2024-01-02 at 3 39 56 PM](https://github.com/discourse/discourse/assets/1681963/cbcd51c9-097b-4f91-873c-e82d187fa961)
