### PR TITLE
DEV: Fix circular import dependency on user topic list route

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
@@ -10,12 +10,8 @@ import {
   NEW_FILTER,
   UNREAD_FILTER,
 } from "discourse/routes/build-private-messages-route";
+import { QUERY_PARAMS } from "discourse/routes/user-topic-list";
 import discourseComputed from "discourse-common/utils/decorators";
-
-export const queryParams = {
-  ascending: { replace: true, refreshModel: true, default: false },
-  order: { replace: true, refreshModel: true },
-};
 
 // Lists of topics on a user's page.
 export default class UserTopicsListController extends Controller {
@@ -25,7 +21,7 @@ export default class UserTopicsListController extends Controller {
   showPosters = false;
   channel = null;
   tagsForUser = null;
-  queryParams = Object.keys(queryParams);
+  queryParams = Object.keys(QUERY_PARAMS);
 
   bulkSelectHelper = new BulkSelectHelper(this);
 
@@ -36,7 +32,8 @@ export default class UserTopicsListController extends Controller {
 
   constructor() {
     super(...arguments);
-    for (const [name, info] of Object.entries(queryParams)) {
+
+    for (const [name, info] of Object.entries(QUERY_PARAMS)) {
       defineTrackedProperty(this, name, info.default);
     }
   }

--- a/app/assets/javascripts/discourse/app/routes/user-topic-list.js
+++ b/app/assets/javascripts/discourse/app/routes/user-topic-list.js
@@ -1,14 +1,18 @@
-import { queryParams } from "discourse/controllers/user-topics-list";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
 import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
+
+export const QUERY_PARAMS = {
+  ascending: { replace: true, refreshModel: true, default: false },
+  order: { replace: true, refreshModel: true },
+};
 
 export default class UserTopicsListRoute extends DiscourseRoute.extend(
   ViewingActionType
 ) {
   templateName = "user-topics-list";
   controllerName = "user-topics-list";
-  queryParams = queryParams;
+  queryParams = QUERY_PARAMS;
 
   setupController(controller, model) {
     setTopicList(model);


### PR DESCRIPTION
Why this change?

This is a follow up to cc917a1d7ff2972014ec0828e184373c0f13535a. It has
been identified that there is a circular dependency issue in our Ember
app with the user topic list route and it looks something like this:

1. `controllers/user-topics-list` imports `routes/build-private-messages-route`
2. `routes/build-private-messages-route` imports
   `routes/user-topic-list`
3. `routes/user-topic-list` imports `controllers/user-topics-list`

This caused some weird problems in production where stuff would just not
load.

What does this change do?

1. Move `QUERY_PARAMS` from `controllers/user-topics-list` to
   `routes/user-topic-list` which is the more apprioriate place for the
   query params to be declared since they are route query params
   after all.

Co-authored-by: Jarek Radosz <jradosz@gmail.com>