### PR TITLE
FIX: Translation missing for Illegal flag on topic

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -612,7 +612,12 @@
 }
 
 .flag-modal-body {
-  max-height: 450px;
+  form {
+    margin: 0;
+  }
+  .flag-action-type .controls .checkbox-label {
+    margin-bottom: 0.25em;
+  }
   .flag-action-type-details {
     width: 100%;
     // max-width: 500px;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3946,7 +3946,7 @@ en:
       notify_user_textarea_label: "Message for the user"
       custom_placeholder_notify_moderators: "Let us know specifically what you are concerned about, and provide relevant links and examples where possible."
       notify_moderators_textarea_label: "Message for the moderators"
-      custom_placeholder_illegal: "Let us know specifically why you believe this post is illegal, and provide relevant links and examples where possible."
+      custom_placeholder_illegal: "Let us know specifically why you believe this content is illegal, and provide relevant links and examples where possible."
       custom_message:
         at_least:
           one: "enter at least %{count} character"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1052,6 +1052,12 @@ en:
       short_description: "Requires staff attention for another reason"
       email_title: 'The topic "%{title}" requires moderator attention'
       email_body: "%{link}\n\n%{message}"
+    illegal:
+      title: "It's Illegal"
+      description: "This topic requires staff attention because I believe it contains content that is illegal."
+      short_description: "This is illegal"
+      email_title: 'A post in "%{title}" requires staff attention'
+      email_body: "%{link}\n\n%{message}"
 
   flagging:
     you_must_edit: '<p>Your post was flagged by the community. Please <a href="%{path}">see your messages</a>.</p>'


### PR DESCRIPTION
Followup to 95a2d285d397edf0c31ac7ac96dac7d3d0f200d3

Fixes a missing translation and also makes it so the
flag modal does not have a scrollbar when it opens.
