### PR TITLE
DEV: Remove version-number-based logic

### DIFF
--- a/app/models/concerns/has_deprecated_columns.rb
+++ b/app/models/concerns/has_deprecated_columns.rb
@@ -5,20 +5,16 @@ module HasDeprecatedColumns
 
   class_methods do
     def deprecate_column(column_name, drop_from:, raise_error: false, message: nil)
-      if Gem::Version.new(Discourse::VERSION::STRING) >= Gem::Version.new(drop_from)
-        self.ignored_columns = self.ignored_columns.dup << column_name.to_s
-      else
-        message = message.presence || "column `#{column_name}` is deprecated"
+      message = message.presence || "column `#{column_name}` is deprecated."
 
-        define_method(column_name) do
-          Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
-          super()
-        end
+      define_method(column_name) do
+        Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
+        super()
+      end
 
-        define_method("#{column_name}=") do |value|
-          Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
-          super(value)
-        end
+      define_method("#{column_name}=") do |value|
+        Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)
+        super(value)
       end
     end
   end


### PR DESCRIPTION
The `deprecate_column` helper would change its behavior based on the current `Discourse::VERSION`. This means that 'finalizing' a stable release introduces a previously untested behavior change.

Much better to keep it as a deprecation until manual action is taken to introduce the breaking change.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
