### PR TITLE
DEV: Add early support for aarch64 dev env

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -89,7 +89,15 @@ done
 # 9292 unicorn
 # 9405 prometheus exporter
 
-docker pull discourse/discourse_dev:release
+if [ "$(uname -m)" == "aarch64" ]; then
+    # NOTE: we currently (2024-01-17) don’t build an aarch64 image, so one must be pre-built locally.
+    # Avoiding `docker pull` so we don't override that local image.
+    ENV_ARGS+=" -e SE_MANAGER_PATH=/usr/local/bin/selenium-manager "
+else
+    # x86_64 environment - pull the latest image from dockerhub
+    docker pull discourse/discourse_dev:release
+fi
+
 docker run -d \
     -p $local_publish:8025:8025 \
     -p $local_publish:3000:3000 \

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -421,6 +421,23 @@ RSpec.configure do |config|
       Capybara::Selenium::Driver.new(app, **mobile_driver_options)
     end
 
+    Capybara.register_driver :selenium_firefox_headless do |app|
+      options =
+        Selenium::WebDriver::Firefox::Options.new(
+          args: %w[--window-size=1400,1400 --headless],
+          prefs: {
+            "browser.download.dir": Downloads::FOLDER,
+          },
+          log_level: ENV["SELENIUM_BROWSER_LOG_LEVEL"] || :warn,
+        )
+      Capybara::Selenium::Driver.new(
+        app,
+        browser: :firefox,
+        timeout: BROWSER_READ_TIMEOUT,
+        options: options,
+      )
+    end
+
     if ENV["ELEVATED_UPLOADS_ID"]
       DB.exec "SELECT setval('uploads_id_seq', 10000)"
     else
@@ -514,7 +531,7 @@ RSpec.configure do |config|
       #
       # The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each
       # process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.
-      if !File.directory?("~/.cache/selenium")
+      if !File.directory?(File.expand_path("~/.cache/selenium"))
         File.open("#{Rails.root}/tmp/chrome_driver_flock", "w") do |file|
           file.flock(File::LOCK_EX)
           `#{Selenium::WebDriver::SeleniumManager.send(:binary)} --browser chrome`
@@ -535,8 +552,15 @@ RSpec.configure do |config|
 
     driver = [:selenium]
     driver << :mobile if example.metadata[:mobile]
-    driver << :chrome
+    driver << (aarch64? ? :firefox : :chrome)
     driver << :headless unless ENV["SELENIUM_HEADLESS"] == "0"
+
+    if driver.include?(:firefox)
+      STDERR.puts(
+        "WARNING: Running system specs using the Firefox driver is not officially supported. Some tests will fail.",
+      )
+    end
+
     driven_by driver.join("_").to_sym
 
     setup_system_test
@@ -554,7 +578,8 @@ RSpec.configure do |config|
       lines << "~~~~~ END DRIVER LOGS ~~~~~"
     end
 
-    js_logs = page.driver.browser.logs.get(:browser)
+    # The logs API isn’t available (yet?) with the Firefox driver
+    js_logs = aarch64? ? [] : page.driver.browser.logs.get(:browser)
 
     # Recommended that this is not disabled, since it makes debugging
     # failed system tests a lot trickier.
@@ -854,6 +879,10 @@ def apply_base_chrome_options(options)
   if ENV["CHROME_DISABLE_FORCE_DEVICE_SCALE_FACTOR"].blank?
     options.add_argument("--force-device-scale-factor=1")
   end
+end
+
+def aarch64?
+  RUBY_PLATFORM == "aarch64-linux"
 end
 
 class SpecSecureRandom


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
This PR allows running system specs on an aarch64 Linux system (typically our `discourse_dev` docker image).
As Chrome isn’t available for the aarch64 architecture (yet), we have to rely on Firefox instead. This has some drawbacks, like not being able to access the browser logs like we do with the Chrome webdriver.


Related PR: https://github.com/discourse/discourse_docker/pull/765