### PR TITLE
FIX: Make similar topics selectable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.hbs
@@ -8,9 +8,13 @@
           @result.topic_title_headline
         )
       }}
-        <span>{{replace-emoji (html-safe @result.topic_title_headline)}}</span>
+        <a href={{if @withTopicUrl @result.url}}>
+          {{replace-emoji (html-safe @result.topic_title_headline)}}
+        </a>
       {{else}}
-        <SearchMenu::HighlightedSearch @string={{@result.topic.fancyTitle}} />
+        <a href={{if @withTopicUrl @result.url}}>
+          <SearchMenu::HighlightedSearch @string={{@result.topic.fancyTitle}} />
+        </a>
       {{/if}}
       <PluginOutlet
         @name="search-menu-results-topic-title-suffix"
@@ -19,7 +23,7 @@
     </span>
   </span>
   <span class="second-line">
-    {{category-link @result.topic.category link=false}}
+    {{category-link @result.topic.category link=(if @withTopicUrl true false)}}
     {{#if this.siteSettings.tagging_enabled}}
       {{discourse-tags @result.topic tagName="span"}}
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
@@ -5,7 +5,10 @@
 <ul class="topics">
   {{#each this.message.similarTopics as |topic|}}
     <div class="similar-topic">
-      <SearchMenu::Results::Type::Topic @result={{topic}} />
+      <SearchMenu::Results::Type::Topic
+        @result={{topic}}
+        @withTopicUrl={{true}}
+      />
     </div>
   {{/each}}
 </ul>


### PR DESCRIPTION
I attempted to add a test for related topics, as they are untested. This was a massive challenge as related topics are only rendered after 
- a user has stopped typing
- there is a timeout after typing

Between system tests, acceptance tests, and stubbing requests, this was difficult. So here is the pr san test.