### PR TITLE
DEV: Replace lazy_load_categories site setting

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -151,7 +151,7 @@ class CategoryList
 
     @categories = query.to_a
 
-    if SiteSetting.lazy_load_categories
+    if @guardian.can_lazy_load_categories?
       categories_with_rownum =
         Category
           .secured(@guardian)


### PR DESCRIPTION
The site setting has been removed in a previous commit abad38c, but it was merged at the same time with 4cfc0e2, which added it back.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
