### PR TITLE
FIX: allows to query a username made of integers

### DIFF
--- a/plugins/chat/app/queries/chat/users_from_usernames_and_groups_query.rb
+++ b/plugins/chat/app/queries/chat/users_from_usernames_and_groups_query.rb
@@ -9,8 +9,8 @@ module Chat
         .where(user_options: { chat_enabled: true })
         .where(
           "username IN (?) OR (groups.name IN (?) AND group_users.user_id IS NOT NULL)",
-          usernames,
-          groups,
+          usernames.map(&:to_s),
+          groups.map(&:to_s),
         )
         .where.not(id: excluded_user_ids)
         .distinct

--- a/plugins/chat/spec/queries/chat/users_from_usernames_and_groups_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/users_from_usernames_and_groups_query_spec.rb
@@ -15,11 +15,23 @@ describe Chat::UsersFromUsernamesAndGroupsQuery do
       result = described_class.call(usernames: [user1.username, user4.username], groups: [])
       expect(result).to contain_exactly(user1, user4)
     end
+
+    it "works with a number" do
+      user = Fabricate(:user, username: 12_345_678)
+      result = described_class.call(usernames: [12_345_678], groups: [])
+      expect(result).to contain_exactly(user)
+    end
   end
 
   context "when searching by groups" do
     it "returns users belonging to the specified groups" do
       result = described_class.call(usernames: [], groups: [group1.name])
+      expect(result).to contain_exactly(user1, user2)
+    end
+
+    it "works with a number" do
+      group = Fabricate(:public_group, users: [user1, user2], name: 12_345_678)
+      result = described_class.call(usernames: [], groups: [12_345_678])
       expect(result).to contain_exactly(user1, user2)
     end
   end


### PR DESCRIPTION
If a user had `123456789` as username, it could be passed to the query as a number and the query would fail as it expects a string.

Also applies the same fix to groups.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
