### PR TITLE
DEV: use chat tracking state manager for unread threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -12,6 +12,7 @@ import ChatChannelRow from "./chat-channel-row";
 
 export default class ChannelsListPublic extends Component {
   @service chatChannelsManager;
+  @service chatTrackingStateManager;
   @service site;
   @service siteSettings;
   @service currentUser;
@@ -40,9 +41,7 @@ export default class ChannelsListPublic extends Component {
   }
 
   get hasUnreadThreads() {
-    return this.chatChannelsManager.publicMessageChannels.some(
-      (channel) => channel.unreadThreadsCount > 0
-    );
+    return this.chatTrackingStateManager.hasUnreadThreads;
   }
 
   @action


### PR DESCRIPTION
This change uses `hasUnreadThreads` that has been added to the Chat Tracking State Manager (#25438 ) so we can refactor the channel list component to use it from the service.