### PR TITLE
PERF: Reduce ActiveRecord allocations in `CategoryList#find_relevant_topics`

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -31,8 +31,8 @@ class CategoryList
     @guardian = guardian || Guardian.new
     @options = options
 
-    find_relevant_topics if options[:include_topics]
     find_categories
+    find_relevant_topics if options[:include_topics]
 
     prune_empty
     find_user_data
@@ -71,17 +71,18 @@ class CategoryList
   private
 
   def find_relevant_topics
-    @topics_by_id = {}
-    @topics_by_category_id = {}
-
-    category_featured_topics = CategoryFeaturedTopic.select(%i[category_id topic_id]).order(:rank)
-
     @all_topics =
-      Topic.where(id: category_featured_topics.map(&:topic_id)).includes(
-        :shared_draft,
-        :category,
-        { topic_thumbnails: %i[optimized_image upload] },
-      )
+      Topic
+        .secured(@guardian)
+        .joins(
+          "INNER JOIN category_featured_topics ON topics.id = category_featured_topics.topic_id",
+        )
+        .where("category_featured_topics.category_id IN (?)", categories_with_descendants.map(&:id))
+        .select(
+          "topics.*, category_featured_topics.category_id AS category_featured_topic_category_id",
+        )
+        .includes(:shared_draft, :category, { topic_thumbnails: %i[optimized_image upload] })
+        .order("category_featured_topics.rank")
 
     @all_topics = @all_topics.joins(:tags).where(tags: { name: @options[:tag] }) if @options[
       :tag
@@ -103,16 +104,18 @@ class CategoryList
     end
 
     @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user).includes(:last_poster)
+
+    featured_topics_by_category_id = Hash.new { |h, k| h[k] = [] }
+
     @all_topics.each do |t|
       # hint for the serializer
       t.include_last_poster = true
       t.dismissed = dismissed_topic?(t)
-      @topics_by_id[t.id] = t
+      featured_topics_by_category_id[t.category_featured_topic_category_id] << t
     end
 
-    category_featured_topics.each do |cft|
-      @topics_by_category_id[cft.category_id] ||= []
-      @topics_by_category_id[cft.category_id] << cft.topic_id
+    categories_with_descendants.each do |category|
+      category.displayable_topics = featured_topics_by_category_id[category.id]
     end
   end
 
@@ -212,23 +215,6 @@ class CategoryList
         category.id,
       )
       category.has_children = category.subcategories.present?
-    end
-
-    if @topics_by_category_id
-      categories_with_descendants.each do |c|
-        topics_in_cat = @topics_by_category_id[c.id]
-        if topics_in_cat.present?
-          c.displayable_topics = []
-          topics_in_cat.each do |topic_id|
-            topic = @topics_by_id[topic_id]
-            if topic.present? && @guardian.can_see?(topic)
-              # topic.category is very slow under rails 4.2
-              topic.association(:category).target = c
-              c.displayable_topics << topic
-            end
-          end
-        end
-      end
     end
   end
 


### PR DESCRIPTION
### Why this change?

Prior to this change, the `CategoryList#find_relevant_topics` method was
loading and allocating all `CategoryFeaturedTopic` records in the
database to eventually only just use its `category_id` and `topic_id`
column. On a site with many `CategoryFeaturedTopic` records, the loading
of the ActiveRecord objects is a source of bottleneck.

The other problem with the `CategoryList#find_relevant_topics` method is
that it is unconditionally loading all records from the database even if
the user may not have access to certain categories. This again is wasteful.

### What does this change do?

This commit makes it such that `CategoryList#find_relevant_topics` is
called only after `CategoryList#find_categories` in the `CategoryList#initialize`
method so that we can filter featured topics against categories that the
user has access to.

The second change is that Instead of loading `CategoryFeaturedTopic` records, we make an
inner join agains the `topics` table instead and skip any allocation of
`CatgoryFeaturedTopic` ActiveRecord objects.