### PR TITLE
FIX: Allow `category` to be set on `topic` model instances

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -1,4 +1,4 @@
-import EmberObject from "@ember/object";
+import EmberObject, { computed } from "@ember/object";
 import { alias, and, equal, notEmpty, or } from "@ember/object/computed";
 import { Promise } from "rsvp";
 import { resolveShareUrl } from "discourse/helpers/share-url";
@@ -214,9 +214,13 @@ const Topic = RestModel.extend({
     return { type: "topic", id };
   },
 
-  @discourseComputed("category_id")
-  category() {
+  @computed("category_id")
+  get category() {
     return Category.findById(this.category_id);
+  },
+
+  set category(newCategory) {
+    this.set("category_id", newCategory?.id);
   },
 
   @discourseComputed("url")


### PR DESCRIPTION
Some parts of our code (e.g. some types of reviewable) set `topic.category`. In the past this would override the computed property value, but with recent Ember it raises an error. This commit adds a setter which handles the situation cleanly

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
