### PR TITLE
FIX: Disappearing reply button

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -23,6 +23,7 @@
     .discourse-no-touch & {
       opacity: 0.7;
       transition: background 0.25s, opacity 0.7s ease-in-out;
+      animation: none; // replaces jsuites animation on .fade-out
     }
     .discourse-touch & {
       opacity: 1;


### PR DESCRIPTION
This PR overrides an animation added by `jsuites` library on `.fade-out`, which was causing the reply button in PMs to disappear after editing a table. This should provide an immediate fix to the issue. However, longer term, it would be good to look into a solution to prefixing imported vendor CSS from table builder libraries.