### PR TITLE
DEV: Add classNames to user menu icon avatar wrapper

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/icon-avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/icon-avatar.gjs
@@ -1,8 +1,9 @@
 import avatar from "discourse/helpers/bound-avatar-template";
+import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse-common/helpers/d-icon";
 
 const IconAvatar = <template>
-  <div class="icon-avatar">
+  <div class={{concatClass "icon-avatar" @data.classNames}}>
     {{avatar @data.avatarTemplate "small"}}
     <div class="icon-avatar__icon-wrapper">
       {{icon @data.icon}}

--- a/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
@@ -46,6 +46,7 @@ export default class UserMenuBaseItem {
       avatarTemplate:
         this.avatarTemplate || this.site.system_user_avatar_template,
       icon: this.icon,
+      classNames: this.avatarTemplate ? "user-avatar" : "system-avatar",
     };
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -1133,4 +1133,11 @@ acceptance("User menu - avatars", function (needs) {
     assert.ok(exists("li.notification.bookmark-reminder .icon-avatar"));
     assert.ok(exists("li.bookmark .icon-avatar"));
   });
+
+  test("Icon avatars have correct class names based on system avatar usage", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+    assert.ok(exists("li.group-message-summary .icon-avatar.system-avatar"));
+    assert.ok(exists("li.notification.replied .icon-avatar.user-avatar"));
+  });
 });

--- a/app/assets/javascripts/discourse/tests/fixtures/notification-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/notification-fixtures.js
@@ -42,7 +42,6 @@ export default {
       {
         id: 789,
         notification_type: NOTIFICATION_TYPES.group_message_summary,
-        acting_user_avatar_template: "/letter_avatar_proxy/v4/letter/o/f05b48/{size}.png",
         read: false,
         post_number: null,
         topic_id: null,


### PR DESCRIPTION
We have a customer who would like to customize the appearance of the user menu notification items when the system avatar is used. Currently there is no way to target these images. Adding this gives us a selector to style!