### PR TITLE
FIX: Category results should be ordered by term

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -394,6 +394,16 @@ class CategoriesController < ApplicationController
 
     Category.preload_user_fields!(guardian, categories)
 
+    # Prioritize categories that start with the term, then top-level
+    # categories, then subcategories
+    categories =
+      categories.to_a.sort_by do |category|
+        [
+          category.name.downcase.starts_with?(term) ? 0 : 1,
+          category.parent_category_id.blank? ? 0 : 1,
+        ]
+      end
+
     if include_ancestors
       ancestors = Category.secured(guardian).ancestors_of(categories.map(&:id))
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1274,6 +1274,27 @@ RSpec.describe CategoriesController do
       end
     end
 
+    context "with order" do
+      fab!(:category1) { Fabricate(:category, name: "Category Ordered", parent_category: category) }
+      fab!(:category2) { Fabricate(:category, name: "Ordered Category", parent_category: category) }
+      fab!(:category3) { Fabricate(:category, name: "Category Ordered") }
+      fab!(:category4) { Fabricate(:category, name: "Ordered Category") }
+
+      before do
+        [category1, category2, category3, category4].each do |c|
+          SearchIndexer.index(c, force: true)
+        end
+      end
+
+      it "returns in correct order" do
+        get "/categories/search.json", params: { term: "ordered" }
+
+        expect(response.parsed_body["categories"].map { |c| c["id"] }).to eq(
+          [category4.id, category2.id, category3.id, category1.id],
+        )
+      end
+    end
+
     it "returns user fields" do
       sign_in(admin)
 


### PR DESCRIPTION
The two criteria used to order the results are if the category name starts with the term and if the category is a top level category or not.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
