### PR TITLE
FIX: no reply as a new topic without permission

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -153,6 +153,18 @@ acceptance("Composer Actions", function (needs) {
     assert.ok(!exists(".dialog-body"));
   });
 
+  test("reply_as_new_topic without a permission to create topic", async function (assert) {
+    updateCurrentUser({ can_create_topic: false });
+    await visit("/t/internationalization-localization/280");
+    await click(".create.reply");
+    const composerActions = selectKit(".composer-actions");
+    await composerActions.expand();
+    assert.ok(
+      !exists(".composer-actions svg.d-icon-plus"),
+      "reply as new topic icon is not visible"
+    );
+  });
+
   test("reply_as_new_group_message", async function (assert) {
     await visit("/t/lorem-ipsum-dolor-sit-amet/130");
     await click(".create.reply");

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -137,6 +137,7 @@ export default DropdownSelectBoxComponent.extend({
       this.topic &&
       !this.topic.isPrivateMessage &&
       !this.isEditing &&
+      this.currentUser.can_create_topic &&
       _topicSnapshot
     ) {
       items.push({
@@ -222,7 +223,7 @@ export default DropdownSelectBoxComponent.extend({
       });
     }
 
-    if (items.length === 0) {
+    if (items.length === 0 && this.currentUser.can_create_topic) {
       items.push({
         name: I18n.t("composer.composer_actions.create_topic.label"),
         description: I18n.t("composer.composer_actions.create_topic.desc"),


### PR DESCRIPTION
`create topic allowed groups` site setting controls permission to create a new topic.

If a user cannot create a topic, a reply as a new topic button should not be visible as well.
