### PR TITLE
UX: show the full mobile read-state indicator

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -387,12 +387,11 @@ span.highlighted {
   // contained within the padding to prevent vertical overflow
   max-width: var(--d-wrap-padding-h);
   right: calc(var(--d-wrap-padding-h) * -1);
-  font-size: var(--font-down-2);
-  overflow: hidden;
-  margin-top: 0.15em;
+  font-size: var(--font-down-5);
+  margin-top: 0.45em;
 
   svg {
-    right: calc(var(--d-wrap-padding-h) / 2.5 * -1);
+    right: 0.25em;
   }
 }
 


### PR DESCRIPTION
A few people (understandably) thought this overflowing indicator was a mistake, so here I'm trying to fit a full tinier version:


Before:
![Screenshot 2024-02-14 at 1 03 12 PM](https://github.com/discourse/discourse/assets/1681963/6c279e13-ef53-4f51-be31-9574e077b56d)


After:
![Screenshot 2024-02-14 at 1 00 53 PM](https://github.com/discourse/discourse/assets/1681963/41883e40-1bc5-4836-9504-c2e06d8a0e69)
