### PR TITLE
FIX: Preload sidebar categories when lazy loading categories

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -106,15 +106,26 @@ class Site
   end
 
   def categories
+    if @guardian.can_lazy_load_categories?
+      preloaded_category_ids = []
+      if @guardian.authenticated?
+        preloaded_category_ids.concat(@guardian.user.secured_sidebar_category_ids(@guardian))
+      end
+    end
+
     @categories ||=
       begin
         categories = []
 
         self.class.all_categories_cache.each do |category|
-          if @guardian.can_see_serialized_category?(
-               category_id: category[:id],
-               read_restricted: category[:read_restricted],
-             )
+          if (
+               !@guardian.can_lazy_load_categories? ||
+                 preloaded_category_ids.include?(category[:id])
+             ) &&
+               @guardian.can_see_serialized_category?(
+                 category_id: category[:id],
+                 read_restricted: category[:read_restricted],
+               )
             categories << category
           end
         end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -240,7 +240,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def include_categories?
-    !scope.can_lazy_load_categories?
+    object.categories.present?
   end
 
   def markdown_additional_options

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -131,12 +131,24 @@ RSpec.describe SiteSerializer do
     expect(serialized[:shared_drafts_category_id]).to eq(nil)
   end
 
-  it "does not include categories if lazy_load_categories" do
-    SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
+  context "with lazy loaded categories enabled" do
+    before { SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}" }
 
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    it "categories does not include any categories for anonymous users" do
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
 
-    expect(serialized[:categories]).to eq(nil)
+      expect(serialized[:categories]).to eq(nil)
+    end
+
+    it "categories include only sidebar categories" do
+      user = Fabricate(:user)
+      guardian = Guardian.new(user)
+      Fabricate(:category_sidebar_section_link, linkable: category, user: user)
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+
+      expect(serialized[:categories].map { |c| c[:id] }).to contain_exactly(category.id)
+    end
   end
 
   describe "#anonymous_default_navigation_menu_tags" do


### PR DESCRIPTION
This fixes a bug where the sidebar categories would not be loaded when the categories were lazy loaded because the sidebar uses the preloaded category list, which was empty.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
