### PR TITLE
FIX: Allow staff to change group members visibility level for automatic groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -740,9 +740,7 @@ class GroupsController < ApplicationController
       flair_upload_id
     ]
 
-    if automatic
-      attributes.push(:visibility_level)
-    else
+    if !automatic
       attributes.push(
         :title,
         :allow_membership_requests,
@@ -752,6 +750,8 @@ class GroupsController < ApplicationController
         :membership_request_template,
       )
     end
+
+    attributes.push(:visibility_level, :members_visibility_level) if current_user.staff?
 
     if !automatic && current_user.staff?
       attributes.push(
@@ -773,8 +773,6 @@ class GroupsController < ApplicationController
         :email_password,
         :email_from_alias,
         :primary_group,
-        :visibility_level,
-        :members_visibility_level,
         :name,
         :grant_trust_level,
         :automatic_membership_email_domains,

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -994,6 +994,7 @@ RSpec.describe GroupsController do
           mentionable_level: 2,
           messageable_level: 2,
           default_notification_level: 2,
+          members_visibility_level: 2,
         )
 
         put "/groups/#{group.id}.json",
@@ -1007,6 +1008,7 @@ RSpec.describe GroupsController do
                 mentionable_level: 1,
                 messageable_level: 1,
                 default_notification_level: 1,
+                members_visibility_level: 1,
                 tracking_category_ids: [category.id],
                 tracking_tags: [tag.name],
               },
@@ -1025,6 +1027,7 @@ RSpec.describe GroupsController do
         expect(group.mentionable_level).to eq(1)
         expect(group.messageable_level).to eq(1)
         expect(group.default_notification_level).to eq(1)
+        expect(group.members_visibility_level).to eq(1)
         expect(group.group_category_notification_defaults.first&.category).to eq(category)
         expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
       end


### PR DESCRIPTION
See https://meta.discourse.org/t/cannot-change-member-visibility-level-of-automatic-groups/280373/11?u=pmusaraj for details, this regressed in 03ad88f2c241062e0bb976b730228f9428edef92 