### PR TITLE
PERF: Improve watched words

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
+++ b/app/assets/javascripts/admin/addon/components/modal/watched-word-test.js
@@ -1,9 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
 
 export default class WatchedWordTest extends Component {
   @tracked value;
@@ -31,7 +27,8 @@ export default class WatchedWordTest extends Component {
     if (this.isReplace || this.isLink) {
       const matches = [];
       this.args.model.watchedWord.words.forEach((word) => {
-        const regexp = createWatchedWordRegExp(word);
+        const caseFlag = word.case_sensitive ? "" : "i";
+        const regexp = new RegExp(word.regexp, `${caseFlag}gu`);
         let match;
 
         while ((match = regexp.exec(this.value)) !== null) {
@@ -45,7 +42,8 @@ export default class WatchedWordTest extends Component {
     } else if (this.isTag) {
       const matches = {};
       this.args.model.watchedWord.words.forEach((word) => {
-        const regexp = createWatchedWordRegExp(word);
+        const caseFlag = word.case_sensitive ? "" : "i";
+        const regexp = new RegExp(word.regexp, `${caseFlag}gu`);
         let match;
 
         while ((match = regexp.exec(this.value)) !== null) {
@@ -66,12 +64,13 @@ export default class WatchedWordTest extends Component {
       }));
     } else {
       let matches = [];
-      this.args.model.watchedWord.compiledRegularExpression.forEach(
-        (regexp) => {
-          const wordRegexp = createWatchedWordRegExp(toWatchedWord(regexp));
-          matches.push(...(this.value.match(wordRegexp) || []));
-        }
-      );
+      this.args.model.watchedWord.compiledRegularExpression.forEach((entry) => {
+        const [regexp, options] = Object.entries(entry)[0];
+        const caseFlag = options.case_sensitive ? "" : "i";
+        const wordRegexp = new RegExp(regexp, `${caseFlag}gu`);
+
+        matches.push(...(this.value.match(wordRegexp) || []));
+      });
 
       return matches;
     }

--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -1,9 +1,0 @@
-export function createWatchedWordRegExp(word) {
-  const caseFlag = word.case_sensitive ? "" : "i";
-  return new RegExp(word.regexp, `${caseFlag}gu`);
-}
-
-export function toWatchedWord(regexp) {
-  const [[regexpString, options]] = Object.entries(regexp);
-  return { ...options, regexp: regexpString };
-}

--- a/app/assets/javascripts/discourse-markdown-it/src/features/emoji.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/emoji.js
@@ -196,7 +196,7 @@ function applyEmoji(
   enableShortcuts,
   inlineEmoji,
   customEmojiTranslation,
-  watchedWordsReplacer,
+  watchedWordsReplace,
   emojiDenyList
 ) {
   let result = null;
@@ -206,19 +206,16 @@ function applyEmoji(
     content = emojiUnicodeReplacer(content);
   }
 
-  if (watchedWordsReplacer) {
-    const watchedWordRegex = Object.keys(watchedWordsReplacer);
-
-    watchedWordRegex.forEach((watchedWord) => {
-      if (content?.match(watchedWord)) {
-        const regex = new RegExp(watchedWord, "g");
+  if (content && watchedWordsReplace) {
+    Object.entries(watchedWordsReplace).forEach(([regexpString, options]) => {
+      if (content.match(regexpString)) {
+        const regex = new RegExp(regexpString, "g");
         const matches = content.match(regex);
-        const replacement = watchedWordsReplacer[watchedWord].replacement;
 
         matches.forEach(() => {
           const matchingRegex = regex.exec(content);
           if (matchingRegex) {
-            content = content.replace(matchingRegex[1], replacement);
+            content = content.replace(matchingRegex[1], options.replacement);
           }
         });
       }
@@ -226,9 +223,9 @@ function applyEmoji(
   }
 
   // prevent denied emoji and aliases from being rendered
-  if (emojiDenyList?.length > 0) {
+  if (content && emojiDenyList?.length > 0) {
     emojiDenyList.forEach((emoji) => {
-      if (content?.match(emoji)) {
+      if (content.match(emoji)) {
         const regex = new RegExp(`:${emoji}:`, "g");
         content = content.replace(regex, "");
       }

--- a/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/watched-words.js
@@ -1,8 +1,3 @@
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
-
 const MAX_MATCHES = 100;
 
 function isLinkOpen(str) {
@@ -58,11 +53,11 @@ export function setup(helper) {
     if (md.options.discourse.watchedWordsReplace) {
       Object.entries(md.options.discourse.watchedWordsReplace).forEach(
         ([regexpString, options]) => {
-          const word = toWatchedWord({ [regexpString]: options });
+          const caseFlag = options.case_sensitive ? "" : "i";
 
           matchers.push({
-            word: new RegExp(options.regexp, options.case_sensitive ? "" : "i"),
-            pattern: createWatchedWordRegExp(word),
+            word: new RegExp(options.regexp, caseFlag),
+            pattern: new RegExp(regexpString, `${caseFlag}gu`),
             replacement: options.replacement,
             link: false,
           });
@@ -73,11 +68,11 @@ export function setup(helper) {
     if (md.options.discourse.watchedWordsLink) {
       Object.entries(md.options.discourse.watchedWordsLink).forEach(
         ([regexpString, options]) => {
-          const word = toWatchedWord({ [regexpString]: options });
+          const caseFlag = options.case_sensitive ? "" : "i";
 
           matchers.push({
-            word: new RegExp(options.regexp, options.case_sensitive ? "" : "i"),
-            pattern: createWatchedWordRegExp(word),
+            word: new RegExp(options.regexp, caseFlag),
+            pattern: new RegExp(regexpString, `${caseFlag}gu`),
             replacement: options.replacement,
             link: true,
           });

--- a/app/assets/javascripts/pretty-text/addon/censored-words.js
+++ b/app/assets/javascripts/pretty-text/addon/censored-words.js
@@ -1,13 +1,9 @@
-import {
-  createWatchedWordRegExp,
-  toWatchedWord,
-} from "discourse-common/utils/watched-words";
-
-export function censorFn(regexpList, replacementLetter) {
+export function censorFn(regexpList, replacementLetter = "&#9632;") {
   if (regexpList?.length) {
-    replacementLetter = replacementLetter || "&#9632;";
-    let censorRegexps = regexpList.map((regexp) => {
-      return createWatchedWordRegExp(toWatchedWord(regexp));
+    const censorRegexps = regexpList.map((entry) => {
+      const [regexp, options] = Object.entries(entry)[0];
+      const caseFlag = options.case_sensitive ? "" : "i";
+      return new RegExp(regexp, `${caseFlag}gu`);
     });
 
     return function (text) {

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -89,7 +89,6 @@ module PrettyText
       discourse-common/addon/lib/deprecated
       discourse-common/addon/lib/escape
       discourse-common/addon/lib/avatar-utils
-      discourse-common/addon/utils/watched-words
       discourse/app/lib/to-markdown
       discourse/app/static/markdown-it/features
     ].each do |f|


### PR DESCRIPTION
Shrink down the json representation that is passed from the rubyland into js/miniracer.

Previously each entry had ~81 characters of overhead:

```json
{"(?:\\P{L}|^)(🌞)(?=\\P{L}|$)":{"word":"🌞","replacement":"🌚","case_sensitive":false}
```

vs now, it's down to ~42:
```json
["(?:\\P{L}|^)(🌞)(?=\\P{L}|$)",false,"🌞","🌚"]
```

---

With the test dataset of 856 watched words, cooking a post goes from:

```rb
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 7414.3910000000005
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 6821.589
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 32.023
```
to
```rb
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 715.76
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 60.162
t1 = Time.now; PrettyText.cook('a'); t2 = Time.now; (t2-t1) * 1000.0
=> 16.461
```