### PR TITLE
FIX: correctly exclude muted channels from thread unreads

### DIFF
--- a/plugins/chat/app/queries/chat/thread_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/thread_unreads_query.rb
@@ -44,6 +44,7 @@ module Chat
           INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
           INNER JOIN chat_threads ON chat_threads.id = chat_messages.thread_id AND chat_threads.channel_id = chat_messages.chat_channel_id
           INNER JOIN user_chat_thread_memberships ON user_chat_thread_memberships.thread_id = chat_threads.id
+          INNER JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_messages.chat_channel_id
           INNER JOIN chat_messages AS original_message ON original_message.id = chat_threads.original_message_id
           AND chat_messages.thread_id = memberships.thread_id
           AND chat_messages.user_id != :user_id
@@ -55,6 +56,7 @@ module Chat
           AND chat_channels.threading_enabled
           AND user_chat_thread_memberships.notification_level NOT IN (:quiet_notification_levels)
           AND original_message.deleted_at IS NULL
+          AND user_chat_channel_memberships.muted = false
         ) AS unread_count,
         0 AS mention_count,
         chat_threads.channel_id,

--- a/plugins/chat/app/queries/chat/thread_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/thread_unreads_query.rb
@@ -57,6 +57,7 @@ module Chat
           AND user_chat_thread_memberships.notification_level NOT IN (:quiet_notification_levels)
           AND original_message.deleted_at IS NULL
           AND user_chat_channel_memberships.muted = false
+          AND user_chat_channel_memberships.user_id = :user_id
         ) AS unread_count,
         0 AS mention_count,
         chat_threads.channel_id,

--- a/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
@@ -64,6 +64,14 @@ describe Chat::ThreadUnreadsQuery do
         )
       end
 
+      it "does not count messages in muted channels" do
+        channel_1.membership_for(current_user).update!(muted: true)
+
+        expect(query.map(&:to_h).find { |tracking| tracking[:thread_id] == thread_1.id }).to eq(
+          { channel_id: channel_1.id, mention_count: 0, thread_id: thread_1.id, unread_count: 0 },
+        )
+      end
+
       it "does not messages in threads where threading_enabled is false on the channel" do
         channel_1.update!(threading_enabled: false)
         expect(query.map(&:to_h).find { |tracking| tracking[:thread_id] == thread_1.id }).to eq(

--- a/plugins/chat/spec/queries/chat/tracking_state_report_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/tracking_state_report_query_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Chat::TrackingStateReportQuery do
     fab!(:channel_2) { Fabricate(:category_channel) }
     let(:channel_ids) { [channel_1.id, channel_2.id] }
 
+    before do
+      channel_1.add(current_user)
+      channel_2.add(current_user)
+    end
+
     it "calls the channel unreads query with the corect params" do
       Chat::ChannelUnreadsQuery
         .expects(:call)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
