### PR TITLE
DEV: Fix flaky "Changing email" system tests

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -5,6 +5,7 @@ describe "Changing email", type: :system do
   fab!(:user) { Fabricate(:user, active: true, password: password) }
   let(:new_email) { "newemail@example.com" }
   let(:user_preferences_security_page) { PageObjects::Pages::UserPreferencesSecurity.new }
+  let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
 
   before { Jobs.run_immediately! }
 
@@ -45,7 +46,8 @@ describe "Changing email", type: :system do
     expect(page).to have_css(".dialog-body", text: I18n.t("js.user.change_email.confirm_success"))
     find(".dialog-footer .btn-primary").click
 
-    expect(user.reload.email).to eq(new_email)
+    expect(page).to have_current_path("/u/#{user.username}/preferences/account")
+    expect(user_preferences_page).to have_primary_email(new_email)
   end
 
   it "works when user has totp 2fa" do
@@ -60,9 +62,8 @@ describe "Changing email", type: :system do
 
     find("button[type=submit]").click
 
-    try_until_success { expect(current_url).to match("/u/#{user.username}/preferences/account") }
-
-    expect(user.reload.email).to eq(new_email)
+    expect(page).to have_current_path("/u/#{user.username}/preferences/account")
+    expect(user_preferences_page).to have_primary_email(new_email)
   end
 
   it "works when user has webauthn 2fa" do
@@ -98,9 +99,8 @@ describe "Changing email", type: :system do
 
     find("#security-key-authenticate-button").click
 
-    try_until_success { expect(current_url).to match("/u/#{user.username}/preferences/account") }
-
-    expect(user.reload.email).to eq(new_email)
+    expect(page).to have_current_path("/u/#{user.username}/preferences/account")
+    expect(user_preferences_page).to have_primary_email(new_email)
   ensure
     authenticator.remove!
   end
@@ -121,8 +121,7 @@ describe "Changing email", type: :system do
 
     find("button[type=submit]").click
 
-    try_until_success { expect(current_url).to match("/latest") }
-
+    expect(page).to have_current_path("/latest")
     expect(user.reload.email).to eq(new_email)
   end
 

--- a/spec/system/page_objects/pages/user_preferences.rb
+++ b/spec/system/page_objects/pages/user_preferences.rb
@@ -41,6 +41,10 @@ module PageObjects
         horizontal_secondary_link_visible?(ACCOUNT_LINK_CSS_SELECTOR, visible: false)
       end
 
+      def has_primary_email?(email)
+        has_css?(".email-first", text: email)
+      end
+
       private
 
       def horizontal_secondary_link_visible?(selector, visible: true)


### PR DESCRIPTION
Why this change?

`current_url` does not rely on Capybara waiters so opt to use
`have_current_path` matcher instead. Also assert for email against
element displayed on the page instead of querying the database for it
which isn't really what system tests are meant for.