### PR TITLE
FIX: User-tips regression in #25361

### DIFF
--- a/app/assets/javascripts/discourse/app/services/user-tips.js
+++ b/app/assets/javascripts/discourse/app/services/user-tips.js
@@ -13,11 +13,12 @@ export default class UserTips extends Service {
   #shouldRenderSet = new TrackedSet();
 
   #updateRenderedId() {
-    if (this.#availableTips.has(this.#renderedId)) {
+    const tipsArray = [...this.#availableTips];
+    if (tipsArray.find((tip) => tip.id === this.#renderedId)) {
       return;
     }
 
-    const newId = [...this.#availableTips]
+    const newId = tipsArray
       .sortBy("priority")
       .reverse()
       .find((tip) => {


### PR DESCRIPTION
It's a set of Tip objects, not ids

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
