### PR TITLE
UX: add max width for c-navbar on mobile to prevent horizontal scroll

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -1,5 +1,6 @@
 .c-navbar {
   &-container {
+    max-width: 100vw;
     padding-inline: 0.25rem;
   }
 }


### PR DESCRIPTION
Long names were causing horizontal scrolling because the new `c-navbar component` didn't have a max-width set

### Before
<img width="470" alt="image" src="https://github.com/discourse/discourse/assets/101828855/db03cca8-f091-4585-9e62-1bffb1318538">

### After
<img width="464" alt="image" src="https://github.com/discourse/discourse/assets/101828855/407546ab-fe10-48af-addc-9904108a9562">
