### PR TITLE
FEATURE: shift+j and shift+k will scroll entire posts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -403,11 +403,11 @@ export default {
   },
 
   selectDown() {
-    this._moveSelection(1);
+    this._moveSelection({ direction: 1, scrollWithinPosts: true });
   },
 
   selectUp() {
-    this._moveSelection(-1);
+    this._moveSelection({ direction: -1, scrollWithinPosts: true });
   },
 
   goBack() {
@@ -640,7 +640,7 @@ export default {
     }
   },
 
-  _moveSelection(direction) {
+  _moveSelection({ direction, scrollWithinPosts }) {
     // Pressing a move key (J/K) very quick (i.e. keeping J or K pressed) will
     // move fast by disabling smooth page scrolling.
     const now = +new Date();
@@ -691,7 +691,7 @@ export default {
     let article = selected;
 
     // Try doing a page scroll in the context of current post.
-    if (!fast && direction !== 0 && article) {
+    if (!fast && direction !== 0 && article && scrollWithinPosts) {
       // The beginning of first article is the beginning of the page.
       const beginArticle =
         article.classList.contains("topic-post") &&
@@ -761,7 +761,12 @@ export default {
 
     const articleTop = domUtils.offset(article).top,
       articleTopPosition = articleTop - headerOffset();
-    if (!fast && direction < 0 && article.offsetHeight > window.innerHeight) {
+    if (
+      scrollWithinPosts &&
+      !fast &&
+      direction < 0 &&
+      article.offsetHeight > window.innerHeight
+    ) {
       // Scrolling to the last "page" of the previous post if post has multiple
       // "pages" (if its height does not fit in the screen).
       return this._scrollTo(
@@ -833,6 +838,11 @@ export default {
 
     if (index >= 0 && index < sections.length) {
       sections[index].querySelector("a")?.click();
+    }
+
+    if (sections.length === 0) {
+      // use for in post navigation
+      this._moveSelection({ direction, scrollWithinPosts: false });
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/keyboard-shortcuts-test.js
@@ -11,20 +11,6 @@ module("Unit | Utility | keyboard-shortcuts", function (hooks) {
     sinon.stub(DiscourseURL, "routeTo");
   });
 
-  test("selectDown calls _moveSelection with 1", function (assert) {
-    let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
-
-    KeyboardShortcuts.selectDown();
-    assert.ok(stub.calledWith(1), "_moveSelection is called with 1");
-  });
-
-  test("selectUp calls _moveSelection with -1", function (assert) {
-    let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
-
-    KeyboardShortcuts.selectUp();
-    assert.ok(stub.calledWith(-1), "_moveSelection is called with -1");
-  });
-
   test("goBack calls history.back", function (assert) {
     let called = false;
     sinon.stub(history, "back").callsFake(function () {


### PR DESCRIPTION
When scrolling through topics with very long posts we would like to use
`shift+j` and `shift+k` to quickly move between posts.

This allows users to bypass the scroll within post behavior when zooming
through topics with keyboard shortcuts

This overloads the behavior of shift+k and j which can be used to scroll
through sections (new/latest/etc...)
