### PR TITLE
FIX: github onebox styles for commits

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -481,7 +481,7 @@ pre.onebox code {
     width: 100%;
     overflow-x: hidden;
     > span {
-      // legacy, can be removed in the future
+      // TODO: remove in a few months
       // replaced by .github-info in new commit oneboxes
       grid-area: info;
     }

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -480,6 +480,11 @@ pre.onebox code {
   .github-info-container {
     width: 100%;
     overflow-x: hidden;
+    > span {
+      // legacy, can be removed in the future
+      // replaced by .github-info in new commit oneboxes
+      grid-area: info;
+    }
   }
 
   .github-info {

--- a/lib/onebox/templates/githubpullrequest.mustache
+++ b/lib/onebox/templates/githubpullrequest.mustache
@@ -29,15 +29,17 @@
         <a href="{{link}}" target="_blank" rel="noopener">{{commit.message.lines.first}}</a>
       </h4>
 
-      <span>
-        Commit by
-        <a href="{{author.html_url}}" target="_blank" rel="noopener">
-          <img alt="{{author.login}}" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
-          {{author.login}}
-        </a>
-        in
-        <a href="{{link}}" target="_blank" rel="noopener">{{title}}</a>
-      </span>
+      <div class="github-info">
+        <span>
+          Commit by
+          <a href="{{author.html_url}}" target="_blank" rel="noopener">
+            <img alt="{{author.login}}" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+            {{author.login}}
+          </a>
+          in
+          <a href="{{link}}" target="_blank" rel="noopener">{{title}}</a>
+        </span>
+      </div>
     {{/commit}}
 
     {{#comment}}


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse/pull/24761, the github oneboxes for commits have a slightly different markup structure (with a naked `span` and no `github-info` parent like PRs have)

Here I've added the `github-info` container, and also apply the relevant style to the span... so new oneboxes will have the container, and old oneboxes will have a fallback style with `> span` (which can be removed at some point in the future)  

Before:
![Screenshot 2024-01-02 at 4 48 44 PM](https://github.com/discourse/discourse/assets/1681963/f51500ca-f222-41be-ab02-90ff94f45f12)

After:
![Screenshot 2024-01-02 at 4 49 01 PM](https://github.com/discourse/discourse/assets/1681963/059c1bb8-81e8-42c2-bc88-c30b05e2a982)
