### PR TITLE
FEATURE: Add plugin-outlet around sidebar container

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -5,6 +5,8 @@
     <Sidebar::SwitchPanelButtons @buttons={{this.switchPanelButtons}} />
   {{/if}}
 
+  <PluginOutlet @name="before-sidebar-sections" />
+
   {{#if this.sidebarState.showMainPanel}}
     <Sidebar::Sections
       @currentUser={{this.currentUser}}
@@ -17,6 +19,8 @@
       @collapsableSections={{true}}
     />
   {{/if}}
+
+  <PluginOutlet @name="after-sidebar-sections" />
 
   {{#unless this.showSwitchPanelButtonsOnTop}}
     <Sidebar::SwitchPanelButtons @buttons={{this.switchPanelButtons}} />


### PR DESCRIPTION
Why this change?

We have been getting customisation requests about adding stuff
before/after the sidebar sections so we are adding plugin outlets to
support those requests.