### PR TITLE
FEATURE: allow disabling user activity tab for non admin users

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav.hbs
@@ -9,15 +9,16 @@
         <span>{{i18n "user.summary.title"}}</span>
       </DNavigationItem>
 
-      <DNavigationItem
-        @route="userActivity"
-        @ariaCurrentContext="parentNav"
-        class="user-nav__activity"
-      >
-        {{d-icon "stream"}}
-        <span>{{i18n "user.activity_stream"}}</span>
-      </DNavigationItem>
-
+      {{#if @showActivityTab}}
+        <DNavigationItem
+          @route="userActivity"
+          @ariaCurrentContext="parentNav"
+          class="user-nav__activity"
+        >
+          {{d-icon "stream"}}
+          <span>{{i18n "user.activity_stream"}}</span>
+        </DNavigationItem>
+      {{/if}}
     {{/unless}}
 
     {{#if @showNotificationsTab}}

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -123,6 +123,11 @@ export default Controller.extend(CanCheckEmails, {
   },
 
   @discourseComputed("viewingSelf", "currentUser.admin")
+  showActivityTab(viewingSelf, isAdmin) {
+    return viewingSelf || isAdmin || !this.siteSettings.hide_user_activity_tab;
+  },
+
+  @discourseComputed("viewingSelf", "currentUser.admin")
   showNotificationsTab(viewingSelf, isAdmin) {
     return viewingSelf || isAdmin;
   },

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -460,6 +460,7 @@
         @user={{this.model}}
         @isStaff={{this.currentUser.staff}}
         @isMobileView={{this.site.mobileView}}
+        @showActivityTab={{this.showActivityTab}}
         @showNotificationsTab={{this.showNotificationsTab}}
         @showPrivateMessages={{this.showPrivateMessages}}
         @canInviteToForum={{this.canInviteToForum}}

--- a/app/assets/javascripts/discourse/app/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.hbs
@@ -51,15 +51,25 @@
             @label="user.summary.posts_read"
           />
         </li>
-        <li class="stats-likes-given linked-stat">
-          <LinkTo @route="userActivity.likesGiven">
+        {{#if this.model.can_see_user_actions}}
+          <li class="stats-likes-given linked-stat">
+            <LinkTo @route="userActivity.likesGiven">
+              <UserStat
+                @value={{this.model.likes_given}}
+                @icon="heart"
+                @label="user.summary.likes_given"
+              />
+            </LinkTo>
+          </li>
+        {{else}}
+          <li class="stats-likes-given">
             <UserStat
               @value={{this.model.likes_given}}
               @icon="heart"
               @label="user.summary.likes_given"
             />
-          </LinkTo>
-        </li>
+          </li>
+        {{/if}}
         <li class="stats-likes-received">
           <UserStat
             @value={{this.model.likes_received}}
@@ -68,31 +78,58 @@
           />
         </li>
         {{#if this.model.bookmark_count}}
-          <li class="stats-bookmark-count linked-stat">
-            <LinkTo @route="userActivity.bookmarks">
+          {{#if this.model.can_see_user_actions}}
+            <li class="stats-bookmark-count linked-stat">
+              <LinkTo @route="userActivity.bookmarks">
+                <UserStat
+                  @value={{this.model.bookmark_count}}
+                  @label="user.summary.bookmark_count"
+                />
+              </LinkTo>
+            </li>
+          {{else}}
+            <li class="stats-bookmark-count">
               <UserStat
                 @value={{this.model.bookmark_count}}
                 @label="user.summary.bookmark_count"
               />
+            </li>
+          {{/if}}
+        {{/if}}
+        {{#if this.model.can_see_user_actions}}
+          <li class="stats-topic-count linked-stat">
+            <LinkTo @route="userActivity.topics">
+              <UserStat
+                @value={{this.model.topic_count}}
+                @label="user.summary.topic_count"
+              />
             </LinkTo>
           </li>
-        {{/if}}
-        <li class="stats-topic-count linked-stat">
-          <LinkTo @route="userActivity.topics">
+        {{else}}
+          <li class="stats-topic-count">
             <UserStat
               @value={{this.model.topic_count}}
               @label="user.summary.topic_count"
             />
-          </LinkTo>
-        </li>
-        <li class="stats-post-count linked-stat">
-          <LinkTo @route="userActivity.replies">
+          </li>
+        {{/if}}
+        {{#if this.model.can_see_user_actions}}
+          <li class="stats-post-count linked-stat">
+            <LinkTo @route="userActivity.replies">
+              <UserStat
+                @value={{this.model.post_count}}
+                @label="user.summary.post_count"
+              />
+            </LinkTo>
+          </li>
+        {{else}}
+          <li class="stats-post-count">
             <UserStat
               @value={{this.model.post_count}}
               @label="user.summary.post_count"
             />
-          </LinkTo>
-        </li>
+          </li>
+        {{/if}}
         <PluginOutlet
           @name="user-summary-stat"
           @connectorTagName="li"

--- a/app/serializers/user_summary_serializer.rb
+++ b/app/serializers/user_summary_serializer.rb
@@ -94,10 +94,15 @@ class UserSummarySerializer < ApplicationSerializer
              :time_read,
              :recent_time_read,
              :bookmark_count,
-             :can_see_summary_stats
+             :can_see_summary_stats,
+             :can_see_user_actions
 
   def can_see_summary_stats
     scope.can_see_summary_stats?(object.user)
+  end
+
+  def can_see_user_actions
+    scope.can_see_user_actions?(object.user, [])
   end
 
   def include_badges?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2206,6 +2206,7 @@ en:
 
     hide_user_profiles_from_public: "Disable user cards, user profiles and user directory for anonymous users."
     allow_users_to_hide_profile: "Allow users to hide their profile and presence"
+    hide_user_activity_tab: "Hide the activity tab on user profiles except for Admin and self."
 
     allow_featured_topic_on_user_profiles: "Allow users to feature a link to a topic on their user card and profile."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -749,6 +749,9 @@ users:
     default: false
   use_name_for_username_suggestions:
     default: true
+  hide_user_activity_tab:
+    default: false
+    client: true
 
 groups:
   enable_group_directory:

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -138,6 +138,7 @@ module UserGuardian
 
   def can_see_user_actions?(user, action_types)
     return true if !@user.anonymous? && (@user.id == user.id || is_admin?)
+    return false if SiteSetting.hide_user_activity_tab?
     (action_types & UserAction.private_types).empty?
   end
 

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -139,6 +139,28 @@ RSpec.describe UserGuardian do
     end
   end
 
+  describe "#can_see_user_actions?" do
+    it "is true by default" do
+      expect(Guardian.new.can_see_user_actions?(nil, [])).to eq(true)
+    end
+
+    context "with 'hide_user_activity_tab' setting" do
+      before { SiteSetting.hide_user_activity_tab = false }
+
+      it "returns true for self" do
+        expect(Guardian.new(user).can_see_user_actions?(user, [])).to eq(true)
+      end
+
+      it "returns true for admin" do
+        expect(Guardian.new(admin).can_see_user_actions?(user, [])).to eq(true)
+      end
+
+      it "returns false for regular user" do
+        expect(Guardian.new.can_see_user_actions?(user, [])).to eq(true)
+      end
+    end
+  end
+
   describe "#allowed_user_field_ids" do
     let! :fields do
       [

--- a/spec/serializers/user_summary_serializer_spec.rb
+++ b/spec/serializers/user_summary_serializer_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe UserSummarySerializer do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:another_user) { Fabricate(:user, refresh_auto_groups: true) }
+
   it "returns expected data" do
     UserActionManager.enable
-    user = Fabricate(:user, refresh_auto_groups: true)
-    another_user = Fabricate(:user, refresh_auto_groups: true)
     liked_user = Fabricate(:user, name: "John Doe", username: "john_doe", refresh_auto_groups: true)
     liked_post = create_post(user: liked_user)
     PostActionCreator.like(user, liked_post)
@@ -23,14 +24,19 @@ RSpec.describe UserSummarySerializer do
     expect(json[:most_liked_users][0][:name]).to eq("John Doe")
     expect(json[:most_liked_users][0][:username]).to eq("john_doe")
     expect(json[:most_liked_users][0][:avatar_template]).to eq(liked_user.avatar_template)
+    expect(json[:can_see_user_actions]).to eq(true)
 
     # do not include full name if disabled
     SiteSetting.enable_names = false
     expect(serializer.as_json[:most_liked_users][0][:name]).to eq(nil)
+  end
 
-    expect(json[:can_see_user_actions]).to eq(true)
+  it "respects hide_user_activity_tab setting" do
     SiteSetting.hide_user_activity_tab = true
+    guardian = Guardian.new(another_user)
+    summary = UserSummary.new(user, guardian)
     serializer = UserSummarySerializer.new(summary, scope: guardian, root: false)
+
     expect(serializer.as_json[:can_see_user_actions]).to eq(false)
   end
 


### PR DESCRIPTION
This PR adds a new site setting to disable activity page on user profiles for non-admin users. The "activity" tab will only be visible to self and admin users.

Setting:
<img width="753" alt="SCR-20240202-rodv" src="https://github.com/discourse/discourse/assets/5732281/a3977dd0-b325-4171-a501-d0b24d66bb30">

Admin/self view:
<img width="1123" alt="SCR-20240202-rogo-2" src="https://github.com/discourse/discourse/assets/5732281/0bb6bbea-d1ff-43fc-a70a-00eb9cbd5211">

Non-admin view:
<img width="1115" alt="SCR-20240202-ronn" src="https://github.com/discourse/discourse/assets/5732281/15d13c52-1921-4919-980d-79f948778edc">
