### PR TITLE
UX: add gap between category and tags in suggested topics

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -224,6 +224,7 @@
         display: flex;
         flex-wrap: wrap;
         align-items: center;
+        gap: 0.5em;
 
         .discourse-tags {
           font-size: var(--font-down-1);

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -223,7 +223,7 @@
       .second-line {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: baseline;
         gap: 0.5em;
 
         .discourse-tags {


### PR DESCRIPTION
this likely regressed after https://github.com/discourse/discourse/pull/24198

Before:
![Screenshot 2024-01-02 at 4 27 40 PM](https://github.com/discourse/discourse/assets/1681963/10734ddb-5652-4a27-a037-8cfa6c036ec2)


After:
![Screenshot 2024-01-02 at 4 27 28 PM](https://github.com/discourse/discourse/assets/1681963/7cb82283-2b7b-4a41-8240-22c672485dab)
