### PR TITLE
DEV: Ensure `rspec_current_example_location` is actually present

### DIFF
--- a/config/initializers/200-first_middlewares.rb
+++ b/config/initializers/200-first_middlewares.rb
@@ -58,7 +58,7 @@ if Rails.env.test?
            (
              @@block_requests ||
                (
-                 self.class.current_example_location.present? &&
+                 request.cookies[RSPEC_CURRENT_EXAMPLE_COOKIE_STRING].present? &&
                    self.class.current_example_location !=
                      request.cookies[RSPEC_CURRENT_EXAMPLE_COOKIE_STRING]
                )


### PR DESCRIPTION

Follow up to https://github.com/discourse/discourse/commit/6e9fbb5babf50c7d00fc612bcd2764bf252b9ffb.

 Ensure the cookie value present before checking agains't `BlockRequestsMiddleware`'s `current_example_location`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
