### PR TITLE
FIX: FinalDestination::HTTP: validate address argument

### DIFF
--- a/lib/final_destination/http.rb
+++ b/lib/final_destination/http.rb
@@ -2,6 +2,8 @@
 
 class FinalDestination::HTTP < Net::HTTP
   def connect
+    raise ArgumentError.new("address cannot be nil or empty") unless @address.present?
+
     original_open_timeout = @open_timeout
     return super if @ipaddr
 

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -112,14 +112,10 @@ describe FinalDestination::HTTP do
   end
 
   it "validates address argument against nil value" do
-    expect do
-      FinalDestination::HTTP.start(nil) {}
-    end.to raise_error(ArgumentError)
+    expect do FinalDestination::HTTP.start(nil) {} end.to raise_error(ArgumentError)
   end
 
   it "validates address argument against empty value" do
-    expect do
-      FinalDestination::HTTP.start("") {}
-    end.to raise_error(ArgumentError)
+    expect do FinalDestination::HTTP.start("") {} end.to raise_error(ArgumentError)
   end
 end

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -110,4 +110,16 @@ describe FinalDestination::HTTP do
       FinalDestination::HTTP.start("example.com", 80, open_timeout: 5) {}
     end.to raise_error(Net::OpenTimeout)
   end
+
+  it "validates address argument against nil value" do
+    expect do
+      FinalDestination::HTTP.start(nil) {}
+    end.to raise_error(ArgumentError)
+  end
+
+  it "validates address argument against empty value" do
+    expect do
+      FinalDestination::HTTP.start("") {}
+    end.to raise_error(ArgumentError)
+  end
 end


### PR DESCRIPTION
This would only be empty due to a programming error elsewhere, but checking this here is a failstop so that it doesn't go further.
