### PR TITLE
UX: Show search history for more contexts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.hbs
@@ -46,6 +46,19 @@
             @closeSearchMenu={{@closeSearchMenu}}
             @searchTermChanged={{@searchTermChanged}}
           />
+
+          {{#if
+            (and
+              this.currentUser
+              this.siteSettings.log_search_queries
+              this.displayInitialOptions
+            )
+          }}
+            <SearchMenu::Results::RecentSearches
+              @closeSearchMenu={{@closeSearchMenu}}
+              @searchTermChanged={{@searchTermChanged}}
+            />
+          {{/if}}
         {{/if}}
       {{else}}
         <SearchMenu::Results::RandomQuickTip

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.js
@@ -14,6 +14,14 @@ const SEARCH_CONTEXT_TYPE_COMPONENTS = {
   user: AssistantItem,
 };
 
+const DISPLAY_INITIAL_OPTIONS_FOR_CONTEXT_TYPES = [
+  "topic",
+  "category",
+  "tag",
+  "tagIntersection",
+  "user",
+];
+
 export default class InitialOptions extends Component {
   @service search;
   @service siteSettings;
@@ -35,6 +43,15 @@ export default class InitialOptions extends Component {
 
   get termMatchesContextTypeKeyword() {
     return this.search.activeGlobalSearchTerm?.match(MODIFIER_REGEXP);
+  }
+
+  get displayInitialOptions() {
+    if (this.search.activeGlobalSearchTerm) {
+      return false;
+    }
+    return DISPLAY_INITIAL_OPTIONS_FOR_CONTEXT_TYPES.includes(
+      this.search.searchContext?.type
+    );
   }
 
   setAttributesForSearchContextType(type) {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -697,7 +697,7 @@ acceptance("Search - Authenticated", function (needs) {
     );
   });
 
-  test("initial options - recent search results", async function (assert) {
+  test("initial options - search history - no context", async function (assert) {
     await visit("/");
     await click("#search-button");
 
@@ -744,6 +744,24 @@ acceptance("Search - Authenticated", function (needs) {
     );
 
     assert.strictEqual(query("#search-term").value, "hijacked!");
+  });
+
+  test("initial options - search history - category context", async function (assert) {
+    await visit("/c/bug");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent li:nth-of-type(1) .search-link")
+      .exists("shows search history");
+  });
+
+  test("initial options - search history - user context", async function (assert) {
+    await visit("/u/eviltrout");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent li:nth-of-type(1) .search-link")
+      .exists("shows search history");
   });
 });
 
@@ -847,6 +865,15 @@ acceptance("Search - with tagging enabled", function (needs) {
     assert.strictEqual(firstTag, "monkey");
   });
 
+  test("initial options - search history - tag context", async function (assert) {
+    await visit("/tags/c/bug/dev");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent li:nth-of-type(1) .search-link")
+      .exists("shows search history");
+  });
+
   test("initial options - tag search scope - shows category / tag combination shortcut when both are present", async function (assert) {
     await visit("/tags/c/bug/dev");
     await click("#search-button");
@@ -893,6 +920,15 @@ acceptance("Search - with tagging enabled", function (needs) {
       "dev",
       "Tag is displayed"
     );
+  });
+
+  test("initial options - search history - tag intersection context", async function (assert) {
+    await visit("/tags/intersection/dev/foo");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent li:nth-of-type(1) .search-link")
+      .exists("shows search history");
   });
 
   test("initial options - tag intersection search scope - shows tag combination shortcut when visiting tag intersection", async function (assert) {
@@ -1169,6 +1205,24 @@ acceptance("Search - assistant", function (needs) {
     assert
       .dom(".search-input .btn.search-context")
       .doesNotExist("'in this topic' button is not shown");
+  });
+
+  test("initial options - search history - topic context", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent li:nth-of-type(1) .search-link")
+      .exists("shows search history");
+  });
+
+  test("initial options - search history - private message context", async function (assert) {
+    await visit("/u/charlie/messages");
+    await click("#search-button");
+
+    assert
+      .dom(".search-menu .search-menu-recent")
+      .doesNotExist("does not show search history");
   });
 
   test("initial options - private message search scope - shows 'in messages' button when in an inbox", async function (assert) {


### PR DESCRIPTION
Add search history to 👇 contexts:

  - "topic",
  - "category",
  - "tag",
  - "tagIntersection",
  - "user",
  
  We display the search history when no search term is present.
  
  # Demo

https://github.com/discourse/discourse/assets/50783505/c720f70e-0c4c-4dbd-9f28-8b046deef674
  
  ## Topic
<img width="1003" alt="Screenshot 2024-02-15 at 12 36 37 PM" src="https://github.com/discourse/discourse/assets/50783505/5a254d94-2489-4c0f-976d-0eb1e2d6d775">


  ## Category
<img width="1003" alt="Screenshot 2024-02-15 at 12 36 23 PM" src="https://github.com/discourse/discourse/assets/50783505/247ec625-0bc2-431b-ae4f-b4e664647cfe">


  ## Tag  
<img width="1020" alt="Screenshot 2024-02-15 at 12 35 50 PM" src="https://github.com/discourse/discourse/assets/50783505/e416a935-00c2-4e8a-aef4-8de6903864bf">


  ## Tag Intersection
<img width="1004" alt="Screenshot 2024-02-15 at 12 35 28 PM" src="https://github.com/discourse/discourse/assets/50783505/d06cb287-52dd-4df4-ade8-75f30f67f07e">

  
  ## User
  <img width="1001" alt="Screenshot 2024-02-15 at 12 34 51 PM" src="https://github.com/discourse/discourse/assets/50783505/85a7a682-46f5-404c-a441-affb6bad05b6">