### PR TITLE
FIX: sort chat channels by mentions, unread and channel title

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -112,16 +112,15 @@ export default class ChatChannelsManager extends Service {
 
   @cached
   get publicMessageChannels() {
-    const myChannels = this.channels.filter((channel) => {
-      return (
+    const channels = this.channels.filter(
+      (channel) =>
         channel.isCategoryChannel && channel.currentUserMembership.following
-      );
-    });
+    );
 
     if (this.site.mobileView) {
-      return this.#sortChannelsByActivity(myChannels);
+      return this.#sortChannelsByActivity(channels);
     } else {
-      return myChannels.sort((a, b) => a?.title?.localeCompare?.(b?.title));
+      return channels.sort((a, b) => a?.title?.localeCompare?.(b?.title));
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -111,17 +111,18 @@ export default class ChatChannelsManager extends Service {
 
   @cached
   get publicMessageChannels() {
-    return this.channels
-      .filter(
-        (channel) =>
+    return this.#sortChannelsByUnread(
+      this.channels.filter((channel) => {
+        return (
           channel.isCategoryChannel && channel.currentUserMembership.following
-      )
-      .sort((a, b) => a?.slug?.localeCompare?.(b?.slug));
+        );
+      })
+    );
   }
 
   @cached
   get directMessageChannels() {
-    return this.#sortDirectMessageChannels(
+    return this.#sortChannelsByUnread(
       this.channels.filter((channel) => {
         const membership = channel.currentUserMembership;
         return channel.isDirectMessageChannel && membership.following;
@@ -154,7 +155,7 @@ export default class ChatChannelsManager extends Service {
     return this._cached[id];
   }
 
-  #sortDirectMessageChannels(channels) {
+  #sortChannelsByUnread(channels) {
     return channels.sort((a, b) => {
       if (!a.lastMessage.id) {
         return 1;

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -127,7 +127,7 @@ export default class ChatChannelsManager extends Service {
 
   @cached
   get directMessageChannels() {
-    return this.#sortChannelsByActivity(
+    return this.#sortDirectMessageChannels(
       this.channels.filter((channel) => {
         const membership = channel.currentUserMembership;
         return channel.isDirectMessageChannel && membership.following;
@@ -183,6 +183,27 @@ export default class ChatChannelsManager extends Service {
       }
 
       return a.title?.localeCompare?.(b.title);
+    });
+  }
+
+  #sortDirectMessageChannels(channels) {
+    return channels.sort((a, b) => {
+      if (!a.lastMessage.id) {
+        return 1;
+      }
+
+      if (!b.lastMessage.id) {
+        return -1;
+      }
+
+      if (a.tracking.unreadCount === b.tracking.unreadCount) {
+        return new Date(a.lastMessage.createdAt) >
+          new Date(b.lastMessage.createdAt)
+          ? -1
+          : 1;
+      } else {
+        return a.tracking.unreadCount > b.tracking.unreadCount ? -1 : 1;
+      }
     });
   }
 }

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
           created_at: 5.minutes.ago,
           use_service: true,
         )
-
         Fabricate(
           :chat_message_with_service,
           chat_channel: channel_4,
@@ -85,15 +84,15 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
           user: Fabricate(:user),
         )
 
-        # channel 3 has most recent message but it's not unread for current_user
         Fabricate(:chat_message, chat_channel: channel_3, user: current_user, use_service: true)
 
         visit("/chat/channels")
 
-        # both channels have unread messages, so they're sorted by last message date
+        # channel with mentions should be first
         expect(page.find("#public-channels a:nth-child(1)")["data-chat-channel-id"]).to eq(
           channel_4.id.to_s,
         )
+        # channels with unread messages are next, sorted by title
         expect(page.find("#public-channels a:nth-child(2)")["data-chat-channel-id"]).to eq(
           channel_1.id.to_s,
         )

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -50,18 +50,36 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
     end
 
     context "when multiple category channels are present" do
-      fab!(:channel_1) { Fabricate(:category_channel, name: "b channel") }
-      fab!(:channel_2) { Fabricate(:category_channel, name: "a channel") }
+      fab!(:channel_1) { Fabricate(:category_channel, name: "a channel") }
+      fab!(:channel_2) { Fabricate(:category_channel, name: "b channel") }
+      fab!(:channel_3) { Fabricate(:category_channel, name: "c channel") }
 
       before do
         channel_1.add(current_user)
         channel_2.add(current_user)
+        channel_3.add(current_user)
       end
 
-      it "sorts them alphabetically" do
-        visit("/chat")
-        page.find("#c-footer-channels").click
+      it "sorts them by unread, then by last activity" do
+        Fabricate(
+          :chat_message,
+          chat_channel: channel_1,
+          created_at: 10.minutes.ago,
+          use_service: true,
+        )
+        Fabricate(
+          :chat_message,
+          chat_channel: channel_2,
+          created_at: 5.minutes.ago,
+          use_service: true,
+        )
 
+        # channel 3 has most recent message but it's not unread for current_user
+        Fabricate(:chat_message, chat_channel: channel_3, user: current_user, use_service: true)
+
+        visit("/chat/channels")
+
+        # both channels have unread messages, so they're sorted by last message date
         expect(page.find("#public-channels a:nth-child(1)")["data-chat-channel-id"]).to eq(
           channel_2.id.to_s,
         )


### PR DESCRIPTION
This change will sort channels by activity on mobile, with preference to those with urgent or unread messages.

For channels we will only do this on mobile initially, direct messages are already sorted by latest activity everywhere.

Channels with **mentions** will appear first, followed by channels with **unread** messages, then finally everything else sorted by the channel title (alphabetically).