### PR TITLE
FIX: convert the route to Ember Octane to fix the dependency issue.

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-topic-list.js
+++ b/app/assets/javascripts/discourse/app/routes/user-topic-list.js
@@ -3,11 +3,12 @@ import { setTopicList } from "discourse/lib/topic-list-tracker";
 import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend(ViewingActionType, {
-  templateName: "user-topics-list",
-  controllerName: "user-topics-list",
-
-  queryParams,
+export default class UserTopicsListRoute extends DiscourseRoute.extend(
+  ViewingActionType
+) {
+  templateName = "user-topics-list";
+  controllerName = "user-topics-list";
+  queryParams = queryParams;
 
   setupController(controller, model) {
     setTopicList(model);
@@ -19,5 +20,5 @@ export default DiscourseRoute.extend(ViewingActionType, {
       model,
       hideCategory: false,
     });
-  },
-});
+  }
+}


### PR DESCRIPTION
The UI is randomly breaking while generating the messages menu in the user profile page when we use the old class format. And it happens only when the `navigation_menu` site setting value is set to `header dropdown`. Users reported issues in some other random cases too.

I'm unable to add any tests for it. If I add the tests are passing even without a fix.