### PR TITLE
FIX: everyone group includes anonymous users

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -90,7 +90,7 @@ class Guardian
     end
 
     def in_any_groups?(group_ids)
-      false
+      group_ids.include?(Group::AUTO_GROUPS[:everyone])
     end
   end
 


### PR DESCRIPTION
The Guardian instance for anonymous user should return `true` for anonymous users too if `group_ids` includes the everyone group ID.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
