### PR TITLE
FIX: Touch up illegal flag type translations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.js
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.js
@@ -17,14 +17,9 @@ export default Component.extend({
     return I18n.t("flagging.custom_placeholder_" + nameKey);
   },
 
-  @discourseComputed(
-    "flag.name",
-    "flag.name_key",
-    "flag.is_custom_flag",
-    "username"
-  )
-  formattedName(name, nameKey, isCustomFlag, username) {
-    if (isCustomFlag) {
+  @discourseComputed("flag.name", "flag.name_key", "username")
+  formattedName(name, nameKey, username) {
+    if (["notify_user", "notify_moderators"].includes(nameKey)) {
       return name.replace(/{{username}}|%{username}/, username);
     } else {
       return I18n.t("flagging.formatted_name." + nameKey);

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -965,7 +965,7 @@ en:
       description: 'This post contains content that a reasonable person would consider offensive, abusive, to be hateful conduct or a violation of <a href="%{base_path}/guidelines">our community guidelines</a>.'
       short_description: 'A violation of <a href="%{base_path}/guidelines">our community guidelines</a>'
     illegal:
-      title: "It's Illegal"
+      title: "Illegal"
       description: "This post requires staff attention because I believe it contains content that is illegal."
       short_description: "This is illegal"
       email_title: 'A post in "%{title}" requires staff attention'
@@ -1053,7 +1053,7 @@ en:
       email_title: 'The topic "%{title}" requires moderator attention'
       email_body: "%{link}\n\n%{message}"
     illegal:
-      title: "It's Illegal"
+      title: "Illegal"
       description: "This topic requires staff attention because I believe it contains content that is illegal."
       short_description: "This is illegal"
       email_title: 'A post in "%{title}" requires staff attention'
@@ -3013,6 +3013,7 @@ en:
   flag_reasons:
     off_topic: "Your post was flagged as **off-topic**: the community feels it is not a good fit for the topic, as currently defined by the title and the first post."
     inappropriate: "Your post was flagged as **inappropriate**: the community feels it is offensive, abusive, to be hateful conduct or a violation of [our community guidelines](%{base_path}/guidelines)."
+    illegal: "Your post was flagged as  **illegal**: the community thinks it might be breaking the law."
     spam: "Your post was flagged as **spam**: the community feels it is an advertisement, something that is overly promotional in nature instead of being useful or relevant to the topic as expected."
     notify_moderators: "Your post was flagged **for moderator attention**: the community feels something about the post requires manual intervention by a staff member."
     responder:


### PR DESCRIPTION
### What is this change?

When we launched the new illegal flag type, there were a few problems with the translations:

- The translation for the message in the e-mail was missing.
- In the review queue, the message read: "Is this it's illegal?"

### How does this change that?

- The missing translation key has been added.
- For the review queue there was a coupling of the name rendering to whether the flag is of "custom" type, but this is also used for deciding whether we render the textbox for additional details. I think these two things should not be coupled together. For now I have instead hard-coded the existing "custom" types when formatting the name. We can potentially improve this later.

### Screenshots

<img width="592" alt="Screenshot 2024-02-14 at 10 11 23 AM" src="https://github.com/discourse/discourse/assets/5259935/0784a187-0d86-4b54-8485-92d09dc083e8">

<img width="238" alt="Screenshot 2024-02-14 at 10 11 34 AM" src="https://github.com/discourse/discourse/assets/5259935/3a176598-1e8e-431a-bd43-5d494013a104">
