### PR TITLE
FEATURE: Add user status to chat members list

### DIFF
--- a/plugins/chat/app/serializers/chat/user_channel_membership_serializer.rb
+++ b/plugins/chat/app/serializers/chat/user_channel_membership_serializer.rb
@@ -2,7 +2,7 @@
 
 module Chat
   class UserChannelMembershipSerializer < BaseChannelMembershipSerializer
-    has_one :user, serializer: ::Chat::BasicUserSerializer, embed: :objects
+    has_one :user, serializer: ::Chat::ChatableUserSerializer, embed: :objects
 
     def user
       object.user || Chat::NullUser.new

--- a/plugins/chat/assets/javascripts/discourse/components/chat-user-display-name.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-user-display-name.gjs
@@ -30,7 +30,6 @@ export default class ChatUserDisplayName extends Component {
     <span class="chat-user-display-name">
       {{#if this.shouldShowNameFirst}}
         <span class="chat-user-display-name__name -first">{{@user.name}}</span>
-        <span class="separator">—</span>
       {{/if}}
 
       <span
@@ -43,7 +42,6 @@ export default class ChatUserDisplayName extends Component {
       </span>
 
       {{#if this.shouldShowNameLast}}
-        <span class="separator">—</span>
         <span class="chat-user-display-name__name">{{@user.name}}</span>
       {{/if}}
     </span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-user-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-user-info.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { userPath } from "discourse/lib/url";
 import ChatUserAvatar from "discourse/plugins/chat/discourse/components/chat-user-avatar";
 import ChatUserDisplayName from "discourse/plugins/chat/discourse/components/chat-user-display-name";
+import UserStatusMessage from "discourse/components/user-status-message";
 
 export default class ChatUserInfo extends Component {
   get avatarSize() {
@@ -14,6 +15,14 @@ export default class ChatUserInfo extends Component {
 
   get interactive() {
     return this.args.interactive ?? false;
+  }
+
+  get showStatus() {
+    return this.args.showStatus ?? false;
+  }
+
+  get showStatusDescription() {
+    return this.args.showStatusDescription ?? false;
   }
 
   <template>
@@ -30,6 +39,13 @@ export default class ChatUserInfo extends Component {
         </a>
       {{else}}
         <ChatUserDisplayName @user={{@user}} />
+      {{/if}}
+
+      {{#if this.showStatus}}
+        <UserStatusMessage
+          @status={{@user.status}}
+          @showDescription={{this.showStatusDescription}}
+        />
       {{/if}}
     {{/if}}
   </template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-user-info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-user-info.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
+import UserStatusMessage from "discourse/components/user-status-message";
 import { userPath } from "discourse/lib/url";
 import ChatUserAvatar from "discourse/plugins/chat/discourse/components/chat-user-avatar";
 import ChatUserDisplayName from "discourse/plugins/chat/discourse/components/chat-user-display-name";
-import UserStatusMessage from "discourse/components/user-status-message";
 
 export default class ChatUserInfo extends Component {
   get avatarSize() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
@@ -176,6 +176,8 @@ export default class ChatRouteChannelInfoMembers extends Component {
                 @user={{membership.user}}
                 @avatarSize="tiny"
                 @interactive={{false}}
+                @showStatus={{true}}
+                @showStatusDescription={{true}}
               />
             </li>
           {{else}}

--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -29,7 +29,8 @@
       }
 
       &.-member {
-        .chat-user-avatar {
+        .chat-user-avatar,
+        .chat-user-display-name {
           margin-right: 0.5rem;
         }
       }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -33,6 +33,10 @@
         .chat-user-display-name {
           margin-right: 0.5rem;
         }
+
+        .user-status-message-description {
+          color: var(--primary-medium);
+        }
       }
 
       &.-add-member {

--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -29,13 +29,25 @@
       }
 
       &.-member {
-        .chat-user-avatar,
-        .chat-user-display-name {
+        .chat-user-avatar {
           margin-right: 0.5rem;
         }
 
-        .user-status-message-description {
+        .chat-user-display-name span:not(.-first) {
+          color: var(--primary-high);
+          font-size: var(--font-down-1);
+          margin-left: 0.5rem;
+        }
+
+        .user-status-message {
           color: var(--primary-medium);
+          font-size: var(--font-down-2);
+          margin-left: 0.5rem;
+
+          .emoji {
+            height: var(--font-0);
+            width: var(--font-0);
+          }
         }
       }
 

--- a/plugins/chat/spec/support/api/schemas/user_chat_channel_membership.json
+++ b/plugins/chat/spec/support/api/schemas/user_chat_channel_membership.json
@@ -24,6 +24,7 @@
         "name": { "type": "string" },
         "avatar_template": { "type": "string" },
         "username": { "type": "string" },
+        "custom_fields": { "type": ["object", "null"] },
         "can_chat": { "type": "boolean" },
         "has_chat_enabled": { "type": "boolean" }
       }

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -62,6 +62,19 @@ RSpec.describe "Channel - Info - Members page", type: :system do
           expect(page).to have_selector(".c-channel-members__list-item", count: 1, text: "cat")
         end
       end
+
+      context "with user status" do
+        it "renders status next to name" do
+          SiteSetting.enable_user_status = true
+          current_user.set_status!("walking the dog", "dog")
+
+          chat_page.visit_channel_members(channel_1)
+
+          expect(page).to have_selector(
+            ".-member .user-status-message img[alt='#{current_user.user_status.emoji}']",
+          )
+        end
+      end
     end
   end
 

--- a/plugins/chat/test/javascripts/components/chat-user-display-name-test.js
+++ b/plugins/chat/test/javascripts/components/chat-user-display-name-test.js
@@ -28,7 +28,7 @@ module(
 
       await render(hbs`<ChatUserDisplayName @user={{this.user}} />`);
 
-      assert.strictEqual(displayName(), "bob — Bobcat");
+      assert.strictEqual(displayName(), "bob Bobcat");
     });
   }
 );
@@ -53,7 +53,7 @@ module(
 
       await render(hbs`<ChatUserDisplayName @user={{this.user}} />`);
 
-      assert.strictEqual(displayName(), "Bobcat — bob");
+      assert.strictEqual(displayName(), "Bobcat bob");
     });
   }
 );


### PR DESCRIPTION
When the site setting `enable_user_status` is true, we allow users to set a custom user status. This is useful to see when someone is on leave, sick or just away from their desk.

This change adds the user status next to the user's name within the chat channel members list.

After this change:

<img width="570" alt="Screenshot 2024-02-26 at 3 27 28 PM" src="https://github.com/discourse/discourse/assets/2257978/91acf352-6e5c-4d17-8200-b6c03b261f2e">
