### PR TITLE
DEV: Add notification href to appEvents args triggered on notification click

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
@@ -82,7 +82,10 @@ export default class UserMenuNotificationItem extends UserMenuBaseItem {
 
   onClick() {
     this.renderDirector.onClick?.();
-    this.appEvents.trigger("user-menu:notification-click", this.notification);
+    this.appEvents.trigger("user-menu:notification-click", {
+      notification: this.notification,
+      href: this.linkHref,
+    });
 
     if (!this.notification.read) {
       this.notification.set("read", true);


### PR DESCRIPTION
The notification itself does not contain contain the path to that the user will be directed to on click, and we want this info in a plugin. Passing an object with the href as key/value pair here.