### PR TITLE
DEV: include more data in Discourse Discover enrollment payload.

### DIFF
--- a/lib/discourse_hub.rb
+++ b/lib/discourse_hub.rb
@@ -15,7 +15,12 @@ module DiscourseHub
   end
 
   def self.discover_enrollment_payload
-    { include_in_discourse_discover: SiteSetting.include_in_discourse_discover? }
+    {
+      include_in_discourse_discover: SiteSetting.include_in_discourse_discover?,
+      forum_url: Discourse.base_url,
+      forum_title: SiteSetting.title,
+      locale: I18n.locale,
+    }
   end
 
   def self.discover_enrollment

--- a/spec/lib/discourse_hub_spec.rb
+++ b/spec/lib/discourse_hub_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe DiscourseHub do
     end
   end
 
+  describe ".discover_enrollment_payload" do
+    it "should return the correct payload" do
+      payload = DiscourseHub.discover_enrollment_payload
+      expect(payload[:forum_url]).to eq(Discourse.base_url)
+      expect(payload[:forum_title]).to eq(SiteSetting.title)
+      expect(payload[:locale]).to eq(I18n.locale)
+    end
+  end
+
   describe ".version_check_payload" do
     describe "when Discourse Hub has not fetched stats since past 7 days" do
       it "should include stats" do


### PR DESCRIPTION
Adding forum's URL, title, and locale to the payload of enrollment can be helpful while managing it in the Discourse Discover.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
