### PR TITLE
UX: remove lock icon positioning

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
@@ -35,10 +35,6 @@
     }
   }
 
-  .d-icon {
-    position: unset;
-  }
-
   .d-icon-lock {
     margin-right: 0.25em;
   }


### PR DESCRIPTION
A recent change was causing alignment issues in the channel titles on mobile:

![image](https://github.com/discourse/discourse/assets/101828855/512969d8-94da-42ac-a207-dc403888a2ab)

