### PR TITLE
DEV: Don't apply this-fallback to strict-mode components

### DIFF
--- a/app/assets/javascripts/patches/ember-this-fallback+0.4.0+003+exclude-strict-mode.patch
+++ b/app/assets/javascripts/patches/ember-this-fallback+0.4.0+003+exclude-strict-mode.patch
@@ -1,0 +1,76 @@
+diff --git a/node_modules/ember-this-fallback/lib/this-fallback-plugin.js b/node_modules/ember-this-fallback/lib/this-fallback-plugin.js
+index a8ee337..9b144de 100644
+--- a/node_modules/ember-this-fallback/lib/this-fallback-plugin.js
++++ b/node_modules/ember-this-fallback/lib/this-fallback-plugin.js
+@@ -60,9 +60,15 @@ class ThisFallbackPlugin {
+     handleBlock() {
+         return {
+             enter: (node) => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 this.scopeStack.push(node.blockParams);
+             },
+             exit: () => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 this.scopeStack.pop();
+             },
+         };
+@@ -70,6 +76,9 @@ class ThisFallbackPlugin {
+     handleAttrNodes() {
+         return {
+             enter: (elementNode, elementPath) => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 const ambiguousHeads = new Map();
+                 const blockParamName = (0, scope_stack_1.unusedNameLike)('maybeHelpers', this.scopeStack);
+                 for (const attrNode of elementNode.attributes) {
+@@ -119,6 +128,9 @@ class ThisFallbackPlugin {
+         return {
+             keys: {
+                 params: (node) => {
++                    if (this.env.strictMode) {
++                      return;
++                    }
+                     const { scopeStack } = this;
+                     node.params = node.params.map((expr) => {
+                         if ((0, fallback_1.needsFallback)(expr, scopeStack)) {
+@@ -131,6 +143,9 @@ class ThisFallbackPlugin {
+                     });
+                 },
+                 hash: (node) => {
++                    if (this.env.strictMode) {
++                      return;
++                    }
+                     const { scopeStack } = this;
+                     node.hash.pairs = node.hash.pairs.map((pair) => {
+                         const { key, value: expr, loc } = pair;
+@@ -149,6 +164,9 @@ class ThisFallbackPlugin {
+     handleMustache() {
+         return {
+             enter: (node, path) => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 // Alias node to n so that the type of `node` doesn't get narrowed,
+                 // which prevents mutation
+                 const n = node;
+@@ -174,9 +192,15 @@ class ThisFallbackPlugin {
+     handleTemplate() {
+         return {
+             enter: (node) => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 this.logger.debug("before: '%s'", (0, string_1.squish)((0, syntax_1.print)(node)));
+             },
+             exit: (node, path) => {
++                if (this.env.strictMode) {
++                  return;
++                }
+                 this.logger.debug("after_: '%s'", (0, string_1.squish)((0, syntax_1.print)(node)));
+                 if (this.scopeStack.size !== 1) {
+                     throw new Error(`unbalanced ScopeStack push and pop, ScopeStack size is ${this.scopeStack.size}`);

--- a/plugins/chat/assets/javascripts/discourse/components/chat/list/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/list/index.gjs
@@ -37,10 +37,6 @@ export default class List extends Component {
     return this.args.itemComponent ?? Item;
   }
 
-  get emptyStateComponent() {
-    return EmptyState;
-  }
-
   @action
   loadCollection() {
     discourseDebounce(this, this.debouncedLoadCollection, INPUT_DELAY);
@@ -57,7 +53,7 @@ export default class List extends Component {
           {{yield (hash Item=(component this.itemComponent item=item))}}
         {{else}}
           {{#if @collection.fetchedOnce}}
-            {{yield (hash EmptyState=this.emptyStateComponent)}}
+            {{yield (hash EmptyState=EmptyState)}}
           {{/if}}
         {{/each}}
       </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/actions.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/actions.gjs
@@ -12,60 +12,20 @@ import ThreadsListButton from "./threads-list-button";
 import ToggleDrawerButton from "./toggle-drawer-button";
 
 export default class ChatNavbarActions extends Component {
-  get openDrawerButtonComponent() {
-    return OpenDrawerButton;
-  }
-
-  get newChannelButtonComponent() {
-    return NewChannelButton;
-  }
-
-  get threadTrackingDropdownComponent() {
-    return ThreadTrackingDropdown;
-  }
-
-  get closeThreadButtonComponent() {
-    return CloseThreadButton;
-  }
-
-  get closeThreadsButtonComponent() {
-    return CloseThreadsButton;
-  }
-
-  get threadSettingsButtonComponent() {
-    return ThreadSettingsButton;
-  }
-
-  get threadsListButtonComponent() {
-    return ThreadsListButton;
-  }
-
-  get closeDrawerButtonComponent() {
-    return CloseDrawerButton;
-  }
-
-  get toggleDrawerButtonComponent() {
-    return ToggleDrawerButton;
-  }
-
-  get chatNavbarFullPageButtonComponent() {
-    return FullPageButton;
-  }
-
   <template>
     <nav class="c-navbar__actions">
       {{yield
         (hash
-          OpenDrawerButton=this.openDrawerButtonComponent
-          NewChannelButton=this.newChannelButtonComponent
-          ThreadTrackingDropdown=this.threadTrackingDropdownComponent
-          CloseThreadButton=this.closeThreadButtonComponent
-          CloseThreadsButton=this.closeThreadsButtonComponent
-          ThreadSettingsButton=this.threadSettingsButtonComponent
-          ThreadsListButton=this.threadsListButtonComponent
-          CloseDrawerButton=this.closeDrawerButtonComponent
-          ToggleDrawerButton=this.toggleDrawerButtonComponent
-          FullPageButton=this.chatNavbarFullPageButtonComponent
+          OpenDrawerButton=OpenDrawerButton
+          NewChannelButton=NewChannelButton
+          ThreadTrackingDropdown=ThreadTrackingDropdown
+          CloseThreadButton=CloseThreadButton
+          CloseThreadsButton=CloseThreadsButton
+          ThreadSettingsButton=ThreadSettingsButton
+          ThreadsListButton=ThreadsListButton
+          CloseDrawerButton=CloseDrawerButton
+          ToggleDrawerButton=ToggleDrawerButton
+          FullPageButton=FullPageButton
         )
       }}
     </nav>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
@@ -9,22 +9,6 @@ import ChannelTitle from "./channel-title";
 import Title from "./title";
 
 export default class ChatNavbar extends Component {
-  get buttonComponent() {
-    return BackButton;
-  }
-
-  get titleComponent() {
-    return Title;
-  }
-
-  get actionsComponent() {
-    return Actions;
-  }
-
-  get channelTitleComponent() {
-    return ChannelTitle;
-  }
-
   <template>
     {{! template-lint-disable no-invalid-interactive }}
     <div
@@ -34,10 +18,10 @@ export default class ChatNavbar extends Component {
       <nav class="c-navbar">
         {{yield
           (hash
-            BackButton=this.buttonComponent
-            ChannelTitle=this.channelTitleComponent
-            Title=this.titleComponent
-            Actions=this.actionsComponent
+            BackButton=BackButton
+            ChannelTitle=ChannelTitle
+            Title=Title
+            Actions=Actions
           )
         }}
       </nav>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/sub-title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/sub-title.gjs
@@ -1,11 +1,6 @@
 import Component from "@glimmer/component";
-import SubTitle from "./sub-title";
 
 export default class ChatNavbarSubTitle extends Component {
-  get subTitleComponent() {
-    return SubTitle;
-  }
-
   <template>
     <div class="c-navbar__sub-title">
       {{#if (has-block)}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
@@ -4,10 +4,6 @@ import icon from "discourse-common/helpers/d-icon";
 import SubTitle from "./sub-title";
 
 export default class ChatNavbarTitle extends Component {
-  get subTitleComponent() {
-    return SubTitle;
-  }
-
   <template>
     <div title={{@title}} class="c-navbar__title">
       {{#if (has-block)}}
@@ -15,7 +11,7 @@ export default class ChatNavbarTitle extends Component {
           {{icon @icon}}
         {{/if}}
         {{@title}}
-        {{yield (hash SubTitle=this.subTitleComponent)}}
+        {{yield (hash SubTitle=SubTitle)}}
       {{else}}
         {{#if @icon}}
           {{icon @icon}}


### PR DESCRIPTION
fixes the issue with imported components references in plugin gjs files

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
