### PR TITLE
DEV: Fix minor broken category link in ADMIN-QUICK-START-GUIDE.md

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -55,7 +55,7 @@ Once you've done the initial setup, you're ready to invite your founding members
 [] Members provide their name, bio and picture
 [] Create interesting topics (at least 5 topics and 30 replies recommended)
 [] Start talking in chat
-[] Talk in #feedback about how to use the site and how it is organized
+[] Talk in #site-feedback about how to use the site and how it is organized
 [] Review and edit the provided Community Guidelines (FAQ) 
 
 ### When you're ready, launch your community!


### PR DESCRIPTION
Change the broken category link `#feedback` to `#site-feedback` instead, which is an existing default category.

### Before:
![discourse-broken-feedback-link](https://github.com/discourse/discourse/assets/22441348/d2e029d5-72c8-4610-96a5-467d59c07fdf)

### After:
![discourse-site-feedback-link](https://github.com/discourse/discourse/assets/22441348/a12c074d-56b8-48d4-ab1a-0ccbab41c970)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

No tests because the admin quick start guide is a Markdown file, used as the contents of a staff post that is seeded when people first install Discourse.

