### PR TITLE
Revert "FIX: Show Uncategorized in category-chooser (#25794)"

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -17,8 +17,7 @@ export default ComboBoxComponent.extend({
 
   selectKitOptions: {
     filterable: true,
-    autoInsertNoneItem: false,
-    allowUncategorized: "allowUncategorizedTopics",
+    allowUncategorized: false,
     allowSubCategories: true,
     permissionType: PermissionType.FULL,
     excludeCategoryId: null,
@@ -55,7 +54,10 @@ export default ComboBoxComponent.extend({
           I18n.t(isString ? this.selectKit.options.none : "category.none")
         )
       );
-    } else if (this.selectKit.options.allowUncategorized) {
+    } else if (
+      this.allowUncategorizedTopics ||
+      this.selectKit.options.allowUncategorized
+    ) {
       return Category.findUncategorized();
     } else {
       const defaultCategoryId = parseInt(
@@ -92,7 +94,6 @@ export default ComboBoxComponent.extend({
   search(filter) {
     if (this.site.lazy_load_categories) {
       return Category.asyncSearch(this._normalize(filter), {
-        includeUncategorized: this.allowUncategorizedTopics,
         scopedCategoryId: this.selectKit.options?.scopedCategoryId,
         prioritizedCategoryId: this.selectKit.options?.prioritizedCategoryId,
       });

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -24,7 +24,6 @@ export default ComboBoxComponent.extend({
   navigateToEdit: false,
   editingCategory: false,
   editingCategoryTab: null,
-  allowUncategorizedTopics: setting("allow_uncategorized_topics"),
 
   selectKitOptions: {
     filterable: true,
@@ -41,7 +40,7 @@ export default ComboBoxComponent.extend({
     displayCategoryDescription: "displayCategoryDescription",
     headerComponent: "category-drop/category-drop-header",
     parentCategory: false,
-    allowUncategorized: "allowUncategorizedTopics",
+    allowUncategorized: setting("allow_uncategorized_topics"),
   },
 
   modifyComponentForRow() {


### PR DESCRIPTION
This reverts commit 1df473b530c780c2c90dcddfd7c75da68afe0bc7. This is temporary, this commit cased the "(no category)" option to go missing from the admin UI of managing categories. See report: https://meta.discourse.org/t/unable-to-remove-parent-category-to-make-subcategory-a-parent/296404 