### PR TITLE
DEV: labeler GitHub action was broken after upgrade to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,9 @@
 chat:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file: plugins/chat/**/*
 
 migrations-tooling:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
         - migrations/**/*
         - script/bulk_import/**/*


### PR DESCRIPTION
Follow-up to 5140caf0e4837526926a27a367b0dd0471e058ad