### PR TITLE
FIX: Preload associations on subcategories when lazy loading categories

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -159,7 +159,7 @@ class CategoryList
           .where(parent_category_id: @categories.map { |c| c.id })
 
       @categories +=
-        Category.where(
+        Category.includes(CategoryList.included_associations).where(
           "id IN (WITH cte AS (#{categories_with_rownum.to_sql}) SELECT id FROM cte WHERE rownum <= ?)",
           SUBCATEGORIES_PER_CATEGORY,
         )


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
