### PR TITLE
DEV: Convert review_media_unless_trust_level to group-based setting

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -14,7 +14,7 @@ class ReviewableScoreSerializer < ApplicationSerializer
     invite_only: "invite_only",
     email_spam: "email_in_spam_header",
     suspect_user: "approve_suspect_users",
-    contains_media: "review_media_unless_trust_level",
+    contains_media: "skip_media_review_groups",
   }
 
   attributes :id, :score, :agree_stats, :reason, :created_at, :reviewed_at

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2362,6 +2362,7 @@ en:
     returning_user_notice_tl: "Minimum trust level required to see returning user post notices."
     returning_users_days: "How many days should pass before a user is considered to be returning."
     review_media_unless_trust_level: "Staff will review posts of users with lower trust levels if they contain embedded media."
+    skip_review_media_groups: "Users who are not in any of these groups will have their posts sent to staff for review if the post contains embedded media."
     blur_tl0_flagged_posts_media: "Blur flagged posts images to hide potentially NSFW content."
     enable_page_publishing: "Allow staff members to publish topics to new URLs with their own styling."
     show_published_pages_login_required: "Anonymous users can see published pages, even when login is required."
@@ -2582,6 +2583,7 @@ en:
       self_wiki_allowed_groups: "min_trust_to_allow_self_wiki"
       create_tag_allowed_groups: "min_trust_to_create_tag"
       send_email_messages_allowed_groups: "min_trust_to_send_email_messages"
+      skip_review_media_groups: "review_media_unless_trust_level"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1149,6 +1149,13 @@ posting:
   review_media_unless_trust_level:
     default: 0
     enum: "TrustLevelSetting"
+    hidden: true
+  skip_review_media_groups:
+    default: "10" # TL0 auto group
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   blur_tl0_flagged_posts_media:
     default: true
     client: true

--- a/db/post_migrate/20240110040813_fill_skip_review_media_groups_based_on_deprecated_setting.rb
+++ b/db/post_migrate/20240110040813_fill_skip_review_media_groups_based_on_deprecated_setting.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FillSkipReviewMediaGroupsBasedOnDeprecatedSetting < ActiveRecord::Migration[7.0]
+  def up
+    old_setting_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'review_media_unless_trust_level' LIMIT 1",
+      ).first
+
+    if old_setting_trust_level.present?
+      allowed_groups = "1#{old_setting_trust_level}"
+
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('skip_review_media_groups', :setting, '20', NOW(), NOW())",
+        setting: allowed_groups,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -117,7 +117,7 @@ class NewPostManager
 
     if (
          manager.args[:image_sizes].present? &&
-           user.trust_level < SiteSetting.review_media_unless_trust_level.to_i
+           !user.in_any_groups?(SiteSetting.skip_review_media_groups_map)
        )
       return :contains_media
     end

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -36,6 +36,7 @@ module SiteSettings::DeprecatedSettings
     ["min_trust_to_allow_self_wiki", "self_wiki_allowed_groups", false, "3.3"],
     ["min_trust_to_create_tag", "create_tag_allowed_groups", false, "3.3"],
     ["min_trust_to_send_email_messages", "send_email_messages_allowed_groups", false, "3.3"],
+    ["review_media_unless_trust_level", "skip_review_media_groups", false, "3.3"],
   ]
 
   OVERRIDE_TL_GROUP_SETTINGS = %w[
@@ -56,6 +57,7 @@ module SiteSettings::DeprecatedSettings
     min_trust_level_to_allow_ignore
     min_trust_to_create_tag
     min_trust_to_send_email_messages
+    review_media_unless_trust_level
   ]
 
   def group_to_tl(old_setting, new_setting)

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -302,10 +302,13 @@ RSpec.describe NewPostManager do
         }
       end
 
-      before { user.update!(trust_level: 0) }
+      before do
+        user.update!(trust_level: 0)
+        Group.refresh_automatic_groups!
+      end
 
-      it "queues the post for review because if it contains embedded media." do
-        SiteSetting.review_media_unless_trust_level = 1
+      it "queues the post for review because it contains embedded media" do
+        SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_1]
         manager = NewPostManager.new(user, manager_opts)
 
         result = NewPostManager.default_handler(manager)
@@ -315,7 +318,7 @@ RSpec.describe NewPostManager do
       end
 
       it "does not enqueue the post if the poster is a trusted user" do
-        SiteSetting.review_media_unless_trust_level = 0
+        SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_0]
         manager = NewPostManager.new(user, manager_opts)
 
         result = NewPostManager.default_handler(manager)

--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 describe "Composer using review_media", type: :system do
-  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:topic) { Fabricate(:topic, category: Category.find(SiteSetting.uncategorized_category_id)) }
   fab!(:post) { Fabricate(:post, topic: topic) }
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
-    SiteSetting.review_media_unless_trust_level = 3
-    sign_in user
+    SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_3]
+    sign_in(current_user)
   end
 
   it "does not flag a post with an emoji" do


### PR DESCRIPTION
This commit moves the review_media_unless_trust_level setting
to skip_review_media_groups as part of our move from TL to group
based settings.

c.f. https://meta.discourse.org/t/changes-coming-to-settings-for-giving-access-to-features-from-trust-levels-to-groups/283408
