### PR TITLE
UX: fix sidebar custom section modal footer styles

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.hbs
@@ -122,10 +122,14 @@
         <label class="checkbox-label">
           {{#if this.transformedModel.sectionType}}
             <DTooltip
-              @icon="check-square"
               @content={{i18n "sidebar.sections.custom.always_public"}}
               class="always-public-tooltip"
-            />
+            >
+              <:trigger>
+                {{d-icon "check-square"}}
+                <span>{{i18n "sidebar.sections.custom.public"}}</span>
+              </:trigger>
+            </DTooltip>
           {{else}}
             <Input
               @type="checkbox"
@@ -133,8 +137,8 @@
               class="mark-public"
               disabled={{this.transformedModel.sectionType}}
             />
+            <span>{{i18n "sidebar.sections.custom.public"}}</span>
           {{/if}}
-          <span>{{i18n "sidebar.sections.custom.public"}}</span>
         </label>
       </div>
     {{/if}}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -230,10 +230,10 @@
       color: var(--tertiary-hover);
     }
   }
-  .modal-footer {
+  .d-modal__footer {
     display: grid;
     grid-template-columns: auto 1fr auto;
-    gap: 0.5em;
+    gap: 0.5em 1em;
     @include breakpoint(mobile-extra-large) {
       grid-template-columns: auto 1fr;
       justify-items: left;


### PR DESCRIPTION
I think this regressed with modal refactoring? 

Before:
![Screenshot 2024-02-21 at 6 04 35 PM](https://github.com/discourse/discourse/assets/1681963/fc5f72cd-a123-4006-a75b-3a3d8b170d9e)

After: 
![Screenshot 2024-02-21 at 6 01 36 PM](https://github.com/discourse/discourse/assets/1681963/d9ec5d43-6e02-4311-b537-7fa5d70f2f71)

I've also updated the `DTooltip` so hovering the checkbox and the label will trigger it (rather than just hovering the checkbox previously)