### PR TITLE
FIX: Allow sanitized-HTML in GH issues and categories oneboxes.

### DIFF
--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -40,7 +40,10 @@ module Onebox
         body, excerpt = compute_body(raw["body"])
         ulink = URI(link)
 
-        labels = raw["labels"].map { |l| { name: Emoji.codes_to_img(CGI.escapeHTML(l["name"])) } }
+        labels =
+          raw["labels"].map do |l|
+            { name: Emoji.codes_to_img(Onebox::Helpers.sanitize(l["name"])) }
+          end
 
         {
           link: @url,

--- a/lib/onebox/templates/discourse_category_onebox.mustache
+++ b/lib/onebox/templates/discourse_category_onebox.mustache
@@ -12,7 +12,7 @@
     {{#description}}
       <div>
         <span class="description">
-          <p>{{description}}</p>
+          <p>{{{description}}}</p>
         </span>
       </div>
     {{/description}}

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -486,7 +486,7 @@ module Oneboxer
         name: category.name,
         color: category.color,
         logo_url: category.uploaded_logo&.url,
-        description: category.description,
+        description: Onebox::Helpers.sanitize(category.description),
         has_subcategories: category.subcategories.present?,
         subcategories:
           category.subcategories.collect { |sc| { name: sc.name, color: sc.color, url: sc.url } },

--- a/spec/lib/onebox/engine/github_issue_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_issue_onebox_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Onebox::Engine::GithubIssueOnebox do
   describe "#to_html" do
     it "sanitizes the input and transform the emoji into an img tag" do
       sanitized_label =
-        'Test <img src="/images/emoji/twitter/+1.png?v=12" title="+1" class="emoji" alt="+1" loading="lazy" width="20" height="20"> &lt;style&gt;body {display: none}&lt;/style&gt;'
+        'Test <img src="/images/emoji/twitter/+1.png?v=12" title="+1" class="emoji" alt="+1" loading="lazy" width="20" height="20">'
 
       expect(html).to include(sanitized_label)
     end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/d78357917c6a917a8a27af68756228e89c69321c

Related meta topic: https://meta.discourse.org/t/html-is-not-render-on-category-onebox-description/289424:

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
