### PR TITLE
FIX: prevents exception when last reply has deleted user

### DIFF
--- a/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
@@ -32,7 +32,7 @@ module Chat
     end
 
     def last_reply_user
-      object.last_message.user
+      object.last_message.user || Chat::NullUser.new
     end
 
     def include_participant_data?

--- a/plugins/chat/spec/system/thread_preview_spec.rb
+++ b/plugins/chat/spec/system/thread_preview_spec.rb
@@ -46,6 +46,17 @@ describe "Thread preview", type: :system do
       expect(channel_page.messages).to have_message(id: message_1.id)
       expect(channel_page).to have_thread_indicator(message_1)
     end
+
+    context "when the user of the preview has been deleted" do
+      before { thread_1_message_1.user.destroy! }
+
+      it "shows a deleted user" do
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page).to have_thread_indicator(message_1)
+        expect(channel_page).to have_css(".chat-user-avatar[data-username='deleted']")
+      end
+    end
   end
 
   context "when message has thread with deleted original message" do


### PR DESCRIPTION
Prior to this fix, if the last message of a thread had been made by a deleted user it would cause an exception as we would have no user to display, this commit uses a solution we have been using at other places: the null pattern, through the use of `Chat::NullUser.new`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
