### PR TITLE
DEV: Temporarily print online_user_ids to logs

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -47,6 +47,7 @@ module Jobs
         user = membership.user
         return unless user.guardian.can_join_chat_channel?(@chat_channel)
         return if ::Chat::Notifier.user_has_seen_message?(membership, @chat_message.id)
+        Rails.logger.warn "online_user_ids: #{online_user_ids}"
         return if online_user_ids.include?(user.id)
 
         translation_key =


### PR DESCRIPTION
We need this to investigate problems with delivering notifications. I'm going to revert this shortly after the merge.
