### PR TITLE
DEV: Print active queries when AR connection timeout error is raised

### DIFF
--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -41,11 +41,18 @@ module TurboTests
     private
 
     def output_activerecord_debug_logs(output, example)
-      if ENV["GITHUB_ACTIONS"] &&
-           active_record_debug_logs = example.metadata[:active_record_debug_logs]
-        output.puts "::group::ActiveRecord Debug Logs"
-        output.puts active_record_debug_logs
-        output.puts "::endgroup::"
+      if ENV["GITHUB_ACTIONS"]
+        if active_record_debug_logs = example.metadata[:active_record_debug_logs]
+          output.puts "::group::ActiveRecord Debug Logs"
+          output.puts active_record_debug_logs
+          output.puts "::endgroup::"
+        end
+
+        if active_postgres_query_logs = example.metadata[:active_postgres_query_logs]
+          output.puts "::group::Active Postgres Query Logs"
+          output.puts active_postgres_query_logs
+          output.puts "::endgroup::"
+        end
       end
     end
 


### PR DESCRIPTION
Why this change?

We have been seeing `ActiveRecord::ConnectionTimeoutError` in CI when
running system tests as the test thread is unable to checkout a
connection within 10 seconds. That means that something else is keeping
the connection busy and not returning it into the pool. When this
happens, we want to print the active queries by querying the
`pg_stat_activity` table.
