### PR TITLE
FIX: email category badges shouldn't use category text color

### DIFF
--- a/lib/category_badge.rb
+++ b/lib/category_badge.rb
@@ -91,6 +91,6 @@ module CategoryBadge
     result << ERB::Util.html_escape(category.name)
     result << "</span></span>"
 
-    wrap_in_link(result, data[:category_url], "")
+    wrap_in_link(result, data[:category_url])
   end
 end

--- a/lib/category_badge.rb
+++ b/lib/category_badge.rb
@@ -91,6 +91,6 @@ module CategoryBadge
     result << ERB::Util.html_escape(category.name)
     result << "</span></span>"
 
-    wrap_in_link(result, data[:category_url], "", "color: ##{category.text_color};")
+    wrap_in_link(result, data[:category_url], "")
   end
 end

--- a/spec/lib/category_badge_spec.rb
+++ b/spec/lib/category_badge_spec.rb
@@ -34,11 +34,10 @@ RSpec.describe CategoryBadge do
   end
 
   it "includes inline color style when inline_style is true" do
-    c = Fabricate(:category, color: "123456", text_color: "654321")
+    c = Fabricate(:category, color: "123456")
 
     html = CategoryBadge.html_for(c, inline_style: true)
 
-    expect(html).to include("color: #654321;")
     expect(html).to include("background-color: #123456;")
   end
 end


### PR DESCRIPTION
This is a follow-up to c49eb37

Since we no longer use the category text color setting for category badges in core (it's used by some theme components), it shouldn't be used in email either... otherwise you can get a situation where a theme may be using the category text color, but since the theme can't extend to email, this may be undesirable (white text on white bg for example). I overlooked this initially. 