### PR TITLE
FIX: fixed a bug where keyboard on ios was broken

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -175,6 +175,7 @@ export default class ChatChannel extends Component {
   onPresenceChangeCallback(present) {
     if (present) {
       this.debouncedUpdateLastReadMessage();
+      bodyScrollFix({ delayed: true });
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-ios-hacks.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-ios-hacks.js
@@ -34,7 +34,7 @@ export function stackingContextFix(scrollable, callback) {
   }
 }
 
-export function bodyScrollFix() {
+export function bodyScrollFix(options = {}) {
   // when keyboard is visible this will ensure body
   // doesn’t scroll out of viewport
   if (
@@ -42,6 +42,12 @@ export function bodyScrollFix() {
     document.documentElement.classList.contains("keyboard-visible") &&
     !isZoomed()
   ) {
-    document.documentElement.scrollTo(0, 0);
+    if (options.delayed) {
+      setTimeout(() => {
+        document.documentElement.scrollTo(0, 0);
+      }, 200);
+    } else {
+      document.documentElement.scrollTo(0, 0);
+    }
   }
 }


### PR DESCRIPTION
It was broken on PWA, when you had the keyboard open and would leave the app. When you came back the body was scrolled and it was looking buggy until you close/reopen keyboard.

This commit attempt to reposition the page correctly 200ms after the tab is visible again.