### PR TITLE
FIX: Insert Hyperlink search badge spacing

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -245,6 +245,17 @@
   margin-bottom: 1em;
 }
 
+.search-category {
+  .badge-category__wrapper,
+  .discourse-tags {
+    margin-left: 0.5em;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}
+
 .fps-result {
   display: flex;
   padding: 0 0.5em 0 0;


### PR DESCRIPTION
The spacing for category badges and tags was missing
spacing in the Insert Hyperlink modal search results,
making everything look cramped.

Before

![image](https://github.com/discourse/discourse/assets/920448/6b806283-ad09-41bc-81d0-4282c70b45cc)

After

![image](https://github.com/discourse/discourse/assets/920448/9ac2a3da-cc70-4aa6-8ab2-e83a5fab2fe8)

