### PR TITLE
FIX: Handle old Firefox versions that do not support isConditionalMed…

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/webauthn.js
+++ b/app/assets/javascripts/discourse/app/lib/webauthn.js
@@ -133,7 +133,8 @@ export async function getPasskeyCredential(
   // We cannot do a general check because iOS Safari and Chrome in Selenium quietly support the feature
   // but they do not support the PublicKeyCredential.isConditionalMediationAvailable() method
   if (mediation === "conditional" && isFirefox) {
-    const isCMA = await PublicKeyCredential.isConditionalMediationAvailable();
+    const isCMA =
+      (await PublicKeyCredential.isConditionalMediationAvailable?.()) ?? false;
     if (!isCMA) {
       return;
     }


### PR DESCRIPTION
…iationAvailable

Some versions of Firefox will throw a TypeError when calling PublicKeyCredential.isConditionalMediationAvailable() because the method does not exist. That would previously lead to a "Sorry, an error has occurred." modal when trying to login.

This commit fixes the issue by properly checking if the method exists. Since it only affects older Firefox versions, no tests are added.

See also https://meta.discourse.org/t/an-error-occurred-at-login-modal-same-as-topic-293167/293720 