### PR TITLE
FIX: Set the video background to be black

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
@@ -67,7 +67,7 @@ export default {
           wrapper.remove();
           video.style.display = "";
           parentDiv.classList.remove("video-placeholder-container");
-          parentDiv.style = "background: black";
+          parentDiv.style.backgroundImage = "none";
         });
       }
 

--- a/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/video-placeholder.js
@@ -67,6 +67,7 @@ export default {
           wrapper.remove();
           video.style.display = "";
           parentDiv.classList.remove("video-placeholder-container");
+          parentDiv.style = "background: black";
         });
       }
 

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -927,6 +927,7 @@ aside.onebox.mixcloud-preview {
   position: relative;
   padding: 0 0 56.25% 0;
   width: 100%;
+  background-color: black;
 
   video {
     position: absolute;


### PR DESCRIPTION
If you upload a portrait video or just a video that doesn't fit in the
normal video dimensions we want it to have a black background instead of
trying to render parts of the placeholder image as the video background.

This change removes the placeholder image for the video background when
the play button is clicked and replaces it with an all black background.
