### PR TITLE
DEV: Do not process requests initiated by browser in a different example

### DIFF
--- a/plugins/chat/spec/system/chat_new_message_spec.rb
+++ b/plugins/chat/spec/system/chat_new_message_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Chat New Message from params", type: :system do
       expect(page).to have_current_path("/chat/c/#{user_2.username}/#{Chat::Channel.last.id}")
     end
 
-    xit "redirects to chat channel if recipients param is missing" do
+    it "redirects to chat channel if recipients param is missing" do
       visit("/chat/new-message")
 
       # chat service selects public channel from getIdealFirstChannelId

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -20,7 +20,7 @@ describe "Single thread in side panel", type: :system do
 
     before { channel.update!(threading_enabled: false) }
 
-    it "does not open the side panel for a single thread", capture_log: true do
+    it "does not open the side panel for a single thread" do
       thread =
         chat_thread_chain_bootstrap(channel: channel, users: [current_user, Fabricate(:user)])
       chat_page.visit_channel(channel)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -152,6 +152,7 @@ module TestSetup
 
     Middleware::AnonymousCache.disable_anon_cache
     BlockRequestsMiddleware.allow_requests!
+    BlockRequestsMiddleware.current_example_location = nil
   end
 end
 
@@ -592,6 +593,14 @@ RSpec.configure do |config|
         ActiveRecord::Base.connection.schema_cache.add(table)
       end
 
+      ApplicationController.before_action do
+        if BlockRequestsMiddleware.current_example_location
+          cookies[
+            BlockRequestsMiddleware::RSPEC_CURRENT_EXAMPLE_COOKIE_STRING
+          ] = BlockRequestsMiddleware.current_example_location
+        end
+      end
+
       system_tests_initialized = true
     end
 
@@ -609,6 +618,8 @@ RSpec.configure do |config|
     driven_by driver.join("_").to_sym
 
     setup_system_test
+
+    BlockRequestsMiddleware.current_example_location = example.location
   end
 
   config.after(:each, type: :system) do |example|


### PR DESCRIPTION
## Why this change?

We noticed that running `LOAD_PLUGINS=1 rspec --seed=38855 plugins/chat/spec/system/chat_new_message_spec.rb` locally
results in the system tests randomly failing. When we inspected the
request logs closely, we noticed that a `/presence/get` request from a
previous rspec example was being processed when a new rspec example is
already being run. We know it was from the previous rspec example
because inspecting the auth token showed the request using the auth
token of a user from the previous example. However, when a request using
an auth token from a previous example is used it ends up logging out the
same user on the server side because the user id in the cookie is the same
due to the use of `fab!`.

I did some research and there is apparently no way to wait until all
inflight requests by the browser has completed through capybara or
selenium. Therefore, we will add an identifier by attaching a cookie to all non-xhr requests so that
xhr requests which are triggered subsequently will contain the cookie in the request.

In the `BlockRequestsMiddleware` middleware, we will then reject any
requests when the value of the identifier in the cookie does not match the current rspec's example
location.

## Reviewer notes

To see the problem locally, change `Auth::DefaultCurrentUserProvider.find_v1_auth_cookie` to the following:

```
  def self.find_v1_auth_cookie(env)
    return env[DECRYPTED_AUTH_COOKIE] if env.key?(DECRYPTED_AUTH_COOKIE)

    env[DECRYPTED_AUTH_COOKIE] = begin
      request = ActionDispatch::Request.new(env)
      cookie = request.cookies[TOKEN_COOKIE]

      # don't even initialize a cookie jar if we don't have a cookie at all
      if cookie&.valid_encoding? && cookie.present?
        puts "#{env["REQUEST_PATH"]} #{request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access}"
        request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access
      end
    end
  end
```

After which run the following command: `LOAD_PLUGINS=1 rspec --format documentation --seed=38855 plugins/chat/spec/system/chat_new_message_spec.rb`

It takes a few tries but the last spec should fail and you should see something like this:

```
assets/chunk.c16f6ba8b6824baa47ac.d41d8cd9.js {"token"=>"37d995a4b65395d3b343ec70fff915b4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591735}
/assets/chunk.050148142e1d2dc992dd.d41d8cd9.js {"token"=>"37d995a4b65395d3b343ec70fff915b4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591735}
/chat/api/channels/527/messages {"token"=>"37d995a4b65395d3b343ec70fff915b4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591735}
/uploads/default/test_0/optimized/1X/_129430568242d1b7f853bb13ebea28b3f6af4e7_2_512x512.png {"token"=>"37d995a4b65395d3b343ec70fff915b4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591735}
    redirects to existing chat channel
    redirects to chat channel if recipients param is missing (PENDING: Temporarily skipped with xit)
  with multiple users
/favicon.ico {"token"=>"9a75c114c4d3401509a23d240f0a46d4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591736}
/chat/new-message {"token"=>"9a75c114c4d3401509a23d240f0a46d4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591736}
/presence/get {"token"=>"37d995a4b65395d3b343ec70fff915b4", "user_id"=>3382, "username"=>"bruce0", "trust_level"=>1, "issued_at"=>1708591735}
 ```
 
 Note how the `/presence/get` request is using a token from the previous example. 