### PR TITLE
DEV: Skip MinioRunner until min.io renews their cert

### DIFF
--- a/script/install_minio_binaries.rb
+++ b/script/install_minio_binaries.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "minio_runner"
+# require "minio_runner"
 
-ENV["MINIO_RUNNER_LOG_LEVEL"] = "DEBUG"
-MinioRunner.install_binaries
+# ENV["MINIO_RUNNER_LOG_LEVEL"] = "DEBUG"
+# MinioRunner.install_binaries


### PR DESCRIPTION
### What is this?

The min.io domain cert has expired, causing our MinioRunner gem to fail. Skip until domain can be connected via SSL again.