### PR TITLE
FIX: export csv file failed message

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -433,7 +433,7 @@ module Jobs
 
       if @current_user
         post =
-          if upload
+          if upload&.errors&.empty?
             SystemMessage.create_from_system_user(
               @current_user,
               :csv_export_succeeded,

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -52,6 +52,26 @@ RSpec.describe Jobs::ExportCsvFile do
         admin.uploads.each(&:destroy!)
       end
     end
+
+    it "generates csv export failed message if upload is too large" do
+      action_log
+      SiteSetting.max_export_file_size_kb = 0
+
+      begin
+        Jobs::ExportCsvFile.new.execute(user_id: admin.id, entity: "staff_action")
+
+        system_message = admin.topics_allowed.last
+
+        expect(system_message.title).to eq(
+          I18n.t(
+            "system_messages.csv_export_failed.subject_template",
+            export_title: "Data export failed",
+          ),
+        )
+      ensure
+        admin.uploads.each(&:destroy!)
+      end
+    end
   end
 
   describe ".report_export" do


### PR DESCRIPTION
When exporting a csv file and the size of the file exceeded the
max_export_file_size_kb it will still send the PM that the export
succeeded with a broken link to a missing export file. This change
ensures that a failed message will be sent instead.
