### PR TITLE
PERF: Stop running bootsnap in development mode in prod

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -14,18 +14,9 @@ require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 if (ENV["DISABLE_BOOTSNAP"] != "1")
   begin
-    require "bootsnap"
+    require "bootsnap/setup"
   rescue LoadError
     # not a strong requirement
-  end
-
-  if defined?(Bootsnap)
-    Bootsnap.setup(
-      cache_dir: "tmp/cache", # Path to your cache
-      load_path_cache: true, # Should we optimize the LOAD_PATH with a cache?
-      compile_cache_iseq: true, # Should compile Ruby code into ISeq cache?
-      compile_cache_yaml: false, # Skip YAML cache for now, cause we were seeing issues with it
-    )
   end
 end
 


### PR DESCRIPTION
Why this change?

For some reason, we were setting up bootsnap manually even though the
official documentation suggests requiring `bootsnap/setup` which will
setup bootsnap using the default configuration. Because we were calling
`Bootsnap.setup` manually, we did not set the `development_mode` option
which defaults to `true`. 

https://github.com/Shopify/bootsnap/blob/8394834cd504548aae3b4651587abd823f0495d1/lib/bootsnap.rb#L50

Hence, we were running bootsnap in development
mode even in the production environment which I suppose is not ideal.

What does this change do?

Instead of calling `Bootsnap.setup` manually, we can just use `require
'bootsnap/setup' instead.`
