### PR TITLE
FIX: Error when integer values are set as default of string type settings

### DIFF
--- a/lib/theme_settings_validator.rb
+++ b/lib/theme_settings_validator.rb
@@ -45,7 +45,7 @@ class ThemeSettingsValidator
         )
       when types[:string]
         validate_value_in_range!(
-          value.length,
+          value.to_s.length,
           min: opts[:min],
           max: opts[:max],
           errors:,

--- a/spec/fixtures/theme_settings/valid_settings.yaml
+++ b/spec/fixtures/theme_settings/valid_settings.yaml
@@ -14,6 +14,10 @@ string_setting_03:
   default: "string value"
   textarea: true
 
+string_setting_04:
+  default: 0
+  type: string
+
 integer_setting: 51
 
 integer_setting_02:

--- a/spec/lib/theme_settings_validator_spec.rb
+++ b/spec/lib/theme_settings_validator_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe ThemeSettingsValidator do
+  describe ".validate_value" do
+    it "does not throw an error when an integer value is given with type `string`" do
+      errors = described_class.validate_value(1, ThemeSetting.types[:string], {})
+
+      expect(errors).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
### Why this change?

```
some_setting:
  default: 0
  type: string
```

A theme setting like the above will cause an error to be thrown on the
server when importing the theme because the default would be parsed as
an integer which caused an error to be thrown when we are validating the
value of the setting.

### What does this change do?

Convert the value to a string when working with string typed theme
settings.