### PR TITLE
UX: show the SSO options when creating an account on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -283,6 +283,9 @@
     </div>
 
     {{#if this.hasAtLeastOneLoginButton}}
+      {{#if this.site.mobileView}}
+        <div class="login-or-separator"><span>
+            {{i18n "login.or"}}</span></div>{{/if}}
       <div class="login-right-side">
         <LoginButtons
           @externalLogin={{this.externalLogin}}

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -281,7 +281,8 @@
         {{loading-spinner size="large"}}
       {{/if}}
     </div>
-    {{#if (and this.hasAtLeastOneLoginButton this.site.desktopView)}}
+
+    {{#if this.hasAtLeastOneLoginButton}}
       <div class="login-right-side">
         <LoginButtons
           @externalLogin={{this.externalLogin}}

--- a/app/assets/stylesheets/mobile/login-modal.scss
+++ b/app/assets/stylesheets/mobile/login-modal.scss
@@ -26,8 +26,26 @@
     }
 
     .login-right-side {
-      padding: 0;
+      padding: 1rem 0 0;
       background: unset;
+    }
+
+    .login-or-separator {
+      border-top: 1px solid var(--primary-low);
+      position: relative;
+      margin-block: 1rem;
+
+      span {
+        transform: translate(-50%, -50%);
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        background: var(--secondary);
+        padding-inline: 0.5rem;
+        color: var(--primary-medium);
+        font-size: var(--font-down-1-rem);
+        text-transform: uppercase;
+      }
     }
 
     #login-buttons {

--- a/app/assets/stylesheets/mobile/login-modal.scss
+++ b/app/assets/stylesheets/mobile/login-modal.scss
@@ -25,6 +25,11 @@
       padding: 1rem;
     }
 
+    .login-right-side {
+      padding: 0;
+      background: unset;
+    }
+
     #login-buttons {
       flex-direction: row;
       flex-wrap: wrap;


### PR DESCRIPTION
Following a remark on [meta](https://meta.discourse.org/t/mobile-registration-has-no-sso-options/291053/5), I'm opting to show the SSO options on the create-account screen on mobile too, but placed at the end instead.

<img width="388" alt="image" src="https://github.com/discourse/discourse/assets/101828855/157beae2-1d58-49e6-b44a-101376512e69">

