### PR TITLE
PERF: Pass the `-ping` option to the `identify` ImageMagick command to speed it up

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -281,6 +281,7 @@ class Upload < ActiveRecord::Base
           begin
             Discourse::Utils.execute_command(
               "identify",
+              "-ping",
               "-format",
               "%w %h",
               path,

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -663,7 +663,7 @@ class UploadCreator
           # Only GIFs, WEBPs and a few other unsupported image types can be animated
           OptimizedImage.ensure_safe_paths!(@file.path)
 
-          command = ["identify", "-format", "%n\\n", @file.path]
+          command = ["identify", "-ping", "-format", "%n\\n", @file.path]
           frames =
             begin
               Discourse::Utils.execute_command(*command, timeout: Upload::MAX_IDENTIFY_SECONDS).to_i


### PR DESCRIPTION
The `-ping` option significantly speeds up the ImageMagick `identify` command per our testing and the [documentation](https://imagemagick.org/script/command-line-options.php#ping):

> -ping
Efficiently determine these image characteristics: image number, the file name, the width and height of the image, whether the image is colormapped or not, the number of colors in the image, the number of bytes in the image, the format of the image (JPEG, PNM, etc.). Use +ping to ensure accurate image properties.

We already pass the `-ping` option in other places where the `identify` command is used, so it makes sense to use the option everywhere.

Internal topic: t/121431.