### PR TITLE
DEV: Enable `query_log_tags_enabled` in the test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,6 +51,7 @@ Discourse::Application.configure do
   config.assets.digest = false
 
   config.active_record.verbose_query_logs = true
+  config.active_record.query_log_tags_enabled = true
 
   config.after_initialize do
     ActiveRecord::LogSubscriber.backtrace_cleaner.add_silencer do |line|


### PR DESCRIPTION
Why this change?

When logging ActiveRecord query logs in the test environment, we want to
include more runtime information about the SQL statement as well.

See
https://guides.rubyonrails.org/debugging_rails_applications.html#verbose-query-logs
for more details