### PR TITLE
DEV: Set `synchronous_commit` to `off` in `start_test_db`

### DIFF
--- a/script/start_test_db.rb
+++ b/script/start_test_db.rb
@@ -29,6 +29,7 @@ if should_setup
   run "#{BIN}/initdb -D #{DATA}"
 
   run "echo fsync = off >> #{DATA}/postgresql.conf"
+  run "echo synchronous_commit = off >> #{DATA}/postgresql.conf"
   run "echo full_page_writes = off >> #{DATA}/postgresql.conf"
   run "echo shared_buffers = 500MB >> #{DATA}/postgresql.conf"
 end


### PR DESCRIPTION
Why this change?

In https://www.postgresql.org/docs/current/non-durability.html, it is
recommended to turn off `synchronous_commit` in environments where
durability is not important. The `start_test_db.rb` script is mainly
used in the CI environment where durability is not important at all.