### PR TITLE
FIX: Enforce proper max for clean_orphan_uploads_grace_period_hours

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1488,7 +1488,9 @@ files:
     regex: '\A((https?:\/\/.+)(\|https?:\/\/.+[|$])*)?\z'
   create_thumbnails: true
   clean_up_uploads: true
-  clean_orphan_uploads_grace_period_hours: 48
+  clean_orphan_uploads_grace_period_hours:
+    default: 48
+    max: 168
   purge_deleted_uploads_grace_period_days:
     default: 30
     max: 36500

--- a/db/migrate/20240112021335_set_max_clean_orphan_uploads_grace_period_hours.rb
+++ b/db/migrate/20240112021335_set_max_clean_orphan_uploads_grace_period_hours.rb
@@ -3,7 +3,7 @@
 class SetMaxCleanOrphanUploadsGracePeriodHours < ActiveRecord::Migration[7.0]
   def up
     DB.exec <<~SQL
-        UPDATE site_settings SET value = '168' WHERE name ='clean_orphan_uploads_grace_period_hours' and value > '168';
+        UPDATE site_settings SET value = '168' WHERE name ='clean_orphan_uploads_grace_period_hours' and value::int > 168;
       SQL
   end
 

--- a/db/migrate/20240112021335_set_max_clean_orphan_uploads_grace_period_hours.rb
+++ b/db/migrate/20240112021335_set_max_clean_orphan_uploads_grace_period_hours.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SetMaxCleanOrphanUploadsGracePeriodHours < ActiveRecord::Migration[7.0]
+  def up
+    DB.exec <<~SQL
+        UPDATE site_settings SET value = '168' WHERE name ='clean_orphan_uploads_grace_period_hours' and value > '168';
+      SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration.new
+  end
+end

--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -84,7 +84,7 @@ class ImportScripts::Base
       clean_up_inactive_users_after_days: 0,
       clean_up_unused_staged_users_after_days: 0,
       clean_up_uploads: false,
-      clean_orphan_uploads_grace_period_hours: 1800,
+      clean_orphan_uploads_grace_period_hours: 168,
     }
   end
 


### PR DESCRIPTION
Currently, due to the following in `CleanUpUploads` we get an error
```
PG::DatetimeFieldOverflow: ERROR:  timestamp out of range: "226136-02-07 08:42:25.827213 BC"
```

https://github.com/discourse/discourse/blob/98b47636aa6cab91c1917a9fe52be3d6347666dd/app/jobs/scheduled/clean_up_uploads.rb#L8-L16

This PR adds a limit to the site setting and a migration to enforce the max.