### PR TITLE
DEV: Increase default SMTP read timeout to 30s

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -96,7 +96,7 @@ smtp_force_tls = false
 smtp_open_timeout = 5
 
 # Number of seconds to wait until timing-out a SMTP read(2) call
-smtp_read_timeout = 5
+smtp_read_timeout = 30
 
 # number of seconds to wait while attempting to open a SMTP connection only when
 # sending emails via group SMTP


### PR DESCRIPTION
A while ago we increased group SMTP read and open timeouts
to address issues we were seeing with Gmail sometimes giving
really long timeouts for these values. The commit was:

3e639e4aa7bfad13cb7bf158e1e775179b00430e

Now, we want to increase all SMTP read timeouts to 30s,
since the 5s is too low sometimes, and the ruby Net::SMTP
stdlib also defaults to 30s.

Also, we want to slightly tweak the group smtp email job
not to fail if the IncomingEmail log fails to create, or if
a ReadTimeout is encountered, to avoid retrying the job in sidekiq
again and sending the same email out.
