### PR TITLE
FIX: Ensure that categories array is not undefined

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -377,7 +377,7 @@ Category.reopenClass({
     const reduce = (values) =>
       values.flatMap((c) => [c, reduce(children.get(c.id) || [])]).flat();
 
-    return reduce(children.get(-1));
+    return reduce(children.get(-1) || []);
   },
 
   isUncategorized(categoryId) {


### PR DESCRIPTION
With lazy_load_categories enabled, the categories array can be undefined because it is not loaded yet (it is populated on demand).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
