### PR TITLE
FIX: Logster backlink config in production

### DIFF
--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -17,9 +17,6 @@ if Rails.env.development? && !Sidekiq.server? && ENV["RAILS_LOGS_STDOUT"] == "1"
     unless ActiveSupport::Logger.logger_outputs_to?(original_logger, STDOUT)
       original_logger.extend(ActiveSupport::Logger.broadcast(console))
     end
-
-    Logster.config.back_to_site_link_path = "#{Discourse.base_path}/admin"
-    Logster.config.back_to_site_link_text = I18n.t("dashboard.back_from_logster_text")
   end
 end
 
@@ -61,6 +58,11 @@ if Rails.env.production?
     /RateLimiter::LimitExceeded.*/m,
   ]
   Logster.config.env_expandable_keys.push(:hostname, :problem_db)
+end
+
+Rails.application.config.after_initialize do
+  Logster.config.back_to_site_link_path = "#{Discourse.base_path}/admin"
+  Logster.config.back_to_site_link_text = I18n.t("dashboard.back_from_logster_text")
 end
 
 Logster.store.max_backlog = GlobalSetting.max_logster_logs


### PR DESCRIPTION
Bug introduced in this PR https://github.com/discourse/discourse/pull/25669

Config should apply to development and production modes, not just the development environment.

