### PR TITLE
FIX: Always allow staff (admins & mods) to post links

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1974,7 +1974,7 @@ en:
     min_trust_to_flag_posts: "The minimum trust level required to flag posts"
     flag_post_allowed_groups: "Groups that are allowed to flag posts."
     min_trust_to_post_links: "The minimum trust level required to include links in posts"
-    post_links_allowed_groups: "Groups that are allowed to include links in posts."
+    post_links_allowed_groups: "Groups that are allowed to include links in posts. Admins and moderators are always allowed to post links."
     min_trust_to_post_embedded_media: "The minimum trust level required to embed media items in a post"
     embedded_media_post_allowed_groups: "The users in these groups are allowed to embed media items in a post"
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -3,7 +3,7 @@
 # mixin for all guardian methods dealing with post permissions
 module PostGuardian
   def unrestricted_link_posting?
-    authenticated? && @user.in_any_groups?(SiteSetting.post_links_allowed_groups_map)
+    authenticated? && (is_staff? || @user.in_any_groups?(SiteSetting.post_links_allowed_groups_map))
   end
 
   def link_posting_access

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Guardian do
       expect(Guardian.new(user).link_posting_access).to eq("full")
     end
 
+    it "is full for staff users regardless of TL" do
+      SiteSetting.post_links_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
+      admin_user = Fabricate(:admin)
+      admin_user.change_trust_level!(TrustLevel[1])
+      expect(Guardian.new(admin_user).link_posting_access).to eq("full")
+    end
+
     it "is none for a user of a low trust level" do
       user.change_trust_level!(TrustLevel[0])
       SiteSetting.post_links_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]


### PR DESCRIPTION
Followup fb087b7ff6d168bbfcaa5f83d53ac122d6a18a1c

post_links_allowed_groups is an odd check tied to
unrestricted_link_posting? in PostGuardian, in that
it doesn't have an escape hatch for staff like most
of the rest of these group based settings.

It doesn't make sense to exclude admins or mods from
posting links, so just always allow them to avoid confusion.
