### PR TITLE
DEV: appEvents when desktop/push JS notifications are opened

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -259,6 +259,11 @@ export default {
 
   @bind
   onAlert(data) {
-    return onNotification(data, this.siteSettings, this.currentUser);
+    return onNotification(
+      data,
+      this.siteSettings,
+      this.currentUser,
+      this.appEvents
+    );
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -144,7 +144,7 @@ function isIdle() {
 }
 
 // Call-in point from message bus
-async function onNotification(data, siteSettings, user) {
+async function onNotification(data, siteSettings, user, appEvents) {
   if (!liveEnabled) {
     return;
   }
@@ -187,6 +187,7 @@ async function onNotification(data, siteSettings, user) {
   });
   notification.onclick = () => {
     DiscourseURL.routeTo(data.post_url);
+    appEvents.trigger("desktop-notification-clicked", { url: data.post_url });
     notification.close();
   };
 

--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -187,7 +187,7 @@ async function onNotification(data, siteSettings, user, appEvents) {
   });
   notification.onclick = () => {
     DiscourseURL.routeTo(data.post_url);
-    appEvents.trigger("desktop-notification-clicked", { url: data.post_url });
+    appEvents.trigger("desktop-notification-opened", { url: data.post_url });
     notification.close();
   };
 

--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -74,7 +74,7 @@ export function register(user, router, appEvents) {
   navigator.serviceWorker.addEventListener("message", (event) => {
     if ("url" in event.data) {
       router.transitionTo(event.data.url);
-      appEvents.trigger("push-notification-clicked", { url: event.data.url });
+      appEvents.trigger("push-notification-opened", { url: event.data.url });
     }
   });
 }

--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -47,7 +47,7 @@ export function isPushNotificationsEnabled(user) {
   );
 }
 
-export function register(user, router) {
+export function register(user, router, appEvents) {
   if (!isPushNotificationsSupported()) {
     return;
   }
@@ -74,6 +74,7 @@ export function register(user, router) {
   navigator.serviceWorker.addEventListener("message", (event) => {
     if ("url" in event.data) {
       router.transitionTo(event.data.url);
+      appEvents.trigger("push-notification-clicked", { url: event.data.url });
     }
   });
 }


### PR DESCRIPTION
In a plugin we want to capture metrics around users clicking browser push notifications. We have a couple protocols on how notifications are delivered to browsers, so have to add a hook in both places. 

I don't love the language of push vs desktop here...... but this is the language Core uses now.