### PR TITLE
Revert "Build(deps-dev): Bump chrome-launcher from 0.15.2 to 1.1.0 (#25894)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ace-builds": "1.4.13",
     "chart.js": "3.5.1",
     "chartjs-plugin-datalabels": "2.2.0",
-    "chrome-launcher": "^1.1.0",
+    "chrome-launcher": "^0.15.1",
     "chrome-remote-interface": "^0.33.0",
     "concurrently": "^8.2.2",
     "diffhtml": "1.0.0-beta.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,15 +4543,15 @@ check-error@^1.0.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chrome-launcher@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-1.1.0.tgz#b5fd371839618bfc38e36cab569ef07c93fc50bf"
-  integrity sha512-rJYWeEAERwWIr3c3mEVXwNiODPEdMRlRxHc47B1qHPOolHZnkj7rMv1QSUfPoG6MgatWj5AxSpnKKR4QEwEQIQ==
+chrome-launcher@^0.15.1:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.15.2.tgz#4e6404e32200095fdce7f6a1e1004f9bd36fa5da"
+  integrity sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
-    lighthouse-logger "^2.0.1"
+    lighthouse-logger "^1.0.0"
 
 chrome-remote-interface@^0.33.0:
   version "0.33.0"
@@ -8973,10 +8973,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lighthouse-logger@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-2.0.1.tgz#48895f639b61cca89346bb6f47f7403a3895fa02"
-  integrity sha512-ioBrW3s2i97noEmnXxmUq7cjIcVRjT5HBpAYy8zE11CxU9HqlWHHeRxfeN1tn8F7OEMVPIC9x1f8t3Z7US9ehQ==
+lighthouse-logger@^1.0.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz#aef90f9e97cd81db367c7634292ee22079280aaa"
+  integrity sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==
   dependencies:
     debug "^2.6.9"
     marky "^1.2.2"


### PR DESCRIPTION
This reverts commit f219135415f7df0be2b4614e33e6ca69c8c77c8d.

Broke our internal smoke tests.