### PR TITLE
FIX: Omit CSP nonce and hash values when unsafe-inline enabled

### DIFF
--- a/lib/content_security_policy/builder.rb
+++ b/lib/content_security_policy/builder.rb
@@ -43,6 +43,10 @@ class ContentSecurityPolicy
 
       @directives.each do |directive, sources|
         if sources.is_a?(Array)
+          if sources.include?("'unsafe-inline'")
+            # Sending nonce- or sha###- values will disable unsafe-inline, so skip them
+            sources = sources.reject { |s| s.start_with?("'nonce-", "'sha") }
+          end
           policy.public_send(directive, *sources)
         else
           policy.public_send(directive, sources)

--- a/spec/lib/content_security_policy/builder_spec.rb
+++ b/spec/lib/content_security_policy/builder_spec.rb
@@ -35,6 +35,25 @@ RSpec.describe ContentSecurityPolicy::Builder do
 
       expect(builder.build).to eq(previous)
     end
+
+    it "omits nonce when unsafe-inline enabled" do
+      builder << { script_src: %w['unsafe-inline' 'nonce-abcde'] }
+
+      expect(builder.build).not_to include("nonce-abcde")
+    end
+
+    it "omits sha when unsafe-inline enabled" do
+      builder << { script_src: %w['unsafe-inline' 'sha256-abcde'] }
+
+      expect(builder.build).not_to include("sha256-abcde")
+    end
+
+    it "keeps sha and nonce when unsafe-inline is not specified" do
+      builder << { script_src: %w['nonce-abcde' 'sha256-abcde'] }
+
+      expect(builder.build).to include("nonce-abcde")
+      expect(builder.build).to include("sha256-abcde")
+    end
   end
 
   def parse(csp_string)


### PR DESCRIPTION
Browsers will ignore unsafe-inline if nonces or hashes are included in the CSP. When unsafe-inline is enabled, nonces and hashes are not required, so we can skip them.

Our strong recommendation remains that unsafe-inline should not be used in production.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
