### PR TITLE
FIX: correctly save scroll position in channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -497,7 +497,7 @@ export default class ChatChannel extends Component {
 
     if (state.atBottom) {
       this.fetchMoreMessages({ direction: FUTURE });
-      this.chatChannelScrollPositions.remove(this.args.channel.id);
+      this.chatChannelScrollPositions.delete(this.args.channel.id);
     } else {
       this.chatChannelScrollPositions.set(
         this.args.channel.id,

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-scroll-positions.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-scroll-positions.js
@@ -5,13 +5,17 @@ import { TrackedMap } from "@ember-compat/tracked-built-ins";
 export default class ChatChannelScrollPositions extends Service {
   @tracked positions = new TrackedMap();
 
-  add(channelId, position) {
-    this.positions.set(channelId, position);
+  get(id) {
+    return this.positions.get(id);
   }
 
-  remove(channelId) {
-    if (this.positions.has(channelId)) {
-      this.positions.delete(channelId);
+  set(id, position) {
+    this.positions.set(id, position);
+  }
+
+  delete(id) {
+    if (this.positions.has(id)) {
+      this.positions.delete(id);
     }
   }
 }

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -375,7 +375,12 @@ RSpec.describe "Chat channel", type: :system do
       sidebar_page.open_channel(channel_2)
       sidebar_page.open_channel(channel_1)
 
-      expect(channel_page.messages).to have_message(id: channel_1.chat_messages[2].id)
+      # we navigated to message at index 2, but the message at the bottom of the page was at index 10
+      # so we expect to load from this message
+      expect(channel_page.messages).to have_message(
+        id: channel_1.chat_messages[10].id,
+        highlighted: true,
+      )
     end
   end
 end

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -375,12 +375,7 @@ RSpec.describe "Chat channel", type: :system do
       sidebar_page.open_channel(channel_2)
       sidebar_page.open_channel(channel_1)
 
-      # we navigated to message at index 2, but the message at the bottom of the page was at index 10
-      # so we expect to load from this message
-      expect(channel_page.messages).to have_message(
-        id: channel_1.chat_messages[10].id,
-        highlighted: true,
-      )
+      expect(channel_page.messages).to have_no_message(id: channel_1.chat_messages[49].id)
     end
   end
 end

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -376,6 +376,12 @@ RSpec.describe "Chat channel", type: :system do
       sidebar_page.open_channel(channel_1)
 
       expect(channel_page.messages).to have_no_message(id: channel_1.chat_messages[49].id)
+
+      find(".chat-scroll-to-bottom__button.visible").click
+      sidebar_page.open_channel(channel_2)
+      sidebar_page.open_channel(channel_1)
+
+      expect(channel_page.messages).to have_message(id: channel_1.chat_messages[49].id)
     end
   end
 end


### PR DESCRIPTION
Due to an incorrect test the previous service was incorrectly implementing the map, and was most importantly not deleting the state when reaching bottom.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
