### PR TITLE
DEV: add `topicProgressExpanded` arg to `topic-navigation` outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -230,9 +230,9 @@
           @outletArgs={{hash
             topic=this.model
             renderTimeline=info.renderTimeline
+            topicProgressExpanded=info.topicProgressExpanded
           }}
         />
-
         {{#if info.renderTimeline}}
           <TopicTimeline
             @info={{info}}


### PR DESCRIPTION
Need this for the DiscoTOC refactor, `renderTimeline` isn't enough on its own to determine progress bar vs timeline, because on mobile we `renderTimeline` when `topicProgressExpanded` — so I also need to check `topicProgressExpanded` to know which state we're in