### PR TITLE
FIX: Admin sidebar on mobile was still showing forum panel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -9,7 +9,7 @@
     <Sidebar::Sections
       @currentUser={{this.currentUser}}
       @collapsableSections={{true}}
-      @panel={{this.currentPanel}}
+      @panel={{this.sidebarState.currentPanel}}
     />
   {{else}}
     <Sidebar::ApiPanels

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.hbs
@@ -7,10 +7,18 @@
     <div class="panel-body">
       <div class="panel-body-contents">
         <div class="sidebar-hamburger-dropdown">
-          <Sidebar::Sections
-            @currentUser={{this.currentUser}}
-            @collapsableSections={{this.collapsableSections}}
-          />
+          {{#if this.sidebarState.showMainPanel}}
+            <Sidebar::Sections
+              @currentUser={{this.currentUser}}
+              @collapsableSections={{this.collapsableSections}}
+              @panel={{this.sidebarState.currentPanel}}
+            />
+          {{else}}
+            <Sidebar::ApiPanels
+              @currentUser={{this.currentUser}}
+              @collapsableSections={{this.collapsableSections}}
+            />
+          {{/if}}
           <Sidebar::Footer @tagName="" />
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.js
@@ -7,6 +7,7 @@ export default class SidebarHamburgerDropdown extends Component {
   @service currentUser;
   @service site;
   @service siteSettings;
+  @service sidebarState;
 
   @action
   triggerRenderedAppEvent() {

--- a/spec/system/admin_revamp_sidebar_navigation_spec.rb
+++ b/spec/system/admin_revamp_sidebar_navigation_spec.rb
@@ -2,7 +2,9 @@
 
 describe "Admin Revamp | Sidebar Navigation", type: :system do
   fab!(:admin)
+
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+  let(:sidebar_dropdown) { PageObjects::Components::SidebarHeaderDropdown.new }
 
   before do
     SiteSetting.admin_sidebar_enabled_groups = Group::AUTO_GROUPS[:admins]
@@ -11,13 +13,33 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
 
   it "shows the sidebar when navigating to an admin route and hides it when leaving" do
     visit("/latest")
+    expect(sidebar).to have_section("community")
     sidebar.click_link_in_section("community", "admin")
     expect(page).to have_current_path("/admin")
     expect(sidebar).to be_visible
+    expect(sidebar).to have_no_section("community")
     expect(page).to have_no_css(".admin-main-nav")
     sidebar.click_link_in_section("admin-nav-section-root", "back_to_forum")
     expect(page).to have_current_path("/latest")
     expect(sidebar).to have_no_section("admin-nav-section-root")
+  end
+
+  context "when on mobile" do
+    it "shows the admin sidebar links in the header-dropdown when navigating to an admin route and hides them when leaving",
+       mobile: true do
+      visit("/latest")
+      sidebar_dropdown.click
+      expect(sidebar).to have_section("community")
+      sidebar.click_link_in_section("community", "admin")
+      expect(page).to have_current_path("/admin")
+      sidebar_dropdown.click
+      expect(sidebar).to have_no_section("community")
+      expect(page).to have_no_css(".admin-main-nav")
+      sidebar.click_link_in_section("admin-nav-section-root", "back_to_forum")
+      expect(page).to have_current_path("/latest")
+      sidebar_dropdown.click
+      expect(sidebar).to have_no_section("admin-nav-section-root")
+    end
   end
 
   context "when the setting is disabled" do


### PR DESCRIPTION
This commit makes it so the admin sidebar (when enabled)
will hide the other forum sidebar sections on mobile, the
same way it does on desktop. It was not happening automatically
because the sidebar component is also inside the hamburger-dropdown
component, which is used on mobile.

![image](https://github.com/discourse/discourse/assets/920448/f6ebc2c6-fcd5-4e08-85f6-f9510ef1068c)

