### PR TITLE
FIX: Logs api scope not working

### DIFF
--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -48,6 +48,9 @@ class RouteMatcher
     # message_bus is not a rails route, special handling
     return true if actions.include?("message_bus") && request.fullpath =~ %r{\A/message-bus/.*/poll}
 
+    # logster is not a rails route, special handling
+    return true if actions.include?(Logster::Web) && request.fullpath =~ %r{\A/logs/.*\.json\z}
+
     path_params = path_params_from_request(request)
     actions.include? "#{path_params[:controller]}##{path_params[:action]}"
   end

--- a/spec/models/api_key_scope_spec.rb
+++ b/spec/models/api_key_scope_spec.rb
@@ -7,5 +7,12 @@ RSpec.describe ApiKeyScope do
         "/posts (POST)",
       )
     end
+
+    it "should return logster urls" do
+      expect(ApiKeyScope.find_urls(actions: [Logster::Web], methods: [])).to contain_exactly(
+        "/logs/messages.json (POST)",
+        "/logs/show/:id.json (GET)",
+      )
+    end
   end
 end

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -290,6 +290,27 @@ RSpec.describe Admin::ApiController do
           expect(scope.allowed_parameters["topic_id"]).to contain_exactly("55")
         end
 
+        it "creates an scope for /logs" do
+          post "/admin/api/keys.json",
+               params: {
+                 key: {
+                   description: "logs",
+                   scopes: [{ scope_id: "logs:messages" }],
+                 },
+               }
+          expect(response.status).to eq(200)
+
+          data = response.parsed_body
+          scope = ApiKeyScope.find_by(api_key_id: data.dig("key", "id"))
+
+          expect(scope.resource).to eq("logs")
+          expect(scope.action).to eq("messages")
+
+          api_key = data.dig("key", "key")
+          post "/logs/messages.json", headers: { "Api-Key": api_key, "Api-Username": "system" }
+          expect(response.status).to eq(200)
+        end
+
         it "allows multiple parameters separated by a comma" do
           post "/admin/api/keys.json",
                params: {


### PR DESCRIPTION
The /logs api scope needs special handling in production environments
because of the admin constraint which doesn't exist in development.

Added a test that creates a /logs scope and makes an api request using
it.
