### PR TITLE
DEV: Set a default PG statement timeout of 5 seconds in CI

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -39,6 +39,8 @@ test:
   pool: 1
   reaping_frequency: 0
   checkout_timeout: <%= ENV["CHECKOUT_TIMEOUT"] || 5 %>
+  variables:
+    statement_timeout: <%= ENV["STATEMENT_TIMEOUT"] || "5000" %>
   host_names:
     - test.localhost
 


### PR DESCRIPTION
Why this change?

We are seeing `ActiveRecord::ConnectionTimeoutError` being raised when
running system tests in CI because ActiveRecord can't checkout a
connection from the pool after 10 seconds when the pool size is only 1.
This means a connection is taking a long time to run and not being
released. By setting statement timeout to 5 second, we expect the query
causing the problem to raise an error that will give us more visibility
to debug the problem.
