### PR TITLE
FIX: never skip push notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -47,7 +47,7 @@ export function isPushNotificationsEnabled(user) {
   );
 }
 
-export function register(user, router, appEvents) {
+export function register(user, router) {
   if (!isPushNotificationsSupported()) {
     return;
   }

--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -18,25 +18,6 @@ function sendSubscriptionToServer(subscription, sendConfirmation) {
   });
 }
 
-function resetIdle() {
-  if (
-    "controller" in navigator.serviceWorker &&
-    navigator.serviceWorker.controller != null
-  ) {
-    navigator.serviceWorker.controller.postMessage({ lastAction: Date.now() });
-  }
-}
-
-function setupActivityListeners(appEvents) {
-  window.addEventListener("focus", resetIdle);
-
-  if (document) {
-    document.addEventListener("scroll", resetIdle);
-  }
-
-  appEvents.on("page:changed", resetIdle);
-}
-
 export function isPushNotificationsSupported() {
   let caps = helperContext().capabilities;
   if (
@@ -83,7 +64,6 @@ export function register(user, router, appEvents) {
           // Resync localStorage
           keyValueStore.setItem(userSubscriptionKey(user), "subscribed");
         }
-        setupActivityListeners(appEvents);
       })
       .catch((e) => {
         // eslint-disable-next-line no-console

--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -144,13 +144,6 @@ workbox.routing.registerRoute(
   })
 );
 
-var idleThresholdTime = 1000 * 10; // 10 seconds
-var lastAction = -1;
-
-function isIdle() {
-  return lastAction + idleThresholdTime < Date.now();
-}
-
 function showNotification(title, body, icon, badge, tag, baseUrl, url) {
   var notificationOptions = {
     body: body,
@@ -175,20 +168,9 @@ function showNotification(title, body, icon, badge, tag, baseUrl, url) {
 
 self.addEventListener('push', function(event) {
   var payload = event.data.json();
-  if(!isIdle() && payload.hide_when_active) {
-    return false;
-  }
 
   event.waitUntil(
-    self.registration.getNotifications({ tag: payload.tag }).then(function(notifications) {
-      if (notifications && notifications.length > 0) {
-        notifications.forEach(function(notification) {
-          notification.close();
-        });
-      }
-
-      return showNotification(payload.title, payload.body, payload.icon, payload.badge, payload.tag, payload.base_url, payload.url);
-    })
+    showNotification(payload.title, payload.body, payload.icon, payload.badge, payload.tag, payload.base_url, payload.url);
   );
 });
 
@@ -258,11 +240,6 @@ self.addEventListener('notificationclick', function(event) {
   }
 });
 
-self.addEventListener('message', function(event) {
-  if('lastAction' in event.data){
-    lastAction = event.data.lastAction;
-  }
-});
 
 self.addEventListener('pushsubscriptionchange', function(event) {
   event.waitUntil(


### PR DESCRIPTION
According to Apple, silent push notifications are automatically punished per:

https://developer.apple.com/videos/play/wwdc2022/10098/?time=814

> As mentioned when I showed you the code on how to request a push
> subscription, you must promise that pushes will be user visible.
> Handling a push event is not an invitation for your JavaScript to
> get silent background runtime. Doing so would violate both a user’s
> trust and a user’s battery life. When handling a push event, you are
> in fact required to post a notification to Notification Center.
> Other browsers all have countermeasures against violating the promise
> to make pushes user visible, and so does Safari.
> In the beta build of macOS Ventura, after three push events where you
> fail to post a notification in a timely manner, your site’s push
> subscription will be revoked. You will need to go through the permission
> workflow again.

The isIdle check was causing certain push notifications to be silent

Additionally, the auto dismissal logic was causing delays which may cause
the device to think the push was a silent one.

By removing this we hope to ensure push notification delivery is more robust
and consistent on iOS.
