### PR TITLE
FEATURE: Mobile Chat Notification Badges

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -9,7 +9,6 @@ import ChatFooterUnreadIndicator from "discourse/plugins/chat/discourse/componen
 export default class ChatFooter extends Component {
   @service router;
   @service chat;
-  @service chatTrackingStateManager;
   @service siteSettings;
 
   threadsEnabled = this.siteSettings.chat_threads_enabled;

--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -4,7 +4,11 @@ import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
 import i18n from "discourse-common/helpers/i18n";
 import eq from "truth-helpers/helpers/eq";
-import ChatFooterUnreadIndicator from "discourse/plugins/chat/discourse/components/chat/footer/unread-indicator";
+import {
+  UnreadChannelsIndicator,
+  UnreadDirectMessagesIndicator,
+  UnreadThreadsIndicator,
+} from "discourse/plugins/chat/discourse/components/chat/footer/unread-indicator";
 
 export default class ChatFooter extends Component {
   @service router;
@@ -36,7 +40,7 @@ export default class ChatFooter extends Component {
             (if (eq this.router.currentRouteName "chat.channels") "--active")
           }}
         >
-          <ChatFooterUnreadIndicator @messageType="channels" />
+          <UnreadChannelsIndicator />
         </DButton>
 
         {{#if this.directMessagesEnabled}}
@@ -55,7 +59,7 @@ export default class ChatFooter extends Component {
               )
             }}
           >
-            <ChatFooterUnreadIndicator @messageType="dms" />
+            <UnreadDirectMessagesIndicator />
           </DButton>
         {{/if}}
 
@@ -72,7 +76,7 @@ export default class ChatFooter extends Component {
               (if (eq this.router.currentRouteName "chat.threads") "--active")
             }}
           >
-            <ChatFooterUnreadIndicator @messageType="threads" />
+            <UnreadThreadsIndicator />
           </DButton>
         {{/if}}
       </nav>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -4,10 +4,12 @@ import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
 import i18n from "discourse-common/helpers/i18n";
 import eq from "truth-helpers/helpers/eq";
+import ChatFooterUnreadIndicator from "discourse/plugins/chat/discourse/components/chat/footer/unread-indicator";
 
 export default class ChatFooter extends Component {
   @service router;
   @service chat;
+  @service chatTrackingStateManager;
   @service siteSettings;
 
   threadsEnabled = this.siteSettings.chat_threads_enabled;
@@ -34,7 +36,9 @@ export default class ChatFooter extends Component {
             "c-footer__item"
             (if (eq this.router.currentRouteName "chat.channels") "--active")
           }}
-        />
+        >
+          <ChatFooterUnreadIndicator @messageType="channels" />
+        </DButton>
 
         {{#if this.directMessagesEnabled}}
           <DButton
@@ -51,7 +55,9 @@ export default class ChatFooter extends Component {
                 "--active"
               )
             }}
-          />
+          >
+            <ChatFooterUnreadIndicator @messageType="dms" />
+          </DButton>
         {{/if}}
 
         {{#if this.threadsEnabled}}
@@ -66,7 +72,9 @@ export default class ChatFooter extends Component {
               "c-footer__item"
               (if (eq this.router.currentRouteName "chat.threads") "--active")
             }}
-          />
+          >
+            <ChatFooterUnreadIndicator @messageType="threads" />
+          </DButton>
         {{/if}}
       </nav>
     {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
@@ -1,0 +1,55 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+const MAX_UNREAD_COUNT = 99;
+
+export default class ChatFooterUnreadIndicator extends Component {
+  @service chatTrackingStateManager;
+
+  badgeType = this.args.messageType;
+
+  get urgentCount() {
+    if (this.badgeType == "channels") {
+      return this.chatTrackingStateManager.publicChannelMentionCount;
+    } else if (this.badgeType == "dms") {
+      return this.chatTrackingStateManager.directMessageUnreadCount;
+    } else {
+      return 0;
+    }
+  }
+
+  get unreadCount() {
+    if (this.badgeType == "channels") {
+      return this.chatTrackingStateManager.publicChannelUnreadCount;
+    } else if (this.badgeType == "threads") {
+      return this.chatTrackingStateManager.hasUnreadThreads ? 1 : 0;
+    } else {
+      return 0;
+    }
+  }
+
+  get showUrgent() {
+    return this.urgentCount > 0;
+  }
+
+  get showUnread() {
+    return this.unreadCount > 0;
+  }
+
+  get urgentBadgeCount() {
+    let totalCount = this.urgentCount;
+    return totalCount > MAX_UNREAD_COUNT ? `${MAX_UNREAD_COUNT}+` : totalCount;
+  }
+
+  <template>
+    {{#if this.showUrgent}}
+      <div class="chat-channel-unread-indicator -urgent">
+        <div class="chat-channel-unread-indicator__number">
+          {{this.urgentBadgeCount}}
+        </div>
+      </div>
+    {{else if this.showUnread}}
+      <div class="chat-channel-unread-indicator"></div>
+    {{/if}}
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
@@ -9,9 +9,9 @@ export default class ChatFooterUnreadIndicator extends Component {
   badgeType = this.args.messageType;
 
   get urgentCount() {
-    if (this.badgeType == "channels") {
+    if (this.badgeType === "channels") {
       return this.chatTrackingStateManager.publicChannelMentionCount;
-    } else if (this.badgeType == "dms") {
+    } else if (this.badgeType === "dms") {
       return this.chatTrackingStateManager.directMessageUnreadCount;
     } else {
       return 0;
@@ -19,9 +19,9 @@ export default class ChatFooterUnreadIndicator extends Component {
   }
 
   get unreadCount() {
-    if (this.badgeType == "channels") {
+    if (this.badgeType === "channels") {
       return this.chatTrackingStateManager.publicChannelUnreadCount;
-    } else if (this.badgeType == "threads") {
+    } else if (this.badgeType === "threads") {
       return this.chatTrackingStateManager.hasUnreadThreads ? 1 : 0;
     } else {
       return 0;

--- a/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
@@ -1,17 +1,32 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 
+const CHANNELS_TAB = "channels";
+const DMS_TAB = "dms";
+const THREADS_TAB = "threads";
 const MAX_UNREAD_COUNT = 99;
 
-export default class ChatFooterUnreadIndicator extends Component {
+export const UnreadChannelsIndicator = <template>
+  <FooterUnreadIndicator @badgeType={{CHANNELS_TAB}} />
+</template>;
+
+export const UnreadDirectMessagesIndicator = <template>
+  <FooterUnreadIndicator @badgeType={{DMS_TAB}} />
+</template>;
+
+export const UnreadThreadsIndicator = <template>
+  <FooterUnreadIndicator @badgeType={{THREADS_TAB}} />
+</template>;
+
+export default class FooterUnreadIndicator extends Component {
   @service chatTrackingStateManager;
 
-  badgeType = this.args.messageType;
+  badgeType = this.args.badgeType;
 
   get urgentCount() {
-    if (this.badgeType === "channels") {
+    if (this.badgeType === CHANNELS_TAB) {
       return this.chatTrackingStateManager.publicChannelMentionCount;
-    } else if (this.badgeType === "dms") {
+    } else if (this.badgeType === DMS_TAB) {
       return this.chatTrackingStateManager.directMessageUnreadCount;
     } else {
       return 0;
@@ -19,9 +34,9 @@ export default class ChatFooterUnreadIndicator extends Component {
   }
 
   get unreadCount() {
-    if (this.badgeType === "channels") {
+    if (this.badgeType === CHANNELS_TAB) {
       return this.chatTrackingStateManager.publicChannelUnreadCount;
-    } else if (this.badgeType === "threads") {
+    } else if (this.badgeType === THREADS_TAB) {
       return this.chatTrackingStateManager.hasUnreadThreads ? 1 : 0;
     } else {
       return 0;

--- a/plugins/chat/assets/javascripts/discourse/services/chat-tracking-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-tracking-state-manager.js
@@ -47,40 +47,36 @@ export default class ChatTrackingStateManager extends Service {
     }, 0);
   }
 
+  get directMessageUnreadCount() {
+    return this.#directMessageChannels.reduce((unreadCount, channel) => {
+      return unreadCount + channel.tracking.unreadCount;
+    }, 0);
+  }
+
+  get publicChannelMentionCount() {
+    return this.#publicChannels.reduce((mentionCount, channel) => {
+      return mentionCount + channel.tracking.mentionCount;
+    }, 0);
+  }
+
+  get directMessageMentionCount() {
+    return this.#directMessageChannels.reduce((dmMentionCount, channel) => {
+      return dmMentionCount + channel.tracking.mentionCount;
+    }, 0);
+  }
+
   get allChannelMentionCount() {
-    let totalPublicMentions = this.#publicChannels.reduce(
-      (channelMentionCount, channel) => {
-        return channelMentionCount + channel.tracking.mentionCount;
-      },
-      0
-    );
-
-    let totalPrivateMentions = this.#directMessageChannels.reduce(
-      (dmMentionCount, channel) => {
-        return dmMentionCount + channel.tracking.mentionCount;
-      },
-      0
-    );
-
-    return totalPublicMentions + totalPrivateMentions;
+    return this.publicChannelMentionCount + this.directMessageMentionCount;
   }
 
   get allChannelUrgentCount() {
-    let publicChannelMentionCount = this.#publicChannels.reduce(
-      (mentionCount, channel) => {
-        return mentionCount + channel.tracking.mentionCount;
-      },
-      0
-    );
+    return this.publicChannelMentionCount + this.directMessageUnreadCount;
+  }
 
-    let dmChannelUnreadCount = this.#directMessageChannels.reduce(
-      (unreadCount, channel) => {
-        return unreadCount + channel.tracking.unreadCount;
-      },
-      0
+  get hasUnreadThreads() {
+    return this.#publicChannels.some(
+      (channel) => channel.unreadThreadsCount > 0
     );
-
-    return publicChannelMentionCount + dmChannelUnreadCount;
   }
 
   willDestroy() {

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -64,26 +64,25 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   }
 }
 
-.header-dropdown-toggle.chat-header-icon {
-  .icon {
-    .chat-channel-unread-indicator {
-      @include chat-unread-indicator;
-      border: 2px solid var(--header_background);
-      position: absolute;
-      top: 0;
-      right: 2px;
+.header-dropdown-toggle.chat-header-icon .icon,
+.c-footer .c-footer__item {
+  .chat-channel-unread-indicator {
+    @include chat-unread-indicator;
+    border: 2px solid var(--header_background);
+    position: absolute;
+    top: 0;
+    right: 2px;
 
-      &.-urgent {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: auto;
-        height: 1em;
-        min-width: 0.6em;
-        padding: 0.21em 0.42em;
-        top: -1px;
-        right: 0;
-      }
+    &.-urgent {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: auto;
+      height: 1em;
+      min-width: 0.6em;
+      padding: 0.21em 0.42em;
+      top: -1px;
+      right: 0;
     }
   }
 

--- a/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
+++ b/plugins/chat/assets/stylesheets/mobile/base-mobile.scss
@@ -72,13 +72,12 @@ html.has-full-page-chat {
   margin-left: 0;
 }
 
-.header-dropdown-toggle.chat-header-icon {
-  .icon {
-    &.active .d-icon {
-      color: var(--primary-medium);
-    }
-    .chat-channel-unread-indicator {
-      border-color: var(--primary-very-low);
-    }
+.header-dropdown-toggle.chat-header-icon .icon,
+.c-footer .c-footer__item {
+  &.active .d-icon {
+    color: var(--primary-medium);
+  }
+  .chat-channel-unread-indicator {
+    border-color: var(--primary-very-low);
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
@@ -61,6 +61,11 @@
         left: 50%;
         margin-left: 0.75rem;
       }
+
+      .chat-channel-unread-indicator:not(.-urgent) {
+        width: 11px;
+        height: 11px;
+      }
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
@@ -30,6 +30,7 @@
       flex-shrink: 0;
       padding-block: 0.75rem;
       height: 100%;
+      position: relative;
 
       &.--active {
         .d-icon,
@@ -51,6 +52,14 @@
       .d-button-label {
         font-size: var(--font-down-1-rem);
         color: var(--primary-medium);
+      }
+
+      .chat-channel-unread-indicator,
+      .chat-channel-unread-indicator.-urgent {
+        top: 0.25rem;
+        right: unset;
+        left: 50%;
+        margin-left: 0.75rem;
       }
     }
   }

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe "Chat footer on mobile", type: :system, mobile: true do
+RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
   fab!(:user)
+  fab!(:user_2) { Fabricate(:user) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
   fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: user) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
@@ -10,6 +11,7 @@ RSpec.describe "Chat footer on mobile", type: :system, mobile: true do
     chat_system_bootstrap
     sign_in(user)
     channel.add(user)
+    channel.add(user_2)
   end
 
   context "with multiple tabs" do
@@ -67,6 +69,64 @@ RSpec.describe "Chat footer on mobile", type: :system, mobile: true do
       chat_page.open_from_header
 
       expect(page).to have_current_path("/chat/channels")
+    end
+  end
+
+  describe "badges" do
+    context "for channels" do
+      it "is unread for messages" do
+        Fabricate(:chat_message, chat_channel: channel)
+
+        visit("/")
+        chat_page.open_from_header
+
+        expect(page).to have_css("#c-footer-channels .chat-channel-unread-indicator")
+      end
+
+      it "is urgent for mentions" do
+        Jobs.run_immediately!
+
+        visit("/")
+        chat_page.open_from_header
+
+        Fabricate(
+          :chat_message_with_service,
+          chat_channel: channel,
+          message: "hello @#{user.username}",
+          user: user_2,
+        )
+
+        expect(page).to have_css(
+          "#c-footer-channels .chat-channel-unread-indicator.-urgent",
+          text: "1",
+        )
+      end
+    end
+
+    context "for direct messages" do
+      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user]) }
+      fab!(:dm_message) { Fabricate(:chat_message, chat_channel: dm_channel) }
+
+      it "is urgent" do
+        visit("/")
+        chat_page.open_from_header
+
+        expect(page).to have_css("#c-footer-direct-messages .chat-channel-unread-indicator.-urgent")
+      end
+    end
+
+    context "for threads" do
+      fab!(:thread) { Fabricate(:chat_thread, channel: channel, original_message: message) }
+      fab!(:thread_message) { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
+
+      it "is unread" do
+        SiteSetting.chat_threads_enabled = true
+
+        visit("/")
+        chat_page.open_from_header
+
+        expect(page).to have_css("#c-footer-threads .chat-channel-unread-indicator")
+      end
     end
   end
 end


### PR DESCRIPTION
This change adds notification badges to the new footer on mobile chat to help users easily find areas where there’s new activity to review.

### Acceptance Criteria

When on mobile chat:
- Show a badge on the DMs footer when there is unread activity in DMs.
- Show a badge on the Channels footer tab when there is unread channel activity.
- Show a badge on the Threads footer tab when there is unread activity in a followed thread.
- Notification badges should be removed once the unread activity is viewed.

### Additional

- Show green notification badges for channel mentions or DMs
- Show blue notification badges for unread messages in channels or threads

### How it looks

<img width="353" alt="Mobile Chat Badges" src="https://github.com/discourse/discourse/assets/2257978/e66e83db-aba9-4e1d-920e-259026f720e1">


/t/119770