### PR TITLE
Revert "FIX: Omit CSP nonce and hash values when unsafe-inline enable…

### DIFF
--- a/lib/content_security_policy/builder.rb
+++ b/lib/content_security_policy/builder.rb
@@ -43,10 +43,6 @@ class ContentSecurityPolicy
 
       @directives.each do |directive, sources|
         if sources.is_a?(Array)
-          if sources.include?("'unsafe-inline'")
-            # Sending nonce- or sha###- values will disable unsafe-inline, so skip them
-            sources = sources.reject { |s| s.start_with?("'nonce-", "'sha") }
-          end
           policy.public_send(directive, *sources)
         else
           policy.public_send(directive, sources)

--- a/spec/lib/content_security_policy/builder_spec.rb
+++ b/spec/lib/content_security_policy/builder_spec.rb
@@ -35,25 +35,6 @@ RSpec.describe ContentSecurityPolicy::Builder do
 
       expect(builder.build).to eq(previous)
     end
-
-    it "omits nonce when unsafe-inline enabled" do
-      builder << { script_src: %w['unsafe-inline' 'nonce-abcde'] }
-
-      expect(builder.build).not_to include("nonce-abcde")
-    end
-
-    it "omits sha when unsafe-inline enabled" do
-      builder << { script_src: %w['unsafe-inline' 'sha256-abcde'] }
-
-      expect(builder.build).not_to include("sha256-abcde")
-    end
-
-    it "keeps sha and nonce when unsafe-inline is not specified" do
-      builder << { script_src: %w['nonce-abcde' 'sha256-abcde'] }
-
-      expect(builder.build).to include("nonce-abcde")
-      expect(builder.build).to include("sha256-abcde")
-    end
   end
 
   def parse(csp_string)


### PR DESCRIPTION
…d (#25590)"

This reverts commit 767b49232e0c4c853e5b92e0abde8381f3aa1e88.

If anything else (e.g. GTM integration) introduces a nonce/hash, then this change stops the splash screen JS to fail and makes sites unusable.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
