### PR TITLE
FIX: Trigger search app event being triggered multiple times

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -541,6 +541,10 @@ export default Controller.extend({
     },
 
     search(options = {}) {
+      if (this.searching) {
+        return;
+      }
+
       if (options.collapseFilters) {
         document
           .querySelector("details.advanced-filters")


### PR DESCRIPTION
Identified in https://github.com/discourse/discourse-ai/pull/422, the app event `"full-page-search:trigger-search"` was being triggered multiple times for a single search query. This is due to the observer on `q` (`qChanged()`) which was triggering `search()` a second time for the same query.

This PR adds a conditional to the `search()` action which prevents the action from firing (and thereby the `appEvent` from firing) if a current search is in progress.