### PR TITLE
FIX: 500 error when reviewable has a missing message

### DIFF
--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -40,7 +40,8 @@ module Chat
 
     def build_actions(actions, guardian, args)
       return unless pending?
-      return if chat_message.blank?
+
+      return build_action(actions, :ignore, icon: "external-link-alt") if chat_message.blank?
 
       agree =
         actions.add_bundle(

--- a/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
@@ -15,7 +15,7 @@ module Chat
     end
 
     def chat_channel
-      object.chat_message.chat_channel
+      object.chat_message&.chat_channel
     end
 
     def target_id

--- a/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.gjs
@@ -17,22 +17,27 @@ export default class ReviewableChatMessage extends Component {
 
   @cached
   get channel() {
+    if (!this.args.reviewable.chat_channel) {
+      return;
+    }
     return ChatChannel.create(this.args.reviewable.chat_channel);
   }
 
   <template>
-    <div class="flagged-post-header">
-      <LinkTo
-        @route="chat.channel.near-message"
-        @models={{array
-          this.channel.slugifiedTitle
-          this.channel.id
-          @reviewable.target_id
-        }}
-      >
-        <ChannelTitle @channel={{this.channel}} />
-      </LinkTo>
-    </div>
+    {{#if this.channel}}
+      <div class="flagged-post-header">
+        <LinkTo
+          @route="chat.channel.near-message"
+          @models={{array
+            this.channel.slugifiedTitle
+            this.channel.id
+            @reviewable.target_id
+          }}
+        >
+          <ChannelTitle @channel={{this.channel}} />
+        </LinkTo>
+      </div>
+    {{/if}}
 
     <div class="post-contents-wrapper">
       <ReviewableCreatedBy

--- a/plugins/chat/spec/system/reviewables_spec.rb
+++ b/plugins/chat/spec/system/reviewables_spec.rb
@@ -24,4 +24,20 @@ describe "Reviewables", type: :system do
       expect(page).to have_content(message_1.message)
     end
   end
+
+  context "when the message is hard deleted" do
+    before { message_1.destroy! }
+
+    it "does not throw an error" do
+      visit("/review?type=Chat%3A%3AReviewableMessage")
+
+      expect(page).to have_selector(".reviewable-item.reviewable-chat-message")
+    end
+
+    it "adds the option to ignore the flag" do
+      visit("/review?type=Chat%3A%3AReviewableMessage")
+
+      expect(page).to have_selector(".reviewable-actions .chat-message-ignore")
+    end
+  end
 end


### PR DESCRIPTION
After this PR if, for some reason, a flagged chat message is not found or has been hard deleted, it does not throw an error and allows the flag to be ignored from the UI