### PR TITLE
UX: `user.account_possessive` was impossible to translate

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -176,9 +176,9 @@ createWidget(
               "aria-haspopup": true,
               "aria-expanded": attrs.active,
               href: attrs.user.path,
-              "aria-label":
-                (attrs.user.name || attrs.user.username) +
-                I18n.t("user.account_possessive"),
+              "aria-label": I18n.t("user.account_possessive", {
+                name: attrs.user.name || attrs.user.username,
+              }),
               "data-auto-route": true,
             },
           },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1095,7 +1095,7 @@ en:
       said: "%{username}:"
       profile: "Profile"
       profile_possessive: "%{username}'s profile"
-      account_possessive: "'s account"
+      account_possessive: "%{name}'s account"
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive:


### PR DESCRIPTION
There were numerous complaints about that string on Crowdin.