### PR TITLE
FIX: live updates threads from my threads page

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -7,12 +7,11 @@ import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-ti
 import List from "discourse/plugins/chat/discourse/components/chat/list";
 import ThreadIndicator from "discourse/plugins/chat/discourse/components/chat-message-thread-indicator";
 import ThreadTitle from "discourse/plugins/chat/discourse/components/thread-title";
-import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
-import ChatThread from "discourse/plugins/chat/discourse/models/chat-thread";
 
 export default class UserThreads extends Component {
   @service chat;
   @service chatApi;
+  @service chatChannelsManager;
 
   @cached
   get threadsCollection() {
@@ -22,9 +21,10 @@ export default class UserThreads extends Component {
   @bind
   handleLoadedThreads(result) {
     return result.threads.map((threadObject) => {
-      const channel = ChatChannel.create(threadObject.channel);
-      const thread = ChatThread.create(channel, threadObject);
+      const channel = this.chatChannelsManager.store(threadObject.channel);
+      const thread = channel.threadsManager.add(channel, threadObject);
       const tracking = result.tracking[thread.id];
+
       if (tracking) {
         thread.tracking.mentionCount = tracking.mention_count;
         thread.tracking.unreadCount = tracking.unread_count;

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
+import User from "discourse/models/user";
 
 export default class ChatThreadPreview {
   static create(args = {}) {
@@ -35,5 +36,18 @@ export default class ChatThreadPreview {
 
   get otherParticipantCount() {
     return this.participantCount - this.participantUsers.length;
+  }
+
+  updateFromMessageObject(messageObject) {
+    const user = User.create(messageObject.user);
+    if (!this.participantUsers.find((u) => u.id === user.id)) {
+      this.participantUsers.push(user);
+      this.participantCount += 1;
+    }
+    this.replyCount += 1;
+    this.lastReplyAt = messageObject.created_at;
+    this.lastReplyId = messageObject.id;
+    this.lastReplyExcerpt = messageObject.excerpt;
+    this.lastReplyUser = user;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -265,6 +265,7 @@ export default class ChatSubscriptionsManager extends Service {
                   busData.thread_id,
                   busData.message.created_at
                 );
+                thread.preview.updateFromMessageObject(busData.message);
                 thread.tracking.unreadCount++;
                 this._updateActiveLastViewedAt(channel);
               }

--- a/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
@@ -41,6 +41,10 @@ module PageObjects
           find(@context).has_no_css?(".chat-thread-participants")
         end
 
+        def has_excerpt?(text)
+          find(@context).find("#{SELECTOR}__last-reply-excerpt", text: text)
+        end
+
         def excerpt
           find(@context).find("#{SELECTOR}__last-reply-excerpt")
         end

--- a/plugins/chat/spec/system/user_threads_spec.rb
+++ b/plugins/chat/spec/system/user_threads_spec.rb
@@ -114,6 +114,23 @@ RSpec.describe "User threads", type: :system do
 
       expect(user_threads_page).to have_threads
     end
+
+    it "updates the thread when another user replies" do
+      chat_thread_chain_bootstrap(channel: channel_1, users: [current_user, Fabricate(:user)])
+      thread = channel_1.threads.last
+      message = thread.original_message
+      last_user = Fabricate(:user)
+
+      chat_page.visit_user_threads
+
+      last_message = Fabricate(:chat_message, thread: thread, user: last_user, use_service: true)
+
+      indicator = PageObjects::Components::Chat::ThreadIndicator.new(".c-user-thread")
+
+      expect(indicator).to have_reply_count(4)
+      expect(indicator).to have_participant(last_user)
+      expect(indicator).to have_excerpt(last_message.excerpt)
+    end
   end
 
   context "when in drawer" do


### PR DESCRIPTION
Prior to this fix if a user was answering to one of the listed screen it wouldn't update while you look at the list.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
