### PR TITLE
FIX: better handling of error on create DM

### DIFF
--- a/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
@@ -17,6 +17,9 @@ class Chat::Api::DirectMessagesController < Chat::ApiController
       on_failed_policy(:satisfies_dms_max_users_limit) do |policy|
         render_json_dump({ error: policy.reason }, status: 400)
       end
+      on_failed_policy(:can_create_direct_message) do |policy|
+        render_json_dump({ error: I18n.t("chat.errors.invalid_direct_message") }, status: 400)
+      end
       on_failed_policy(:actor_allows_dms) do
         render_json_error(I18n.t("chat.errors.actor_disallowed_dms"))
       end

--- a/plugins/chat/assets/javascripts/discourse/components/chat/user-card-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/user-card-button.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import DButton from "discourse/components/d-button";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default class ChatUserCardButton extends Component {
   @service chat;
@@ -13,13 +14,20 @@ export default class ChatUserCardButton extends Component {
   }
 
   @action
-  startChatting() {
-    return this.chat
-      .upsertDmChannel({ usernames: [this.args.user.username] })
-      .then((channel) => {
-        this.router.transitionTo("chat.channel", ...channel.routeModels);
-        this.appEvents.trigger("card:close");
+  async startChatting() {
+    try {
+      const channel = await this.chat.upsertDmChannel({
+        usernames: [this.args.user.username],
       });
+
+      if (channel) {
+        this.router.transitionTo("chat.channel", ...channel.routeModels);
+      }
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.appEvents.trigger("card:close");
+    }
   }
 
   <template>

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -94,6 +94,7 @@ en:
       original_message_not_found: "The ancestor of the message you are replying to cannot be found or has been deleted."
       thread_invalid_for_channel: "Thread is not part of the provided channel."
       thread_does_not_match_parent: "Thread does not match parent message."
+      invalid_direct_message: "You are not allowed to create this direct message."
     reviewables:
       message_already_handled: "Thanks, but we've already reviewed this message and determined it does not need to be flagged again."
       actions:


### PR DESCRIPTION
Prior to this fix we were correctly failing but just returning a generic error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
