### PR TITLE
FIX: Do not async already loaded categories

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -484,7 +484,7 @@ Category.reopenClass({
   async asyncFindByIds(ids = []) {
     ids = ids.map((x) => parseInt(x, 10));
 
-    if (!Site.current().lazy_load_categories) {
+    if (!Site.current().lazy_load_categories || this.hasAsyncFoundAll(ids)) {
       return this.findByIds(ids);
     }
 


### PR DESCRIPTION
Use sync findByIds to return the category list if all of them have been previously loaded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
