### PR TITLE
FIX: Do not show quote copy button to anon

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -260,7 +260,10 @@ export default class PostTextSelection extends Component {
   }
 
   get canCopyQuote() {
-    return this.siteSettings.enable_quote_copy;
+    return (
+      this.siteSettings.enable_quote_copy &&
+      this.currentUser?.get("user_option.enable_quoting")
+    );
   }
 
   // on Desktop, shows the bar at the beginning of the selection

--- a/spec/system/post_selection_copy_quote_spec.rb
+++ b/spec/system/post_selection_copy_quote_spec.rb
@@ -8,27 +8,38 @@ describe "Post selection | Copy quote", type: :system do
   fab!(:post) { Fabricate(:post, topic: topic, raw: "Hello world it's time for quoting!") }
   fab!(:current_user) { Fabricate(:admin) }
 
-  before do
-    sign_in(current_user)
-    cdp.allow_clipboard
-  end
+  context "when logged in" do
+    before do
+      sign_in(current_user)
+      cdp.allow_clipboard
+    end
 
-  it "copies the selection from the post the clipboard" do
-    topic_page.visit_topic(topic)
+    it "copies the selection from the post the clipboard" do
+      topic_page.visit_topic(topic)
 
-    select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
-    topic_page.copy_quote_button.click
+      select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
+      topic_page.copy_quote_button.click
 
-    expect(cdp.read_clipboard.chomp).to eq(<<~QUOTE.chomp)
+      expect(cdp.read_clipboard.chomp).to eq(<<~QUOTE.chomp)
     [quote=\"#{post.user.username}, post:1, topic:#{topic.id}\"]\nHello worl\n[/quote]\n
     QUOTE
+    end
+
+    it "does not show the copy quote button if it has been disabled" do
+      SiteSetting.enable_quote_copy = false
+      topic_page.visit_topic(topic)
+
+      select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
+      expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+    end
   end
 
-  it "does not show the copy quote button if it has been disabled" do
-    SiteSetting.enable_quote_copy = false
-    topic_page.visit_topic(topic)
+  context "when anon" do
+    it "does not show the copy quote button to anon users" do
+      topic_page.visit_topic(topic)
 
-    select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
-    expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+      select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
+      expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+    end
   end
 end


### PR DESCRIPTION
This was an oversight in 51016e56dd99a9ad4bd82cdc6c0cf968754c70ed,
anon doesn't have any need to copy quotes, just as they have
no need to open the composer with a quote prefilled.
