### PR TITLE
FIX: allows to translate yesterday

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import I18n from "I18n";
 import ChatChannelUnreadIndicator from "./chat-channel-unread-indicator";
 
 export default class ChatChannelMetadata extends Component {
@@ -8,10 +9,8 @@ export default class ChatChannelMetadata extends Component {
 
   get lastMessageFormattedDate() {
     return moment(this.args.channel.lastMessage.createdAt).calendar(null, {
-      sameDay: "LT",
-      nextDay: "[Tomorrow]",
-      nextWeek: "dddd",
-      lastDay: "[Yesterday]",
+      sameDay: "[LT]",
+      lastDay: `[${I18n.t("chat.dates.yesterday")}]`,
       lastWeek: "dddd",
       sameElse: "l",
     });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
@@ -9,7 +9,7 @@ export default class ChatChannelMetadata extends Component {
 
   get lastMessageFormattedDate() {
     return moment(this.args.channel.lastMessage.createdAt).calendar(null, {
-      sameDay: "[LT]",
+      sameDay: "LT",
       lastDay: `[${I18n.t("chat.dates.yesterday")}]`,
       lastWeek: "dddd",
       sameElse: "l",

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -40,6 +40,7 @@ en:
       back_to_forum: "Forum"
       deleted_chat_username: deleted
       dates:
+        yesterday: "Yesterday"
         time_tiny: "h:mm"
       all_loaded: "Showing all messages"
       already_enabled: "Chat is already enabled on this topic. Please refresh."


### PR DESCRIPTION
`[Yesterday]` was a fixed string which couldn't be translated. Also removes nextWeek/nextDay which make no sense for dates which are always supposed to be in the past.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
