### PR TITLE
UX: fix border-radius for dropdown in chat msg actions

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -80,6 +80,7 @@
       padding: 0.5em 0;
       width: 2.5em;
       transition: background 0.2s, border-color 0.2s;
+      border-radius: var(--d-border-radius);
       border-top-left-radius: 0px;
       border-bottom-left-radius: 0px;
 


### PR DESCRIPTION
Should fix visual bugs like

![image](https://github.com/discourse/discourse/assets/101828855/0594fef5-8baa-4ea2-b2cb-d85ff06dbea1)
