### PR TITLE
Version bumps for main: v3.2.0.beta4, v3.2.0.beta5-dev

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      STRING = "3.2.0.beta4"
+      STRING = "3.2.0.beta5-dev"
 
       PARTS = STRING.split(".")
       private_constant :PARTS

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      STRING = "3.2.0.beta4-dev"
+      STRING = "3.2.0.beta4"
 
       PARTS = STRING.split(".")
       private_constant :PARTS


### PR DESCRIPTION
> :warning: This PR should not be merged via the GitHub web interface
> 
> It should only be merged (via fast-forward) using the associated `bin/rake version_bump:*` task.
