### PR TITLE
DEV: Create unlogged tables by default in the test environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,7 @@ jobs:
             ${{ runner.os }}-
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
+            ${{ hashFiles('config/environments/test.rb') }}-
             ${{ env.USES_PARALLEL_DATABASES }}
 
       - name: Restore database from cache

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -104,4 +104,10 @@ Discourse::Application.configure do
 
     SiteSetting.refresh!
   end
+
+  if ENV["CI"].present?
+    config.to_prepare do
+      ActiveSupport.on_load(:active_record_postgresqladapter) { self.create_unlogged_tables = true }
+    end
+  end
 end


### PR DESCRIPTION
Why this change?

In https://www.postgresql.org/docs/current/non-durability.html, it is
recommended to create unlogged tables to avoid WAL writes which can help
speed at performance at the expense of durability. In the test
environment, there is no need for durability at all. Therefore, we are
creating unlogged tables by default.

Co-authored-by: Ted Johansson <ted@discourse.org>
Co-authored-by: Rafael dos Santos Silva <xfalcox@gmail.com>