### PR TITLE
DEV: add bootbox to deprecation warnings to admins

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -12,6 +12,7 @@ import I18n from "discourse-i18n";
 // not being triggered by core or official themes/plugins.
 export const CRITICAL_DEPRECATIONS = [
   /^discourse.modal-controllers$/,
+  /^discourse.bootbox$/,
   /^(?!discourse\.)/, // All unsilenced ember deprecations
 ];
 


### PR DESCRIPTION
As we will be resolving the bootbox deprecation soon, this adds a warning banner to admins for instances of Discourse that are running with plugins or themes relying on bootbox.