### PR TITLE
UX: overflow fix for add participants to PM on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/modal-overrides.scss
+++ b/app/assets/stylesheets/mobile/modal-overrides.scss
@@ -18,3 +18,9 @@
     justify-content: center;
   }
 }
+
+.d-modal.add-pm-participants {
+  .d-modal__body {
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
Making an exception for this modal, which has fixed content/height and an unfortunately placed dropdown.

### Before
<img width="383" alt="image" src="https://github.com/discourse/discourse/assets/101828855/4a478f0a-975a-4538-b561-c25056a5d7e5">

### After
<img width="373" alt="image" src="https://github.com/discourse/discourse/assets/101828855/59206aca-eb6f-4fb4-aafc-6b0a945a22a6">

