### PR TITLE
DEV: Disable `BlockRequestsMiddleware` before every test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -151,6 +151,7 @@ module TestSetup
     OmniAuth.config.test_mode = false
 
     Middleware::AnonymousCache.disable_anon_cache
+    BlockRequestsMiddleware.allow_requests!
   end
 end
 
@@ -608,7 +609,6 @@ RSpec.configure do |config|
     driven_by driver.join("_").to_sym
 
     setup_system_test
-    BlockRequestsMiddleware.allow_requests!
   end
 
   config.after(:each, type: :system) do |example|


### PR DESCRIPTION
Why this change?

This is a follow up to c30aeafd9db40bfbd848430359285547a1b1f605. The
commit was calling `BlockRequestsMiddleware.allow_requests!` only before
`type: :system` tests but non system type tests could be running as well
and needs the `BlockRequestsMiddleware` middleware to be
disabled too.
