### PR TITLE
FIX: quoted private topic url respects subfolder install

### DIFF
--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -92,7 +92,7 @@ module PrettyText
       if topic && Guardian.new.can_see?(topic)
         { title: Rack::Utils.escape_html(topic.title), href: topic.url }
       elsif topic
-        { title: I18n.t("on_another_topic"), href: Discourse.base_url + topic.slugless_url }
+        { title: I18n.t("on_another_topic"), href: topic.slugless_url }
       end
     end
 

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe PrettyText do
           <aside class="quote no-group" data-username="maja" data-post="3" data-topic="#{topic.id}">
           <div class="title">
           <div class="quote-controls"></div>
-          <a href="http://test.localhost/t/#{topic.id}/3">#{I18n.t("on_another_topic")}</a></div>
+          <a href="/t/#{topic.id}/3">#{I18n.t("on_another_topic")}</a></div>
           <blockquote>
           <p>I have nothing to say.</p>
           </blockquote>

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -311,6 +311,16 @@ RSpec.describe Topic do
     end
   end
 
+  describe "slugless_url" do
+    fab!(:topic)
+
+    it "includes subfolder install path" do
+      set_subfolder "/forum"
+
+      expect(topic.slugless_url).to eq("/forum/t/#{topic.id}")
+    end
+  end
+
   describe "updating a title to be shorter" do
     let!(:topic) { Fabricate(:topic) }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -314,7 +314,15 @@ RSpec.describe Topic do
   describe "slugless_url" do
     fab!(:topic)
 
-    it "includes subfolder install path" do
+    it "returns the correct url" do
+      expect(topic.slugless_url).to eq("/t/#{topic.id}")
+    end
+
+    it "works with post id" do
+      expect(topic.slugless_url(123)).to eq("/t/#{topic.id}/123")
+    end
+
+    it "works with subfolder install" do
       set_subfolder "/forum"
 
       expect(topic.slugless_url).to eq("/forum/t/#{topic.id}")


### PR DESCRIPTION
Fixes an issue where private topics that are quoted have an incorrectly formatted url when using a subfolder install.

This update returns a relative url that includes the `base_path` rather than a combination of `base_url` + `base_path`.