### PR TITLE
UX: tweaks for send button

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-composer.scss
@@ -5,12 +5,14 @@
   }
   &__outer-container {
     padding: 0;
+    align-items: flex-end;
 
     .chat-composer.is-disabled {
       opacity: 0.5;
     }
   }
   &__inner-container {
+    align-self: stretch;
     min-height: unset;
     .chat-composer.is-focused & {
       border-color: var(--primary-low);
@@ -27,19 +29,20 @@
     }
   }
   &-button__wrapper {
-    align-self: unset;
+    margin-bottom: 0.3em;
   }
   &-button.-send {
-    height: 100%;
+    height: auto;
     width: auto;
-    align-self: unset;
-    .d-icon {
-      padding: 0.5rem;
-      border-radius: 100%;
+    margin-inline: 0.7rem;
+    padding: 0.425em 0.5em;
+    border-radius: 100%;
 
-      .is-send-enabled.is-focused & {
-        background-color: var(--tertiary-high);
-        color: var(--secondary);
+    .is-send-enabled.is-focused & {
+      background-color: var(--tertiary-high);
+      color: var(--secondary);
+      .d-icon {
+        color: inherit;
       }
     }
   }


### PR DESCRIPTION
Issue on safari with the svg getting cutoff due to border-radius:

![image](https://github.com/discourse/discourse/assets/101828855/5012aff3-56ca-46c9-b34b-e0082eaf96df)

For posterity:
To avoid the issue, padding, bg-color, and radius need to be moved to the parent `button` element. 
Due to this, the padding on the button is smaller (otherwise the button looks too big when the color is applied) because lateral spacing had to be replaced by margin.
Due to this, the click target is smaller than it was.