### PR TITLE
FIX: add status to channel membership serializer

### DIFF
--- a/plugins/chat/app/serializers/chat/user_channel_membership_serializer.rb
+++ b/plugins/chat/app/serializers/chat/user_channel_membership_serializer.rb
@@ -2,10 +2,11 @@
 
 module Chat
   class UserChannelMembershipSerializer < BaseChannelMembershipSerializer
-    has_one :user, serializer: ::Chat::ChatableUserSerializer, embed: :objects
+    has_one :user, embed: :objects
 
     def user
-      object.user || Chat::NullUser.new
+      user = object.user || Chat::NullUser.new
+      Chat::BasicUserSerializer.new(user, root: false, scope: scope, include_status: true)
     end
   end
 end

--- a/plugins/chat/spec/support/api/schemas/user_chat_channel_membership.json
+++ b/plugins/chat/spec/support/api/schemas/user_chat_channel_membership.json
@@ -24,7 +24,6 @@
         "name": { "type": "string" },
         "avatar_template": { "type": "string" },
         "username": { "type": "string" },
-        "custom_fields": { "type": ["object", "null"] },
         "can_chat": { "type": "boolean" },
         "has_chat_enabled": { "type": "boolean" }
       }

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Channel - Info - Members page", type: :system do
       end
 
       context "with user status" do
-        xit "renders status next to name" do
+        it "renders status next to name" do
           SiteSetting.enable_user_status = true
           current_user.set_status!("walking the dog", "dog")
 


### PR DESCRIPTION
Updates chat membership serializer to work with recent changes in #24300 