### PR TITLE
UX: fix and improve topic title badge spacing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
@@ -14,9 +14,9 @@
     {{raw "topic-status" topic=this.topic}}
     {{topic-link this.topic}}
     {{~#if this.topic.featured_link}}
-      {{topic-featured-link this.topic}}
-    {{/if}}
-    <TopicPostBadges
+      &nbsp;{{topic-featured-link this.topic}}
+    {{/if}}{{! intentionally inline 
+    to avoid whitespace}}<TopicPostBadges
       @unreadPosts={{this.topic.unread_posts}}
       @unseen={{this.topic.unseen}}
       @url={{this.topic.lastUnreadUrl}}

--- a/app/assets/javascripts/discourse/app/components/topic-post-badges.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-post-badges.hbs
@@ -1,14 +1,12 @@
-{{#if this.displayUnreadPosts}}
-  &nbsp;<a
+{{~#if this.displayUnreadPosts}}&nbsp;<a
     href={{this.url}}
     title={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
     class="badge badge-notification unread-posts"
   >{{this.displayUnreadPosts}}</a>
-{{/if}}
-{{#if this.unseen}}
-  &nbsp;<a
+{{/if~}}
+{{~#if this.unseen}}&nbsp;<a
     href={{this.url}}
     title={{i18n "topic.new"}}
     class="badge badge-notification new-topic"
   >{{this.newDotText}}</a>
-{{/if}}
+{{/if~}}

--- a/app/assets/javascripts/discourse/app/raw-templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/list/topic-list-item.hbr
@@ -22,7 +22,7 @@
     {{~raw "topic-status" topic=topic}}
     {{~topic-link topic class="raw-link raw-topic-link"}}
     {{~#if topic.featured_link}}
-      {{~topic-featured-link topic}}
+      &nbsp;{{~topic-featured-link topic}}
     {{~/if}}
     {{~raw-plugin-outlet name="topic-list-after-title"}}
     {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -293,10 +293,6 @@
     }
   }
 
-  .topic-featured-link {
-    padding-left: 5px;
-  }
-
   .topic-excerpt {
     display: block;
     font-size: var(--font-down-1);

--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -72,6 +72,8 @@
 
 .badge-notification {
   @extend %badge;
+  position: relative;
+  top: -2px;
   padding: 0.21em 0.42em;
   min-width: 0.5em;
   color: var(--secondary);
@@ -97,6 +99,7 @@
 
   &.new-topic {
     background-color: transparent;
+    padding-left: 0.15em;
   }
 
   &.new-topic::before {

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -142,10 +142,6 @@
     }
   }
 
-  .topic-featured-link {
-    padding-left: 8px;
-  }
-
   .subcategories-with-subcategories {
     .category-description {
       display: none;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -68,16 +68,6 @@
     }
   }
 
-  .badge-notification {
-    position: relative;
-    top: -2px;
-
-    &.new-topic {
-      top: -1px;
-      padding-left: 2px;
-    }
-  }
-
   $td-posters-height: 29px; // min-height of td with avatar glow
   $td-posters-more-lh: $td-posters-height - 4;
 


### PR DESCRIPTION
fixes an extra space issue added by 3c54d9e, and also controls some whitespace and seeks to improve the consistency of spacing between the main topic list and the categories topic list

before:

![Screenshot 2024-01-26 at 9 51 00 AM](https://github.com/discourse/discourse/assets/1681963/4240635b-cb0b-498d-b9a1-40416fdd41f5)



after:

![Screenshot 2024-01-26 at 9 50 47 AM](https://github.com/discourse/discourse/assets/1681963/572a792b-fabd-45fc-9667-b52167b4e43e)


before:

![Screenshot 2024-01-26 at 9 51 12 AM](https://github.com/discourse/discourse/assets/1681963/dc74afdf-2320-4b3c-a4da-97441d2debe6)

after:

![Screenshot 2024-01-26 at 9 50 18 AM](https://github.com/discourse/discourse/assets/1681963/1f3903be-9078-4bec-9d5f-222910d94159)

