### PR TITLE
DEV: Suppress verbose command failure output in plugin:turbo_spec

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -199,7 +199,9 @@ def spec(plugin, parallel: false, argv: nil)
     cmd = parallel ? "bin/turbo_rspec" : "bin/rspec"
 
     Rake::FileUtilsExt.verbose(!parallel) do
-      sh("LOAD_PLUGINS=1 #{cmd} #{files.join(" ")} #{params.join(" ")}")
+      sh("LOAD_PLUGINS=1 #{cmd} #{files.join(" ")} #{params.join(" ")}") do |ok, status|
+        fail "Spec command failed with status (#{status.exitstatus})" if !ok
+      end
     end
   else
     abort "No specs found."


### PR DESCRIPTION
Before this change, if the "Plugins backend" task on GitHub CI
failed, we would get a huge amount of extra output at the end
just to show the command that rake ran which failed (the bin/turbo_rspec
command). This is useless and just makes it hard to see the failing
specs. If you need the full command, it's already output at the
top of the "Plugins backend" task in the GitHub CI.

**Before** (not pictured: the pages of scrolling up from the bottom I had to do)

Example run: https://github.com/discourse/discourse/actions/runs/8090033230/job/22106872663

![image](https://github.com/discourse/discourse/assets/920448/edfd66c3-b513-4205-a036-7c5cbf75cee5)

**After**

![image](https://github.com/discourse/discourse/assets/920448/47332ca9-27b2-45e9-8650-e946566c1952)
