### PR TITLE
UX: move the margin to 'configure more' link on the setup wizard

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -366,7 +366,6 @@ body.wizard {
   }
 
   &__button.primary {
-    margin-left: 1em;
     background-color: var(--tertiary);
     color: var(--secondary);
     @include breakpoint("mobile-extra-large") {
@@ -388,7 +387,7 @@ body.wizard {
   }
 
   &__button.configure-more {
-    //background-color: var(--primary-200);
+    margin-right: 1em;
     background-color: transparent;
     color: var(--tertiary);
     @include breakpoint("mobile-extra-large") {


### PR DESCRIPTION
Moved the margin to `configure more` link on the setup wizard so it doesn't affect the alignment of the input fields and CTA during installation.

### Before
![image](https://github.com/discourse/discourse/assets/2790986/a9401561-ee0b-4e61-afa9-503e1b04c296)

![image](https://github.com/discourse/discourse/assets/2790986/81fa4e2a-ba29-4973-9c41-bd9f332315eb)
