### PR TITLE
UX: add spacing in new topic draft text - timestamp

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -39,6 +39,7 @@
     align-items: end;
     display: flex;
     flex-direction: column;
+    margin-left: 0.25em;
   }
 
   .type,


### PR DESCRIPTION
https://meta.discourse.org/t/new-topic-draft-menu-missing-space/292788

