### PR TITLE
DEV: add `topic-below-suggested` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -560,6 +560,10 @@
       </span>
 
       <MoreTopics @topic={{this.model}} />
+      <PluginOutlet
+        @name="topic-below-suggested"
+        @outletArgs={{hash model=this.model}}
+      />
     {{/if}}
   {{else}}
     <div class="container">


### PR DESCRIPTION
Adding this for use in a theme component, this pairs with `topic-above-suggested` 