### PR TITLE
DEV: Fix reloading type map not clearing cache

### DIFF
--- a/lib/freedom_patches/cache_postgresql_connection_type_map.rb
+++ b/lib/freedom_patches/cache_postgresql_connection_type_map.rb
@@ -9,6 +9,12 @@
 # The latest attempt to fix the problem in Rails is in https://github.com/rails/rails/pull/46409 but it has gone stale.
 module FreedomPatches
   module PostgreSQLAdapter
+    # Definition as of writing: https://github.com/rails/rails/blob/5bf5344521a6f305ca17e0004273322a0a26f50a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L316
+    def reload_type_map
+      self.class.type_map = nil
+      super
+    end
+
     # Definition as of writing: https://github.com/rails/rails/blob/5bf5344521a6f305ca17e0004273322a0a26f50a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L614
     def initialize_type_map(m = type_map)
       if !self.class.type_map.nil?

--- a/spec/lib/freedom_patches/cache_postgresql_connection_type_map_spec.rb
+++ b/spec/lib/freedom_patches/cache_postgresql_connection_type_map_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe "Caching PostgreSQL connection type map" do
         end
       end
 
-    expect do ActiveRecord::Base.connection.reconnect! end.not_to change { pg_type_queries.length }
+    expect do
+      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.establish_connection
+    end.to change { pg_type_queries.length }.by(1) # There is some default pg_type query but if stuff was not cached, we would see 4 queries here
   ensure
     ActiveSupport::Notifications.unsubscribe(subscriber)
   end


### PR DESCRIPTION
Why this change?

This is a follow up to 408d2f8e692868779b1b05c19fcb32c35897184b. When
`ActiveRecord::ConnectionAdapaters::PostgreSQLAdatper#reload_type_map`
is called, we need to clear the type map cache otherwise migrations
adding an array column will end up throwing errors.