### PR TITLE
DEV: Update email_change_spec to increase wait time in CI

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -19,7 +19,7 @@ describe "Changing email", type: :system do
 
     find(".save-button button").click
 
-    wait_for(timeout: 5) { ActionMailer::Base.deliveries.count === 1 }
+    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 1 }
 
     if user.admin?
       get_link_from_email(:old)
@@ -136,7 +136,7 @@ describe "Changing email", type: :system do
     find(".dialog-footer .btn-primary").click
 
     # Confirm new email
-    wait_for(timeout: 5) { ActionMailer::Base.deliveries.count === 2 }
+    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 2 }
     confirm_new_link = get_link_from_email(:new)
 
     visit confirm_new_link
@@ -167,7 +167,7 @@ describe "Changing email", type: :system do
     find(".dialog-footer .btn-primary").click
 
     # Confirm new email
-    wait_for(timeout: 5) { ActionMailer::Base.deliveries.count === 2 }
+    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 2 }
     confirm_new_link = get_link_from_email(:new)
 
     visit confirm_new_link


### PR DESCRIPTION
CI runs on slower machines, so we need to use longer wait times. `Capybara.default_max_wait_time` is automatically reconfigured based on the environment.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
