### PR TITLE
FIX: Save previous chat state when navigating with the sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -8,24 +8,34 @@ import getURL from "discourse-common/lib/get-url";
 export default class SwitchPanelButtons extends Component {
   @service router;
   @service sidebarState;
+  @tracked currentPanel;
   @tracked isSwitching = false;
+
+  get destination() {
+    if (this.currentPanel) {
+      const url =
+        this.currentPanel.switchButtonDefaultUrl ||
+        this.currentPanel.lastKnownURL;
+      return url === "/" ? `discovery.${defaultHomepage()}` : getURL(url);
+    }
+    return null;
+  }
 
   @action
   switchPanel(panel) {
     this.isSwitching = true;
+    this.currentPanel = panel;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
 
-    const url = panel.lastKnownURL || panel.switchButtonDefaultUrl;
-    const destination =
-      url === "/" ? `discovery.${defaultHomepage()}` : getURL(url);
-
-    this.router
-      .transitionTo(destination)
-      .then(() => {
-        this.sidebarState.setPanel(panel.key);
-      })
-      .finally(() => {
-        this.isSwitching = false;
-      });
+    if (this.destination) {
+      this.router
+        .transitionTo(this.destination)
+        .then(() => {
+          this.sidebarState.setPanel(this.currentPanel.key);
+        })
+        .finally(() => {
+          this.isSwitching = false;
+        });
+    }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -22,20 +22,18 @@ export default class SwitchPanelButtons extends Component {
   }
 
   @action
-  switchPanel(panel) {
+  async switchPanel(panel) {
     this.isSwitching = true;
     this.currentPanel = panel;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
 
     if (this.destination) {
-      this.router
-        .transitionTo(this.destination)
-        .then(() => {
-          this.sidebarState.setPanel(this.currentPanel.key);
-        })
-        .finally(() => {
-          this.isSwitching = false;
-        });
+      try {
+        await this.router.transitionTo(this.destination);
+        this.sidebarState.setPanel(this.currentPanel.key);
+      } finally {
+        this.isSwitching = false;
+      }
     }
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -29,13 +29,18 @@ export default {
     this.currentUser = container.lookup("service:current-user");
 
     withPluginApi("1.8.0", (api) => {
+      const chatStateManager = container.lookup("service:chat-state-manager");
+
       api.addSidebarPanel(
         (BaseCustomSidebarPanel) =>
           class ChatSidebarPanel extends BaseCustomSidebarPanel {
             key = CHAT_PANEL;
             switchButtonLabel = I18n.t("sidebar.panels.chat.label");
             switchButtonIcon = "d-chat";
-            switchButtonDefaultUrl = getURL("/chat");
+
+            get switchButtonDefaultUrl() {
+              return getURL(chatStateManager.lastKnownChatURL || "/chat");
+            }
           }
       );
 

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe "Navigation", type: :system do
         thread.add(current_user)
       end
 
-      it "correctly closes the panel" do
+      it "correctly shows the thread panel" do
         chat_page.visit_thread(thread)
 
         expect(side_panel_page).to have_open_thread(thread)
@@ -425,7 +425,7 @@ RSpec.describe "Navigation", type: :system do
         find("#site-logo").click
         sidebar_component.switch_to_chat
 
-        expect(page).to have_no_css(".chat-side-panel")
+        expect(side_panel_page).to have_open_thread(thread)
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -27,6 +27,10 @@ module PageObjects
         find(".chat-header-icon").click
       end
 
+      def close_from_header
+        find(".chat-header-icon").click
+      end
+
       def has_header_href?(href)
         find(".chat-header-icon").has_link?(href: href)
       end

--- a/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
+++ b/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:channel_2) { Fabricate(:chat_channel) }
 
   before do
     SiteSetting.navigation_menu = "sidebar"
     channel_1.add(current_user)
+    channel_2.add(current_user)
     chat_system_bootstrap
     sign_in(current_user)
   end
@@ -145,6 +147,15 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_no_section("chat-channels")
         expect(sidebar_component).to have_section("Categories")
+
+        chat_drawer_page.open_channel(channel_2)
+
+        expect(chat_drawer_page).to have_open_channel(channel_2)
+
+        chat_drawer_page.close
+        sidebar_component.switch_to_chat
+
+        expect(chat_drawer_page).to have_open_channel(channel_2)
       end
     end
 
@@ -182,6 +193,16 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_no_section("chat-channels")
         expect(sidebar_component).to have_section("Categories")
+
+        sidebar_component.switch_to_chat
+        sidebar_page.open_channel(channel_2)
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
+
+        chat_page.close_from_header
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
       end
     end
   end
@@ -222,6 +243,15 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_section("Categories")
         expect(sidebar_component).to have_section("chat-channels")
+
+        sidebar_page.open_channel(channel_2)
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
+
+        chat_drawer_page.close
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
       end
     end
 
@@ -259,6 +289,16 @@ RSpec.describe "Separate sidebar mode", type: :system do
 
         expect(sidebar_component).to have_section("chat-channels")
         expect(sidebar_component).to have_section("Categories")
+
+        sidebar_component.switch_to_chat
+        sidebar_page.open_channel(channel_2)
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
+
+        chat_page.close_from_header
+        sidebar_component.switch_to_chat
+
+        expect(sidebar_component).to have_section_link(channel_2.name, active: true)
       end
     end
   end


### PR DESCRIPTION
Ensures consistency when navigating in and out of chat using the sidebar button. The chat sidebar button is only visible when `Show separate sidebar modes for forum and chat` is set to `Always` or `When chat is in fullscreen`.