### PR TITLE
DEV: Reduce pool size for test environment to 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,7 +242,7 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
         run: |
           GLOBIGNORE="plugins/chat/*";
-          PREFABRICATION=0 LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
+          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
         timeout-minutes: 30
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -36,7 +36,8 @@ test:
   adapter: postgresql
   database: <%= test_db %>
   min_messages: warning
-  pool: 5
+  pool: 1
+  reaping_frequency: 0
   host_names:
     - test.localhost
 


### PR DESCRIPTION
Why this change?

I have been investigating ActiveRecord transaction related issues with our system
tests and I have a hard time figuring out what is causing the problem.
To help simplify our test environment further, we will set the pool size in
the test environment to 1 so that it is impossible for us to be fetching
a different connection between the threads since they all share the
connection pool.

Also set `reaping_frequency` to `0` to ensure we don't reap any
connection ensuring the same connection is always used.
