### PR TITLE
UX: ensure links styled as buttons don't get visited color

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -20,6 +20,10 @@
   margin: 0;
   font-weight: normal;
   color: $text-color;
+  &:visited {
+    // covers cases where we add button classes to links
+    color: $text-color;
+  }
   background-color: $bg-color;
   background-image: linear-gradient(
     to bottom,


### PR DESCRIPTION
This will replace a shortcoming from removing the old `btn[href]` style in https://github.com/discourse/discourse/commit/71b996d70f4444c6c3a5351a2f3c69b03c9bf5a7

Before:
![Screenshot 2024-01-09 at 6 24 58 PM](https://github.com/discourse/discourse/assets/1681963/470fbd85-9546-459d-91bc-b6c160ae172c)

After:
![Screenshot 2024-01-09 at 6 24 48 PM](https://github.com/discourse/discourse/assets/1681963/c9766a5e-8c35-453e-955f-3ce080aa030b)


The problem solved by https://github.com/discourse/discourse/commit/71b996d70f4444c6c3a5351a2f3c69b03c9bf5a7 was that `.btn[href]:focus` could be too specific, so it would override something like `.btn-transparent:focus`

When `.btn[href]` was removed, this meant that `a.btn` links would unfortunately take on `a:visited` styles. 

By moving to `.btn:visited`, the issue will be solved without reintroducing the specificity problem created by `.btn[href]:focus`. This style will only be applied to links styled as buttons, and existing pseudo selectors like `.btn:focus` are already specific enough to override this without the `[href]` check. 

(ideally we should never style links as buttons, but sometimes we have a set of controls we want to keep visually consistent with each other) 