### PR TITLE
DEV: remove unused isInAnyGroups function

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -702,20 +702,6 @@ export default class User extends RestModel.extend(Evented) {
     return groups.length === 0 ? null : groups;
   }
 
-  // NOTE: This only includes groups *visible* to the user via the serializer,
-  // so be wary when using this.
-  isInAnyGroups(groupIds) {
-    if (!this.groups) {
-      return;
-    }
-
-    // auto group ID 0 is "everyone"
-    return (
-      groupIds.includes(0) ||
-      this.groups.mapBy("id").some((groupId) => groupIds.includes(groupId))
-    );
-  }
-
   // The user's stat count, excluding PMs.
   @discourseComputed("statsExcludingPms.@each.count")
   statsCountNonPM() {

--- a/app/assets/javascripts/discourse/app/services/site-settings.js
+++ b/app/assets/javascripts/discourse/app/services/site-settings.js
@@ -18,11 +18,6 @@ export function createSiteSettingsFromPreloaded(data) {
       .map((groupId) => parseInt(groupId, 10));
   };
 
-  settings.userInAnyGroups = (groupSetting, user) => {
-    const groupIds = settings.groupSettingArray(groupSetting);
-    return user.isInAnyGroups(groupIds);
-  };
-
   return settings;
 }
 


### PR DESCRIPTION
Recently we changed the code to check permission in the backend. Example PR https://github.com/discourse/discourse/pull/25735

After those changes, `isInAnyGroups` and `userInAnyGroups` functions are not used anymore.

