### PR TITLE
FIX: chat channel row indicator should only show urgent count

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
@@ -19,7 +19,7 @@ export default class ChatChannelUnreadIndicator extends Component {
   }
 
   get unreadCount() {
-    if (this.#onlyMentions() && this.#hasChannelMentions()) {
+    if (this.#hasChannelMentions()) {
       return this.args.channel.tracking.mentionCount;
     }
     return this.args.channel.tracking.unreadCount;

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
@@ -34,13 +34,6 @@ export default class ChatChannelUnreadIndicator extends Component {
     );
   }
 
-  get showUnreadCount() {
-    if (this.#onlyMentions()) {
-      return this.#hasChannelMentions();
-    }
-    return this.args.channel.isDirectMessageChannel || this.isUrgent;
-  }
-
   #hasChannelMentions() {
     return this.args.channel.tracking.mentionCount > 0;
   }
@@ -58,7 +51,7 @@ export default class ChatChannelUnreadIndicator extends Component {
         }}
       >
         <div class="chat-channel-unread-indicator__number">{{#if
-            this.showUnreadCount
+            this.isUrgent
           }}{{this.unreadCount}}{{else}}&nbsp;{{/if}}</div>
       </div>
     {{/if}}

--- a/plugins/chat/spec/system/message_notifications_mobile_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_mobile_spec.rb
@@ -104,6 +104,26 @@ RSpec.describe "Message notifications - mobile", type: :system, mobile: true do
               expect(page).to have_css(".chat-header-icon .chat-channel-unread-indicator")
               expect(channel_index_page).to have_unread_channel(channel_1, count: 1)
             end
+
+            it "shows correct count when there are multiple messages but only 1 is urgent" do
+              Jobs.run_immediately!
+
+              visit("/chat/channels")
+
+              create_message(
+                channel_1,
+                user: user_1,
+                text: "Are you busy @#{current_user.username}?",
+              )
+
+              3.times { create_message(channel_1, user: user_1) }
+
+              expect(page).to have_css(
+                ".chat-header-icon .chat-channel-unread-indicator",
+                text: "1",
+              )
+              expect(channel_index_page).to have_unread_channel(channel_1, count: 1)
+            end
           end
         end
       end


### PR DESCRIPTION
Correctly shows the number of urgent notifications, rather than all new notifications as urgent.

This is even more important now since adding the mobile chat footer tabs, as it becomes very obvious that the numbers don't add up correctly, for example:

| Before this change | After this change |
| --- | --- |
| <img width="356" alt="Screenshot 2024-01-29 at 2 58 34 PM" src="https://github.com/discourse/discourse/assets/2257978/baced037-afc6-4fa2-aa5c-2cd3c3ff45d4"> | <img width="355" alt="Screenshot 2024-01-29 at 2 59 26 PM" src="https://github.com/discourse/discourse/assets/2257978/9641ff19-9703-44f5-acfe-ab000a1f33b2"> |
