### PR TITLE
DEV: Fix spec for post menu

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -645,12 +645,12 @@ class Post < ActiveRecord::Base
     publish_change_to_clients!(:acted)
   end
 
-  def full_url
-    "#{Discourse.base_url}#{url}"
+  def full_url(opts = {})
+    "#{Discourse.base_url}#{url(opts)}"
   end
 
-  def relative_url
-    "#{Discourse.base_path}#{url}"
+  def relative_url(opts = {})
+    "#{Discourse.base_path}#{url(opts)}"
   end
 
   def url(opts = nil)
@@ -685,7 +685,11 @@ class Post < ActiveRecord::Base
     result = +"/t/"
     result << "#{slug}/" if !opts[:without_slug]
 
-    "#{result}#{topic_id}/#{post_number}"
+    if post_number == 1 && opts[:share_url]
+      "#{result}#{topic_id}"
+    else
+      "#{result}#{topic_id}/#{post_number}"
+    end
   end
 
   def self.urls(post_ids)

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -2,7 +2,8 @@
 
 describe "Post menu", type: :system, js: true do
   fab!(:current_user) { Fabricate(:user) }
-  fab!(:post)
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic: topic) }
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
@@ -13,10 +14,12 @@ describe "Post menu", type: :system, js: true do
 
     before { cdp.allow_clipboard }
 
-    xit "copies the absolute link to the post when clicked" do
+    it "copies the absolute link to the post when clicked" do
       topic_page.visit_topic(post.topic)
       topic_page.click_post_action_button(post, :copy_link)
-      expect(cdp.read_clipboard).to eq(post.full_url + "?u=#{current_user.username}")
+      expect(cdp.read_clipboard).to eq(
+        post.full_url(share_url: true) + "?u=#{current_user.username}",
+      )
     end
   end
 end


### PR DESCRIPTION
Followup to b92993fceea107c6f1cbc04eac6008827a61a000
I ran out of time to get this working for that fix,
also here I am making the post.url method have parity
with post.shareUrl in JS, which omits the post number
for the first post.
