### PR TITLE
FEATURE: Track all mentions in a post

### DIFF
--- a/app/models/post_mention.rb
+++ b/app/models/post_mention.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class PostMention < ActiveRecord::Base
+  belongs_to :post
+  belongs_to :mention, polymorphic: true
+
+  def self.ensure_exist!(post_id:, mentions: [], ids_by_type: {})
+    if mentions.present? && ids_by_type.blank?
+      ids_by_type = {}
+      mentions.each { |mention| (ids_by_type[mention.class.name] ||= []) << mention.id }
+    end
+
+    rows =
+      ids_by_type
+        .map do |mention_type, mention_ids|
+          mention_ids.map do |mention_id|
+            {
+              post_id: post_id,
+              mention_type: mention_type,
+              mention_id: mention_id,
+              created_at: Time.zone.now,
+              updated_at: Time.zone.now,
+            }
+          end
+        end
+        .flatten
+
+    PostMention.transaction do |transaction|
+      PostMention.where(post_id: post_id).delete_all
+      PostMention.insert_all(rows) if rows.present?
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: post_mentions
+#
+#  id           :bigint           not null, primary key
+#  post_id      :bigint           not null
+#  mention_type :string           not null
+#  mention_id   :bigint           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_post_mentions_on_mention           (mention_type,mention_id)
+#  index_post_mentions_on_post_and_mention  (post_id,mention_type,mention_id) UNIQUE
+#  index_post_mentions_on_post_id           (post_id)
+#

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -88,7 +88,8 @@ class PostSerializer < BasicPostSerializer
              :reviewable_score_pending_count,
              :user_suspended,
              :user_status,
-             :mentioned_users
+             :mentioned_users,
+             :mentions
 
   def initialize(object, opts)
     super(object, opts)
@@ -591,6 +592,14 @@ class PostSerializer < BasicPostSerializer
 
   def include_mentioned_users?
     SiteSetting.enable_user_status
+  end
+
+  def mentions
+    object.post_mentions.map { |mention| { id: mention.mention_id, type: mention.mention_type } }
+  end
+
+  def include_mentions?
+    scope.can_lazy_load_categories?
   end
 
   private

--- a/db/migrate/20240214163042_create_post_mentions.rb
+++ b/db/migrate/20240214163042_create_post_mentions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreatePostMentions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_mentions do |t|
+      t.references :post, null: false
+      t.references :mention, polymorphic: true, null: false
+      t.timestamps
+    end
+
+    add_index :post_mentions,
+              %i[post_id mention_type mention_id],
+              unique: true,
+              name: "index_post_mentions_on_post_and_mention"
+  end
+end

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -49,6 +49,7 @@ class CookedPostProcessor
       enforce_nofollow
       grant_badges
       @post.link_post_uploads(fragments: @doc)
+      @post.link_post_mentions(fragments: @doc)
       DiscourseEvent.trigger(:post_process_cooked, @doc, @post)
       nil
     end

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -843,6 +843,7 @@ class TopicView
         :deleted_by,
         :incoming_email,
         :image_upload,
+        :post_mentions,
       )
 
     @posts = @posts.includes({ user: :user_status }) if SiteSetting.enable_user_status

--- a/spec/models/post_mention_spec.rb
+++ b/spec/models/post_mention_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe PostMention do
+  fab!(:post)
+
+  fab!(:user)
+  fab!(:category)
+
+  describe "#ensure_exist!" do
+    it "creates records from objects" do
+      PostMention.ensure_exist!(post_id: post.id, mentions: [user, category])
+
+      expect(post.post_mentions.size).to eq(2)
+      expect(post.post_mentions.map(&:mention)).to contain_exactly(user, category)
+    end
+
+    it "creates records from IDs" do
+      PostMention.ensure_exist!(
+        post_id: post.id,
+        ids_by_type: {
+          user.class.name => [user.id],
+          category.class.name => [category.id],
+        },
+      )
+
+      expect(post.post_mentions.size).to eq(2)
+      expect(post.post_mentions.map(&:mention)).to contain_exactly(user, category)
+    end
+
+    it "does not create duplicate records" do
+      PostMention.create!(post: post, mention: user)
+      PostMention.create!(post: post, mention: category)
+
+      PostMention.ensure_exist!(post_id: post.id, mentions: [user, category, user])
+
+      expect(post.post_mentions.size).to eq(2)
+      expect(post.post_mentions.map(&:mention)).to contain_exactly(user, category)
+    end
+
+    it "deletes records" do
+      PostMention.create!(post: post, mention: user)
+
+      PostMention.ensure_exist!(post_id: post.id)
+
+      expect(post.post_mentions.size).to eq(0)
+    end
+
+    it "deletes and creates new records" do
+      PostMention.create!(post: post, mention: user)
+
+      PostMention.ensure_exist!(post_id: post.id, mentions: [category])
+
+      expect(post.post_mentions.size).to eq(1)
+      expect(post.post_mentions.map(&:mention)).to contain_exactly(category)
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2273,4 +2273,19 @@ RSpec.describe Post do
       ).to eq(6.days.ago.to_date => 1, 7.days.ago.to_date => 1)
     end
   end
+
+  describe "#link_post_mentions" do
+    fab!(:category)
+
+    it "should link category" do
+      post = Fabricate(:post, raw: "##{category.slug}")
+
+      post.link_post_mentions(fragments: Loofah.html5_fragment(post.cooked))
+
+      expect(PostMention.where(post: post).count).to eq(1)
+      post_mention = PostMention.where(post: post).first
+      expect(post_mention.mention_type).to eq("Category")
+      expect(post_mention.mention_id).to eq(category.id)
+    end
+  end
 end


### PR DESCRIPTION
This commit introduces a new model that can be used to track what other entities have been mentioned in a post. The other mentionable entities are so far limited to categories and chat channels, but proper integration points are coming soon to allow other entity registration and extraction mechanisms.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
