### PR TITLE
UX: fix post count position on avatars in topic map

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -696,6 +696,7 @@ aside.quote {
     }
     .post-count {
       position: absolute;
+      top: 0;
       right: 0;
       border-radius: 100px;
       padding: 0.15em 0.4em 0.2em;


### PR DESCRIPTION
Not sure how this regressed, but here's a fix

Before:
![Screenshot 2024-02-08 at 4 59 06 PM](https://github.com/discourse/discourse/assets/1681963/7fc0f3a6-6ec0-4e83-8ff9-b7f8e0224bdf)

After:
![Screenshot 2024-02-08 at 4 59 02 PM](https://github.com/discourse/discourse/assets/1681963/d91f7710-b59e-4fe8-906a-2044f03225d6)
