### PR TITLE
FIX: "Action Logs" button on user admin page

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-tools.js
+++ b/app/assets/javascripts/admin/addon/services/admin-tools.js
@@ -1,4 +1,3 @@
-import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import Service, { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
@@ -14,13 +13,11 @@ import AdminUser from "admin/models/admin-user";
 export default class AdminToolsService extends Service {
   @service dialog;
   @service modal;
+  @service router;
 
   showActionLogs(target, filters) {
-    const controller = getOwner(target).lookup(
-      "controller:adminLogs.staffActionLogs"
-    );
-    target.transitionToRoute("adminLogs.staffActionLogs").then(() => {
-      controller.changeFilters(filters);
+    this.router.transitionTo("adminLogs.staffActionLogs", {
+      queryParams: { filters },
     });
   }
 


### PR DESCRIPTION
The `transitionToRoute` API was removed in Ember 5 in favour of the route service

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
