### PR TITLE
FIX: add desktop redirect for mobile only chat routes

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channels.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channels.js
@@ -10,6 +10,10 @@ export default class ChatChannelsRoute extends DiscourseRoute {
   }
 
   model() {
+    if (this.site.desktopView) {
+      return this.router.replaceWith("chat");
+    }
+
     return this.chatChannelsManager.publicMessageChannels;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-direct-messages.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-direct-messages.js
@@ -10,6 +10,10 @@ export default class ChatDirectMessagesRoute extends DiscourseRoute {
   }
 
   model() {
+    if (this.site.desktopView) {
+      return this.router.replaceWith("chat");
+    }
+
     return this.chatChannelsManager.directMessageChannels;
   }
 }

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe "Navigation", type: :system do
     end
   end
 
+  context "when visiting mobile only routes on desktop" do
+    it "redirects /chat/channels to ideal first channel" do
+      visit("/chat/channels")
+
+      expect(page).to have_current_path(
+        chat.channel_path(category_channel.slug, category_channel.id),
+      )
+    end
+
+    it "redirects /chat/direct-messages to ideal first channel" do
+      visit("/chat/direct-messages")
+
+      expect(page).to have_current_path(
+        chat.channel_path(category_channel.slug, category_channel.id),
+      )
+    end
+  end
+
   context "when opening chat" do
     it "opens the drawer by default" do
       visit("/")


### PR DESCRIPTION
Chat mobile has separate routes for channels and direct messages. However on desktop we want to prevent these routes from being accessible as they aren't intended to be used by chat in full-page or drawer mode.