### PR TITLE
FIX: Hide deprecated site settings that were missed out before

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1730,6 +1730,7 @@ trust:
   min_trust_to_flag_posts:
     default: 1
     enum: "TrustLevelSetting"
+    hidden: true
   flag_post_allowed_groups:
     default: "11"
     type: group_list
@@ -1750,6 +1751,7 @@ trust:
     default: 0
     client: true
     enum: "TrustLevelSetting"
+    hidden: true
   user_card_background_allowed_groups:
     default: "10"
     type: group_list
@@ -1770,6 +1772,7 @@ trust:
     default: 2
     enum: "TrustLevelSetting"
     client: true
+    hidden: true
   ignore_allowed_groups:
     default: "12"
     type: group_list


### PR DESCRIPTION
### What is this?

While on a roll to deprecate TL based access site settings and replace them with group based ones, I forgot to hide some of the old ones. Thankfully we have JammyDodger who highlighted this. ❤️ 