### PR TITLE
DEV: remove old keyboard modal CSS

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -41,10 +41,6 @@
   }
 }
 
-.modal-body:has(#keyboard-shortcuts-help) {
-  overflow-y: hidden;
-}
-
 #keyboard-shortcuts-help {
   box-sizing: border-box;
 


### PR DESCRIPTION
The keyboard shortcut modal uses the new modals now, which no longer uses `modal-body`, so this rule isn't doing anything. 


![Screenshot 2024-01-12 at 3 56 48 PM](https://github.com/discourse/discourse/assets/1681963/606d65af-c028-4cf6-a7ae-44c91dd70920)
