### PR TITLE
PERF: Use `-ping` option to ImageMagick `identify` command

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -414,6 +414,7 @@ class Upload < ActiveRecord::Base
       begin
         Discourse::Utils.execute_command(
           "identify",
+          "-ping",
           "-format",
           "%Q",
           local_path,

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe UploadCreator do
     describe "converting to jpeg" do
       def image_quality(path)
         local_path = File.join(Rails.root, "public", path)
-        Discourse::Utils.execute_command("identify", "-format", "%Q", local_path).to_i
+        Discourse::Utils.execute_command("identify", "-ping", "-format", "%Q", local_path).to_i
       end
 
       let(:filename) { "should_be_jpeg.png" }


### PR DESCRIPTION
Why this change?

This adds the `-ping` option to the spots we missed in
cfdb461e9a4e791dfa604cfb14be503c0932481e.
