### PR TITLE
DEV: Bump content-tag to 2.0.1

### DIFF
--- a/app/assets/javascripts/patches/content-tag+2.0.1.patch
+++ b/app/assets/javascripts/patches/content-tag+2.0.1.patch
@@ -14,7 +14,7 @@ index 7be08fc..35777bf 100644
  const defaultOptions = {
    inline_source_map: false,
 diff --git a/node_modules/content-tag/pkg/standalone/content_tag.js b/node_modules/content-tag/pkg/standalone/content_tag.js
-index aaefe00..9374f10 100644
+index aaefe00..bb20026 100644
 --- a/node_modules/content-tag/pkg/standalone/content_tag.js
 +++ b/node_modules/content-tag/pkg/standalone/content_tag.js
 @@ -20,6 +20,7 @@ function takeObject(idx) {

--- a/app/assets/javascripts/theme-transpiler/package.json
+++ b/app/assets/javascripts/theme-transpiler/package.json
@@ -10,7 +10,7 @@
     "@babel/standalone": "^7.23.10",
     "@zxing/text-encoding": "^0.9.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
-    "content-tag": "^2.0.0",
+    "content-tag": "^2.0.1",
     "discourse-common": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/app/assets/javascripts/yarn-ember3.lock
+++ b/app/assets/javascripts/yarn-ember3.lock
@@ -4199,10 +4199,10 @@ content-tag@^1.1.2:
   resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-1.2.2.tgz#8cbc3cdb9957a81f7c425b138e334330dd6fd78d"
   integrity sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==
 
-content-tag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-2.0.0.tgz#932e609c800aa85adf0a4ef07b86d91dd1492c0a"
-  integrity sha512-4P7sbMEX37J0yBS/b4HZn3cQCI+w+CR7URiA7KRSBSuI8P/bFuxu7Y1srfbV9BWTCXwyVGxXo1lIpNTGL0FQUQ==
+content-tag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-2.0.1.tgz#0b908ed97e13df60b019039713ab63f1b73f2b22"
+  integrity sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==
 
 content-type@~1.0.4:
   version "1.0.5"

--- a/app/assets/javascripts/yarn-ember5.lock
+++ b/app/assets/javascripts/yarn-ember5.lock
@@ -4356,10 +4356,10 @@ content-tag@^1.1.2:
   resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-1.2.2.tgz#8cbc3cdb9957a81f7c425b138e334330dd6fd78d"
   integrity sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==
 
-content-tag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-2.0.0.tgz#932e609c800aa85adf0a4ef07b86d91dd1492c0a"
-  integrity sha512-4P7sbMEX37J0yBS/b4HZn3cQCI+w+CR7URiA7KRSBSuI8P/bFuxu7Y1srfbV9BWTCXwyVGxXo1lIpNTGL0FQUQ==
+content-tag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-2.0.1.tgz#0b908ed97e13df60b019039713ab63f1b73f2b22"
+  integrity sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==
 
 content-type@~1.0.4:
   version "1.0.5"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
