### PR TITLE
FIX: Correctly save group invites (stable)

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.js
@@ -54,7 +54,7 @@ export default Component.extend(bufferedProperty("invite"), {
         moment()
           .add(this.siteSettings.invite_expiry_days, "days")
           .format(FORMAT),
-      groupIds: this.model.invite?.groupIds,
+      groupIds: this.model.groupIds ?? this.model.invite?.groupIds,
       topicId: this.model.invite?.topicId,
       topicTitle: this.model.invite?.topicTitle,
     });

--- a/app/assets/javascripts/discourse/app/routes/group-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-index.js
@@ -36,7 +36,7 @@ export default DiscourseRoute.extend({
   showInviteModal() {
     const group = this.modelFor("group");
     this.modal.show(CreateInvite, {
-      model: { invite: { groupIds: [group.id] } },
+      model: { groupIds: [group.id] },
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -262,6 +262,8 @@ acceptance(
           },
         ]);
       });
+
+      server.post("/invites", () => helper.response({}));
     });
 
     test("shows correct saved data in form", async function (assert) {
@@ -281,6 +283,8 @@ acceptance(
       await visit("/g/discourse");
       await click(".group-members-invite");
       assert.dom(".invite-to-groups .formatted-selection").hasText("Discourse");
+
+      await click(".save-invite");
     });
   }
 );


### PR DESCRIPTION
regressed in 19b86e7ea26b8c818e13040da0c68e6e312a804c

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
