### PR TITLE
FIX: Ignore invalid images when shrinking uploads

### DIFF
--- a/lib/shrink_uploaded_image.rb
+++ b/lib/shrink_uploaded_image.rb
@@ -40,7 +40,11 @@ class ShrinkUploadedImage
       return false
     end
 
-    w, h = FastImage.size(path, timeout: 15, raise_on_failure: true)
+    begin
+      w, h = FastImage.size(path, timeout: 15, raise_on_failure: true)
+    rescue FastImage::SizeNotFound
+      return false
+    end
 
     if !w || !h
       log "Invalid image dimensions after resizing"

--- a/spec/lib/shrink_uploaded_image_spec.rb
+++ b/spec/lib/shrink_uploaded_image_spec.rb
@@ -110,6 +110,21 @@ RSpec.describe ShrinkUploadedImage do
 
       expect(result).to be(false)
     end
+
+    it "returns false if the image is invalid" do
+      post = Fabricate(:post, raw: "<img src='#{upload.url}'>")
+      post.link_post_uploads
+      FastImage.stubs(:size).raises(FastImage::SizeNotFound.new)
+
+      result =
+        ShrinkUploadedImage.new(
+          upload: upload,
+          path: Discourse.store.path_for(upload),
+          max_pixels: 10_000,
+        ).perform
+
+      expect(result).to be(false)
+    end
   end
 
   context "when S3 uploads are enabled" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
