### PR TITLE
DEV: Fix system tests stuck on flock

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -573,7 +573,7 @@ RSpec.configure do |config|
       # The long term fix here is to get `selenium-manager` to download the `chromedriver` binary to a unique path for each
       # process but the `--cache-path` option for `selenium-manager` is currently not supported in `selenium-webdriver`.
       if !File.directory?(File.expand_path("~/.cache/selenium"))
-        File.open("#{Rails.root}/tmp/chrome_driver_flock", "w") do |file|
+        File.open("#{Rails.root}/tmp/chrome_driver_flock", File::RDWR | File::CREAT, 0644) do |file|
           file.flock(File::LOCK_EX)
           `#{Selenium::WebDriver::SeleniumManager.send(:binary)} --browser chrome`
         end


### PR DESCRIPTION
Why this change?

In workflow runs, we have seen processes being stuck on a flock lock and
I'm guessing because we are using `"w"` when opening the file which the
ruby documentation advises against as it states "don't use "w" because it truncates the file before lock."

Stuck workflow run: https://github.com/discourse/discourse/actions/runs/7690278010/job/20953851469
