### PR TITLE
FEATURE: add username header to global-rate-limited responses

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -275,6 +275,7 @@ class Auth::DefaultCurrentUserProvider
     data = {
       token: unhashed_auth_token,
       user_id: user.id,
+      username: user.username,
       trust_level: user.trust_level,
       issued_at: Time.zone.now.to_i,
     }

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -221,6 +221,9 @@ class Middleware::RequestTracker
         "Retry-After" => available_in.to_s,
         "Discourse-Rate-Limit-Error-Code" => error_code,
       }
+      if username = cookie&.[](:username)
+        headers["X-Discourse-Username"] = username
+      end
       return 429, headers, [message]
     end
     env["discourse.request_tracker"] = self


### PR DESCRIPTION
This will make it easier to analyze rate limiting in reverse-proxy logs. To make this possible without a database lookup, we add the username to the encrypted `_t` cookie data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
