### PR TITLE
A11Y: Better contrast for lightbox overlay links

### DIFF
--- a/app/assets/stylesheets/common/base/magnific-popup.scss
+++ b/app/assets/stylesheets/common/base/magnific-popup.scss
@@ -29,7 +29,7 @@
 
 @use "sass:math";
 
-$overlay-color: #0b0b0b !default;
+$overlay-color: #000000 !default;
 $overlay-opacity: 0.8 !default;
 $shadow: 0 0 8px rgba(0, 0, 0, 0.6) !default; // shadow on image or iframe
 $popup-padding-left: 8px !default; // Padding from left and from right side
@@ -79,7 +79,7 @@ $use-visuallyhidden: false !default; // Hide content from browsers, but make it 
   position: fixed;
 
   background: $overlay-color;
-  opacity: $overlay-opacity;
+  animation: fade 0.3s alternate;
 }
 
 // Wrapper for popup
@@ -486,6 +486,10 @@ button {
     a.image-source-link .d-icon {
       padding-right: 5px;
     }
+
+    a {
+      color: var(--tertiary-medium);
+    }
   }
 
   .mfp-ready {
@@ -617,7 +621,7 @@ button {
       @include transform(scale(1));
     }
     &.mfp-bg {
-      opacity: 0.8;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
See the "download" and "original image" links. This PR also updates the backdrop styling and animation to match that of core's modal in opacity and fade-in effect. 

Before

<img width="800" alt="image" src="https://github.com/discourse/discourse/assets/368961/818223de-f87d-4588-a73e-5f0d0fa5b79e">


After

<img width="800" alt="image" src="https://github.com/discourse/discourse/assets/368961/653c6072-b3c0-4344-87a3-a3678f9696da">
