### PR TITLE
FIX: Prevent admin sidebar errors in safe mode

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -224,6 +224,7 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const siteSettings = getOwnerWithFallback(this).lookup(
       "service:site-settings"
     );
+    const session = getOwnerWithFallback(this).lookup("service:session");
     if (!currentUser.use_admin_sidebar) {
       return [];
     }
@@ -235,7 +236,9 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const savedConfig = this.adminSidebarExperimentStateManager.navConfig;
     const navMap = savedConfig || ADMIN_NAV_MAP;
 
-    navMap.findBy("name", "plugins").links.push(...pluginAdminRouteLinks());
+    if (!session.get("safe_mode")) {
+      navMap.findBy("name", "plugins").links.push(...pluginAdminRouteLinks());
+    }
 
     if (siteSettings.experimental_form_templates) {
       navMap.findBy("name", "customize").links.push({

--- a/app/views/safe_mode/index.html.erb
+++ b/app/views/safe_mode/index.html.erb
@@ -34,7 +34,7 @@
     </p>
 
     <p>
-      <%= submit_tag t('safe_mode.enter'), class: 'btn btn-danger' %>
+      <%= submit_tag t('safe_mode.enter'), class: 'btn btn-danger', id: "btn-enter-safe-mode" %>
       <%- if flash[:must_select] %>
         <span class='safe-mode-warning'>
           ⚠️ <%= t 'safe_mode.must_select' %>

--- a/plugins/chat/spec/system/admin_sidebar_navigation_spec.rb
+++ b/plugins/chat/spec/system/admin_sidebar_navigation_spec.rb
@@ -23,6 +23,14 @@ describe "Admin Revamp | Sidebar Navigation | Plugin Links", type: :system do
     expect(sidebar).to have_section_link("Chat", href: "/admin/plugins/chat", count: 1)
   end
 
+  it "does not show plugin links in the admin sidebar in safe mode" do
+    visit("/safe-mode")
+    find("#btn-enter-safe-mode").click
+    expect(sidebar).to have_section_link("Admin", href: "/admin")
+    sidebar.click_link_in_section("community", "admin")
+    expect(sidebar).to have_no_section_link("Chat", href: "/admin/plugins/chat")
+  end
+
   describe "admin sidebar respects separated and combined sidebar modes" do
     it "reverts to always (separated) mode after entering and leaving admin section" do
       admin.user_option.update!(


### PR DESCRIPTION
In safe mode plugins are not loaded, so the plugin admin
routes are not loaded. This was causing errors in the
admin sidebar because we are trying to show links to the plugin
admin routes.

This fixes the issue by just not adding the plugin links if
we are in safe mode.
