### PR TITLE
DEV: API extra markup to image wrapper

### DIFF
--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -2,6 +2,13 @@ import I18n from "discourse-i18n";
 
 const SCALES = ["100", "75", "50"];
 
+let apiExtraMarkup = [];
+let apiExtraMarkupAllowList = [];
+export function addImageControlExtraMarkup(markup, allowList) {
+  apiExtraMarkup.push(markup);
+  apiExtraMarkupAllowList.push(allowList);
+}
+
 function isUpload(token) {
   return token.content.includes("upload://");
 }
@@ -156,6 +163,7 @@ function ruleWithImageControls(oldRule) {
       ).join("");
       result += `</span>`;
       result += buildImageDeleteButton();
+      result += apiExtraMarkup.join("");
 
       result += "</span></span>";
 
@@ -205,6 +213,8 @@ export function setup(helper) {
       "span.wrap-image-grid-button[data-image-count]",
       "svg[class=fa d-icon d-icon-th svg-icon svg-string]",
       "use[href=#th]",
+
+      ...apiExtraMarkupAllowList,
     ]);
 
     helper.registerPlugin((md) => {

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -138,6 +138,7 @@ import {
   registerIconRenderer,
   replaceIcon,
 } from "discourse-common/lib/icon-library";
+import { addImageControlExtraMarkup } from "discourse-markdown-it/features/image-controls";
 import { CUSTOM_USER_SEARCH_OPTIONS } from "select-kit/components/user-chooser";
 import { modifySelectKit } from "select-kit/mixins/plugin-api";
 
@@ -146,7 +147,7 @@ import { modifySelectKit } from "select-kit/mixins/plugin-api";
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.24.0";
+export const PLUGIN_API_VERSION = "1.25.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -2696,6 +2697,19 @@ class PluginApi {
     this.container
       .lookup("service:admin-custom-user-fields")
       .addProperty(userFieldProperty);
+  }
+
+  /**
+   * Add custom markup to the composer preview's image wrapper
+   *
+   *
+   * ```
+   * api.addImageWrapperExtraMarkup(`<span class="my-custom-button">My Button</span>`, ["my-custom-button"]);
+   * ```
+   *
+   */
+  addImageWrapperExtraMarkup(markup, allowList) {
+    addImageControlExtraMarkup(markup, allowList);
   }
 }
 

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -200,6 +200,14 @@
     z-index: 1; // needs to be higher than image
     background: var(--secondary); // for when images are wider than controls
 
+    .generate-caption-button {
+      position: absolute;
+      top: -50px;
+      left: 10px;
+      background: var(--tertiary);
+      padding: 0.5em;
+    }
+
     &[editing] {
       opacity: 1;
     }

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,10 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.0] - 2024-02-05
+
+- Added `addImageWrapperExtraMarkup` which is used to add any additional markup, such as a button to the composer's image preview wrapper.
+
 ## [1.24.0] - 2024-01-08
 
 - Added `addAdminSidebarSectionLink` which is used to add a link to a specific admin sidebar section, as a replacement for the `admin-menu` plugin outlet. This only has an effect if the `admin_sidebar_enabled_groups` site setting is in use, which enables the new admin nav sidebar.


### PR DESCRIPTION
Adds a plugin API method to add extra markup (such as a button) to the image wrapper.