### PR TITLE
FIX: serialize can_ignore_users

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -25,6 +25,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :no_password,
              :can_delete_account,
              :can_post_anonymously,
+             :can_ignore_users,
              :custom_fields,
              :muted_category_ids,
              :indirectly_muted_category_ids,

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CurrentUserSerializer do
     end
 
     context "when user is a staff member" do
-      let(:user) { Fabricate(:admin) }
+      let(:user) { Fabricate(:moderator) }
 
       it "returns true" do
         expect(payload[:can_ignore_users]).to eq(true)

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -150,6 +150,27 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  describe "#can_ignore_users" do
+    let(:guardian) { Guardian.new(user) }
+    let(:payload) { serializer.as_json }
+
+    context "when user is a regular one" do
+      let(:user) { Fabricate(:user) }
+
+      it "return false for regular users" do
+        expect(payload[:can_ignore_users]).to eq(false)
+      end
+    end
+
+    context "when user is a staff member" do
+      let(:user) { Fabricate(:admin) }
+
+      it "returns true" do
+        expect(payload[:can_ignore_users]).to eq(true)
+      end
+    end
+  end
+
   describe "#can_review" do
     let(:guardian) { Guardian.new(user) }
     let(:payload) { serializer.as_json }


### PR DESCRIPTION
Bug introduced in this PR https://github.com/discourse/discourse/pull/25585/files#diff-55dea7dea5b8655da575a2f23156240686c956d081d36ea9976d38b29b72b5d2R130

`can_ignore_users` method was created but not added to attributes and therefore it was not serialized.

