### PR TITLE
UX: hide the draggable icon in the sidebar form on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
@@ -13,9 +13,11 @@
   {{on "drop" this.dropItem}}
   role="row"
 >
-  <div class="draggable" data-link-name={{@link.name}}>
-    {{d-icon "grip-lines"}}
-  </div>
+  {{#unless this.site.mobileView}}
+    <div class="draggable" data-link-name={{@link.name}}>
+      {{d-icon "grip-lines"}}
+    </div>
+  {{/unless}}
   <div class="input-group" role="cell">
     <IconPicker
       @name="icon"

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.js
@@ -1,9 +1,11 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 import discourseLater from "discourse-common/lib/later";
 
 export default class SectionFormLink extends Component {
+  @service site;
   @tracked dragCssClass;
 
   dragCount = 0;

--- a/app/assets/stylesheets/mobile/_index.scss
+++ b/app/assets/stylesheets/mobile/_index.scss
@@ -27,6 +27,7 @@
 @import "push-notifications-mobile";
 @import "reviewables";
 @import "search";
+@import "sidebar";
 @import "tagging";
 @import "topic-list";
 @import "topic-post";

--- a/app/assets/stylesheets/mobile/sidebar.scss
+++ b/app/assets/stylesheets/mobile/sidebar.scss
@@ -1,9 +1,6 @@
 .sidebar-section-form-modal {
   .row-wrapper {
     grid-template-columns: 4.5em repeat(2, 1fr) 2em;
-    .draggable {
-      display: none;
-    }
     .link-icon {
       grid-column: 1;
     }

--- a/app/assets/stylesheets/mobile/sidebar.scss
+++ b/app/assets/stylesheets/mobile/sidebar.scss
@@ -1,0 +1,11 @@
+.sidebar-section-form-modal {
+  .row-wrapper {
+    grid-template-columns: 4.5em repeat(2, 1fr) 2em;
+    .draggable {
+      display: none;
+    }
+    .link-icon {
+      grid-column: 1;
+    }
+  }
+}

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -190,6 +190,27 @@ describe "Custom sidebar sections", type: :system do
     )
   end
 
+  it "does not allow to drag on mobile" do
+    sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
+
+    Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|
+      Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+    end
+
+    Fabricate(:sidebar_url, name: "Sidebar Categories", value: "/categories").tap do |sidebar_url|
+      Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url)
+    end
+
+    sign_in user
+
+    visit("/latest?mobile_view=1")
+
+    sidebar.open_on_mobile
+    sidebar.edit_custom_section("My section")
+
+    expect(page).not_to have_css(".sidebar-section-form-link .draggable")
+  end
+
   it "does not allow the user to edit public section" do
     sidebar_section = Fabricate(:sidebar_section, title: "Public section", public: true)
     sidebar_url_1 = Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags")


### PR DESCRIPTION
Drag and drop link works only on desktop. Therefore, the drag icon should be hidden on mobile.

Mobile
<img width="383" alt="Screenshot 2024-02-19 at 1 54 07 pm" src="https://github.com/discourse/discourse/assets/72780/b7acb31d-4d1b-41b4-9058-302cec9fcfa6">

Desktop
<img width="1119" alt="Screenshot 2024-02-19 at 1 54 44 pm" src="https://github.com/discourse/discourse/assets/72780/dcb96f81-3f3f-4449-8c8d-853cb973d840">

