### PR TITLE
FIX: Hide deprecated site setting that was missed out

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3018,6 +3018,7 @@ tags:
   min_trust_to_create_tag:
     default: "3"
     enum: "TrustLevelAndStaffSetting"
+    hidden: true
   create_tag_allowed_groups:
     default: "1|3|13"
     type: group_list


### PR DESCRIPTION
### What is this?

In the heat of converting TL based access settings to groups, the now deprecated setting was left visible. Caught by our one and only JammyDodger. This PR hides it. (But it can't hide my shame. 😶)