### PR TITLE
UX: remove specific href styling

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -73,12 +73,7 @@
       @include darken-background($hover-bg-color, 0.1);
     }
   }
-  &[href] {
-    color: $text-color;
-    &:focus {
-      color: $hover-text-color;
-    }
-  }
+
   .discourse-no-touch &:active:not(:hover):not(:focus),
   .discourse-no-touch &.btn-active:not(:hover):not(:focus),
   &:active:not(:hover):not(:focus),


### PR DESCRIPTION
As agreed on with Kris, removing the [href] specific styling which causes overrides where we don't want them.