### PR TITLE
FIX: only use mention styling for valid mentions in chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -70,12 +70,17 @@
       width: 100%;
     }
 
-    .mention {
+    a.mention {
       @include mention;
 
       &.highlighted {
         background: var(--tertiary-low);
       }
+    }
+
+    // unlinked, invalid mention
+    span.mention {
+      color: var(--primary-high);
     }
 
     // Automatic aspect-ratio mapping https://developer.mozilla.org/en-US/docs/Web/Media/images/aspect_ratio_mapping


### PR DESCRIPTION
Chat should follow the same convention as topics, where invalid mentions are not styled the same as valid mentions, e.g.:

<img width="270" alt="Screenshot 2024-02-01 at 18 58 24" src="https://github.com/discourse/discourse/assets/1274517/e1419cf5-7476-4570-90b8-ad7bfedbeb84">

This PR makes chat use such styling. Before:

<img width="348" alt="Screenshot 2024-02-01 at 18 46 06" src="https://github.com/discourse/discourse/assets/1274517/451fa3a2-8b63-4fba-b96b-de46cbd92966">

After:

<img width="349" alt="Screenshot 2024-02-01 at 18 45 38" src="https://github.com/discourse/discourse/assets/1274517/a85865a1-5e8e-4eca-bf8a-9bb24c2eb731">

I'm following the same pattern that we use for invalid mentions in posts:

https://github.com/discourse/discourse/blob/9bd652358106da2b116e9013d669ee2df7941bc1/app/assets/stylesheets/common/base/topic-post.scss#L1285-L1288

This way it'll be easier to dry it up if we decide to do that at some point.



