### PR TITLE
DEV: remove chat footer thread count reference

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -22,7 +22,7 @@ export default class ChatFooter extends Component {
 
   <template>
     {{#if this.shouldRenderFooter}}
-      <nav class="c-footer" {{this.updateThreadCount}}>
+      <nav class="c-footer">
         <DButton
           @route="chat.channels"
           @icon="comments"


### PR DESCRIPTION
This change removes a remnant from [#25277](https://github.com/discourse/discourse/pull/25277). We no longer use this modifier so it should be removed.