### PR TITLE
FIX: Make long thread titles readable

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -150,6 +150,7 @@ export default class ChatThread extends Component {
     this.isScrolling = false;
     this.resetIdle();
     this.atBottom = state.atBottom;
+    this.args.setFullTitle?.(state.atTop);
 
     if (state.atBottom) {
       this.fetchMoreMessages({ direction: FUTURE });

--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-thread.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { array } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -14,6 +15,8 @@ export default class ChatDrawerRoutesChannelThread extends Component {
   @service chatStateManager;
   @service chatChannelsManager;
   @service chatHistory;
+
+  @tracked showfullTitle = false;
 
   get backButton() {
     const link = {
@@ -65,8 +68,17 @@ export default class ChatDrawerRoutesChannelThread extends Component {
     }
   }
 
+  @action
+  setFullTitle(value) {
+    this.showfullTitle = value;
+  }
+
   <template>
-    <Navbar @onClick={{this.chat.toggleDrawer}} as |navbar|>
+    <Navbar
+      @onClick={{this.chat.toggleDrawer}}
+      @showFullTitle={{this.showfullTitle}}
+      as |navbar|
+    >
       <navbar.BackButton
         @title={{this.backButton.title}}
         @route={{this.backButton.route}}
@@ -92,6 +104,7 @@ export default class ChatDrawerRoutesChannelThread extends Component {
             <ChatThread
               @thread={{thread}}
               @targetMessageId={{@params.messageId}}
+              @setFullTitle={{this.setFullTitle}}
             />
           {{/if}}
         {{/each}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel-thread.gjs
@@ -16,7 +16,11 @@ export default class ChatDrawerRoutesChannelThread extends Component {
   @service chatChannelsManager;
   @service chatHistory;
 
-  @tracked showfullTitle = false;
+  @tracked showThreadFullTitle = false;
+
+  get showfullTitle() {
+    return this.chatStateManager.isDrawerExpanded && this.showThreadFullTitle;
+  }
 
   get backButton() {
     const link = {
@@ -70,7 +74,7 @@ export default class ChatDrawerRoutesChannelThread extends Component {
 
   @action
   setFullTitle(value) {
-    this.showfullTitle = value;
+    this.showThreadFullTitle = value;
   }
 
   <template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/threads.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/threads.gjs
@@ -17,10 +17,7 @@ export default class ChatDrawerRoutesThreads extends Component {
       <navbar.Title
         @title={{i18n "chat.my_threads.title"}}
         @icon="discourse-threads"
-        as |title|
-      >
-        <title.SubTitle @title={{this.chat.activeChannel.title}} />
-      </navbar.Title>
+      />
       <navbar.Actions as |action|>
         <action.ThreadsListButton />
         <action.ToggleDrawerButton />

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
@@ -1,29 +1,46 @@
+import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import concatClass from "discourse/helpers/concat-class";
 import noop from "discourse/helpers/noop";
+import ChatOnResize from "../../../modifiers/chat/on-resize";
 import Actions from "./actions";
 import BackButton from "./back-button";
 import ChannelTitle from "./channel-title";
 import Title from "./title";
 
-const ChatNavbar = <template>
-  {{! template-lint-disable no-invalid-interactive }}
-  <div
-    class={{concatClass "c-navbar-container" (if @onClick "-clickable")}}
-    {{on "click" (if @onClick @onClick (noop))}}
-  >
-    <nav class="c-navbar">
-      {{yield
-        (hash
-          BackButton=BackButton
-          ChannelTitle=ChannelTitle
-          Title=Title
-          Actions=Actions
-        )
-      }}
-    </nav>
-  </div>
-</template>;
+export default class ChatNavbar extends Component {
+  @action
+  handleResize(entries) {
+    for (let entry of entries) {
+      const height = entry.target.clientHeight;
+      document.documentElement.style.setProperty(
+        "--chat-thread-header-offset",
+        `${height}px`
+      );
+    }
+  }
 
-export default ChatNavbar;
+  <template>
+    {{! template-lint-disable no-invalid-interactive }}
+    <div
+      class={{concatClass "c-navbar-container" (if @onClick "-clickable")}}
+      {{on "click" (if @onClick @onClick (noop))}}
+    >
+      <nav
+        class={{concatClass "c-navbar" (if @showFullTitle "-full-title")}}
+        {{ChatOnResize this.handleResize}}
+      >
+        {{yield
+          (hash
+            BackButton=BackButton
+            ChannelTitle=ChannelTitle
+            Title=Title
+            Actions=Actions
+          )
+        }}
+      </nav>
+    </div>
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/index.gjs
@@ -15,23 +15,28 @@ export default class ChatNavbar extends Component {
   handleResize(entries) {
     for (let entry of entries) {
       const height = entry.target.clientHeight;
-      document.documentElement.style.setProperty(
-        "--chat-thread-header-offset",
-        `${height}px`
-      );
+
+      requestAnimationFrame(() => {
+        document.documentElement.style.setProperty(
+          "--chat-header-expanded-offset",
+          `${height}px`
+        );
+      });
     }
   }
 
   <template>
     {{! template-lint-disable no-invalid-interactive }}
     <div
-      class={{concatClass "c-navbar-container" (if @onClick "-clickable")}}
+      class={{concatClass
+        "c-navbar-container"
+        (if @onClick "-clickable")
+        (if @showFullTitle "-full-title")
+      }}
       {{on "click" (if @onClick @onClick (noop))}}
+      {{ChatOnResize this.handleResize}}
     >
-      <nav
-        class={{concatClass "c-navbar" (if @showFullTitle "-full-title")}}
-        {{ChatOnResize this.handleResize}}
-      >
+      <nav class="c-navbar">
         {{yield
           (hash
             BackButton=BackButton

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
@@ -9,12 +9,14 @@ const ChatNavbarTitle = <template>
     class={{concatClass "c-navbar__title" (if @showFullTitle "full-title")}}
   >
     {{#if (has-block)}}
-      {{if @icon (icon @icon)}}
-      {{@title}}
+      <span class="c-navbar__title-text">{{if @icon (icon @icon)}}
+        {{@title}}</span>
       {{yield (hash SubTitle=SubTitle)}}
     {{else}}
-      {{if @icon (icon @icon)}}
-      {{@title}}
+      <span class="c-navbar__title-text">{{if
+          @icon
+          (icon @icon)
+        }}{{@title}}</span>
     {{/if}}
   </div>
 </template>;

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/title.gjs
@@ -1,9 +1,13 @@
 import { hash } from "@ember/helper";
+import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse-common/helpers/d-icon";
 import SubTitle from "./sub-title";
 
 const ChatNavbarTitle = <template>
-  <div title={{@title}} class="c-navbar__title">
+  <div
+    title={{@title}}
+    class={{concatClass "c-navbar__title" (if @showFullTitle "full-title")}}
+  >
     {{#if (has-block)}}
       {{if @icon (icon @icon)}}
       {{@title}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-thread.gjs
@@ -6,7 +6,7 @@ import ThreadHeader from "discourse/plugins/chat/discourse/components/chat/threa
 import Thread from "discourse/plugins/chat/discourse/components/chat-thread";
 
 export default class ChatRoutesChannelThread extends Component {
-  @tracked showfullTitle = true;
+  @tracked showfullTitle = false;
 
   @action
   setFullTitle(value) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-thread.gjs
@@ -1,19 +1,33 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { array } from "@ember/helper";
+import { action } from "@ember/object";
 import ThreadHeader from "discourse/plugins/chat/discourse/components/chat/thread/header";
 import Thread from "discourse/plugins/chat/discourse/components/chat-thread";
 
-const ChatRoutesChannelThread = <template>
-  <div class="c-routes-channel-thread">
-    {{#each (array @thread) as |thread|}}
-      <ThreadHeader @thread={{thread}} />
+export default class ChatRoutesChannelThread extends Component {
+  @tracked showfullTitle = true;
 
-      <Thread
-        @thread={{thread}}
-        @targetMessageId={{@targetMessageId}}
-        @includeHeader={{true}}
-      />
-    {{/each}}
-  </div>
-</template>;
+  @action
+  setFullTitle(value) {
+    this.showfullTitle = value;
+  }
 
-export default ChatRoutesChannelThread;
+  <template>
+    <div class="c-routes-channel-thread">
+      {{#each (array @thread) as |thread|}}
+        <ThreadHeader
+          @thread={{thread}}
+          @showFullTitle={{this.showfullTitle}}
+        />
+
+        <Thread
+          @thread={{thread}}
+          @targetMessageId={{@targetMessageId}}
+          @includeHeader={{true}}
+          @setFullTitle={{this.setFullTitle}}
+        />
+      {{/each}}
+    </div>
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.gjs
@@ -53,7 +53,7 @@ export default class ChatThreadHeader extends Component {
   }
 
   <template>
-    <Navbar as |navbar|>
+    <Navbar @showFullTitle={{@showFullTitle}} as |navbar|>
       {{#if @thread}}
         <navbar.BackButton
           @route={{this.backLink.route}}

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -3,7 +3,8 @@
   --full-page-border-radius: 12px;
   --full-page-sidebar-width: 275px;
   --channel-list-avatar-size: 30px;
-  --chat-header-offset: 46px;
+  --chat-header-offset: 45px;
+  --chat-header-expanded-offset: 0px;
 }
 
 // Very specific hack to ensure the contextual menu (copy/paste/...) is

--- a/plugins/chat/assets/stylesheets/common/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel.scss
@@ -7,7 +7,7 @@
   overflow: hidden;
   grid-area: main;
   min-width: 250px;
-  @include chat-height;
+  @include chat-height(var(--chat-header-offset, 0px));
 
   .chat-messages-scroll {
     flex-grow: 1;

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -1,16 +1,15 @@
 @mixin chat-height($inset: 0px) {
   // desktop and mobile
-  // 46px is the height of the navbar
+  // -1px is for the bottom border of the chat navbar
   height: calc(
     var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-      var(--composer-height, 0px) - var(--chat-header-offset, 0px)
+      var(--composer-height, 0px) - 1px - $inset
   );
 
   // mobile with keyboard opened
   .keyboard-visible & {
     height: calc(
-      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--chat-header-offset, 0px)
+      var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) - 1px - $inset
     );
   }
 
@@ -18,7 +17,7 @@
   .footer-nav-ipad & {
     height: calc(
       var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-        var(--chat-header-offset, 0px) - var(--composer-height, 0px)
+        var(--composer-height, 0px) - 1px - $inset
     );
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -47,6 +47,7 @@
   }
 
   .c-navbar__channel-title {
+    @include ellipsis();
     font-weight: 700;
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -89,3 +89,7 @@
   display: flex;
   align-items: center;
 }
+
+.chat-drawer:not(.is-expanded) .c-navbar .c-navbar__title {
+  @include ellipsis();
+}

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -13,12 +13,12 @@
     // This is to keep the buttons in the same place.
     // 1px to account for the border.
     .c-navbar__title {
-      padding-block: calc(0.75rem + 0.5px);
+      padding-block: calc(0.75rem + 1px);
     }
 
     .c-navbar__actions,
     .c-navbar__back-button {
-      height: calc(var(--chat-header-offset) - 1px);
+      height: var(--chat-header-offset);
     }
   }
 
@@ -47,7 +47,6 @@
   }
 
   .c-navbar__channel-title {
-    @include ellipsis();
     font-weight: 700;
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -1,85 +1,93 @@
-.c-navbar {
+.c-navbar-container {
+  position: relative;
+  border-bottom: 1px solid var(--primary-low);
+  background: var(--secondary);
+  box-sizing: border-box;
   display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 0.25rem;
+  z-index: z("composer", "content") - 1;
+  padding: 0 1rem;
+
+  &.-clickable {
+    cursor: pointer;
+  }
 
   &.-full-title {
-    position: absolute;
-    align-items: flex-start;
-    border-bottom: 1px solid var(--primary-low);
-    background: var(--secondary);
-
-    // This is to keep the buttons in the same place.
-    // 1px to account for the border.
     .c-navbar__title {
-      padding-block: calc(0.75rem + 1px);
+      min-height: var(--chat-header-offset);
     }
 
-    .c-navbar__actions,
-    .c-navbar__back-button {
-      height: var(--chat-header-offset);
+    .c-navbar__title,
+    .c-navbar__title-text {
+      height: auto;
+      overflow: visible;
+      white-space: normal;
+      text-overflow: unset;
     }
   }
+}
 
-  &:not(.-full-title) .c-navbar__title {
-    @include ellipsis();
-  }
-
-  &-container {
-    position: relative;
-    border-bottom: 1px solid var(--primary-low);
-    background: var(--secondary);
-    height: var(--chat-header-offset);
-    min-height: var(--chat-header-offset);
-    box-sizing: border-box;
-    display: flex;
-    z-index: z("composer", "content") - 1;
-    padding-inline: 1rem;
-
-    &.-clickable {
-      cursor: pointer;
-    }
-  }
+.c-navbar {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  gap: 0.25rem;
+  position: relative;
 
   .single-select-header {
     padding: 0.3675rem 0.584rem;
   }
+}
 
-  .c-navbar__channel-title {
+.c-navbar__back-button {
+  height: var(--chat-header-offset);
+}
+
+.c-navbar__channel-title {
+  @include ellipsis();
+  font-weight: 700;
+  height: var(--chat-header-offset);
+  display: flex;
+  align-items: center;
+}
+
+.c-navbar__title {
+  display: flex;
+  align-items: center;
+  @include ellipsis();
+  height: var(--chat-header-offset);
+
+  &-text {
     @include ellipsis();
     font-weight: 700;
-  }
+    max-width: 100%;
+    vertical-align: middle;
 
-  .c-navbar__title {
-    font-weight: 700;
-
-    .chat-drawer & {
-      padding-left: 1rem;
-    }
-
-    .d-icon {
-      vertical-align: middle;
+    > .d-icon {
+      margin-right: 5px;
     }
   }
 
-  .c-navbar__back-button ~ .c-navbar__title {
-    padding-left: 0;
+  .chat-drawer & {
+    padding-left: 1rem;
   }
 
-  .c-navbar__sub-title {
-    line-height: var(--line-height-small);
-    font-size: var(--font-down-1-rem);
-    font-weight: normal;
+  .d-icon {
+    vertical-align: middle;
   }
+}
 
-  .c-navbar__threads-list-button {
-    gap: 0.25rem;
+.c-navbar__sub-title {
+  line-height: var(--line-height-small);
+  font-size: var(--font-down-1-rem);
+  font-weight: normal;
+}
 
-    &.has-unreads {
-      .d-icon-discourse-threads {
-        color: var(--tertiary-med-or-tertiary);
-      }
+.c-navbar__threads-list-button {
+  gap: 0.25rem;
+
+  &.has-unreads {
+    .d-icon-discourse-threads {
+      color: var(--tertiary-med-or-tertiary);
     }
   }
 }
@@ -89,8 +97,12 @@
   margin-left: auto;
   display: flex;
   align-items: center;
+
+  > .btn {
+    height: var(--chat-header-offset);
+  }
 }
 
-.chat-drawer:not(.is-expanded) .c-navbar .c-navbar__title {
-  @include ellipsis();
+.c-navbar__back-button ~ .c-navbar__title {
+  padding-left: 0;
 }

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -4,7 +4,30 @@
   width: 100%;
   gap: 0.25rem;
 
+  &.-full-title {
+    position: absolute;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--primary-low);
+    background: var(--secondary);
+
+    // This is to keep the buttons in the same place.
+    // 1px to account for the border.
+    .c-navbar__title {
+      padding-block: calc(0.75rem + 0.5px);
+    }
+
+    .c-navbar__actions,
+    .c-navbar__back-button {
+      height: calc(var(--chat-header-offset) - 1px);
+    }
+  }
+
+  &:not(.-full-title) .c-navbar__title {
+    @include ellipsis();
+  }
+
   &-container {
+    position: relative;
     border-bottom: 1px solid var(--primary-low);
     background: var(--secondary);
     height: var(--chat-header-offset);
@@ -29,11 +52,14 @@
   }
 
   .c-navbar__title {
-    @include ellipsis();
     font-weight: 700;
 
     .chat-drawer & {
       padding-left: 1rem;
+    }
+
+    .d-icon {
+      vertical-align: middle;
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -61,6 +61,7 @@
     font-weight: 700;
     max-width: 100%;
     vertical-align: middle;
+    padding-block: 5px;
 
     > .d-icon {
       margin-right: 5px;

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -1,4 +1,4 @@
-.chat-thread {
+div.chat-thread {
   display: flex;
   flex-direction: column;
   position: relative;
@@ -13,9 +13,12 @@
     display: flex;
     flex-direction: column-reverse;
     transition: padding-top 0.2s ease-in-out;
-    padding-top: calc(
-      var(--chat-thread-header-offset, var(--chat-header-offset)) -
-        var(--chat-header-offset)
-    );
+
+    &.chat-messages-scroll {
+      padding-top: calc(
+        var(--chat-thread-header-offset, var(--chat-header-offset)) -
+          var(--chat-header-offset)
+      );
+    }
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -12,5 +12,10 @@
     overscroll-behavior: contain;
     display: flex;
     flex-direction: column-reverse;
+    transition: padding-top 0.2s ease-in-out;
+    padding-top: calc(
+      var(--chat-thread-header-offset, var(--chat-header-offset)) -
+        var(--chat-header-offset)
+    );
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -1,8 +1,8 @@
-div.chat-thread {
+.chat-thread {
   display: flex;
   flex-direction: column;
   position: relative;
-  @include chat-height;
+  @include chat-height(var(--chat-header-expanded-offset, 0px));
 
   &__body {
     overflow-y: scroll;
@@ -13,12 +13,5 @@ div.chat-thread {
     display: flex;
     flex-direction: column-reverse;
     transition: padding-top 0.2s ease-in-out;
-
-    &.chat-messages-scroll {
-      padding-top: calc(
-        var(--chat-thread-header-offset, var(--chat-header-offset)) -
-          var(--chat-header-offset)
-      );
-    }
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-threads-list.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-threads-list.scss
@@ -2,7 +2,9 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  @include chat-height(env(safe-area-inset-bottom));
+  @include chat-height(
+    calc(var(--chat-header-offset) + env(safe-area-inset-bottom))
+  );
 
   &__items {
     overflow-y: scroll;

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -10,6 +10,19 @@
   &__back-button {
     align-self: stretch;
   }
+  &.-full-title {
+    .c-navbar {
+      &__actions,
+      &__back-button {
+        height: calc(var(--chat-header-offset) - 2px) !important;
+      }
+      &__title {
+        padding-block: calc(1rem + 2px);
+      }
+    }
+    left: 0.25rem;
+    width: calc(100% - 0.5rem);
+  }
 
   .c-navbar__title {
     .c-routes-direct-messages &,


### PR DESCRIPTION
When reaching the top of a thread, the full thread title will be displayed if it was too long to fit.
It works in mobile, drawer mode, and fullscreen.

![ezgif com-cut](https://github.com/discourse/discourse/assets/66427541/b00caa31-c171-4113-bf63-3c8ba9bdbd2b)
