### PR TITLE
FIX: Preload user-specific category fields

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -240,7 +240,11 @@ class Category < ActiveRecord::Base
 
     # Categories with children
     with_children =
-      Category.where(parent_category_id: category_ids).pluck(:parent_category_id).to_set
+      Category
+        .secured(@guardian)
+        .where(parent_category_id: category_ids)
+        .pluck(:parent_category_id)
+        .to_set
 
     # Update category attributes
     categories.each do |category|

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1041,6 +1041,7 @@ RSpec.describe CategoriesController do
   end
 
   describe "#find" do
+    fab!(:group)
     fab!(:category) { Fabricate(:category, name: "Foo") }
     fab!(:subcategory) { Fabricate(:category, name: "Foobar", parent_category: category) }
 
@@ -1049,6 +1050,17 @@ RSpec.describe CategoriesController do
         get "/categories/find.json", params: { ids: [subcategory.id] }
 
         expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq([subcategory.id])
+      end
+
+      it "preloads user-specific fields" do
+        subcategory.update!(read_restricted: true)
+
+        get "/categories/find.json", params: { ids: [category.id] }
+
+        serialized = response.parsed_body["categories"].first
+        expect(serialized["notification_level"]).to eq(CategoryUser.default_notification_level)
+        expect(serialized["permission"]).to eq(nil)
+        expect(serialized["has_children"]).to eq(false)
       end
 
       it "does not return hidden category" do


### PR DESCRIPTION
This is used when lazy_load_categories is enabled to fetch more info about the category.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
