### PR TITLE
DEV: Enable rspec `full_cause_backtrace` option

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -232,6 +232,8 @@ RSpec.configure do |config|
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = true
 
+  config.full_cause_backtrace = true
+
   config.before(:suite) do
     CachedCounting.disable
 


### PR DESCRIPTION
This new rspec option shows the entire backtrace in the '--- Caused by: ---' section of RSpec failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
