### PR TITLE
UX: Chat composer dropdown styling mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
@@ -26,6 +26,7 @@ export default class ChatComposerDropdown extends Component {
         @disabled={{@isDisabled}}
         @arrow={{true}}
         @placements={{array "top" "bottom"}}
+        @identifier="chat-composer-dropdown__menu"
         ...attributes
         as |menu|
       >

--- a/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
@@ -1,0 +1,20 @@
+.has-full-page-chat {
+  .fk-d-menu {
+    width: calc(100% - 2rem);
+    max-width: unset;
+  }
+
+  .fk-d-menu__inner-content {
+    width: 100%;
+  }
+
+  .chat-composer-dropdown {
+    &__list {
+      width: 100%;
+    }
+    &__action-btn {
+      padding-block: 1rem;
+      gap: 0.5rem;
+    }
+  }
+}

--- a/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
@@ -1,8 +1,6 @@
-.has-full-page-chat {
-  .fk-d-menu {
-    width: calc(100% - 2rem);
-    max-width: unset;
-  }
+[data-content][data-identifier="chat-composer-dropdown__menu"] {
+  width: calc(100% - 2rem);
+  max-width: unset;
 
   .fk-d-menu__inner-content {
     width: 100%;

--- a/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-composer-dropdown.scss
@@ -11,7 +11,7 @@
       width: 100%;
     }
     &__action-btn {
-      padding-block: 1rem;
+      padding-block: 0.75rem;
       gap: 0.5rem;
     }
   }

--- a/plugins/chat/assets/stylesheets/mobile/index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/index.scss
@@ -1,6 +1,7 @@
 @import "base-mobile";
 @import "chat-channel";
 @import "chat-composer";
+@import "chat-composer-dropdown";
 @import "chat-index";
 @import "chat-message-actions";
 @import "chat-message";


### PR DESCRIPTION
While not ideal still, I wanted to make an easy upgrade for the dropdown, to make it feel a bit more mobile-friendly, by making it full-width and spacier, with bigger tap-targets

### Before
<img width="352" alt="image" src="https://github.com/discourse/discourse/assets/101828855/8d8115a6-4801-4c63-8836-d57b21e51e30">

### After
<img width="351" alt="image" src="https://github.com/discourse/discourse/assets/101828855/3e3ce873-30bf-479b-82d3-1a8779a6297f">
