### PR TITLE
FIX: expand regex for fast-edit to support multi-language

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -177,14 +177,17 @@ export default class PostTextSelection extends Component {
     if (this.canEditPost) {
       const regexp = new RegExp(escapeRegExp(quoteState.buffer), "gi");
       const matches = cooked.innerHTML.match(regexp);
-      const non_ascii_regex = /[^\x00-\x7F]/;
+      // allow letters (with diacritics), numbers, spaces and punctuation
+      // also works for CJK ranges (Chinese, Japanese, Korean, etc)
+      const validChars = /[\p{Letter}\p{Number}\p{Mark}\p{P}\s]/gu;
+      const validCharCount = quoteState.buffer.match(validChars)?.length || 0;
 
       if (
         quoteState.buffer.length === 0 ||
         quoteState.buffer.includes("|") || // tables are too complex
         quoteState.buffer.match(/\n/g) || // linebreaks are too complex
         matches?.length > 1 || // duplicates are too complex
-        non_ascii_regex.test(quoteState.buffer) // non-ascii chars break fast-edit
+        validCharCount !== quoteState.buffer.length // contains non-supported chars
       ) {
         supportsFastEdit = false;
       } else if (matches?.length === 1) {

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -86,18 +86,116 @@ acceptance("Fast Edit", function (needs) {
     assert.dom(".d-editor-input").exists();
   });
 
-  test("Opens full composer when editing non-ascii characters", async function (assert) {
+  test("Works with diacritics in Latin languages", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
+    // French
     query("#post_2 .cooked").append(
       `Je suis désolé, ”comment ça va”? A bientôt!`
     );
-    const textNode = query("#post_2 .cooked").childNodes[2];
+    let textNode = query("#post_2 .cooked").childNodes[2];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");
 
-    assert.dom("#fast-edit-input").doesNotExist();
-    assert.dom(".d-editor-input").exists();
+    assert.dom("#fast-edit-input").exists();
+
+    // exit fast edit and remove the text node
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Spanish
+    query("#post_2 .cooked").append(`Lo siento, ”¿cómo estás”? ¡Hasta pronto!`);
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Vietnamese
+    query("#post_2 .cooked").append(
+      `Tôi là người Việt Nam. Tôi yêu đất nước tôi. Tôi yêu quê hương tôi. Tôi yêu gia đình tôi.`
+    );
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+  });
+
+  test("Works with CJK Ranges (Chinese, Japanese, Korean etc)", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    // Chinese (Simplified)
+    query("#post_2 .cooked").append(
+      `我是中国人。我爱我的祖国。我爱我的家乡。我爱我的家人。`
+    );
+    let textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+
+    // exit fast edit and remove the text node
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Chinese (Traditional)
+    query("#post_2 .cooked").append(
+      `我是中國人。我愛我的祖國。我愛我的家鄉。我愛我的家人。`
+    );
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Japanese
+    query("#post_2 .cooked").append(`日本語の文章を入力してください。`);
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Korean
+    query("#post_2 .cooked").append(
+      `국민경제의 발전을 위한 중요정책의 수립에 관하여 대통령의 자문에 응하기 위하여 국민경제자문회의를 둘 수 있다.`
+    );
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+
+    await triggerKeyEvent("#fast-edit-input", "keydown", "Escape");
+    query("#post_2 .cooked").childNodes[2].remove();
+
+    // Greek
+    query("#post_2 .cooked").append(
+      `Λορεμ ιπσθμ δολορ σιτ αμετ, μει ιδ νοvθμ φαβελλασ πετεντιθμ vελ νε, ατ νισλ σονετ οπορτερε εθμ. Αλιι δοcτθσ μει ιδ, νο αθτεμ αθδιρε ιντερεσσετ μελ, δοcενδι cομμθνε οπορτεατ τε cθμ.`
+    );
+
+    textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
   });
 });


### PR DESCRIPTION
Expands the regex for fast-edit to allow easy editing of multi-language content. If we encounter characters in the selected text that don't match our regex then we will fall back to composer for editing of full post content.