### PR TITLE
DEV: remove `:has` selector from chat settings

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/form/section.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/form/section.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import concatClass from "discourse/helpers/concat-class";
 import ChatFormRow from "discourse/plugins/chat/discourse/components/chat/form/row";
 
 export default class ChatFormSection extends Component {
@@ -8,7 +7,7 @@ export default class ChatFormSection extends Component {
   }
 
   <template>
-    <div class={{concatClass "chat-form__section" @extraClass}} ...attributes>
+    <div class="chat-form__section" ...attributes>
       {{#if @title}}
         <div class="chat-form__section-title">
           {{@title}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/form/section.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/form/section.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import concatClass from "discourse/helpers/concat-class";
 import ChatFormRow from "discourse/plugins/chat/discourse/components/chat/form/row";
 
 export default class ChatFormSection extends Component {
@@ -7,7 +8,7 @@ export default class ChatFormSection extends Component {
   }
 
   <template>
-    <div class="chat-form__section" ...attributes>
+    <div class={{concatClass "chat-form__section" @extraClass}} ...attributes>
       {{#if @title}}
         <div class="chat-form__section-title">
           {{@title}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
@@ -578,7 +578,7 @@ export default class ChatRouteChannelInfoSettings extends Component {
           </form.section>
         {{/if}}
 
-        <form.section as |section|>
+        <form.section @extraClass="--leave-channel" as |section|>
           <section.row>
             <:action>
               <ToggleChannelMembershipButton

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
@@ -578,7 +578,7 @@ export default class ChatRouteChannelInfoSettings extends Component {
           </form.section>
         {{/if}}
 
-        <form.section @extraClass="--leave-channel" as |section|>
+        <form.section class="--leave-channel" as |section|>
           <section.row>
             <:action>
               <ToggleChannelMembershipButton

--- a/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
@@ -18,4 +18,10 @@
       color: var(--danger);
     }
   }
+
+  .chat-form__section.--leave-channel {
+    .chat-form__section-content {
+      gap: 0.25rem 0.5rem;
+    }
+  }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-settings.scss
@@ -18,8 +18,4 @@
       color: var(--danger);
     }
   }
-
-  .chat-form__section-content:has(.c-channel-settings__leave-info) {
-    gap: 0.25rem;
-  }
 }


### PR DESCRIPTION
Adding an `@extraClass` here so we can remove the `:has` selector, which has not-so-great performance at the moment. No visual changes here.