### PR TITLE
Revert "Build(deps): Bump regexp_parser from 2.8.3 to 2.9.0 (#25149)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ GEM
     redis (4.8.1)
     redis-namespace (1.11.0)
       redis (>= 4)
-    regexp_parser (2.9.0)
+    regexp_parser (2.8.3)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.6)


### PR DESCRIPTION
This reverts commit 50be3b887d767da1a67f6d89933299484da9fc72.

2.9.0 seems to have been yanked because bundler is complaining that it
can't find it.