### PR TITLE
UX: grant names some more space on /u

### DIFF
--- a/app/assets/javascripts/discourse/app/components/directory-table.js
+++ b/app/assets/javascripts/discourse/app/components/directory-table.js
@@ -13,7 +13,7 @@ export default Component.extend({
         : this.columns.length,
     });
 
-    this._table.style.gridTemplateColumns = `minmax(13em, 3fr) repeat(${this._columnCount}, minmax(max-content, 1fr))`;
+    this._table.style.gridTemplateColumns = `minmax(15em, 3fr) repeat(${this._columnCount}, minmax(max-content, 1fr))`;
   },
 
   @action

--- a/app/assets/stylesheets/common/components/user-info.scss
+++ b/app/assets/stylesheets/common/components/user-info.scss
@@ -17,11 +17,13 @@
     .name-line {
       > a {
         display: flex;
-        gap: 0.5em;
+        flex-wrap: wrap;
+        gap: 0 0.5em;
         color: var(--primary-high);
       }
       .name,
       .username {
+        width: 100%;
         @include ellipsis;
       }
 
@@ -39,6 +41,7 @@
 
     .title {
       color: var(--primary-medium);
+      @include ellipsis;
     }
   }
 


### PR DESCRIPTION
* gives the name column on /u some more width
* puts name and username on separate lines to avoid over-truncating
* limits title to a single line 


Before:
![Screenshot 2024-02-05 at 6 55 07 PM](https://github.com/discourse/discourse/assets/1681963/7c2a5106-efaa-453e-b30b-c83b29e41ff7)

After:
![Screenshot 2024-02-05 at 6 51 08 PM](https://github.com/discourse/discourse/assets/1681963/9944f4ac-3677-478e-a9a1-c817dc868c44)
