### PR TITLE
FIX: followRedirects when changing sidebar panel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.js
@@ -29,7 +29,7 @@ export default class SwitchPanelButtons extends Component {
 
     if (this.destination) {
       try {
-        await this.router.transitionTo(this.destination);
+        await this.router.transitionTo(this.destination).followRedirects();
         this.sidebarState.setPanel(this.currentPanel.key);
       } finally {
         this.isSwitching = false;


### PR DESCRIPTION
It was necessary in chat as we will for example:

- transition to `/chat`
- and then attempt to transition to ideal first channel, eg: `/chat/-/1`
- and then redirect to `/chat/browse` if no channels exist

Prior to this fix, clicking on `chat` button in the sidebar from the homepage would work but generate an error in the console:

```
Uncaught (in promise) TransitionAborted: TransitionAborted
    at buildTransitionAborted (http://127.0.0.1:4200/assets/vendor.js:42895:17)
    at logAbort (http://127.0.0.1:4200/assets/vendor.js:43345:12)
    at PrivateRouter.transitionDidError (http://127.0.0.1:4200/assets/vendor.js:24561:44)
    at http://127.0.0.1:4200/assets/vendor.js:43129:35
    at invokeCallback (http://127.0.0.1:4200/assets/vendor.js:45239:17)
    at publish (http://127.0.0.1:4200/assets/vendor.js:45225:9)
    at publishRejection (http://127.0.0.1:4200/assets/vendor.js:45174:5)
    at http://127.0.0.1:4200/assets/vendor.js:40914:52
    at invoke (http://127.0.0.1:4200/assets/vendor.js:39539:16)
    at Queue.flush (http://127.0.0.1:4200/assets/vendor.js:39455:13)
    at DeferredActionQueues.flush (http://127.0.0.1:4200/assets/vendor.js:39611:21)
    at Backburner._end (http://127.0.0.1:4200/assets/vendor.js:40040:34)
    at Backburner._boundAutorunEnd (http://127.0.0.1:4200/assets/vendor.js:39776:14)
```

As explained above, this was only redproducible when no channels are present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
