### PR TITLE
PERF: Better query performance for user avatar consistency check

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -178,10 +178,14 @@ class UserAvatar < ActiveRecord::Base
 
     ids =
       DB.query_single(<<~SQL, sizes: Discourse.avatar_sizes, limit: max_optimized_avatars_to_remove)
-      SELECT oi.id FROM user_avatars a
+      SELECT oi.id FROM (
+        SELECT custom_upload_id FROM user_avatars
+        EXCEPT
+        SELECT upload_id FROM  upload_references WHERE target_type <> 'UserAvatar'
+        AND upload_id IS NOT NULL
+      ) AS a
       JOIN optimized_images oi ON oi.upload_id = a.custom_upload_id
-      LEFT JOIN upload_references ur ON ur.upload_id = a.custom_upload_id and ur.target_type <> 'UserAvatar'
-      WHERE oi.width not in (:sizes) AND oi.height not in (:sizes) AND ur.upload_id IS NULL
+      WHERE oi.width not in (:sizes) AND oi.height not in (:sizes)
       LIMIT :limit
     SQL
 


### PR DESCRIPTION
This is all @xfalcox's work. On a large DB, this query was stalling, with this refactor, it runs in 3s. (There's an existing test to cover this use case as well.) 