### PR TITLE
DEV: allows stop/resume streaming on a message

### DIFF
--- a/plugins/chat/app/services/chat/stop_message_streaming.rb
+++ b/plugins/chat/app/services/chat/stop_message_streaming.rb
@@ -38,7 +38,8 @@ module Chat
     end
 
     def can_stop_streaming(guardian:, message:, **)
-      guardian.is_admin? || message.in_reply_to && message.in_reply_to.user_id == guardian.user.id
+      guardian.is_admin? || message.user.id == guardian.user.id ||
+        message.in_reply_to && message.in_reply_to.user_id == guardian.user.id
     end
 
     def stop_message_streaming(message:, **)

--- a/plugins/chat/assets/stylesheets/common/chat-message-text.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-text.scss
@@ -7,7 +7,7 @@
     }
 
     p::after {
-      margin-left: 3px;
+      margin-left: 1px;
       margin-bottom: -4px;
       content: "";
       width: 6px;

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -217,7 +217,7 @@ module Chat
     end
 
     def can_edit_chat?(message)
-      (message.user_id == @user.id && !@user.silenced?)
+      (message.user_id == @user.id && !@user.silenced?) || is_admin?
     end
 
     def can_react?

--- a/plugins/chat/lib/chat_sdk/channel.rb
+++ b/plugins/chat/lib/chat_sdk/channel.rb
@@ -26,10 +26,7 @@ module ChatSDK
         direction: "future",
       ) do
         on_success { result.messages }
-        on_failure do
-          p Chat::StepsInspector.new(result)
-          raise "Unexpected error"
-        end
+        on_failure { raise "Unexpected error" }
         on_failed_policy(:can_view_channel) { raise "Guardian can't view channel" }
         on_failed_policy(:target_message_exists) { raise "Target message doesn't exist" }
       end

--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -100,10 +100,7 @@ module ChatSDK
         on_failed_policy(:can_stop_streaming) do
           raise "User with id: `#{guardian.user.id}` can't stop streaming this message"
         end
-        on_failure do
-          p Chat::StepsInspector.new(result)
-          raise "Unexpected error"
-        end
+        on_failure { raise "Unexpected error" }
       end
     end
 
@@ -142,10 +139,7 @@ module ChatSDK
           end
           on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
           on_success { result.message_instance }
-          on_failure do
-            p Chat::StepsInspector.new(result)
-            raise "Unexpected error"
-          end
+          on_failure { raise "Unexpected error" }
         end
 
       if streaming && block_given?
@@ -183,12 +177,7 @@ module ChatSDK
         message: self.message.message + raw,
         guardian: self.guardian,
         streaming: true,
-      ) do
-        on_failure do
-          p Chat::StepsInspector.new(result)
-          raise "Unexpected error"
-        end
-      end
+      ) { on_failure { raise "Unexpected error" } }
 
       self.message
     end

--- a/plugins/chat/lib/chat_sdk/thread.rb
+++ b/plugins/chat/lib/chat_sdk/thread.rb
@@ -48,10 +48,7 @@ module ChatSDK
         on_failed_policy(:ensure_thread_enabled) do
           raise "Threading is not enabled for this channel"
         end
-        on_failure do
-          p Chat::StepsInspector.new(result)
-          raise "Unexpected error"
-        end
+        on_failure { raise "Unexpected error" }
       end
     end
 
@@ -70,10 +67,7 @@ module ChatSDK
         end
         on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
         on_success { result.thread_instance }
-        on_failure do
-          p Chat::StepsInspector.new(result)
-          raise "Unexpected error"
-        end
+        on_failure { raise "Unexpected error" }
       end
     end
   end

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -479,6 +479,30 @@ RSpec.describe Chat::GuardianExtensions do
       end
     end
 
+    describe "#can_edit_chat" do
+      fab!(:message) { Fabricate(:chat_message, chat_channel: channel) }
+
+      context "when user is staff" do
+        it "returns true" do
+          expect(staff_guardian.can_edit_chat?(message)).to eq(true)
+        end
+      end
+
+      context "when user is not staff" do
+        it "returns false" do
+          expect(guardian.can_edit_chat?(message)).to eq(false)
+        end
+      end
+
+      context "when user is owner of the message" do
+        fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: user) }
+
+        it "returns true" do
+          expect(guardian.can_edit_chat?(message)).to eq(true)
+        end
+      end
+    end
+
     describe "#can_delete_category?" do
       alias_matcher :be_able_to_delete_category, :be_can_delete_category
 

--- a/plugins/chat/spec/lib/chat_sdk/message_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/message_spec.rb
@@ -47,9 +47,9 @@ describe ChatSDK::Message do
 
     context "when membership is enforced" do
       it "works" do
+        SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
         params[:enforce_membership] = true
         params[:guardian] = Fabricate(:user).guardian
-        SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
 
         message = described_class.create(**params)
 
@@ -95,6 +95,67 @@ describe ChatSDK::Message do
 
       expect(created_message.streaming).to eq(false)
       expect(created_message.message).to eq("something test")
+    end
+  end
+
+  describe ".stop_stream" do
+    fab!(:message_1) { Fabricate(:chat_message, message: "first") }
+
+    before do
+      SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+      message_1.update!(streaming: true)
+    end
+
+    it "stop streaming message" do
+      described_class.stop_stream(message_id: message_1.id, guardian: message_1.user.guardian)
+
+      expect(message_1.reload.streaming).to eq(false)
+    end
+
+    context "when user can't stop streaming" do
+      it "fails" do
+        user = Fabricate(:user)
+        message_1.chat_channel.add(user)
+
+        expect {
+          described_class.stop_stream(message_id: message_1.id, guardian: user.guardian)
+        }.to raise_error("User with id: `#{user.id}` can't stop streaming this message")
+      end
+    end
+
+    context "when user can't join channel" do
+      fab!(:message_1) do
+        Fabricate(:chat_message, chat_channel: Fabricate(:private_category_channel))
+      end
+
+      it "fails" do
+        user = Fabricate(:user)
+
+        expect {
+          described_class.stop_stream(message_id: message_1.id, guardian: user.guardian)
+        }.to raise_error("User with id: `#{user.id}` can't join this channel")
+      end
+    end
+  end
+
+  describe ".stream" do
+    fab!(:message_1) { Fabricate(:chat_message, message: "first") }
+
+    it "streams the message" do
+      initial_message = message_1.message
+
+      described_class.stream(
+        message_id: message_1.id,
+        guardian: message_1.user.guardian,
+      ) do |helper|
+        edit =
+          MessageBus
+            .track_publish("/chat/#{message_1.chat_channel.id}") { helper.stream(raw: "test") }
+            .find { |m| m.data["type"] == "edit" }
+      end
+
+      expect(message_1.reload.message).to eq(initial_message + " test")
+      expect(message_1.streaming).to eq(false)
     end
   end
 end


### PR DESCRIPTION
```ruby
ChatSDK::Message.start_stream(message_id: 1, guardian: guardian)
ChatSDK::Message.stream(raw: "foo", message_id: 1, guardian: guardian)
ChatSDK::Message.stream(raw: "bar", message_id: 1, guardian: guardian)
ChatSDK::Message.stop_stream(message_id: 1, guardian: guardian)
```

Generally speaking only admins or owners of the message can interact with a message.  Also note, Streaming to an existing message with a different user won't change the initial user of the message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
