### PR TITLE
FIX: Delete topicNotificationLevel key/value before creating post in post widget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -885,6 +885,7 @@ createWidget("post-article", {
             delete result.shareUrl;
             delete result.firstPost;
             delete result.usernameUrl;
+            delete result.topicNotificationLevel;
 
             result.customShare = `${topicUrl}/${p.post_number}`;
             result.asPost = this.store.createRecord("post", result);


### PR DESCRIPTION
This was causing issues if a theme/plugin added `api.includePostAttributes("topicNotificationLevel");`. There is a `getter` for this attr on the post model but not a setter, and it was being set previously. No good!