### PR TITLE
FIX: Preload parent categories for sidebar

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -109,7 +109,16 @@ class Site
     if @guardian.can_lazy_load_categories?
       preloaded_category_ids = []
       if @guardian.authenticated?
-        preloaded_category_ids.concat(@guardian.user.secured_sidebar_category_ids(@guardian))
+        sidebar_category_ids = @guardian.user.secured_sidebar_category_ids(@guardian)
+        preloaded_category_ids.concat(
+          Category
+            .secured(@guardian)
+            .select(:parent_category_id)
+            .distinct
+            .where(id: sidebar_category_ids)
+            .pluck(:parent_category_id),
+        )
+        preloaded_category_ids.concat(sidebar_category_ids)
       end
     end
 


### PR DESCRIPTION
When lazy load categories is enabled, only the categories present in the sidebar are preloaded. This is insufficient because the parent categories are necessary too in order for the sidebar to be rendered properly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
