### PR TITLE
DEV: Only enable turbo_rspec retry on main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       EMBER_VERSION: ${{ (matrix.updated_ember && '5') || '3' }}
-      DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref_name == 'main' }}
+      DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/main/head' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Why this change?

Our tests are more stable these days and there is little to no need for
us to be retrying on PRs which helps to increase confidence in our test
suite since flaky tests are raised earlier.