### PR TITLE
DEV: switch to asyncFindByIds in category-list site-setting component

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
@@ -1,13 +1,36 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import Category from "discourse/models/category";
 import htmlSafe from "discourse-common/helpers/html-safe";
 import SettingValidationMessage from "admin/components/setting-validation-message";
 import CategorySelector from "select-kit/components/category-selector";
 
 export default class CategoryList extends Component {
-  get selectedCategories() {
-    return Category.findByIds(this.args.value.split("|").filter(Boolean));
+  @tracked selectedCategories = [];
+
+  constructor() {
+    super(...arguments);
+
+    this.pendingCategoriesRequest = Promise.resolve();
+    this.valueChanged();
+  }
+
+  get categoryIds() {
+    return this.args.value
+      .split("|")
+      .map((x) => parseInt(x, 10))
+      .filter(Boolean);
+  }
+
+  @action
+  valueChanged() {
+    this.pendingCategoriesRequest = this.pendingCategoriesRequest
+      .then(() => Category.asyncFindByIds(this.categoryIds))
+      .then((categories) => {
+        this.selectedCategories = categories;
+      });
   }
 
   @action
@@ -16,12 +39,14 @@ export default class CategoryList extends Component {
   }
 
   <template>
-    <CategorySelector
-      @categories={{this.selectedCategories}}
-      @onChange={{this.onChangeSelectedCategories}}
-    />
+    <div ...attributes {{didUpdate this.valueChanged @value}}>
+      <CategorySelector
+        @categories={{this.selectedCategories}}
+        @onChange={{this.onChangeSelectedCategories}}
+      />
 
-    <div class="desc">{{htmlSafe this.setting.description}}</div>
-    <SettingValidationMessage @message={{this.validationMessage}} />
+      <div class="desc">{{htmlSafe this.setting.description}}</div>
+      <SettingValidationMessage @message={{this.validationMessage}} />
+    </div>
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
@@ -24,13 +24,14 @@ export default class CategoryList extends Component {
       .filter(Boolean);
   }
 
+  async updateSelectedCategories() {
+    await this.pendingCategoriesRequest;
+    this.selectedCategories = await Category.asyncFindByIds(this.categoryIds);
+  }
+
   @action
   valueChanged() {
-    this.pendingCategoriesRequest = this.pendingCategoriesRequest
-      .then(() => Category.asyncFindByIds(this.categoryIds))
-      .then((categories) => {
-        this.selectedCategories = categories;
-      });
+    this.pendingCategoriesRequest = this.updateSelectedCategories();
   }
 
   @action


### PR DESCRIPTION
We no longer want to rely on preloading every single category, which means we need to do http requests for categories when we need them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
