### PR TITLE
UX: fix topic map link expansion hover

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-map.js
@@ -34,7 +34,7 @@ createWidget("topic-map-show-links", {
         title: "topic_map.links_shown",
         icon: "chevron-down",
         action: "showLinks",
-        className: "btn",
+        className: "btn btn-flat",
       })
     );
   },

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -759,6 +759,18 @@ aside.quote {
     }
   }
 
+  .link-summary .btn {
+    width: 100%;
+    .d-icon {
+      color: var(--primary-high);
+    }
+    .discourse-no-touch & {
+      &:hover {
+        background: var(--primary-low);
+      }
+    }
+  }
+
   .controls {
     display: flex;
     align-items: center;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -316,15 +316,6 @@ pre.codeblock-buttons:hover {
       }
     }
   }
-  .link-summary .btn {
-    color: var(--primary-med-or-secondary-high);
-    background: var(--blend-primary-secondary-5);
-    width: 100%;
-    &:hover {
-      color: var(--primary);
-      background: var(--primary-low);
-    }
-  }
 
   .toggle-summary .summarization-buttons .top-replies {
     margin-left: 10px;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -194,11 +194,6 @@ a.reply-to-tab {
       }
     }
   }
-  .link-summary .btn {
-    color: var(--primary-med-or-secondary-high);
-    background: var(--blend-primary-secondary-5);
-    width: 100%;
-  }
 
   .toggle-summary {
     .summarization-buttons {


### PR DESCRIPTION
Fixes the hover style, and also adds a missing class to the button and consolidates styles into /common

Before:
![Screenshot 2024-02-22 at 2 58 25 PM](https://github.com/discourse/discourse/assets/1681963/95ee3913-94c6-43de-afd3-bb28ae3eec13)


After:
![Screenshot 2024-02-22 at 2 58 40 PM](https://github.com/discourse/discourse/assets/1681963/1fd6e204-3328-45c4-a127-b4ee4b2e6af7)
