### PR TITLE
UX: Tweaks on the admin sidebar

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -686,6 +686,20 @@ $mobile-breakpoint: 700px;
   @media (max-width: 500px) {
     width: 50%;
   }
+  .nav-stacked {
+    background-color: inherit;
+
+    a.active {
+      color: initial;
+      background-color: initial;
+      font-weight: 700;
+      border-right: 4px solid var(--quaternary);
+
+      &::after {
+        display: none; // Hides the arrow
+      }
+    }
+  }
 }
 
 .admin-detail {

--- a/app/assets/stylesheets/common/admin/admin_revamp.scss
+++ b/app/assets/stylesheets/common/admin/admin_revamp.scss
@@ -25,3 +25,7 @@
     }
   }
 }
+
+.admin-area .sidebar-wrapper {
+  background-color: var(--d-sidebar-admin-background);
+}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -11,6 +11,7 @@
   --d-sidebar-row-height: 2.1em;
 
   --d-sidebar-background: var(--secondary);
+  --d-sidebar-admin-background: var(--primary-very-low);
   --d-sidebar-prefix-background: var(
     --primary-low
   ); // example: chat participant count

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -74,7 +74,7 @@
   background: var(--primary-low);
 
   li {
-    border-bottom: 1px solid var(--primary-low-mid-or-secondary-high);
+    border-bottom: 1px solid var(--primary-low);
 
     &:last-of-type {
       border-bottom: 0;
@@ -88,7 +88,6 @@
   a {
     margin: 0;
     padding: 0.75em;
-    font-size: var(--font-up-1);
     line-height: var(--line-height-small);
     cursor: pointer;
     color: var(--primary);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

* Added a background color to the admin sidebar to differentiator from the forum sidebar
* Remove the background color of the inner sidebar

### Before
![image](https://github.com/discourse/discourse/assets/2790986/2ee971a7-e684-4ad3-87f4-e0ad22b8f1c4)


### After
![image](https://github.com/discourse/discourse/assets/2790986/04213996-6770-4564-a358-a24db8d82449)

With a disabled admin sidebar


![image](https://github.com/discourse/discourse/assets/2790986/056080e2-70b1-4cf8-a432-6804b6f196dc)
