### PR TITLE
DEV: Do lazy_load_categories check inside asyncFindByIds

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -484,6 +484,10 @@ Category.reopenClass({
   async asyncFindByIds(ids = []) {
     ids = ids.map((x) => parseInt(x, 10));
 
+    if (!Site.current().lazy_load_categories) {
+      return this.findByIds(ids);
+    }
+
     const result = await categoryMultiCache.fetch(ids);
     if (categoryMultiCache.hadTooManyCalls()) {
       warn(


### PR DESCRIPTION
This way, we can use asyncFindByIds indiscriminately.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
