### PR TITLE
FIX: include only author username in the schema

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -53,8 +53,7 @@
       <% if @topic_view.prev_page %>
         <meta itemprop='datePublished' content='<%= @topic_view.topic.created_at.to_formatted_s(:iso8601) %>'>
         <span itemprop='author' itemscope itemtype="http://schema.org/Person">
-          <link itemprop='url' href='<%= @topic_view.topic.user.username %>'>
-          <meta itemprop='name' content='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
+          <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
         </span>
         <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
       <% end %>


### PR DESCRIPTION
Only include required details in metadata schema.