### PR TITLE
FIX: Make category-drop search subcategories

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -139,22 +139,26 @@ export default ComboBoxComponent.extend({
 
   async search(filter) {
     if (this.site.lazy_load_categories) {
-      const results = await Category.asyncSearch(filter, {
-        parentCategoryId: this.options.parentCategory?.id || -1,
-        includeUncategorized: this.siteSettings.allow_uncategorized_topics,
-        limit: 15,
-      });
-      return this.shortcuts.concat(
-        results.sort((a, b) => {
-          if (a.parent_category_id && !b.parent_category_id) {
-            return 1;
-          } else if (!a.parent_category_id && b.parent_category_id) {
-            return -1;
-          } else {
-            return 0;
-          }
+      let parentCategoryId;
+      if (this.options.parentCategory?.id) {
+        parentCategoryId = this.options.parentCategory.id;
+      } else if (!filter) {
+        // Only top-level categories should be displayed by default.
+        // If there is a search term, the term can match any category,
+        // including subcategories.
+        parentCategoryId = -1;
+      }
+
+      const results = (
+        await Category.asyncSearch(filter, {
+          parentCategoryId,
+          includeUncategorized: this.siteSettings.allow_uncategorized_topics,
+          includeAncestors: true,
+          limit: 15,
         })
-      );
+      ).categories;
+
+      return this.shortcuts.concat(results);
     }
 
     const opts = {


### PR DESCRIPTION
Subcategories were not returned when lazy loaded categories are enabled. This commit implements the old behavior which displayed only top level categories when there was no search term, but when there was one, it searched subcategories too.

This commit also removes the client-side ordering of categories, because the results are already ordered on the server-side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
