### PR TITLE
DEV: Avoid building JS test files with ember-cli when we don't need it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,6 +223,10 @@ jobs:
           name: ember-exam-execution-plugins-frontend-${{ hashFiles('./app/assets/javascripts/discourse/test-execution-*.json') }}
           path: ./app/assets/javascripts/discourse/test-execution-*.json
 
+      - name: Set environment for Ember build
+        if: matrix.build_type == 'system' && matrix.target != 'core'
+        run: echo "DISABLE_EMBER_CLI_TESTS=1" >> "$GITHUB_ENV"
+
       - name: Ember Build for System Tests
         if: matrix.build_type == 'system'
         run: bin/ember-cli --build


### PR DESCRIPTION
### Why this change?

In certain cases, we do not need `ember-cli --build` to build the test
files so we are adding a `DISABLE_EMBER_CLI_TESTS_DISABLE` env variable
to skip building test files.