### PR TITLE
FIX: remove fast-edit regex and string replacement

### DIFF
--- a/app/assets/javascripts/discourse/app/components/fast-edit.gjs
+++ b/app/assets/javascripts/discourse/app/components/fast-edit.gjs
@@ -5,7 +5,6 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import { fixQuotes } from "discourse/components/post-text-selection";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { translateModKey } from "discourse/lib/utilities";
@@ -52,10 +51,7 @@ export default class FastEdit extends Component {
 
     try {
       const result = await ajax(`/posts/${this.args.post.id}`);
-      const newRaw = result.raw.replace(
-        fixQuotes(this.args.initialValue),
-        fixQuotes(this.value)
-      );
+      const newRaw = result.raw.replace(this.args.initialValue, this.value);
 
       await this.args.post.save({ raw: newRaw });
     } catch (error) {

--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -31,12 +31,6 @@ function getQuoteTitle(element) {
   return titleEl.textContent.trim().replace(/:$/, "");
 }
 
-export function fixQuotes(str) {
-  // u+201c, u+201d = “ ”
-  // u+2018, u+2019 = ‘ ’
-  return str.replace(/[\u201C\u201D]/g, '"').replace(/[\u2018\u2019]/g, "'");
-}
-
 export default class PostTextSelection extends Component {
   @service appEvents;
   @service capabilities;
@@ -177,14 +171,12 @@ export default class PostTextSelection extends Component {
     if (this.canEditPost) {
       const regexp = new RegExp(escapeRegExp(quoteState.buffer), "gi");
       const matches = cooked.innerHTML.match(regexp);
-      const non_ascii_regex = /[^\x00-\x7F]/;
 
       if (
         quoteState.buffer.length === 0 ||
         quoteState.buffer.includes("|") || // tables are too complex
         quoteState.buffer.match(/\n/g) || // linebreaks are too complex
-        matches?.length > 1 || // duplicates are too complex
-        non_ascii_regex.test(quoteState.buffer) // non-ascii chars break fast-edit
+        matches?.length > 1 // duplicates are too complex
       ) {
         supportsFastEdit = false;
       } else if (matches?.length === 1) {

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -86,18 +86,39 @@ acceptance("Fast Edit", function (needs) {
     assert.dom(".d-editor-input").exists();
   });
 
-  test("Opens full composer when editing non-ascii characters", async function (assert) {
+  test("Works with diacritics", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    query("#post_2 .cooked").append(
-      `Je suis désolé, ”comment ça va”? A bientôt!`
-    );
+    query("#post_2 .cooked").append(`Je suis désolé, comment ça va?`);
     const textNode = query("#post_2 .cooked").childNodes[2];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");
 
-    assert.dom("#fast-edit-input").doesNotExist();
-    assert.dom(".d-editor-input").exists();
+    assert.dom("#fast-edit-input").exists();
+  });
+
+  test("Works with CJK ranges", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    query("#post_2 .cooked").append(`这是一个测试`);
+    const textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
+  });
+
+  test("Works with emoji", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    query("#post_2 .cooked").append(`This is great 👍`);
+    const textNode = query("#post_2 .cooked").childNodes[2];
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.dom("#fast-edit-input").exists();
   });
 });


### PR DESCRIPTION
Previously we restricted the fast-edit feature to only work with ASCII characters using regex `/[^\x00-\x7F]/`.

This approach was an effort to prevent common errors when trying to save the edited content. The side effect of this approach is that all non English content then uses composer rather than fast edit, which is a little too cumbersome.

---

This PR removes the regex we used previously, allowing multi-language use.

It also removes the string replacement we relied on in the past to catch various forms of punctuation marks, as this no longer appears necessary (possibly since this component was updated to use Glimmer).