### PR TITLE
FIX: `move-topics` topic search losing focus

### DIFF
--- a/app/assets/javascripts/discourse/app/components/choose-topic.js
+++ b/app/assets/javascripts/discourse/app/components/choose-topic.js
@@ -3,8 +3,10 @@ import { action } from "@ember/object";
 import { isEmpty } from "@ember/utils";
 import { searchForTerm } from "discourse/lib/search";
 import { INPUT_DELAY } from "discourse-common/config/environment";
-import discourseDebounce from "discourse-common/lib/debounce";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed, {
+  debounce,
+  observes,
+} from "discourse-common/utils/decorators";
 
 export default Component.extend({
   loading: null,
@@ -69,7 +71,7 @@ export default Component.extend({
       oldTopicTitle: this.topicTitle,
     });
 
-    this.searchDebounced(this.topicTitle);
+    this.search(this.topicTitle);
   },
 
   @discourseComputed("label")
@@ -86,10 +88,7 @@ export default Component.extend({
     this.set("loading", false);
   },
 
-  searchDebounced(title) {
-    discourseDebounce(this, this.search, title, INPUT_DELAY);
-  },
-
+  @debounce(INPUT_DELAY)
   search(title) {
     if (!this.element || this.isDestroying || this.isDestroyed) {
       return;

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.hbs
@@ -95,7 +95,6 @@
       {{/if}}
 
     {{else}}
-
       <div class="radios">
         {{#if this.canSplitTopic}}
           <label class="radio-label" for="move-to-new-topic">
@@ -133,16 +132,17 @@
       </div>
 
       {{#if this.existingTopic}}
-        <p>{{html-safe
+        <p>
+          {{html-safe
             (i18n
               "topic.merge_topic.instructions" count=@model.selectedPostsCount
             )
-          }}</p>
+          }}
+        </p>
         <form>
           <ChooseTopic
             @currentTopicId={{@model.topic.id}}
             @selectedTopicId={{this.selectedTopicId}}
-            @autoFocus={{this.existingTopic}}
           />
 
           {{#if this.selectedTopicId}}
@@ -161,11 +161,13 @@
 
       {{#if this.canSplitTopic}}
         {{#if this.newTopic}}
-          <p>{{html-safe
+          <p>
+            {{html-safe
               (i18n
                 "topic.split_topic.instructions" count=@model.selectedPostsCount
               )
-            }}</p>
+            }}
+          </p>
           <form class="split-new-topic-form">
             <div class="control-group">
               <label>{{i18n "topic.split_topic.topic_name"}}</label>


### PR DESCRIPTION
- [Meta Report](https://meta.discourse.org/t/moving-posts-the-input-focus-shifts-when-searching-for-a-topic-to-move-a-post-to-as-typing/284924/1)

### Correct Focus kept during Search
https://github.com/discourse/discourse/assets/50783505/ae9b4480-208e-470a-98c4-5ba10a053eb7

### Search Log after search
<img width="430" alt="Screenshot 2024-01-03 at 11 08 08 AM" src="https://github.com/discourse/discourse/assets/50783505/155f413a-adc1-4e59-a74b-dcef7af01990">
