### PR TITLE
FIX: Chat summary email link in subfolder setups

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -236,7 +236,7 @@ module Chat
     end
 
     def full_url
-      "#{Discourse.base_url}#{url}"
+      "#{Discourse.base_url_no_prefix}#{url}"
     end
 
     def url

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -642,7 +642,9 @@ describe UserNotifications do
 
             it "includes correct view summary link in template" do
               email = described_class.chat_summary(user, {})
-              expect(email.html_part.body.to_s).to include("#{Discourse.base_url}/chat")
+              expect(email.html_part.body.to_s).to include(
+                "<a class=\"more-messages-link\" href=\"#{Discourse.base_url}/chat",
+              )
             end
           end
 

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -637,6 +637,15 @@ describe UserNotifications do
             expect(user_avatar.attribute("alt").value).to eq(sender.username)
           end
 
+          context "with subfolder" do
+            before { set_subfolder "/community" }
+
+            it "includes correct view summary link in template" do
+              email = described_class.chat_summary(user, {})
+              expect(email.html_part.body.to_s).to include("#{Discourse.base_url}/chat")
+            end
+          end
+
           context "when there are more than two mentions" do
             it "includes a view more link " do
               2.times do


### PR DESCRIPTION
This regressed in https://github.com/discourse/discourse/commit/2791e75072329fdbf9ebd6849cea3c63664b123c. That commit fixed subfolder URLs in general, but the `full_url` method was adding the subfolder prefix a second time, thus breaking this URL in emails.