### PR TITLE
DEV: Remove TagGuardian#can_create_tag? fallback

### DIFF
--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -7,11 +7,7 @@ module TagGuardian
   end
 
   def can_create_tag?
-    SiteSetting.tagging_enabled &&
-      (
-        @user.has_trust_level_or_staff?(SiteSetting.min_trust_to_create_tag) ||
-          @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map)
-      )
+    SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map)
   end
 
   def can_tag_topics?

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -7,7 +7,7 @@ describe Chat::ChannelArchiveService do
   end
 
   fab!(:channel) { Fabricate(:category_channel) }
-  fab!(:user) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
+  fab!(:user) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:category)
 
   let(:topic_params) { { topic_title: "This will be a new topic", category_id: category.id } }
@@ -117,7 +117,7 @@ describe Chat::ChannelArchiveService do
         reaction_message = Chat::Message.last
         Chat::MessageReaction.create!(
           chat_message: reaction_message,
-          user: Fabricate(:user),
+          user: Fabricate(:user, refresh_auto_groups: true),
           emoji: "+1",
         )
         stub_const(Chat::ChannelArchiveService, "ARCHIVED_MESSAGES_PER_POST", 5) do


### PR DESCRIPTION
### What is this change?

We've changed access settings to be group membership based rather than based on the TL value directly. We kept both conditions here while we updated any plugins and themes. It should now be safe to remove.