### PR TITLE
FIX: Default more group settings to staff + TL(N)

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -683,7 +683,7 @@ users:
     client: true
     hidden: true
   anonymous_posting_allowed_groups:
-    default: "11" # auto group trust_level_1
+    default: "3|11" # auto group staff and trust_level_1
     type: group_list
     client: true
     allow_any: false
@@ -862,7 +862,7 @@ posting:
   enable_system_message_replies:
     default: true
   personal_message_enabled_groups:
-    default: "11" # auto group trust_level_1
+    default: "3|11" # auto group trust_level_1
     type: group_list
     client: true
     allow_any: false
@@ -961,7 +961,7 @@ posting:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   here_mention_allowed_groups:
-    default: "12" # auto group trust_level_2
+    default: "3|12" # auto group staff and trust_level_2
     type: group_list
     client: true
     allow_any: false
@@ -1071,7 +1071,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   approve_unless_allowed_groups:
-    default: 10
+    default: "3|10" # auto groups staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1081,7 +1081,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   approve_new_topics_unless_allowed_groups:
-    default: 10
+    default: "3|10" # auto groups staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1155,7 +1155,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   skip_review_media_groups:
-    default: "10" # TL0 auto group
+    default: "3|10" # auto groups staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1273,7 +1273,7 @@ email:
     enum: "TrustLevelSetting"
     hidden: true
   email_in_allowed_groups:
-    default: 12
+    default: "3|12" # auto group staff and trust_level_2
     type: group_list
     allow_any: false
     refresh: true
@@ -1702,7 +1702,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   create_topic_allowed_groups:
-    default: 10
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1712,7 +1712,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   edit_wiki_post_allowed_groups:
-    default: 11
+    default: "3|11" # auto group staff and trust_level_1
     type: group_list
     allow_any: false
     refresh: true
@@ -1722,7 +1722,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   edit_post_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1732,7 +1732,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   self_wiki_allowed_groups:
-    default: "13"
+    default: "3|13" # auto group staff and trust_level_3
     type: group_list
     allow_any: false
     refresh: true
@@ -1742,7 +1742,7 @@ trust:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   send_email_messages_allowed_groups:
-    default: "1|3|14"
+    default: "3|14" # auto group staff and trust_level_4
     type: group_list
     allow_any: false
     refresh: true
@@ -1752,7 +1752,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   flag_post_allowed_groups:
-    default: "11"
+    default: "3|11" # auto group staff and trust_level_1
     type: group_list
     allow_any: false
     refresh: true
@@ -1762,7 +1762,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   post_links_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1772,7 +1772,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   embedded_media_post_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1787,7 +1787,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   user_card_background_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -1797,7 +1797,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   invite_allowed_groups:
-    default: "12"
+    default: "3|12" # auto group staff and trust_level_2
     type: group_list
     allow_any: false
     refresh: true
@@ -1808,7 +1808,7 @@ trust:
     client: true
     hidden: true
   ignore_allowed_groups:
-    default: "12"
+    default: "3|12" # auto group staff and trust_level_2
     type: group_list
     client: true
     allow_any: false
@@ -3004,7 +3004,7 @@ user_api:
     enum: "TrustLevelSetting"
     hidden: true
   user_api_key_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true
@@ -3057,7 +3057,7 @@ tags:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   create_tag_allowed_groups:
-    default: "1|3|13"
+    default: "3|13" # auto group staff and trust_level_3
     type: group_list
     allow_any: false
     refresh: true
@@ -3068,7 +3068,7 @@ tags:
     client: true
     hidden: true
   tag_topic_allowed_groups:
-    default: "10"
+    default: "3|10" # auto group staff and trust_level_0
     type: group_list
     allow_any: false
     refresh: true


### PR DESCRIPTION
There are some cases where staff (admins/mods) can
be in lower trust levels, so some of these checks will
fail for them. Since we want to keep allowing this (for now)
we should set most settings to also default to be allowed
for staff too, since the old `has_trust_level?` check
worked in this way.
