### PR TITLE
UX: Chat Sizing on Mobile

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -11,8 +11,7 @@
   }
 
   .emoji {
-    height: 1.2em;
-    vertical-align: text-bottom;
-    width: 1.2em;
+    height: 1em;
+    width: 1em;
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
@@ -25,6 +25,15 @@
     }
   }
 
+  .chat-channel-icon {
+    font-size: var(--font-down-1-rem);
+  }
+
+  .chat-channel-name {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-high);
+  }
+
   .chat-channel-title__name {
     color: var(--primary-high);
     font-size: var(--font-down-1);

--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -114,8 +114,12 @@
     &__last-message {
       @include ellipsis;
       grid-area: msg;
-      font-size: var(--font-down-1-rem);
       color: var(--primary-high);
+
+      .emoji {
+        width: 1em;
+        height: 1em;
+      }
     }
   }
 

--- a/plugins/chat/assets/stylesheets/mobile/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-index.scss
@@ -1,75 +1,10 @@
 @import "common/foundation/mixins";
 
-.full-page-chat {
-  .channels-list {
-    padding-bottom: 6rem;
-    box-sizing: border-box;
+.channels-list-container {
+  overflow: hidden;
 
-    .channels-list-container {
-      background: var(--secondary);
-      overflow: hidden;
-    }
-
-    .chat-channel-divider {
-      font-size: var(--font-up-1);
-
-      &:first-of-type {
-        padding-top: 1rem;
-      }
-
-      .channel-title {
-        color: var(--primary);
-        font-size: var(--font-down-1);
-      }
-    }
-
-    .chat-channel-row {
-      &.--threads {
-        color: var(--primary);
-        padding-inline: 1.5rem;
-        font-size: var(--font-up-1-rem);
-        border: 0;
-
-        .chat-channel-title {
-          gap: 0.5rem;
-        }
-
-        .c-unread-indicator {
-          width: 8px;
-          height: 8px;
-        }
-      }
-    }
-
-    .chat-user-avatar {
-      + .chat-channel-title__usernames {
-        margin-left: 1rem;
-      }
-    }
-
-    .chat-channel-title {
-      &__users-count {
-        font-size: var(--font-up-2);
-        & + .chat-channel-title__name {
-          margin-left: 1rem;
-        }
-      }
-
-      &__name {
-        margin-left: 0.75em;
-        font-size: var(--font-up-1);
-      }
-
-      &__category-badge {
-        font-size: var(--font-up-1);
-      }
-
-      &__user-status-message {
-        flex-shrink: 3;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
+  .chat-channel-name {
+    font-size: var(--font-up-1-rem);
   }
 }
 


### PR DESCRIPTION
This commit: 
* increases the overall font-size for chat on mobile devices
* fixes some inconsistencies
* decreases emoji sizes to be the same as the font
* deletes unused css due to the latest refactors

<img width="282" alt="image" src="https://github.com/discourse/discourse/assets/101828855/91515380-6265-4f02-bd9a-624ed118acd8">

