### PR TITLE
PERF: Prefer subquery instead of two queries

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -58,10 +58,9 @@ class CategoryList
     if SiteSetting.fixed_category_positions
       categories.order(:position, :id)
     else
-      allowed_category_ids = categories.pluck(:id) << nil # `nil` is necessary to include categories without any associated topics
       categories
         .left_outer_joins(:featured_topics)
-        .where(topics: { category_id: allowed_category_ids })
+        .where("topics.category_id IS NULL OR topics.category_id IN (?)", categories.select(:id))
         .group("categories.id")
         .order("max(topics.bumped_at) DESC NULLS LAST")
         .order("categories.id ASC")


### PR DESCRIPTION
The query that is now a subquery could return a long list of category IDs, which slowed down the query considerably. This improvement reduces the execution time from over 2 seconds down to about 100ms.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
