### PR TITLE
UX: increase chat pre scrollbar contrast

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -140,6 +140,10 @@
     width: 28px;
     height: 28px;
   }
+
+  pre {
+    scrollbar-color: var(--primary-300) transparent;
+  }
 }
 
 .touch .chat-message-container {


### PR DESCRIPTION
The contrast is too low here, especially with some dark color combos... this increases it 

Before: 

![image](https://github.com/discourse/discourse/assets/1681963/43f638d0-2109-4a05-b17c-3e472eba741d)


![image](https://github.com/discourse/discourse/assets/1681963/68cac9d2-d62c-4134-b393-12cd6d556cc9)

![image](https://github.com/discourse/discourse/assets/1681963/794accb3-eb89-4484-a88c-2bd8c5d59477)



After:

![image](https://github.com/discourse/discourse/assets/1681963/2b6c30ce-a2ec-4b48-b001-b83e3646b927)


![image](https://github.com/discourse/discourse/assets/1681963/51940bf0-0426-4c9e-94c6-a165a488b945)

![image](https://github.com/discourse/discourse/assets/1681963/dc27e2f1-4281-4712-9bf6-de872388da75)

