### PR TITLE
FIX: Hide timer info on topic status toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timer-info.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timer-info.js
@@ -69,7 +69,16 @@ export default Component.extend({
 
     const topicStatus = this.topicClosed ? "close" : "open";
     const topicStatusKnown = this.topicClosed !== undefined;
+    const topicStatusUpdate = this.statusUpdate !== undefined;
     if (topicStatusKnown && topicStatus === this.statusType) {
+      if (!topicStatusUpdate) {
+        return;
+      }
+
+      // The topic status has just been toggled, so we can hide the timer info.
+      this.set("showTopicTimer", null);
+      // The timer has already been removed on the back end. The front end is not aware of the change yet.
+      this.set("executeAt", null);
       return;
     }
 

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -462,6 +462,7 @@
               <TopicTimerInfo
                 @topicClosed={{this.model.closed}}
                 @statusType={{this.model.topic_timer.status_type}}
+                @statusUpdate={{this.model.topic_status_update}}
                 @executeAt={{this.model.topic_timer.execute_at}}
                 @basedOnLastPost={{this.model.topic_timer.based_on_last_post}}
                 @durationMinutes={{this.model.topic_timer.duration_minutes}}

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -426,4 +426,55 @@ acceptance("Topic - Edit timer", function (needs) {
 
     assert.notOk(exists(".topic-timer-heading"));
   });
+
+  test("Close timer removed after manual close", async function (assert) {
+    updateCurrentUser({ moderator: true, trust_level: 4 });
+
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".admin-topic-timer-update button");
+    await click("#tap_tile_tomorrow");
+    await click(".edit-topic-timer-modal button.btn-primary");
+
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-close button");
+
+    assert.notOk(exists(".topic-timer-heading"));
+  });
+
+  test("Open timer removed after manual open", async function (assert) {
+    updateCurrentUser({ moderator: true, trust_level: 4 });
+
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-close button");
+
+    await click(".toggle-admin-menu");
+    await click(".admin-topic-timer-update button");
+    await click("#tap_tile_tomorrow");
+    await click(".edit-topic-timer-modal button.btn-primary");
+
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-open button");
+
+    assert.notOk(exists(".topic-timer-heading"));
+  });
+
+  test("timer removed after manual toggle close and open", async function (assert) {
+    updateCurrentUser({ moderator: true, trust_level: 4 });
+
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".admin-topic-timer-update button");
+    await click("#tap_tile_tomorrow");
+    await click(".edit-topic-timer-modal button.btn-primary");
+
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-close button");
+
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-open button");
+
+    assert.notOk(exists(".topic-timer-heading"));
+  });
 });

--- a/app/assets/javascripts/discourse/tests/fixtures/topic.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/topic.js
@@ -2186,6 +2186,7 @@ export default {
       auto_close_at: null,
       auto_close_hours: null,
       auto_close_based_on_last_post: false,
+      can_close_topic: true,
       created_by: {
         id: 255,
         username: "uwe_keim",


### PR DESCRIPTION
Fix for https://meta.discourse.org/t/minor-ui-bug-with-manually-closing-a-topic-that-has-a-topic-timer-set-for-auto-close-in-the-future/289482

When an auto close/open timer is set and the user manually opens/closes the topic, the timer info remains displayed until the page is refreshed.

The changes here fix that by adding a `@statusUpdate` property to the timer info within the topic template.

The `@statusUpdate` property is read in the `topic-timer-info` component. When this value is defined, and the timer `statusType` matches the the topic status, the timer info `showTopicTimer` and `executedAt` values are set to null. The latter is modified to prevent the info from being incorrectly displayed if the user toggles the status back to open.

The `@statusUpdate` property is set to the value of the topic `topic_status_update`  which is undefined by default. After the topic controller `toggleClosed` function finishes, this value is updated with the return value from the API. This in turn triggers another render of the `topic-timer-info` component which now has the information it needs to hide itself. 

This does trigger an additional render of the timer info after the hooks are fired, but I felt it was acceptable.

Three acceptance tests have been added to topic-edit-timer-test.js.
- auto-close timer is hidden after manually closing the topic
- auto-open timer is hidden after manually opening the topic
- auto-close timer is hidden after manually closing and then re-opening the topic

The topic test fixture needed a minor adjustment to enable toggling the topic status.
