### PR TITLE
FEATURE: Add hot as a homepage option

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -44,6 +44,10 @@ export default Controller.extend({
     this._super(...arguments);
 
     this.set("selectedDarkColorSchemeId", this.session.userDarkSchemeId);
+
+    if (this.siteSettings.experimental_hot_topics) {
+      USER_HOMES[8] = "hot";
+    }
   },
 
   @discourseComputed("makeThemeDefault")

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -185,6 +185,12 @@ class UserOption < ActiveRecord::Base
       "bookmarks"
     when 7
       "unseen"
+    when 8
+      if SiteSetting.experimental_hot_topics
+        "hot"
+      else
+        SiteSetting.homepage
+      end
     else
       SiteSetting.homepage
     end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2956,6 +2956,7 @@ en:
         bookmarks: "You have no bookmarked topics yet."
         category: "There are no %{category} topics."
         top: "There are no top topics."
+        hot: "There are no hot topics."
         filter: "There are no topics."
         educate:
           new: '<p>Your new topics will appear here. By default, topics are considered new and will show a <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;"></span> indicator if they were created in the last 2 days.</p><p>Visit your <a href="%{userPrefsUrl}">preferences</a> to change this.</p>'

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -189,6 +189,7 @@ basic:
       - read
       - posted
       - bookmarks
+      - hot
   post_menu:
     client: true
     type: list
@@ -3114,6 +3115,7 @@ dashboard:
   experimental_hot_topics:
     hidden: true
     default: false
+    client: true
   hot_topics_gravity:
     hidden: true
     default: 1.2


### PR DESCRIPTION
This will allow 'hot' to be selected as a user's homepage.

See: https://github.com/discourse/discourse/pull/25274
