### PR TITLE
FIX: Load categories with search topic results

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -57,11 +57,12 @@ export function translateResults(results, opts) {
 
   results.categories = results.categories
     .map(function (category) {
+      Site.current().updateCategory(category);
       return Category.list().findBy("id", category.id || category.model.id);
     })
     .compact();
 
-  results.topic_categories?.forEach((category) =>
+  results.grouped_search_result?.extra?.categories?.forEach((category) =>
     Site.current().updateCategory(category)
   );
 

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -57,10 +57,13 @@ export function translateResults(results, opts) {
 
   results.categories = results.categories
     .map(function (category) {
-      Site.current().updateCategory(category);
       return Category.list().findBy("id", category.id || category.model.id);
     })
     .compact();
+
+  results.topic_categories?.forEach((category) =>
+    Site.current().updateCategory(category)
+  );
 
   results.groups = results.groups
     .map((group) => {

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -9,6 +9,7 @@ import userSearch from "discourse/lib/user-search";
 import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Post from "discourse/models/post";
+import Site from "discourse/models/site";
 import Topic from "discourse/models/topic";
 import User from "discourse/models/user";
 import getURL from "discourse-common/lib/get-url";
@@ -56,6 +57,7 @@ export function translateResults(results, opts) {
 
   results.categories = results.categories
     .map(function (category) {
+      Site.current().updateCategory(category);
       return Category.list().findBy("id", category.id || category.model.id);
     })
     .compact();

--- a/app/serializers/grouped_search_result_serializer.rb
+++ b/app/serializers/grouped_search_result_serializer.rb
@@ -4,6 +4,7 @@ class GroupedSearchResultSerializer < ApplicationSerializer
   has_many :posts, serializer: SearchPostSerializer
   has_many :users, serializer: SearchResultUserSerializer
   has_many :categories, serializer: BasicCategorySerializer
+  has_many :topic_categories, serializer: BasicCategorySerializer
   has_many :tags, serializer: TagSerializer
   has_many :groups, serializer: BasicGroupSerializer
   attributes :more_posts,
@@ -21,6 +22,10 @@ class GroupedSearchResultSerializer < ApplicationSerializer
 
   def include_search_log_id?
     search_log_id.present?
+  end
+
+  def include_topic_categories?
+    object.topic_categories.present?
   end
 
   def include_tags?

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -338,12 +338,9 @@ class Search
 
     find_grouped_results if @results.posts.blank?
 
-    if @results.posts.present?
+    if preloaded_topic_custom_fields.present? && @results.posts.present?
       topics = @results.posts.map(&:topic)
-
-      if preloaded_topic_custom_fields.present?
-        Topic.preload_custom_fields(topics, preloaded_topic_custom_fields)
-      end
+      Topic.preload_custom_fields(topics, preloaded_topic_custom_fields)
     end
 
     Search.preload(@results, self)

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1211,36 +1211,6 @@ RSpec.describe Search do
         expect(result(admin).posts).to be_present
       end
     end
-
-    context "with topic categories" do
-      fab!(:parent_category) { Fabricate(:category) }
-      fab!(:category) { Fabricate(:category, parent_category: parent_category) }
-      fab!(:other_category) { Fabricate(:category, parent_category: parent_category) }
-
-      it "returns categories and parent categories" do
-        topic = Fabricate(:topic, category: category)
-        Fabricate(:post, topic: topic, raw: "hello world. first topic")
-
-        other_topic = Fabricate(:topic, category: other_category)
-        Fabricate(:post, topic: other_topic, raw: "hello world. second topic")
-
-        results =
-          Search.execute(
-            "hello world",
-            type_filter: "topic",
-            search_type: :full_page,
-            guardian: admin.guardian,
-            can_lazy_load_categories: true,
-          )
-
-        expect(results.categories).to eq([])
-        expect(results.topic_categories).to contain_exactly(
-          parent_category,
-          category,
-          other_category,
-        )
-      end
-    end
   end
 
   describe "cyrillic topic" do

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1212,17 +1212,10 @@ RSpec.describe Search do
       end
     end
 
-    context "with categories" do
-      fab!(:group)
-
+    context "with topic categories" do
       fab!(:parent_category) { Fabricate(:category) }
       fab!(:category) { Fabricate(:category, parent_category: parent_category) }
       fab!(:other_category) { Fabricate(:category, parent_category: parent_category) }
-
-      before do
-        SiteSetting.lazy_load_categories_groups = "#{group.id}"
-        group.add(admin)
-      end
 
       it "returns categories and parent categories" do
         topic = Fabricate(:topic, category: category)
@@ -1237,9 +1230,15 @@ RSpec.describe Search do
             type_filter: "topic",
             search_type: :full_page,
             guardian: admin.guardian,
+            can_lazy_load_categories: true,
           )
 
-        expect(results.categories).to contain_exactly(parent_category, category, other_category)
+        expect(results.categories).to eq([])
+        expect(results.topic_categories).to contain_exactly(
+          parent_category,
+          category,
+          other_category,
+        )
       end
     end
   end

--- a/spec/requests/api/schemas/json/search_response.json
+++ b/spec/requests/api/schemas/json/search_response.json
@@ -74,6 +74,17 @@
             "null"
           ]
         },
+        "extra": {
+          "type": "object",
+          "properties": {
+            "categories": {
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          }
+        },
         "post_ids": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Add categories to the serialized search results together with the topics when lazy load categories is enabled. This is necessary in order for the results to be rendered correctly and display the category information.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
