### PR TITLE
UX: chat > channel info: show member count on tab

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
@@ -3,7 +3,6 @@ import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { inject as service } from "@ember/service";
 import I18n from "discourse-i18n";
-import eq from "truth-helpers/helpers/eq";
 import ChatModalEditChannelName from "discourse/plugins/chat/discourse/components/chat/modal/edit-channel-name";
 import Navbar from "discourse/plugins/chat/discourse/components/chat/navbar";
 import ChatChannelStatus from "discourse/plugins/chat/discourse/components/chat-channel-status";
@@ -79,9 +78,9 @@ export default class ChatRoutesChannelInfo extends Component {
                   @replace={{true}}
                 >
                   {{this.membersLabel}}
-                  {{#if (eq @channel.chatableType "Category")}}
+                  {{#if @channel.isCategoryChannel}}
                     <span
-                      class="c-channel-info__membercount"
+                      class="c-channel-info__member-count"
                     >({{@channel.membershipsCount}})</span>
                   {{/if}}
                 </LinkTo>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
@@ -78,7 +78,6 @@ export default class ChatRoutesChannelInfo extends Component {
                   @model={{@channel}}
                   @replace={{true}}
                 >
-                  {{log @channel.chatableType @channel.membershipsCount}}
                   {{this.membersLabel}}
                   {{#if (eq @channel.chatableType "Category")}}
                     <span

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { inject as service } from "@ember/service";
 import I18n from "discourse-i18n";
+import eq from "truth-helpers/helpers/eq";
 import ChatModalEditChannelName from "discourse/plugins/chat/discourse/components/chat/modal/edit-channel-name";
 import Navbar from "discourse/plugins/chat/discourse/components/chat/navbar";
 import ChatChannelStatus from "discourse/plugins/chat/discourse/components/chat-channel-status";
@@ -77,7 +78,13 @@ export default class ChatRoutesChannelInfo extends Component {
                   @model={{@channel}}
                   @replace={{true}}
                 >
+                  {{log @channel.chatableType @channel.membershipsCount}}
                   {{this.membersLabel}}
+                  {{#if (eq @channel.chatableType "Category")}}
+                    <span
+                      class="c-channel-info__membercount"
+                    >({{@channel.membershipsCount}})</span>
+                  {{/if}}
                 </LinkTo>
               </li>
             </ul>

--- a/plugins/chat/assets/stylesheets/common/chat-channel-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-info.scss
@@ -13,6 +13,10 @@
       padding-bottom: 1rem;
     }
   }
+
+  &__membercount {
+    margin-left: 0.25em;
+  }
 }
 
 .c-channel-members__add-members {

--- a/plugins/chat/assets/stylesheets/common/chat-channel-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-info.scss
@@ -14,7 +14,7 @@
     }
   }
 
-  &__membercount {
+  &__member-count {
     margin-left: 0.25em;
   }
 }


### PR DESCRIPTION
Noticed there wasn't a mention of the number of chat members in a channel.

Added it in for categories only 

<img width="608" alt="image" src="https://github.com/discourse/discourse/assets/101828855/2d9d2fb6-6271-4fd8-aee0-268796a2d15d">


