### PR TITLE
FIX: missing ampersand in input class selector

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -204,7 +204,7 @@ input {
   &[type="search"],
   &[type="tel"],
   &[type="color"],
-  .input-setting-integer {
+  &.input-setting-integer {
     @include appearance-none;
     @include form-item-sizing;
     display: inline-block;


### PR DESCRIPTION
Missed this when reviewing df2f63c, this follow-up fixes it! 