### PR TITLE
UX: group names shouldn't always be capitalized

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -1,7 +1,6 @@
 import Controller, { inject as controller } from "@ember/controller";
 import EmberObject, { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { capitalize } from "@ember/string";
 import GroupDeleteDialog from "discourse/components/dialog-messages/group-delete";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
@@ -108,11 +107,6 @@ export default Controller.extend({
     }
 
     return isGroupUser || (this.currentUser && this.currentUser.admin);
-  },
-
-  @discourseComputed("model.displayName", "model.full_name")
-  groupName(displayName, fullName) {
-    return capitalize(fullName || displayName);
   },
 
   @discourseComputed("model.messageable")

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -31,11 +31,19 @@
       {{/if}}
 
       <div class="group-info-names">
-        <span class="group-info-name">{{this.groupName}}</span>
+        <span class="group-info-name">
+          {{#if this.model.full_name}}
+            {{this.model.full_name}}
+          {{else}}
+            {{this.model.name}}
+          {{/if}}
+        </span>
 
-        {{#if this.model.full_name}}<div
-            class="group-info-full-name"
-          >{{this.model.name}}</div>{{/if}}
+        {{#if this.model.full_name}}
+          <div class="group-info-full-name">
+            {{this.model.name}}
+          </div>
+        {{/if}}
       </div>
 
       <div class="group-details-button">

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -32,11 +32,7 @@
 
       <div class="group-info-names">
         <span class="group-info-name">
-          {{#if this.model.full_name}}
-            {{this.model.full_name}}
-          {{else}}
-            {{this.model.name}}
-          {{/if}}
+          {{or this.model.full_name this.model.name}}
         </span>
 
         {{#if this.model.full_name}}


### PR DESCRIPTION
Admins should be able to control this by changing the text input.

Before:
![Screenshot 2024-02-22 at 2 49 17 PM](https://github.com/discourse/discourse/assets/1681963/65d1ab0a-b227-436f-906b-52d90db9a071)


After:
![Screenshot 2024-02-22 at 2 48 58 PM](https://github.com/discourse/discourse/assets/1681963/b059c2eb-5df0-4392-80d0-a7386738d901)
