### PR TITLE
UX: improve featured link positioning in topic titles

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -285,7 +285,7 @@ acceptance("Topic featured links", function (needs) {
     await visit("/t/-/299/1");
 
     const link = query(".title-wrapper .topic-featured-link");
-    assert.strictEqual(link.innerText, " example.com");
+    assert.strictEqual(link.innerText, "example.com");
     assert.strictEqual(link.getAttribute("rel"), "ugc");
   });
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -293,10 +293,6 @@
     }
   }
 
-  .topic-featured-link {
-    padding-left: 5px;
-  }
-
   .topic-excerpt {
     display: block;
     font-size: var(--font-down-1);

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -148,6 +148,7 @@
     padding: 15px 0;
     word-break: break-word;
     color: var(--primary);
+    margin-right: 0.5em;
   }
 
   .anon & {

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -338,6 +338,7 @@
     display: inline-flex;
     align-items: center;
     max-width: 100%;
+    gap: 0.5em;
     .discourse-tags {
       display: inline;
       color: var(--header_primary-high);

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -43,6 +43,7 @@
   .topic-header-extra {
     display: inline-flex;
     align-items: center;
+    gap: 0.5em;
   }
 
   .badge-wrapper {
@@ -128,9 +129,6 @@
   .discourse-tags {
     font-size: var(--font-down-1);
   }
-  .discourse-tags + .topic-featured-link {
-    margin-left: 0.5em;
-  }
 }
 
 .discourse-tags {
@@ -155,7 +153,6 @@ header .discourse-tag {
 
 .list-tags {
   display: inline-block;
-  margin-right: 3px;
   font-size: var(--font-down-1);
 }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -267,9 +267,6 @@ $topic-progress-height: 42px;
   button {
     margin: 0 0.5em 0 0;
   }
-  a.topic-featured-link {
-    display: inline-block;
-  }
   .topic-statuses {
     line-height: 1.2;
     .d-icon {
@@ -287,9 +284,6 @@ $topic-progress-height: 42px;
     display: flex;
     flex-wrap: wrap;
     width: 90%;
-    a.topic-featured-link {
-      display: inline-block;
-    }
   }
   h1 {
     margin-bottom: 0;
@@ -435,12 +429,14 @@ $topic-progress-height: 42px;
 }
 
 a.topic-featured-link {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   text-transform: lowercase;
   color: var(--primary-med-or-secondary-med);
   font-size: 0.875rem;
   .d-icon {
-    margin-right: 3px;
+    font-size: var(--font-down-1);
+    margin-right: 0.25em;
   }
 }
 

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -142,10 +142,6 @@
     }
   }
 
-  .title {
-    margin-right: 0.5em;
-  }
-
   .subcategories-with-subcategories {
     .category-description {
       display: none;

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -142,8 +142,8 @@
     }
   }
 
-  .topic-featured-link {
-    padding-left: 8px;
+  .title {
+    margin-right: 0.5em;
   }
 
   .subcategories-with-subcategories {


### PR DESCRIPTION
Styles for the featured link in the topic title are fairly messy at the moment, this cleans them up and simplifies the CSS. 

Before:

![Screenshot 2024-01-25 at 4 17 07 PM](https://github.com/discourse/discourse/assets/1681963/ce06ef2a-7c0b-468a-9e14-25ee7390c037)
![Screenshot 2024-01-25 at 4 17 23 PM](https://github.com/discourse/discourse/assets/1681963/3ec78a19-7952-4db9-bf70-0d35d4b31731)
![Screenshot 2024-01-25 at 4 17 18 PM](https://github.com/discourse/discourse/assets/1681963/d93ebf69-fc18-401e-955b-55badde532ee)
![Screenshot 2024-01-25 at 4 17 13 PM](https://github.com/discourse/discourse/assets/1681963/de2ad51b-237d-46a9-a7d8-eba3e6c6f1ee)

After:
![Screenshot 2024-01-25 at 4 18 45 PM](https://github.com/discourse/discourse/assets/1681963/770137bc-9f4f-4bd0-85fa-d614044402a4)
![Screenshot 2024-01-25 at 4 15 13 PM](https://github.com/discourse/discourse/assets/1681963/b2b50c07-72d4-44d9-95f4-bc32eab2b81a)
![Screenshot 2024-01-25 at 4 15 17 PM](https://github.com/discourse/discourse/assets/1681963/3c59ee5d-25e8-453a-b00b-969f204a1e3f)
![Screenshot 2024-01-25 at 4 16 27 PM](https://github.com/discourse/discourse/assets/1681963/34d55bad-0158-4992-bded-343e890eb3ee)
