### PR TITLE
FEATURE: Add loading spinner on categories page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -7,6 +7,7 @@ import CategoriesBoxes from "discourse/components/categories-boxes";
 import CategoriesBoxesWithTopics from "discourse/components/categories-boxes-with-topics";
 import CategoriesOnly from "discourse/components/categories-only";
 import CategoriesWithFeaturedTopics from "discourse/components/categories-with-featured-topics";
+import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import LoadMore from "discourse/components/load-more";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import SubcategoriesWithFeaturedTopics from "discourse/components/subcategories-with-featured-topics";
@@ -94,6 +95,7 @@ export default class CategoriesDisplay extends Component {
           @categories={{@categories}}
           @topics={{@topics}}
         />
+        <ConditionalLoadingSpinner @condition={{@loadingMore}} />
       </LoadMore>
     {{else}}
       <this.categoriesComponent

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -35,6 +35,7 @@
         @topics={{this.model.topics}}
         @parentCategory={{this.model.parentCategory}}
         @loadMore={{this.model.loadMore}}
+        @loadingMore={{this.model.isLoading}}
       />
     </div>
 


### PR DESCRIPTION
The list of categories is loaded async when lazy_load_categories is enabled, but there is no visual indication that the list of categories is being loaded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
