### PR TITLE
FIX: Allow several chat channels to have an empty slug

### DIFF
--- a/plugins/chat/db/migrate/20240214135517_fix_chat_channel_slug_index.rb
+++ b/plugins/chat/db/migrate/20240214135517_fix_chat_channel_slug_index.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class FixChatChannelSlugIndex < ActiveRecord::Migration[7.0]
+  def up
+    remove_index(:chat_channels, :slug)
+    add_index :chat_channels, :slug, unique: true, where: "slug != ''"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/spec/services/chat/create_category_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_category_channel_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe Chat::CreateCategoryChannel do
     let(:guardian) { Guardian.new(current_user) }
     let(:params) { { guardian: guardian, category_id: category_id, name: "cool channel" } }
 
+    it "can create several channels with empty slugs" do
+      SiteSetting.slug_generation_method = "none"
+      expect do
+        described_class.call(params.merge(name: "channel 1", slug: nil))
+      end.not_to raise_error
+      expect do
+        described_class.call(params.merge(name: "channel 2", slug: nil))
+      end.not_to raise_error
+    end
+
+    it "can create several channels with unicode names" do
+      expect do described_class.call(params.merge(name: "マイキ")) end.not_to raise_error
+      expect do described_class.call(params.merge(name: "境界")) end.not_to raise_error
+    end
+
     context "when public channels are disabled" do
       fab!(:current_user) { Fabricate(:user) }
 


### PR DESCRIPTION
In certain cases, chat channels may have empty slugs, it happens when:
1. The `slug_generation_method` setting is set to `None`
2. `slug_generation_method` is set to `ASCII` and a channel with a Unicode name and an empty slug is created (in this case, the code that creates channels tries to generate a slug and fallbacks to an empty slug)

At the moment, we have a unique index on the `chat_channels.slug` column which leads to errors when creating several channels with empty slugs (Discourse is able to create one such channel, but when trying to create the second one fails because of the unique constraint). This PR fixes that by adding a `where` condition to the index. Slugs still have to be unique, but now many channels may have empty slugs.

This fix is similar to the one we made to the category slugs – https://github.com/discourse/discourse/commit/7ba914f1e10d90b1e4d25b0ab2427c94df456eae.