### PR TITLE
DEV: Avoid duplicating constant between client and server

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/notifications-list.js
@@ -3,6 +3,7 @@ import { inject as service } from "@ember/service";
 import DismissNotificationConfirmationModal from "discourse/components/modal/dismiss-notification-confirmation";
 import UserMenuItemsList from "discourse/components/user-menu/items-list";
 import { ajax } from "discourse/lib/ajax";
+import { MAX_NOTIFICATIONS_LIMIT_PARAMS } from "discourse/lib/constants";
 import UserMenuNotificationItem from "discourse/lib/user-menu/notification-item";
 import UserMenuReviewableItem from "discourse/lib/user-menu/reviewable-item";
 import {
@@ -13,7 +14,7 @@ import Notification from "discourse/models/notification";
 import UserMenuReviewable from "discourse/models/user-menu-reviewable";
 import I18n from "discourse-i18n";
 
-const MAX_LIMIT = 60;
+const MAX_LIMIT = MAX_NOTIFICATIONS_LIMIT_PARAMS;
 const DEFAULT_LIMIT = 30;
 let limit = DEFAULT_LIMIT;
 

--- a/app/assets/javascripts/discourse/app/lib/constants.js
+++ b/app/assets/javascripts/discourse/app/lib/constants.js
@@ -68,3 +68,5 @@ export const AUTO_GROUPS = {
     display_name: "trust_level_4",
   },
 };
+
+export const MAX_NOTIFICATIONS_LIMIT_PARAMS = 60;

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -160,6 +160,8 @@ task "javascript:update_constants" => :environment do
     }
 
     export const AUTO_GROUPS = #{auto_groups.to_json};
+
+    export const MAX_NOTIFICATIONS_LIMIT_PARAMS = #{NotificationsController::INDEX_LIMIT};
   JS
 
   pretty_notifications = Notification.types.map { |n| "  #{n[0]}: #{n[1]}," }.join("\n")


### PR DESCRIPTION
Why this change?

While the constant does not change very often, we should still avoid
duplicating the value of a constant used on the server side in the
client side to avoid the values going out of sync.