### PR TITLE
DEV: Make lazy_load_categories setting use groups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -77,7 +77,7 @@ export default class CategoriesDisplay extends Component {
   }
 
   get canLoadMore() {
-    return this.siteSettings.lazy_load_categories && this.args.loadMore;
+    return this.site.lazy_load_categories && this.args.loadMore;
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -201,7 +201,7 @@ const Group = RestModel.extend({
   @dependentKeyCompat
   get watchingCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.watching_category_ids)
     ) {
       Category.asyncFindByIds(this.watching_category_ids).then(() =>
@@ -222,7 +222,7 @@ const Group = RestModel.extend({
   @dependentKeyCompat
   get trackingCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.tracking_category_ids)
     ) {
       Category.asyncFindByIds(this.tracking_category_ids).then(() =>
@@ -243,7 +243,7 @@ const Group = RestModel.extend({
   @dependentKeyCompat
   get watchingFirstPostCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.watching_first_post_category_ids)
     ) {
       Category.asyncFindByIds(this.watching_first_post_category_ids).then(() =>
@@ -264,7 +264,7 @@ const Group = RestModel.extend({
   @dependentKeyCompat
   get regularCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.regular_category_ids)
     ) {
       Category.asyncFindByIds(this.regular_category_ids).then(() =>
@@ -285,7 +285,7 @@ const Group = RestModel.extend({
   @dependentKeyCompat
   get mutedCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.muted_category_ids)
     ) {
       Category.asyncFindByIds(this.muted_category_ids).then(() =>

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -857,7 +857,7 @@ const User = RestModel.extend({
   @dependentKeyCompat
   get mutedCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.muted_category_ids)
     ) {
       Category.asyncFindByIds(this.muted_category_ids).then(() =>
@@ -877,7 +877,7 @@ const User = RestModel.extend({
   @dependentKeyCompat
   get regularCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.regular_category_ids)
     ) {
       Category.asyncFindByIds(this.regular_category_ids).then(() =>
@@ -897,7 +897,7 @@ const User = RestModel.extend({
   @dependentKeyCompat
   get trackedCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.tracked_category_ids)
     ) {
       Category.asyncFindByIds(this.tracked_category_ids).then(() =>
@@ -917,7 +917,7 @@ const User = RestModel.extend({
   @dependentKeyCompat
   get watchedCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.watched_category_ids)
     ) {
       Category.asyncFindByIds(this.watched_category_ids).then(() =>
@@ -937,7 +937,7 @@ const User = RestModel.extend({
   @dependentKeyCompat
   get watchedFirstPostCategories() {
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll(this.watched_first_post_category_ids)
     ) {
       Category.asyncFindByIds(this.watched_first_post_category_ids).then(() =>

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -18,7 +18,7 @@ import I18n from "discourse-i18n";
 class AbstractCategoryRoute extends DiscourseRoute {
   @service composer;
   @service router;
-  @service siteSettings;
+  @service site;
   @service store;
   @service topicTrackingState;
   @service("search") searchService;
@@ -30,7 +30,7 @@ class AbstractCategoryRoute extends DiscourseRoute {
   controllerName = "discovery/list";
 
   async model(params, transition) {
-    const category = this.siteSettings.lazy_load_categories
+    const category = this.site.lazy_load_categories
       ? await Category.asyncFindBySlugPathWithID(
           params.category_slug_path_with_id
         )

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -29,7 +29,7 @@ export default ComboBoxComponent.extend({
     this._super(...arguments);
 
     if (
-      this.siteSettings.lazy_load_categories &&
+      this.site.lazy_load_categories &&
       !Category.hasAsyncFoundAll([this.value])
     ) {
       // eslint-disable-next-line no-console
@@ -92,7 +92,7 @@ export default ComboBoxComponent.extend({
   },
 
   search(filter) {
-    if (this.siteSettings.lazy_load_categories) {
+    if (this.site.lazy_load_categories) {
       return Category.asyncSearch(this._normalize(filter), {
         scopedCategoryId: this.selectKit.options?.scopedCategoryId,
         prioritizedCategoryId: this.selectKit.options?.prioritizedCategoryId,

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -135,7 +135,7 @@ export default ComboBoxComponent.extend({
   ),
 
   async search(filter) {
-    if (this.siteSettings.lazy_load_categories) {
+    if (this.site.lazy_load_categories) {
       const results = await Category.asyncSearch(filter, {
         parentCategoryId: this.options.parentCategory?.id || -1,
         includeUncategorized: this.siteSettings.allow_uncategorized_topics,

--- a/app/assets/javascripts/select-kit/addon/components/category-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-selector.js
@@ -51,7 +51,7 @@ export default MultiSelectComponent.extend({
   },
 
   async search(filter) {
-    if (!this.siteSettings.lazy_load_categories) {
+    if (!this.site.lazy_load_categories) {
       return this._super(filter);
     }
 

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -136,7 +136,7 @@ class CategoryList
 
     query = self.class.order_categories(query)
 
-    if SiteSetting.lazy_load_categories
+    if @guardian.can_lazy_load_categories?
       page = [1, @options[:page].to_i].max
       query = query.limit(CATEGORIES_PER_PAGE).offset((page - 1) * CATEGORIES_PER_PAGE)
     end
@@ -155,7 +155,7 @@ class CategoryList
     notification_levels = CategoryUser.notification_levels_for(@guardian.user)
     default_notification_level = CategoryUser.default_notification_level
 
-    if SiteSetting.lazy_load_categories
+    if @guardian.can_lazy_load_categories?
       subcategory_ids = {}
       Category
         .secured(@guardian)

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -47,6 +47,7 @@ class SiteSerializer < ApplicationSerializer
     :tos_url,
     :privacy_policy_url,
     :system_user_avatar_template,
+    :lazy_load_categories,
   )
 
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
@@ -239,7 +240,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def include_categories?
-    !SiteSetting.lazy_load_categories
+    !scope.can_lazy_load_categories?
   end
 
   def markdown_additional_options
@@ -343,6 +344,14 @@ class SiteSerializer < ApplicationSerializer
 
   def include_system_user_avatar_template?
     SiteSetting.show_user_menu_avatars
+  end
+
+  def lazy_load_categories
+    true
+  end
+
+  def include_lazy_load_categories?
+    scope.can_lazy_load_categories?
   end
 
   private

--- a/app/serializers/topic_list_serializer.rb
+++ b/app/serializers/topic_list_serializer.rb
@@ -39,6 +39,6 @@ class TopicListSerializer < ApplicationSerializer
   end
 
   def include_categories?
-    SiteSetting.lazy_load_categories
+    scope.can_lazy_load_categories?
   end
 end

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -319,6 +319,6 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_categories?
-    SiteSetting.lazy_load_categories
+    scope.can_lazy_load_categories?
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2502,6 +2502,7 @@ en:
 
     experimental_form_templates: "EXPERIMENTAL: Enable the form templates feature. <b>After enabled,</b> manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     admin_sidebar_enabled_groups: "EXPERIMENTAL: Enable sidebar navigation for the admin UI for the specified groups, which replaces the top-level admin navigation buttons."
+    lazy_load_categories_groups: "EXPERIMENTAL: Lazy load category information only for users of these groups. This improves performance on sites with many categories."
 
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2328,10 +2328,10 @@ developer:
     default: ""
     allow_any: false
     refresh: true
-  lazy_load_categories:
-    default: false
-    client: true
-    hidden: true
+  lazy_load_categories_groups:
+    default: ""
+    type: group_list
+    list_type: compact
   warn_critical_js_deprecations:
     default: true
     client: true

--- a/db/migrate/20240116182229_migrate_lazy_load_categories_to_groups.rb
+++ b/db/migrate/20240116182229_migrate_lazy_load_categories_to_groups.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MigrateLazyLoadCategoriesToGroups < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'lazy_load_categories_groups', data_type = 20, value = '0'
+      WHERE name = 'lazy_load_categories' AND value = 't'
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'lazy_load_categories_groups', data_type = 20, value = ''
+      WHERE name = 'lazy_load_categories' AND value = 'f'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'lazy_load_categories', data_type = 5, value = 't'
+      WHERE name = 'lazy_load_categories_groups' AND value != ''
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'lazy_load_categories', data_type = 5, value = 'f'
+      WHERE name = 'lazy_load_categories_groups' AND value = ''
+    SQL
+  end
+end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -628,6 +628,11 @@ class Guardian
       @user.has_trust_level_or_staff?(SiteSetting.min_trust_level_for_here_mention)
   end
 
+  def can_lazy_load_categories?
+    SiteSetting.lazy_load_categories_groups_map.include?(Group::AUTO_GROUPS[:everyone]) ||
+      @user.in_any_groups?(SiteSetting.lazy_load_categories_groups_map)
+  end
+
   def is_me?(other)
     other && authenticated? && other.is_a?(User) && @user == other
   end

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -375,11 +375,11 @@ RSpec.describe CategoryList do
     end
   end
 
-  describe "lazy_load_categories" do
+  describe "with lazy load categories enabled" do
     fab!(:category) { Fabricate(:category, user: admin) }
     fab!(:subcategory) { Fabricate(:category, user: admin, parent_category: category) }
 
-    before { SiteSetting.lazy_load_categories = true }
+    before { SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}" }
 
     it "returns categories with subcategory_ids" do
       expect(category_list.categories.size).to eq(3)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -224,14 +224,14 @@ RSpec.describe ListController do
       end
     end
 
-    context "with lazy_load_categories" do
+    context "with lazy load categories enabled" do
       fab!(:category)
       fab!(:subcategory) { Fabricate(:category, parent_category: category) }
 
       before { topic.update!(category: subcategory) }
 
       it "returns categories and parent categories if true" do
-        SiteSetting.lazy_load_categories = true
+        SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
 
         get "/latest.json"
 
@@ -245,7 +245,7 @@ RSpec.describe ListController do
       end
 
       it "does not return categories if not true" do
-        SiteSetting.lazy_load_categories = false
+        SiteSetting.lazy_load_categories_groups = ""
 
         get "/latest.json"
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3227,7 +3227,7 @@ RSpec.describe TopicsController do
     end
 
     it "returns a list of categories" do
-      SiteSetting.lazy_load_categories = true
+      SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
       topic.update!(category: Fabricate(:category))
       dest_topic.update!(category: Fabricate(:category))
 

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe SiteSerializer do
   end
 
   it "does not include categories if lazy_load_categories" do
-    SiteSetting.lazy_load_categories = true
+    SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
 
     serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
 


### PR DESCRIPTION
This allows certain users to test the new feature and avoid disruptions in other's workflows.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
