### PR TITLE
FIX: `ThemeSettingsValidator.validate_value` returning wrong error

### DIFF
--- a/lib/theme_settings_validator.rb
+++ b/lib/theme_settings_validator.rb
@@ -52,7 +52,7 @@ class ThemeSettingsValidator
           translation_prefix: "string",
         )
       when types[:objects]
-        errors.push(
+        errors.concat(
           ThemeSettingsObjectValidator.validate_objects(schema: opts[:schema], objects: value),
         )
       end

--- a/spec/lib/theme_settings_validator_spec.rb
+++ b/spec/lib/theme_settings_validator_spec.rb
@@ -7,5 +7,30 @@ RSpec.describe ThemeSettingsValidator do
 
       expect(errors).to eq([])
     end
+
+    it "returns the right error messages when value is invalid for type `objects`" do
+      errors =
+        described_class.validate_value(
+          [{ name: "something" }],
+          ThemeSetting.types[:objects],
+          {
+            schema: {
+              name: "test",
+              properties: {
+                name: {
+                  type: "string",
+                  validations: {
+                    max_length: 1,
+                  },
+                },
+              },
+            },
+          },
+        )
+
+      expect(errors).to contain_exactly(
+        "The property at JSON Pointer '/0/name' must be at most 1 characters long.",
+      )
+    end
   end
 end


### PR DESCRIPTION
Why this change?

Before this change, the error messages returned when validating theme
settings of typed objects was an array of array instead of just an
array.