### PR TITLE
FIX: Admin nav active link in dark mode

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -690,7 +690,7 @@ $mobile-breakpoint: 700px;
     background-color: inherit;
 
     a.active {
-      color: initial;
+      color: var(--primary);
       background-color: initial;
       font-weight: 700;
       border-right: 4px solid var(--quaternary);


### PR DESCRIPTION
Followup e4b6142d6ac0117237bf034aa9abad9ec3b73c41,
the link was still black in dark mode.

Before:

![image](https://github.com/discourse/discourse/assets/920448/2860cce8-f1fe-413a-84cd-155cc62a3600)

After:

![image](https://github.com/discourse/discourse/assets/920448/5f9d2db2-9a6f-420a-819b-e3f98a1ecb22)


