### PR TITLE
FEATURE: Add new 'illegal' flag reason

### DIFF
--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -100,6 +100,9 @@ class PostActionType < ActiveRecord::Base
         notify_type: true,
         custom_type: true,
       )
+      @flag_settings.add(10, :illegal, topic_type: true, notify_type: true, custom_type: true)
+      # When adding a new ID here, check that it doesn't clash with any added in
+      # `ReviewableScore.types`. You can thank me later.
     end
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3658,6 +3658,7 @@ en:
           off_topic: "You flagged this as off-topic"
           spam: "You flagged this as spam"
           inappropriate: "You flagged this as inappropriate"
+          illegal: "You flagged this as illegal"
           notify_moderators: "You flagged this for moderation"
           notify_user: "You sent a message to this user"
 
@@ -3940,10 +3941,12 @@ en:
         off_topic: "It's Off-Topic"
         inappropriate: "It's Inappropriate"
         spam: "It's Spam"
+        illegal: "It's Illegal"
       custom_placeholder_notify_user: "Be specific, be constructive, and always be kind."
       notify_user_textarea_label: "Message for the user"
       custom_placeholder_notify_moderators: "Let us know specifically what you are concerned about, and provide relevant links and examples where possible."
       notify_moderators_textarea_label: "Message for the moderators"
+      custom_placeholder_illegal: "Let us know specifically why you believe this post is illegal, and provide relevant links and examples where possible."
       custom_message:
         at_least:
           one: "enter at least %{count} character"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -964,6 +964,12 @@ en:
       title: "Inappropriate"
       description: 'This post contains content that a reasonable person would consider offensive, abusive, to be hateful conduct or a violation of <a href="%{base_path}/guidelines">our community guidelines</a>.'
       short_description: 'A violation of <a href="%{base_path}/guidelines">our community guidelines</a>'
+    illegal:
+      title: "It's Illegal"
+      description: "This post requires staff attention because I believe it contains content that is illegal."
+      short_description: "This is illegal"
+      email_title: 'A post in "%{title}" requires staff attention'
+      email_body: "%{link}\n\n%{message}"
     notify_user:
       title: "Send @%{username} a message"
       description: "I want to talk to this person directly and personally about their post."

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -32,7 +32,7 @@ class PostActionCreator
         create(created_by, post, action, silent: silent)
       end
     end
-    %i[notify_moderators notify_user].each do |action|
+    %i[notify_moderators notify_user illegal].each do |action|
       define_method(action) do |created_by, post, message = nil|
         create(created_by, post, action, message: message)
       end
@@ -114,7 +114,8 @@ class PostActionCreator
     end
 
     # create meta topic / post if needed
-    if @message.present? && %i[notify_moderators notify_user spam].include?(@post_action_name)
+    if @message.present? &&
+         %i[notify_moderators notify_user spam illegal].include?(@post_action_name)
       creator = create_message_creator
       # We need to check if the creator exists because it's possible `create_message_creator` returns nil
       # in the event that a `post_action_notify_user_handler` evaluated to false, haulting the post creation.
@@ -334,7 +335,7 @@ class PostActionCreator
       raw: body,
     }
 
-    if %i[notify_moderators spam].include?(@post_action_name)
+    if %i[notify_moderators spam illegal].include?(@post_action_name)
       create_args[:subtype] = TopicSubtype.notify_moderators
       create_args[:target_group_names] = [Group[:moderators].name]
 

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -755,11 +755,11 @@ RSpec.describe PostAction do
     end
   end
 
-  it "prevents user to act twice at the same time" do
-    # flags are already being tested
-    all_types_except_flags =
-      PostActionType.types.except(*PostActionType.flag_types_without_custom.keys)
-    all_types_except_flags.values.each do |action|
+  # flags are already being tested
+  all_types_except_flags =
+    PostActionType.types.except(*PostActionType.flag_types_without_custom.keys)
+  all_types_except_flags.values.each do |action|
+    it "prevents user to act twice at the same time" do
       expect(PostActionCreator.new(eviltrout, post, action).perform).to be_success
       expect(PostActionCreator.new(eviltrout, post, action).perform).to be_failed
     end


### PR DESCRIPTION
### What is this feature?

To comply with Digital Services Act we need a way for users to flag a post as potentially illegal. This PR adds that functionality.

### In the list of available flags

<img width="551" alt="Screenshot 2024-01-31 at 1 49 49 PM" src="https://github.com/discourse/discourse/assets/5259935/7c2939d8-ec4e-438c-9101-923e114653aa">

### When selecting "Illegal"

<img width="567" alt="Screenshot 2024-01-31 at 1 49 55 PM" src="https://github.com/discourse/discourse/assets/5259935/605e1cee-22dc-48c7-a601-a73d0777d014">

### It's included in the flags report for auditing purposes

<img width="856" alt="Screenshot 2024-02-05 at 4 22 33 PM" src="https://github.com/discourse/discourse/assets/5259935/628ece3c-c957-49d3-9872-65b6ad3d67f3">

### Notifications and a DM are sent to moderators

<img width="584" alt="Screenshot 2024-02-05 at 4 39 24 PM" src="https://github.com/discourse/discourse/assets/5259935/db6b6955-723e-4eea-8058-cad6fbf0c5ab">
