### PR TITLE
FEATURE: support silent internal links

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -289,6 +289,10 @@ class TopicLink < ActiveRecord::Base
       # Store the same URL that will be used in the cooked version of the post
       url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
     elsif route = Discourse.route_for(parsed)
+      # this is a special case for the silent flag
+      # in internal links
+      return nil if url && (url.split("?")[1] == "silent=true")
+
       internal = true
 
       # We aren't interested in tracking internal links to users

--- a/spec/models/topic_link_spec.rb
+++ b/spec/models/topic_link_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe TopicLink do
   end
 
   describe "internal links" do
+    it "can exclude links with ?silent=true" do
+      url = topic.url
+      raw = "[silent link](#{url}?silent=true)"
+
+      post = Fabricate(:post, user: user, raw: raw)
+
+      TopicLink.extract_from(post)
+
+      expect(topic.topic_links.count).to eq(0)
+      expect(post.topic.topic_links.count).to eq(0)
+    end
+
     it "extracts onebox" do
       other_topic = Fabricate(:topic, user: user)
       Fabricate(:post, topic: other_topic, user: user, raw: "some content for the first post")


### PR DESCRIPTION
Internal links always notify and add internal connections in topics.

This adds a special feature that lets you append `?silent=true` to a link
to have it excluded from:

1. Notifications - users will not be notified for these links
2. Post links below posts in the UI

This is specifically useful for large reports where adding all these connections
just results in noise.
