### PR TITLE
A11Y: Show focus state in user PM topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/basic-topic-list.hbs
@@ -11,6 +11,7 @@
       @changeSort={{this.changeSort}}
       @order={{this.order}}
       @ascending={{this.ascending}}
+      @focusLastVisitedTopic={{this.focusLastVisitedTopic}}
     />
   {{else}}
     {{#unless this.loadingMore}}

--- a/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
@@ -53,6 +53,7 @@
       @changeSort={{this.changeSort}}
       @order={{this.order}}
       @ascending={{this.ascending}}
+      @focusLastVisitedTopic={{true}}
     />
 
     <TopicDismissButtons


### PR DESCRIPTION
When navigating in a PM topic list via keyboard by pressing Tab repeatedly, the selected PM's row did not have a visible focus state. 

Before (focus is on "Bulk user invite processed with errors", but can't see it): 
<img width="1092" alt="image" src="https://github.com/discourse/discourse/assets/368961/075c6caf-ec99-4788-8614-111884b7bf25">


After: 
<img width="1100" alt="image" src="https://github.com/discourse/discourse/assets/368961/f32f1fd8-f51e-4c39-887e-a4a144bf79de">

This fix doesn't affect navigating using J/K (that already works). 
