### PR TITLE
DEV: Minor formatting fix when reporting server exceptions

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -603,7 +603,7 @@ RSpec.configure do |config|
       lines << "~~~~~~~ SERVER EXCEPTIONS ~~~~~~~"
 
       RspecErrorTracker.exceptions.each_with_index do |(path, ex), index|
-        lines << "\n" if index != 0
+        lines << "\n"
         lines << "Error encountered while proccessing #{path}"
         lines << "  #{ex.class}: #{ex.message}"
         ex.backtrace.each { |line| lines << "    #{line}\n" }


### PR DESCRIPTION
What we have now:

```
~~~~~~~ SERVER EXCEPTIONS ~~~~~~~Error encountered while proccessing /tag/tag24/l/latest  ArgumentError: wrong number of arguments (given 1, expected 0)    /__w/discourse/discourse/lib/site_setting_extension.rb:521:in `block in setup_methods'
```

What we actually want:

```
~~~~~~~ SERVER EXCEPTIONS ~~~~~~~
Error encountered while proccessing /tag/tag24/l/latest  ArgumentError: wrong number of arguments (given 1, expected 0)    /__w/discourse/discourse/lib/site_setting_extension.rb:521:in `block in setup_methods'
```