### PR TITLE
FIX: prevents discourse header to go under ipad navigation

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -2,6 +2,10 @@
   @include sticky;
   top: 0;
   z-index: z("header");
+
+  .footer-nav-ipad & {
+    top: var(--footer-nav-height, 0px);
+  }
 }
 
 .d-header {

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -249,6 +249,10 @@ html.has-full-page-chat {
   height: 100%;
   width: 100%;
 
+  &.footer-nav-ipad {
+    height: calc(100% - var(--footer-nav-height, 0px));
+  }
+
   body {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
We had two issues which were present for a long time I think:
- one that impacts both core discourse and chat. We not setting top on the header when `footer-nav-ipad` was present, meaning that you could make it scroll under if you try to scroll up by putting your finger on the discourse header
- one that impacted only chat. It's also present in core, but in core it's not a probem because we don't have a fixed height div. The body height was higher than the screen which would cause a second scrollbar to appear and would slightly break layout, if you scroll on this scrollbar (body).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
