### PR TITLE
FIX: Update themes javascript cache after running themes migrations

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -172,7 +172,9 @@ class Theme < ActiveRecord::Base
       js_compiler = ThemeJavascriptCompiler.new(id, name)
       js_compiler.append_tree(all_extra_js)
       settings_hash = build_settings_hash
+
       js_compiler.prepend_settings(settings_hash) if settings_hash.present?
+
       javascript_cache || build_javascript_cache
       javascript_cache.update!(content: js_compiler.content, source_map: js_compiler.source_map)
     else
@@ -879,6 +881,7 @@ class Theme < ActiveRecord::Base
       end
 
       self.reload
+      self.update_javascript_cache!
     end
 
     if start_transaction


### PR DESCRIPTION
Why this change?

This is caused by a regression in
59839e428f3dc49213fedfd8b67acb9f2a5ec69a, where we stopped saving the `Theme` object because it was unnecessary. However, it resulted in the `after_save` callback not being called and hence
`Theme#update_javascript_cache!` not being called. As a result, some sites were reporting that after runing a theme migration, the defaults for the theme settings were used instead of the settings overrides stored in the database.

What does this change do?

Add a call to `Theme#update_javascript_cache!` after running theme migrations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
