### PR TITLE
DEV: Shorten a confusing condition

### DIFF
--- a/plugins/poll/lib/polls_updater.rb
+++ b/plugins/poll/lib/polls_updater.rb
@@ -131,13 +131,10 @@ module DiscoursePoll
         return true if old_poll.public_send(attr) != new_poll.public_send(attr)
       end
 
-      # an option was changed?
-      if old_poll.poll_options.map { |o| o.digest }.sort != new_options.map { |o| o["id"] }.sort
-        return true
-      end
+      sorted_old_options = old_poll.poll_options.map { |o| o.digest }.sort
+      sorted_new_options = new_options.map { |o| o["id"] }.sort
 
-      # it's the same!
-      false
+      sorted_old_options != sorted_new_options
     end
   end
 end

--- a/plugins/poll/spec/controllers/posts_controller_spec.rb
+++ b/plugins/poll/spec/controllers/posts_controller_spec.rb
@@ -206,7 +206,25 @@ RSpec.describe PostsController do
           expect(json["post"]["polls"][0]["options"][2]["html"]).to eq("C")
         end
 
-        it "resets the votes" do
+        it "does not clear votes when poll has no change" do
+          DiscoursePoll::Poll.vote(user, post_id, "poll", ["5c24fc1df56d764b550ceae1b9319125"])
+          put :update,
+              params: {
+                id: post_id,
+                post: {
+                  raw: "[poll]\n- A\n- B\n[/poll]\n This poll has no change, but the raw does.",
+                },
+              },
+              format: :json
+
+          expect(response.status).to eq(200)
+          json = response.parsed_body
+          expect(json["post"]["polls_votes"]["poll"]).to match_array(
+            "5c24fc1df56d764b550ceae1b9319125",
+          )
+        end
+
+        it "resets the votes when poll is changed" do
           DiscoursePoll::Poll.vote(user, post_id, "poll", ["5c24fc1df56d764b550ceae1b9319125"])
 
           put :update,


### PR DESCRIPTION
Shortening this

```
def is_different?
  ...
  if ["A"] != ["A"]
    return true
  end
  return false
end
```

to

```
def is_different?
  ...
  ["A"] != ["A"]
end
```