### PR TITLE
DEV: Fix test incorrectly removing stylesheet cache of other processes

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -9,7 +9,9 @@ end
 class Stylesheet::Manager
   BASE_COMPILER_VERSION = 1
 
-  CACHE_PATH ||= "tmp/stylesheet-cache"
+  CACHE_PATH = "tmp/stylesheet-cache"
+  private_constant :CACHE_PATH
+
   MANIFEST_DIR ||= "#{Rails.root}/tmp/cache/assets/#{Rails.env}"
   THEME_REGEX ||= /_theme\z/
   COLOR_SCHEME_STYLESHEET ||= "color_definitions"
@@ -189,6 +191,12 @@ class Stylesheet::Manager
     path = "#{Rails.root}/#{CACHE_PATH}"
     return path if !Rails.env.test?
     File.join(path, "test_#{ENV["TEST_ENV_NUMBER"].presence || "0"}")
+  end
+
+  if Rails.env.test?
+    def self.rm_cache_folder
+      FileUtils.rm_rf(cache_fullpath)
+    end
   end
 
   attr_reader :theme_ids

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -886,7 +886,7 @@ RSpec.describe Stylesheet::Manager do
 
     after do
       STDERR.unstub(:write)
-      FileUtils.rm_rf("tmp/stylesheet-cache")
+      Stylesheet::Manager.rm_cache_folder
     end
 
     it "correctly generates precompiled CSS" do

--- a/spec/requests/stylesheets_controller_spec.rb
+++ b/spec/requests/stylesheets_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StylesheetsController do
     expect(cached.digest).to eq digest
 
     # tmp folder destruction and cached
-    `rm -rf #{Stylesheet::Manager.cache_fullpath}`
+    Stylesheet::Manager.rm_cache_folder
 
     get "/stylesheets/desktop_rtl_#{digest}.css"
     expect(response.status).to eq(200)
@@ -35,7 +35,7 @@ RSpec.describe StylesheetsController do
     builder = Stylesheet::Manager::Builder.new(target: :desktop, theme: theme, manager: manager)
     builder.compile
 
-    `rm -rf #{Stylesheet::Manager.cache_fullpath}`
+    Stylesheet::Manager.rm_cache_folder
 
     get "/stylesheets/#{builder.stylesheet_filename.sub(".css", "")}.css"
 
@@ -49,7 +49,7 @@ RSpec.describe StylesheetsController do
       Stylesheet::Manager::Builder.new(target: :desktop_theme, theme: theme, manager: manager)
     builder.compile
 
-    `rm -rf #{Stylesheet::Manager.cache_fullpath}`
+    Stylesheet::Manager.rm_cache_folder
 
     get "/stylesheets/#{builder.stylesheet_filename.sub(".css", "")}.css"
 


### PR DESCRIPTION
Why this change?

The `can survive cache miss` test in `spec/requests/stylesheets_controller_spec.rb`
was failing because the file was not found on disk for the cache to be
regenerated. This is because a test in
`spec/lib/stylesheet/manager_spec.rb` was removing the entire
`tmp/stylesheet-cache` directory which is incorrect because the folder
in the test environment further segretates the stylesheet caches based
on the process of the test.

What does this change do?

1. Introduce `Stylesheet::Manager.rm_cache_folder` method for the test
   environment to properly clean up the cache folder.

2. Make `Stylesheet::Manager::CACHE_PATH` a private constant since the
   cache path should be obtained from the `Stylesheet::Manager.cache_fullpath` method.