### PR TITLE
DEV: Set `ExtraNavItem` count property to be a tracked property

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -325,9 +325,9 @@ export default class NavItem extends EmberObject {
   }
 }
 
-class ExtraNavItem extends NavItem {
+export class ExtraNavItem extends NavItem {
   @tracked href;
-  count = 0;
+  @tracked count = 0;
   customFilter = null;
 }
 

--- a/app/assets/javascripts/discourse/tests/unit/models/extra-nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/extra-nav-item-test.js
@@ -1,0 +1,25 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { ExtraNavItem } from "discourse/models/nav-item";
+
+module("Unit | Model | extra-nav-item", function (hooks) {
+  setupTest(hooks);
+
+  test("displayName updates when count property changes", function (assert) {
+    const extraNavItem = ExtraNavItem.create({
+      name: "something",
+    });
+
+    assert.strictEqual(
+      extraNavItem.displayName,
+      "[en.filters.something.title count=0]"
+    );
+
+    extraNavItem.count = 2;
+
+    assert.strictEqual(
+      extraNavItem.displayName,
+      "[en.filters.something.title_with_count count=2]"
+    );
+  });
+});


### PR DESCRIPTION
Why this change?

This regressed in b797434376133351dd1bfd728ab74551a8b0655a where
the count property in `ExtraNavItem` needs to be tracked as plugins can
be updating the count property directly.