### PR TITLE
PERF: Avoid loading the whole record when we only need id

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/notify_mentioned.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_mentioned.rb
@@ -161,7 +161,7 @@ module Jobs
           target_id = user_id
         elsif mention_klass == ::Chat::GroupMention
           begin
-            target_id = Group.where("LOWER(name) = ?", "#{mention_type}").first.id
+            target_id = Group.where("LOWER(name) = ?", "#{mention_type}").pick(:id)
           rescue => e
             Discourse.warn_exception(e, message: "Mentioned group doesn't exist")
           end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
