### PR TITLE
UX: make sure a-tag uses border radius var

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -56,6 +56,7 @@
       line-height: var(--line-height-large);
       display: flex;
       align-items: center;
+      border-radius: var(--d-input-border-radius);
       .d-icon {
         margin-left: 5px;
         margin-right: 0;


### PR DESCRIPTION
Fixes the background-color on the tag creating this bug at the corners:
<img width="192" alt="image" src="https://github.com/discourse/discourse/assets/101828855/7a2ec0c3-80e9-48b1-bdc9-41dcb0f4d02d">

