### PR TITLE
DEV: Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,10 +160,7 @@ GEM
     gc_tracer (1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.1-aarch64-linux)
-    google-protobuf (3.25.1-arm64-darwin)
-    google-protobuf (3.25.1-x86_64-darwin)
-    google-protobuf (3.25.1-x86_64-linux)
+    google-protobuf (3.25.1)
     guess_html_encoding (0.0.11)
     hana (1.3.7)
     hashdiff (1.1.0)
@@ -672,4 +669,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.13
+   2.5.3


### PR DESCRIPTION
Why this change?

We have been using an older version of bundler that was released on 9
May 2023.