### PR TITLE
UX: clarify old dates with YYYY instead of 'YY

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -56,7 +56,7 @@ module("Unit | Utility | formatter", function (hooks) {
   });
 
   test("formatting medium length dates", function (assert) {
-    const shortDateYear = shortDateTester("MMM D, 'YY");
+    const shortDateYear = shortDateTester("MMM D, YYYY");
 
     assert.strictEqual(
       strip(formatMins(1.4, { format: "medium", leaveAgo: true })),
@@ -152,7 +152,7 @@ module("Unit | Utility | formatter", function (hooks) {
   test("formatting tiny dates", function (assert) {
     const siteSettings = getOwner(this).lookup("service:site-settings");
 
-    const shortDateYear = shortDateTester("MMM 'YY");
+    const shortDateYear = shortDateTester("MMM YYYY");
     siteSettings.relative_date_duration = 14;
 
     assert.strictEqual(formatMins(0), "1m");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -42,15 +42,15 @@ en:
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       full_with_year_no_time: "MMMM Do, YYYY"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-      long_date_with_year: "MMM D, 'YY LT"
+      long_date_with_year: "MMM D, YYYY LT"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       long_date_without_year: "MMM D, LT"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-      long_date_with_year_without_time: "MMM D, 'YY"
+      long_date_with_year_without_time: "MMM D, YYYY"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       long_date_without_year_with_linebreak: "MMM D <br/>LT"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-      long_date_with_year_with_linebreak: "MMM D, 'YY <br/>LT"
+      long_date_with_year_with_linebreak: "MMM D, YYYY <br/>LT"
 
       wrap_ago: "%{date} ago"
       wrap_on: "on %{date}"
@@ -90,7 +90,7 @@ en:
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
         date_month: "MMM D"
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-        date_year: "MMM 'YY"
+        date_year: "MMM YYYY"
       medium:
         less_than_x_minutes:
           one: "less than %{count} min"
@@ -120,7 +120,7 @@ en:
           one: "almost %{count} year"
           other: "almost %{count} years"
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-        date_year: "MMM D, 'YY"
+        date_year: "MMM D, YYYY"
       medium_with_ago:
         x_minutes:
           one: "%{count} min ago"


### PR DESCRIPTION
We've had a consistent string of feedback over the years that the `Feb '13` `MMM 'YY` format for years is easy to overlook and misunderstand (Especially when paired with a recent date sans year, like `Feb 13`), and `Feb 2013` `MMM YYYY` would be easier to understand at a glance (and to differentiate. 


[Short date format on old posts: YYYY vs ‘YY](https://meta.discourse.org/t/short-date-format-on-old-posts-yyyy-vs-yy/295184)
[Change to DD Mmm / Mmm 'YY for post dates](https://meta.discourse.org/t/change-to-dd-mmm-mmm-yy-for-post-dates/13625)
[Displaying dates of posts - mixed formats make it hard to read](https://meta.discourse.org/t/displaying-dates-of-posts-mixed-formats-make-it-hard-to-read/32659)
[Year should be added to post date at some point](https://meta.discourse.org/t/year-should-be-added-to-post-date-at-some-point/12716)
[Year format on abbreviated post dates not clear](https://meta.discourse.org/t/year-format-on-abbreviated-post-dates-not-clear/29198)
[Add full year to date to make them less visually confusing](https://meta.discourse.org/t/add-full-year-to-date-to-make-them-less-visually-confusing/86674)