### PR TITLE
DEV: remove pseudo-class selector in chat channel page object

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/channel_index.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_index.rb
@@ -6,7 +6,7 @@ module PageObjects
       class ChannelIndex < PageObjects::Components::Base
         attr_reader :context
 
-        SELECTOR = ".channels-list:first-child"
+        SELECTOR = ".channels-list"
 
         def initialize(context = nil)
           @context = context


### PR DESCRIPTION
The channels-list div is only rendered once now so the `:first-child` pseudo-class can be removed.