### PR TITLE
DEV: remove user thread count route

### DIFF
--- a/plugins/chat/app/controllers/chat/api/current_user_threads_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/current_user_threads_controller.rb
@@ -21,11 +21,4 @@ class Chat::Api::CurrentUserThreadsController < Chat::ApiController
       on_model_not_found(:threads) { render json: success_json.merge(threads: []) }
     end
   end
-
-  def thread_count
-    with_service(::Chat::LookupUserThreads) do
-      on_success { render json: success_json.merge(thread_count: result.threads.size) }
-      on_model_not_found(:threads) { render json: success_json.merge(thread_count: 0) }
-    end
-  end
 end

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -322,13 +322,6 @@ export default class ChatApi extends Service {
   }
 
   /**
-   * Get the total number of threads for the current user.
-   */
-  userThreadCount() {
-    return this.#getRequest("/me/threads/count");
-  }
-
-  /**
    * Update notifications settings of current user for a channel.
    * @param {number} channelId - The ID of the channel.
    * @param {object} data - The settings to modify.

--- a/plugins/chat/config/routes.rb
+++ b/plugins/chat/config/routes.rb
@@ -6,7 +6,6 @@ Chat::Engine.routes.draw do
     get "/channels" => "channels#index"
     get "/me/channels" => "current_user_channels#index"
     get "/me/threads" => "current_user_threads#index"
-    get "/me/threads/count" => "current_user_threads#thread_count"
     post "/channels" => "channels#create"
     put "/channels/read/" => "reads#update_all"
     put "/channels/:channel_id/read/:message_id" => "reads#update"

--- a/plugins/chat/spec/requests/chat/api/current_user_threads_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/current_user_threads_spec.rb
@@ -29,24 +29,4 @@ describe Chat::Api::CurrentUserThreadsController do
       end
     end
   end
-
-  describe "#thread_count" do
-    describe "success" do
-      it "works" do
-        get "/chat/api/me/threads/count"
-
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["thread_count"]).to eq(0)
-      end
-    end
-
-    context "when threads are not found" do
-      it "returns a 200 when there are no threads" do
-        get "/chat/api/me/threads/count"
-
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["thread_count"]).to eq(0)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Removes a now redundant route for the user thread count.