### PR TITLE
DEV: Update deprecation banner to include id and remove Ember 5 link

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -82,7 +82,9 @@ export default class DeprecationWarningHandler extends Service {
   notifyAdmin(id, source) {
     this.#adminWarned = true;
 
-    let notice = I18n.t("critical_deprecation.notice");
+    let notice = I18n.t("critical_deprecation.notice", {
+      id: escapeExpression(id),
+    });
 
     if (this.siteSettings.warn_critical_js_deprecations_message) {
       notice += " " + this.siteSettings.warn_critical_js_deprecations_message;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -226,7 +226,7 @@ en:
     broken_plugin_alert: "Caused by plugin '%{name}'"
 
     critical_deprecation:
-      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (<a target='_blank' href='https://meta.discourse.org/t/287211'>more info</a>)."
+      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (<em>%{id}</em>)."
       theme_source: "Identified theme: <a target='_blank' href='%{path}'>'%{name}'</a>."
       plugin_source: "Identified plugin: '%{name}'"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -226,7 +226,7 @@ en:
     broken_plugin_alert: "Caused by plugin '%{name}'"
 
     critical_deprecation:
-      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (<em>%{id}</em>)."
+      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (id:<em>%{id}</em>)."
       theme_source: "Identified theme: <a target='_blank' href='%{path}'>'%{name}'</a>."
       plugin_source: "Identified plugin: '%{name}'"
 


### PR DESCRIPTION
We're starting to use this system for non-ember-5 deprecations, so linking to the Ember 5 topic doesn't make sense. Instead, we can include the deprecation ID to help with identifying the issue.

<img width="1115" alt="SCR-20240221-jodu" src="https://github.com/discourse/discourse/assets/6270921/44760de2-fbae-4026-a2ec-1a4fe364890b">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
