### PR TITLE
DEV: Convert composer model to native class syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -12,7 +12,9 @@ import { prioritizeNameFallback } from "discourse/lib/settings";
 import { emailValid, escapeExpression } from "discourse/lib/utilities";
 import Draft from "discourse/models/draft";
 import RestModel from "discourse/models/rest";
+import Site from "discourse/models/site";
 import Topic from "discourse/models/topic";
+import User from "discourse/models/user";
 import { tinyAvatar } from "discourse-common/lib/avatar-utils";
 import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -131,6 +133,14 @@ export default class Composer extends RestModel {
   static NEW_PRIVATE_MESSAGE_KEY = NEW_PRIVATE_MESSAGE_KEY;
   static NEW_TOPIC_KEY = NEW_TOPIC_KEY;
 
+  // TODO: Replace with injection
+  static create(args) {
+    args = args || {};
+    args.user = args.user || User.current();
+    args.site = args.site || Site.current();
+    return super.create(args);
+  }
+
   static serializeToTopic(fieldName, property) {
     if (!property) {
       property = fieldName;
@@ -173,8 +183,6 @@ export default class Composer extends RestModel {
   }
 
   @service dialog;
-  @service currentUser;
-  @service site;
 
   unlistTopic = false;
   noBump = false;

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -3,6 +3,7 @@ import { and, equal, not, or, reads } from "@ember/object/computed";
 import { next, throttle } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
+import { observes, on } from "@ember-decorators/object";
 import { Promise } from "rsvp";
 import { extractError, throwAjaxError } from "discourse/lib/ajax-error";
 import { propertyNotEqual } from "discourse/lib/computed";
@@ -14,10 +15,7 @@ import RestModel from "discourse/models/rest";
 import Topic from "discourse/models/topic";
 import { tinyAvatar } from "discourse-common/lib/avatar-utils";
 import deprecated from "discourse-common/lib/deprecated";
-import discourseComputed, {
-  observes,
-  on,
-} from "discourse-common/utils/decorators";
+import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
 let _customizations = [];

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1,4 +1,6 @@
+import { tracked } from "@glimmer/tracking";
 import EmberObject, { set } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { and, equal, not, or, reads } from "@ember/object/computed";
 import { next, throttle } from "@ember/runloop";
 import { inject as service } from "@ember/service";
@@ -217,12 +219,9 @@ export default class Composer extends RestModel {
   @and("canEditTitle", "notCreatingPrivateMessage", "notPrivateMessage")
   canCategorize;
 
-  _categoryId = null;
+  @tracked _categoryId = null;
 
-  get user() {
-    return this.currentUser;
-  }
-
+  @dependentKeyCompat
   get categoryId() {
     return this._categoryId;
   }


### PR DESCRIPTION
This commit was created with a combination of the ember-native-class-codemod and manual cleanup

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
