### PR TITLE
FIX: Customize form template view modal footer buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/customize-form-template-view.js
+++ b/app/assets/javascripts/discourse/app/components/modal/customize-form-template-view.js
@@ -18,17 +18,20 @@ export default class CustomizeFormTemplateViewModal extends Component {
 
   @action
   editTemplate() {
-    this.router.transitionTo("adminCustomizeFormTemplates.edit", this.model);
+    this.router.transitionTo(
+      "adminCustomizeFormTemplates.edit",
+      this.args.model
+    );
   }
 
   @action
   deleteTemplate() {
     return this.dialog.yesNoConfirm({
       message: I18n.t("admin.form_templates.delete_confirm", {
-        template_name: this.model.name,
+        template_name: this.args.model.name,
       }),
       didConfirm: () => {
-        ajax(`/admin/customize/form-templates/${this.model.id}.json`, {
+        ajax(`/admin/customize/form-templates/${this.args.model.id}.json`, {
           type: "DELETE",
         })
           .then(() => {

--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -44,6 +44,25 @@ describe "Admin Customize Form Templates", type: :system do
       form_template_page.click_toggle_preview
       expect(form_template_page).to have_input_field("input")
     end
+
+    context "when using the view template modal" do
+      it "should navigate to the edit page when clicking the edit button" do
+        form_template_page.visit
+        form_template_page.click_view_form_template
+        form_template_page.find(".d-modal__footer .btn-primary").click
+        expect(page).to have_current_path("/admin/customize/form-templates/#{form_template.id}")
+      end
+
+      it "should delete the form template when clicking the delete button" do
+        form_template_page.visit
+        original_template_name = form_template.name
+        form_template_page.click_view_form_template
+        form_template_page.find(".d-modal__footer .btn-danger").click
+        form_template_page.find(".dialog-footer .btn-primary").click
+
+        expect(form_template_page).to have_no_form_template(original_template_name)
+      end
+    end
   end
 
   describe "when visiting the page to edit a form template" do

--- a/spec/system/page_objects/pages/form_template.rb
+++ b/spec/system/page_objects/pages/form_template.rb
@@ -31,6 +31,10 @@ module PageObjects
         find(".form-templates__table tbody tr td", text: name).present?
       end
 
+      def has_no_form_template?(name)
+        has_no_css?(".form-templates__table tbody tr td", text: name)
+      end
+
       def has_category_in_template_row?(category_name)
         find(
           ".form-templates__table .categories .badge-category__name",


### PR DESCRIPTION
This PR fixes an issue with the "Customize Form Templates" view modal where the footer buttons (Edit & Delete) were not working.

<img width="599" alt="Screenshot 2024-02-21 at 16 50 22" src="https://github.com/discourse/discourse/assets/30090424/818ffafa-7f23-44b4-ab30-edcb72cca9b0">
