### PR TITLE
FIX: instantly removes group message when leaving

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,7 +251,7 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system/drawer/index_spec.rb:26
+        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system
         timeout-minutes: 30
 
       - name: Theme System Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,7 +251,7 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system
+        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system/drawer/index_spec.rb:26
         timeout-minutes: 30
 
       - name: Theme System Tests

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -322,8 +322,14 @@ export default class ChatApi extends Service {
    * @param {number} channelId - The ID of the channel.
    * @returns {Promise}
    */
-  leaveChannel(channelId) {
-    return this.#deleteRequest(`/channels/${channelId}/memberships/me`);
+  async leaveChannel(channelId) {
+    await this.#deleteRequest(`/channels/${channelId}/memberships/me`);
+    const channel = await this.chatChannelsManager.find(channelId, {
+      fetchIfNotFound: false,
+    });
+    if (channel) {
+      this.chatChannelsManager.remove(channel);
+    }
   }
 
   /**

--- a/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
@@ -23,19 +23,19 @@
     &.active {
       background: var(--primary-very-low);
     }
+  }
 
-    &.can-leave:hover {
-      .toggle-channel-membership-button.-leave {
-        display: block;
+  &.can-leave:hover {
+    .toggle-channel-membership-button.-leave {
+      display: block;
 
-        > * {
-          pointer-events: auto;
-        }
+      > * {
+        pointer-events: auto;
       }
+    }
 
-      .chat-channel__metadata {
-        display: none;
-      }
+    .chat-channel__metadata {
+      display: none;
     }
   }
 

--- a/plugins/chat/spec/system/drawer/index_spec.rb
+++ b/plugins/chat/spec/system/drawer/index_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe "Drawer - index", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+
+  let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
+
+  before do
+    chat_system_bootstrap
+    sign_in(current_user)
+  end
+
+  it "can leave a direct message" do
+    channel = Fabricate(:direct_message_channel, users: [current_user])
+    row = PageObjects::Components::Chat::ChannelRow.new(channel.id)
+
+    drawer_page.visit_index
+
+    expect(row).to exist
+
+    row.leave
+
+    expect(row).to be_non_existent
+  end
+
+  it "can leave a group message" do
+    channel =
+      Fabricate(
+        :direct_message_channel,
+        group: true,
+        users: [current_user, Fabricate(:user), Fabricate(:user)],
+      )
+    row = PageObjects::Components::Chat::ChannelRow.new(channel.id)
+
+    drawer_page.visit_index
+
+    expect(row).to exist
+
+    row.leave
+
+    expect(row).to be_non_existent
+  end
+end

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -23,7 +23,7 @@ module PageObjects
         end
 
         def leave
-          component(class: ".can-leave").hover
+          component(class: ".can-leave").find(".chat-channel-row__content").hover
           component.find(".chat-channel-leave-btn").click
         end
 

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -23,8 +23,12 @@ module PageObjects
         end
 
         def leave
-          component(class: ".can-leave").find(".chat-channel-row__content").hover
-          component.find(".chat-channel-leave-btn").click
+          p "will leave"
+          p component(class: ".can-leave")
+          p component(class: ".can-leave")["outerHTML"]
+          element = component(class: ".can-leave")
+          element.hover
+          element.find(".chat-channel-leave-btn").click
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -24,7 +24,15 @@ module PageObjects
 
         def leave
           component(class: ".can-leave").hover
-          component.find(".chat-channel-leave-btn", visible: :all).click
+          btn = component.find(".chat-channel-leave-btn", visible: :all)
+          # style manipulation is necessary to have it working with @media(hover: hover) on CI
+          page.execute_script(
+            "document.querySelector('#{build_selector} .chat-channel-leave-btn').style.display = 'block';",
+          )
+          btn.click
+          page.execute_script(
+            "document.querySelector('#{build_selector} .chat-channel-leave-btn').style.display = '';",
+          )
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -23,12 +23,9 @@ module PageObjects
         end
 
         def leave
-          p "will leave"
-          p component(class: ".can-leave")
-          p component(class: ".can-leave")["outerHTML"]
           element = component(class: ".can-leave")
           element.hover
-          element.find(".chat-channel-leave-btn").click
+          element.find(".chat-channel-leave-btn", visible: :all).click
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -23,18 +23,19 @@ module PageObjects
         end
 
         def leave
-          component.hover
+          component(class: ".can-leave").hover
           component.find(".chat-channel-leave-btn").click
         end
 
-        def component
-          find(build_selector)
+        def component(**args)
+          find(build_selector(**args))
         end
 
         private
 
         def build_selector(**args)
           selector = SELECTOR
+          selector += args[:class] if args[:class]
           selector += "[data-chat-channel-id=\"#{self.id}\"]" if self.id
           selector
         end

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -24,10 +24,7 @@ module PageObjects
 
         def leave
           component(class: ".can-leave").hover
-          btn = component.find(".chat-channel-leave-btn", visible: :all)
-          btn.style("display", "block")
-          btn.click
-          btn.style("display", "")
+          component.find(".chat-channel-leave-btn", visible: :all).click
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    module Chat
+      class ChannelRow < PageObjects::Components::Base
+        SELECTOR = ".chat-channel-row"
+
+        attr_reader :id
+
+        def initialize(id)
+          @id = id
+        end
+
+        def non_existent?(**args)
+          exists?(**args, does_not_exist: true)
+        end
+
+        def exists?(**args)
+          selector = build_selector(**args)
+          selector_method = args[:does_not_exist] ? :has_no_selector? : :has_selector?
+          page.send(selector_method, selector)
+        end
+
+        def leave
+          component.hover
+          component.find(".chat-channel-leave-btn").click
+        end
+
+        def component
+          find(build_selector)
+        end
+
+        private
+
+        def build_selector(**args)
+          selector = SELECTOR
+          selector += "[data-chat-channel-id=\"#{self.id}\"]" if self.id
+          selector
+        end
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -24,8 +24,10 @@ module PageObjects
 
         def leave
           component(class: ".can-leave").hover
-          save_screenshot
-          component.find(".chat-channel-leave-btn", visible: :all).click
+          btn = component.find(".chat-channel-leave-btn", visible: :all)
+          btn.style("display", "block")
+          btn.click
+          btn.style("display", "")
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -23,9 +23,9 @@ module PageObjects
         end
 
         def leave
-          element = component(class: ".can-leave")
-          element.hover
-          element.find(".chat-channel-leave-btn", visible: :all).click
+          component(class: ".can-leave").hover
+          save_screenshot
+          component.find(".chat-channel-leave-btn", visible: :all).click
         end
 
         def component(**args)

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -24,6 +24,16 @@ module PageObjects
         find("#{VISIBLE_DRAWER} .c-navbar__back-button").click
       end
 
+      def visit_index
+        visit("/")
+        PageObjects::Pages::Chat.new.open_from_header
+      end
+
+      def visit_channel(channel)
+        visit_index
+        open_channel(channel)
+      end
+
       def open_channel(channel)
         channel_index.open_channel(channel)
         has_no_css?(".chat-skeleton")


### PR DESCRIPTION
Prior to this fix clicking <kbd>x</kbd> on a channel row would effectively leave the channel on server side, but it wouldn't disappear from the screen before a page refresh.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
