### PR TITLE
FIX: clear db_backup_port default value

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -35,7 +35,7 @@ db_backup_host =
 db_port =
 
 # db server port to use when taking a backup via `pg_dump`
-db_backup_port = 5432
+db_backup_port =
 
 # database name running discourse
 db_name = discourse


### PR DESCRIPTION
The presence of this value with the postgresql default keeps tripping up
people. We shouldn't set this here.

examples:
* https://meta.discourse.org/t/84439/2
* https://meta.discourse.org/t/100604/7
* https://meta.discourse.org/t/223144/6
* https://meta.discourse.org/t/291992/10

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
