### PR TITLE
FIX: remove excess margin after title

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -148,7 +148,6 @@
     padding: 15px 0;
     word-break: break-word;
     color: var(--primary);
-    margin-right: 0.5em;
   }
 
   .anon & {


### PR DESCRIPTION
Missed this one in 4266b0c because I had a bad merge locally! 