### PR TITLE
DEV: Add delegated Group#human_users scope

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -24,6 +24,7 @@ class Group < ActiveRecord::Base
 
   has_many :categories, through: :category_groups
   has_many :users, through: :group_users
+  has_many :human_users, -> { human_users }, through: :group_users, source: :user
   has_many :requesters, through: :group_requests, source: :user
   has_many :group_histories, dependent: :destroy
   has_many :category_reviews,
@@ -939,7 +940,9 @@ class Group < ActiveRecord::Base
       SET user_count =
         (SELECT COUNT(gu.user_id)
          FROM group_users gu
-         WHERE gu.group_id = g.id)
+         JOIN users u ON u.id = gu.user_id
+         WHERE gu.group_id = g.id
+         AND u.id > 0)
       WHERE g.id = #{self.id};
     SQL
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -940,9 +940,7 @@ class Group < ActiveRecord::Base
       SET user_count =
         (SELECT COUNT(gu.user_id)
          FROM group_users gu
-         JOIN users u ON u.id = gu.user_id
-         WHERE gu.group_id = g.id
-         AND u.id > 0)
+         WHERE gu.group_id = g.id)
       WHERE g.id = #{self.id};
     SQL
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Group do
     end
   end
 
+  describe ".human_users" do
+    before { group.users << user << Discourse.system_user }
+
+    it "returns only human users" do
+      expect(group.human_users).to contain_exactly(user)
+    end
+  end
+
   describe "#posts_for" do
     it "returns the post in the group" do
       p = Fabricate(:post)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -205,18 +205,6 @@ RSpec.describe Group do
     end
   end
 
-  def real_admins
-    Group[:admins].user_ids.reject { |id| id < 0 }
-  end
-
-  def real_moderators
-    Group[:moderators].user_ids.reject { |id| id < 0 }
-  end
-
-  def real_staff
-    Group[:staff].user_ids.reject { |id| id < 0 }
-  end
-
   describe "#primary_group=" do
     before { group.add(user) }
 
@@ -432,33 +420,33 @@ RSpec.describe Group do
 
     Group.refresh_automatic_groups!(:admins, :staff, :moderators)
 
-    expect(real_admins).to eq [admin.id]
-    expect(real_moderators).to eq [moderator.id]
-    expect(real_staff.sort).to eq [moderator.id, admin.id].sort
+    expect(Group[:admins].human_users).to contain_exactly(admin)
+    expect(Group[:moderators].human_users).to contain_exactly(moderator)
+    expect(Group[:staff].human_users).to contain_exactly(moderator, admin)
 
     admin.admin = false
     admin.save
 
     Group.refresh_automatic_group!(:admins)
-    expect(real_admins).to be_empty
+    expect(Group[:admins].human_users).to be_empty
 
     moderator.revoke_moderation!
 
     admin.grant_admin!
-    expect(real_admins).to eq [admin.id]
-    expect(real_staff).to eq [admin.id]
+    expect(Group[:admins].human_users).to contain_exactly(admin)
+    expect(Group[:staff].human_users).to contain_exactly(admin)
 
     admin.revoke_admin!
-    expect(real_admins).to be_empty
-    expect(real_staff).to be_empty
+    expect(Group[:admins].human_users).to be_empty
+    expect(Group[:staff].human_users).to be_empty
 
     admin.grant_moderation!
-    expect(real_moderators).to eq [admin.id]
-    expect(real_staff).to eq [admin.id]
+    expect(Group[:moderators].human_users).to contain_exactly(admin)
+    expect(Group[:staff].human_users).to contain_exactly(admin)
 
     admin.revoke_moderation!
-    expect(real_admins).to be_empty
-    expect(real_staff).to eq []
+    expect(Group[:admins].human_users).to be_empty
+    expect(Group[:staff].human_users).to be_empty
 
     # we need some work to set min username to 6
 


### PR DESCRIPTION
### What is this change?

Some preparatory refactoring as we're working on TL groups for the system user. On `User` we have a scope `#human_users` to exclude the system user, DiscoBot, etc. This PR adds the same scope (delegated to `User`) on `Group`, so you can now do:

```ruby
group.human_users
```