### PR TITLE
DEV: adds before-header-logo outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/before-header-logo-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/before-header-logo-outlet.js
@@ -1,0 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
+import { registerWidgetShim } from "discourse/widgets/render-glimmer";
+
+registerWidgetShim(
+  "before-header-logo-outlet",
+  "div.before-header-logo-outlet",
+  hbs`<PluginOutlet @name="before-header-logo" @outletArgs={{hash attrs=@data}} /> `
+);

--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -15,6 +15,8 @@ createWidget("header-contents", {
       {{/if}}
     {{/if}}
 
+    {{before-header-logo-outlet attrs=attrs}}
+
     {{home-logo-wrapper-outlet attrs=attrs}}
 
     {{#if attrs.topic}}


### PR DESCRIPTION
This adds a plugin outlet to the header before the logo, `home-logo-wrapper-outlet` is already used by chat so we need a separate one. 