### PR TITLE
UX: prevent groupname from wrapping (first)

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
@@ -224,6 +224,7 @@
 
   &.-group {
     .chat-message-creator__group-name {
+      flex-shrink: 0;
       padding-left: 0.5rem;
     }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
@@ -217,6 +217,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  flex-wrap: wrap;
 
   &.-user .chat-user-display-name {
     padding-left: 0.5rem;


### PR DESCRIPTION
### Before
<img width="707" alt="image" src="https://github.com/discourse/discourse/assets/101828855/30564946-6a67-4f07-a18f-7f7572ab7d24">

### After
<img width="773" alt="image" src="https://github.com/discourse/discourse/assets/101828855/37811f4f-d9bc-4432-aa94-828b6b6c13f3">

