### PR TITLE
FIX: Radar chart not widely available.

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -102,7 +102,7 @@ class Report
     @average = false
     @percent = false
     @higher_is_better = true
-    @modes = %i[table chart radar]
+    @modes = %i[table chart]
     @prev_data = nil
     @dates_filtering = true
     @available_filters = {}


### PR DESCRIPTION
We added support for radar type charts in #24274. However, radar charts work with three variables, meaning we can't display any report that way.

Unfortunately, by adding `:radar` to the `Report#modes` variable, I made them widely available.

Related bug report: https://meta.discourse.org/t/report-radar-graph-uncaught-typeerror/292360

