### PR TITLE
DEV: update modal classes, remove unused CSS

### DIFF
--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -1127,7 +1127,7 @@ table.permalinks {
 }
 
 .customize-form-template-view-modal {
-  .modal-footer {
+  .d-modal__footer {
     .btn:last-child {
       margin-left: auto;
     }

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -70,13 +70,8 @@
       }
     }
   }
-  .modal-footer {
-    display: flex;
+  .d-modal__footer {
     justify-content: space-between;
-
-    .reset-to-default {
-      margin-right: 0;
-    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -15,8 +15,7 @@
     min-height: 65dvh;
   }
 
-  .modal-footer {
-    gap: 0.5em;
+  .d-modal__footer {
     justify-content: space-between;
   }
 

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -8,20 +8,6 @@ body.invite-page {
 
 .invites-show,
 .admin-invite-page {
-  .modal-inner-container {
-    position: relative;
-  }
-  .modal-body {
-    padding: 0;
-  }
-  .modal-header {
-    border-bottom: none;
-    padding: 0;
-    position: absolute;
-    top: 0.75em;
-    right: 0.75em;
-    z-index: z("max");
-  }
   #modal-alert {
     box-sizing: border-box;
     display: inline-block;
@@ -37,11 +23,6 @@ body.invite-page {
     padding: 0px;
     overflow: hidden;
     display: inline;
-  }
-  .modal-footer {
-    .inline-spinner {
-      display: inline-flex;
-    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -160,36 +160,6 @@
   color: var(--secondary-high);
 }
 
-.modal-header {
-  display: flex;
-  padding: 10px 15px;
-  border-bottom: 1px solid var(--primary-low);
-  align-items: center;
-
-  .title {
-    margin-right: 1em;
-
-    h3 {
-      margin-bottom: 0;
-    }
-
-    p {
-      margin: 0;
-    }
-  }
-
-  .modal-close {
-    order: 2;
-    margin-left: auto;
-    align-self: start;
-    padding: 0.15em 0;
-
-    .close {
-      color: var(--primary-high);
-    }
-  }
-}
-
 .modal-backdrop {
   user-select: none;
   position: fixed;
@@ -260,21 +230,6 @@
 
 .modal-form {
   margin-bottom: 0;
-}
-
-.modal-footer {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  padding: 14px 15px 10px;
-  border-top: 1px solid var(--primary-low);
-  gap: 0.3em 0;
-  .btn {
-    margin: 0 0.75em 0 0;
-    &[href] {
-      min-height: unset;
-    }
-  }
 }
 
 .modal {
@@ -469,14 +424,6 @@
       .discourse-tag {
         color: var(--text-color);
       }
-    }
-  }
-}
-
-.delete-user-modal {
-  .modal-footer {
-    .btn {
-      line-height: var(--line-height-medium);
     }
   }
 }

--- a/app/assets/stylesheets/common/base/topic-admin-menu.scss
+++ b/app/assets/stylesheets/common/base/topic-admin-menu.scss
@@ -91,33 +91,6 @@
   }
 }
 
-.desktop-view .feature-topic-modal {
-  .pin-until {
-    position: relative;
-    display: inline-block;
-  }
-  .modal-inner-container {
-    overflow: visible;
-  }
-  .modal-footer {
-    background: var(--secondary);
-  }
-}
-
-.mobile-view .feature-topic .feature-section {
-  .desc {
-    display: block;
-    clear: both;
-    max-width: 90%;
-    margin: 0;
-  }
-  .badge-category__wrapper {
-    white-space: nowrap;
-    overflow: hidden;
-    max-width: 19em;
-  }
-}
-
 // Select posts
 
 .selected-posts {

--- a/app/assets/stylesheets/common/components/add-pm-participants.scss
+++ b/app/assets/stylesheets/common/components/add-pm-participants.scss
@@ -1,16 +1,3 @@
-.add-pm-participants.modal {
-  .modal-body {
-    max-width: 475px;
-    min-width: 320px;
-  }
-
-  .modal-header {
-    .modal-close {
-      padding-left: 0;
-    }
-  }
-}
-
 .add-pm-participants.modal .share.modal-panel {
   .header {
     display: flex;

--- a/app/assets/stylesheets/common/table-builder/insert-table-modal.scss
+++ b/app/assets/stylesheets/common/table-builder/insert-table-modal.scss
@@ -39,10 +39,7 @@
     margin: 0;
   }
 
-  .d-modal__footer,
-  .modal-footer {
-    display: flex;
-    align-items: center;
+  .d-modal__footer {
     justify-content: space-between;
 
     .primary-actions {

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -158,14 +158,6 @@ input {
   }
 }
 
-.bootbox.modal {
-  .modal-footer {
-    a.btn-primary {
-      color: var(--secondary);
-    }
-  }
-}
-
 /* bootstrap columns */
 
 .offset {

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -32,16 +32,6 @@
   }
 }
 
-.modal-footer .btn.right {
-  float: right;
-}
-
-.modal-header {
-  h3 {
-    font-size: var(--font-up-3);
-  }
-}
-
 .close {
   font-size: var(--font-up-3);
   text-decoration: none;

--- a/app/assets/stylesheets/mobile/invite-signup.scss
+++ b/app/assets/stylesheets/mobile/invite-signup.scss
@@ -1,7 +1,6 @@
 .invites-show {
-  width: 100vw;
   box-sizing: border-box;
-  padding: 0 1em 1em;
+  padding: 1em;
 
   .invitation-cta {
     display: flex;

--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -51,61 +51,14 @@
   }
 }
 
-// we need a little extra room on mobile for the
-// stuff inside the footer to fit
-.modal-footer {
-  padding: 10px;
-}
-
-.modal-header {
-  padding: 10px;
-  h3 {
-    font-size: var(--font-up-2);
-  }
-}
-
 .close {
   font-size: var(--font-up-4);
 }
 
-#choosing-topic {
-  p {
-    margin-top: 0;
-    padding-bottom: 0;
-  }
-
-  input[type="radio"] {
-    margin-right: 10px;
-  }
-
-  .category-chooser {
-    margin-bottom: 9px;
-  }
-
-  button {
-    margin-top: 10px;
-    display: block;
-  }
-
-  form {
-    margin-top: 20px;
-    input:not(.filter-input)[type="text"] {
-      box-sizing: border-box;
-      width: 100%;
-    }
-  }
-}
-
 @media only screen and (max-device-width: 568px) {
-  .modal .flag-modal-body .flag-message {
+  .flag-modal-body .flag-message {
     height: 3em;
   }
-}
-
-/* fixes for the new account confirm dialog on mobile */
-
-.modal-inner-container {
-  margin-bottom: 20px;
 }
 
 /* fix for tall modals */
@@ -128,25 +81,6 @@
 
     .modal-inner-container {
       margin: auto;
-    }
-  }
-}
-
-.modal .modal-body.reorder-categories {
-  max-height: calc(100vh - 220px);
-}
-
-.discard-draft-modal {
-  .modal-inner-container {
-    width: 250px;
-  }
-  .modal-footer {
-    justify-content: center;
-    flex-flow: column nowrap;
-    align-items: stretch;
-
-    .btn {
-      margin-right: 0;
     }
   }
 }


### PR DESCRIPTION
There were some cases where `modal-footer` and `modal-header` needed to be converted to `d-modal__footer` and `d-modal__header`

I've double-checked the relevant places for the removals, so as far as I know they're safe! 