### PR TITLE
FIX: Chat messages exporter

### DIFF
--- a/plugins/chat/lib/chat/messages_exporter.rb
+++ b/plugins/chat/lib/chat/messages_exporter.rb
@@ -48,10 +48,10 @@ module Chat
             yield(
               [
                 chat_message.id,
-                chat_message.chat_channel.id,
-                chat_message.chat_channel.name,
-                chat_message.user.id,
-                chat_message.user.username,
+                chat_message.chat_channel&.id,
+                chat_message.chat_channel&.name,
+                chat_message.user&.id,
+                chat_message.user&.username,
                 chat_message.message,
                 chat_message.cooked,
                 chat_message.created_at,


### PR DESCRIPTION
We usually don't enforce foreign key relationships on the database level. Because of that, occasionally it's possible to see  a chat message that references to a non-existent `chat_channel` or `user`. `MessagesExporter` failed in such case before, this PR fixes that.