### PR TITLE
FEATURE: show unread post indicator on mobile

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -345,10 +345,11 @@ textarea {
 }
 
 .wrap {
+  --d-wrap-padding-h: 10px;
   max-width: var(--d-max-width);
   margin-right: auto;
   margin-left: auto;
-  padding: 0 10px;
+  padding: 0 var(--d-wrap-padding-h);
   .contents {
     position: relative;
   }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1747,3 +1747,17 @@ html.discourse-no-touch .fullscreen-table-wrapper:hover {
     opacity: 100%;
   }
 }
+
+.read-state {
+  position: absolute;
+  // We use absolute positioning here because we want it to display in the padding
+  align-self: center;
+  color: var(--tertiary-medium);
+  right: 0;
+  font-size: 0.571em;
+  &.read {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 1s, opacity ease-out 1s;
+  }
+}

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -636,21 +636,6 @@ span.highlighted {
   color: var(--primary-low-mid);
 }
 
-.read-state {
-  position: absolute;
-  // We use absolute positioning here because we want it to display in the padding
-  align-self: center;
-  color: var(--tertiary-medium);
-  right: 0;
-  font-size: 0.571em;
-}
-
-.read-state.read {
-  visibility: hidden;
-  opacity: 0;
-  transition: visibility 1s, opacity ease-out 1s;
-}
-
 .topic-post.sticky-avatar {
   .topic-avatar {
     position: sticky;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -387,11 +387,12 @@ span.highlighted {
   // contained within the padding to prevent vertical overflow
   max-width: var(--d-wrap-padding-h);
   right: calc(var(--d-wrap-padding-h) * -1);
-  font-size: var(--font-down-1);
+  font-size: var(--font-down-2);
   overflow: hidden;
+  margin-top: 0.15em;
 
   svg {
-    right: calc(var(--d-wrap-padding-h) / 3 * -1);
+    right: calc(var(--d-wrap-padding-h) / 2.5 * -1);
   }
 }
 

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -384,7 +384,15 @@ span.highlighted {
 }
 
 .read-state {
-  display: none;
+  // contained within the padding to prevent vertical overflow
+  max-width: var(--d-wrap-padding-h);
+  right: calc(var(--d-wrap-padding-h) * -1);
+  font-size: var(--font-down-1);
+  overflow: hidden;
+
+  svg {
+    right: calc(var(--d-wrap-padding-h) / 3 * -1);
+  }
 }
 
 .post-notice {


### PR DESCRIPTION
On desktop we show a 🔵 to indicate that you haven't read a post yet:

![Screenshot 2024-01-25 at 11 18 24 AM](https://github.com/discourse/discourse/assets/1681963/eec3fbdc-0aa1-474b-85ee-a174b96bfe73)

We've never shown this on mobile due to the lack of space, but I think we can try to show it hanging off to the side like this:


![Screenshot 2024-01-25 at 11 22 16 AM](https://github.com/discourse/discourse/assets/1681963/be70bb46-3e72-4e4e-b480-77cdba5be5af)


the max-width of the container (which has `overflow: hidden`) is tied to the width of the padding, so it doesn't cause overflow
