### PR TITLE
DEV: Remove full group refreshes from tests

### DIFF
--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -4,8 +4,15 @@ require "rails_helper"
 
 describe Chat::Mailer do
   fab!(:chatters_group) { Fabricate(:group) }
-  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id]) }
-  fab!(:user_1) { Fabricate(:user, group_ids: [chatters_group.id], last_seen_at: 15.minutes.ago) }
+  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id], refresh_auto_groups: true) }
+  fab!(:user_1) do
+    Fabricate(
+      :user,
+      group_ids: [chatters_group.id],
+      last_seen_at: 15.minutes.ago,
+      refresh_auto_groups: true,
+    )
+  end
   fab!(:chat_channel) { Fabricate(:category_channel) }
   fab!(:chat_message) { Fabricate(:chat_message, user: sender, chat_channel: chat_channel) }
   fab!(:user_1_chat_channel_membership) do
@@ -17,7 +24,6 @@ describe Chat::Mailer do
     )
   end
   fab!(:private_chat_channel) do
-    Group.refresh_automatic_groups!
     result =
       Chat::CreateDirectMessageChannel.call(
         guardian: sender.guardian,

--- a/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
+++ b/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 describe "Automatic user removal from channels" do
-  fab!(:user_1) { Fabricate(:user, trust_level: TrustLevel[1]) }
+  fab!(:user_1) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
   let(:user_1_guardian) { Guardian.new(user_1) }
-  fab!(:user_2) { Fabricate(:user, trust_level: TrustLevel[1]) }
+  fab!(:user_2) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
 
   fab!(:secret_group) { Fabricate(:group) }
   fab!(:private_category) { Fabricate(:private_category, group: secret_group) }
@@ -15,7 +15,6 @@ describe "Automatic user removal from channels" do
   before do
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
     SiteSetting.chat_enabled = true
-    Group.refresh_automatic_groups!
     Jobs.run_immediately!
 
     secret_group.add(user_1)

--- a/plugins/chat/spec/integration/thread_replies_count_cache_accuracy_spec.rb
+++ b/plugins/chat/spec/integration/thread_replies_count_cache_accuracy_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Chat::Thread replies_count cache accuracy" do
   include ActiveSupport::Testing::TimeHelpers
 
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:thread) { Fabricate(:chat_thread) }
 
   let(:guardian) { user.guardian }
@@ -12,7 +12,6 @@ RSpec.describe "Chat::Thread replies_count cache accuracy" do
     SiteSetting.chat_enabled = true
     thread.add(user)
     thread.channel.add(user)
-    Group.refresh_automatic_groups!
   end
 
   it "keeps an accurate replies_count cache" do

--- a/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_mentioned_spec.rb
@@ -5,12 +5,11 @@ require "rails_helper"
 describe Jobs::Chat::NotifyMentioned do
   subject(:job) { described_class.new }
 
-  fab!(:user_1) { Fabricate(:user) }
-  fab!(:user_2) { Fabricate(:user) }
+  fab!(:user_1) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:public_channel) { Fabricate(:category_channel) }
 
   before do
-    Group.refresh_automatic_groups!
     user_1.reload
     user_2.reload
 

--- a/plugins/chat/spec/lib/chat/channel_hashtag_data_source_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_hashtag_data_source_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Chat::ChannelHashtagDataSource do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:category)
   fab!(:group)
   fab!(:private_category) { Fabricate(:private_category, group: group) }
@@ -26,10 +26,7 @@ RSpec.describe Chat::ChannelHashtagDataSource do
   end
   let!(:guardian) { Guardian.new(user) }
 
-  before do
-    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
-    Group.refresh_automatic_groups!
-  end
+  before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_1] }
 
   describe "#enabled?" do
     it "returns false if public channels are disabled" do
@@ -87,7 +84,6 @@ RSpec.describe Chat::ChannelHashtagDataSource do
 
     it "returns nothing if the user cannot chat" do
       SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:staff]
-      Group.refresh_automatic_groups!
       expect(described_class.lookup(Guardian.new(user), ["random"])).to be_empty
     end
   end
@@ -152,7 +148,6 @@ RSpec.describe Chat::ChannelHashtagDataSource do
 
     it "returns nothing if the user cannot chat" do
       SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:staff]
-      Group.refresh_automatic_groups!
       expect(described_class.search(Guardian.new(user), "rand", 10)).to be_empty
     end
   end
@@ -195,7 +190,6 @@ RSpec.describe Chat::ChannelHashtagDataSource do
 
     it "returns nothing if the user cannot chat" do
       SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:staff]
-      Group.refresh_automatic_groups!
       expect(described_class.search_without_term(Guardian.new(user), 10)).to be_empty
     end
   end

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Chat::GuardianExtensions do
   fab!(:chatters) { Fabricate(:group) }
-  fab!(:user) { Fabricate(:user, group_ids: [chatters.id]) }
+  fab!(:user) { Fabricate(:user, group_ids: [chatters.id], refresh_auto_groups: true) }
   fab!(:staff) { Fabricate(:user, admin: true) }
   fab!(:chat_group) { Fabricate(:group) }
   fab!(:channel) { Fabricate(:category_channel) }
@@ -25,10 +25,8 @@ RSpec.describe Chat::GuardianExtensions do
   end
 
   it "allows TL1 to chat by default and by extension higher trust levels" do
-    Group.refresh_automatic_groups!
     expect(guardian.can_chat?).to eq(true)
-    user.update!(trust_level: TrustLevel[3])
-    Group.refresh_automatic_groups!
+    user.change_trust_level!(TrustLevel[3])
     expect(guardian.can_chat?).to eq(true)
   end
 
@@ -588,8 +586,6 @@ RSpec.describe Chat::GuardianExtensions do
       end
 
       context "for direct message channels" do
-        before { Group.refresh_automatic_groups! }
-
         it "it still allows the user to message even if they are not in direct_message_enabled_groups because they are not creating the channel" do
           SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
           dm_channel.update!(status: :open)

--- a/plugins/chat/spec/lib/chat/notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat/notifier_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Chat::Notifier do
   describe "#notify_new" do
     fab!(:channel) { Fabricate(:category_channel) }
-    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_1) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:user_2) { Fabricate(:user) }
 
     before do
@@ -424,7 +424,6 @@ describe Chat::Notifier do
 
       context "when in a personal message" do
         let(:personal_chat_channel) do
-          Group.refresh_automatic_groups!
           result =
             Chat::CreateDirectMessageChannel.call(
               guardian: user_1.guardian,

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -6,7 +6,7 @@ describe Chat::ReviewQueue do
   subject(:queue) { described_class.new }
 
   fab!(:message_poster) { Fabricate(:user) }
-  fab!(:flagger) { Fabricate(:user) }
+  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:chat_channel) { Fabricate(:category_channel) }
   fab!(:message) { Fabricate(:chat_message, user: message_poster, chat_channel: chat_channel) }
   fab!(:admin)
@@ -17,7 +17,6 @@ describe Chat::ReviewQueue do
   before do
     chat_channel.add(message_poster)
     chat_channel.add(flagger)
-    Group.refresh_automatic_groups!
   end
 
   describe "#flag_message" do

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 describe UserNotifications do
   fab!(:chatters_group) { Fabricate(:group) }
-  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id]) }
-  fab!(:user) { Fabricate(:user, group_ids: [chatters_group.id]) }
+  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id], refresh_auto_groups: true) }
+  fab!(:user) { Fabricate(:user, group_ids: [chatters_group.id], refresh_auto_groups: true) }
 
   before do
     SiteSetting.chat_enabled = true
@@ -13,7 +13,6 @@ describe UserNotifications do
   end
 
   def refresh_auto_groups
-    Group.refresh_automatic_groups!
     user.reload
     sender.reload
   end
@@ -111,11 +110,11 @@ describe UserNotifications do
         end
 
         it "displays a count when there are more than two DMs with unread messages" do
-          user = Fabricate(:user, group_ids: [chatters_group.id])
+          user = Fabricate(:user, group_ids: [chatters_group.id], refresh_auto_groups: true)
           senders = []
 
           3.times do
-            sender = Fabricate(:user, group_ids: [chatters_group.id])
+            sender = Fabricate(:user, group_ids: [chatters_group.id], refresh_auto_groups: true)
             refresh_auto_groups
             sender.reload
             senders << sender

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Chat::Api::ChannelThreadsController do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
-    Group.refresh_automatic_groups!
+
     sign_in(current_user)
   end
 

--- a/plugins/chat/spec/requests/chat/api/direct_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/direct_messages_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Chat::Api::DirectMessagesController do
-  fab!(:current_user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
@@ -21,8 +21,6 @@ RSpec.describe Chat::Api::DirectMessagesController do
   end
 
   describe "#create" do
-    before { Group.refresh_automatic_groups! }
-
     describe "dm with one other user" do
       let(:usernames) { user1.username }
       let(:direct_message_user_ids) { [current_user.id, user1.id] }

--- a/plugins/chat/spec/requests/core_ext/latest_performance_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/latest_performance_spec.rb
@@ -5,7 +5,6 @@ describe ListController do
 
   before do
     SiteSetting.chat_enabled = true
-    Group.refresh_automatic_groups!
     sign_in(current_user)
   end
 

--- a/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
@@ -8,7 +8,7 @@ describe Chat::MessageSerializer do
   fab!(:chat_channel) { Fabricate(:category_channel) }
   fab!(:message_poster) { Fabricate(:user) }
   fab!(:message_1) { Fabricate(:chat_message, user: message_poster, chat_channel: chat_channel) }
-  fab!(:guardian_user) { Fabricate(:user) }
+  fab!(:guardian_user) { Fabricate(:user, refresh_auto_groups: true) }
 
   let(:guardian) { Guardian.new(guardian_user) }
 
@@ -83,8 +83,6 @@ describe Chat::MessageSerializer do
   end
 
   describe "#available_flags" do
-    before { Group.refresh_automatic_groups! }
-
     context "when flagging on a regular channel" do
       let(:options) { { scope: guardian, root: nil, chat_channel: message_1.chat_channel } }
 
@@ -167,7 +165,6 @@ describe Chat::MessageSerializer do
 
       it "doesn't include notify_user if they are not in a PM allowed group" do
         SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
-        Group.refresh_automatic_groups!
 
         serialized = described_class.new(message_1, options).as_json
 
@@ -175,9 +172,8 @@ describe Chat::MessageSerializer do
       end
 
       it "returns an empty list if the user needs a higher TL to flag" do
-        guardian.user.update!(trust_level: TrustLevel[2])
+        guardian.user.change_trust_level!(TrustLevel[2])
         SiteSetting.chat_message_flag_allowed_groups = Group::AUTO_GROUPS[:trust_level_3]
-        Group.refresh_automatic_groups!
 
         serialized = described_class.new(message_1, options).as_json
 

--- a/plugins/chat/spec/services/auto_remove/handle_chat_allowed_groups_change_spec.rb
+++ b/plugins/chat/spec/services/auto_remove/handle_chat_allowed_groups_change_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Chat::AutoRemove::HandleChatAllowedGroupsChange do
     subject(:result) { described_class.call(params) }
 
     let(:params) { { new_allowed_groups: new_allowed_groups } }
-    fab!(:user_1) { Fabricate(:user) }
-    fab!(:user_2) { Fabricate(:user) }
+    fab!(:user_1) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:admin_1) { Fabricate(:admin) }
     fab!(:admin_2) { Fabricate(:admin) }
 
@@ -124,7 +124,6 @@ RSpec.describe Chat::AutoRemove::HandleChatAllowedGroupsChange do
         before do
           public_channel_1.add(user_1)
           public_channel_2.add(user_1)
-          Group.refresh_automatic_groups!
         end
 
         it "does nothing" do

--- a/plugins/chat/spec/services/auto_remove/handle_destroyed_group_spec.rb
+++ b/plugins/chat/spec/services/auto_remove/handle_destroyed_group_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Chat::AutoRemove::HandleDestroyedGroup do
     subject(:result) { described_class.call(params) }
 
     let(:params) { { destroyed_group_user_ids: [admin_1.id, admin_2.id, user_1.id, user_2.id] } }
-    fab!(:user_1) { Fabricate(:user) }
-    fab!(:user_2) { Fabricate(:user) }
+    fab!(:user_1) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:admin_1) { Fabricate(:admin) }
     fab!(:admin_2) { Fabricate(:admin) }
 
@@ -130,7 +130,6 @@ RSpec.describe Chat::AutoRemove::HandleDestroyedGroup do
             channel_2.add(user_2)
             channel_1.add(admin_1)
             channel_1.add(admin_2)
-            Group.refresh_automatic_groups!
           end
 
           it "sets the service result as successful" do
@@ -151,7 +150,6 @@ RSpec.describe Chat::AutoRemove::HandleDestroyedGroup do
             channel_2.add(user_2)
             channel_1.add(admin_1)
             channel_1.add(admin_2)
-            Group.refresh_automatic_groups!
           end
 
           it { is_expected.to fail_a_policy(:not_everyone_allowed) }
@@ -170,7 +168,6 @@ RSpec.describe Chat::AutoRemove::HandleDestroyedGroup do
           channel_2.add(user_2)
           channel_1.add(admin_1)
           channel_1.add(admin_2)
-          Group.refresh_automatic_groups!
         end
 
         context "when channel category not read_restricted with no category_groups" do

--- a/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Chat::CreateDirectMessageChannel do
   describe ".call" do
     subject(:result) { described_class.call(params) }
 
-    fab!(:current_user) { Fabricate(:user, username: "guybrush") }
+    fab!(:current_user) { Fabricate(:user, username: "guybrush", refresh_auto_groups: true) }
     fab!(:user_1) { Fabricate(:user, username: "lechuck") }
     fab!(:user_2) { Fabricate(:user, username: "elaine") }
     fab!(:user_3) { Fabricate(:user) }
@@ -40,8 +40,6 @@ RSpec.describe Chat::CreateDirectMessageChannel do
     let(:target_usernames) { [user_1.username, user_2.username] }
     let(:name) { "" }
     let(:params) { { guardian: guardian, target_usernames: target_usernames, name: name } }
-
-    before { Group.refresh_automatic_groups! }
 
     context "when all steps pass" do
       it "sets the service result as successful" do

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Chat::UpdateMessage do
     let(:guardian) { Guardian.new(user1) }
     fab!(:admin1) { Fabricate(:admin) }
     fab!(:admin2) { Fabricate(:admin) }
-    fab!(:user1) { Fabricate(:user) }
+    fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:user2) { Fabricate(:user) }
     fab!(:user3) { Fabricate(:user) }
     fab!(:user4) { Fabricate(:user) }
@@ -46,7 +46,6 @@ RSpec.describe Chat::UpdateMessage do
       [admin1, admin2, user1, user2, user3, user4].each do |user|
         Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
       end
-      Group.refresh_automatic_groups!
     end
 
     def create_chat_message(user, message, channel, upload_ids: nil)

--- a/spec/integration/category_tag_spec.rb
+++ b/spec/integration/category_tag_spec.rb
@@ -793,10 +793,9 @@ RSpec.describe "tag topic counts per category" do
   end
 
   context "with topic with 2 tags" do
-    fab!(:topic) { Fabricate(:topic, category: category, tags: [tag1, tag2]) }
-    fab!(:post) { Fabricate(:post, user: topic.user, topic: topic) }
-
-    before { Group.refresh_automatic_groups! }
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:topic) { Fabricate(:topic, user: user, category: category, tags: [tag1, tag2]) }
+    fab!(:post) { Fabricate(:post, user: user, topic: topic) }
 
     it "has correct counts after tag is removed from a topic" do
       post
@@ -837,14 +836,13 @@ RSpec.describe "tag topic counts per category" do
   end
 
   context "with topic with one tag" do
-    fab!(:topic) { Fabricate(:topic, tags: [tag1], category: category) }
-    fab!(:post) { Fabricate(:post, user: topic.user, topic: topic) }
-
-    before { Group.refresh_automatic_groups! }
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:topic) { Fabricate(:topic, user: user, tags: [tag1], category: category) }
+    fab!(:post) { Fabricate(:post, user: user, topic: topic) }
 
     it "counts after topic becomes uncategorized" do
       PostRevisor.new(post).revise!(
-        topic.user,
+        user,
         raw: post.raw,
         tags: [tag1.name],
         category_id: SiteSetting.uncategorized_category_id,

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -187,7 +187,6 @@ RSpec.describe WatchedWord do
     end
 
     it "doesn't need approval in a private message" do
-      Group.refresh_automatic_groups!
       manager =
         NewPostManager.new(
           tl2_user,

--- a/spec/jobs/pending_users_reminder_spec.rb
+++ b/spec/jobs/pending_users_reminder_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe Jobs::PendingUsersReminder do
     end
 
     context "when there are pending users" do
-      before do
-        Fabricate(:moderator, approved: true, approved_by_id: -1, approved_at: 1.week.ago)
-        Group.refresh_automatic_group!(:moderators)
-      end
+      before { Fabricate(:moderator, approved: true, approved_by_id: -1, approved_at: 1.week.ago) }
 
       it "sends a message if user was created more than pending_users_reminder_delay minutes ago" do
         SiteSetting.pending_users_reminder_delay_minutes = 8

--- a/spec/jobs/refresh_users_reviewable_counts_spec.rb
+++ b/spec/jobs/refresh_users_reviewable_counts_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Jobs::RefreshUsersReviewableCounts do
     SiteSetting.enable_category_group_moderation = true
     group.add(user)
     topic.category.update!(reviewable_by_group: group)
-    Group.refresh_automatic_groups!
   end
 
   describe "#execute" do

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Jobs::UserEmail do
   before { SiteSetting.email_time_window_mins = 10 }
 
-  fab!(:user) { Fabricate(:user, last_seen_at: 11.minutes.ago) }
+  fab!(:user) { Fabricate(:user, last_seen_at: 11.minutes.ago, refresh_auto_groups: true) }
   fab!(:staged) { Fabricate(:user, staged: true, last_seen_at: 11.minutes.ago) }
   fab!(:suspended) do
     Fabricate(
@@ -133,10 +133,7 @@ RSpec.describe Jobs::UserEmail do
         data: { original_post_id: post.id }.to_json,
       )
     end
-    before do
-      user.update_column(:last_seen_at, 9.minutes.ago)
-      Group.refresh_automatic_groups!
-    end
+    before { user.update_column(:last_seen_at, 9.minutes.ago) }
 
     it "doesn't send an email to a user that's been recently seen" do
       Jobs::UserEmail.new.execute(type: :user_replied, user_id: user.id, post_id: post.id)

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -143,9 +143,7 @@ RSpec.describe ComposerMessagesFinder do
     end
 
     it "doesn't notify users if 'allow_uploaded_avatars' setting is disabled" do
-      user.update!(trust_level: 3)
-      Group.refresh_automatic_groups!
-      user.reload
+      user.change_trust_level!(TrustLevel[3])
 
       SiteSetting.uploaded_avatars_allowed_groups = ""
       expect(finder.check_avatar_notification).to be_blank

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1687,8 +1687,6 @@ RSpec.describe Email::Receiver do
       category.set_permissions(Group[:trust_level_4] => :full)
       category.save!
 
-      Group.refresh_automatic_group!(:trust_level_4)
-
       expect { process(:tl3_user) }.to raise_error(Email::Receiver::InvalidPost)
       expect { process(:tl4_user) }.to change(Topic, :count)
     end

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicGuardian do
-  fab!(:user)
-  fab!(:admin)
-  fab!(:tl3_user) { Fabricate(:trust_level_3) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:tl3_user) { Fabricate(:trust_level_3, refresh_auto_groups: true) }
   fab!(:tl4_user) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
   fab!(:moderator)
   fab!(:category)
@@ -18,8 +18,6 @@ RSpec.describe TopicGuardian do
   after { Guardian.disable_topic_can_see_consistency_check }
 
   describe "#can_create_shared_draft?" do
-    before { Group.refresh_automatic_groups! }
-
     it "when shared_drafts are disabled" do
       SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:admins]
 
@@ -49,8 +47,6 @@ RSpec.describe TopicGuardian do
   end
 
   describe "#can_see_shared_draft?" do
-    before { Group.refresh_automatic_groups! }
-
     it "when shared_drafts are disabled (existing shared drafts)" do
       SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:admins]
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Guardian do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:another_user) { Fabricate(:user) }
   fab!(:member) { Fabricate(:user) }
   fab!(:owner) { Fabricate(:user) }
-  fab!(:moderator)
-  fab!(:admin)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:anonymous_user) { Fabricate(:anonymous) }
   fab!(:staff_post) { Fabricate(:post, user: moderator) }
   fab!(:group)
@@ -20,15 +20,12 @@ RSpec.describe Guardian do
   fab!(:trust_level_3) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
   fab!(:trust_level_4) { Fabricate(:user, trust_level: 4, refresh_auto_groups: true) }
   fab!(:another_admin) { Fabricate(:admin) }
-  fab!(:coding_horror)
+  fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
 
   fab!(:topic) { Fabricate(:topic, user: user) }
   fab!(:post) { Fabricate(:post, topic: topic, user: topic.user) }
 
-  before do
-    Group.refresh_automatic_groups!
-    Guardian.enable_topic_can_see_consistency_check
-  end
+  before { Guardian.enable_topic_can_see_consistency_check }
 
   after { Guardian.disable_topic_can_see_consistency_check }
 
@@ -4312,8 +4309,6 @@ RSpec.describe Guardian do
   end
 
   describe "#can_mention_here?" do
-    before { Group.refresh_automatic_groups! }
-
     it "returns false if disabled" do
       SiteSetting.max_here_mentioned = 0
       expect(admin.guardian.can_mention_here?).to eq(false)

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -4,7 +4,7 @@ require "new_post_manager"
 
 RSpec.describe NewPostManager do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:topic)
+  fab!(:topic) { Fabricate(:topic, user: user) }
 
   describe "default action" do
     it "creates the post by default" do
@@ -22,7 +22,6 @@ RSpec.describe NewPostManager do
     fab!(:other_user) { Fabricate(:user) }
 
     it "doesn't enqueue private messages" do
-      Group.refresh_automatic_groups!
       SiteSetting.approve_unless_trust_level = 4
 
       manager =
@@ -302,10 +301,7 @@ RSpec.describe NewPostManager do
         }
       end
 
-      before do
-        user.update!(trust_level: 0)
-        Group.refresh_automatic_groups!
-      end
+      before { user.change_trust_level!(TrustLevel[0]) }
 
       it "queues the post for review because it contains embedded media" do
         SiteSetting.skip_review_media_groups = Group::AUTO_GROUPS[:trust_level_1]
@@ -335,7 +331,6 @@ RSpec.describe NewPostManager do
     context "with a high trust level setting for new topics" do
       before do
         SiteSetting.approve_new_topics_unless_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
-        Group.refresh_automatic_groups!
       end
       it "will return an enqueue result" do
         result = NewPostManager.default_handler(manager)
@@ -391,7 +386,6 @@ RSpec.describe NewPostManager do
 
       NewPostManager.add_handler(&@counter_handler)
       NewPostManager.add_handler(&@queue_handler)
-      Group.refresh_automatic_groups!
     end
 
     after { NewPostManager.clear_handlers! }
@@ -461,7 +455,6 @@ RSpec.describe NewPostManager do
     end
 
     it "if nothing returns a result it creates a post" do
-      Group.refresh_automatic_groups!
       manager = NewPostManager.new(user, raw: "this is a new post", topic_id: topic.id)
 
       result = manager.perform
@@ -497,7 +490,7 @@ RSpec.describe NewPostManager do
   end
 
   context "when posting in the category requires approval" do
-    let!(:user) { Fabricate(:user) }
+    let!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     let!(:review_group) { Fabricate(:group) }
     let!(:category) { Fabricate(:category, reviewable_by_group_id: review_group.id) }
 
@@ -506,7 +499,6 @@ RSpec.describe NewPostManager do
         SiteSetting.tagging_enabled = true
         category.require_topic_approval = true
         category.save
-        Group.refresh_automatic_groups!
       end
 
       it "enqueues new topics" do
@@ -634,7 +626,6 @@ RSpec.describe NewPostManager do
       before do
         category.require_reply_approval = true
         category.save
-        Group.refresh_automatic_groups!
       end
 
       it "enqueues new posts" do

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe PostActionCreator do
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post)
   let(:like_type_id) { PostActionType.types[:like] }
-
-  before { Group.refresh_automatic_groups! }
 
   describe "rate limits" do
     before { RateLimiter.enable }

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -1081,7 +1081,6 @@ RSpec.describe PostCreator do
     fab!(:target_user2) { Fabricate(:moderator) }
     fab!(:unrelated_user) { Fabricate(:user) }
     let(:post) do
-      Group.refresh_automatic_groups!
       PostCreator.create!(
         user,
         title: "hi there welcome to my topic",
@@ -1097,8 +1096,7 @@ RSpec.describe PostCreator do
       SiteSetting.min_first_post_length = 20
       SiteSetting.min_post_length = 25
       SiteSetting.body_min_entropy = 20
-      user.update!(trust_level: 3)
-      Group.refresh_automatic_groups!
+      user.change_trust_level!(TrustLevel[3])
 
       expect {
         PostCreator.create!(
@@ -1198,13 +1196,12 @@ RSpec.describe PostCreator do
     end
 
     it "does not increase posts count for small actions" do
-      topic = Fabricate(:private_message_topic, user: Fabricate(:user))
+      topic = Fabricate(:private_message_topic, user: Fabricate(:user, refresh_auto_groups: true))
 
       Fabricate(:post, topic: topic)
 
       1.upto(3) do |i|
         user = Fabricate(:user)
-        Group.refresh_automatic_groups!
         topic.invite(topic.user, user.username)
         topic.reload
         expect(topic.posts_count).to eq(1)
@@ -1235,7 +1232,6 @@ RSpec.describe PostCreator do
     end
 
     it "works as expected" do
-      Group.refresh_automatic_groups!
       # Invalid archetype
       creator = PostCreator.new(user, base_args)
       creator.create
@@ -1324,7 +1320,6 @@ RSpec.describe PostCreator do
     end
     fab!(:unrelated) { Fabricate(:user) }
     let(:post) do
-      Group.refresh_automatic_groups!
       PostCreator.create!(
         user,
         title: "hi there welcome to my topic",

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe PostDestroyer do
   before { UserActionManager.enable }
 
-  fab!(:moderator)
-  fab!(:admin)
-  fab!(:coding_horror)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
   let(:post) { create_post }
 
   describe "destroy_old_hidden_posts" do

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -633,10 +633,16 @@ RSpec.describe Search do
     end
 
     context "with personal-direct and group_messages flags" do
-      let!(:current) { Fabricate(:user, admin: true, username: "current_user") }
-      let!(:participant) { Fabricate(:user, username: "participant_1") }
-      let!(:participant_2) { Fabricate(:user, username: "participant_2") }
-      let!(:non_participant) { Fabricate(:user, username: "non_participant") }
+      let!(:current) do
+        Fabricate(:user, admin: true, username: "current_user", refresh_auto_groups: true)
+      end
+      let!(:participant) { Fabricate(:user, username: "participant_1", refresh_auto_groups: true) }
+      let!(:participant_2) do
+        Fabricate(:user, username: "participant_2", refresh_auto_groups: true)
+      end
+      let!(:non_participant) do
+        Fabricate(:user, username: "non_participant", refresh_auto_groups: true)
+      end
 
       let(:group) do
         group = Fabricate(:group, has_messages: true)
@@ -646,7 +652,6 @@ RSpec.describe Search do
       end
 
       def create_pm(users:, group: nil)
-        Group.refresh_automatic_groups!
         pm = Fabricate(:private_message_post_one_user, user: users.first).topic
         users[1..-1].each do |u|
           pm.invite(users.first, u.username)

--- a/spec/lib/spam_handler_spec.rb
+++ b/spec/lib/spam_handler_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe SpamHandler do
       Fabricate(:user, ip_address: "42.42.42.42", trust_level: TrustLevel[0])
       Fabricate(:moderator, ip_address: "42.42.42.42", trust_level: TrustLevel[0])
 
-      Group.refresh_automatic_groups!(:staff)
-
       # should not limit registration
       SiteSetting.max_new_accounts_per_registration_ip = 1
       Fabricate(:user, ip_address: "42.42.42.42", trust_level: TrustLevel[0])

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicCreator do
-  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2]) }
+  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true) }
   fab!(:moderator)
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
   let(:valid_attrs) { Fabricate.attributes_for(:topic) }
   let(:pm_valid_attrs) do
@@ -23,8 +23,6 @@ RSpec.describe TopicCreator do
       target_emails: "moderator@example.com",
     }
   end
-
-  before { Group.refresh_automatic_groups! }
 
   describe "#create" do
     context "with topic success cases" do
@@ -497,7 +495,6 @@ RSpec.describe TopicCreator do
           TopicCreator.any_instance.expects(:watch_topic).returns(true)
           SiteSetting.allow_duplicate_topic_titles = true
           SiteSetting.enable_staged_users = true
-          Group.refresh_automatic_groups!
         end
 
         it "should be possible for a regular user to send private message" do
@@ -546,8 +543,6 @@ RSpec.describe TopicCreator do
       end
 
       context "with to emails" do
-        before { Group.refresh_automatic_groups! }
-
         it "works for staff" do
           SiteSetting.send_email_messages_allowed_groups = "1|3"
           expect(

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -2,12 +2,10 @@
 
 RSpec.describe TopicQuery::PrivateMessageLists do
   fab!(:admin)
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:user_3) { Fabricate(:user) }
   fab!(:user_4) { Fabricate(:user) }
-
-  before_all { Group.refresh_automatic_groups! }
 
   fab!(:group) do
     Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]).tap { |g| g.add(user_2) }
@@ -163,10 +161,8 @@ RSpec.describe TopicQuery::PrivateMessageLists do
   end
 
   describe "#list_private_messages_unread" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:user_2) { Fabricate(:user) }
-
-    before_all { Group.refresh_automatic_groups! }
 
     fab!(:pm) do
       create_post(
@@ -207,10 +203,8 @@ RSpec.describe TopicQuery::PrivateMessageLists do
   end
 
   describe "#list_private_messages_new" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:user_2) { Fabricate(:user) }
-
-    before_all { Group.refresh_automatic_groups! }
 
     fab!(:pm) do
       create_post(

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1870,7 +1870,6 @@ RSpec.describe TopicQuery do
       SiteSetting.shared_drafts_category = shared_drafts_category.id
       SiteSetting.shared_drafts_allowed_groups =
         Group::AUTO_GROUPS[:trust_level_3].to_s + "|" + Group::AUTO_GROUPS[:staff].to_s
-      Group.refresh_automatic_groups!
     end
 
     context "with destination_category_id" do

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -1004,7 +1004,6 @@ RSpec.describe TopicView do
 
   describe "#reviewable_counts" do
     it "exclude posts queued because the category needs approval" do
-      Group.refresh_automatic_groups!
       category =
         Fabricate.create(
           :category,

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicsBulkAction do
-  fab!(:topic)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
 
   describe "#dismiss_topics" do
     fab!(:user) { Fabricate(:user, created_at: 1.days.ago, refresh_auto_groups: true) }
@@ -156,10 +157,7 @@ RSpec.describe TopicsBulkAction do
 
     context "when the user can edit the topic" do
       context "with 'create_revision_on_bulk_topic_moves' setting enabled" do
-        before do
-          SiteSetting.create_revision_on_bulk_topic_moves = true
-          Group.refresh_automatic_groups!
-        end
+        before { SiteSetting.create_revision_on_bulk_topic_moves = true }
 
         it "changes the category, creates a post revision and returns the topic_id" do
           old_category_id = topic.category_id
@@ -198,10 +196,7 @@ RSpec.describe TopicsBulkAction do
       end
 
       context "with 'create_revision_on_bulk_topic_moves' setting disabled" do
-        before do
-          SiteSetting.create_revision_on_bulk_topic_moves = false
-          Group.refresh_automatic_groups!
-        end
+        before { SiteSetting.create_revision_on_bulk_topic_moves = false }
 
         it "changes the category, doesn't create a post revision and returns the topic_id" do
           tba =
@@ -421,7 +416,6 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
-      Group.refresh_automatic_groups!
     end
 
     it "can change the tags, and can create new tags" do
@@ -490,7 +484,6 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
-      Group.refresh_automatic_groups!
     end
 
     it "can append new or existing tags" do
@@ -561,7 +554,6 @@ RSpec.describe TopicsBulkAction do
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_level_to_tag_topics = 0
       topic.tags = [tag1, tag2]
-      Group.refresh_automatic_groups!
     end
 
     it "can remove all tags" do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -632,11 +632,13 @@ RSpec.describe Category do
   end
 
   describe "update_stats" do
-    before { @category = Fabricate(:category_with_definition) }
+    before do
+      @category =
+        Fabricate(:category_with_definition, user: Fabricate(:user, refresh_auto_groups: true))
+    end
 
     context "with regular topics" do
       before do
-        Group.refresh_automatic_groups!
         create_post(user: @category.user, category: @category.id)
         Category.update_stats
         @category.reload
@@ -675,7 +677,6 @@ RSpec.describe Category do
 
     context "with revised post" do
       before do
-        Group.refresh_automatic_groups!
         post = create_post(user: @category.user, category: @category.id)
 
         SiteSetting.editing_grace_period = 1.minute
@@ -714,7 +715,6 @@ RSpec.describe Category do
     end
 
     context "when there are no topics left" do
-      before { Group.refresh_automatic_groups! }
       let!(:topic) { create_post(user: @category.user, category: @category.id).reload.topic }
 
       it "can update the topic count to zero" do

--- a/spec/models/group_archived_message_spec.rb
+++ b/spec/models/group_archived_message_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe GroupArchivedMessage do
   fab!(:user)
   fab!(:user_2) { Fabricate(:user) }
 
-  before_all { Group.refresh_automatic_groups! }
-
   fab!(:group) do
     Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]).tap { |g| g.add(user_2) }
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1041,7 +1041,6 @@ RSpec.describe Group do
 
     it "should return the right groups" do
       Group.delete_all
-      Group.refresh_automatic_groups!
 
       group_name =
         Fabricate(:group, name: "tEsT_more_things", full_name: "Abc something awesome").name

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe GroupUser do
   it "correctly sets notification level" do
     moderator = Fabricate(:moderator)
 
-    Group.refresh_automatic_groups!(:moderators)
     gu = GroupUser.find_by(user_id: moderator.id, group_id: Group::AUTO_GROUPS[:moderators])
 
     expect(gu.notification_level).to eq(NotificationLevels.all[:tracking])

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe PostAction do
   it { is_expected.to rate_limit }
 
-  fab!(:moderator)
+  fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
   fab!(:codinghorror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
   fab!(:eviltrout) { Fabricate(:evil_trout, refresh_auto_groups: true) }
   fab!(:admin)
@@ -25,7 +25,6 @@ RSpec.describe PostAction do
     it "notifies moderators (integration test)" do
       post = create_post
       mod = moderator
-      Group.refresh_automatic_groups!
 
       result =
         PostActionCreator.notify_moderators(codinghorror, post, "this is my special long message")
@@ -757,7 +756,6 @@ RSpec.describe PostAction do
   end
 
   it "prevents user to act twice at the same time" do
-    Group.refresh_automatic_groups!
     # flags are already being tested
     all_types_except_flags =
       PostActionType.types.except(*PostActionType.flag_types_without_custom.keys)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -359,8 +359,6 @@ RSpec.describe Post do
     end
 
     describe "embedded_media_allowed_groups" do
-      before { Group.refresh_automatic_groups! }
-
       it "doesn't allow users outside of `embedded_media_post_allowed_groups`" do
         SiteSetting.embedded_media_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
         post_one_image.user.change_trust_level!(3)

--- a/spec/models/private_message_topic_tracking_state_spec.rb
+++ b/spec/models/private_message_topic_tracking_state_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe PrivateMessageTopicTrackingState do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user_2) { Fabricate(:user) }
-
-  before_all { Group.refresh_automatic_groups! }
 
   fab!(:group) do
     Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]).tap { |g| g.add(user_2) }

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -244,8 +244,6 @@ RSpec.describe Reviewable, type: :model do
       fab!(:admin)
 
       it "respects category id on the reviewable" do
-        Group.refresh_automatic_group!(:staff)
-
         reviewable =
           ReviewableFlaggedPost.needs_review!(
             target: post,

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3,8 +3,8 @@
 
 RSpec.describe Topic do
   let(:now) { Time.zone.local(2013, 11, 20, 8, 0) }
-  fab!(:user)
-  fab!(:user1) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user1) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:whisperers_group) { Fabricate(:group) }
   fab!(:user2) { Fabricate(:user, groups: [whisperers_group]) }
   fab!(:moderator)
@@ -782,10 +782,7 @@ RSpec.describe Topic do
     fab!(:topic) { Fabricate(:topic, user: user) }
 
     context "with rate limits" do
-      before do
-        RateLimiter.enable
-        Group.refresh_automatic_groups!
-      end
+      before { RateLimiter.enable }
 
       use_redis_snapshotting
 
@@ -869,8 +866,6 @@ RSpec.describe Topic do
     describe "private message" do
       fab!(:user) { trust_level_2 }
       fab!(:topic) { Fabricate(:private_message_topic, user: trust_level_2) }
-
-      before { Group.refresh_automatic_groups! }
 
       describe "by username" do
         it "should be able to invite a user" do
@@ -977,8 +972,6 @@ RSpec.describe Topic do
       end
 
       describe "by email" do
-        before { Group.refresh_automatic_groups! }
-
         it "should be able to invite a user" do
           expect(topic.invite(user, user1.email)).to eq(true)
           expect(topic.allowed_users).to include(user1)
@@ -1121,9 +1114,8 @@ RSpec.describe Topic do
   end
 
   describe "private message" do
-    fab!(:pm_user) { Fabricate(:user) }
+    fab!(:pm_user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:topic) do
-      Group.refresh_automatic_groups!
       PostCreator
         .new(
           pm_user,
@@ -2730,7 +2722,6 @@ RSpec.describe Topic do
     use_redis_snapshotting
 
     it "limits according to max_personal_messages_per_day" do
-      Group.refresh_automatic_groups!
       create_post(
         user: user,
         archetype: "private_message",

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe TopicUser do
     end
 
     context "with private messages" do
-      fab!(:target_user) { Fabricate(:user) }
+      fab!(:target_user) { Fabricate(:user, refresh_auto_groups: true) }
 
       let(:post) do
         create_post(archetype: Archetype.private_message, target_usernames: target_user.username)
@@ -304,7 +304,7 @@ RSpec.describe TopicUser do
         end
 
         it "should use group's default notification level" do
-          another_user = Fabricate(:user)
+          another_user = Fabricate(:user, refresh_auto_groups: true)
           group.add(another_user)
 
           Jobs.run_immediately!
@@ -467,8 +467,7 @@ RSpec.describe TopicUser do
       it "should not automatically track PMs" do
         new_user.user_option.update!(auto_track_topics_after_msecs: 0)
 
-        another_user = Fabricate(:user)
-        Group.refresh_automatic_groups!
+        another_user = Fabricate(:user, refresh_auto_groups: true)
         pm = Fabricate(:private_message_topic, user: another_user)
         pm.invite(another_user, new_user.username)
 

--- a/spec/models/trust_level3_requirements_spec.rb
+++ b/spec/models/trust_level3_requirements_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe TrustLevel3Requirements do
   subject(:tl3_requirements) { described_class.new(user) }
 
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:moderator)
   fab!(:topic1) { Fabricate(:topic) }
   fab!(:topic2) { Fabricate(:topic) }
@@ -241,7 +241,6 @@ RSpec.describe TrustLevel3Requirements do
   describe "num_topics_replied_to" do
     it "counts topics in which user replied in last 100 days" do
       user.save
-      Group.refresh_automatic_groups!
 
       _not_a_reply = create_post(user: user) # user created the topic, so it doesn't count
 
@@ -454,10 +453,7 @@ RSpec.describe TrustLevel3Requirements do
   end
 
   describe "num_likes_received" do
-    before do
-      UserActionManager.enable
-      Group.refresh_automatic_groups!
-    end
+    before { UserActionManager.enable }
 
     let(:topic) { Fabricate(:topic, user: user, created_at: 102.days.ago) }
     let(:old_post) { create_post(topic: topic, user: user, created_at: 102.days.ago) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1760,7 +1760,7 @@ RSpec.describe User do
   end
 
   describe "#purge_unactivated" do
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:unactivated) { Fabricate(:user, active: false) }
     fab!(:unactivated_old) { Fabricate(:user, active: false, created_at: 1.month.ago) }
     fab!(:unactivated_old_with_system_pm) do
@@ -1769,11 +1769,11 @@ RSpec.describe User do
     fab!(:unactivated_old_with_human_pm) do
       Fabricate(:user, active: false, created_at: 2.months.ago)
     end
-    fab!(:unactivated_old_with_post) { Fabricate(:user, active: false, created_at: 1.month.ago) }
+    fab!(:unactivated_old_with_post) do
+      Fabricate(:user, active: false, created_at: 1.month.ago, refresh_auto_groups: true)
+    end
 
     before do
-      Group.refresh_automatic_groups!
-
       PostCreator.new(
         Discourse.system_user,
         title: "Welcome to our Discourse",

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ApplicationController do
 
   describe "#redirect_to_second_factor_if_required" do
     let(:admin) { Fabricate(:admin) }
-    fab!(:user)
+    fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
     before do
       admin # to skip welcome wizard at home page `/`
@@ -153,7 +153,7 @@ RSpec.describe ApplicationController do
     it "should not redirect anonymous users when enforce_second_factor is 'all'" do
       SiteSetting.enforce_second_factor = "all"
       SiteSetting.allow_anonymous_posting = true
-      Group.refresh_automatic_groups!
+
       sign_in(user)
 
       post "/u/toggle-anon.json"

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ListController do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:topic) { Fabricate(:topic, user: user) }
   fab!(:group) { Fabricate(:group, name: "AwesomeGroup") }
   fab!(:admin)
@@ -366,7 +366,6 @@ RSpec.describe ListController do
       before do
         group.add(user)
         SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:staff]
-        Group.refresh_automatic_groups!
       end
 
       it "should display group private messages for an admin" do
@@ -424,7 +423,6 @@ RSpec.describe ListController do
         group.add(user)
         sign_in(user)
         SiteSetting.unicode_usernames = false
-        Group.refresh_automatic_groups!
       end
 
       it "should return the right response when user does not belong to group" do
@@ -451,7 +449,6 @@ RSpec.describe ListController do
       before do
         sign_in(user)
         SiteSetting.unicode_usernames = true
-        Group.refresh_automatic_groups!
       end
 
       it "Returns a 200 with unicode group name" do

--- a/spec/requests/post_actions_controller_spec.rb
+++ b/spec/requests/post_actions_controller_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe PostActionsController do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:coding_horror)
-
-  before { Group.refresh_automatic_groups! }
 
   describe "#destroy" do
     fab!(:post) { Fabricate(:post, user: coding_horror) }
@@ -120,7 +118,7 @@ RSpec.describe PostActionsController do
     end
 
     describe "as a moderator" do
-      fab!(:user) { Fabricate(:moderator) }
+      fab!(:user) { Fabricate(:moderator, refresh_auto_groups: true) }
       fab!(:post_1) { Fabricate(:post, user: coding_horror) }
 
       before { sign_in(user) }

--- a/spec/requests/similar_topics_controller_spec.rb
+++ b/spec/requests/similar_topics_controller_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe SimilarTopicsController do
             reindex_posts
             Topic.stubs(:count).returns(50)
             sign_in(Fabricate(:moderator))
-            Group.refresh_automatic_groups!
           end
 
           it "passes a user through if logged in" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TopicsController do
 
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:post_author1) { Fabricate(:user) }
+  fab!(:post_author1) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:post_author2) { Fabricate(:user) }
   fab!(:post_author3) { Fabricate(:user) }
   fab!(:post_author4) { Fabricate(:user) }
@@ -32,7 +32,7 @@ RSpec.describe TopicsController do
     end
   end
 
-  fab!(:group_user)
+  fab!(:group_user) { Fabricate(:group_user, user: Fabricate(:user, refresh_auto_groups: true)) }
 
   fab!(:tag)
 
@@ -242,7 +242,6 @@ RSpec.describe TopicsController do
       before do
         sign_in(user)
         SiteSetting.enable_category_group_moderation = true
-        Group.refresh_automatic_groups!
       end
 
       it "moves the posts" do
@@ -3194,8 +3193,6 @@ RSpec.describe TopicsController do
     end
 
     describe "image only topic" do
-      before { Group.refresh_automatic_groups! }
-
       it "uses image alt tag for meta description" do
         post =
           Fabricate(

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe UploadsController do
         post "/uploads.json", params: { file: logo, type: "avatar" }
         expect(response.status).to eq(422)
 
-        user.update!(trust_level: 3)
-        Group.refresh_automatic_groups!
+        user.change_trust_level!(TrustLevel[3])
+
         post "/uploads.json", params: { file: logo, type: "avatar" }
         expect(response.status).to eq(200)
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe UsersController do
   fab!(:invitee) { Fabricate(:user) }
   fab!(:inviter) { Fabricate(:user) }
 
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:moderator)
   fab!(:inactive_user)
-
-  before { Group.refresh_automatic_groups! }
 
   # Unfortunately, there are tests that depend on the user being created too
   # late for fab! to work.
@@ -604,10 +602,7 @@ RSpec.describe UsersController do
     it "allows you to toggle anon if enabled" do
       SiteSetting.allow_anonymous_posting = true
 
-      user = sign_in(Fabricate(:user))
-      user.trust_level = 1
-      user.save!
-      Group.refresh_automatic_groups!
+      user = sign_in(Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true))
 
       post "/u/toggle-anon.json"
       expect(response.status).to eq(200)
@@ -1711,7 +1706,7 @@ RSpec.describe UsersController do
     context "while logged in" do
       let(:old_username) { "OrigUsername" }
       let(:new_username) { "#{old_username}1234" }
-      fab!(:user) { Fabricate(:user, username: "OrigUsername") }
+      fab!(:user) { Fabricate(:user, username: "OrigUsername", refresh_auto_groups: true) }
 
       before do
         user.username = old_username
@@ -2261,7 +2256,7 @@ RSpec.describe UsersController do
     context "with authenticated user" do
       context "with permission to update" do
         fab!(:upload)
-        fab!(:user)
+        fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
         before { sign_in(user) }
 
@@ -3400,8 +3395,8 @@ RSpec.describe UsersController do
             }
         expect(response.status).to eq(422)
 
-        user1.update!(trust_level: 3)
-        Group.refresh_automatic_groups!
+        user1.change_trust_level!(TrustLevel[3])
+
         put "/u/#{user1.username}/preferences/avatar/pick.json",
             params: {
               upload_id: upload.id,

--- a/spec/serializers/basic_group_serializer_spec.rb
+++ b/spec/serializers/basic_group_serializer_spec.rb
@@ -42,19 +42,16 @@ RSpec.describe BasicGroupSerializer do
   describe "#has_messages" do
     fab!(:group) { Fabricate(:group, has_messages: true) }
 
-    before { Group.refresh_automatic_groups! }
-
     describe "for a staff user" do
-      let(:guardian) { Guardian.new(Fabricate(:moderator)) }
+      let!(:guardian) { Guardian.new(Fabricate(:moderator)) }
 
       it "should be present" do
-        Group.refresh_automatic_groups!
         expect(serializer.as_json[:has_messages]).to eq(true)
       end
     end
 
     describe "for a group user" do
-      fab!(:user)
+      fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
       let(:guardian) { Guardian.new(user) }
 
       before { group.add(user) }

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -3,10 +3,8 @@
 RSpec.describe PostSerializer do
   fab!(:post)
 
-  before { Group.refresh_automatic_groups! }
-
   context "with a post with lots of actions" do
-    fab!(:actor) { Fabricate(:user) }
+    fab!(:actor) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:admin)
     let(:acted_ids) do
       PostActionType.public_types.values.concat(

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -95,8 +95,6 @@ RSpec.describe TopicViewSerializer do
   end
 
   describe "#suggested_topics" do
-    before { Group.refresh_automatic_groups! }
-
     fab!(:topic2) { Fabricate(:topic) }
 
     before { TopicUser.update_last_read(user, topic2.id, 0, 0, 0) }
@@ -125,8 +123,6 @@ RSpec.describe TopicViewSerializer do
     end
 
     describe "with private messages" do
-      before { Group.refresh_automatic_groups! }
-
       fab!(:topic) do
         Fabricate(
           :private_message_topic,
@@ -166,8 +162,6 @@ RSpec.describe TopicViewSerializer do
   describe "#suggested_group_name" do
     fab!(:pm) { Fabricate(:private_message_post).topic }
     fab!(:group)
-
-    before { Group.refresh_automatic_groups! }
 
     it "is nil for a regular topic" do
       json = serialize_topic(topic, user)
@@ -457,8 +451,7 @@ RSpec.describe TopicViewSerializer do
         json = serialize_topic(topic, user)
         expect(json[:details][:can_edit_tags]).to be_nil
 
-        user.update!(trust_level: 2)
-        Group.refresh_automatic_groups!
+        user.change_trust_level!(TrustLevel[2])
 
         json = serialize_topic(topic, user.reload)
         expect(json[:details][:can_edit_tags]).to eq(true)

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe AnonymousShadowCreator do
     before do
       SiteSetting.allow_anonymous_posting = true
       SiteSetting.anonymous_posting_allowed_groups = "11"
-      Group.refresh_automatic_groups!
     end
 
     it "returns no shadow if the user is not in a group that is allowed to anonymously post" do
@@ -33,7 +32,7 @@ RSpec.describe AnonymousShadowCreator do
       shadow2 = AnonymousShadowCreator.get(user)
 
       expect(shadow.id).to eq(shadow2.id)
-      Group.refresh_automatic_groups!
+      shadow.send(:trigger_user_automatic_group_refresh)
       create_post(user: shadow)
 
       user.reload

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe PostAlerter do
   fab!(:group)
 
   fab!(:admin)
-  fab!(:evil_trout)
+  fab!(:evil_trout) { Fabricate(:evil_trout, refresh_auto_groups: true) }
   fab!(:coding_horror)
-  fab!(:walterwhite) { Fabricate(:walter_white) }
+  fab!(:walterwhite) { Fabricate(:walter_white, refresh_auto_groups: true) }
   fab!(:user)
   fab!(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }
 

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe UserMerger do
-  fab!(:target_user) { Fabricate(:user, username: "alice", email: "alice@example.com") }
-  fab!(:source_user) { Fabricate(:user, username: "alice1", email: "alice@work.com") }
+  fab!(:target_user) do
+    Fabricate(:user, username: "alice", email: "alice@example.com", refresh_auto_groups: true)
+  end
+  fab!(:source_user) do
+    Fabricate(:user, username: "alice1", email: "alice@work.com", refresh_auto_groups: true)
+  end
   fab!(:walter) { Fabricate(:walter_white) }
   fab!(:coding_horror)
 
@@ -12,8 +16,6 @@ RSpec.describe UserMerger do
   fab!(:p4) { Fabricate(:post) }
   fab!(:p5) { Fabricate(:post) }
   fab!(:p6) { Fabricate(:post) }
-
-  before { Group.refresh_automatic_groups! }
 
   def merge_users!(source = nil, target = nil)
     source ||= source_user

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -40,10 +40,7 @@ module Helpers
   def create_topic(args = {})
     args[:title] ||= "This is my title #{Helpers.next_seq}"
     user = args.delete(:user)
-    if !user
-      user = Fabricate(:user)
-      Group.refresh_automatic_groups!
-    end
+    user = Fabricate(:user, refresh_auto_groups: true) if !user
     guardian = Guardian.new(user)
     args[:category] = args[:category].id if args[:category].is_a?(Category)
     TopicCreator.create(user, guardian, args)
@@ -57,9 +54,7 @@ module Helpers
     args[:title] ||= "This is my title #{Helpers.next_seq}"
     args[:raw] ||= "This is the raw body of my post, it is cool #{Helpers.next_seq}"
     args[:topic_id] = args[:topic].id if args[:topic]
-    automated_group_refresh_required = args[:user].blank?
-    user = args.delete(:user) || Fabricate(:user)
-    Group.refresh_automatic_groups! if automated_group_refresh_required
+    user = args.delete(:user) || Fabricate(:user, refresh_auto_groups: true)
     args[:category] = args[:category].id if args[:category].is_a?(Category)
     creator = PostCreator.new(user, args)
     post = creator.create

--- a/spec/system/hashtag_autocomplete_spec.rb
+++ b/spec/system/hashtag_autocomplete_spec.rb
@@ -2,7 +2,7 @@
 
 describe "Using #hashtag autocompletion to search for and lookup categories and tags",
          type: :system do
-  fab!(:current_user) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:category) do
     Fabricate(:category, name: "Cool Category", slug: "cool-cat", topic_count: 3234)
   end
@@ -100,7 +100,6 @@ describe "Using #hashtag autocompletion to search for and lookup categories and 
   end
 
   it "cooks the hashtags for tag and category correctly serverside when the post is saved to the database" do
-    Group.refresh_automatic_groups!
     topic_page.visit_topic_and_open_composer(topic)
 
     expect(topic_page).to have_expanded_composer


### PR DESCRIPTION
### What is this change?

We have all these calls to `Group.refresh_automatic_groups!` littered throughout the tests. Including tests that are seemingly unrelated to groups. This is because automatic group memberships aren't fabricated when making a vanilla user. There are two places where you'd want to use this:

1. You have fabricated a user that needs a certain trust level (which is now based on group membership.)
2. You need the system user to have a certain trust level.

In the first case, we can pass `refresh_auto_groups: true` to the fabricator instead. This is a more lightweight operation that only considers a single user, instead of all users in all groups.

The second case is no longer a thing after #25400.