### PR TITLE
DEV: Use DistributedCache#defer_get_set instead of getting and setting

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -352,27 +352,26 @@ class Stylesheet::Manager
     target = COLOR_SCHEME_STYLESHEET.to_sym
     current_hostname = Discourse.current_hostname
     cache_key = self.class.color_scheme_cache_key(color_scheme, theme_id)
-    stylesheets = cache[cache_key]
-    return stylesheets if stylesheets.present?
 
-    stylesheet = { color_scheme_id: color_scheme.id }
+    cache.defer_get_set(cache_key) do
+      stylesheet = { color_scheme_id: color_scheme.id }
 
-    theme = get_theme(theme_id)
+      theme = get_theme(theme_id)
 
-    builder =
-      Builder.new(
-        target: target,
-        theme: get_theme(theme_id),
-        color_scheme: color_scheme,
-        manager: self,
-      )
+      builder =
+        Builder.new(
+          target: target,
+          theme: get_theme(theme_id),
+          color_scheme: color_scheme,
+          manager: self,
+        )
 
-    builder.compile unless File.exist?(builder.stylesheet_fullpath)
+      builder.compile unless File.exist?(builder.stylesheet_fullpath)
 
-    href = builder.stylesheet_absolute_url
-    stylesheet[:new_href] = href
-    cache.defer_set(cache_key, stylesheet.freeze)
-    stylesheet
+      href = builder.stylesheet_absolute_url
+      stylesheet[:new_href] = href
+      stylesheet.freeze
+    end
   end
 
   def color_scheme_stylesheet_preload_tag(color_scheme_id = nil, media = "all")


### PR DESCRIPTION
We use defer_get_set everywhere else, so for consistency and reducing complexity, this is better.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
