### PR TITLE
UX: fix group search result alignment and styles

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/group.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/group.hbs
@@ -1,15 +1,16 @@
-<div class="group-result">
+<div class="group-result {{if @result.flairUrl '--with-flair'}}">
   {{#if @result.flairUrl}}
     <AvatarFlair
       @flairName={{@result.name}}
       @flairUrl={{@result.flairUrl}}
       @flairBgColor={{@result.flairBgColor}}
       @flairColor={{@result.flairColor}}
+      @class="avatar-flair__wrapper"
     />
   {{else}}
     {{d-icon "users"}}
   {{/if}}
-  <div class="group-names">
+  <div class="group-names {{if @result.fullName '--group-with-slug'}}">
     <span class="name">{{or @result.fullName @result.name}}</span>
     {{! show the name of the group if we also show the full name }}
     {{#if @result.fullName}}

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -165,15 +165,29 @@ $search-pad-horizontal: 0.5em;
     }
 
     .search-result-group .group-result {
-      .d-icon,
-      .avatar-flair {
-        width: 20px;
-        height: 20px;
+      display: flex;
+      gap: 0.5em;
+
+      &.--with-flair {
+        align-items: center;
       }
 
-      .avatar-flair,
+      .avatar-flair__wrapper,
       .d-icon-users {
-        margin-right: 0.5em;
+        margin-top: 0.1em; // vertical alignment
+      }
+
+      .avatar-flair {
+        width: 1.58em;
+        height: 1.6em;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        .d-icon {
+          font-size: var(--font-down-1);
+          color: currentColor;
+        }
       }
 
       .avatar-flair {
@@ -182,20 +196,20 @@ $search-pad-horizontal: 0.5em;
           background-repeat: no-repeat;
           background-size: 100% 100%;
         }
-        .d-icon {
-          margin-right: 0;
-        }
       }
 
       .group-names {
         @include user-item-flex;
+        min-width: 0;
         .name,
         .slug {
           @include ellipsis;
         }
 
-        .name {
-          font-weight: 700;
+        &.--group-with-slug {
+          .name {
+            font-weight: 700;
+          }
         }
       }
     }


### PR DESCRIPTION
Groups in search were a little broken, and when flair was set they didn't take on the icon color. 

This fixes the issues and makes the styles more consistent with user results. 

Before:
![Screenshot 2024-02-14 at 5 10 25 PM](https://github.com/discourse/discourse/assets/1681963/21fea79a-a485-42b9-aecd-0630fc39a338)

![Screenshot 2024-02-14 at 5 09 51 PM](https://github.com/discourse/discourse/assets/1681963/f92a0f9a-a4a9-40f8-8013-ded5d284cdf2)

![Screenshot 2024-02-14 at 5 10 07 PM](https://github.com/discourse/discourse/assets/1681963/305bb52b-00ac-4324-b1c3-1316956fa3de)


After: 
![Screenshot 2024-02-14 at 4 57 42 PM](https://github.com/discourse/discourse/assets/1681963/0c6a2ea6-d5e3-40f1-8d98-17c1c1452a09)

![Screenshot 2024-02-14 at 5 09 16 PM](https://github.com/discourse/discourse/assets/1681963/9d0cd9b2-a2f1-4568-85fd-fc869e9b4ae5)

![Screenshot 2024-02-14 at 5 09 28 PM](https://github.com/discourse/discourse/assets/1681963/cfe42e4d-c279-498f-a30a-8339e599d4d9)
