### PR TITLE
Revert "Build(deps): Bump @glimmer/syntax from 0.84.3 to 0.88.0 in /app/assets/javascripts (#25450)"

### DIFF
--- a/app/assets/javascripts/discourse-widget-hbs/package.json
+++ b/app/assets/javascripts/discourse-widget-hbs/package.json
@@ -25,7 +25,7 @@
     "@ember/string": "^3.1.1",
     "@embroider/test-setup": "^3.0.3",
     "@glimmer/component": "^1.1.2",
-    "@glimmer/syntax": "^0.88.0",
+    "@glimmer/syntax": "^0.84.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~5.0.0",
     "ember-cli-inject-live-reload": "^2.1.0",

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -16,7 +16,7 @@
     "postinstall": "../run-patch-package"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.88.0",
+    "@glimmer/syntax": "^0.84.3",
     "@highlightjs/cdn-assets": "^11.9.0",
     "discourse-hbr": "1.0.0",
     "discourse-widget-hbs": "1.0.0",

--- a/app/assets/javascripts/yarn-ember3.lock
+++ b/app/assets/javascripts/yarn-ember3.lock
@@ -1456,13 +1456,6 @@
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/interfaces@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.88.0.tgz#d16e0e015b12e43ed8c128b5c01ba2a4575e41c9"
-  integrity sha512-Y5VJurwUOz5pgCWCdRr2lzB5MchOXSSFwqeCrKmUdzXrFuEweRinoRPcqLYSJ+u85h/oTV9dtJqZJOHNqABJJw==
-  dependencies:
-    "@simple-dom/interface" "^1.4.0"
-
 "@glimmer/syntax@^0.84.3":
   version "0.84.3"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.84.3.tgz#4045a1708cef7fd810cff42fe6deeba40c7286d0"
@@ -1470,17 +1463,6 @@
   dependencies:
     "@glimmer/interfaces" "0.84.3"
     "@glimmer/util" "0.84.3"
-    "@handlebars/parser" "~2.0.0"
-    simple-html-tokenizer "^0.5.11"
-
-"@glimmer/syntax@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.88.0.tgz#26cbf1dac9b3d22397cb1697921331f6d7a81198"
-  integrity sha512-ncKgfaVcT/7wcAtT0WJzZuASODx0cx4qQ+vgWmyJD7WBDXT5ST0k3Z9+D0mJWQkThD4V9DV+dIFkrpOZiv6YPg==
-  dependencies:
-    "@glimmer/interfaces" "^0.88.0"
-    "@glimmer/util" "^0.88.0"
-    "@glimmer/wire-format" "^0.88.0"
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
@@ -1506,14 +1488,6 @@
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
   integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
 
-"@glimmer/util@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.88.0.tgz#6ffa4e7ae6ed8fb830bb516c35e855d180b6d3ff"
-  integrity sha512-O1+gHjHFnrHH/xDfTDHR/h8x4JmT3yJcNlJFV+K84mffEHgdTqdIDI+F01YndDugULUEUaqH5+PAEOie7eAPfg==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.88.0"
-
 "@glimmer/validator@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
@@ -1525,14 +1499,6 @@
   integrity sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
-
-"@glimmer/wire-format@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.88.0.tgz#1f2380444ae9cb8b40c0234df5b3ca83e19bbd06"
-  integrity sha512-XOxNoWWt3b45SIsVcn4gT+KTwacuNX710PInSwPa3QaTFXrWp+DnjcJR3P8qe9PJ8+u/9mQFshMly3qhWsUhdA==
-  dependencies:
-    "@glimmer/interfaces" "^0.88.0"
-    "@glimmer/util" "^0.88.0"
 
 "@handlebars/parser@~2.0.0":
   version "2.0.0"

--- a/app/assets/javascripts/yarn-ember5.lock
+++ b/app/assets/javascripts/yarn-ember5.lock
@@ -1486,13 +1486,6 @@
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/interfaces@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.88.0.tgz#d16e0e015b12e43ed8c128b5c01ba2a4575e41c9"
-  integrity sha512-Y5VJurwUOz5pgCWCdRr2lzB5MchOXSSFwqeCrKmUdzXrFuEweRinoRPcqLYSJ+u85h/oTV9dtJqZJOHNqABJJw==
-  dependencies:
-    "@simple-dom/interface" "^1.4.0"
-
 "@glimmer/low-level@0.78.2":
   version "0.78.2"
   resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.78.2.tgz#bca5f666760ce98345e87c5b3e37096e772cb2de"
@@ -1594,17 +1587,6 @@
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/syntax@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.88.0.tgz#26cbf1dac9b3d22397cb1697921331f6d7a81198"
-  integrity sha512-ncKgfaVcT/7wcAtT0WJzZuASODx0cx4qQ+vgWmyJD7WBDXT5ST0k3Z9+D0mJWQkThD4V9DV+dIFkrpOZiv6YPg==
-  dependencies:
-    "@glimmer/interfaces" "^0.88.0"
-    "@glimmer/util" "^0.88.0"
-    "@glimmer/wire-format" "^0.88.0"
-    "@handlebars/parser" "~2.0.0"
-    simple-html-tokenizer "^0.5.11"
-
 "@glimmer/tracking@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.1.2.tgz#74e71be07b0a7066518d24044d2665d0cf8281eb"
@@ -1626,14 +1608,6 @@
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
   integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
-
-"@glimmer/util@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.88.0.tgz#6ffa4e7ae6ed8fb830bb516c35e855d180b6d3ff"
-  integrity sha512-O1+gHjHFnrHH/xDfTDHR/h8x4JmT3yJcNlJFV+K84mffEHgdTqdIDI+F01YndDugULUEUaqH5+PAEOie7eAPfg==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.88.0"
 
 "@glimmer/validator@0.84.3":
   version "0.84.3"
@@ -1670,14 +1644,6 @@
   dependencies:
     "@glimmer/interfaces" "0.84.3"
     "@glimmer/util" "0.84.3"
-
-"@glimmer/wire-format@^0.88.0":
-  version "0.88.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.88.0.tgz#1f2380444ae9cb8b40c0234df5b3ca83e19bbd06"
-  integrity sha512-XOxNoWWt3b45SIsVcn4gT+KTwacuNX710PInSwPa3QaTFXrWp+DnjcJR3P8qe9PJ8+u/9mQFshMly3qhWsUhdA==
-  dependencies:
-    "@glimmer/interfaces" "^0.88.0"
-    "@glimmer/util" "^0.88.0"
 
 "@handlebars/parser@~2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This reverts commit ef8762952682e5cec3ea9b24208b280102ee1824.

Breaks licensee on CI which I have no time to figure out now