### PR TITLE
FIX: do not show send pm prompt when user cant pm

### DIFF
--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -181,6 +181,7 @@ class ComposerMessagesFinder
   end
 
   def check_get_a_room(min_users_posted: 5)
+    return unless @user.guardian.can_send_private_messages?
     return unless educate_reply?(:notified_about_get_a_room)
     return unless @details[:post_id].present?
     return if @topic.category&.read_restricted

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -441,10 +441,11 @@ RSpec.describe ComposerMessagesFinder do
       SiteSetting.educate_until_posts = 10
       user.stubs(:post_count).returns(11)
       SiteSetting.get_a_room_threshold = 2
+      SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
     end
 
     context "when user can't send private messages" do
-      let(:group) { Fabricate(:group) }
+      fab!(:group) { Fabricate(:group) }
       before { SiteSetting.personal_message_enabled_groups = group.id }
 
       it "does not show the message " do

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe ComposerMessagesFinder do
       fab!(:group) { Fabricate(:group) }
       before { SiteSetting.personal_message_enabled_groups = group.id }
 
-      it "does not show the message " do
+      it "does not show the message" do
         expect(
           ComposerMessagesFinder.new(
             user,

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -443,6 +443,22 @@ RSpec.describe ComposerMessagesFinder do
       SiteSetting.get_a_room_threshold = 2
     end
 
+    context "when user can't send private messages" do
+      let(:group) { Fabricate(:group) }
+      before { SiteSetting.personal_message_enabled_groups = group.id }
+
+      it "does not show the message " do
+        expect(
+          ComposerMessagesFinder.new(
+            user,
+            composer_action: "reply",
+            topic_id: topic.id,
+            post_id: op.id,
+          ).check_get_a_room(min_users_posted: 2),
+        ).to be_blank
+      end
+    end
+
     it "does not show the message for new topics" do
       finder = ComposerMessagesFinder.new(user, composer_action: "createTopic")
       expect(finder.check_get_a_room(min_users_posted: 2)).to be_blank


### PR DESCRIPTION
Prior to this fix even when the user was not part of a group allowing sending pm we would show the prompt: "You've replied to ... X times, did you know you could send them a personal message instead?"

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
