### PR TITLE
DEV: pass renderTimeline to topic-navigation outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -227,7 +227,10 @@
         <PluginOutlet
           @name="topic-navigation"
           @connectorTagName="div"
-          @outletArgs={{hash topic=this.model}}
+          @outletArgs={{hash
+            topic=this.model
+            renderTimeline=info.renderTimeline
+          }}
         />
 
         {{#if info.renderTimeline}}


### PR DESCRIPTION
Utilizing this for a DiscoTOC refactor, but should generally be useful to differentiate between the timeline and topic progress bar 