### PR TITLE
DEV: Remove broken link and comments from no_index.erb

### DIFF
--- a/app/views/robots_txt/no_index.erb
+++ b/app/views/robots_txt/no_index.erb
@@ -1,9 +1,3 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-
-# Googlebot must be allowed to index so it can remove items from the index
-# we return the X-Robots-Tag with noindex, nofollow which will ensure
-# indexing is minimized and nothing shows up in Google search results
 User-agent: googlebot
 Allow: <%= Discourse.base_path + "/" %>
 Disallow: <%= Discourse.base_path + "/uploads/*" %>


### PR DESCRIPTION
We intend to move guidance about how to configure robots.txt to the admin interface and a documentation topic on meta. First step is to delete the broken link and comments from the robots.txt file. 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
