### PR TITLE
FEATURE: introduces chat_preferred_mobile_index setting

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
@@ -5,6 +5,21 @@ export default class ChatIndexRoute extends DiscourseRoute {
   @service chat;
   @service chatChannelsManager;
   @service router;
+  @service siteSettings;
+  @service currentUser;
+
+  get hasThreads() {
+    if (!this.siteSettings.chat_threads_enabled) {
+      return false;
+    }
+    return this.currentUser?.chat_channels?.public_channels?.some(
+      (channel) => channel.threading_enabled
+    );
+  }
+
+  get hasDirectMessages() {
+    return this.chat.userCanAccessDirectMessages;
+  }
 
   activate() {
     this.chat.activeChannel = null;
@@ -13,7 +28,19 @@ export default class ChatIndexRoute extends DiscourseRoute {
   redirect() {
     // on mobile redirect user to the first footer tab route
     if (this.site.mobileView) {
-      return this.router.replaceWith("chat.channels");
+      if (
+        this.siteSettings.chat_preferred_mobile_index === "my_threads" &&
+        this.hasThreads
+      ) {
+        return this.router.replaceWith("chat.threads");
+      } else if (
+        this.siteSettings.chat_preferred_mobile_index === "direct_messages" &&
+        this.hasDirectMessages
+      ) {
+        return this.router.replaceWith("chat.direct-messages");
+      } else {
+        return this.router.replaceWith("chat.channels");
+      }
     }
 
     // We are on desktop. Check for a channel to enter and transition if so

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -25,6 +25,7 @@ en:
     chat_editing_grace_period: "For (n) seconds after sending a chat, editing will not display the (edited) tag by the chat message."
     chat_editing_grace_period_max_diff_low_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 0 and 1)."
     chat_editing_grace_period_max_diff_high_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 2 and up)."
+    chat_preferred_mobile_index: "Preferred tab when loading /chat on mobile."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
       direct_message_enabled_groups_invalid: "You must specify at least one group for this setting. If you do not want anyone except staff to send direct messages, choose the staff group."

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -137,3 +137,11 @@ chat:
     type: integer
     default: 40
     min: 0
+  chat_preferred_mobile_index:
+    client: true
+    type: enum
+    default: channels
+    choices:
+      - channels
+      - direct_messages
+      - my_threads

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
     end
 
     context "when user can't use direct messages" do
-      before { SiteSetting.direct_message_enabled_groups_map }
+      before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:staff] }
 
       it "redirects to channels" do
         visit("/chat")
@@ -222,7 +222,7 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
   end
 
   context "when chat_preferred_mobile_index is not set" do
-    it "loads public channels" do
+    it "redirects to channels" do
       visit("/chat")
 
       expect(page).to have_current_path("/chat/channels")
@@ -230,9 +230,15 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
   end
 
   context "when chat_preferred_mobile_index is set to my_threads" do
-    before { SiteSetting.chat_preferred_mobile_index = "my_threads" }
+    before do
+      SiteSetting.chat_threads_enabled = true
+      SiteSetting.chat_preferred_mobile_index = "my_threads"
+    end
 
     it "redirects to threads" do
+      channel = Fabricate(:chat_channel, threading_enabled: true)
+      channel.add(current_user)
+
       visit("/chat")
 
       expect(page).to have_current_path("/chat/threads")
@@ -241,7 +247,7 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
     context "when no threads" do
       before { SiteSetting.chat_threads_enabled = false }
 
-      it "redirects to channels if no threads" do
+      it "redirects to channels" do
         visit("/chat")
 
         expect(page).to have_current_path("/chat/channels")

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -201,6 +201,54 @@ RSpec.describe "List channels | mobile", type: :system, mobile: true do
     end
   end
 
+  context "when chat_preferred_mobile_index is set to direct_messages" do
+    before { SiteSetting.chat_preferred_mobile_index = "direct_messages" }
+
+    it "changes the default index" do
+      visit("/chat")
+
+      expect(page).to have_current_path("/chat/direct-messages")
+    end
+
+    context "when user can't use direct messages" do
+      before { SiteSetting.direct_message_enabled_groups_map }
+
+      it "redirects to channels" do
+        visit("/chat")
+
+        expect(page).to have_current_path("/chat/channels")
+      end
+    end
+  end
+
+  context "when chat_preferred_mobile_index is not set" do
+    it "loads public channels" do
+      visit("/chat")
+
+      expect(page).to have_current_path("/chat/channels")
+    end
+  end
+
+  context "when chat_preferred_mobile_index is set to my_threads" do
+    before { SiteSetting.chat_preferred_mobile_index = "my_threads" }
+
+    it "redirects to threads" do
+      visit("/chat")
+
+      expect(page).to have_current_path("/chat/threads")
+    end
+
+    context "when no threads" do
+      before { SiteSetting.chat_threads_enabled = false }
+
+      it "redirects to channels if no threads" do
+        visit("/chat")
+
+        expect(page).to have_current_path("/chat/channels")
+      end
+    end
+  end
+
   it "has a new dm channel button" do
     visit("/chat/direct-messages")
     find(".c-navbar__new-dm-button").click


### PR DESCRIPTION
`chat_preferred_mobile_index` allows to set the preferred default tab when loading chat on mobile.

Current choices are:
- channels
- direct_messages
- my_threads

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
