### PR TITLE
FIX: Set allowUncategorized SelectKit option

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -2,6 +2,7 @@ import { computed } from "@ember/object";
 import { readOnly } from "@ember/object/computed";
 import { htmlSafe } from "@ember/template";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import { setting } from "discourse/lib/computed";
 import DiscourseURL, {
   getCategoryAndTagUrl,
   getEditCategoryUrl,
@@ -39,6 +40,7 @@ export default ComboBoxComponent.extend({
     displayCategoryDescription: "displayCategoryDescription",
     headerComponent: "category-drop/category-drop-header",
     parentCategory: false,
+    allowUncategorized: setting("allow_uncategorized_topics"),
   },
 
   modifyComponentForRow() {


### PR DESCRIPTION
CategoryRow component uses allowUncategorized SelectKit option to decide whether to show the "Uncategorized" category or not. This was undefined which lead to "Uncategorized" category being always hidden causing a minor visual glitch.

Before:

<img width="236" alt="image" src="https://github.com/discourse/discourse/assets/23153890/27489c0b-941b-4dd6-afce-2d4cfcf895dd">

After:

<img width="236" alt="image" src="https://github.com/discourse/discourse/assets/23153890/cecddb2b-6f3f-45a9-a6e1-18a7a468fb56">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
