### PR TITLE
UX: add padding to bottom of mobile chat channel settings page

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-settings.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-settings.scss
@@ -1,3 +1,10 @@
 .c-channel-settings {
   min-width: 320px;
+
+  html.footer-nav-ipad &,
+  html.footer-nav-visible & {
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--footer-nav-height, 0px)
+    );
+  }
 }


### PR DESCRIPTION
The leave channel button is cut off when accessing the channel settings page on mobile.

This change adds additional padding to the bottom of the channel settings page when accessing via iPad/PWA/Hub.