### PR TITLE
UX: Improve invite error message when a user uses an email that has already redeemed

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -192,7 +192,7 @@ class InviteRedeemer
     redeeming_user ||= User.where(admin: false, staged: false).find_by_email(email)
     if redeeming_user.present? &&
          InvitedUser.exists?(user_id: redeeming_user.id, invite_id: invite.id)
-      return false
+      raise Invite::UserExists.new(I18n.t("invite.existing_user_already_redemeed"))
     end
 
     true

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -563,16 +563,6 @@ RSpec.describe InviteRedeemer do
           )
         end
       end
-
-      it "raises an error if the email is already being used by an existing user" do
-        email = "tomtom@test.com"
-        Fabricate(:invited_user, invite: invite, user: Fabricate(:user, email: email))
-        redeemer = InviteRedeemer.new(invite: invite, email: email, username: username, name: name)
-        expect { redeemer.redeem }.to raise_error(
-          Invite::UserExists,
-          I18n.t("invite.existing_user_already_redemeed"),
-        )
-      end
     end
 
     context "with invite_link" do
@@ -597,13 +587,15 @@ RSpec.describe InviteRedeemer do
         expect(invite_link.redemption_count).to eq(1)
       end
 
-      it "should not redeem the invite if InvitedUser record already exists for email" do
+      it "raises an error if email has already been invited" do
         invite_redeemer.redeem
         invite_link.reload
 
         another_invite_redeemer = InviteRedeemer.new(invite: invite_link, email: "foo@example.com")
-        another_user = another_invite_redeemer.redeem
-        expect(another_user).to eq(nil)
+        expect { another_invite_redeemer.redeem }.to raise_error(
+          Invite::UserExists,
+          I18n.t("invite.existing_user_already_redemeed"),
+        )
       end
 
       it "should redeem the invite if InvitedUser record does not exists for email" do

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -563,6 +563,16 @@ RSpec.describe InviteRedeemer do
           )
         end
       end
+
+      it "raises an error if the email is already being used by an existing user" do
+        email = "tomtom@test.com"
+        Fabricate(:invited_user, invite: invite, user: Fabricate(:user, email: email))
+        redeemer = InviteRedeemer.new(invite: invite, email: email, username: username, name: name)
+        expect { redeemer.redeem }.to raise_error(
+          Invite::UserExists,
+          I18n.t("invite.existing_user_already_redemeed"),
+        )
+      end
     end
 
     context "with invite_link" do


### PR DESCRIPTION
While hunting for a bug, I found that the error shown when a user has already used an email to redeem an invite was quite vague and not useful for staff. This PR makes it more obvious.

Before
<img width="380" alt="Screenshot 2024-02-15 at 6 44 13 PM" src="https://github.com/discourse/discourse/assets/1555215/bd575128-4128-4b78-b80e-c4a99985c8cd">

After
<img width="347" alt="Screenshot 2024-02-15 at 6 44 34 PM" src="https://github.com/discourse/discourse/assets/1555215/893ec172-aade-49ac-b605-0b36372f27ad">
