### PR TITLE
DEV: Use PosterSerializer for SuggestedTopicSerializer posters

### DIFF
--- a/app/serializers/suggested_topic_serializer.rb
+++ b/app/serializers/suggested_topic_serializer.rb
@@ -7,7 +7,7 @@ class SuggestedTopicSerializer < ListableTopicSerializer
   # front page json gets away without embedding
   class SuggestedPosterSerializer < ApplicationSerializer
     attributes :extras, :description
-    has_one :user, serializer: BasicUserSerializer, embed: :objects
+    has_one :user, serializer: PosterSerializer, embed: :objects
   end
 
   attributes :archetype,


### PR DESCRIPTION
The only addition is `PosterSerializer` is this:

https://github.com/discourse/discourse/blob/4a5616fe86d42e38b63bfcd5b46c547157b2025b/app/serializers/poster_serializer.rb#L4

Which allows themes to check the posters' primary group!