### PR TITLE
UX: clean up some label and form inconsistencies, reduce excess bolding

### DIFF
--- a/app/assets/javascripts/admin/addon/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/components/watched-word-form.hbs
@@ -66,7 +66,7 @@
   <label for="watched-case-sensitivity">{{i18n
       "admin.watched_words.form.case_sensitivity_label"
     }}</label>
-  <label class="case-sensitivity-checkbox">
+  <label class="case-sensitivity-checkbox checkbox-label">
     <Input
       @type="checkbox"
       @checked={{this.isCaseSensitive}}

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -236,7 +236,7 @@
       </div>
 
       <div>
-        <label>
+        <label class="checkbox-label">
           <Input
             @type="checkbox"
             @checked={{this.buffered.multiple_grant}}
@@ -247,7 +247,7 @@
       </div>
 
       <div>
-        <label>
+        <label class="checkbox-label">
           <Input
             @type="checkbox"
             @checked={{this.buffered.listable}}
@@ -258,7 +258,7 @@
       </div>
 
       <div>
-        <label>
+        <label class="checkbox-label">
           <Input
             @type="checkbox"
             @checked={{this.buffered.show_posts}}

--- a/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
@@ -32,7 +32,7 @@
       />
     </div>
 
-    <label>
+    <label class="checkbox-label">
       <input
         id="toggle-overridden"
         type="checkbox"
@@ -42,7 +42,7 @@
       {{i18n "admin.site_text.show_overriden"}}
     </label>
 
-    <label>
+    <label class="checkbox-label">
       <input
         id="toggle-outdated"
         type="checkbox"

--- a/app/assets/javascripts/discourse/app/components/group-flair-inputs.hbs
+++ b/app/assets/javascripts/discourse/app/components/group-flair-inputs.hbs
@@ -11,7 +11,7 @@
         @value="icon"
         @selection={{this.model.flair_type}}
       />
-      <b>{{i18n "groups.flair_type.icon"}}</b>
+      {{i18n "groups.flair_type.icon"}}
     </label>
 
     <label class="radio-label" for="avatar-flair-image">
@@ -21,7 +21,7 @@
         @value="image"
         @selection={{this.model.flair_type}}
       />
-      <b>{{i18n "groups.flair_type.image"}}</b>
+      {{i18n "groups.flair_type.image"}}
     </label>
   </div>
 

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.hbs
@@ -85,7 +85,7 @@
                   )
                 }}
               />
-              <label for="matching-title-only">
+              <label class="checkbox-label" for="matching-title-only">
                 {{i18n "search.advanced.filters.title"}}
               </label>
             </div>
@@ -103,7 +103,7 @@
                   )
                 }}
               />
-              <label for="matching-liked">{{i18n
+              <label class="checkbox-label" for="matching-liked">{{i18n
                   "search.advanced.filters.likes"
                 }}</label>
             </div>
@@ -122,7 +122,7 @@
                   )
                 }}
               />
-              <label for="matching-in-messages">{{i18n
+              <label class="checkbox-label" for="matching-in-messages">{{i18n
                   "search.advanced.filters.private"
                 }}</label>
             </div>
@@ -140,7 +140,7 @@
                   )
                 }}
               />
-              <label for="matching-seen">{{i18n
+              <label class="checkbox-label" for="matching-seen">{{i18n
                   "search.advanced.filters.seen"
                 }}</label>
             </div>

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -18,7 +18,9 @@
 
   <div class="reviewable-filters">
     <div class="reviewable-filter">
-      <label class="filter-label">{{i18n "review.filters.status"}}</label>
+      <label class="filter-label">
+        {{i18n "review.filters.status"}}
+      </label>
       <ComboBox
         @value={{this.filterStatus}}
         @content={{this.statuses}}
@@ -40,7 +42,9 @@
       </span>
 
       <div class="reviewable-filter">
-        <label class="filter-label">{{i18n "review.filters.type.title"}}</label>
+        <label class="filter-label">
+          {{i18n "review.filters.type.title"}}
+        </label>
         <ComboBox
           @value={{this.filterType}}
           @content={{this.allTypes}}
@@ -50,9 +54,9 @@
       </div>
 
       <div class="reviewable-filter">
-        <label class="filter-label">{{i18n
-            "review.filters.priority.title"
-          }}</label>
+        <label class="filter-label">
+          {{i18n "review.filters.priority.title"}}
+        </label>
         <ComboBox
           @value={{this.filterPriority}}
           @content={{this.priorities}}
@@ -61,7 +65,9 @@
       </div>
 
       <div class="reviewable-filter">
-        <label class="filter-label">{{i18n "review.filters.category"}}</label>
+        <label class="filter-label">
+          {{i18n "review.filters.category"}}
+        </label>
         <CategoryChooser
           @value={{this.filterCategoryId}}
           @onChange={{action (mut this.filterCategoryId)}}
@@ -70,7 +76,9 @@
       </div>
 
       <div class="reviewable-filter topic-filter">
-        {{i18n "review.filtered_reviewed_by"}}
+        <label class="filter-label">
+          {{i18n "review.filtered_reviewed_by"}}
+        </label>
         <EmailGroupUserChooser
           @value={{this.filterReviewedBy}}
           @onChange={{action "updateFilterReviewedBy"}}
@@ -83,7 +91,9 @@
       </div>
 
       <div class="reviewable-filter topic-filter">
-        {{i18n "review.filtered_user"}}
+        <label class="filter-label">
+          {{i18n "review.filtered_user"}}
+        </label>
         <EmailGroupUserChooser
           @value={{this.filterUsername}}
           @onChange={{action "updateFilterUsername"}}
@@ -98,7 +108,9 @@
 
       {{#if this.filterTopic}}
         <div class="reviewable-filter topic-filter">
-          {{i18n "review.filtered_topic"}}
+          <label class="filter-label">
+            {{i18n "review.filtered_topic"}}
+          </label>
           <DButton
             @label="review.show_all_topics"
             @icon="times"
@@ -109,7 +121,9 @@
       {{/if}}
 
       <div class="reviewable-filter date-range">
-        {{i18n "review.date_filter"}}
+        <label class="filter-label">
+          {{i18n "review.date_filter"}}
+        </label>
         <DateTimeInputRange
           @from={{this.filterFromDate}}
           @to={{this.filterToDate}}
@@ -120,7 +134,9 @@
       </div>
 
       <div class="reviewable-filter sort-order">
-        {{i18n "review.order_by"}}
+        <label class="filter-label">
+          {{i18n "review.order_by"}}
+        </label>
         <ComboBox
           @value={{this.filterSortOrder}}
           @content={{this.sortOrders}}

--- a/app/assets/stylesheets/common/admin/admin_emojis.scss
+++ b/app/assets/stylesheets/common/admin/admin_emojis.scss
@@ -7,7 +7,6 @@
     text-align: right;
   }
   #emoji-uploader {
-    padding: 10px;
     transition: box-shadow ease-in-out 0.25s;
   }
   .uppy-is-drag-over {

--- a/app/assets/stylesheets/common/admin/backups.scss
+++ b/app/assets/stylesheets/common/admin/backups.scss
@@ -107,4 +107,7 @@ button.ru {
       margin: 1.25em 0 0;
     }
   }
+  label {
+    font-weight: normal;
+  }
 }

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -282,6 +282,9 @@ table.screened-ip-addresses {
 
 .watched-words-uploader {
   display: inline-block;
+  label {
+    font-weight: normal;
+  }
 }
 
 .watched-words-list {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -140,6 +140,11 @@ span.relative-date {
   white-space: nowrap;
 }
 
+legend {
+  color: var(--primary-high);
+  font-weight: bold;
+}
+
 label {
   display: flex;
   margin-bottom: 5px;
@@ -587,8 +592,12 @@ textarea {
     line-height: var(--line-height-large);
   }
 
+  .control-group,
   .controls {
     margin-left: 0;
+    label {
+      font-weight: normal;
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -177,6 +177,10 @@
           background-color: var(--tertiary-very-low);
         }
       }
+      .control-label {
+        font-weight: bold;
+        color: var(--primary-high);
+      }
     }
 
     details.search-advanced-additional-options {

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -295,7 +295,6 @@
         width: auto;
         text-align: left;
         font-weight: normal;
-        font-weight: bold;
       }
 
       .instructions {

--- a/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/categories-modal.scss
+++ b/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/categories-modal.scss
@@ -35,6 +35,7 @@
     padding: 0.75em 1em;
     margin: 0;
     flex-grow: 1;
+    font-weight: normal;
     input[type="checkbox"] {
       margin-right: 0;
     }

--- a/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/tags-modal.scss
+++ b/app/assets/stylesheets/common/components/sidebar/edit-navigation-menu/tags-modal.scss
@@ -21,6 +21,7 @@
       margin-bottom: 0;
       min-width: 0;
       padding: 0.33em 0;
+      font-weight: normal;
       @include breakpoint(tablet) {
         // extra tappable space
         padding: 0.5em 0;
@@ -43,6 +44,5 @@
 
   .sidebar-tags-form__tag-label-count {
     color: var(--primary-medium);
-    margin-left: 0.33em;
   }
 }


### PR DESCRIPTION
We have a lot of form inconsistencies at the moment. I'd like to revamp all of these to a consistent structure, but this reduces some of the most obvious issues for now. 


Before (everything is bold): 
![Screenshot 2024-02-15 at 10 51 06 AM](https://github.com/discourse/discourse/assets/1681963/18a25ff9-db83-45de-8f49-4a2490889739)

After (headings are bold):
![Screenshot 2024-02-15 at 10 46 27 AM](https://github.com/discourse/discourse/assets/1681963/85121d29-6d5e-4ddf-8af9-b02ee2580c41)

Before (different heading colors, inconsistent bold):
![Screenshot 2024-02-15 at 10 52 22 AM](https://github.com/discourse/discourse/assets/1681963/a9a1d224-5c6d-42ba-8111-43a760bdb07a)

After (consistent heading colors, bold headings):
![Screenshot 2024-02-14 at 5 49 59 PM](https://github.com/discourse/discourse/assets/1681963/f565305f-799a-4c00-abc6-d7694cee2056)

Before (inconsistent bold):
![Screenshot 2024-02-15 at 10 53 55 AM](https://github.com/discourse/discourse/assets/1681963/7e21a42e-ed80-4574-ba43-34ce6abe0d9c)

After: 
![Screenshot 2024-02-14 at 5 55 18 PM](https://github.com/discourse/discourse/assets/1681963/e85b9a99-4165-43d6-a6c9-4cad2262819a)

Before: 
![Screenshot 2024-02-14 at 5 58 17 PM](https://github.com/discourse/discourse/assets/1681963/b37c0473-1dc1-47f8-a88f-56fe201733f0)

After:
![Screenshot 2024-02-14 at 5 58 12 PM](https://github.com/discourse/discourse/assets/1681963/cc716ccf-d41a-4c3e-bf61-0c53577d6cbd)

Before:
![Screenshot 2024-02-14 at 6 07 25 PM](https://github.com/discourse/discourse/assets/1681963/8553e792-82cd-40a9-bf42-320d9bd8542c)

After:
![Screenshot 2024-02-14 at 6 07 14 PM](https://github.com/discourse/discourse/assets/1681963/c7e2c065-a1af-4a66-8c68-3f3f63f653ab)

Before (only some labels bold):
![Screenshot 2024-02-14 at 6 13 21 PM](https://github.com/discourse/discourse/assets/1681963/3e755b64-b47d-4c8e-8230-7954b6cefea0)

After (all labels bold):
![Screenshot 2024-02-14 at 6 13 11 PM](https://github.com/discourse/discourse/assets/1681963/6a6638ed-4199-4631-89b3-3fc63f1bf12a)

Before (tags bold for no reason):
![Screenshot 2024-02-15 at 10 56 16 AM](https://github.com/discourse/discourse/assets/1681963/c2323070-a1ef-42b5-ae27-665138ddced7)

After: 
![Screenshot 2024-02-14 at 6 10 12 PM](https://github.com/discourse/discourse/assets/1681963/12a737c8-867d-49ef-89b2-7ad18d058761)





