### PR TITLE
DEV: Update `addToHeaderIcons` plugin API to handle a component and panel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { inject as service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import concatClass from "discourse/helpers/concat-class";
@@ -16,7 +17,6 @@ import HamburgerDropdownWrapper from "./glimmer-header/hamburger-dropdown-wrappe
 import Icons from "./glimmer-header/icons";
 import SearchMenuWrapper from "./glimmer-header/search-menu-wrapper";
 import UserMenuWrapper from "./glimmer-header/user-menu-wrapper";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 
 const SEARCH_BUTTON_ID = "search-button";
 

--- a/app/assets/javascripts/discourse/app/components/glimmer-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header.gjs
@@ -16,14 +16,9 @@ import HamburgerDropdownWrapper from "./glimmer-header/hamburger-dropdown-wrappe
 import Icons from "./glimmer-header/icons";
 import SearchMenuWrapper from "./glimmer-header/search-menu-wrapper";
 import UserMenuWrapper from "./glimmer-header/user-menu-wrapper";
-import MountWidget from "./mount-widget";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 
 const SEARCH_BUTTON_ID = "search-button";
-
-let additionalPanels = [];
-export function attachAdditionalPanel(name, toggle, transformAttrs) {
-  additionalPanels.push({ name, toggle, transformAttrs });
-}
 
 let _customHeaderClasses = [];
 export function addCustomHeaderClass(className) {
@@ -40,6 +35,7 @@ export default class GlimmerHeader extends Component {
   @service header;
 
   @tracked skipSearchContext = this.site.mobileView;
+  @tracked panelElement;
 
   appEventsListeners = modifier(() => {
     this.appEvents.on(
@@ -169,6 +165,11 @@ export default class GlimmerHeader extends Component {
     scrollLock(bool);
   }
 
+  @action
+  setPanelElement(element) {
+    this.panelElement = element;
+  }
+
   <template>
     <header
       class={{concatClass this.customHeaderClasses "d-header"}}
@@ -196,6 +197,7 @@ export default class GlimmerHeader extends Component {
               @toggleHamburger={{this.toggleHamburger}}
               @toggleUserMenu={{this.toggleUserMenu}}
               @searchButtonId={{SEARCH_BUTTON_ID}}
+              @panelElement={{this.panelElement}}
             />
           {{/if}}
 
@@ -209,10 +211,8 @@ export default class GlimmerHeader extends Component {
             <UserMenuWrapper @toggleUserMenu={{this.toggleUserMenu}} />
           {{/if}}
 
-          {{#each this.additionalPanels as |panel|}}
-            {{! we need toggle state and attrs }}
-            <MountWidget @widget={{panel.name}} />
-          {{/each}}
+          <div id="additional-panel-wrapper" {{didInsert this.setPanelElement}}>
+          </div>
 
           {{#if
             (and

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
@@ -27,16 +27,16 @@ export default class Icons extends Component {
 
   <template>
     <ul class="icons d-header-icons">
-      {{#each _extraHeaderIcons as |icon|}}
-        {{#if (this._isStringType icon)}}
-          <MountWidget @widget={{icon}} />
+      {{#each _extraHeaderIcons as |Icon|}}
+        {{#if (this._isStringType Icon)}}
+          <MountWidget @widget={{Icon}} />
         {{else}}
-          {{#with
+          {{#let
             (component PanelWrapper panelElement=@panelElement)
             as |panelWrapper|
           }}
-            <icon @panelWrapper={{panelWrapper}} />
-          {{/with}}
+            <Icon @panelWrapper={{panelWrapper}} />
+          {{/let}}
         {{/if}}
       {{/each}}
 

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
@@ -6,9 +6,9 @@ import or from "truth-helpers/helpers/or";
 import MountWidget from "../mount-widget";
 import Dropdown from "./dropdown";
 import UserDropdown from "./user-dropdown";
+import PanelWrapper from "./panel-wrapper";
 
 let _extraHeaderIcons = [];
-
 export function addToHeaderIcons(icon) {
   _extraHeaderIcons.push(icon);
 }
@@ -23,12 +23,21 @@ export default class Icons extends Component {
   @service header;
   @service search;
 
+  _isStringType = (icon) => typeof icon === "string";
+
   <template>
     <ul class="icons d-header-icons">
       {{#each _extraHeaderIcons as |icon|}}
-        <MountWidget @widget={{icon}} />
-        {{! I am not sure how we are going to render glimmer components here without
-        being able to import them. }}
+        {{#if (this._isStringType icon)}}
+          <MountWidget @widget={{icon}} />
+        {{else}}
+          {{#with
+            (component PanelWrapper panelElement=@panelElement)
+            as |panelWrapper|
+          }}
+            <icon @panelWrapper={{panelWrapper}} />
+          {{/with}}
+        {{/if}}
       {{/each}}
 
       <Dropdown

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
@@ -5,8 +5,8 @@ import not from "truth-helpers/helpers/not";
 import or from "truth-helpers/helpers/or";
 import MountWidget from "../mount-widget";
 import Dropdown from "./dropdown";
-import UserDropdown from "./user-dropdown";
 import PanelWrapper from "./panel-wrapper";
+import UserDropdown from "./user-dropdown";
 
 let _extraHeaderIcons = [];
 export function addToHeaderIcons(icon) {

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/icons.gjs
@@ -35,7 +35,7 @@ export default class Icons extends Component {
             (component PanelWrapper panelElement=@panelElement)
             as |panelWrapper|
           }}
-            <Icon @panelWrapper={{panelWrapper}} />
+            <Icon @panelPortal={{panelWrapper}} />
           {{/let}}
         {{/if}}
       {{/each}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/panel-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/panel-wrapper.gjs
@@ -1,9 +1,9 @@
+import ConditionalInElement from "../conditional-in-element";
+
 const PanelWrapper = <template>
-  {{#if @panelElement}}
-    {{#in-element @panelElement}}
-      {{yield}}
-    {{/in-element}}
-  {{/if}}
+  <ConditionalInElement @element={{@panelElement}}>
+    {{yield}}
+  </ConditionalInElement>
 </template>;
 
 export default PanelWrapper;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/panel-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/panel-wrapper.gjs
@@ -1,0 +1,9 @@
+const PanelWrapper = <template>
+  {{#if @panelElement}}
+    {{#in-element @panelElement}}
+      {{yield}}
+    {{/in-element}}
+  {{/if}}
+</template>;
+
+export default PanelWrapper;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/topic/info.gjs
@@ -19,12 +19,6 @@ import FeaturedLink from "./featured-link";
 import Participant from "./participant";
 import Status from "./status";
 
-let _additionalFancyTitleClasses = [];
-
-export function addHeaderFancyTitleClass(className) {
-  _additionalFancyTitleClasses.push(className);
-}
-
 export default class Info extends Component {
   @service currentUser;
   @service site;
@@ -43,10 +37,6 @@ export default class Info extends Component {
 
   get maxExtraItems() {
     return this.args.topic.tags?.length > 0 ? 5 : 10;
-  }
-
-  get additionalFancyTitleClasses() {
-    return _additionalFancyTitleClasses.join(" ");
   }
 
   get twoRows() {
@@ -106,10 +96,7 @@ export default class Info extends Component {
               <Status @topic={{@topic}} @disableActions={{@disableActions}} />
 
               <a
-                class={{concatClass
-                  "topic-link"
-                  this.additionalFancyTitleClasses
-                }}
+                class="topic-link"
                 {{on "click" this.jumpToTopPost}}
                 href={{@topic.url}}
                 data-topic-id={{@topic.id}}

--- a/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
+++ b/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
@@ -1,0 +1,25 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { schedule } from "@ember/runloop";
+import { PANEL_WRAPPER_ID } from "discourse/widgets/header";
+import PanelWrapper from "./glimmer-header/panel-wrapper";
+
+export default class LegacyHeaderIconShim extends Component {
+  @tracked panelElement;
+
+  constructor() {
+    super(...arguments);
+    schedule("afterRender", () => {
+      this.panelElement = document.querySelector(`#${PANEL_WRAPPER_ID}`);
+    });
+  }
+
+  <template>
+    {{#with
+      (component PanelWrapper panelElement=this.panelElement)
+      as |panelWrapper|
+    }}
+      <@component @panelWrapper={{panelWrapper}} />
+    {{/with}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
+++ b/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
@@ -15,11 +15,11 @@ export default class LegacyHeaderIconShim extends Component {
   }
 
   <template>
-    {{#with
+    {{#let
       (component PanelWrapper panelElement=this.panelElement)
       as |panelWrapper|
     }}
       <@component @panelWrapper={{panelWrapper}} />
-    {{/with}}
+    {{/let}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
+++ b/app/assets/javascripts/discourse/app/components/legacy-header-icon-shim.gjs
@@ -19,7 +19,7 @@ export default class LegacyHeaderIconShim extends Component {
       (component PanelWrapper panelElement=this.panelElement)
       as |panelWrapper|
     }}
-      <@component @panelWrapper={{panelWrapper}} />
+      <@component @panelPortal={{panelWrapper}} />
     {{/let}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/menu-panel.hbs
+++ b/app/assets/javascripts/discourse/app/components/menu-panel.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{concat-class "search-menu-panel menu-panel" @animationClass}}
+  class={{concat-class "menu-panel" @panelClass @animationClass}}
   data-max-width="500"
 >
   <div class="panel-body">

--- a/app/assets/javascripts/discourse/app/components/search-menu-panel.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu-panel.hbs
@@ -1,4 +1,7 @@
-<MenuPanel @animationClass={{this.animationClass}}>
+<MenuPanel
+  @animationClass={{this.animationClass}}
+  @panelClass="search-menu-panel"
+>
   <SearchMenu
     @onClose={{@closeSearchMenu}}
     @inlineResults={{true}}

--- a/app/assets/javascripts/discourse/app/components/search-menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.hbs
@@ -67,7 +67,7 @@
       @clearSearch={{this.clearSearch}}
     />
   {{else if this.displayMenuPanelResults}}
-    <MenuPanel>
+    <MenuPanel @panelClass="search-menu-panel">
       <SearchMenu::Results
         @loading={{this.loading}}
         @noResults={{this.noResults}}

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -11,7 +11,6 @@ import { addToolbarCallback } from "discourse/components/d-editor";
 import { addCategorySortCriteria } from "discourse/components/edit-category-settings";
 import { addCustomHeaderClass } from "discourse/components/glimmer-header";
 import { addToHeaderIcons as addToGlimmerHeaderIcons } from "discourse/components/glimmer-header/icons";
-import { addHeaderFancyTitleClass } from "discourse/components/glimmer-header/topic/info";
 import { forceDropdownForMenuPanels as glimmerForceDropdownForMenuPanels } from "discourse/components/glimmer-site-header";
 import { addGlobalNotice } from "discourse/components/global-notice";
 import { _addBulkButton } from "discourse/components/modal/topic-bulk-actions";
@@ -146,7 +145,7 @@ import { modifySelectKit } from "select-kit/mixins/plugin-api";
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.26.0";
+export const PLUGIN_API_VERSION = "1.25.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -1292,19 +1291,6 @@ class PluginApi {
    */
   modifySelectKit(pluginApiKey) {
     return modifySelectKit(pluginApiKey);
-  }
-
-  /**
-   * Add a custom CSS class to the topic title within the header.
-   *
-   * ```javascript
-   * api.addHeaderFancyTitleClass('foo');
-   * api.addHeaderFancyTitleClass('bar');
-   * ```
-   *
-   **/
-  addHeaderFancyTitleClass(titleClass) {
-    return addHeaderFancyTitleClass(titleClass);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -935,10 +935,10 @@ class PluginApi {
    *
    **/
   addHeaderPanel(name, toggle, transformAttrs) {
-    deprecated(
-      "addHeaderPanel has been removed. Use api.addToHeaderIcons instead.",
-      { id: "discourse.add-header-panel" }
-    );
+    // deprecated(
+    //   "addHeaderPanel has been removed. Use api.addToHeaderIcons instead.",
+    //   { id: "discourse.add-header-panel" }
+    // );
     attachAdditionalPanel(name, toggle, transformAttrs);
   }
 
@@ -1741,7 +1741,7 @@ class PluginApi {
    * ```
    *
    * If adding a component you can pass the component directly. Additionally, you can
-   * utilize the `@panelWrapper` argument to create a dropdown panel. This can be useful when
+   * utilize the `@panelPortal` argument to create a dropdown panel. This can be useful when
    * you want create a button in the header that opens a dropdown panel with additional content.
    *
    * ```
@@ -1749,9 +1749,9 @@ class PluginApi {
       <template>
         <span>Icon</span>
 
-        <@panelWrapper>
+        <@panelPortal>
           <div>Panel</div>
-        </@panelWrapper>
+        </@panelPortal>
       </template>
     );
    * ```

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -100,12 +100,7 @@ import {
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 import { setNotificationsLimit } from "discourse/routes/user-notifications";
 import { addComposerSaveErrorCallback } from "discourse/services/composer";
-import {
-  addToHeaderIcons,
-  attachAdditionalPanel,
-} from "discourse/widgets/header";
-// todo, add glimmer version
-// import { attachAdditionalPanel as attachAdditionalGlimmerPanel } from "discourse/widgets/header";
+import { addToHeaderIcons } from "discourse/widgets/header";
 import { addPostClassesCallback } from "discourse/widgets/post";
 import { addDecorator } from "discourse/widgets/post-cooked";
 import {
@@ -918,27 +913,6 @@ class PluginApi {
       "addFlagProperty has been removed. Use the reviewable API instead.",
       { id: "discourse.add-flag-property" }
     );
-  }
-
-  /**
-   * Adds a panel to the header
-   *
-   * takes a widget name, a value to toggle on, and a function which returns the attrs for the widget
-   * Example:
-   * ```javascript
-   * api.addHeaderPanel('widget-name', 'widgetVisible', function(attrs, state) {
-   *   return { name: attrs.name, description: state.description };
-   * });
-   * ```
-   * 'toggle' is an attribute on the state of the header widget,
-   *
-   * 'transformAttrs' is a function which is passed the current attrs and state of the widget,
-   * and returns a hash of values to pass to attach
-   *
-   **/
-  addHeaderPanel(name, toggle, transformAttrs) {
-    attachAdditionalPanel(name, toggle, transformAttrs);
-    // attachAdditionalGlimmerPanel(name, toggle, transformAttrs);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -100,7 +100,10 @@ import {
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 import { setNotificationsLimit } from "discourse/routes/user-notifications";
 import { addComposerSaveErrorCallback } from "discourse/services/composer";
-import { addToHeaderIcons } from "discourse/widgets/header";
+import {
+  addToHeaderIcons,
+  attachAdditionalPanel,
+} from "discourse/widgets/header";
 import { addPostClassesCallback } from "discourse/widgets/post";
 import { addDecorator } from "discourse/widgets/post-cooked";
 import {
@@ -916,6 +919,30 @@ class PluginApi {
   }
 
   /**
+   * Adds a panel to the header
+   *
+   * takes a widget name, a value to toggle on, and a function which returns the attrs for the widget
+   * Example:
+   * ```javascript
+   * api.addHeaderPanel('widget-name', 'widgetVisible', function(attrs, state) {
+   *   return { name: attrs.name, description: state.description };
+   * });
+   * ```
+   * 'toggle' is an attribute on the state of the header widget,
+   *
+   * 'transformAttrs' is a function which is passed the current attrs and state of the widget,
+   * and returns a hash of values to pass to attach
+   *
+   **/
+  addHeaderPanel(name, toggle, transformAttrs) {
+    deprecated(
+      "addHeaderPanel has been removed. Use api.addToHeaderIcons instead.",
+      { id: "discourse.add-header-panel" }
+    );
+    attachAdditionalPanel(name, toggle, transformAttrs);
+  }
+
+  /**
    * Adds a pluralization to the store
    *
    * Example:
@@ -1703,12 +1730,30 @@ class PluginApi {
     addExtraIconRenderer(renderer);
   }
   /**
-   * Adds a widget to the header-icon ul. The widget must already be created. You can create new widgets
+   * Adds a widget or a component to the header-icon ul.
+   *
+   * If adding a widget it must already be created. You can create new widgets
    * in a theme or plugin via an initializer prior to calling this function.
    *
    * ```
    * api.addToHeaderIcons(
-   *  createWidget('some-widget')
+   *  createWidget("some-widget")
+   * ```
+   *
+   * If adding a component you can pass the component directly. Additionally, you can
+   * utilize the `@panelWrapper` argument to create a dropdown panel. This can be useful when
+   * you want create a button in the header that opens a dropdown panel with additional content.
+   *
+   * ```
+   * api.addToHeaderIcons(
+      <template>
+        <span>Icon</span>
+
+        <@panelWrapper>
+          <div>Panel</div>
+        </@panelWrapper>
+      </template>
+    );
    * ```
    *
    **/

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -325,6 +325,11 @@ createWidget("header-cloak", {
   scheduleRerender() {},
 });
 
+let additionalPanels = [];
+export function attachAdditionalPanel(name, toggle, transformAttrs) {
+  additionalPanels.push({ name, toggle, transformAttrs });
+}
+
 createWidget("hamburger-dropdown-wrapper", {
   buildAttributes() {
     return { "data-click-outside": true };
@@ -526,16 +531,16 @@ export default createWidget("header", {
         panels.push(this.attach("revamped-user-menu-wrapper", {}));
       }
 
-      // additionalPanels.map((panel) => {
-      //   if (this.state[panel.toggle]) {
-      //     panels.push(
-      //       this.attach(
-      //         panel.name,
-      //         panel.transformAttrs.call(this, attrs, state)
-      //       )
-      //     );
-      //   }
-      // });
+      additionalPanels.map((panel) => {
+        if (this.state[panel.toggle]) {
+          panels.push(
+            this.attach(
+              panel.name,
+              panel.transformAttrs.call(this, attrs, state)
+            )
+          );
+        }
+      });
 
       if (this.site.mobileView || this.site.narrowDesktopView) {
         panels.push(this.attach("header-cloak"));

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -325,11 +325,6 @@ createWidget("header-cloak", {
   scheduleRerender() {},
 });
 
-let additionalPanels = [];
-export function attachAdditionalPanel(name, toggle, transformAttrs) {
-  additionalPanels.push({ name, toggle, transformAttrs });
-}
-
 createWidget("hamburger-dropdown-wrapper", {
   buildAttributes() {
     return { "data-click-outside": true };
@@ -531,16 +526,16 @@ export default createWidget("header", {
         panels.push(this.attach("revamped-user-menu-wrapper", {}));
       }
 
-      additionalPanels.map((panel) => {
-        if (this.state[panel.toggle]) {
-          panels.push(
-            this.attach(
-              panel.name,
-              panel.transformAttrs.call(this, attrs, state)
-            )
-          );
-        }
-      });
+      // additionalPanels.map((panel) => {
+      //   if (this.state[panel.toggle]) {
+      //     panels.push(
+      //       this.attach(
+      //         panel.name,
+      //         panel.transformAttrs.call(this, attrs, state)
+      //       )
+      //     );
+      //   }
+      // });
 
       if (this.site.mobileView || this.site.narrowDesktopView) {
         panels.push(this.attach("header-cloak"));

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -447,4 +447,5 @@ $mobile-avatar-height: 1.532em;
   right: -10px; // 10px to the right of .panel - adjust as needed
   max-height: 80vh;
   border-radius: var(--d-border-radius-large);
+  overflow: scroll;
 }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -447,5 +447,5 @@ $mobile-avatar-height: 1.532em;
   right: -10px; // 10px to the right of .panel - adjust as needed
   max-height: 80vh;
   border-radius: var(--d-border-radius-large);
-  overflow: scroll;
+  overflow: auto;
 }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -439,3 +439,12 @@ $mobile-avatar-height: 1.532em;
     background: transparent;
   }
 }
+
+#additional-panel-wrapper {
+  position: absolute;
+  // positions are relative to the .d-header .panel div
+  top: 100%; // directly underneath .panel
+  right: -10px; // 10px to the right of .panel - adjust as needed
+  max-height: 80vh;
+  border-radius: var(--d-border-radius-large);
+}

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,10 +7,6 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.26.0] - 2024-02-08
-
-- Added `addHeaderFancyTitleClass` which is used to add a custom CSS class to the topic title in the header.
-
 ## [1.25.0] - 2024-02-05
 
 - Added `addComposerImageWrapperButton` which is used to add a custom button to the composer preview's image wrapper that appears on hover of an uploaded image.


### PR DESCRIPTION
# Description

This PR adds the ability to pass a component to the `addToHeaderIcons` function, allowing the addition of both widgets and components to the header-icon `ul`. There is backwards compatibility for widgets (just pass a widget as a string), while components can be directly passed to the function and will be rendered in the same fashion as widgets. Additionally, the `@panelWrapper` argument allows you to create dropdown panels, useful for incorporating buttons that open panels with additional content in the header.

# Example
An example of the new `addToHeaderIcons` in action can be found here: https://github.com/discourse/discourse-multilingual/pull/11