### PR TITLE
DEV: adds a `chat_can_create_direct_message_channel` modifier

### DIFF
--- a/plugins/chat/app/services/chat/create_direct_message_channel.rb
+++ b/plugins/chat/app/services/chat/create_direct_message_channel.rb
@@ -22,9 +22,9 @@ module Chat
     #   @option params_to_create [Array<String>] target_groups
     #   @return [Service::Base::Context]
 
-    policy :can_create_direct_message
     contract
     model :target_users
+    policy :can_create_direct_message
     policy :satisfies_dms_max_users_limit,
            class_name: Chat::DirectMessageChannel::MaxUsersExcessPolicy
     model :user_comm_screener
@@ -53,8 +53,13 @@ module Chat
 
     private
 
-    def can_create_direct_message(guardian:, **)
-      guardian.can_create_direct_message?
+    def can_create_direct_message(guardian:, target_users:, **)
+      guardian.can_create_direct_message? &&
+        DiscoursePluginRegistry.apply_modifier(
+          :chat_can_create_direct_message_channel,
+          guardian.user,
+          target_users,
+        )
     end
 
     def fetch_target_users(guardian:, contract:, **)

--- a/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
@@ -178,6 +178,22 @@ RSpec.describe Chat::CreateDirectMessageChannel do
       it { is_expected.to fail_a_policy(:can_create_direct_message) }
     end
 
+    context "when the plugin modifier returns false" do
+      it "fails a policy" do
+        modifier_block = Proc.new { false }
+        plugin_instance = Plugin::Instance.new
+        plugin_instance.register_modifier(:chat_can_create_direct_message_channel, &modifier_block)
+
+        expect(result).to fail_a_policy(:can_create_direct_message)
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :chat_can_create_direct_message_channel,
+          &modifier_block
+        )
+      end
+    end
+
     context "when the actor is not allowing anyone to message them" do
       before { current_user.user_option.update!(allow_private_messages: false) }
 


### PR DESCRIPTION
Plugins can now register this modifier:

```ruby
register_modifier(:chat_can_create_direct_message_channel) do |user, target_users|
  # your logic which should return true or false
end
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
