### PR TITLE
A11Y: markup sidebar custom section form errors as live regions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.hbs
@@ -35,7 +35,7 @@
       ariaLabel={{i18n "sidebar.sections.custom.links.icon.label"}}
     />
     {{#if @link.invalidIconMessage}}
-      <div class="icon warning">
+      <div class="icon warning" role="alert" aria-live="assertive">
         {{@link.invalidIconMessage}}
       </div>
     {{/if}}
@@ -50,7 +50,7 @@
       {{on "input" (with-event-value (fn (mut @link.name)))}}
     />
     {{#if @link.invalidNameMessage}}
-      <div class="name warning">
+      <div class="name warning" role="alert" aria-live="assertive">
         {{@link.invalidNameMessage}}
       </div>
     {{/if}}
@@ -65,7 +65,7 @@
       {{on "input" (with-event-value (fn (mut @link.value)))}}
     />
     {{#if @link.invalidValueMessage}}
-      <div class="value warning">
+      <div class="value warning" role="alert" aria-live="assertive">
         {{@link.invalidValueMessage}}
       </div>
     {{/if}}


### PR DESCRIPTION
This means that the error messages will be read as soon as they appear, so a screen reader user can be aware that there's an error with their form input. 