### PR TITLE
DEV: Update shoulda-matchers to 6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ group :test, :development do
 
   gem "rspec-rails"
 
-  gem "shoulda-matchers", require: false, github: "thoughtbot/shoulda-matchers"
+  gem "shoulda-matchers", require: false
   gem "rspec-html-matchers"
   gem "byebug", require: ENV["RM_INFO"].nil?, platform: :mri
   gem "rubocop-discourse", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
 
-GIT
-  remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: 367500d9fc3c76aef7add29f48459236928af96e
-  specs:
-    shoulda-matchers (6.0.0)
-      activesupport (>= 5.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -461,6 +454,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.1.0)
+      activesupport (>= 5.2.0)
     sidekiq (6.5.12)
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
@@ -652,7 +647,7 @@ DEPENDENCIES
   sassc-embedded
   selenium-devtools
   selenium-webdriver (~> 4.14)
-  shoulda-matchers!
+  shoulda-matchers
   sidekiq
   simplecov
   sprockets!


### PR DESCRIPTION
No need to stay on the git version anymore

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
