### PR TITLE
UX: remove margin on bookmark icon on chat msg

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-info.scss
@@ -53,7 +53,6 @@
   .d-icon-bookmark {
     color: var(--primary-low-mid);
     font-size: var(--font-down-2);
-    margin-left: 0.5rem;
   }
 }
 


### PR DESCRIPTION
Removing unnecessary margin which interferes with positioning

<img width="1041" alt="image" src="https://github.com/discourse/discourse/assets/101828855/4701bbbd-becb-4071-9404-8c540e8b4f27">

