### PR TITLE
DEV: Automatically update groups for test users with explicit TL

### DIFF
--- a/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
+++ b/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 describe "Automatic user removal from channels" do
-  fab!(:user_1) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
+  fab!(:user_1) { Fabricate(:user, trust_level: TrustLevel[1]) }
   let(:user_1_guardian) { Guardian.new(user_1) }
-  fab!(:user_2) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
+  fab!(:user_2) { Fabricate(:user, trust_level: TrustLevel[1]) }
 
   fab!(:secret_group) { Fabricate(:group) }
   fab!(:private_category) { Fabricate(:private_category, group: secret_group) }

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -4,17 +4,21 @@ Fabricator(:user_stat) {}
 
 Fabricator(:user, class_name: :user) do
   transient refresh_auto_groups: false
+  transient trust_level: nil
 
   name "Bruce Wayne"
   username { sequence(:username) { |i| "bruce#{i}" } }
   email { sequence(:email) { |i| "bruce#{i}@wayne.com" } }
   password "myawesomepassword"
-  trust_level TrustLevel[1]
   ip_address { sequence(:ip_address) { |i| "99.232.23.#{i % 254}" } }
   active true
 
+  after_build { |user, transients| user.trust_level = transients[:trust_level] || TrustLevel[1] }
+
   after_create do |user, transients|
-    Group.user_trust_level_change!(user.id, user.trust_level) if transients[:refresh_auto_groups]
+    if transients[:refresh_auto_groups] || transients[:trust_level]
+      Group.user_trust_level_change!(user.id, user.trust_level)
+    end
   end
 end
 
@@ -103,9 +107,8 @@ Fabricator(:leader, from: :user) do
 end
 
 Fabricator(:trust_level_0, from: :user) { trust_level TrustLevel[0] }
-
 Fabricator(:trust_level_1, from: :user) { trust_level TrustLevel[1] }
-
+Fabricator(:trust_level_2, from: :user) { trust_level TrustLevel[2] }
 Fabricator(:trust_level_3, from: :user) { trust_level TrustLevel[3] }
 
 Fabricator(:trust_level_4, from: :user) do

--- a/spec/integration/flags_spec.rb
+++ b/spec/integration/flags_spec.rb
@@ -2,15 +2,15 @@
 
 RSpec.describe PostAction do
   it "triggers the 'flag_reviewed' event when there was at least one flag" do
-    admin = Fabricate(:admin, refresh_auto_groups: true)
+    user = Fabricate(:user, trust_level: TrustLevel[4])
 
     post = Fabricate(:post)
-    events = DiscourseEvent.track_events { PostDestroyer.new(admin, post).destroy }
+    events = DiscourseEvent.track_events { PostDestroyer.new(user, post).destroy }
     expect(events.map { |e| e[:event_name] }).to_not include(:flag_reviewed)
 
     flagged_post = Fabricate(:post)
-    PostActionCreator.spam(admin, flagged_post)
-    events = DiscourseEvent.track_events { PostDestroyer.new(admin, flagged_post).destroy }
+    PostActionCreator.spam(user, flagged_post)
+    events = DiscourseEvent.track_events { PostDestroyer.new(user, flagged_post).destroy }
     expect(events.map { |e| e[:event_name] }).to include(:flag_reviewed)
   end
 end

--- a/spec/integration/same_ip_spammers_spec.rb
+++ b/spec/integration/same_ip_spammers_spec.rb
@@ -3,9 +3,9 @@
 
 RSpec.describe "spammers on same IP" do
   let(:ip_address) { "182.189.119.174" }
-  let!(:spammer1) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
-  let!(:spammer2) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
-  let(:spammer3) { Fabricate(:user, ip_address: ip_address, refresh_auto_groups: true) }
+  let!(:spammer1) { Fabricate(:user, ip_address: ip_address, trust_level: TrustLevel[0]) }
+  let!(:spammer2) { Fabricate(:user, ip_address: ip_address, trust_level: TrustLevel[0]) }
+  let(:spammer3) { Fabricate(:user, ip_address: ip_address, trust_level: TrustLevel[0]) }
 
   context "when flag_sockpuppets is disabled" do
     let!(:first_post) { create_post(user: spammer1) }
@@ -47,13 +47,7 @@ RSpec.describe "spammers on same IP" do
 
     context "when first user is not new" do
       let!(:old_user) do
-        Fabricate(
-          :user,
-          ip_address: ip_address,
-          created_at: 2.days.ago,
-          trust_level: TrustLevel[1],
-          refresh_auto_groups: true,
-        )
+        Fabricate(:user, ip_address: ip_address, created_at: 2.days.ago, trust_level: TrustLevel[1])
       end
 
       context "when first user starts a topic" do

--- a/spec/integration/spam_rules_spec.rb
+++ b/spec/integration/spam_rules_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "spam rules for users" do
     end
 
     context "when spammer is a new user" do
-      fab!(:spammer) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+      fab!(:spammer) { Fabricate(:user, trust_level: TrustLevel[0]) }
 
       context "when spammer post is not flagged enough times" do
         let!(:spam_post) { create_post(user: spammer) }
@@ -98,7 +98,7 @@ RSpec.describe "spam rules for users" do
     end
 
     context "when spammer has trust level basic" do
-      let(:spammer) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
+      let(:spammer) { Fabricate(:user, trust_level: TrustLevel[1]) }
 
       context "when one spam post is flagged enough times by enough users" do
         let!(:spam_post) { Fabricate(:post, user: spammer) }

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe WatchedWord do
-  fab!(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true) }
+  fab!(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }
   fab!(:admin)
   fab!(:moderator)
 

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1536,7 +1536,7 @@ RSpec.describe Email::Receiver do
     end
 
     it "raises an InsufficientTrustLevelError when user's trust level isn't enough" do
-      Fabricate(:user, email: "existing@bar.com", trust_level: 3, refresh_auto_groups: true)
+      Fabricate(:user, email: "existing@bar.com", trust_level: TrustLevel[3])
       SiteSetting.email_in_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
       expect { process(:existing_user) }.to raise_error(
         Email::Receiver::InsufficientTrustLevelError,
@@ -1681,8 +1681,8 @@ RSpec.describe Email::Receiver do
     it "works when approving is enabled" do
       SiteSetting.approve_unless_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
 
-      Fabricate(:user, email: "tl3@bar.com", trust_level: TrustLevel[3], refresh_auto_groups: true)
-      Fabricate(:user, email: "tl4@bar.com", trust_level: TrustLevel[4], refresh_auto_groups: true)
+      Fabricate(:user, email: "tl3@bar.com", trust_level: TrustLevel[3])
+      Fabricate(:user, email: "tl4@bar.com", trust_level: TrustLevel[4])
 
       category.set_permissions(Group[:trust_level_4] => :full)
       category.save!
@@ -1729,13 +1729,13 @@ RSpec.describe Email::Receiver do
     end
 
     it "lets an email in from a high-TL user" do
-      Fabricate(:user, email: "tl4@bar.com", trust_level: TrustLevel[4], refresh_auto_groups: true)
+      Fabricate(:user, email: "tl4@bar.com", trust_level: TrustLevel[4])
       expect { process(:tl4_user) }.to change(Topic, :count)
     end
 
     it "fails on email from a low-TL user" do
       SiteSetting.email_in_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
-      Fabricate(:user, email: "tl3@bar.com", trust_level: TrustLevel[3], refresh_auto_groups: true)
+      Fabricate(:user, email: "tl3@bar.com", trust_level: TrustLevel[3])
       expect { process(:tl3_user) }.to raise_error(Email::Receiver::InsufficientTrustLevelError)
     end
   end

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe TopicGuardian do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
-  fab!(:tl3_user) { Fabricate(:trust_level_3, refresh_auto_groups: true) }
-  fab!(:tl4_user) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
+  fab!(:tl3_user) { Fabricate(:trust_level_3) }
+  fab!(:tl4_user) { Fabricate(:trust_level_4) }
   fab!(:moderator)
   fab!(:category)
   fab!(:group)
@@ -130,7 +130,7 @@ RSpec.describe TopicGuardian do
 
   describe "#can_edit_topic?" do
     context "when the topic is a shared draft" do
-      let(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true) }
+      let(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }
 
       before do
         SiteSetting.shared_drafts_category = category.id

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe UserGuardian do
 
   let(:moderator_upload) { Upload.new(user_id: moderator.id, id: 4) }
 
-  fab!(:trust_level_1) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
-  fab!(:trust_level_2) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
+  fab!(:trust_level_1)
+  fab!(:trust_level_2)
 
   describe "#can_pick_avatar?" do
     let :guardian do

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Guardian do
   fab!(:automatic_group) { Fabricate(:group, automatic: true) }
   fab!(:plain_category) { Fabricate(:category) }
 
-  fab!(:trust_level_0) { Fabricate(:user, trust_level: 0, refresh_auto_groups: true) }
-  fab!(:trust_level_1) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
-  fab!(:trust_level_2) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
-  fab!(:trust_level_3) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
-  fab!(:trust_level_4) { Fabricate(:user, trust_level: 4, refresh_auto_groups: true) }
+  fab!(:trust_level_0)
+  fab!(:trust_level_1)
+  fab!(:trust_level_2)
+  fab!(:trust_level_3)
+  fab!(:trust_level_4)
   fab!(:another_admin) { Fabricate(:admin) }
   fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
 
@@ -1225,37 +1225,35 @@ RSpec.describe Guardian do
         SiteSetting.min_trust_to_create_topic = 1
         SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 0, refresh_auto_groups: true)).can_create?(
-            Topic,
-            plain_category,
-          ),
+          Guardian.new(Fabricate(:user, trust_level: 0)).can_create?(Topic, plain_category),
         ).to be_falsey
       end
 
       it "is true if user has met or exceeded the minimum trust level" do
         SiteSetting.create_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 1, refresh_auto_groups: true)).can_create?(
+          Guardian.new(Fabricate(:user, trust_level: TrustLevel[1])).can_create?(
             Topic,
             plain_category,
           ),
         ).to be_truthy
         expect(
-          Guardian.new(Fabricate(:user, trust_level: 2, refresh_auto_groups: true)).can_create?(
+          Guardian.new(Fabricate(:user, trust_level: TrustLevel[2])).can_create?(
             Topic,
             plain_category,
           ),
         ).to be_truthy
         expect(
-          Guardian.new(Fabricate(:admin, trust_level: 0, refresh_auto_groups: true)).can_create?(
+          Guardian.new(Fabricate(:admin, trust_level: TrustLevel[0])).can_create?(
             Topic,
             plain_category,
           ),
         ).to be_truthy
         expect(
-          Guardian.new(
-            Fabricate(:moderator, trust_level: 0, refresh_auto_groups: true),
-          ).can_create?(Topic, plain_category),
+          Guardian.new(Fabricate(:moderator, trust_level: TrustLevel[0])).can_create?(
+            Topic,
+            plain_category,
+          ),
         ).to be_truthy
       end
     end
@@ -3542,7 +3540,7 @@ RSpec.describe Guardian do
 
     context "when muter's trust level is below tl1" do
       let(:guardian) { Guardian.new(trust_level_0) }
-      let!(:trust_level_0) { Fabricate(:user, trust_level: 0) }
+      fab!(:trust_level_0)
 
       it "does not allow muting user" do
         expect(guardian.can_mute_user?(another_user)).to eq(false)

--- a/spec/lib/new_post_manager_spec.rb
+++ b/spec/lib/new_post_manager_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe NewPostManager do
   end
 
   describe "user needs approval?" do
-    fab!(:user) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+    fab!(:user) { Fabricate(:user, trust_level: TrustLevel[0]) }
 
     it "handles post_needs_approval? correctly" do
       user.user_stat = UserStat.new(post_count: 0, new_since: DateTime.now)

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicCreator do
-  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true) }
+  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2]) }
   fab!(:moderator)
   fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1884,7 +1884,7 @@ RSpec.describe TopicQuery do
       end
 
       it "allow group members with enough trust level to query destination_category_id" do
-        member = Fabricate(:user, trust_level: TrustLevel[3], refresh_auto_groups: true)
+        member = Fabricate(:user, trust_level: TrustLevel[3])
         group.add(member)
 
         list = TopicQuery.new(member, destination_category_id: category.id).list_latest
@@ -1893,7 +1893,7 @@ RSpec.describe TopicQuery do
       end
 
       it "doesn't allow group members without enough trust level to query destination_category_id" do
-        member = Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true)
+        member = Fabricate(:user, trust_level: TrustLevel[2])
         group.add(member)
 
         list = TopicQuery.new(member, destination_category_id: category.id).list_latest

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe InviteMailer do
     end
 
     context "when inviting to topic" do
-      fab!(:trust_level_2) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
+      fab!(:trust_level_2)
       let(:topic) do
         Fabricate(
           :topic,

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Post do
   end
 
   describe "maximum media embeds" do
-    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0]) }
     let(:post_no_images) { Fabricate.build(:post, post_args.merge(user: newuser)) }
     let(:post_one_image) { post_with_body("![sherlock](http://bbc.co.uk/sherlock.jpg)", newuser) }
     let(:post_two_images) do
@@ -424,7 +424,7 @@ RSpec.describe Post do
   end
 
   describe "maximum attachments" do
-    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0]) }
     let(:post_no_attachments) { Fabricate.build(:post, post_args.merge(user: newuser)) }
     let(:post_one_attachment) do
       post_with_body(
@@ -477,7 +477,7 @@ RSpec.describe Post do
   end
 
   describe "links" do
-    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0]) }
     let(:no_links) { post_with_body("hello world my name is evil trout", newuser) }
     let(:one_link) { post_with_body("[jlawr](http://www.imdb.com/name/nm2225369)", newuser) }
     let(:two_links) do
@@ -560,7 +560,7 @@ RSpec.describe Post do
   end
 
   describe "maximums" do
-    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+    fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0]) }
     let(:post_one_link) do
       post_with_body("[sherlock](http://www.bbc.co.uk/programmes/b018ttws)", newuser)
     end
@@ -689,7 +689,7 @@ RSpec.describe Post do
     end
 
     context "with max mentions" do
-      fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+      fab!(:newuser) { Fabricate(:user, trust_level: TrustLevel[0]) }
       let(:post_with_one_mention) { post_with_body("@Jake is the person I'm mentioning", newuser) }
       let(:post_with_two_mentions) do
         post_with_body("@Jake @Finn are the people I'm mentioning", newuser)
@@ -1763,7 +1763,7 @@ RSpec.describe Post do
     end
 
     describe "#update_uploads_secure_status" do
-      fab!(:user) { Fabricate(:user, trust_level: 0, refresh_auto_groups: true) }
+      fab!(:user) { Fabricate(:user, trust_level: TrustLevel[0]) }
 
       let(:raw) { <<~RAW }
         <a href="#{attachment_upload.url}">Link</a>

--- a/spec/models/reviewable_score_spec.rb
+++ b/spec/models/reviewable_score_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ReviewableScore, type: :model do
   describe "transitions" do
-    fab!(:user) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
+    fab!(:user) { Fabricate(:user, trust_level: TrustLevel[3]) }
     fab!(:post)
     fab!(:moderator)
 
@@ -46,9 +46,9 @@ RSpec.describe ReviewableScore, type: :model do
   end
 
   describe "overall score" do
-    fab!(:user0) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
-    fab!(:user1) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
-    fab!(:user2) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
+    fab!(:user0) { Fabricate(:user, trust_level: TrustLevel[1]) }
+    fab!(:user1) { Fabricate(:user, trust_level: TrustLevel[2]) }
+    fab!(:user2) { Fabricate(:user, trust_level: TrustLevel[3]) }
     fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
     fab!(:post)
     let(:topic) { post.topic }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Topic do
   fab!(:evil_trout)
   fab!(:admin)
   fab!(:group)
-  fab!(:trust_level_2) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
+  fab!(:trust_level_2)
 
   it_behaves_like "it has custom fields"
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe InvitesController do
   fab!(:admin)
-  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true) }
+  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[2]) }
 
   describe "#show" do
     fab!(:invite)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe PostsController do
   fab!(:admin)
   fab!(:moderator) { Fabricate(:moderator, refresh_auto_groups: true) }
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:user_trust_level_0) { Fabricate(:trust_level_0, refresh_auto_groups: true) }
-  fab!(:user_trust_level_1) { Fabricate(:trust_level_1, refresh_auto_groups: true) }
+  fab!(:user_trust_level_0) { Fabricate(:trust_level_0) }
+  fab!(:user_trust_level_1) { Fabricate(:trust_level_1) }
   fab!(:category)
   fab!(:topic)
   fab!(:post_by_user) { Fabricate(:post, user: user) }
@@ -1643,7 +1643,7 @@ RSpec.describe PostsController do
 
         it "it triggers flag_linked_posts_as_spam when the post creator returns spam" do
           SiteSetting.newuser_spam_host_threshold = 1
-          sign_in(Fabricate(:user, trust_level: 0, refresh_auto_groups: true))
+          sign_in(Fabricate(:user, trust_level: TrustLevel[0]))
 
           post "/posts.json",
                params: {
@@ -1936,7 +1936,7 @@ RSpec.describe PostsController do
       end
 
       context "with TL4 users" do
-        fab!(:trust_level_4) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
+        fab!(:trust_level_4)
 
         before { sign_in(trust_level_4) }
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe TopicsController do
   fab!(:post_author6) { Fabricate(:user) }
   fab!(:moderator)
   fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
-  fab!(:trust_level_0) { Fabricate(:trust_level_0, refresh_auto_groups: true) }
-  fab!(:trust_level_1) { Fabricate(:trust_level_1, refresh_auto_groups: true) }
-  fab!(:trust_level_4) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
+  fab!(:trust_level_0)
+  fab!(:trust_level_1)
+  fab!(:trust_level_4)
 
   fab!(:category)
   fab!(:tracked_category) { Fabricate(:category) }

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect]
 
-      user = Fabricate(:user, trust_level: 1, moderator: true, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[1], moderator: true)
 
       sign_in(user)
 
@@ -79,7 +79,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect]
 
-      user = Fabricate(:user, trust_level: 1, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[1])
       sign_in(user)
 
       post "/user-api-key.json", params: args
@@ -91,7 +91,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect]
       SiteSetting.allow_user_api_key_scopes = "write"
 
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       post "/user-api-key.json", params: args
@@ -156,7 +156,7 @@ RSpec.describe UserApiKeysController do
       args[:scopes] = "push,read"
       args[:push_url] = "https://push.it/here"
 
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       post "/user-api-key.json", params: args
@@ -189,7 +189,7 @@ RSpec.describe UserApiKeysController do
       args[:scopes] = "push,notifications,message_bus,session_info,one_time_password"
       args[:push_url] = "https://push.it/here"
 
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       post "/user-api-key.json", params: args
@@ -235,7 +235,7 @@ RSpec.describe UserApiKeysController do
     end
 
     it "will just show the payload if no redirect" do
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       args.delete(:auth_redirect)
@@ -252,7 +252,7 @@ RSpec.describe UserApiKeysController do
     end
 
     it "will just show the JSON payload if no redirect" do
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       args.delete(:auth_redirect)
@@ -282,7 +282,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
       SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect] + "/*"
 
-      user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       sign_in(user)
 
       query_str = "/?param1=val1"
@@ -320,7 +320,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       SiteSetting.allowed_user_api_auth_redirects = otp_args[:auth_redirect]
 
-      user = Fabricate(:user, trust_level: 1, moderator: true, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[1], moderator: true)
 
       sign_in(user)
 
@@ -332,7 +332,7 @@ RSpec.describe UserApiKeysController do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
       SiteSetting.allowed_user_api_auth_redirects = otp_args[:auth_redirect]
 
-      user = Fabricate(:user, trust_level: 1, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[1])
       sign_in(user)
 
       post "/user-api-key/otp", params: otp_args

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -602,7 +602,7 @@ RSpec.describe UsersController do
     it "allows you to toggle anon if enabled" do
       SiteSetting.allow_anonymous_posting = true
 
-      user = sign_in(Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true))
+      user = sign_in(Fabricate(:user, trust_level: TrustLevel[1]))
 
       post "/u/toggle-anon.json"
       expect(response.status).to eq(200)
@@ -1974,7 +1974,7 @@ RSpec.describe UsersController do
     end
 
     it "returns success" do
-      user = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[2])
       Fabricate(:invite, invited_by: user)
 
       sign_in(user)
@@ -1986,7 +1986,7 @@ RSpec.describe UsersController do
     end
 
     it "filters by all if viewing self" do
-      inviter = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
+      inviter = Fabricate(:user, trust_level: TrustLevel[2])
       sign_in(inviter)
 
       Fabricate(:invite, email: "billybob@example.com", invited_by: inviter)
@@ -2013,8 +2013,8 @@ RSpec.describe UsersController do
     end
 
     it "doesn't filter by email if another regular user" do
-      inviter = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
-      sign_in(Fabricate(:user, trust_level: 2, refresh_auto_groups: true))
+      inviter = Fabricate(:user, trust_level: TrustLevel[2])
+      sign_in(Fabricate(:user, trust_level: TrustLevel[2]))
 
       Fabricate(:invite, email: "billybob@example.com", invited_by: inviter)
       redeemed_invite = Fabricate(:invite, email: "jimtom@example.com", invited_by: inviter)
@@ -2069,7 +2069,7 @@ RSpec.describe UsersController do
 
       context "with redeemed invites" do
         it "returns invited_users" do
-          inviter = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
+          inviter = Fabricate(:user, trust_level: TrustLevel[2])
           sign_in(inviter)
           invite = Fabricate(:invite, invited_by: inviter)
           _invited_user = Fabricate(:invited_user, invite: invite, user: invitee)
@@ -2088,7 +2088,7 @@ RSpec.describe UsersController do
       context "with pending invites" do
         context "with permission to see pending invites" do
           it "returns invites" do
-            inviter = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
+            inviter = Fabricate(:user, trust_level: TrustLevel[2])
             invite = Fabricate(:invite, invited_by: inviter)
             sign_in(inviter)
 
@@ -2117,7 +2117,7 @@ RSpec.describe UsersController do
 
         context "with permission to see invite links" do
           it "returns own invites" do
-            inviter = sign_in(Fabricate(:user, trust_level: 2, refresh_auto_groups: true))
+            inviter = sign_in(Fabricate(:user, trust_level: TrustLevel[2]))
             invite =
               Fabricate(
                 :invite,

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AnonymousShadowCreator do
   end
 
   context "when anonymous posting is enabled" do
-    fab!(:user) { Fabricate(:user, trust_level: 3, refresh_auto_groups: true) }
+    fab!(:user) { Fabricate(:user, trust_level: TrustLevel[3]) }
 
     before do
       SiteSetting.allow_anonymous_posting = true
@@ -14,7 +14,7 @@ RSpec.describe AnonymousShadowCreator do
     end
 
     it "returns no shadow if the user is not in a group that is allowed to anonymously post" do
-      user = Fabricate(:user, trust_level: 0)
+      user = Fabricate(:user, trust_level: TrustLevel[0])
       expect(AnonymousShadowCreator.get(user)).to eq(nil)
     end
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe UserUpdater do
     end
 
     it "allows user to update user card background when the user has required trust level" do
-      user = Fabricate(:user, trust_level: 2, refresh_auto_groups: true)
+      user = Fabricate(:user, trust_level: TrustLevel[2])
       updater = UserUpdater.new(user, user)
       upload = Fabricate(:upload)
       SiteSetting.min_trust_level_to_allow_user_card_background = 2

--- a/spec/system/composer/post_validation_spec.rb
+++ b/spec/system/composer/post_validation_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 describe "Composer Post Validations", type: :system do
-  fab!(:tl0_user) { Fabricate(:user, trust_level: 0, refresh_auto_groups: true) }
-  fab!(:tl1_user) { Fabricate(:user, trust_level: 1, refresh_auto_groups: true) }
-  fab!(:tl2_user) { Fabricate(:user, trust_level: 2, refresh_auto_groups: true) }
+  fab!(:tl0_user) { Fabricate(:user, trust_level: TrustLevel[0]) }
+  fab!(:tl1_user) { Fabricate(:user, trust_level: TrustLevel[1]) }
+  fab!(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }
   fab!(:topic)
   fab!(:post) { Fabricate(:post, topic: topic) }
 


### PR DESCRIPTION
### Background

For performance reasons we don't automatically add fabricated users to trust level auto-groups. However, when explicitly passing a trust level to the fabricator, in 99% of cases it means that trust level is relevant for the test, and we need the groups.

### What is this change?

This change makes it so that when a trust level is explicitly passed to the fabricator, the auto-groups are refreshed. There's no longer a need to also pass `refresh_auto_groups: true`, which means clearer tests, fewer mistakes, and less confusion.