### PR TITLE
DEV: Fix hot topic flaky spec

### DIFF
--- a/spec/models/topic_hot_scores_spec.rb
+++ b/spec/models/topic_hot_scores_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe TopicHotScore do
     end
 
     it "can correctly update like counts and post counts and account for activity" do
-      freeze_time
+      # freeze to specific date + time to avoid flakiness from leap years
+      freeze_time(DateTime.parse("2024-02-01 01:00"))
 
       TopicHotScore.create!(topic_id: -1, score: 0.0, recent_likes: 99, recent_posters: 0)
 


### PR DESCRIPTION
It's February 29th, you know what that means...date-based flaky specs! If today is
February 29th 2024:

```
freeze_time(1.year.ago) -> Tue, 28 Feb 2023 01:38:42.732875000 UTC +00:00
```

Then

```
freeze_time(1.year.from_now) -> Wed, 28 Feb 2024 01:38:42.732875000 UTC +00:00
```

So then our "now" for the insert query ends up being "yesterday"

```
WHERE topic_hot_scores.topic_id IS NULL
  AND topics.deleted_at IS NULL
  AND topics.archetype <> :private_message
  AND topics.created_at <= :now
```
