### PR TITLE
FIX: is_my_own? check for users who are anonymously doing actions

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -97,7 +97,7 @@ class Guardian
   attr_reader :request
 
   def initialize(user = nil, request = nil)
-    @user = user.presence || AnonymousUser.new
+    @user = user.presence || Guardian::AnonymousUser.new
     @request = request
   end
 
@@ -640,12 +640,17 @@ class Guardian
   private
 
   def is_my_own?(obj)
-    if anonymous?
+    # NOTE: This looks strange...but we are checking if someone is posting anonymously
+    # as a AnonymousUser model, _not_ as Guardian::AnonymousUser which is a different thing
+    # used when !authenticated?
+    if authenticated? && is_anonymous?
       return(
         SiteSetting.allow_anonymous_likes? && obj.class == PostAction && obj.is_like? &&
           obj.user_id == @user.id
       )
     end
+
+    return false if anonymous?
     return obj.user_id == @user.id if obj.respond_to?(:user_id) && obj.user_id && @user.id
     return obj.user == @user if obj.respond_to?(:user)
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Guardian do
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:post)
 
-    describe "an anonymous user" do
+    describe "an authenticated user posting anonymously" do
       before { SiteSetting.allow_anonymous_posting = true }
 
       context "when allow_anonymous_likes is enabled" do
@@ -2504,7 +2504,7 @@ RSpec.describe Guardian do
     end
   end
 
-  describe "#can_delete_post_action" do
+  describe "#can_delete_post_action?" do
     before do
       SiteSetting.allow_anonymous_posting = true
       Guardian.any_instance.stubs(:anonymous?).returns(true)
@@ -2512,7 +2512,8 @@ RSpec.describe Guardian do
 
     context "with allow_anonymous_likes enabled" do
       before { SiteSetting.allow_anonymous_likes = true }
-      describe "an anonymous user" do
+
+      describe "an authenticated anonymous user" do
         let(:post_action) do
           user.id = anonymous_user.id
           post.id = 1
@@ -2552,6 +2553,10 @@ RSpec.describe Guardian do
 
         it "returns true if the post belongs to the anonymous user" do
           expect(Guardian.new(anonymous_user).can_delete_post_action?(post_action)).to be_truthy
+        end
+
+        it "returns false if the user is an unauthenticated anonymous user" do
+          expect(Guardian.new.can_delete_post_action?(post_action)).to be_falsey
         end
 
         it "return false if the post belongs to another user" do


### PR DESCRIPTION
Followup to 978d52841af23c0709bb646ba3ca91a5e6e7ce64

It's complicated...we have multiple "anonymous" user concepts
in core, and even two classes called the exact same thing --
AnonymousUser.

The first case is Guardian::AnonymousUser, which is used for
people who are browsing the forum without being authenticated.

The second case is the model AnonymousUser, which is used when
a user is liking or posting anonymously via allow_anonymous_likes
or allow_anonymous_posting site settings.

We will untangle this naming nightmare later on...but for the
time being, only authenticated users who are pretending to be
anonymous should be able to like posts if allow_anonymous_likes
is on.