### PR TITLE
FIX: Restore support for `.js.es6` files in PrettyText

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -105,8 +105,8 @@ module PrettyText
 
     Discourse.plugins.each do |plugin|
       Dir
-        .glob("#{plugin.directory}/assets/javascripts/**/discourse-markdown/**/*.js")
-        .filter { |a| File.file?(a) && a.end_with?(".js", ".js.es6") }
+        .glob("#{plugin.directory}/assets/javascripts/**/discourse-markdown/**/*.{js,js.es6}")
+        .filter { |a| File.file?(a) }
         .each do |f|
           module_name =
             f.sub(%r{\A.+assets/javascripts/}, "discourse/plugins/#{plugin.name}/").sub(


### PR DESCRIPTION
Regressed in 1757a688c4749968db8e27623b975fc57519b97a

https://meta.discourse.org/t/294155

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
