### PR TITLE
DEV: Implement text() for SidebarChatMyThreadsSection

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -88,6 +88,10 @@ export default {
             get links() {
               return [new SidebarChatMyThreadsSectionLink()];
             }
+
+            get text() {
+              return null;
+            }
           };
 
           return SidebarChatMyThreadsSection;


### PR DESCRIPTION
In normal use, this `text()` getter is never called. However, when running with the Ember inspector, it is eagerly evaluated and hits throws the "not implemented" error in the base class.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
