### PR TITLE
DEV: Add admin warning for sites on Ember 3

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -219,7 +219,8 @@ class AdminDashboardData
                       :unreachable_themes,
                       :watched_words_check,
                       :google_analytics_version_check,
-                      :translation_overrides_check
+                      :translation_overrides_check,
+                      :ember_version_check
 
     register_default_scheduled_problem_checks
 
@@ -443,6 +444,10 @@ class AdminDashboardData
       end
     end
     nil
+  end
+
+  def ember_version_check
+    I18n.t("dashboard.ember_version_warning") if ENV["EMBER_VERSION"] == "3"
   end
 
   def out_of_date_themes

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1525,6 +1525,7 @@ en:
     watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
     v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
     category_style_deprecated: "Your Discourse is currently using a deprecated category style which will be removed before the final beta release of Discourse 3.2. Please refer to <a href='https://meta.discourse.org/t/282441'>Moving to a Single Category Style Site Setting</a> for instructions on how to keep your selected category style."
+    ember_version_warning: "Your site is running with the unsupported EMBER_VERSION=3 configuration. This may lead to unexpected issues with themes/plugins. Please remove the EMBER_VERSION configuration from your app.yml file and rebuild. See <a href='https://meta.discourse.org/t/287211'>https://meta.discourse.org/t/287211</a> for more information."
 
   site_settings:
     allow_bulk_invite: "Allow bulk invites by uploading a CSV file"


### PR DESCRIPTION
Running Discourse 3.2 stable under Ember 3 will technically be possible, but is only intended as a short-term migration point. This commit adds an admin warning for sites which are using this configuration, to make it clear that themes and plugins are unlikely to support the configuration.

https://meta.discourse.org/t/287211