### PR TITLE
FIX: Webauthn origin was incorrect for subfolder setups

### DIFF
--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -92,10 +92,8 @@ module DiscourseWebauthn
       # you might need to change this and the rp_id above
       # if you are using a non-default port/hostname locally
       "http://localhost:4200"
-    when "test"
-      "http://localhost:3000"
     else
-      Discourse.base_url
+      Discourse.base_url_no_prefix
     end
   end
 

--- a/spec/lib/concern/second_factor_manager_spec.rb
+++ b/spec/lib/concern/second_factor_manager_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe SecondFactorManager do
         disable_totp
         simulate_localhost_webauthn_challenge
         DiscourseWebauthn.stage_challenge(user, secure_session)
+        DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
       end
 
       context "when security key params are valid" do
@@ -265,6 +266,7 @@ RSpec.describe SecondFactorManager do
       before do
         simulate_localhost_webauthn_challenge
         DiscourseWebauthn.stage_challenge(user, secure_session)
+        DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
       end
 
       context "when method selected is invalid" do

--- a/spec/lib/discourse_webauthn/authentication_service_spec.rb
+++ b/spec/lib/discourse_webauthn/authentication_service_spec.rb
@@ -97,8 +97,10 @@ RSpec.describe DiscourseWebauthn::AuthenticationService do
   let(:current_user) { Fabricate(:user) }
 
   before do
-    # we have to stub here because the public key was created using this specific challenge
+    # we have to stub here because the test public key was created
+    # using this specific challenge and this origin
     DiscourseWebauthn.stubs(:challenge).returns(challenge)
+    DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
   end
 
   it "updates last_used when the security key and params are valid" do

--- a/spec/lib/discourse_webauthn/discourse_webauthn_spec.rb
+++ b/spec/lib/discourse_webauthn/discourse_webauthn_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWebauthn do
+  describe "#origin" do
+    it "returns the current hostname" do
+      expect(DiscourseWebauthn.origin).to eq("http://test.localhost")
+    end
+
+    context "with subfolder" do
+      it "does not append /forum to origin" do
+        set_subfolder "/forum"
+        expect(DiscourseWebauthn.origin).to eq("http://test.localhost")
+      end
+    end
+  end
+end

--- a/spec/lib/discourse_webauthn/registration_service_spec.rb
+++ b/spec/lib/discourse_webauthn/registration_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DiscourseWebauthn::RegistrationService do
   let(:secure_session) { SecureSession.new("tester") }
   let(:client_data_challenge) { Base64.encode64(challenge) }
   let(:client_data_webauthn_type) { "webauthn.create" }
-  let(:client_data_origin) { "http://localhost:3000" }
+  let(:client_data_origin) { "http://test.localhost" }
   let(:client_data_param) do
     {
       challenge: client_data_challenge,

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -403,6 +403,7 @@ RSpec.describe SessionController do
 
         before do
           simulate_localhost_webauthn_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
 
           # store challenge in secure session by visiting the email login page
           get "/session/email-login/#{email_token.token}.json"
@@ -422,6 +423,7 @@ RSpec.describe SessionController do
             expect(response_body["error"]).to eq(I18n.t("login.not_enabled_second_factor_method"))
           end
         end
+
         context "when the security key params are invalid" do
           it "shows an error message and denies login" do
             post "/session/email-login/#{email_token.token}.json",
@@ -442,6 +444,7 @@ RSpec.describe SessionController do
             expect(response_body["error"]).to eq(I18n.t("webauthn.validation.not_found_error"))
           end
         end
+
         context "when the security key params are valid" do
           it "logs the user in" do
             post "/session/email-login/#{email_token.token}.json",
@@ -2021,6 +2024,7 @@ RSpec.describe SessionController do
 
         before do
           simulate_localhost_webauthn_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
 
           # store challenge in secure session by failing login once
           post "/session.json", params: { login: user.username, password: "myawesomepassword" }
@@ -3097,6 +3101,8 @@ RSpec.describe SessionController do
   end
 
   describe "#passkey_login" do
+    before { DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000") }
+
     it "returns 404 if feature is not enabled" do
       SiteSetting.enable_passkeys = false
 


### PR DESCRIPTION
Addresses issue raised when registering passkeys or security keys in https://meta.discourse.org/t/issues-using-passkeys-with-vaultwarden/294865/10 