### PR TITLE
Update client.en.yml to rename email settings menu item

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5580,7 +5580,7 @@ en:
 
       email:
         title: "Emails"
-        settings: "Settings"
+        settings: "Email Settings"
         templates: "Templates"
         templates_title: "Email Templates"
         preview_digest: "Preview Summary"


### PR DESCRIPTION
changed emails > "Settings" to emails > "Email Settings" to differentiate it better from the main site settings menu item.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
