### PR TITLE
DEV: Replace DistributedCache with new implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -269,3 +269,5 @@ gem "net-http"
 gem "cgi", ">= 0.3.6", require: false
 
 gem "tzinfo-data"
+
+gem "concurrent-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,6 +560,7 @@ DEPENDENCIES
   certified
   cgi (>= 0.3.6)
   colored2
+  concurrent-ruby
   cose
   cppjieba_rb
   css_parser

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -704,7 +704,7 @@ class ApplicationController < ActionController::Base
   end
 
   def self.banner_json_cache
-    @banner_json_cache ||= DistributedCache.new("banner_json")
+    @banner_json_cache ||= Discourse.new_cache("banner_json", max_size_per_site: 1)
   end
 
   def banner_json

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -275,7 +275,7 @@ class Category < ActiveRecord::Base
   end
 
   def self.topic_id_cache
-    @topic_id_cache ||= DistributedCache.new("category_topic_ids")
+    @topic_id_cache ||= Discourse.new_cache("category_topic_ids", max_size_per_site: 1)
   end
 
   def self.topic_ids
@@ -334,7 +334,7 @@ class Category < ActiveRecord::Base
     DB.query_single(sqls.join("\nUNION ALL\n"), params)
   end
 
-  @@subcategory_ids = DistributedCache.new("subcategory_ids")
+  @@subcategory_ids = Discourse.new_cache("subcategory_ids", max_size_per_site: 1000)
 
   def self.subcategory_ids(category_id)
     @@subcategory_ids.defer_get_set(category_id.to_s) do
@@ -929,7 +929,7 @@ class Category < ActiveRecord::Base
     url[start_idx..-1].gsub("/", separator)
   end
 
-  @@url_cache = DistributedCache.new("category_url")
+  @@url_cache = Discourse.new_cache("category_url", max_size_per_site: 1000)
 
   def clear_url_cache
     @@url_cache.clear

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -296,7 +296,7 @@ class ColorScheme < ActiveRecord::Base
   end
 
   def self.hex_cache
-    @hex_cache ||= DistributedCache.new("scheme_hex_for_name")
+    @hex_cache ||= Discourse.new_cache("scheme_hex_for_name", max_size_per_site: 100)
   end
 
   attr_accessor :is_base

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -7,7 +7,7 @@ class Developer < ActiveRecord::Base
   after_destroy :rebuild_cache
 
   def self.id_cache
-    @id_cache ||= DistributedCache.new("developer_ids")
+    @id_cache ||= Discourse.new_cache("developer_ids", max_size_per_site: 1)
   end
 
   def self.user_ids

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -13,11 +13,12 @@ class Emoji
   attr_accessor :name, :url, :tonable, :group, :search_aliases
 
   def self.global_emoji_cache
-    @global_emoji_cache ||= DistributedCache.new("global_emoji_cache", namespace: false)
+    @global_emoji_cache ||=
+      Discourse.new_cache("global_emoji_cache", max_size_per_site: 1000, namespace: false)
   end
 
   def self.site_emoji_cache
-    @site_emoji_cache ||= DistributedCache.new("site_emoji_cache")
+    @site_emoji_cache ||= Discourse.new_cache("site_emoji_cache", max_size_per_site: 1000)
   end
 
   def self.all

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -14,7 +14,8 @@ class Theme < ActiveRecord::Base
   attr_accessor :child_components
 
   def self.cache
-    @cache ||= DistributedCache.new("theme:compiler:#{BASE_COMPILER_VERSION}")
+    @cache ||=
+      Discourse.new_cache("theme:compiler:#{BASE_COMPILER_VERSION}", max_size_per_site: 10_000)
   end
 
   belongs_to :user

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "distributed_cache"
-
 class ApplicationSerializer < ActiveModel::Serializer
   embed :ids, include: true
 
@@ -25,7 +23,7 @@ class ApplicationSerializer < ActiveModel::Serializer
   end
 
   def self.fragment_cache
-    @cache ||= DistributedCache.new("am_serializer_fragment_cache")
+    @cache ||= Discourse.new_cache("am_serializer_fragment_cache", max_size_per_site: 10_000)
   end
 
   protected

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -390,8 +390,11 @@ log_line_max_chars = 160000
 # this value is included when generating static asset URLs.
 # Updating the value will allow site operators to invalidate all asset urls
 # to recover from configuration issues which may have been cached by CDNs/browsers.
-asset_url_salt = 
+asset_url_salt =
 
 # disable service-worker caching. An 'offline' page will still be used as an offline fallback.
 # This flag is for a temporary experiment, and may be removed at any time
 disable_service_worker_cache = true
+
+# Sets cache sizes. This many sites can have the maximum number of keys in each LiveCache
+live_cache_multiplier = 200

--- a/config/initializers/002-rails_failover.rb
+++ b/config/initializers/002-rails_failover.rb
@@ -15,7 +15,7 @@ if defined?(RailsFailover::Redis)
     MessageBus.keepalive_interval = message_bus_keepalive_interval
 
     ObjectSpace.each_object(DistributedCache) { |cache| cache.clear }
-    ObjectSpace.each_object(LiveCache) { |cache| cache.clear }
+    ObjectSpace.each_object(LiveCache) { |cache| cache.clear_all }
 
     SiteSetting.refresh!
   end

--- a/config/initializers/002-rails_failover.rb
+++ b/config/initializers/002-rails_failover.rb
@@ -15,6 +15,7 @@ if defined?(RailsFailover::Redis)
     MessageBus.keepalive_interval = message_bus_keepalive_interval
 
     ObjectSpace.each_object(DistributedCache) { |cache| cache.clear }
+    ObjectSpace.each_object(LiveCache) { |cache| cache.clear }
 
     SiteSetting.refresh!
   end

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2874,6 +2874,10 @@ uncategorized:
     client: true
     default: true
 
+  use_live_caches:
+    default: false
+    hidden: true
+
 user_preferences:
   default_email_digest_frequency:
     enum: "DigestEmailSiteSetting"

--- a/lib/content_security_policy/extension.rb
+++ b/lib/content_security_policy/extension.rb
@@ -37,7 +37,7 @@ class ContentSecurityPolicy
     private
 
     def cache
-      @cache ||= DistributedCache.new("csp_extensions")
+      @cache ||= Discourse.new_cache("csp_extensions", max_size_per_site: 1000)
     end
 
     def find_theme_extensions(theme_id)

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1218,6 +1218,13 @@ module Discourse
   end
 
   def self.new_cache(name, max_size_per_site:, namespace: true)
-    LiveCache.new(name, max_size_per_site: max_size_per_site, namespace: namespace)
+    should_use_live_caches =
+      RailsMultisite::ConnectionManagement.with_connection { SiteSetting.use_live_caches? }
+
+    if should_use_live_caches
+      LiveCache.new(name, max_size_per_site: max_size_per_site, namespace: namespace)
+    else
+      DistributedCache.new(name, namespace: namespace)
+    end
   end
 end

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -763,7 +763,7 @@ module Discourse
 
   # Shared between processes
   def self.postgres_last_read_only
-    @postgres_last_read_only ||= DistributedCache.new("postgres_last_read_only")
+    @postgres_last_read_only ||= new_cache("postgres_last_read_only", max_size_per_site: 1)
   end
 
   # Per-process
@@ -1215,5 +1215,9 @@ module Discourse
         request.env["HTTP_ACCEPT_LANGUAGE"],
       ) if SiteSetting.set_locale_from_accept_language_header
     locale
+  end
+
+  def self.new_cache(name, max_size_per_site:, namespace: true)
+    LiveCache.new(name, max_size_per_site: max_size_per_site, namespace: namespace)
   end
 end

--- a/lib/distributed_cache.rb
+++ b/lib/distributed_cache.rb
@@ -51,4 +51,8 @@ class DistributedCache < MessageBus::DistributedCache
   def clear_regex(regex)
     hash.keys.select { |k| k =~ regex }.each { |k| delete(k) }
   end
+
+  def keys
+    hash.keys
+  end
 end

--- a/lib/live_cache.rb
+++ b/lib/live_cache.rb
@@ -57,10 +57,15 @@ class LiveCache
   )
     @manager = manager
     @hash_key = hash_key
-    @data = SiteCache.new(live_cache_multiplier * max_size_per_site, max_size_per_site)
     @manager.register(hash_key, self)
     @identity = SecureRandom.hex
     @namespace = namespace
+
+    @data =
+      SiteCache.new(
+        max_global_size: live_cache_multiplier * max_size_per_site,
+        max_size_per_site: max_size_per_site,
+      )
   end
 
   def getset(key, &blk)

--- a/lib/live_cache.rb
+++ b/lib/live_cache.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# This is a replacement for DistributedCache which is bounded and respects
+# clears during deploys
+class LiveCache
+  class Manager
+    CHANNEL_NAME ||= "/live_cache"
+
+    def initialize(message_bus: MessageBus)
+      @message_bus = message_bus
+      @subscription = Concurrent::Promises.delay(&method(:subscribe))
+      @mutex = Mutex.new
+      @caches = Hash.new { |h, k| h[k] = WeakList.new }
+    end
+
+    def register(hash_key, cache)
+      @mutex.synchronize { @caches[hash_key] << cache }
+
+      ensure_subscribed!
+    end
+
+    def publish(message)
+      @message_bus.publish(CHANNEL_NAME, message)
+    end
+
+    private
+
+    def process_message(message)
+      @mutex.synchronize do
+        @caches[message.data["hash_key"]].each { |cache| cache.process_message(message) }
+      end
+    end
+
+    def subscribe
+      @message_bus.subscribe(CHANNEL_NAME) { |message| process_message(message) }
+    end
+
+    def ensure_subscribed!
+      @subscription.wait!
+    end
+  end
+
+  class << self
+    attr_accessor :default_manager
+  end
+
+  self.default_manager = Manager.new
+
+  attr_reader :identity
+
+  def initialize(
+    hash_key,
+    max_size_per_site:,
+    live_cache_multiplier: GlobalSetting.live_cache_multiplier,
+    manager: LiveCache.default_manager,
+    namespace: true
+  )
+    @manager = manager
+    @hash_key = hash_key
+    @data = SiteCache.new(live_cache_multiplier * max_size_per_site, max_size_per_site)
+    @manager.register(hash_key, self)
+    @identity = SecureRandom.hex
+    @namespace = namespace
+  end
+
+  def getset(key, &blk)
+    raise TypeError if !Rails.env.production? && !k.is_a?(String)
+
+    @data.getset(get_site_id, key, &blk)
+  end
+
+  alias_method :defer_get_set, :getset
+
+  def getset_bulk(ks, key_blk, &blk)
+    @data.getset_bulk(get_site_id, ks, key_blk, &blk)
+  end
+
+  alias_method :defer_get_set_bulk, :getset_bulk
+
+  def clear(after_commit: true)
+    if after_commit
+      DB.after_commit { clear_now }
+    else
+      clear_now
+    end
+  end
+
+  def delete(key)
+    raise TypeError unless String === key
+
+    clear_regex(/\A#{key}\z/)
+  end
+
+  def clear_regex(regex)
+    site_id = get_site_id
+    @data.clear_site_regex(site_id, regex)
+
+    Scheduler::Defer.later("#{@hash_key}_clear_site") do
+      @manager.publish(
+        {
+          "hash_key" => @hash_key,
+          "identity" => identity,
+          "op" => "clear_site_regex",
+          "regex" => regex.to_s,
+        },
+      )
+    end
+  end
+
+  def clear_all
+    @data.clear
+
+    Scheduler::Defer.later("#{@hash_key}_clear_all") do
+      @manager.publish({ "hash_key" => @hash_key, "identity" => identity, "op" => "clear_all" })
+    end
+  end
+
+  def keys
+    @data.site_keys(get_site_id)
+  end
+
+  def process_message(message)
+    site_id = message.site_id
+    message_data = message.data
+    return if message_data["identity"] == identity
+
+    case message_data["op"]
+    when "clear_all"
+      @data.clear
+    when "clear_site"
+      @data.clear_site(site_id)
+    when "clear_site_regex"
+      @data.clear_site_regex(site_id, Regexp.new(message_data["regex"]))
+    end
+  end
+
+  private
+
+  def clear_now
+    site_id = get_site_id
+    @data.clear_site(site_id)
+
+    Scheduler::Defer.later("#{@hash_key}_clear_site") do
+      @manager.publish({ "hash_key" => @hash_key, "identity" => identity, "op" => "clear_site" })
+    end
+  end
+
+  def get_site_id
+    RailsMultisite::ConnectionManagement.current_db if @namespace
+  end
+end

--- a/lib/site_cache.rb
+++ b/lib/site_cache.rb
@@ -20,7 +20,7 @@ require "monitor"
 class SiteCache
   include MonitorMixin
 
-  def initialize(max_global_size, max_size_per_site)
+  def initialize(max_global_size:, max_size_per_site:)
     mon_initialize
 
     raise ArgumentError.new(:max_global_size) if max_global_size < 1

--- a/lib/site_cache.rb
+++ b/lib/site_cache.rb
@@ -25,6 +25,7 @@ class SiteCache
 
     raise ArgumentError.new(:max_global_size) if max_global_size < 1
     raise ArgumentError.new(:max_size_per_site) if max_size_per_site < 1
+    raise ArgumentError.new if max_size_per_site > max_global_size
 
     @max_global_size = max_global_size
     @max_size_per_site = max_size_per_site

--- a/lib/site_cache.rb
+++ b/lib/site_cache.rb
@@ -95,7 +95,6 @@ class SiteCache
   end
 
   def getset_bulk(site_id, keys, key_blk, &blk)
-    result = {}
     synchronize do
       hash = @nested[site_id] || {}
       missing_keys = keys.select { |key| !hash.key?(key_blk.call(key)) }

--- a/lib/site_cache.rb
+++ b/lib/site_cache.rb
@@ -2,6 +2,21 @@
 
 require "monitor"
 
+# This is an LRU cache in two dimensions. There are limits on:
+#
+# * The global size of the cache,
+# * The per-site size of the cache,
+#
+# In order to enforce these limits, we need be able to efficiently get the next
+# least recently used item globally and per site. To do this, there are two
+# structures:
+#
+# `@flattened' is a Hash from [site, key] -> value
+# `@nested' is a Hash from site -> Hash from key -> value
+#
+# In both cases, we exploit the ordered property of ruby hashes. `#shift` on a
+# hash pops the least recently inserted key-value pair. If all accesses delete
+# the item and reinsert it, this gives us LRU order.
 class SiteCache
   include MonitorMixin
 

--- a/lib/site_cache.rb
+++ b/lib/site_cache.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "monitor"
+
+class SiteCache
+  include MonitorMixin
+
+  def initialize(max_global_size, max_size_per_site)
+    mon_initialize
+
+    raise ArgumentError.new(:max_global_size) if max_global_size < 1
+    raise ArgumentError.new(:max_size_per_site) if max_size_per_site < 1
+
+    @max_global_size = max_global_size
+    @max_size_per_site = max_size_per_site
+    @flattened = {}
+    @nested = {}
+  end
+
+  def delete(site_id, key)
+    synchronize do
+      found = true
+      value = @flattened.delete([site_id, key]) { found = false }
+
+      if found
+        delete_nested(site_id, key)
+        value
+      else
+        nil
+      end
+    end
+  end
+
+  def set(site_id, key, value)
+    synchronize do
+      found = true
+      @flattened.delete([site_id, key]) { found = false }
+
+      if found
+        @flattened[[site_id, key]] = value
+        replace_nested(site_id, key, value)
+      else
+        insert_non_existent(site_id, key, value)
+      end
+
+      nil
+    end
+  end
+
+  def lookup(site_id, key)
+    synchronize do
+      found = true
+      value = @flattened.delete([site_id, key]) { found = false }
+
+      if found
+        @flattened[[site_id, key]] = value
+        replace_nested(site_id, key, value)
+        value
+      else
+        nil
+      end
+    end
+  end
+
+  def getset(site_id, key)
+    synchronize do
+      found = true
+      value = @flattened.delete([site_id, key]) { found = false }
+
+      if found
+        @flattened[[site_id, key]] = value
+        replace_nested(site_id, key, value)
+        value
+      else
+        value = yield
+        insert_non_existent(site_id, key, value)
+        value
+      end
+    end
+  end
+
+  def getset_bulk(site_id, keys, key_blk, &blk)
+    result = {}
+    synchronize do
+      hash = @nested[site_id] || {}
+      missing_keys = keys.select { |key| !hash.key?(key_blk.call(key)) }
+
+      unless missing_keys.empty?
+        missing_values = blk.call(missing_keys)
+
+        missing_keys
+          .map(&key_blk)
+          .zip(missing_values)
+          .each { |key, value| set(site_id, key, value) }
+      end
+
+      keys.map { |key| [key, lookup(site_id, key_blk.call(key))] }.to_h
+    end
+  end
+
+  def key?(site_id, key)
+    synchronize { @flattened.key?([site_id, key]) }
+  end
+
+  def count
+    synchronize { @flattened.size }
+  end
+
+  def clear
+    synchronize do
+      @flattened.clear
+      @nested.clear
+    end
+  end
+
+  def clear_site(site_id)
+    synchronize do
+      (@nested[site_id] || {}).keys.each { |key| @flattened.delete([site_id, key]) }
+      @nested.delete(site_id)
+      nil
+    end
+  end
+
+  def clear_site_regex(site_id, regex)
+    synchronize do
+      site_hash = @nested[site_id] || {}
+      deleted_keys = site_hash.keys.grep(regex)
+
+      deleted_keys.each do |key|
+        site_hash.delete(key)
+        @flattened.delete([site_id, key])
+      end
+
+      @nested.delete(site_id) if site_hash.empty?
+
+      nil
+    end
+  end
+
+  def to_a
+    synchronize do
+      array = @flattened.to_a
+      array.reverse!
+    end
+  end
+
+  def keys
+    synchronize do
+      array = @flattened.keys
+      array.reverse!
+    end
+  end
+
+  def site_keys(site_id)
+    synchronize do
+      array = (@nested[site_id] || {}).keys
+      array.reverse!
+    end
+  end
+
+  def values
+    synchronize do
+      array = @flattened.values
+      array.reverse!
+    end
+  end
+
+  private
+
+  def insert_non_existent(site_id, key, value)
+    @flattened[[site_id, key]] = value
+    site_hash = (@nested[site_id] ||= {})
+    site_hash[key] = value
+
+    while site_hash.size > @max_size_per_site
+      evicted_key = site_hash.shift.first
+      @flattened.delete([site_id, evicted_key])
+    end
+
+    while @flattened.size > @max_global_size
+      evicted_site_id, evicted_key = @flattened.shift.first
+      delete_nested(evicted_site_id, evicted_key)
+    end
+  end
+
+  def replace_nested(site_id, key, value)
+    site_hash = @nested[site_id]
+    site_hash.delete(key)
+    site_hash[key] = value
+  end
+
+  def delete_nested(site_id, key)
+    site_hash = @nested[site_id]
+    site_hash.delete(key)
+
+    @nested.delete(site_id) if site_hash.empty?
+  end
+end

--- a/lib/site_icon_manager.rb
+++ b/lib/site_icon_manager.rb
@@ -3,7 +3,7 @@
 module SiteIconManager
   extend GlobalPath
 
-  @cache = DistributedCache.new("icon_manager")
+  @cache = Discourse.new_cache("icon_manager", max_size_per_site: 1000)
 
   SKETCH_LOGO_ID = -6
 

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "distributed_cache"
 require "stylesheet/compiler"
 
 module Stylesheet
@@ -19,7 +18,7 @@ class Stylesheet::Manager
   @@lock = Mutex.new
 
   def self.cache
-    @cache ||= DistributedCache.new("discourse_stylesheet")
+    @cache ||= Discourse.new_cache("discourse_stylesheet", max_size_per_site: 1000)
   end
 
   def self.clear_theme_cache!

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -380,7 +380,7 @@ module SvgSprite
   end
 
   def self.expire_cache
-    cache&.clear
+    cache.clear
   end
 
   def self.svgs_for(theme_id)
@@ -517,6 +517,6 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
   end
 
   def self.cache
-    @cache ||= DistributedCache.new("svg_sprite")
+    @cache ||= Discourse.new_cache("svg_sprite", max_size_per_site: 1000)
   end
 end

--- a/lib/weak_list.rb
+++ b/lib/weak_list.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "weakref"
+
+class WeakList
+  include Enumerable
+
+  def initialize
+    @items = []
+  end
+
+  def <<(item)
+    @items << WeakRef.new(item)
+  end
+
+  def to_a
+    @items.select!(&:weakref_alive?)
+
+    @items.filter_map do |ref|
+      begin
+        ref.__getobj__
+      rescue WeakRef::RefError
+      end
+    end
+  end
+
+  def each(&blk)
+    to_a.each(&blk)
+  end
+end

--- a/spec/lib/site_cache_spec.rb
+++ b/spec/lib/site_cache_spec.rb
@@ -27,7 +27,8 @@ class CachePathGenerator
 
   def initialize(global_limit, site_limit, path)
     @path = path
-    @cache = MethodLogger.new(SiteCache.new(global_limit, site_limit))
+    @cache =
+      MethodLogger.new(SiteCache.new(max_global_size: global_limit, max_size_per_site: site_limit))
     @keys = Hash.new { |h, k| h[k] = [] }
   end
 
@@ -168,7 +169,7 @@ RSpec.describe SiteCache do
 
   describe "getset" do
     it "caches nil" do
-      cache = SiteCache.new(2, 2)
+      cache = SiteCache.new(max_global_size: 2, max_size_per_site: 2)
 
       cache.getset("site", "test") { nil }
       cache.getset("site", "test") { raise }
@@ -244,7 +245,7 @@ RSpec.describe SiteCache do
     end
 
     it "doesn't clear other sites" do
-      cache = SiteCache.new(3, 2)
+      cache = SiteCache.new(max_global_size: 3, max_size_per_site: 2)
       site1_id = Object.new
       site2_id = Object.new
       key = Object.new

--- a/spec/lib/site_cache_spec.rb
+++ b/spec/lib/site_cache_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+class MethodLogger
+  Log = Struct.new(:method_name, :args, :blk, :result)
+  attr_reader :operations
+
+  def initialize(obj)
+    @obj = obj
+    @operations = []
+  end
+
+  def method_missing(method_name, *args, &blk)
+    result = @obj.public_send(method_name, *args, &blk)
+    @operations << Log.new(method_name, args, blk, result)
+    result
+  end
+end
+
+class CachePathGenerator
+  def self.complete(global_limit, site_limit, &blk)
+    Concurrency::Logic::Complete.run do |path|
+      blk.call(CachePathGenerator.new(global_limit, site_limit, path))
+    end
+  end
+
+  attr_reader :path, :cache, :keys
+
+  def initialize(global_limit, site_limit, path)
+    @path = path
+    @cache = MethodLogger.new(SiteCache.new(global_limit, site_limit))
+    @keys = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def generate_lookup_for_site(site_id)
+    operation = path.choose(:lookup_existing, :delete_existing)
+
+    public_send(operation, site_id)
+    @cache.operations.last
+  end
+
+  def generate_lookup
+    operation = path.choose(:lookup_existing, :delete_existing)
+
+    public_send(operation)
+    @cache.operations.last
+  end
+
+  def generate_operation
+    operation =
+      path.choose(
+        :insert_new,
+        :insert_existing_site_id,
+        :insert_existing_key,
+        :lookup_existing,
+        :getset_existing,
+        :delete_existing,
+        :clear,
+        :clear_existing_site,
+      )
+
+    public_send(operation)
+    @cache.operations.last
+  end
+
+  def generate_operations(upto:)
+    CacheOperations.new(path.choose(*(1..upto)).times.map { generate_operation })
+  end
+
+  def insert_new
+    site_id = Object.new
+    key = Object.new
+    keys[site_id] << key
+    value = Object.new
+
+    if path.choose(true, false)
+      cache.set(site_id, key, value)
+    else
+      cache.getset(site_id, key) { value }
+    end
+    [site_id, key, value]
+  end
+
+  def insert_existing_site_id
+    site_id = path.choose(*keys.keys)
+    key = Object.new
+    keys[site_id] << key
+    value = Object.new
+
+    if path.choose(true, false)
+      cache.set(site_id, key, value)
+    else
+      cache.getset(site_id, key) { value }
+    end
+  end
+
+  def insert_existing_key
+    site_id = path.choose(*keys.keys)
+    key = path.choose(*keys[site_id])
+    value = Object.new
+    cache.set(site_id, key, value)
+  end
+
+  def lookup_existing(site_id = nil)
+    site_id ||= path.choose(*keys.keys)
+    key = path.choose(*keys[site_id])
+    cache.lookup(site_id, key)
+  end
+
+  def getset_existing
+    site_id = path.choose(*keys.keys)
+    key = path.choose(*keys[site_id])
+    value = Object.new
+    cache.getset(site_id, key) { value }
+  end
+
+  def delete_existing(site_id = nil)
+    site_id ||= path.choose(*keys.keys)
+    key = path.choose(*keys[site_id])
+    cache.delete(site_id, key)
+  end
+
+  def clear
+    cache.clear
+  end
+
+  def clear_site(site_id)
+    cache.clear_site(site_id)
+  end
+
+  def clear_existing_site
+    site_id = path.choose(*keys.keys)
+    cache.clear_site(site_id)
+  end
+end
+
+class CacheOperations
+  def initialize(operations)
+    @operations = operations
+  end
+
+  def values_inserted_at(site_id, key)
+    @operations.filter_map do |op|
+      case op.method_name
+      when :set
+        op_site_id, op_key, op_value = op.args
+        op_value if site_id == op_site_id && key == op_key
+      when :getset
+        op_site_id, op_key = op.args
+        op_value = op.blk.call
+        op_value if site_id == op_site_id && key == op_key && op_value == op.result
+      end
+    end
+  end
+end
+
+RSpec.describe SiteCache do
+  it "produces values from lookups and deletes that were previously inserted" do
+    CachePathGenerator.complete(3, 2) do |g|
+      operations = g.generate_operations(upto: 4)
+      last_op = g.generate_lookup
+
+      site_id, key = last_op.args
+      result = last_op.result
+
+      expect(operations.values_inserted_at(site_id, key)).to include(result) if result
+    end
+  end
+
+  describe "getset" do
+    it "caches nil" do
+      cache = SiteCache.new(2, 2)
+
+      cache.getset("site", "test") { nil }
+      cache.getset("site", "test") { raise }
+
+      expect(cache.keys).to contain_exactly(%w[site test])
+    end
+  end
+
+  describe "#keys" do
+    it "reports all and only the keys that exist according to get/delete" do
+      CachePathGenerator.complete(3, 2) do |g|
+        operations = g.generate_operations(upto: 4)
+        keys = g.cache.keys
+        last_op = g.generate_lookup
+
+        site_id, key = last_op.args
+
+        if keys.include?([site_id, key])
+          result = last_op.result
+          expect(result).not_to be(nil)
+        else
+          expect(result).to be(nil)
+        end
+      end
+    end
+
+    it "never has more than the global limit on the number of keys" do
+      CachePathGenerator.complete(3, 2) do |g|
+        g.generate_operations(upto: 4)
+        keys = g.cache.keys
+
+        expect(keys.size).to be <= 3
+      end
+    end
+
+    it "never has more than the per site limit on the number of keys" do
+      CachePathGenerator.complete(3, 2) do |g|
+        g.generate_operations(upto: 4)
+
+        g
+          .cache
+          .keys
+          .group_by(&:first)
+          .transform_values(&:size)
+          .values
+          .each { |s| expect(s).to be <= 2 }
+      end
+    end
+  end
+
+  describe "#clear" do
+    it "causes future lookups to return nil" do
+      CachePathGenerator.complete(3, 2) do |g|
+        g.generate_operations(upto: 4)
+        g.cache.clear
+        last_op = g.generate_lookup
+
+        expect(last_op.result).to be(nil)
+      end
+    end
+  end
+
+  describe "#clear_site" do
+    it "causes future lookups for that site to return nil" do
+      CachePathGenerator.complete(3, 2) do |g|
+        site_id, key, value = g.insert_new
+        g.generate_operations(upto: 3)
+        g.cache.clear_site(site_id)
+        last_op = g.generate_lookup_for_site(site_id)
+
+        expect(last_op.result).to be(nil)
+      end
+    end
+
+    it "doesn't clear other sites" do
+      cache = SiteCache.new(3, 2)
+      site1_id = Object.new
+      site2_id = Object.new
+      key = Object.new
+      value = Object.new
+
+      cache.set(site1_id, key, value)
+      cache.set(site2_id, key, value)
+
+      cache.clear_site(site2_id)
+
+      expect(cache.lookup(site1_id, key)).to be(value)
+    end
+  end
+end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe SiteSettingExtension do
   # of unneeded messaging, tests are careful to call refresh
   # when they need to.
   #
-  # DistributedCache used by locale handler can under certain
-  # cases take a tiny bit to stabilize.
-  #
   # TODO: refactor SiteSettingExtension not to rely on statics in
   # DefaultsProvider
   #

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -188,14 +188,14 @@ RSpec.describe SvgSprite do
       expect(sprite_files).to match(/my-custom-theme-icon/)
 
       SvgSprite.bundle(theme.id)
-      expect(SvgSprite.cache.hash.keys).to include("theme_svg_sprites_#{theme.id}")
+      expect(SvgSprite.cache.keys).to include("theme_svg_sprites_#{theme.id}")
 
       external_copy = Discourse.store.download(upload_s3)
       File.delete external_copy.try(:path)
 
       SvgSprite.bundle(theme.id)
       # after a temp file is missing, bundling still works
-      expect(SvgSprite.cache.hash.keys).to include("theme_svg_sprites_#{theme.id}")
+      expect(SvgSprite.cache.keys).to include("theme_svg_sprites_#{theme.id}")
     end
   end
 

--- a/spec/lib/weak_list_spec.rb
+++ b/spec/lib/weak_list_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe WeakList do
+  it "acts like a list" do
+    original = 10.times.map { Object.new }
+
+    l = WeakList.new
+
+    original.each { |item| l << item }
+
+    expect(l.to_a).to eq(original)
+  end
+
+  it "removes GCed items" do
+    prefix = 5.times.map { Object.new }
+    suffix = 5.times.map { Object.new }
+
+    l = WeakList.new
+
+    (prefix + [Object.new] + suffix).each { |item| l << item }
+
+    GC.start
+
+    expect(l.to_a).to eq(prefix + suffix)
+  end
+end

--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe PostActionType do
       it "should clear the cache on save" do
         cache = ApplicationSerializer.fragment_cache
 
-        cache["post_action_types_#{I18n.locale}"] = "test"
-        cache["post_action_flag_types_#{I18n.locale}"] = "test2"
+        cache.defer_get_set("post_action_types_#{I18n.locale}") { "test" }
+        cache.defer_get_set("post_action_flag_types_#{I18n.locale}") { "test2" }
 
         PostActionType.new(name_key: "some_key").save!
 
-        expect(cache["post_action_types_#{I18n.locale}"]).to eq(nil)
-        expect(cache["post_action_flag_types_#{I18n.locale}"]).to eq(nil)
+        expect(cache.defer_get_set("post_action_types_#{I18n.locale}") { nil }).to eq(nil)
+        expect(cache.defer_get_set("post_action_flag_types_#{I18n.locale}") { nil }).to eq(nil)
       ensure
         ApplicationSerializer.fragment_cache.clear
       end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1619,7 +1619,7 @@ RSpec.describe Topic do
 
         channels = messages.map(&:channel)
         expect(channels).to include("/site/banner")
-        expect(channels).to include("/live_cache")
+        expect(channels.intersection(%w[/distributed_hash /live_cache])).not_to be_empty
       end
 
       it "ensures only one banner topic at all time" do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1619,7 +1619,7 @@ RSpec.describe Topic do
 
         channels = messages.map(&:channel)
         expect(channels).to include("/site/banner")
-        expect(channels).to include("/distributed_hash")
+        expect(channels).to include("/live_cache")
       end
 
       it "ensures only one banner topic at all time" do


### PR DESCRIPTION
This bounds the number of keys that are stored and is less susceptible to race conditions.

In particular:

* Currently, during deploys, there are two sets of processes and each set won't honor the other's clears,
* The way we use DistributedCaches means that sets can be delayed passed a relevant clear command,
* When we delete keys according to a regex, we rely on having the complete set of keys in the process, but this may not be the case,