### PR TITLE
DEV: Add ENV var to skip verbose gem backtrace in rspec failure

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -695,7 +695,12 @@ RSpec.configure do |config|
         lines << "\n"
         lines << "Error encountered while proccessing #{path}"
         lines << "  #{ex.class}: #{ex.message}"
-        ex.backtrace.each { |line| lines << "    #{line}\n" }
+        ex.backtrace.each_with_index do |line, backtrace_index|
+          if ENV["RSPEC_EXCLUDE_GEMS_IN_BACKTRACE"]
+            next if line.match?(%r{/gems/})
+          end
+          lines << "    #{line}\n"
+        end
       end
 
       lines << "~~~~~~~ END SERVER EXCEPTIONS ~~~~~~~"


### PR DESCRIPTION
In rspec request specs, we do a huge verbose backtrace
when there is an error. However, 99% of the time you don't
care about pages and pages of activesupport/rspec gem
LOC in the backtrace...so this commit introduces an
env var RSPEC_EXCLUDE_GEMS_IN_BACKTRACE to allow for
turning this off.

Before: (this goes on for 2-3 terminal screens):

![image](https://github.com/discourse/discourse/assets/920448/3b022758-b729-4076-9cf8-60f2b392faf9)

After:

![image](https://github.com/discourse/discourse/assets/920448/be81dee9-55e0-4db5-89c3-1677138ea053)

Much more manageable.
