### PR TITLE
DEV: Update RestModel and RestAdapter to native class syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/pending-post.js
+++ b/app/assets/javascripts/discourse/app/adapters/pending-post.js
@@ -1,9 +1,9 @@
 import RestAdapter from "discourse/adapters/rest";
 
-export default RestAdapter.extend({
-  jsonMode: true,
+export default class PendingPostAdapter extends RestAdapter {
+  jsonMode = true;
 
   pathFor(_store, _type, params) {
     return `/posts/${params.username}/pending.json`;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/adapters/published-page.js
+++ b/app/assets/javascripts/discourse/app/adapters/published-page.js
@@ -1,9 +1,9 @@
 import RestAdapter from "discourse/adapters/rest";
 
-export default RestAdapter.extend({
-  jsonMode: true,
+export default class PublishedPageAdapter extends RestAdapter {
+  jsonMode = true;
 
   pathFor(store, type, id) {
     return `/pub/by-topic/${id}`;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/adapters/rest.js
+++ b/app/assets/javascripts/discourse/app/adapters/rest.js
@@ -26,8 +26,9 @@ function rethrow(error) {
   throw error;
 }
 
-export default EmberObject.extend({
-  primaryKey: "id",
+export default class RestAdapter extends EmberObject {
+  primaryKey = "id";
+  jsonMode = false;
 
   storageKey(type, findArgs, options) {
     if (options && options.cacheKey) {
@@ -35,14 +36,14 @@ export default EmberObject.extend({
     }
     const hashedArgs = Math.abs(hashString(JSON.stringify(findArgs)));
     return `${type}_${hashedArgs}`;
-  },
+  }
 
   basePath(store, type) {
     if (ADMIN_MODELS.includes(type.replace("_", "-"))) {
       return "/admin/";
     }
     return "/";
-  },
+  }
 
   appendQueryParams(path, findArgs, extension) {
     if (findArgs) {
@@ -66,39 +67,37 @@ export default EmberObject.extend({
       }
     }
     return path;
-  },
+  }
 
   pathFor(store, type, findArgs) {
     let path =
       this.basePath(store, type, findArgs) +
       underscore(store.pluralize(this.apiNameFor(type)));
     return this.appendQueryParams(path, findArgs);
-  },
+  }
 
   apiNameFor(type) {
     return type;
-  },
+  }
 
   findAll(store, type, findArgs) {
     return ajax(this.pathFor(store, type, findArgs)).catch(rethrow);
-  },
+  }
 
   find(store, type, findArgs) {
     return ajax(this.pathFor(store, type, findArgs)).catch(rethrow);
-  },
+  }
 
   findStale(store, type, findArgs, options) {
     if (this.cached) {
       return this.cached[this.storageKey(type, findArgs, options)];
     }
-  },
+  }
 
   cacheFind(store, type, findArgs, opts, hydrated) {
     this.cached = this.cached || {};
     this.cached[this.storageKey(type, findArgs, opts)] = hydrated;
-  },
-
-  jsonMode: false,
+  }
 
   getPayload(method, data) {
     let payload = { method, data };
@@ -109,7 +108,7 @@ export default EmberObject.extend({
     }
 
     return payload;
-  },
+  }
 
   update(store, type, id, attrs) {
     const data = {};
@@ -122,7 +121,7 @@ export default EmberObject.extend({
     ).then(function (json) {
       return new Result(json[typeField], json);
     });
-  },
+  }
 
   createRecord(store, type, attrs) {
     const data = {};
@@ -133,11 +132,11 @@ export default EmberObject.extend({
         return new Result(json[typeField], json);
       }
     );
-  },
+  }
 
   destroyRecord(store, type, record) {
     return ajax(this.pathFor(store, type, record.get(this.primaryKey)), {
       type: "DELETE",
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/adapters/reviewable-explanation.js
+++ b/app/assets/javascripts/discourse/app/adapters/reviewable-explanation.js
@@ -1,9 +1,9 @@
 import RestAdapter from "discourse/adapters/rest";
 
-export default RestAdapter.extend({
-  jsonMode: true,
+export default class ReviewableExplanationAdapter extends RestAdapter {
+  jsonMode = true;
 
   pathFor(store, type, id) {
     return `/review/${id}/explain.json`;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/adapters/reviewable.js
+++ b/app/assets/javascripts/discourse/app/adapters/reviewable.js
@@ -1,9 +1,9 @@
 import RestAdapter from "discourse/adapters/rest";
 
-export default RestAdapter.extend({
-  jsonMode: true,
+export default class ReviewableAdapter extends RestAdapter {
+  jsonMode = true;
 
   pathFor(store, type, findArgs) {
     return this.appendQueryParams("/review", findArgs);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -9,19 +9,19 @@ import { currentSettings } from "discourse/tests/helpers/site-settings";
 import deprecated from "discourse-common/lib/deprecated";
 import { buildResolver } from "discourse-common/resolver";
 
-const CatAdapter = RestAdapter.extend({
-  primaryKey: "cat_id",
-});
+class CatAdapter extends RestAdapter {
+  primaryKey = "cat_id";
+}
 
-const CachedCatAdapter = RestAdapter.extend({
-  primaryKey: "cat_id",
-  cache: true,
+class CachedCatAdapter extends RestAdapter {
+  primaryKey = "cat_id";
+  cache = true;
   apiNameFor() {
     return "cat";
-  },
-});
+  }
+}
 
-const CachedCat = RestModel.extend({
+class CachedCat extends RestModel {
   init(...args) {
     // Simulate an implicit injection
     Object.defineProperty(this, "injectedProperty", {
@@ -29,9 +29,9 @@ const CachedCat = RestModel.extend({
       enumerable: true,
       value: "hello world",
     });
-    this._super(...args);
-  },
-});
+    return super.init(...args);
+  }
+}
 
 export default function (customLookup = () => {}) {
   deprecated(


### PR DESCRIPTION
This commit also updates a handful of simple adapters which overrode the jsonMode or primaryKey options. These updates are necessary because class fields cannot be overwritten via `EmberObject`'s `.extend()` syntax. These options do not appear to be widely used by themes/plugins.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
