### PR TITLE
FIX: prevent popup when thread count request fails

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -4,7 +4,6 @@ import { inject as service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 import i18n from "discourse-common/helpers/i18n";
 import eq from "truth-helpers/helpers/eq";
 
@@ -23,7 +22,8 @@ export default class ChatFooter extends Component {
         this.threadsEnabled = result.thread_count > 0;
       })
       .catch((error) => {
-        popupAjaxError(error);
+        // eslint-disable-next-line no-console
+        console.error(error);
       });
 
     return () => {


### PR DESCRIPTION
On the rare occasions that an ajax request for thread count fails, we should fail silently without alerting the user.

This is a temporary fix, a better approach to showing My Threads based on certain criteria will replace this soon.