### PR TITLE
FEATURE: add option to sort topic query result via plugin.

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-views/topic-list-header-column.js
+++ b/app/assets/javascripts/discourse/app/raw-views/topic-list-header-column.js
@@ -18,13 +18,18 @@ export default EmberObject.extend({
 
   @discourseComputed
   sortIcon() {
-    const asc = this.parent.ascending ? "up" : "down";
+    const isAscending = this.parent.ascending || this.parent.context?.ascending;
+    const asc = isAscending ? "up" : "down";
     return `chevron-${asc}`;
   },
 
   @discourseComputed
   isSorting() {
-    return this.sortable && this.parent.order === this.order;
+    return (
+      this.sortable &&
+      (this.parent.order === this.order ||
+        this.parent.context?.order === this.order)
+    );
   },
 
   @discourseComputed

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -83,7 +83,7 @@ class TopicQuery
   end
 
   # Maps `order` to a columns in `topics`
-  SORTABLE_MAPPING = {
+  DEFAULT_SORTABLE_MAPPING = {
     "likes" => "like_count",
     "op_likes" => "op_likes",
     "views" => "views",
@@ -668,14 +668,15 @@ class TopicQuery
       begin
         DiscoursePluginRegistry.apply_modifier(
           :topic_query_sortable_mapping,
-          SORTABLE_MAPPING.dup,
+          DEFAULT_SORTABLE_MAPPING.dup,
           self,
         )
       end
   end
 
   def apply_ordering(result, options = {})
-    sort_column = sortable_mapping[options[:order]] || "default"
+    order_option = options[:order]
+    sort_column = sortable_mapping[order_option] || "default"
     sort_dir = (options[:ascending] == "true") ? "ASC" : "DESC"
 
     # If we are sorting in the default order desc, we should consider including pinned
@@ -714,7 +715,8 @@ class TopicQuery
       )
     end
 
-    if options[:order].present? && SORTABLE_MAPPING[options[:order]].blank?
+    if order_option.present? && DEFAULT_SORTABLE_MAPPING[order_option].blank? &&
+         sortable_mapping[order_option].present?
       return(
         DiscoursePluginRegistry.apply_modifier(
           :topic_query_apply_ordering_result,

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -665,13 +665,11 @@ class TopicQuery
 
   def sortable_mapping
     @sortable_mapping ||=
-      begin
-        DiscoursePluginRegistry.apply_modifier(
-          :topic_query_sortable_mapping,
-          DEFAULT_SORTABLE_MAPPING.dup,
-          self,
-        )
-      end
+      DiscoursePluginRegistry.apply_modifier(
+        :topic_query_sortable_mapping,
+        DEFAULT_SORTABLE_MAPPING.dup,
+        self,
+      )
   end
 
   def apply_ordering(result, options = {})

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -964,7 +964,7 @@ RSpec.describe TopicQuery do
 
           # adds the custom field as a viable sort option
           class ::TopicQuery
-            SORTABLE_MAPPING["sheep"] = "custom_fields.sheep"
+            DEFAULT_SORTABLE_MAPPING["sheep"] = "custom_fields.sheep"
           end
           # returns the topics in the sheep order if requested" do
           expect(ids_in_order("sheep")).to eq(

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2111,7 +2111,7 @@ RSpec.describe TopicQuery do
 
       topics = TopicQuery.new(nil, order: "spam", ascending: "false").list_latest.topics
       expect(topics.map(&:id)).to eq([topic3.id, topic1.id, topic2.id])
-
+   ensure
       DiscoursePluginRegistry.unregister_modifier(
         plugin_instance,
         :topic_query_apply_ordering_result,

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2111,7 +2111,7 @@ RSpec.describe TopicQuery do
 
       topics = TopicQuery.new(nil, order: "spam", ascending: "false").list_latest.topics
       expect(topics.map(&:id)).to eq([topic3.id, topic1.id, topic2.id])
-   ensure
+    ensure
       DiscoursePluginRegistry.unregister_modifier(
         plugin_instance,
         :topic_query_apply_ordering_result,


### PR DESCRIPTION
Previously, it was not possible to modify the sorting order of the `TopicQuery` result from a plugin. This feature adds support to both specifying the available `sortable_mapping` values and applying custom sorting functionality in a plugin. We're using the `apply_modifier` method in the `DiscoursePluginRegistry` module to achieve the both.