### PR TITLE
DEV: Add `disable_service_worker_cache` global setting

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -12,6 +12,35 @@
   workbox_base = "#{base}/assets/#{EmberCli.workbox_dir_name}"
 %>
 
+<% if GlobalSetting.disable_service_worker_cache %>
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      if ("navigationPreload" in self.registration) {
+        await self.registration.navigationPreload.enable();
+      }
+    })()
+  );
+
+  // Tell the active service worker to take control of the page immediately.
+  self.clients.claim();
+});
+
+this.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request.url).catch(error => {
+        return new Response("<center><h1>You are currently offline</h1><p>Try <a href='#' onclick='window.location.reload()'>refreshing</a></p></center>", {
+          headers: {'Content-Type': 'text/html'}
+        })
+      })
+    );
+  }
+});
+
+<% else %>
+
 importScripts("<%= "#{workbox_base}/workbox-sw.js" %>");
 
 workbox.setConfig({
@@ -143,6 +172,7 @@ workbox.routing.registerRoute(
     ],
   })
 );
+<% end %>
 
 function showNotification(title, body, icon, badge, tag, baseUrl, url) {
   var notificationOptions = {

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -391,3 +391,7 @@ log_line_max_chars = 160000
 # Updating the value will allow site operators to invalidate all asset urls
 # to recover from configuration issues which may have been cached by CDNs/browsers.
 asset_url_salt = 
+
+# disable service-worker caching. An 'offline' page will still be used as an offline fallback.
+# This flag is for a temporary experiment, and may be removed at any time
+disable_service_worker_cache = false


### PR DESCRIPTION
When enabled, the workbox caching logic in the service worker will be replaced with a very simple offline error page. We plan to use this as an experiment to see how it affects performance and stability of Discourse.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
