### PR TITLE
FIX: errors when loading My Threads and Channel Threads

### DIFF
--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -77,7 +77,7 @@ module Chat
             :uploads,
             :chat_webhook_event,
             :chat_channel,
-            chat_mentions: {
+            user_mentions: {
               user: :user_status,
             },
             user: :user_status,
@@ -86,7 +86,7 @@ module Chat
             :uploads,
             :chat_webhook_event,
             :chat_channel,
-            chat_mentions: {
+            user_mentions: {
               user: :user_status,
             },
             user: :user_status,

--- a/plugins/chat/app/services/chat/lookup_user_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_user_threads.rb
@@ -55,7 +55,7 @@ module Chat
             :uploads,
             :chat_webhook_event,
             :chat_channel,
-            chat_mentions: {
+            user_mentions: {
               user: :user_status,
             },
             user: :user_status,
@@ -64,7 +64,7 @@ module Chat
             :uploads,
             :chat_webhook_event,
             :chat_channel,
-            chat_mentions: {
+            user_mentions: {
               user: :user_status,
             },
             user: :user_status,


### PR DESCRIPTION
This PR fixes the problems described below. We also need tests for this, they'll be in a follow-up.

When there is a group mention inside a chat thread, the next problems are happening.

1. When trying to look at _My Threads_ the list of threads is failing to load and there are errors on the console:

<img width="300" alt="Screenshot 2024-01-18 at 17 08 19" src="https://github.com/discourse/discourse/assets/1274517/50071a57-6fd4-47bf-934a-ff5c477b7ea1">

<img width="500" alt="Screenshot 2024-01-18 at 17 08 41" src="https://github.com/discourse/discourse/assets/1274517/cd7d0486-1479-4215-aed5-0c616746c220">

<details>
<summary>Server Error in the current_user_threads_controller</summary>

Message
ActiveRecord::AssociationNotFoundError (Association named 'user' was not found on Chat::GroupMention; perhaps you misspelled it?)
app/controllers/application_controller.rb:423:in `block in with_resolved_locale'
app/controllers/application_controller.rb:423:in `with_resolved_locale'
lib/middleware/omniauth_bypass_middleware.rb:64:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/gtm_script_nonce_injector.rb:10:in `call'
config/initializers/008-rack-cors.rb:14:in `call'
config/initializers/100-quiet_logger.rb:20:in `call'
config/initializers/100-silence_logger.rb:29:in `call'
lib/middleware/missing_avatars.rb:22:in `call'
lib/middleware/turbo_dev.rb:31:in `call'
Backtrace
activerecord (7.0.8) lib/active_record/associations.rb:302:in `association'
activerecord (7.0.8) lib/active_record/associations/preloader/branch.rb:79:in `block in grouped_records'
activerecord (7.0.8) lib/active_record/associations/preloader/branch.rb:77:in `each'
activerecord (7.0.8) lib/active_record/associations/preloader/branch.rb:77:in `grouped_records'
activerecord (7.0.8) lib/active_record/associations/preloader/branch.rb:114:in `loaders'
activerecord (7.0.8) lib/active_record/associations/preloader/branch.rb:71:in `runnable_loaders'
activerecord (7.0.8) lib/active_record/associations/preloader/batch.rb:15:in `each'
activerecord (7.0.8) lib/active_record/associations/preloader/batch.rb:15:in `flat_map'
activerecord (7.0.8) lib/active_record/associations/preloader/batch.rb:15:in `call'
activerecord (7.0.8) lib/active_record/associations/preloader.rb:118:in `call'
activerecord (7.0.8) lib/active_record/relation.rb:830:in `block in preload_associations'
activerecord (7.0.8) lib/active_record/relation.rb:829:in `each'
activerecord (7.0.8) lib/active_record/relation.rb:829:in `preload_associations'
activerecord (7.0.8) lib/active_record/relation.rb:918:in `block in exec_queries'
activerecord (7.0.8) lib/active_record/relation.rb:962:in `skip_query_cache_if_necessary'
activerecord (7.0.8) lib/active_record/relation.rb:908:in `exec_queries'
activerecord (7.0.8) lib/active_record/relation.rb:695:in `load'
activerecord (7.0.8) lib/active_record/relation.rb:250:in `records'
activerecord (7.0.8) lib/active_record/relation.rb:783:in `blank?'
plugins/chat/app/services/service/base.rb:143:in `call'
plugins/chat/app/services/service/base.rb:368:in `block in run!'
plugins/chat/app/services/service/base.rb:368:in `each'
plugins/chat/app/services/service/base.rb:368:in `run!'
plugins/chat/app/services/service/base.rb:361:in `run'
<internal:kernel>:90:in `tap'
plugins/chat/app/services/service/base.rb:229:in `call'
plugins/chat/app/helpers/chat/with_service_helper.rb:22:in `run_service'
plugins/chat/lib/service_runner.rb:121:in `call'
plugins/chat/lib/service_runner.rb:115:in `call'
plugins/chat/app/helpers/chat/with_service_helper.rb:18:in `with_service'
plugins/chat/app/controllers/chat/api/current_user_threads_controller.rb:5:in `index'
actionpack (7.0.8) lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
actionpack (7.0.8) lib/abstract_controller/base.rb:215:in `process_action'
actionpack (7.0.8) lib/action_controller/metal/rendering.rb:165:in `process_action'
actionpack (7.0.8) lib/abstract_controller/callbacks.rb:234:in `block in process_action'
activesupport (7.0.8) lib/active_support/callbacks.rb:118:in `block in run_callbacks'
app/controllers/application_controller.rb:423:in `block in with_resolved_locale'
i18n (1.14.1) lib/i18n.rb:322:in `with_locale'
app/controllers/application_controller.rb:423:in `with_resolved_locale'
activesupport (7.0.8) lib/active_support/callbacks.rb:127:in `block in run_callbacks'
activesupport (7.0.8) lib/active_support/callbacks.rb:138:in `run_callbacks'
actionpack (7.0.8) lib/abstract_controller/callbacks.rb:233:in `process_action'
actionpack (7.0.8) lib/action_controller/metal/rescue.rb:23:in `process_action'
actionpack (7.0.8) lib/action_controller/metal/instrumentation.rb:67:in `block in process_action'
activesupport (7.0.8) lib/active_support/notifications.rb:206:in `block in instrument'
activesupport (7.0.8) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
activesupport (7.0.8) lib/active_support/notifications.rb:206:in `instrument'
actionpack (7.0.8) lib/action_controller/metal/instrumentation.rb:66:in `process_action'
actionpack (7.0.8) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
activerecord (7.0.8) lib/active_record/railties/controller_runtime.rb:27:in `process_action'
actionpack (7.0.8) lib/abstract_controller/base.rb:151:in `process'
actionview (7.0.8) lib/action_view/rendering.rb:39:in `process'
rack-mini-profiler (3.3.0) lib/mini_profiler/profiling_methods.rb:115:in `block in profile_method' 
actionpack (7.0.8) lib/action_controller/metal.rb:188:in `dispatch'
actionpack (7.0.8) lib/action_controller/metal.rb:251:in `dispatch'
actionpack (7.0.8) lib/action_dispatch/routing/route_set.rb:49:in `dispatch'
actionpack (7.0.8) lib/action_dispatch/routing/route_set.rb:32:in `serve'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:50:in `block in serve'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:32:in `each'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:32:in `serve'
actionpack (7.0.8) lib/action_dispatch/routing/route_set.rb:852:in `call'
railties (7.0.8) lib/rails/engine.rb:530:in `call'
railties (7.0.8) lib/rails/railtie.rb:226:in `public_send'
railties (7.0.8) lib/rails/railtie.rb:226:in `method_missing'
actionpack (7.0.8) lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
actionpack (7.0.8) lib/action_dispatch/routing/mapper.rb:48:in `serve'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:50:in `block in serve'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:32:in `each'
actionpack (7.0.8) lib/action_dispatch/journey/router.rb:32:in `serve'
actionpack (7.0.8) lib/action_dispatch/routing/route_set.rb:852:in `call'
lib/middleware/omniauth_bypass_middleware.rb:64:in `call'
rack (2.2.8) lib/rack/tempfile_reaper.rb:15:in `call'
rack (2.2.8) lib/rack/conditional_get.rb:27:in `call'
rack (2.2.8) lib/rack/head.rb:12:in `call'
actionpack (7.0.8) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/gtm_script_nonce_injector.rb:10:in `call'
config/initializers/008-rack-cors.rb:14:in `call'
rack (2.2.8) lib/rack/session/abstract/id.rb:266:in `context'
rack (2.2.8) lib/rack/session/abstract/id.rb:260:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/cookies.rb:704:in `call'
activerecord (7.0.8) lib/active_record/migration.rb:638:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
activesupport (7.0.8) lib/active_support/callbacks.rb:99:in `run_callbacks'
actionpack (7.0.8) lib/action_dispatch/middleware/callbacks.rb:26:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/executor.rb:14:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/debug_exceptions.rb:28:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/show_exceptions.rb:29:in `call'
logster (2.14.0) lib/logster/middleware/reporter.rb:40:in `call'
railties (7.0.8) lib/rails/rack/logger.rb:40:in `call_app'
railties (7.0.8) lib/rails/rack/logger.rb:27:in `call'
config/initializers/100-quiet_logger.rb:20:in `call'
config/initializers/100-silence_logger.rb:29:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/request_id.rb:26:in `call'
rack (2.2.8) lib/rack/method_override.rb:24:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/executor.rb:14:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/static.rb:23:in `call'
rack (2.2.8) lib/rack/sendfile.rb:110:in `call'
actionpack (7.0.8) lib/action_dispatch/middleware/host_authorization.rb:138:in `call'
lib/middleware/missing_avatars.rb:22:in `call'
lib/middleware/turbo_dev.rb:31:in `call'
rack-mini-profiler (3.3.0) lib/mini_profiler.rb:334:in `call'
message_bus (4.3.8) lib/message_bus/rack/middleware.rb:60:in `call'
railties (7.0.8) lib/rails/engine.rb:530:in `call'
railties (7.0.8) lib/rails/railtie.rb:226:in `public_send'
railties (7.0.8) lib/rails/railtie.rb:226:in `method_missing'
rack (2.2.8) lib/rack/urlmap.rb:74:in `block in call'
rack (2.2.8) lib/rack/urlmap.rb:58:in `each'
rack (2.2.8) lib/rack/urlmap.rb:58:in `call'
unicorn (6.1.0) lib/unicorn/http_server.rb:634:in `process_client'
unicorn (6.1.0) lib/unicorn/http_server.rb:739:in `worker_loop'
unicorn (6.1.0) lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
unicorn (6.1.0) lib/unicorn/http_server.rb:143:in `start'
unicorn (6.1.0) bin/unicorn:128:in `<top (required)>'
bin/unicorn:93:in `load'
bin/unicorn:93:in `block in <main>'
bin/unicorn:92:in `fork'
bin/unicorn:92:in `<main>'

</details>

2. When looking at _channel threads_, threads are getting rendered succesfully, but still there are errors on the console. The server error is similar to the first case, but it's in the `channel_threads_controller`:

<img width="425" alt="Screenshot 2024-01-18 at 17 07 49" src="https://github.com/discourse/discourse/assets/1274517/d801789f-07c0-45f7-931e-bc284a4ada50">

This regression was introduced in 62f423da15edbbfbe4e37d218544a3e1ca427e6a.

The idea of the fix is that we only need to load user_mentions in those controllers anyway (we send them to the client in order to be able to show user status on mentions).





