### PR TITLE
DEV: add anonymousOnly opt to registerTopicFooterButton

### DIFF
--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.hbs
@@ -1,0 +1,24 @@
+<div class="topic-footer-main-buttons">
+  {{#each this.buttons as |button|}}
+    <DButton
+      @action={{button.action}}
+      @icon={{button.icon}}
+      @translatedLabel={{button.label}}
+      @translatedTitle={{button.title}}
+      @translatedAriaLabel={{button.ariaLabel}}
+      @disabled={{button.disabled}}
+      id={{concat "topic-footer-button-" button.id}}
+      class={{concatClass
+        "btn-default"
+        "topic-footer-button"
+        button.classNames
+      }}
+    />
+  {{/each}}
+  <DButton
+    @icon="reply"
+    @action={{route-action "showLogin"}}
+    @label="topic.reply.title"
+    class="btn-primary"
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
@@ -1,0 +1,21 @@
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+import { getTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
+
+export default Component.extend({
+  elementId: "topic-footer-buttons",
+
+  attributeBindings: ["role"],
+
+  role: "region",
+
+  allButtons: getTopicFooterButtons(),
+
+  @computed("inlineButtons.[]")
+  get buttons() {
+    return this.allButtons
+      .filterBy("displayForAnonymous", true)
+      .sortBy("priority")
+      .reverse();
+  },
+});

--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
@@ -11,7 +11,7 @@ export default Component.extend({
 
   allButtons: getTopicFooterButtons(),
 
-  @computed("inlineButtons.[]")
+  @computed("allButtons.[]")
   get buttons() {
     return this.allButtons
       .filterBy("displayForAnonymous", true)

--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js
@@ -14,7 +14,7 @@ export default Component.extend({
   @computed("allButtons.[]")
   get buttons() {
     return this.allButtons
-      .filterBy("displayForAnonymous", true)
+      .filterBy("anonymousOnly", true)
       .sortBy("priority")
       .reverse();
   },

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -27,8 +27,8 @@ export default Component.extend({
     function () {
       return this.inlineButtons
         .filterBy("dropdown", false)
-        .concat(this.inlineDropdowns)
         .filterBy("displayForUser", true)
+        .concat(this.inlineDropdowns)
         .sortBy("priority")
         .reverse();
     }

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -28,6 +28,7 @@ export default Component.extend({
       return this.inlineButtons
         .filterBy("dropdown", false)
         .concat(this.inlineDropdowns)
+        .filterBy("displayForUser", true)
         .sortBy("priority")
         .reverse();
     }

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -27,7 +27,7 @@ export default Component.extend({
     function () {
       return this.inlineButtons
         .filterBy("dropdown", false)
-        .filterBy("displayForUser", true)
+        .filterBy("anonymousOnly", false)
         .concat(this.inlineDropdowns)
         .sortBy("priority")
         .reverse();

--- a/app/assets/javascripts/discourse/app/lib/register-topic-footer-button.js
+++ b/app/assets/javascripts/discourse/app/lib/register-topic-footer-button.js
@@ -52,11 +52,8 @@ export function registerTopicFooterButton(button) {
     // display order, higher comes first
     priority: 0,
 
-    // is this button displayed for logged-in users ?
-    displayForUser: true,
-
     // is this button displayed for anonymous users ?
-    displayForAnonymous: false,
+    anonymousOnly: false,
   };
 
   const normalizedButton = Object.assign(defaultButton, button);
@@ -132,13 +129,9 @@ export function getTopicFooterButtons() {
           discourseComputedButton.dropdown = _compute(button, "dropdown");
           discourseComputedButton.priority = _compute(button, "priority");
 
-          discourseComputedButton.displayForUser = _compute(
+          discourseComputedButton.anonymousOnly = _compute(
             button,
-            "displayForUser"
-          );
-          discourseComputedButton.displayForAnonymous = _compute(
-            button,
-            "displayForAnonymous"
+            "anonymousOnly"
           );
 
           if (_isFunction(button.action)) {

--- a/app/assets/javascripts/discourse/app/lib/register-topic-footer-button.js
+++ b/app/assets/javascripts/discourse/app/lib/register-topic-footer-button.js
@@ -51,6 +51,12 @@ export function registerTopicFooterButton(button) {
 
     // display order, higher comes first
     priority: 0,
+
+    // is this button displayed for logged-in users ?
+    displayForUser: true,
+
+    // is this button displayed for anonymous users ?
+    displayForAnonymous: false,
   };
 
   const normalizedButton = Object.assign(defaultButton, button);
@@ -125,6 +131,15 @@ export function getTopicFooterButtons() {
           discourseComputedButton.disabled = _compute(button, "disabled");
           discourseComputedButton.dropdown = _compute(button, "dropdown");
           discourseComputedButton.priority = _compute(button, "priority");
+
+          discourseComputedButton.displayForUser = _compute(
+            button,
+            "displayForUser"
+          );
+          discourseComputedButton.displayForAnonymous = _compute(
+            button,
+            "displayForAnonymous"
+          );
 
           if (_isFunction(button.action)) {
             discourseComputedButton.action = () => button.action.apply(this);

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -542,6 +542,10 @@
           />
         {{else}}
           <div id="topic-footer-buttons">
+            <PluginOutlet
+              @name="topic-before-anon-reply-footer-button"
+              @outletArgs={{hash model=this.model}}
+            />
             <DButton
               @icon="reply"
               @action={{route-action "showLogin"}}

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -542,16 +542,7 @@
           />
         {{else}}
           <div id="topic-footer-buttons">
-            <PluginOutlet
-              @name="topic-before-anon-reply-footer-button"
-              @outletArgs={{hash model=this.model}}
-            />
-            <DButton
-              @icon="reply"
-              @action={{route-action "showLogin"}}
-              @label="topic.reply.title"
-              class="btn-primary"
-            />
+            <AnonymousTopicFooterButtons @topic={{this.model}} />
           </div>
         {{/if}}
       {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
@@ -4,7 +4,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance(
-  "Topic - Plugin API - registerTopicFooterButton - logged user",
+  "Topic - Plugin API - registerTopicFooterButton - logged in user",
   function (needs) {
     needs.user();
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
@@ -27,13 +27,13 @@ acceptance(
       assert.verifySteps(["action called"]);
     });
 
-    test("doesn't show footer button if displayForUser is false", async function (assert) {
+    test("doesn't show footer button if anonymousOnly is true", async function (assert) {
       withPluginApi("0.13.1", (api) => {
         api.registerTopicFooterButton({
           id: "my-button",
           icon: "cog",
           action() {},
-          displayForUser: false,
+          anonymousOnly: true,
         });
       });
 
@@ -56,7 +56,7 @@ acceptance(
             assert.step("action called");
             done();
           },
-          displayForAnonymous: true,
+          anonymousOnly: true,
         });
       });
 
@@ -66,7 +66,7 @@ acceptance(
       assert.verifySteps(["action called"]);
     });
 
-    test("doesn't show footer button if displayForAnonymous is false/unset", async function (assert) {
+    test("doesn't show footer button if anonymousOnly is false/unset", async function (assert) {
       withPluginApi("0.13.1", (api) => {
         api.registerTopicFooterButton({
           id: "my-button",

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-button-api-test.js
@@ -1,27 +1,82 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
-acceptance("Topic - Plugin API - registerTopicFooterButton", function (needs) {
-  needs.user();
+acceptance(
+  "Topic - Plugin API - registerTopicFooterButton - logged user",
+  function (needs) {
+    needs.user();
 
-  test("adds topic footer button through API", async function (assert) {
-    const done = assert.async();
-    withPluginApi("0.13.1", (api) => {
-      api.registerTopicFooterButton({
-        id: "my-button",
-        icon: "cog",
-        action() {
-          assert.step("action called");
-          done();
-        },
+    test("adds topic footer button through API", async function (assert) {
+      const done = assert.async();
+      withPluginApi("0.13.1", (api) => {
+        api.registerTopicFooterButton({
+          id: "my-button",
+          icon: "cog",
+          action() {
+            assert.step("action called");
+            done();
+          },
+        });
       });
+
+      await visit("/t/internationalization-localization/280");
+      await click("#topic-footer-button-my-button");
+
+      assert.verifySteps(["action called"]);
     });
 
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-button-my-button");
+    test("doesn't show footer button if displayForUser is false", async function (assert) {
+      withPluginApi("0.13.1", (api) => {
+        api.registerTopicFooterButton({
+          id: "my-button",
+          icon: "cog",
+          action() {},
+          displayForUser: false,
+        });
+      });
 
-    assert.verifySteps(["action called"]);
-  });
-});
+      await visit("/t/internationalization-localization/280");
+      assert.ok(!exists("#topic-footer-button-my-button"));
+    });
+  }
+);
+
+acceptance(
+  "Topic - Plugin API - registerTopicFooterButton - anonymous",
+  function () {
+    test("adds topic footer button through API", async function (assert) {
+      const done = assert.async();
+      withPluginApi("0.13.1", (api) => {
+        api.registerTopicFooterButton({
+          id: "my-button",
+          icon: "cog",
+          action() {
+            assert.step("action called");
+            done();
+          },
+          displayForAnonymous: true,
+        });
+      });
+
+      await visit("/t/internationalization-localization/280");
+      await click("#topic-footer-button-my-button");
+
+      assert.verifySteps(["action called"]);
+    });
+
+    test("doesn't show footer button if displayForAnonymous is false/unset", async function (assert) {
+      withPluginApi("0.13.1", (api) => {
+        api.registerTopicFooterButton({
+          id: "my-button",
+          icon: "cog",
+          action() {},
+        });
+      });
+
+      await visit("/t/internationalization-localization/280");
+      assert.ok(!exists("#topic-footer-button-my-button"));
+    });
+  }
+);


### PR DESCRIPTION
Adds support to `anonymousOnly` as opt when using `registerTopicFooterButton`, rendering the buttons accordingly.

#### Usage example
![image](https://github.com/discourse/discourse/assets/3530/1bdcf37e-45b8-4700-855b-3107cbdd0b75)
