### PR TITLE
DEV: Use `autocomplete="new-password"`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -137,9 +137,9 @@
             {{#if this.passwordRequired}}
               <PasswordField
                 @value={{this.accountPassword}}
-                @type={{if this.maskPassword "password" "text"}}
-                @autocomplete="current-password"
                 @capsLockOn={{this.capsLockOn}}
+                type={{if this.maskPassword "password" "text"}}
+                autocomplete="current-password"
                 aria-describedby="password-validation password-validation-more-info"
                 aria-invalid={{this.passwordValidation.failed}}
                 id="new-account-password"

--- a/app/assets/javascripts/discourse/app/components/modal/login/local-login-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/login/local-login-form.hbs
@@ -32,16 +32,16 @@
     </div>
     <div class="input-group">
       <PasswordField
+        {{on "keydown" this.loginOnEnter}}
         @value={{@loginPassword}}
-        @type={{if this.maskPassword "password" "text"}}
-        class={{value-entered @loginPassword}}
-        id="login-account-password"
+        @capsLockOn={{this.capsLockOn}}
+        type={{if this.maskPassword "password" "text"}}
+        disabled={{this.disableLoginFields}}
         autocomplete="current-password"
         maxlength="200"
-        @capsLockOn={{this.capsLockOn}}
-        disabled={{this.disableLoginFields}}
         tabindex="1"
-        {{on "keydown" this.loginOnEnter}}
+        id="login-account-password"
+        class={{value-entered @loginPassword}}
       />
       <label class="alt-placeholder" for="login-account-password">
         {{i18n "login.password"}}

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -137,9 +137,10 @@
                   <div class="input password-input input-group">
                     <PasswordField
                       @value={{this.accountPassword}}
-                      @type={{if this.maskPassword "password" "text"}}
-                      @id="new-account-password"
                       @capsLockOn={{this.capsLockOn}}
+                      type={{if this.maskPassword "password" "text"}}
+                      autocomplete="new-password"
+                      id="new-account-password"
                       class={{value-entered this.accountPassword}}
                     />
                     <label class="alt-placeholder" for="new-account-password">

--- a/app/assets/javascripts/discourse/app/templates/password-reset.hbs
+++ b/app/assets/javascripts/discourse/app/templates/password-reset.hbs
@@ -64,10 +64,11 @@
           <div class="input">
             <PasswordField
               @value={{this.accountPassword}}
-              @type={{if this.maskPassword "password" "text"}}
-              @id="new-account-password"
               @capsLockOn={{this.capsLockOn}}
-              @autofocus="autofocus"
+              type={{if this.maskPassword "password" "text"}}
+              autofocus="autofocus"
+              autocomplete="new-password"
+              id="new-account-password"
             />
             <TogglePasswordMask
               @maskPassword={{this.maskPassword}}

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/atoms/05-input-fields.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/atoms/05-input-fields.hbs
@@ -3,7 +3,7 @@
 </StyleguideExample>
 
 <StyleguideExample @title="password">
-  <PasswordField @type="password" @placeholder="Placeholder" />
+  <PasswordField type="password" placeholder="Placeholder" />
 </StyleguideExample>
 
 <StyleguideExample @title="textarea">


### PR DESCRIPTION
And normalize `<PasswordField />` arguments

(we were getting `[DOM] Input elements should have autocomplete attributes (suggested: "current-password")` in smoke test logs, this may or may not fix that 😛)