### PR TITLE
UX: Add loading indicator to 'new or updated' PM banner

### DIFF
--- a/app/assets/javascripts/discourse/app/services/pm-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/services/pm-topic-tracking-state.js
@@ -91,8 +91,18 @@ class PrivateMessageTopicTrackingState extends Service {
     });
   }
 
-  resetIncomingTracking() {
-    if (this.isTrackingIncoming) {
+  resetIncomingTracking(topicIds) {
+    if (!this.isTrackingIncoming) {
+      return;
+    }
+
+    if (topicIds) {
+      const topicIdSet = new Set(topicIds);
+      this.set(
+        "newIncoming",
+        this.newIncoming.filter((id) => !topicIdSet.has(id))
+      );
+    } else {
       this.set("newIncoming", []);
     }
   }

--- a/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
@@ -26,19 +26,23 @@
       }}
     />
 
-    {{#if (gt this.incomingCount 0)}}
+    {{#if (or this.model.loadingBefore this.incomingCount)}}
       <div class="show-mores">
         <a
           tabindex="0"
           href
           {{on "click" this.showInserted}}
-          class="alert alert-info clickable"
+          class="alert alert-info clickable
+            {{if this.model.loadingBefore 'loading'}}"
         >
           <CountI18n
             @key="topic_count_"
             @suffix="latest"
-            @count={{this.incomingCount}}
+            @count={{or this.model.loadingBefore this.incomingCount}}
           />
+          {{#if @model.loadingBefore}}
+            {{loading-spinner size="small"}}
+          {{/if}}
         </a>
       </div>
     {{/if}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -64,6 +64,15 @@
 
   .show-mores {
     width: 100%;
+
+    .alert-info.clickable {
+      gap: 0.5em;
+
+      &.loading {
+        color: var(--primary-medium);
+        cursor: default;
+      }
+    }
   }
 
   .d-icon-heart {


### PR DESCRIPTION
Same as 9883e6a0c88b66c718a885f091fe921e76fc3f22, but for lists of PMs

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
