### PR TITLE
UX: Improve border-radius stuff in chat-message actions

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -3,12 +3,6 @@
   z-index: z("dropdown");
 }
 
-.chat-message-actions {
-  .chat-message-reaction {
-    @include chat-reaction;
-  }
-}
-
 .chat-message-actions-container {
   @include unselectable;
   z-index: z("dropdown") - 1;
@@ -16,6 +10,7 @@
 
 .chat-message-actions {
   background-color: var(--secondary);
+  border-radius: var(--d-border-radius);
   display: flex;
 
   .emoji-picker-anchor {
@@ -138,6 +133,8 @@
   }
 
   .chat-message-reaction {
+    @include chat-reaction;
+
     align-items: center;
     border-radius: 0;
     border-left-color: transparent;

--- a/plugins/chat/assets/stylesheets/desktop/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message.scss
@@ -8,6 +8,12 @@
     border-radius: 0;
     border-top-color: var(--primary-300);
 
+    &:first-child {
+      border-left-color: var(--primary-300);
+      border-top-left-radius: var(--d-border-radius);
+      border-bottom-left-radius: var(--d-border-radius);
+    }
+
     &:hover {
       background: var(--primary-low);
       border-color: var(--primary-low-mid);


### PR DESCRIPTION
Before / After (Channel)

<img width="250" alt="Screenshot 2024-01-04 at 11 39 25" src="https://github.com/discourse/discourse/assets/66961/737b031c-e450-41cb-bd36-6451b20ffc4d"> <img width="250" alt="Screenshot 2024-01-04 at 11 37 58" src="https://github.com/discourse/discourse/assets/66961/438c762f-2b27-424c-8aef-3070c51764c1">


Before / After (Thread)

<img width="118" alt="Screenshot 2024-01-04 at 11 40 33" src="https://github.com/discourse/discourse/assets/66961/049e39ae-1d47-4be2-a3ab-658b6b97823a"> <img width="118" alt="Screenshot 2024-01-04 at 11 40 55" src="https://github.com/discourse/discourse/assets/66961/77be56f2-c356-4d0c-9b0d-95fe84e75434">
