### PR TITLE
DEV: Include deprecation link in warning banner

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -58,10 +58,10 @@ export default class DeprecationWarningHandler extends Service {
       return;
     }
 
-    this.maybeNotifyAdmin(opts.id, source);
+    this.maybeNotifyAdmin(opts, source);
   }
 
-  maybeNotifyAdmin(id, source) {
+  maybeNotifyAdmin(opts, source) {
     if (this.#adminWarned) {
       return;
     }
@@ -74,17 +74,26 @@ export default class DeprecationWarningHandler extends Service {
       return;
     }
 
-    if (CRITICAL_DEPRECATIONS.some((pattern) => pattern.test(id))) {
-      this.notifyAdmin(id, source);
+    if (CRITICAL_DEPRECATIONS.some((pattern) => pattern.test(opts.id))) {
+      this.notifyAdmin(opts, source);
     }
   }
 
-  notifyAdmin(id, source) {
+  notifyAdmin({ id, url }, source) {
     this.#adminWarned = true;
 
-    let notice = I18n.t("critical_deprecation.notice", {
-      id: escapeExpression(id),
-    });
+    let notice = I18n.t("critical_deprecation.notice") + " ";
+
+    if (url) {
+      notice += I18n.t("critical_deprecation.linked_id", {
+        id: escapeExpression(id),
+        url: escapeExpression(url),
+      });
+    } else {
+      notice += I18n.t("critical_deprecation.id", {
+        id: escapeExpression(id),
+      });
+    }
 
     if (this.siteSettings.warn_critical_js_deprecations_message) {
       notice += " " + this.siteSettings.warn_critical_js_deprecations_message;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -226,7 +226,9 @@ en:
     broken_plugin_alert: "Caused by plugin '%{name}'"
 
     critical_deprecation:
-      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (id:<em>%{id}</em>)."
+      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes."
+      id: "(id:<em>%{id}</em>)"
+      linked_id: "(id:<a href='%{url}' target='_blank'><em>%{id}</em></a>)"
       theme_source: "Identified theme: <a target='_blank' href='%{path}'>'%{name}'</a>."
       plugin_source: "Identified plugin: '%{name}'"
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
<img width="661" alt="SCR-20240223-koyt" src="https://github.com/discourse/discourse/assets/6270921/f343f29e-6c4f-471d-a7f0-b49f1c81bb38">
