### PR TITLE
FIX: Incorrect admin sidebar setting migration

### DIFF
--- a/db/post_migrate/20240108022138_change_enable_admin_sidebar_to_group_post_migration.rb
+++ b/db/post_migrate/20240108022138_change_enable_admin_sidebar_to_group_post_migration.rb
@@ -7,7 +7,7 @@ class ChangeEnableAdminSidebarToGroupPostMigration < ActiveRecord::Migration[7.0
         "SELECT value FROM site_settings WHERE name = 'enable_admin_sidebar_navigation'",
       ).first
 
-    if enable_admin_sidebar_navigation_raw.present?
+    if enable_admin_sidebar_navigation_raw.present? && enable_admin_sidebar_navigation_raw == "t"
       DB.exec(
         "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
         VALUES('admin_sidebar_enabled_groups', :setting, '20', NOW(), NOW())",


### PR DESCRIPTION
Fixes the migration in 8c6144d116f77e4f46f04993c0c08c5320f7ef1d
which was unconditionally enabling the new admin sidebar for admins
if they ever changed the old setting `enable_admin_sidebar_navigation`,
even if they changed it to false.
