### PR TITLE
DEV: prevents flakey spec

### DIFF
--- a/plugins/chat/spec/system/thread_preview_spec.rb
+++ b/plugins/chat/spec/system/thread_preview_spec.rb
@@ -48,6 +48,10 @@ describe "Thread preview", type: :system do
     end
 
     context "when the user of the preview has been deleted" do
+      fab!(:thread_1_message_1) do
+        Fabricate(:chat_message, thread: thread_1, in_reply_to: message_1, use_service: true)
+      end
+
       before { thread_1_message_1.user.destroy! }
 
       it "shows a deleted user" do


### PR DESCRIPTION
Deleting the user of the message was unreliable, giving the test its own message to act on fixes it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
