### PR TITLE
DEV: Fix flaky table builder system spec

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -328,58 +328,61 @@ export default class SpreadsheetEditor extends Component {
       </:body>
 
       <:footer>
-        <div class="primary-actions">
-          <DButton
-            @label={{this.modalAttributes.insertTable.title}}
-            @icon={{this.modalAttributes.insertTable.icon}}
-            @action={{this.insertTable}}
-            class="btn-insert-table"
-          />
+        {{#unless this.loading}}
+          <div class="primary-actions">
+            <DButton
+              @label={{this.modalAttributes.insertTable.title}}
+              @icon={{this.modalAttributes.insertTable.icon}}
+              @action={{this.insertTable}}
+              class="btn-insert-table"
+            />
 
-          <DModalCancel @close={{this.interceptCloseModal}} />
-        </div>
+            <DModalCancel @close={{this.interceptCloseModal}} />
+          </div>
 
-        <div class="secondary-actions">
-          {{#if this.isEditingTable}}
-            <div class="edit-reason">
-              <DButton
-                @icon="info-circle"
-                @title="table_builder.edit.modal.trigger_reason"
-                @action={{this.showEditReasonField}}
-                class="btn-edit-reason"
-              />
-              {{#if this.showEditReason}}
-                <TextField
-                  @value={{this.editReason}}
-                  @placeholderKey="table_builder.edit.modal.reason"
+          <div class="secondary-actions">
+            {{#if this.isEditingTable}}
+              <div class="edit-reason">
+                <DButton
+                  @icon="info-circle"
+                  @title="table_builder.edit.modal.trigger_reason"
+                  @action={{this.showEditReasonField}}
+                  class="btn-edit-reason"
                 />
-              {{/if}}
-            </div>
-          {{/if}}
-          <DTooltip
-            @icon="question"
-            @triggers="click"
-            @arrow={{false}}
-            class="btn btn-icon no-text"
-          >
-            <ul>
-              <h4>{{i18n "table_builder.modal.help.title"}}</h4>
-              <li>
-                <kbd>
-                  {{i18n "table_builder.modal.help.enter_key"}}
-                </kbd>
-                {{i18n "table_builder.modal.help.new_row"}}
-              </li>
-              <li>
-                <kbd>
-                  {{i18n "table_builder.modal.help.tab_key"}}
-                </kbd>
-                {{i18n "table_builder.modal.help.new_col"}}
-              </li>
-              <li>{{i18n "table_builder.modal.help.options"}}</li>
-            </ul>
-          </DTooltip>
-        </div>
+                {{#if this.showEditReason}}
+                  <TextField
+                    @value={{this.editReason}}
+                    @placeholderKey="table_builder.edit.modal.reason"
+                  />
+                {{/if}}
+              </div>
+            {{/if}}
+            <DTooltip
+              @icon="question"
+              @triggers="click"
+              @arrow={{false}}
+              class="btn btn-icon no-text"
+            >
+              <ul>
+                <h4>{{i18n "table_builder.modal.help.title"}}</h4>
+                <li>
+                  <kbd>
+                    {{i18n "table_builder.modal.help.enter_key"}}
+                  </kbd>
+                  {{i18n "table_builder.modal.help.new_row"}}
+                </li>
+                <li>
+                  <kbd>
+                    {{i18n "table_builder.modal.help.tab_key"}}
+                  </kbd>
+                  {{i18n "table_builder.modal.help.new_col"}}
+                </li>
+                <li>{{i18n "table_builder.modal.help.options"}}</li>
+              </ul>
+            </DTooltip>
+          </div>
+        {{/unless}}
+
       </:footer>
     </DModal>
   </template>


### PR DESCRIPTION
Why this change?

The `Table Builder when editing a table when cancelling table creation should close the modal if there are no changes made` system
test in `spec/system/table_builder_spec.rb` was flaky. It turns out that
when the modal is opened, we have to load some JS/CSS files. While that
is happening, the modal is actually not functional and clicking stuff
in the footer can actually result in an error. In this case, the
`interceptCloseModal` calls the private `_hasChanges` function which
then calls `this.spreadsheet.getHeaders()`. When stuff is still loading,
`this.spreadsheet` has not been set. As a result we get the following
error:

```
Cannot read properties of null (reading 'getHeaders')
```

What does this change do?

When stuff is loading, we will now hide the footer in the modal.