### PR TITLE
DEV: Skip flaky specs

### DIFF
--- a/spec/models/trust_level_setting_spec.rb
+++ b/spec/models/trust_level_setting_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TrustLevelSetting do
     end
   end
 
-  describe ".valid_value?" do
+  xdescribe ".valid_value?" do
     let(:deprecated_test) { "#{Rails.root}/spec/fixtures/site_settings/deprecated_test.yml" }
 
     before { SiteSetting.load_settings(deprecated_test) }


### PR DESCRIPTION
Dynamically adding and removing deprecated or TL-related site settings in specs is leaky

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
