### PR TITLE
DEV: Compile theme migrations javascript files when running theme qunit

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -913,21 +913,27 @@ class Theme < ActiveRecord::Base
 
   def baked_js_tests_with_digest
     tests_tree =
-      theme_fields
-        .where(target_id: Theme.targets[:tests_js])
-        .order(name: :asc)
-        .pluck(:name, :value)
-        .to_h
+      theme_fields_to_tree(
+        theme_fields.where(target_id: Theme.targets[:tests_js]).order(name: :asc),
+      )
 
     return nil, nil if tests_tree.blank?
 
-    compiler = ThemeJavascriptCompiler.new(id, name)
-    compiler.append_tree(tests_tree, for_tests: true)
+    migrations_tree =
+      theme_fields_to_tree(
+        theme_fields.where(target_id: Theme.targets[:migrations]).order(name: :asc),
+      )
+
+    compiler = ThemeJavascriptCompiler.new(id, name, minify: false)
+    compiler.append_tree(migrations_tree, include_variables: false)
+    compiler.append_tree(tests_tree)
+
     compiler.append_raw_script "test_setup.js", <<~JS
       (function() {
         require("discourse/lib/theme-settings-store").registerSettings(#{self.id}, #{cached_default_settings.to_json}, { force: true });
       })();
     JS
+
     content = compiler.content
 
     if compiler.source_map
@@ -941,6 +947,13 @@ class Theme < ActiveRecord::Base
   private
 
   attr_accessor :theme_setting_requests_refresh
+
+  def theme_fields_to_tree(theme_fields_scope)
+    theme_fields_scope.reduce({}) do |tree, theme_field|
+      tree[theme_field.file_path] = theme_field.value
+      tree
+    end
+  end
 
   def to_scss_variable(name, value)
     escaped = SassC::Script::Value::String.quote(value.to_s, sass: true)

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -916,18 +916,35 @@ HTML
         name: "yaml",
         value: "some_number: 1",
       )
+
       theme.set_field(
         target: :tests_js,
         type: :js,
         name: "acceptance/some-test.js",
         value: "assert.ok(true);",
       )
+
       theme.save!
     end
 
     it "returns nil for content and digest if theme does not have tests" do
       ThemeField.destroy_all
       expect(theme.baked_js_tests_with_digest).to eq([nil, nil])
+    end
+
+    it "includes theme's migrations theme fields" do
+      theme.set_field(
+        target: :migrations,
+        type: :js,
+        name: "0001-some-migration",
+        value: "export default function migrate(settings) { return settings; }",
+      )
+
+      theme.save!
+
+      content, _digest = theme.baked_js_tests_with_digest
+
+      expect(content).to include("function migrate(settings)")
     end
 
     it "digest does not change when settings are changed" do

--- a/spec/requests/theme_javascripts_controller_spec.rb
+++ b/spec/requests/theme_javascripts_controller_spec.rb
@@ -229,13 +229,5 @@ RSpec.describe ThemeJavascriptsController do
       expect(response.status).to eq(200)
       expect(response.body).to include("assert.ok(343434);")
     end
-
-    it "includes inline sourcemap" do
-      ThemeJavascriptCompiler.enable_terser!
-      content, digest = component.baked_js_tests_with_digest
-      get "/theme-javascripts/tests/#{component.id}-#{digest}.js"
-      expect(response.status).to eq(200)
-      expect(response.body).to include("//# sourceMappingURL=data:application/json;base64,")
-    end
   end
 end


### PR DESCRIPTION
Why this change?

Currently, is it hard to iteratively write a theme settings migrations
because our theme migrations system does not rollback. Therefore, we
want to allow theme developers to be able to write QUnit tests for their
theme migrations files enabling them to iteratively write their theme
migrations.

What does this change do?

1. Update `Theme#baked_js_tests_with_digest` to include all `ThemeField`
records of `ThemeField#target` equal to `migrations`. Note that we do
not include the `settings` and `themePrefix` variables for migration files.

2. Don't minify JavaScript test files becasue it makes debugging in
   development hard.