### PR TITLE
FIX: Correct className for notification avatars using system avatar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
@@ -42,11 +42,18 @@ export default class UserMenuBaseItem {
   }
 
   get iconComponentArgs() {
+    // Use endsWith to determine if the avatarTemplate is the system avatar, because locally the
+    // system avatar is a relative path and doesn't contain hostname. Exact matches will also
+    // evaluate to true.
+    const usingSystemAvatar =
+      !this.avatarTemplate ||
+      this.avatarTemplate.endsWith(this.site.system_user_avatar_template);
+
     return {
       avatarTemplate:
         this.avatarTemplate || this.site.system_user_avatar_template,
       icon: this.icon,
-      classNames: this.avatarTemplate ? "user-avatar" : "system-avatar",
+      classNames: usingSystemAvatar ? "system-avatar" : "user-avatar",
     };
   }
 


### PR DESCRIPTION
It was pointed out to me that notifications that were ACTUALLY generated by the system user had the `user-avatar` className b/c the avatar template isn't just missing, it's serialized as normal, but _is the system avatar template_. This is a simply change to make sure that when the system user generated a notification, the correct `system-avatar` className is used.