### PR TITLE
FIX: Show Uncategorized in category-chooser

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -17,7 +17,8 @@ export default ComboBoxComponent.extend({
 
   selectKitOptions: {
     filterable: true,
-    allowUncategorized: false,
+    autoInsertNoneItem: false,
+    allowUncategorized: "allowUncategorizedTopics",
     allowSubCategories: true,
     permissionType: PermissionType.FULL,
     excludeCategoryId: null,
@@ -54,10 +55,7 @@ export default ComboBoxComponent.extend({
           I18n.t(isString ? this.selectKit.options.none : "category.none")
         )
       );
-    } else if (
-      this.allowUncategorizedTopics ||
-      this.selectKit.options.allowUncategorized
-    ) {
+    } else if (this.selectKit.options.allowUncategorized) {
       return Category.findUncategorized();
     } else {
       const defaultCategoryId = parseInt(
@@ -94,6 +92,7 @@ export default ComboBoxComponent.extend({
   search(filter) {
     if (this.site.lazy_load_categories) {
       return Category.asyncSearch(this._normalize(filter), {
+        includeUncategorized: this.allowUncategorizedTopics,
         scopedCategoryId: this.selectKit.options?.scopedCategoryId,
         prioritizedCategoryId: this.selectKit.options?.prioritizedCategoryId,
       });

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -24,6 +24,7 @@ export default ComboBoxComponent.extend({
   navigateToEdit: false,
   editingCategory: false,
   editingCategoryTab: null,
+  allowUncategorizedTopics: setting("allow_uncategorized_topics"),
 
   selectKitOptions: {
     filterable: true,
@@ -40,7 +41,7 @@ export default ComboBoxComponent.extend({
     displayCategoryDescription: "displayCategoryDescription",
     headerComponent: "category-drop/category-drop-header",
     parentCategory: false,
-    allowUncategorized: setting("allow_uncategorized_topics"),
+    allowUncategorized: "allowUncategorizedTopics",
   },
 
   modifyComponentForRow() {


### PR DESCRIPTION
The uncategorized category was not rendered correctly and it was also sometimes displayed twice. This commit is a similar bug fix to commit 76647d3a340dac63d5ec26699d586afec7930380 and is a follow up to commit 63a50b12fd1dcfeabb0a3c9cae5c883313bbe233.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
