### PR TITLE
UX: adjust onebox styles for chat and header line-height

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -130,6 +130,7 @@ aside.onebox {
     h4 {
       font-size: var(--font-up-1);
       margin: 0 0 10px 0;
+      line-height: var(--line-height-medium);
     }
 
     a[href] {

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -31,9 +31,18 @@ $max_image_height: 150px;
 
     @container (width < 400px) {
       .onebox-body {
-        &:not(:has(.thumbnail.onebox-avatar)) {
-          display: flex;
-          flex-direction: column;
+        display: flex;
+        flex-direction: column;
+
+        .thumbnail.onebox-avatar {
+          display: none;
+        }
+        .aspect-image {
+          margin-right: 0;
+          max-width: 100%;
+          + h3 {
+            margin-top: 0.25rem;
+          }
         }
 
         h3 {


### PR DESCRIPTION
Removing `:has` here due to poor performance, and also adjusting styles a little: 


* We have space for the image when in a column, so let it be full-width

* Avatars don't wrap or expand to the full width well, and at these narrow widths they may be more harmful by messing up the title text

* Line height was fairly large at 1.4 for headers, so I bumped it down to 1.2 

Before|After
![Screenshot 2024-01-12 at 6 00 41 PM](https://github.com/discourse/discourse/assets/1681963/afadcf14-0300-4adc-9d41-738fc9927026) ![Screenshot 2024-01-12 at 5 55 00 PM](https://github.com/discourse/discourse/assets/1681963/2c96e529-0d39-4743-8074-ae64f2afdb3d)

fyi @chapoi 