### PR TITLE
UX: cleaning up some invite page styles

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/account-created/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/account-created/index.hbs
@@ -1,3 +1,4 @@
+{{body-class "account-activation-page"}}
 <div class="container invites-show">
   <div class="login-welcome-header">
     <h1 class="login-title">{{this.welcomeTitle}}</h1>

--- a/app/assets/stylesheets/common/base/activation.scss
+++ b/app/assets/stylesheets/common/base/activation.scss
@@ -1,26 +1,43 @@
 // Styles used before the user is logged into discourse. For example, activating their
 // account or changing their email.
 
-#simple-container {
-  border-radius: 10px;
-  background-color: var(--secondary);
-  padding: 20px;
-  width: 550px;
-  margin: 0 auto;
-
-  .account-created {
-    .ac-message {
-      font-size: var(--font-up-1);
-      line-height: var(--line-height-large);
+.account-activation-page {
+  .desktop-view & {
+    background: var(--primary-very-low);
+  }
+  #main-outlet-wrapper {
+    display: block;
+    .sidebar-wrapper {
+      display: none;
     }
-    .activation-controls {
-      button {
-        margin-right: 0.5em;
+  }
+  #main-outlet {
+    padding: 0;
+    height: 100%;
+  }
+  #simple-container {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    border-radius: 10px;
+    width: 100%;
+    padding: 20px;
+    justify-content: center;
+    margin-top: var(--header-offset);
+    .account-created {
+      .ac-message {
+        font-size: var(--font-up-1);
+        line-height: var(--line-height-large);
       }
-    }
-    .ac-page {
-      border-radius: 10px;
-      margin-top: 25px;
+      .activation-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
+      .ac-page {
+        border-radius: 10px;
+        margin-top: 25px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -1,7 +1,9 @@
 body.invite-page {
-  background-color: var(--primary-50);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
+  #main-outlet-wrapper {
+    padding: 0;
+  }
 }
 
 .invites-show,

--- a/app/assets/stylesheets/common/login/invite-signup.scss
+++ b/app/assets/stylesheets/common/login/invite-signup.scss
@@ -1,16 +1,3 @@
-#main-outlet-wrapper:has(.invites-show) {
-  display: block;
-  height: 100vh;
-
-  .sidebar-wrapper {
-    display: none;
-  }
-
-  #main-outlet {
-    padding: 0;
-    height: 100%;
-  }
-}
 .invites-show {
   padding: 2rem 3rem;
   background: var(--secondary);

--- a/app/assets/stylesheets/desktop/invite-signup.scss
+++ b/app/assets/stylesheets/desktop/invite-signup.scss
@@ -1,10 +1,14 @@
+.invite-page {
+  background: var(--primary-50);
+}
+
 .invites-show {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translateX(-50%) translateY(-50%);
   max-width: 500px;
   padding: 2rem 3rem;
   background: var(--secondary);
   box-shadow: var(--shadow-menu-panel);
+  margin: 10vh auto 1em auto;
+  @media screen and (max-height: 700px) {
+    margin: 1em auto 1em auto;
+  }
 }

--- a/app/assets/stylesheets/mobile/invite-signup.scss
+++ b/app/assets/stylesheets/mobile/invite-signup.scss
@@ -1,10 +1,7 @@
-#main-outlet-wrapper:has(.invites-show) {
-  padding: 0;
-}
 .invites-show {
-  height: 100vh;
   width: 100vw;
   box-sizing: border-box;
+  padding: 0 1em 1em;
 
   .invitation-cta {
     display: flex;


### PR DESCRIPTION
I've added a new class to the account activation page so that can be targeted a little more easily. This allows us to drop the `:has` selector, which can be a little slow. 

There were some misalignment and inconsistencies I've cleaned up here. 


Before/After
![Screenshot 2024-01-12 at 4 59 18 PM](https://github.com/discourse/discourse/assets/1681963/fcba2c47-9e04-4249-95eb-791c964bbce0)


![Screenshot 2024-01-12 at 4 59 59 PM](https://github.com/discourse/discourse/assets/1681963/18752c25-137f-42f5-b0fb-c0ac30afe34f)

![Screenshot 2024-01-12 at 5 05 05 PM](https://github.com/discourse/discourse/assets/1681963/b014f25b-169b-4daf-b513-9845374ec3fd)
