### PR TITLE
UX: Change the color of the overriden dot to be slightly visible in dark mode

### DIFF
--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -123,7 +123,7 @@
         width: 0.5rem;
         height: 0.5rem;
         border-radius: 100%;
-        background-color: var(--quaternary-low);
+        background-color: var(--tertiary-medium);
       }
     }
   }

--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -123,7 +123,7 @@
         width: 0.5rem;
         height: 0.5rem;
         border-radius: 100%;
-        background-color: var(--tertiary-medium);
+        background-color: var(--highlight-high);
       }
     }
   }


### PR DESCRIPTION
### Before
![image](https://github.com/discourse/discourse/assets/2790986/3b77cd72-2312-4ac2-be8b-771b69c87f83)


### After
![image](https://github.com/discourse/discourse/assets/2790986/6a9fbf92-b5cc-40e1-8ad9-2a7136cd5515)

