### PR TITLE
UX: Onebox container sizing

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -17,8 +17,10 @@ $max_image_height: 150px;
     overflow: hidden;
   }
 
-  .onebox:not(img) {
-    container-type: inline-size;
+  .onebox {
+    &:not(img) {
+      container-type: inline-size;
+    }
 
     .thumbnail {
       &.onebox-avatar {
@@ -27,6 +29,10 @@ $max_image_height: 150px;
         max-width: 60px;
         margin-right: 0.5rem;
       }
+    }
+
+    .onebox-body .aspect-image {
+      max-width: 50%;
     }
 
     @container (width < 400px) {

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -17,7 +17,7 @@ $max_image_height: 150px;
     overflow: hidden;
   }
 
-  .onebox {
+  .onebox:not(img) {
     container-type: inline-size;
 
     .thumbnail {


### PR DESCRIPTION
* fixed a bug that made oneboxed images not appear, caused by `container-type: inline-size;` => fixed by scoping to `:not(img)` elements
* increased max-width for the `.aspect-images` in a onebox which will benefit smaller screens:
⬇️ 
### BEFORE
<img width="664" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c85b07af-6b42-4266-95b2-3eda5a458ab9">

### AFTER
<img width="658" alt="image" src="https://github.com/discourse/discourse/assets/101828855/687cc30c-5329-4623-9704-5174428b7671">

