### PR TITLE
DEV: Add modifiers for plugins to customize PN translation arguments

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -38,6 +38,12 @@ class PostAlerter
       DiscourseEvent.trigger(:pre_notification_alert, user, payload)
 
       if user.allow_live_notifications?
+        payload =
+          DiscoursePluginRegistry.apply_modifier(
+            :post_alerter_live_notification_payload,
+            payload,
+            user,
+          )
         MessageBus.publish("/notification-alert/#{user.id}", payload, user_ids: [user.id])
       end
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -49,6 +49,10 @@ class PushNotificationPusher
         "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}"
       end
 
+    # Payload modifier used to adjust arguments to the translation
+    payload =
+      DiscoursePluginRegistry.apply_modifier(:push_notification_pusher_title_payload, payload)
+
     I18n.t(
       translation_key,
       site_title: SiteSetting.title,

--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -60,6 +60,11 @@ module Jobs
 
         translation_args = { username: @creator.username }
         translation_args[:channel] = @chat_channel.title(user) unless @is_direct_message_channel
+        translation_args =
+          DiscoursePluginRegistry.apply_modifier(
+            :chat_notification_translation_args,
+            translation_args,
+          )
 
         payload = {
           username: @creator.username,

--- a/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/notify_watching_spec.rb
@@ -62,6 +62,29 @@ RSpec.describe Jobs::Chat::NotifyWatching do
       )
     end
 
+    context "with chat_notification_translation_args plugin_modifier" do
+      let(:modifier_block) do
+        Proc.new do |args|
+          args[:username] = "Hijacked"
+          args
+        end
+      end
+      it "Allows for changes to the translation args" do
+        plugin_instance = Plugin::Instance.new
+        plugin_instance.register_modifier(:chat_notification_translation_args, &modifier_block)
+
+        messages = notification_messages_for(user2)
+
+        expect(messages.first.data[:translated_title]).to start_with("Hijacked")
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :chat_notification_translation_args,
+          &modifier_block
+        )
+      end
+    end
+
     context "when the channel is muted via membership preferences" do
       before { membership2.update!(muted: true) }
 

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -207,5 +207,35 @@ RSpec.describe PushNotificationPusher do
         )
       end
     end
+
+    describe "push_notification_pusher_title_payload modifier" do
+      let(:modifier_block) do
+        Proc.new do |payload|
+          payload[:username] = "super_hijacked"
+          payload
+        end
+      end
+      it "Allows modifications to the payload passed to the translation" do
+        plugin_instance = Plugin::Instance.new
+        plugin_instance.register_modifier(:push_notification_pusher_title_payload, &modifier_block)
+
+        message = execute_push(notification_type: Notification.types[:mentioned], post_number: 2)
+
+        expect(message[:title]).to eq(
+          I18n.t(
+            "discourse_push_notifications.popup.mentioned",
+            site_title: SiteSetting.title,
+            topic: topic_title,
+            username: "super_hijacked",
+          ),
+        )
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :push_notification_pusher_title_payload,
+          &modifier_block
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds 3 plugin_modifiers for plugins to be able to hook into to adjust arguments to translations for push notifications.