### PR TITLE
DEV: Change Group.trusted_group_ids to use const

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -478,7 +478,7 @@ class Group < ActiveRecord::Base
   end
 
   def self.trust_group_ids
-    (10..19).to_a
+    Group.auto_groups_between(:trust_level_0, :trust_level_4).to_a
   end
 
   def set_message_default_notification_levels!(topic, ignore_existing: false)


### PR DESCRIPTION
We have AUTO_GROUPS, we can use this instead of the
hardcoded 10..19 (not even sure why it goes up to 19,
trust levels previously only went to 5 max).
