### PR TITLE
FIX: Serialize categories when viewing a topic

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -36,6 +36,7 @@ export function loadTopicView(topic, args) {
   return PreloadStore.getAndRemove(`topic_${topic.id}`, () =>
     ajax(jsonUrl, { data })
   ).then((json) => {
+    json.categories?.forEach((c) => topic.site.updateCategory(c));
     topic.updateFromJson(json);
     return json;
   });

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -83,6 +83,7 @@ class TopicViewSerializer < ApplicationSerializer
 
   has_one :details, serializer: TopicViewDetailsSerializer, root: false, embed: :objects
   has_many :pending_posts, serializer: TopicPendingPostSerializer, root: false, embed: :objects
+  has_many :categories, serializer: TopicCategorySerializer, embed: :objects
 
   has_one :published_page, embed: :objects
 
@@ -315,5 +316,9 @@ class TopicViewSerializer < ApplicationSerializer
 
   def summarizable
     object.summarizable?
+  end
+
+  def include_categories?
+    SiteSetting.lazy_load_categories
   end
 end

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -726,6 +726,10 @@ class TopicView
     Summarization::Base.can_see_summary?(@topic, @user)
   end
 
+  def categories
+    ([category, category&.parent_category] + suggested_topics.categories).compact.uniq
+  end
+
   protected
 
   def read_posts_set

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -727,7 +727,9 @@ class TopicView
   end
 
   def categories
-    ([category, category&.parent_category] + suggested_topics.categories).compact.uniq
+    categories = [category, category&.parent_category]
+    categories += suggested_topics.categories if suggested_topics
+    categories.compact.uniq
   end
 
   protected

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3225,6 +3225,20 @@ RSpec.describe TopicsController do
         expect(body).to have_tag(:link, with: { itemprop: "image", href: post.image_url })
       end
     end
+
+    it "returns a list of categories" do
+      SiteSetting.lazy_load_categories = true
+      topic.update!(category: Fabricate(:category))
+      dest_topic.update!(category: Fabricate(:category))
+
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.parsed_body["categories"].map { |c| c["id"] }).to contain_exactly(
+        SiteSetting.uncategorized_category_id,
+        topic.category_id,
+        dest_topic.category_id,
+      )
+    end
   end
 
   describe "#post_ids" do


### PR DESCRIPTION
When navigating straight to a topic the category was not displayed at all because the categories were not loaded. Similarly, the categories for suggested topics were not loaded either.

This commit adds a list of categories to topic view model class and serializer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
