### PR TITLE
FIX: Account for moderators in group to TL mapping

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3029,6 +3029,7 @@ tags:
     client: true
   min_trust_to_create_tag:
     default: "3"
+    type: enum
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   create_tag_allowed_groups:

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -77,13 +77,16 @@ module SiteSettings::DeprecatedSettings
 
     if tl_and_staff
       valid_auto_groups_excluding_staff_and_admins =
-        valid_auto_groups - [Group::AUTO_GROUPS[:staff], Group::AUTO_GROUPS[:admins]]
+        valid_auto_groups -
+          [Group::AUTO_GROUPS[:staff], Group::AUTO_GROUPS[:admins], Group::AUTO_GROUPS[:moderators]]
 
       if valid_auto_groups_excluding_staff_and_admins.any?
         return valid_auto_groups_excluding_staff_and_admins.min - Group::AUTO_GROUPS[:trust_level_0]
       end
 
-      if valid_auto_groups.include?(Group::AUTO_GROUPS[:staff])
+      if valid_auto_groups.include?(Group::AUTO_GROUPS[:moderators])
+        "moderator"
+      elsif valid_auto_groups.include?(Group::AUTO_GROUPS[:staff])
         "staff"
       elsif valid_auto_groups.include?(Group::AUTO_GROUPS[:admins])
         "admin"

--- a/spec/lib/site_settings/deprecated_settings_spec.rb
+++ b/spec/lib/site_settings/deprecated_settings_spec.rb
@@ -152,6 +152,11 @@ RSpec.xdescribe SiteSettings::DeprecatedSettings do
         )
       end
 
+      it "returns moderator if there is only the moderators auto group in the new group setting" do
+        SiteSetting.invite_allowed_groups = "#{Group::AUTO_GROUPS[:moderators]}"
+        expect(SiteSetting.min_trust_level_to_allow_invite_tl_and_staff).to eq("moderator")
+      end
+
       it "returns staff if there are staff and admin auto groups in the new group setting" do
         SiteSetting.invite_allowed_groups =
           "#{Group::AUTO_GROUPS[:admins]}|#{Group::AUTO_GROUPS[:staff]}"


### PR DESCRIPTION
### What was happening?

If configuring only `moderators` in a group based access setting, the mapping to the old setting wouldn't work correctly, because the case was unaccounted for.

### How does this fix it?

Account for moderators group when doing the mapping.