### PR TITLE
FIX: Ensure consistent `datePublished` on follow-up pages in topic microdata schema

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -37,6 +37,7 @@
     <div itemscope itemtype='http://schema.org/DiscussionForumPosting'>
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
       <link itemprop='url' href='<%= @topic_view.absolute_url %>'>
+      <meta itemprop='datePublished' content='<%= @topic_view.topic.created_at.to_formatted_s(:iso8601) %>'>
       <% if @topic_view.topic.category.present? %>
         <meta itemprop='articleSection' content='<%= @topic_view.topic.category.name %>'>
       <% end %>
@@ -51,12 +52,10 @@
       </div>
 
       <% if @topic_view.prev_page %>
-        <meta itemprop='datePublished' content='<%= @topic_view.topic.created_at.to_formatted_s(:iso8601) %>'>
         <span itemprop='author' itemscope itemtype="http://schema.org/Person">
           <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
           <link itemprop='url' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
         </span>
-        <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
       <% end %>
 
       <% @topic_view.posts.each do |post| %>
@@ -85,7 +84,7 @@
               <% end %>
 
               <span class="crawler-post-infos">
-                  <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
+                  <time <%= post.is_first_post? ? "" : "itemprop='datePublished'".html_safe %> datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
                     <%= l post.created_at, format: :long %>
                   </time>
                 <% if post.version > 1 %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -56,6 +56,7 @@
           <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
           <link itemprop='url' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
         </span>
+        <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
       <% end %>
 
       <% @topic_view.posts.each do |post| %>


### PR DESCRIPTION
Always use `datePublished` from topic and never from `first_post`. This ensures `datePublished` to be consistent on `first page` and `page=2+`.