### PR TITLE
FIX: Computed property override error for webhook.categories

### DIFF
--- a/app/assets/javascripts/admin/addon/models/web-hook.js
+++ b/app/assets/javascripts/admin/addon/models/web-hook.js
@@ -25,9 +25,16 @@ export default class WebHook extends RestModel {
     this.set("wildcard_web_hook", value === "wildcard");
   }
 
-  @discourseComputed("category_ids")
-  categories(categoryIds) {
-    return Category.findByIds(categoryIds);
+  @computed("category_ids")
+  get categories() {
+    return Category.findByIds(this.category_ids);
+  }
+
+  set categories(value) {
+    this.set(
+      "category_ids",
+      value.map((c) => c.id)
+    );
   }
 
   @observes("group_ids")


### PR DESCRIPTION
In old versions of Ember the computed property would be overridden. But in modern Ember, that throws an exception. <!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
