### PR TITLE
DEV: fix typo in `addSidebarSection` API example

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -2432,7 +2432,7 @@ class PluginApi {
    *           get text() {
    *             return "dev channel";
    *           }
-   *           get prefixValue() {
+   *           get prefixType() {
    *             return "icon";
    *           }
    *           get prefixValue() {


### PR DESCRIPTION
`prefixValue` was repeated, the first should be `prefixType`