### PR TITLE
A11Y: Fix sidebar toggle icon color contrast

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -95,7 +95,8 @@ html {
     }
   }
 
-  .d-header-icons .d-icon {
+  .d-header-icons .d-icon,
+  .header-sidebar-toggle button .d-icon {
     color: var(--primary-low-mid);
   }
 


### PR DESCRIPTION
Color contrast issue was raised by an A11Y audit. 

See /t/118576