### PR TITLE
FIX: Regression with `onFilesPicked` action

### DIFF
--- a/app/assets/javascripts/discourse/app/components/pick-files-button.js
+++ b/app/assets/javascripts/discourse/app/components/pick-files-button.js
@@ -91,6 +91,10 @@ export default Component.extend({
       this.dialog.alert(message);
       return;
     }
+
+    if (typeof this.onFilesPicked === "function") {
+      this.onFilesPicked(files);
+    }
   },
 
   _haveAcceptedTypes(files) {


### PR DESCRIPTION
A regression was introduced in a previous commit (https://github.com/discourse/discourse/pull/22232#discussion_r1244417291) which removed `this.onFilesPicked(files)` action because it seemed as if it was not being used. It was also causing errors in the console with usage in the composer for form templates.

However, `<PickFilesButton />` in fact accepts `this.onFilesPicked` as an action passed, which is used, for example, in the Data Explorer plugin. This was apparent as imports [stopped working](https://meta.discourse.org/t/discourse-data-explorer-import-no-longer-works/295074) in Data Explorer.

In this PR, we reintroduce the call to the `this.onFilesPicked(files)` action, however we wrap it in a type check so that it doesn't get called in other usages of the component such as with the form template uploader where it was previously causing errors in the console.