### PR TITLE
FIX: Hide 'My Threads' if no followed channels have threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -47,7 +47,7 @@ export default class ChannelsListPublic extends Component {
 
   get isThreadEnabledInAnyChannel() {
     return this.currentUser?.chat_channels?.public_channels?.some(
-      (channel) => channel.threading_enabled === true
+      (channel) => channel.threading_enabled
     );
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -8,6 +8,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
+import and from "truth-helpers/helpers/and";
 import ChatChannelRow from "./chat-channel-row";
 
 export default class ChannelsListPublic extends Component {
@@ -44,13 +45,19 @@ export default class ChannelsListPublic extends Component {
     return this.chatTrackingStateManager.hasUnreadThreads;
   }
 
+  get isThreadEnabledInAnyChannel() {
+    return this.currentUser?.chat_channels?.public_channels?.some(
+      (channel) => channel.threading_enabled === true
+    );
+  }
+
   @action
   toggleChannelSection(section) {
     this.args.toggleSection(section);
   }
 
   <template>
-    {{#if this.site.desktopView}}
+    {{#if (and this.site.desktopView this.isThreadEnabledInAnyChannel)}}
       <LinkTo @route="chat.threads" class="chat-channel-row --threads">
         <span class="chat-channel-title">
           {{dIcon "discourse-threads" class="chat-user-threads__icon"}}

--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
+import i18n from "discourse-common/helpers/i18n";
 import { bind } from "discourse-common/utils/decorators";
 import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-title";
 import List from "discourse/plugins/chat/discourse/components/chat/list";
@@ -50,6 +51,11 @@ export default class UserThreads extends Component {
           />
         </div>
       </list.Item>
+      <list.EmptyState>
+        <div class="empty-state-threads">
+          {{i18n "chat.empty_state.my_threads"}}
+        </div>
+      </list.EmptyState>
     </List>
   </template>
 }

--- a/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
@@ -31,6 +31,14 @@
   }
 }
 
+.c-user-threads .empty-state-threads {
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 1rem;
+  font-size: var(--font-up-1-rem);
+  color: var(--primary);
+}
+
 //sidebar
 #sidebar-section-content-user-threads {
   padding-bottom: 0.5rem;

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -115,6 +115,7 @@ en:
         direct_message_cta: "Start a personal Chat"
         direct_message: "You can also start a personal chat with one or more users."
         title: "No channels found"
+        my_threads: "You don't have any threads yet. Threads you participate in will be displayed here."
       email_frequency:
         description: "We'll only email you if we haven't seen you in the last 15 minutes."
         never: "Never"

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -41,6 +41,10 @@ module PageObjects
         has_css?(".chat-channel-row.--threads[href='/chat/threads']")
       end
 
+      def has_no_user_threads_section?
+        has_no_css?(".chat-channel-row.--threads[href='/chat/threads']")
+      end
+
       def has_unread_user_threads?
         has_css?(".chat-channel-row.--threads .c-unread-indicator")
       end

--- a/plugins/chat/spec/system/page_objects/sidebar/sidebar.rb
+++ b/plugins/chat/spec/system/page_objects/sidebar/sidebar.rb
@@ -44,6 +44,13 @@ module PageObjects
         )
       end
 
+      def has_no_user_threads_section?
+        has_no_css?(
+          ".sidebar-section-link[data-link-name='user-threads'][href='/chat/threads']",
+          text: I18n.t("js.chat.my_threads.title"),
+        )
+      end
+
       def has_unread_user_threads?
         has_css?(
           ".sidebar-section-link[data-link-name='user-threads'] .sidebar-section-link-suffix.icon.unread",

--- a/plugins/chat/spec/system/user_threads_spec.rb
+++ b/plugins/chat/spec/system/user_threads_spec.rb
@@ -17,10 +17,27 @@ RSpec.describe "User threads", type: :system do
   end
 
   context "when in sidebar" do
-    it "shows a link to user threads" do
-      visit("/")
+    context "when user is a member of at least one channel with threads" do
+      before { channel_1.add(current_user) }
 
-      expect(sidebar_page).to have_user_threads_section
+      it "shows a link to user threads" do
+        visit("/")
+
+        expect(sidebar_page).to have_user_threads_section
+      end
+    end
+
+    context "when user is not a member of any channel with threads" do
+      before do
+        channel_1.update!(threading_enabled: false)
+        channel_1.add(current_user)
+      end
+
+      it "does not show a link to user threads" do
+        visit("/")
+
+        expect(sidebar_page).to have_no_user_threads_section
+      end
     end
 
     context "when user has unreads" do
@@ -100,11 +117,29 @@ RSpec.describe "User threads", type: :system do
   end
 
   context "when in drawer" do
-    it "shows a link to user threads" do
-      visit("/")
-      chat_page.open_from_header
+    context "when user is a member of at least one channel with threads" do
+      before { channel_1.add(current_user) }
 
-      expect(drawer_page).to have_user_threads_section
+      it "shows a link to user threads" do
+        visit("/")
+        chat_page.open_from_header
+
+        expect(drawer_page).to have_user_threads_section
+      end
+    end
+
+    context "when user is not a member of any channel with threads" do
+      before do
+        channel_1.update!(threading_enabled: false)
+        channel_1.add(current_user)
+      end
+
+      it "does not show a link to user threads" do
+        visit("/")
+        chat_page.open_from_header
+
+        expect(drawer_page).to have_no_user_threads_section
+      end
     end
 
     context "when user has unreads" do


### PR DESCRIPTION
This PR hides the 'My Threads' link from the channel list and sidebar if the user is not a member of any channels with threads enabled. It also adds a message to the 'My Threads' page when the user hasn't participated in any threads yet.