### PR TITLE
FIX: Make recent search items populate input with value

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.js
@@ -95,7 +95,10 @@ export default class AssistantItem extends Component {
   @debounce(100)
   itemSelected() {
     let updatedTerm = "";
-    if (this.args.slug && this.args.suggestionKeyword) {
+    if (
+      this.args.slug &&
+      (this.args.suggestionKeyword || this.args.concatSlug)
+    ) {
       updatedTerm = this.prefix.concat(this.args.slug);
     } else {
       updatedTerm = this.prefix.trim();

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.hbs
@@ -18,6 +18,7 @@
         @closeSearchMenu={{@closeSearchMenu}}
         @searchTermChanged={{@searchTermChanged}}
         @usage="recent-search"
+        @concatSlug={{true}}
       />
     {{/each}}
   </div>

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.js
@@ -20,12 +20,11 @@ export default class RecentSearches extends Component {
   }
 
   @action
-  clearRecent() {
-    return User.resetRecentSearches().then((result) => {
-      if (result.success) {
-        this.currentUser.recent_searches.clear();
-      }
-    });
+  async clearRecent() {
+    const result = await User.resetRecentSearches();
+    if (result.success) {
+      this.currentUser.recent_searches.clear();
+    }
   }
 
   @action
@@ -39,11 +38,10 @@ export default class RecentSearches extends Component {
     this.search.handleArrowUpOrDown(e);
   }
 
-  loadRecentSearches() {
-    User.loadRecentSearches().then((result) => {
-      if (result.success && result.recent_searches?.length) {
-        this.currentUser.set("recent_searches", result.recent_searches);
-      }
-    });
+  async loadRecentSearches() {
+    const result = await User.loadRecentSearches();
+    if (result.success && result.recent_searches?.length) {
+      this.currentUser.set("recent_searches", result.recent_searches);
+    }
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -237,6 +237,10 @@ export function applySearchAutocomplete($input, siteSettings) {
 }
 
 export function updateRecentSearches(currentUser, term) {
+  if (!term) {
+    return;
+  }
+
   let recentSearches = Object.assign(currentUser.recent_searches || []);
 
   if (recentSearches.includes(term)) {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -716,6 +716,12 @@ acceptance("Search - Authenticated", function (needs) {
       "blue",
       "shows second recent search"
     );
+
+    await click(
+      ".search-menu .search-menu-recent li:nth-of-type(1) .search-link"
+    );
+
+    assert.dom("input#search-term").hasValue("yellow");
   });
 
   test("initial options - overriding behavior with addSearchMenuAssistantSelectCallback", async function (assert) {


### PR DESCRIPTION
- Make clicking a recent search item populate the search input with said value
- Don't add empty search strings to recent search history.
