### PR TITLE
FIX: Run admin sidebar init after an earlier initializer

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/admin-sidebar.js
@@ -240,6 +240,10 @@ function pluginAdminRouteLinks() {
 export default {
   name: "admin-sidebar-initializer",
 
+  // Necessary for plugins (e.g. docker_manager) to be able to add links to the admin sidebar
+  // and still work with older Discourse versions.
+  after: "logs-notice",
+
   initialize(owner) {
     this.currentUser = owner.lookup("service:current-user");
     this.siteSettings = owner.lookup("service:site-settings");


### PR DESCRIPTION
This gives us a stable "marker" for plugins (like docker_manager)
to use when running their initializers. Previously, I had to revert
my change to docker_manager because it did `before: "admin-sidebar-initializer"`,
but this broke older versions of Discourse when they tried to upgrade
to the latest because that initializer did not exist yet.

Using an initializer like `logs-notice` which has been around for years
now is a better strategy. Then, the plugin can just do `before: "logs-notice"`
to register its admin link.
