### PR TITLE
FIX: search escape handler should be on keydown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.hbs
@@ -6,6 +6,7 @@
   placeholder={{i18n "search.title"}}
   aria-label={{i18n "search.title"}}
   {{on "keyup" this.onKeyup}}
+  {{on "keydown" this.onKeydown}}
   {{on "input" this.updateSearchTerm}}
   {{on "focus" @openSearchMenu}}
   {{did-insert this.focus}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.js
@@ -50,6 +50,14 @@ export default class SearchTerm extends Component {
   }
 
   @action
+  onKeydown(e) {
+    if (e.key === "Escape") {
+      this.args.closeSearchMenu();
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+
   onKeyup(e) {
     if (
       onKeyUpCallbacks.length &&
@@ -57,12 +65,6 @@ export default class SearchTerm extends Component {
     ) {
       // Return early if any callbacks return false
       return;
-    }
-
-    if (e.key === "Escape") {
-      this.args.closeSearchMenu();
-      e.preventDefault();
-      return false;
     }
 
     this.args.openSearchMenu();

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.js
@@ -58,6 +58,7 @@ export default class SearchTerm extends Component {
     }
   }
 
+  @action
   onKeyup(e) {
     if (
       onKeyUpCallbacks.length &&

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-search-test.js
@@ -600,7 +600,7 @@ acceptance("Search - Glimmer - Authenticated", function (needs) {
       "arrow down sets focus to more results link"
     );
 
-    await triggerKeyEvent("#search-term", "keyup", "Escape");
+    await triggerKeyEvent("#search-term", "keydown", "Escape");
     assert.strictEqual(
       document.activeElement,
       query("#search-button"),

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
@@ -43,7 +43,7 @@ module("Integration | Component | search-menu", function (hooks) {
       "search result is a list of topics"
     );
 
-    await triggerKeyEvent("#search-term", "keyup", "Escape");
+    await triggerKeyEvent("#search-term", "keydown", "Escape");
 
     assert.notOk(exists(".menu-panel"), "Menu panel is gone");
 


### PR DESCRIPTION
The keydown event fires as soon as the key is pressed down. This is often preferred for actions that need to occur immediately, like stopping a process, closing a modal window, or canceling an ongoing operation. The immediacy of keydown makes it more responsive, as the user doesn't have to fully press and release the key.

Moreover, it allows us to not close chat on escape when the search menu is open.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
