### PR TITLE
FEATURE: Create a link to start a new chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/chat-route-map.js
+++ b/plugins/chat/assets/javascripts/discourse/chat-route-map.js
@@ -15,6 +15,8 @@ export default function () {
     this.route("channels");
     this.route("threads");
 
+    this.route("message-from-params", { path: "/new-message" });
+
     this.route(
       "channel.info",
       { path: "/c/:channelTitle/:channelId/info" },

--- a/plugins/chat/assets/javascripts/discourse/controllers/chat-message-from-params.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/chat-message-from-params.js
@@ -1,0 +1,8 @@
+import Controller from "@ember/controller";
+import { inject as service } from "@ember/service";
+
+export default class ChatMessageFromParamsController extends Controller {
+  @service chat;
+
+  queryParams = ["username"];
+}

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-message-from-params.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-message-from-params.js
@@ -1,0 +1,19 @@
+import { inject as service } from "@ember/service";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default class ChatMessageFromParamsRoute extends DiscourseRoute {
+  @service chat;
+  @service router;
+
+  beforeModel() {
+    const usernames = this.paramsFor(this.routeName).username?.split(",");
+
+    if (!usernames) {
+      return this.router.transitionTo("chat");
+    }
+
+    this.chat.upsertDmChannel({ usernames }).then((channel) => {
+      this.router.transitionTo("chat.channel", channel.title, channel.id);
+    });
+  }
+}

--- a/plugins/chat/config/routes.rb
+++ b/plugins/chat/config/routes.rb
@@ -73,6 +73,7 @@ Chat::Engine.routes.draw do
 
   # chat_controller routes
   get "/" => "chat#respond"
+  get "/new-message" => "chat#respond"
   get "/direct-messages" => "chat#respond"
   get "/channels" => "chat#respond"
   get "/threads" => "chat#respond"

--- a/plugins/chat/spec/system/chat_message_from_params_spec.rb
+++ b/plugins/chat/spec/system/chat_message_from_params_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat from URL params", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:user_1) { Fabricate(:user) }
+  fab!(:user_2) { Fabricate(:user) }
+  fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user, user_1]) }
+
+  before do
+    chat_system_bootstrap
+    sign_in(current_user)
+  end
+
+  context "with a single user" do
+    it "redirects to existing chat channel" do
+      visit("/chat/new-message?username=#{user_1.username}")
+
+      expect(page).to have_current_path("/chat/c/#{user_1.username}/#{dm_channel.id}")
+    end
+
+    it "creates a dm channel and redirects if none exists" do
+      visit("/chat/new-message?username=#{user_2.username}")
+
+      expect(page).to have_current_path("/chat/c/#{user_2.username}/#{Chat::Channel.last.id}")
+    end
+
+    it "redirects to chat home if username param is missing" do
+      visit("/chat/new-message?abc=def")
+
+      # chat selects the first dm channel by default
+      expect(page).to have_current_path("/chat/c/#{user_1.username}/#{dm_channel.id}")
+    end
+  end
+
+  context "with multiple users" do
+    it "creates a dm channel with multiple users" do
+      visit("/chat/new-message?username=#{user_1.username},#{user_2.username}")
+
+      expect(page).to have_current_path(
+        "/chat/c/#{user_1.username}-#{user_2.username}/#{Chat::Channel.last.id}",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This feature adds the functionality to start a new chat directly from the URL using query params.

The format for these urls are:

- `/chat/new-message?username=buford` (single user)
- `/chat/new-message?username=buford,jona` (multiple users)

The initial version of this feature allows for the following:

- Open an existing direct message channel with a single user
- Create a new direct message channel with a single user (and auto redirect)
- Create or open a channel with multiple users (and auto redirect)
- Redirects to chat home if the `username` param is missing 