### PR TITLE
DEV: Add a plugin modifier for user_action_stream_builder

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -227,6 +227,7 @@ class UserAction < ActiveRecord::Base
       LEFT JOIN categories c on c.id = t.category_id
       LEFT JOIN post_custom_fields pc ON pc.post_id = a.target_post_id AND pc.name = 'action_code_who'
       LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc2.name = 'action_code_path'
+      /*left_join*/
       /*where*/
       /*order_by*/
       /*offset*/
@@ -256,6 +257,8 @@ class UserAction < ActiveRecord::Base
 
       builder.order_by("a.created_at desc").offset(offset.to_i).limit(limit.to_i)
     end
+
+    DiscoursePluginRegistry.apply_modifier(:user_action_stream_builder, builder)
 
     builder.query
   end

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe UserAction do
     end
 
     describe "assignments" do
-      let(:stream) { UserAction.stream(user_id: user.id, guardian: Guardian.new(user)) }
+      let(:stream) { UserAction.stream(user_id: user.id, guardian: user.guardian) }
 
       before do
         log_test_action(action_type: UserAction::ASSIGNED)
@@ -146,7 +146,7 @@ RSpec.describe UserAction do
     describe "mentions" do
       before { log_test_action(action_type: UserAction::MENTION) }
 
-      let(:stream) { UserAction.stream(user_id: user.id, guardian: Guardian.new(user)) }
+      let(:stream) { UserAction.stream(user_id: user.id, guardian: user.guardian) }
 
       it "is returned by the stream" do
         expect(stream.count).to eq(1)
@@ -156,6 +156,33 @@ RSpec.describe UserAction do
       it "isn't returned when mentions aren't enabled" do
         SiteSetting.enable_mentions = false
         expect(stream).to be_blank
+      end
+    end
+
+    describe "when a plugin registers the :user_action_stream_builder modifier" do
+      before do
+        log_test_action(action_type: UserAction::LIKE)
+        log_test_action(action_type: UserAction::WAS_LIKED)
+      end
+
+      after { DiscoursePluginRegistry.clear_modifiers! }
+
+      it "allows the plugin to modify the builder query" do
+        Plugin::Instance
+          .new
+          .register_modifier(:user_action_stream_builder) do |builder|
+            expect(builder).to be_a(MiniSqlMultisiteConnection::CustomBuilder)
+            builder.limit(1)
+          end
+
+        stream = UserAction.stream(user_id: user.id, guardian: user.guardian)
+
+        expect(stream.count).to eq(1)
+
+        DiscoursePluginRegistry.clear_modifiers!
+
+        stream = UserAction.stream(user_id: user.id, guardian: user.guardian)
+        expect(stream.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Reactions needs this to be able to filter out likes received
actions, where there is also an associated reaction, since
now most reactions also count as a like.
