### PR TITLE
FIX: Add a border around the video placeholder play button

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -957,6 +957,17 @@ aside.onebox.mixcloud-preview {
       width: 2em;
       transition: width 0.15s, height 0.15s;
     }
+
+    .d-icon-play {
+      cursor: pointer;
+      padding: 1em;
+      margin: 0.5em;
+      background-color: rgba(0, 0, 0, 0.5);
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      color: var(--secondary-or-primary);
+    }
   }
 
   &:hover .video-placeholder-overlay .d-icon {


### PR DESCRIPTION
The video placeholder play button is white, so on a video placeholder
that is also white it is very hard to see where the play button is, so
this change adds a dark grey transparent background to the play button
so that it stands out. This is similar to how we have done the
play/pause button on animated gifs.
