### PR TITLE
FIX: Always trust admin and moderators with post edits

### DIFF
--- a/app/models/concerns/limited_edit.rb
+++ b/app/models/concerns/limited_edit.rb
@@ -4,21 +4,12 @@ module LimitedEdit
   extend ActiveSupport::Concern
 
   def edit_time_limit_expired?(user)
-    return true if !trusted_with_edits?(user)
+    return true if !user.guardian.trusted_with_post_edits?
     time_limit = user_time_limit(user)
     created_at && (time_limit > 0) && (created_at < time_limit.minutes.ago)
   end
 
   private
-
-  # TODO: This duplicates some functionality from PostGuardian. This should
-  #       probably be checked there instead, because this has nothing to do
-  #       with time limits.
-  #
-  def trusted_with_edits?(user)
-    user.trust_level >= SiteSetting.min_trust_to_edit_post ||
-      user.in_any_groups?(SiteSetting.edit_post_allowed_groups_map)
-  end
 
   def user_time_limit(user)
     if user.trust_level < 2

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -163,7 +163,7 @@ module PostGuardian
       return can_create_post?(post.topic)
     end
 
-    return false if !trusted_with_edits?
+    return false if !trusted_with_post_edits?
 
     if is_my_own?(post)
       return false if @user.silenced?
@@ -369,12 +369,11 @@ module PostGuardian
     is_staff? || @user.has_trust_level?(TrustLevel[4])
   end
 
-  private
-
-  def trusted_with_edits?
-    @user.trust_level >= SiteSetting.min_trust_to_edit_post ||
-      @user.in_any_groups?(SiteSetting.edit_post_allowed_groups_map)
+  def trusted_with_post_edits?
+    is_staff? || @user.in_any_groups?(SiteSetting.edit_post_allowed_groups_map)
   end
+
+  private
 
   def can_create_post_in_topic?(topic)
     if !SiteSetting.enable_system_message_replies? && topic.try(:subtype) == "system_message"

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1670,25 +1670,31 @@ RSpec.describe Guardian do
         expect(Guardian.new(trust_level_4).can_edit?(post)).to be_truthy
       end
 
-      it "returns false when trying to edit a topic with no trust" do
-        SiteSetting.min_trust_to_edit_post = 2
-        SiteSetting.edit_post_allowed_groups = 12
-        post.user.trust_level = 1
+      it "returns false when trying to edit a topic when the user is not in the allowed groups" do
+        SiteSetting.edit_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
+        post.user.change_trust_level!(TrustLevel[1])
 
         expect(Guardian.new(topic.user).can_edit?(topic)).to be_falsey
       end
 
-      it "returns false when trying to edit a post with no trust" do
-        SiteSetting.min_trust_to_edit_post = 2
-        SiteSetting.edit_post_allowed_groups = 12
-        post.user.trust_level = 1
+      it "returns false when trying to edit a post when the user is not in the allowed groups" do
+        SiteSetting.edit_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
+        post.user.change_trust_level!(TrustLevel[1])
 
         expect(Guardian.new(post.user).can_edit?(post)).to be_falsey
       end
 
-      it "returns true when trying to edit a post with trust" do
-        SiteSetting.min_trust_to_edit_post = 1
-        post.user.trust_level = 1
+      it "returns true when editing a post when the user is in the allowed groups" do
+        SiteSetting.edit_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+        post.user.change_trust_level!(TrustLevel[1])
+
+        expect(Guardian.new(post.user).can_edit?(post)).to be_truthy
+      end
+
+      it "returns true when editing a post when the user is admin regardless of groups" do
+        SiteSetting.edit_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_2]
+        post.user.update!(admin: true)
+        post.user.change_trust_level!(TrustLevel[1])
 
         expect(Guardian.new(post.user).can_edit?(post)).to be_truthy
       end


### PR DESCRIPTION
Removes duplication from LimitedEdit to see who can edit
posts, and also removes the old trust level setting check
since it's no longer necessary.

Also make it so staff can always edit since can_edit_post?
already has a staff escape hatch.
