### PR TITLE
UX: flexible autocomplete width

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -433,8 +433,8 @@ html.composer-open {
 .autocomplete {
   z-index: z("composer", "dropdown") + 1;
   position: absolute;
-  max-width: 300px;
-  width: 300px;
+  max-width: 600px;
+  min-width: 300px;
   background-color: var(--secondary);
   border: 1px solid var(--primary-low);
   box-shadow: var(--shadow-dropdown);

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -433,7 +433,7 @@ html.composer-open {
 .autocomplete {
   z-index: z("composer", "dropdown") + 1;
   position: absolute;
-  max-width: 600px;
+  max-width: 370px;
   min-width: 300px;
   background-color: var(--secondary);
   border: 1px solid var(--primary-low);

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -11,6 +11,10 @@
     }
   }
 
+  .autocomplete {
+    max-width: 600px;
+  }
+
   .select-kit.is-expanded {
     z-index: z("composer", "dropdown") + 1;
   }


### PR DESCRIPTION
When tagging a user with the `@` the autocomplete div has a fixed width, causing longer names and usernames to get cut off. When users have a custom status this can happen easily.

This change allows the div to expand up until a max-width of 600px.

Example after this change:
<img width="609" alt="Screenshot 2024-02-27 at 12 52 17 PM" src="https://github.com/discourse/discourse/assets/2257978/6d233701-4f46-4988-bbf1-332e0f587da5">

On mobile:
<img width="390" alt="Screenshot 2024-02-27 at 4 20 16 PM" src="https://github.com/discourse/discourse/assets/2257978/249c2213-57f7-48dd-9700-07d43906ffb5">
