### PR TITLE
DEV: Add more debugging information to AR query logs on GitHub actions

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,6 +53,16 @@ Discourse::Application.configure do
   config.active_record.verbose_query_logs = true
   config.active_record.query_log_tags_enabled = true
 
+  config.active_record.query_log_tags = [
+    :application,
+    :controller,
+    :action,
+    {
+      request_path: ->(context) { context[:controller]&.request&.path },
+      thread_id: ->(context) { Thread.current.object_id },
+    },
+  ]
+
   config.after_initialize do
     ActiveRecord::LogSubscriber.backtrace_cleaner.add_silencer do |line|
       line =~ %r{lib/freedom_patches}


### PR DESCRIPTION
Why this change?

We have been chasing a problem with our flaky system test where the user
is logged out when it should never be.

What does this change do?

1. Logs the request path when lookup a user auth token.
2. Logs the request path and also the current thread's object id in
   ActiveRecord query logs.