### PR TITLE
DEV: Make more group-based settings client: false

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -221,7 +221,7 @@ export default function () {
     );
   });
 
-  // EXPERIMENTAL: These admin routes are hidden behind an `enable_experimental_admin_ui_groups`
+  // EXPERIMENTAL: These admin routes are hidden behind an `admin_sidebar_enabled_groups`
   // site setting and are subject to constant change.
   this.route("admin-revamp", { resetNamespace: true }, function () {
     this.route("lobby", { path: "/" }, function () {});

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -735,12 +735,7 @@ export default class Topic extends RestModel {
             !deleted_by.groups.some(
               (group) => group.name === this.category?.reviewable_by_group_name
             ) &&
-            !(
-              this.siteSettings.delete_all_posts_and_topics_allowed_groups &&
-              deleted_by.isInAnyGroups(
-                this.siteSettings.delete_all_posts_and_topics_allowed_groups
-              )
-            ))
+            !deleted_by.can_delete_all_posts_and_topics)
         ) {
           DiscourseURL.redirectTo("/");
         }

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -26,6 +26,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_delete_account,
              :can_post_anonymously,
              :can_ignore_users,
+             :can_delete_all_posts_and_topics,
+             :can_summarize,
              :custom_fields,
              :muted_category_ids,
              :indirectly_muted_category_ids,
@@ -140,6 +142,14 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def can_ignore_users
     !is_anonymous && object.in_any_groups?(SiteSetting.ignore_allowed_groups_map)
+  end
+
+  def can_delete_all_posts_and_topics
+    object.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
+  end
+
+  def can_summarize
+    object.in_any_groups?(SiteSetting.custom_summarization_allowed_groups_map)
   end
 
   def can_upload_avatar

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1872,7 +1872,6 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
-    client: true
   edit_all_topic_groups:
     default: "13"
     type: group_list
@@ -2325,14 +2324,6 @@ developer:
   instrument_gc_stat_per_request:
     default: false
     hidden: true
-  enable_experimental_admin_ui_groups:
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true
-    hidden: true
-    client: true
   admin_sidebar_enabled_groups:
     type: group_list
     list_type: compact
@@ -2607,7 +2598,6 @@ uncategorized:
     enum: "SummarizationStrategy"
     validator: "SummarizationValidator"
   custom_summarization_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3|13" # 3: @staff, 13: @trust_level_3
@@ -3087,7 +3077,6 @@ tags:
     client: true
     default: false
   pm_tags_allowed_for_groups:
-    client: true
     type: group_list
     list_type: compact
     default: ""

--- a/db/migrate/20240219012001_remove_enable_experimental_admin_ui_groups_site_settings.rb
+++ b/db/migrate/20240219012001_remove_enable_experimental_admin_ui_groups_site_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveEnableExperimentalAdminUiGroupsSiteSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'enable_experimental_admin_ui_groups'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -96,17 +96,10 @@ export default {
         },
       });
 
-      const summarizationAllowedGroups =
-        this.siteSettings.custom_summarization_allowed_groups
-          .split("|")
-          .map((id) => parseInt(id, 10));
-
       const canSummarize =
         this.siteSettings.summarization_strategy &&
         this.currentUser &&
-        this.currentUser.groups.some((g) =>
-          summarizationAllowedGroups.includes(g.id)
-        );
+        this.currentUser.can_summarize;
 
       if (canSummarize) {
         api.registerChatComposerButton({

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -65,13 +65,7 @@ export default class Chat extends Service {
       return false;
     }
 
-    return (
-      this.currentUser.staff ||
-      this.siteSettings.userInAnyGroups(
-        "direct_message_enabled_groups",
-        this.currentUser
-      )
-    );
+    return this.currentUser.staff || this.currentUser.can_direct_message;
   }
 
   @computed("chatChannelsManager.directMessageChannels")

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -6,7 +6,6 @@ chat:
     default: true
     client: true
   chat_allowed_groups:
-    client: true
     type: group_list
     list_type: compact
     default: "3|11" # 3: @staff, 11: @trust_level_1
@@ -101,14 +100,12 @@ chat:
   direct_message_enabled_groups:
     default: "11" # @trust_level_1
     type: group_list
-    client: true
     allow_any: false
     refresh: true
     validator: "Chat::DirectMessageEnabledGroupsValidator"
   chat_message_flag_allowed_groups:
     default: "11" # @trust_level_1
     type: group_list
-    client: true
     allow_any: false
     refresh: true
   max_mentions_per_chat_message:

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -16,6 +16,10 @@ module Chat
       @user.staff? || @user.in_any_groups?(Chat.allowed_group_ids)
     end
 
+    def can_direct_message?
+      @user.in_any_groups?(SiteSetting.direct_message_enabled_groups_map)
+    end
+
     def can_create_chat_message?
       !SpamRule::AutoSilence.prevent_posting?(@user)
     end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -145,6 +145,15 @@ after_initialize do
 
   add_to_serializer(
     :current_user,
+    :can_direct_message,
+    include_condition: -> do
+      return @can_direct_message if defined?(@can_direct_message)
+      @can_direct_message = SiteSetting.chat_enabled && scope.can_direct_message?
+    end,
+  ) { true }
+
+  add_to_serializer(
+    :current_user,
     :has_chat_enabled,
     include_condition: -> do
       return @has_chat_enabled if defined?(@has_chat_enabled)


### PR DESCRIPTION
Affects the following settings:

delete_all_posts_and_topics_allowed_groups
experimental_new_new_view_groups
enable_experimental_admin_ui_groups
custom_summarization_allowed_groups
pm_tags_allowed_for_groups
chat_allowed_groups
direct_message_enabled_groups
chat_message_flag_allowed_groups

This turns off client: true for these group-based settings, because there is no guarantee that the current user gets all their group memberships serialized to the client. Better to check server-side first.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
