### PR TITLE
UX: remove hardcoded value

### DIFF
--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -5,9 +5,6 @@
 .d-header {
   left: 0;
   height: 4em;
-  #site-logo {
-    height: 2.667em; // 40px with default 15px font size
-  }
   #site-text-logo {
     font-size: var(--font-up-3);
   }


### PR DESCRIPTION
The site logo height was still hardcoded here, while we have a var `--d-logo-height` for it. No need to replace it in this desktop file, because the common equivalent has it already defined.