### PR TITLE
DEV: Add  env var to bin/docker/exec

### DIFF
--- a/bin/docker/exec
+++ b/bin/docker/exec
@@ -6,6 +6,7 @@ exec docker exec \
   -w '/src' \
   -e RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 \
   -e LD_PRELOAD=/usr/lib/libjemalloc.so \
+  -e CI \
   -e RAILS_ENV \
   -e NO_EMBER_CLI \
   -e QUNIT_RAILS_ENV \


### PR DESCRIPTION
There are reports that `CI=1` is needed when running QUnit tests for plugins so that ember-exam runs Chrome with specific arguments -- right now the Docker scripts don't forward that specific ENV var.