### PR TITLE
DEV: Support category type in theme setting object schema

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -142,6 +142,7 @@ en:
         not_valid_float_value: "must be a float"
         not_valid_boolean_value: "must be a boolean"
         not_valid_enum_value: "must be one of the following: %{choices}"
+        not_valid_category_value: "must be a valid category id"
         string_value_not_valid_min: "must be at least %{min} characters long"
         string_value_not_valid_max: "must be at most %{max} characters long"
         number_value_not_valid_min: "must be larger than or equal to %{min}"


### PR DESCRIPTION
## Why this change?

This change supports a property of `type: category` in the schema that is declared for a theme setting object. Example:

```
sections:
  type: objects
  schema:
    name: section
    properties:
      category_property:
        type: category
```

The value of a property declared as `type: category` will have to be a valid id of a row in the `categories` table.

## What does this change do?

Adds a property value validation step for `type: category`. Care has been taken to ensure that we do not spam the database with a ton of requests if there are alot of category typed properties. This is done by walking through the entire object and collecting all the values for properties typed category. After which, a single database query is executed to validate which values are valid.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
