### PR TITLE
DEV: add tag arg to after-create-topic-button outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -91,6 +91,7 @@
       createTopicDisabled=this.createTopicDisabled
       createTopicLabel=this.createTopicLabel
       category=this.category
+      tag=this.tag
     }}
   />
 


### PR DESCRIPTION
Need this to get a couple customers off of deprecated theme methods 