### PR TITLE
DEV: add plugin outlet to admin badge page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -269,6 +269,11 @@
       </div>
     </div>
 
+    <PluginOutlet
+      @name="admin-above-badge-buttons"
+      @outletArgs={{hash badge=this.buffered}}
+    />
+
     <div class="buttons">
       <DButton
         @action={{this.save}}


### PR DESCRIPTION
Adds an outlet here when creating/editing a badge:

![Screenshot 2024-01-08 at 4 07 01 PM](https://github.com/discourse/discourse/assets/1681963/9c2f7ed4-bdb0-41fa-9a8b-2f61c6a584f5)



As requested in: https://meta.discourse.org/t/request-for-a-plugin-outlet-on-admin-badge-page/290716