### PR TITLE
A11Y: change composer role to dialog, improve aria-labels

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -22,8 +22,8 @@
 
     {{#if this.composer.model.viewOpenOrFullscreen}}
       <div
-        role="form"
-        aria-label={{i18n this.composer.saveLabel}}
+        role="dialog"
+        aria-label={{this.composer.ariaLabel}}
         class="reply-area
           {{if this.composer.canEditTags 'with-tags' 'without-tags'}}
           {{if

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -483,6 +483,47 @@ export default class ComposerService extends Service {
     return uploadIcon(this.currentUser.staff, this.siteSettings);
   }
 
+  @discourseComputed(
+    "model.action",
+    "isWhispering",
+    "model.privateMessage",
+    "model.post.username"
+  )
+  ariaLabel(modelAction, isWhispering, privateMessage, postUsername) {
+    const getLabel = {
+      createSharedDraft: () => I18n.t("composer.create_shared_draft"),
+      editSharedDraft: () => I18n.t("composer.edit_shared_draft"),
+      createTopic: () => I18n.t("composer.composer_actions.create_topic.label"),
+      privateMessage: () => I18n.t("user.new_private_message"),
+      edit: () => I18n.t("composer.composer_actions.edit"),
+      reply: () => {
+        if (isWhispering) {
+          return `${I18n.t("composer.create_whisper")} ${this.site.get(
+            "whispers_allowed_groups_names"
+          )}`;
+        }
+
+        if (privateMessage) {
+          return I18n.t("composer.create_pm");
+        }
+
+        if (postUsername) {
+          return I18n.t("composer.composer_actions.reply_to_post.label", {
+            postUsername,
+          });
+        } else {
+          return I18n.t("composer.composer_actions.reply_to_topic.label");
+        }
+      },
+    };
+
+    if (getLabel[modelAction]) {
+      return getLabel[modelAction]();
+    }
+
+    return I18n.t("keyboard_shortcuts_help.composing.title");
+  }
+
   // Use this to open the composer when you are not sure whether it is
   // already open and whether it already has a draft being worked on. Supports
   // options to append text once the composer is open if required.

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -490,23 +490,26 @@ export default class ComposerService extends Service {
     "model.post.username"
   )
   ariaLabel(modelAction, isWhispering, privateMessage, postUsername) {
-    const getLabel = {
-      createSharedDraft: () => I18n.t("composer.create_shared_draft"),
-      editSharedDraft: () => I18n.t("composer.edit_shared_draft"),
-      createTopic: () => I18n.t("composer.composer_actions.create_topic.label"),
-      privateMessage: () => I18n.t("user.new_private_message"),
-      edit: () => I18n.t("composer.composer_actions.edit"),
-      reply: () => {
+    switch (modelAction) {
+      case "createSharedDraft":
+        return I18n.t("composer.create_shared_draft");
+      case "editSharedDraft":
+        return I18n.t("composer.edit_shared_draft");
+      case "createTopic":
+        return I18n.t("composer.composer_actions.create_topic.label");
+      case "privateMessage":
+        return I18n.t("user.new_private_message");
+      case "edit":
+        return I18n.t("composer.composer_actions.edit");
+      case "reply":
         if (isWhispering) {
           return `${I18n.t("composer.create_whisper")} ${this.site.get(
             "whispers_allowed_groups_names"
           )}`;
         }
-
         if (privateMessage) {
           return I18n.t("composer.create_pm");
         }
-
         if (postUsername) {
           return I18n.t("composer.composer_actions.reply_to_post.label", {
             postUsername,
@@ -514,14 +517,9 @@ export default class ComposerService extends Service {
         } else {
           return I18n.t("composer.composer_actions.reply_to_topic.label");
         }
-      },
-    };
-
-    if (getLabel[modelAction]) {
-      return getLabel[modelAction]();
+      default:
+        return I18n.t("keyboard_shortcuts_help.composing.title");
     }
-
-    return I18n.t("keyboard_shortcuts_help.composing.title");
   }
 
   // Use this to open the composer when you are not sure whether it is


### PR DESCRIPTION
As recommended by a recent accessibility audit, the composer should have the role "dialog" rather than "form".

I also noticed that our `saveLabel` was the aria-label, which isn't always ideal because it will read as "open dialog, save edit" rather than something more appropriate like "open dialog, edit" 

So the new `ariaLabel` computed property will provide some more specific labels... this will help differentiate replying to a topic vs a user, creating a new topic, whispering (including the groups whispers are visible to), shared drafts, messages, and edits. 