### PR TITLE
DEV: add matching plugin outlet to mobile template

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
@@ -34,7 +34,8 @@
       {{~/if~}}
        {{~raw-plugin-outlet name="topic-list-main-link-bottom"}}
     </div>
-    <div class='pull-right'>
+    {{~raw-plugin-outlet name="topic-list-after-main-link"}}
+    <div class='pull-right'>  
       {{raw "list/post-count-or-badges" topic=topic postBadgesEnabled=showTopicPostBadges}}
     </div>
     <div class="topic-item-stats clearfix">


### PR DESCRIPTION
The desktop template has this outlet, so mobile should too! 