### PR TITLE
DEV: Allow rebakes to generate optimized images at the same time

### DIFF
--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -50,12 +50,14 @@ class OptimizedImage < ActiveRecord::Base
 
     return thumbnail if thumbnail
 
+    store = Discourse.store
+
     # create the thumbnail otherwise
-    original_path = Discourse.store.path_for(upload)
+    original_path = store.path_for(upload)
 
     if original_path.blank?
       # download is protected with a DistributedMutex
-      external_copy = Discourse.store.download_safe(upload)
+      external_copy = store.download_safe(upload)
       original_path = external_copy&.path
     end
 
@@ -106,8 +108,7 @@ class OptimizedImage < ActiveRecord::Base
 
           # store the optimized image and update its url
           File.open(temp_path) do |file|
-            url =
-              Discourse.store.store_optimized_image(file, thumbnail, nil, secure: upload.secure?)
+            url = store.store_optimized_image(file, thumbnail, nil, secure: upload.secure?)
             if url.present?
               thumbnail.url = url
               thumbnail.save
@@ -124,7 +125,7 @@ class OptimizedImage < ActiveRecord::Base
       end
 
       # make sure we remove the cached copy from external stores
-      external_copy&.close if Discourse.store.external?
+      external_copy&.close if store.external?
 
       thumbnail
     end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -720,63 +720,48 @@ desc "Rebake posts that contain polls"
 task "import:rebake_uncooked_posts_with_polls" => :environment do
   log "Rebaking posts with polls"
 
-  Jobs.run_immediately!
+  posts = Post.where("EXISTS (SELECT 1 FROM polls WHERE polls.post_id = posts.id)")
 
-  posts =
-    Post.where("EXISTS (SELECT 1 FROM polls WHERE polls.post_id = posts.id)").where(
-      "baked_version <> ? or baked_version IS NULL",
-      Post::BAKED_VERSION,
-    )
-
-  max_count = posts.count
-  current_count = 0
-
-  posts.find_each(order: :desc) do |post|
-    post.rebake!
-    current_count += 1
-    print "\r%7d / %7d" % [current_count, max_count]
-  end
+  rebake_posts(posts)
 end
 
 desc "Rebake posts that contain events"
 task "import:rebake_uncooked_posts_with_events" => :environment do
   log "Rebaking posts with events"
 
-  Jobs.run_immediately!
-
   posts =
     Post.where(
       "EXISTS (SELECT 1 FROM discourse_post_event_events WHERE discourse_post_event_events.id = posts.id)",
-    ).where("baked_version <> ? or baked_version IS NULL", Post::BAKED_VERSION)
+    )
 
-  max_count = posts.count
-  current_count = 0
-
-  posts.find_each(order: :desc) do |post|
-    post.rebake!
-    current_count += 1
-    print "\r%7d / %7d" % [current_count, max_count]
-  end
+  rebake_posts(posts)
 end
 
 desc "Rebake posts that have tag"
 task "import:rebake_uncooked_posts_with_tag", [:tag_name] => :environment do |_task, args|
   log "Rebaking posts with tag"
 
-  Jobs.run_immediately!
-
   posts =
     Post.where(
       "EXISTS (SELECT 1 FROM topic_tags JOIN tags ON tags.id = topic_tags.tag_id WHERE topic_tags.topic_id = posts.topic_id AND tags.name = ?)",
       args[:tag_name],
-    ).where("baked_version <> ? or baked_version IS NULL", Post::BAKED_VERSION)
+    )
+
+  rebake_posts(posts)
+end
+
+def rebake_posts(posts)
+  Jobs.run_immediately!
+  OptimizedImage.lock_per_machine = false
 
   max_count = posts.count
   current_count = 0
 
-  posts.find_each(order: :desc) do |post|
-    post.rebake!
-    current_count += 1
-    print "\r%7d / %7d" % [current_count, max_count]
-  end
+  posts
+    .where("baked_version <> ? or baked_version IS NULL", Post::BAKED_VERSION)
+    .find_each(order: :desc) do |post|
+      post.rebake!
+      current_count += 1
+      print "\r%7d / %7d" % [current_count, max_count]
+    end
 end

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -13,6 +13,9 @@ task "posts:rebake_uncooked_posts" => :environment do
   # this rake task without worrying about your sidekiq imploding
   Jobs.run_immediately!
 
+  # don't lock per machine, we want to be able to run this from multiple consoles
+  OptimizedImage.lock_per_machine = false
+
   ENV["RAILS_DB"] ? rebake_uncooked_posts : rebake_uncooked_posts_all_sites
 end
 


### PR DESCRIPTION
Previously only Sidekiq was allowed to generate more than one optimized image at the same time per machine. This adds an easy mechanism to allow the same in rake tasks and other tools.