### PR TITLE
FIX: global selector needed to avoid clicks registering on other elements

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -223,7 +223,8 @@
   .main-link {
     @extend .topic-list-main-link;
 
-    .raw-topic-link a {
+    .raw-topic-link > * {
+      // important to prevent clicks registering on non-link elements and resulting in a full page reload
       pointer-events: none;
     }
 


### PR DESCRIPTION
Reverts part of 6b185f8, turns out this one is important (was especially noticeable with mixed text direction enabled)

Reported in: https://meta.discourse.org/t/refreshing-everytime-i-open-a-topic/293095