### PR TITLE
FIX: Preload the right fields on categories

### DIFF
--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -161,12 +161,11 @@ module Chat
     end
 
     def self.preload_custom_fields_for(channels)
-      preload_fields = Category.instance_variable_get(:@custom_field_types).keys
       Category.preload_custom_fields(
         channels
           .select { |c| c.chatable_type == "Category" || c.chatable_type == "category" }
           .map(&:chatable),
-        preload_fields,
+        Site.preloaded_category_custom_fields,
       )
     end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
