### PR TITLE
DEV: Skip consistently flaky tests on CI

### DIFF
--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Drawer", type: :system do
     let(:topic_page) { PageObjects::Pages::Topic.new }
 
     context "when on a channel" do
-      it "has context" do
+      xit "has context" do
         ::Chat::CreateMessage
           .expects(:call)
           .with do |value|
@@ -186,7 +186,7 @@ RSpec.describe "Drawer", type: :system do
       let(:thread_list_page) { PageObjects::Components::Chat::ThreadList.new }
       let(:thread_page) { PageObjects::Pages::ChatThread.new }
 
-      it "has context" do
+      xit "has context" do
         ::Chat::CreateMessage
           .expects(:call)
           .with do |value|


### PR DESCRIPTION
Why this change?

The tests are consistently flaky and failing with the following error:

```
CapybaraTimeoutExtension::CapybaraTimedOut:
  This spec passed, but capybara waited for the full wait duration (10s) at least once. This will slow down the test suite. Beware of negating the result of selenium's RSpec matchers.
```
