### PR TITLE
UX: simplify education message layout on empty /new route

### DIFF
--- a/app/assets/javascripts/discourse/app/components/footer-message.hbs
+++ b/app/assets/javascripts/discourse/app/components/footer-message.hbs
@@ -1,7 +1,9 @@
-{{#if this.education}}<div class="education">{{html-safe
-      this.education
-    }}</div>{{/if}}
 <h3>
   {{this.message}}
   {{yield}}
 </h3>
+{{#if this.education}}
+  <div class="education">
+    {{html-safe this.education}}
+  </div>
+{{/if}}

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -415,12 +415,13 @@
 
 div.education {
   color: var(--primary);
-  padding: 1em 2.5em 1em 1em;
   margin-bottom: 2em;
-  border-top: 3px solid var(--primary-low);
-  border-bottom: 1px solid var(--primary-low);
 
-  .badge-notification.unread-posts {
+  p {
+    max-width: 62em;
+  }
+
+  .badge-notification {
     vertical-align: text-bottom;
   }
 }


### PR DESCRIPTION
This simplifies and relocates the education message so the header can be a header. 


Before: 
![Screenshot 2024-01-24 at 5 18 18 PM](https://github.com/discourse/discourse/assets/1681963/34ab6e12-b8ae-4466-81bb-08fc79e6f2cb)

![Screenshot 2024-01-24 at 5 18 25 PM](https://github.com/discourse/discourse/assets/1681963/c68b1fa0-3650-4077-9a8b-1da5c74f83ea)


After:
![Screenshot 2024-01-24 at 5 14 06 PM](https://github.com/discourse/discourse/assets/1681963/e4e350de-f04b-464e-92af-bbd3752d21a3)

![Screenshot 2024-01-24 at 5 15 27 PM](https://github.com/discourse/discourse/assets/1681963/5480d46d-7c74-495e-873c-f20391c78d28)
