### PR TITLE
DEV: add plugin outlet above sidebar panels

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -5,6 +5,8 @@
     <Sidebar::SwitchPanelButtons @buttons={{this.switchPanelButtons}} />
   {{/if}}
 
+  <PluginOutlet @name="above-sidebar-panels" />
+
   {{#if this.sidebarState.showMainPanel}}
     <Sidebar::Sections
       @currentUser={{this.currentUser}}


### PR DESCRIPTION
This adds a plugin outlet above the sidebar panels 

As requested here: https://meta.discourse.org/t/a-plugin-outlet-on-top-of-the-sidebar/285248