### PR TITLE
UX: fix spacing for about page headings

### DIFF
--- a/app/assets/stylesheets/common/base/about.scss
+++ b/app/assets/stylesheets/common/base/about.scss
@@ -10,10 +10,15 @@ section.about {
   h3 {
     margin-bottom: 1em;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    gap: 0 0.35em;
     .d-icon {
-      margin-right: 0.5em;
       color: var(--primary-high);
+    }
+    .badge-category__wrapper {
+      font-size: var(--font-0);
+      align-self: baseline;
     }
   }
 


### PR DESCRIPTION
Before:
![Screenshot 2024-01-24 at 4 28 15 PM](https://github.com/discourse/discourse/assets/1681963/bdf567dd-1cfc-404c-b45d-e9d5edcfe800)


After:
![Screenshot 2024-01-24 at 4 28 06 PM](https://github.com/discourse/discourse/assets/1681963/5563cc1b-6c9e-49fd-ae5b-e725ae505f97)
