### PR TITLE
DEV: Upgrade from Ember 5.4 to 5.5

### DIFF
--- a/app/assets/javascripts/package-ember5.json
+++ b/app/assets/javascripts/package-ember5.json
@@ -25,7 +25,7 @@
   ],
   "resolutions": {
     "**/unset-value": "2.0.1",
-    "**/ember-source": "5.4.0"
+    "**/ember-source": "5.5.0"
   },
   "devDependencies": {
     "patch-package": "^8.0.0",

--- a/app/assets/javascripts/yarn-ember5.lock
+++ b/app/assets/javascripts/yarn-ember5.lock
@@ -3396,7 +3396,7 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
-backburner.js@^2.7.0:
+backburner.js@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/backburner.js/-/backburner.js-2.8.0.tgz#72f8c7455ff664ff8e79a32415977e10a18e03c7"
   integrity sha512-zYXY0KvpD7/CWeOLF576mV8S+bQsaIoj/GNLXXB+Eb8SJcQy5lqSjkRrZ0MZhdKUs9QoqmGNIEIe3NQfGiiscQ==
@@ -5525,10 +5525,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@5.4.0, ember-source@~3.28.12:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-5.4.0.tgz#c18df972074aad8b891c289f4657af63844a242c"
-  integrity sha512-y2fPd7DJ8D9IBjHSf6CPwU8TqNpqytpMgFyzf+9tPvu/u2Wdd45jEd2W1weKE3URQwPTcA0vK8Q1w6uzLOx/EA==
+ember-source@5.5.0, ember-source@~3.28.12:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-5.5.0.tgz#62f4f439d6642b7b70dd0cd53786be5058eab40b"
+  integrity sha512-OTJ9kt76wyvEkdSdjmonoLUTTqYg5OaFxicSiwKsjX9gJ9bVzuCu3uInhBKEfTdC5lSBMEcVuGk8f9LUF3pxJQ==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
     "@babel/plugin-transform-block-scoping" "^7.22.5"
@@ -5553,7 +5553,7 @@ ember-source@5.4.0, ember-source@~3.28.12:
     "@simple-dom/interface" "^1.4.0"
     babel-plugin-debug-macros "^0.3.4"
     babel-plugin-filter-imports "^4.0.0"
-    backburner.js "^2.7.0"
+    backburner.js "^2.8.0"
     broccoli-concat "^4.2.5"
     broccoli-debug "^0.6.4"
     broccoli-file-creator "^2.1.1"
@@ -5571,11 +5571,11 @@ ember-source@5.4.0, ember-source@~3.28.12:
     ember-cli-version-checker "^5.1.2"
     ember-router-generator "^2.0.0"
     inflection "^2.0.1"
-    resolve "^1.22.2"
     route-recognizer "^0.3.4"
     router_js "^8.0.3"
     semver "^7.5.2"
     silent-error "^1.1.1"
+    simple-html-tokenizer "^0.5.11"
 
 ember-template-imports@^4.0.0:
   version "4.0.0"
@@ -6577,11 +6577,6 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
-  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
 function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
@@ -6957,13 +6952,6 @@ hash-for-dep@^1.0.2, hash-for-dep@^1.4.7, hash-for-dep@^1.5.0, hash-for-dep@^1.5
     path-root "^0.1.1"
     resolve "^1.10.0"
     resolve-package-path "^1.0.11"
-
-hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
-  dependencies:
-    function-bind "^1.1.2"
 
 heimdalljs-fs-monitor@^1.1.1:
   version "1.1.1"
@@ -7366,13 +7354,6 @@ is-core-module@^2.11.0:
   integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
   dependencies:
     has "^1.0.3"
-
-is-core-module@^2.13.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
-  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
-  dependencies:
-    hasown "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -9742,15 +9723,6 @@ resolve@^1.10.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.1
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
   dependencies:
     is-core-module "^2.11.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^1.22.2:
-  version "1.22.8"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
-  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
-  dependencies:
-    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
This change only applies when EMBER_VERSION=5. Discourse's default is still Ember 3.28

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
