### PR TITLE
A11Y: when adding custom sidebar link, first input of new row should get focus

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
@@ -2,6 +2,7 @@ import { cached, tracked } from "@glimmer/tracking";
 import { A } from "@ember/array";
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
@@ -367,6 +368,14 @@ export default class SidebarSectionForm extends Component {
       });
   }
 
+  focusNewRowInput(id) {
+    schedule("afterRender", () => {
+      document
+        .querySelector(`[data-row-id="${id}"] .icon-picker summary`)
+        .focus();
+    });
+  }
+
   get activeLinks() {
     return this.transformedModel.links.filter((link) => !link._destroy);
   }
@@ -445,6 +454,8 @@ export default class SidebarSectionForm extends Component {
         segment: "primary",
       })
     );
+
+    this.focusNewRowInput(this.nextObjectId);
   }
 
   @action
@@ -457,6 +468,8 @@ export default class SidebarSectionForm extends Component {
         segment: "secondary",
       })
     );
+
+    this.focusNewRowInput(this.nextObjectId);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
@@ -2,7 +2,6 @@ import { cached, tracked } from "@glimmer/tracking";
 import { A } from "@ember/array";
 import Component from "@ember/component";
 import { action } from "@ember/object";
-import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
@@ -10,7 +9,7 @@ import { extractError } from "discourse/lib/ajax-error";
 import { SIDEBAR_SECTION, SIDEBAR_URL } from "discourse/lib/constants";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 import { sanitize } from "discourse/lib/text";
-import { bind } from "discourse-common/utils/decorators";
+import { afterRender, bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
 const FULL_RELOAD_LINKS_REGEX = [
@@ -368,14 +367,6 @@ export default class SidebarSectionForm extends Component {
       });
   }
 
-  focusNewRowInput(id) {
-    schedule("afterRender", () => {
-      document
-        .querySelector(`[data-row-id="${id}"] .icon-picker summary`)
-        .focus();
-    });
-  }
-
   get activeLinks() {
     return this.transformedModel.links.filter((link) => !link._destroy);
   }
@@ -390,6 +381,13 @@ export default class SidebarSectionForm extends Component {
     return this.transformedModel.id
       ? "sidebar.sections.custom.edit"
       : "sidebar.sections.custom.add";
+  }
+
+  @afterRender
+  focusNewRowInput(id) {
+    document
+      .querySelector(`[data-row-id="${id}"] .icon-picker summary`)
+      .focus();
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
@@ -12,6 +12,7 @@
   {{on "dragend" this.dragEnd}}
   {{on "drop" this.dropItem}}
   role="row"
+  data-row-id={{@link.objectId}}
 >
   {{#unless this.site.mobileView}}
     <div class="draggable" data-link-name={{@link.name}}>

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -127,6 +127,19 @@ describe "Custom sidebar sections", type: :system do
     expect(sidebar).to have_section_link("Faq", target: "_blank")
   end
 
+  it "accessibility - when new row is added in custom section, first new input is focused" do
+    sign_in user
+    visit("/latest")
+
+    sidebar.click_add_section_button
+    sidebar.click_add_link_button
+
+    is_focused =
+      page.evaluate_script("document.activeElement.classList.contains('multi-select-header')")
+
+    expect(is_focused).to be true
+  end
+
   it "allows the user to edit custom section" do
     sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
     sidebar_url_1 = Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags")

--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -138,6 +138,10 @@ module PageObjects
           click_button(add_section_button_text)
         end
 
+        def click_add_link_button
+          click_button(add_link_button_text)
+        end
+
         def has_no_add_section_button?
           page.has_no_button?(add_section_button_text)
         end
@@ -182,6 +186,10 @@ module PageObjects
 
         def add_section_button_text
           I18n.t("js.sidebar.sections.custom.add")
+        end
+
+        def add_link_button_text
+          I18n.t("js.sidebar.sections.custom.links.add")
         end
       end
     end


### PR DESCRIPTION
The first input in this case is the link dropdown. At the moment nothing gets focused when a new row is added, so someone using a screenreader would need to know to reverse tab to find it. 


https://github.com/discourse/discourse/assets/1681963/6beb03d6-4f8d-4282-bbd1-c50193093164

