### PR TITLE
FEATURE: Add support for custom site name in Open Graph metadata

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -301,7 +301,7 @@ module ApplicationHelper
     ) if opts[:twitter_summary_large_image].present?
 
     result = []
-    result << tag(:meta, property: "og:site_name", content: SiteSetting.title)
+    result << tag(:meta, property: "og:site_name", content: opts[:site_name] || SiteSetting.title)
     result << tag(:meta, property: "og:type", content: "website")
 
     generate_twitter_card_metadata(result, opts)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -687,6 +687,27 @@ RSpec.describe ApplicationHelper do
         expect(metadata).to include output_tags
       end
     end
+
+    context "with custom site name" do
+      before { SiteSetting.title = "Default Site Title" }
+
+      it "uses the provided site name in og:site_name" do
+        custom_site_name = "Custom Site Name"
+        result = helper.crawlable_meta_data(site_name: custom_site_name)
+
+        expect(result).to include(
+          "<meta property=\"og:site_name\" content=\"#{custom_site_name}\" />",
+        )
+      end
+
+      it "falls back to the default site title if no custom site name is provided" do
+        result = helper.crawlable_meta_data
+
+        expect(result).to include(
+          "<meta property=\"og:site_name\" content=\"#{SiteSetting.title}\" />",
+        )
+      end
+    end
   end
 
   describe "discourse_color_scheme_stylesheets" do


### PR DESCRIPTION
Allows passing a custom site name to override the default Open Graph meta data.

``` ruby
# custom_view.html.erb
<% content_for :title do %><%= @full_title %><% end %>

<% content_for :head do %>
  <%= raw crawlable_meta_data(title: @title, description: @description_meta, site_name: @site_name) %>
<% end %>
```

It will default to `SiteSettings.title` if `site_name` is not provided.