### PR TITLE
UX: Don't display empty state while changing notification filter

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.gjs
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.gjs
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
@@ -23,8 +24,9 @@ export default class UserNotificationsController extends Controller {
   @service site;
   @service siteSettings;
 
-  queryParams = ["filter"];
-  filter = "all";
+  @tracked filter = "all";
+queryParams = ["filter"];
+
 
   get listContainerClassNames() {
     return `user-notifications-list ${
@@ -61,9 +63,9 @@ export default class UserNotificationsController extends Controller {
     );
   }
 
-  @discourseComputed("isFiltered", "model.content.length")
-  doesNotHaveNotifications(isFiltered, contentLength) {
-    return !isFiltered && contentLength === 0;
+  @discourseComputed("isFiltered", "model.content.length", "loading")
+  doesNotHaveNotifications(isFiltered, contentLength, loading) {
+    return !loading && !isFiltered && contentLength === 0;
   }
 
   @discourseComputed("isFiltered", "model.content.length")
@@ -84,6 +86,12 @@ export default class UserNotificationsController extends Controller {
   async markRead() {
     await ajax("/notifications/mark-read", { type: "PUT" });
     this.model.forEach((notification) => notification.set("read", true));
+  }
+
+  @action
+  updateFilter(value) {
+    this.loading = true;
+    this.filter = value;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.gjs
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.gjs
@@ -25,8 +25,8 @@ export default class UserNotificationsController extends Controller {
   @service siteSettings;
 
   @tracked filter = "all";
-queryParams = ["filter"];
 
+  queryParams = ["filter"];
 
   get listContainerClassNames() {
     return `user-notifications-list ${

--- a/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
@@ -18,7 +18,7 @@
   <div class="user-notifications-filter">
     <NotificationsFilter
       @value={{this.filter}}
-      @onChange={{action (mut this.filter)}}
+      @onChange={{this.updateFilter}}
     />
     <PluginOutlet
       @name="user-notifications-after-filter"


### PR DESCRIPTION
We have been flashing the empty state when changing the filter (from unread when you have no unread, to a state with notifications). 

This sets `loading = true` so that we get the spinner instead. Woo!