### PR TITLE
FIX: Cache category order in database

### DIFF
--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -18,6 +18,10 @@ module Jobs
       # Feature topics in categories
       CategoryFeaturedTopic.feature_topics(batched: true)
 
+      # Categories are ordered by the bump date of featured topics (if not
+      # fixed)
+      Category.reorder_categories! if !SiteSetting.fixed_category_positions
+
       # Update the scores of posts
       args = { min_topic_age: 1.day.ago }
       args[:max_topic_length] = 500 unless self.class.should_update_long_topics?

--- a/db/migrate/20240118155540_add_index_on_categories_position.rb
+++ b/db/migrate/20240118155540_add_index_on_categories_position.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexOnCategoriesPosition < ActiveRecord::Migration[7.0]
+  def change
+    add_index :categories, :position
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1342,6 +1342,27 @@ RSpec.describe Category do
     end
   end
 
+  describe ".reorder_categories!" do
+    fab!(:category1) { Fabricate(:category) }
+    fab!(:category2) { Fabricate(:category) }
+    fab!(:category3) { Fabricate(:category, parent_category: category1) }
+    fab!(:category4) { Fabricate(:category, parent_category: category1) }
+    fab!(:category5) { Fabricate(:category, parent_category: category2) }
+
+    before { SiteSetting.fixed_category_positions = true }
+
+    it "reorders categories" do
+      Category.reorder_categories!
+
+      expect(Category.find(SiteSetting.uncategorized_category_id).position).to eq(1)
+      expect(category1.reload.position).to eq(2)
+      expect(category3.reload.position).to eq(3)
+      expect(category4.reload.position).to eq(4)
+      expect(category2.reload.position).to eq(5)
+      expect(category5.reload.position).to eq(6)
+    end
+  end
+
   describe "#deleting the general category" do
     fab!(:category)
 


### PR DESCRIPTION
Categories are ordered by admins setting `position` attribute of the category (if fixed_category_position is enabled) or by the bump date of featured topics.

Since featured topics are only updated once every 15 minutes, they can be saved in the database for efficiency, but also to simplify various category queries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
