### PR TITLE
FIX: Save category order in database

### DIFF
--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -18,6 +18,10 @@ module Jobs
       # Feature topics in categories
       CategoryFeaturedTopic.feature_topics(batched: true)
 
+      # Categories are ordered by the bump date of featured topics (if not
+      # fixed)
+      Category.reorder_categories! if SiteSetting.lazy_load_categories
+
       # Update the scores of posts
       args = { min_topic_age: 1.day.ago }
       args[:max_topic_length] = 500 unless self.class.should_update_long_topics?

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -134,7 +134,16 @@ class CategoryList
         @options[:parent_category_id].to_i,
       ) if @options[:parent_category_id].present?
 
-    query = self.class.order_categories(query)
+    if SiteSetting.lazy_load_categories
+      query =
+        query.where(
+          "categories.depth = 0 OR (categories.depth != 0 AND categories.position_to_parent <= 5)",
+        ) if @options[:parent_category_id].blank?
+
+      query = query.order(:position, :id)
+    else
+      query = self.class.order_categories(query)
+    end
 
     if SiteSetting.lazy_load_categories
       page = [1, @options[:page].to_i].max

--- a/db/migrate/20240104143422_add_order_columns_to_categories.rb
+++ b/db/migrate/20240104143422_add_order_columns_to_categories.rb
@@ -4,8 +4,10 @@ class AddOrderColumnsToCategories < ActiveRecord::Migration[7.0]
   def change
     add_column :categories, :position_to_parent, :integer, default: 0
     add_column :categories, :depth, :integer, default: 0
+    add_column :categories, :path, :integer, array: true
 
     add_index :categories, :position
     add_index :categories, :position_to_parent
+    add_index :categories, :path
   end
 end

--- a/db/migrate/20240104143422_add_order_columns_to_categories.rb
+++ b/db/migrate/20240104143422_add_order_columns_to_categories.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddOrderColumnsToCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :categories, :position_to_parent, :integer, default: 0
+    add_column :categories, :depth, :integer, default: 0
+
+    add_index :categories, :position
+    add_index :categories, :position_to_parent
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1342,6 +1342,29 @@ RSpec.describe Category do
     end
   end
 
+  describe ".reorder_categories!" do
+    fab!(:category1) { Fabricate(:category) }
+    fab!(:category2) { Fabricate(:category) }
+    fab!(:category3) { Fabricate(:category, parent_category: category1) }
+    fab!(:category4) { Fabricate(:category, parent_category: category1) }
+    fab!(:category5) { Fabricate(:category, parent_category: category2) }
+
+    before { SiteSetting.fixed_category_positions = true }
+
+    it "reorders categories" do
+      Category.reorder_categories!
+
+      [category1, category2, category3, category4, category5].each { |c| c.reload }
+      uncat = Category.find(SiteSetting.uncategorized_category_id)
+      expect([uncat.position, uncat.position_to_parent, uncat.depth]).to eq([1, 1, 0])
+      expect([category1.position, category1.position_to_parent, category1.depth]).to eq([2, 2, 0])
+      expect([category3.position, category3.position_to_parent, category3.depth]).to eq([3, 1, 1])
+      expect([category4.position, category4.position_to_parent, category4.depth]).to eq([4, 2, 1])
+      expect([category2.position, category2.position_to_parent, category2.depth]).to eq([5, 3, 0])
+      expect([category5.position, category5.position_to_parent, category5.depth]).to eq([6, 1, 1])
+    end
+  end
+
   describe "#deleting the general category" do
     fab!(:category)
 


### PR DESCRIPTION
Categories are ordered by admins setting `position` attribute of the category or by the bump date of featured topics.

Since featured topics are only updated once every 15 minutes, they can be saved in the database for efficiency, but also to make pagination among categories easier to implement.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
