### PR TITLE
FIX: Allow staff to create tags and tag topics

### DIFF
--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -7,11 +7,13 @@ module TagGuardian
   end
 
   def can_create_tag?
-    SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map)
+    SiteSetting.tagging_enabled &&
+      (is_staff? || @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map))
   end
 
   def can_tag_topics?
-    SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.tag_topic_allowed_groups_map)
+    SiteSetting.tagging_enabled &&
+      (is_staff? || @user.in_any_groups?(SiteSetting.tag_topic_allowed_groups_map))
   end
 
   def can_tag_pms?

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3726,7 +3726,8 @@ RSpec.describe Guardian do
 
       context "when minimum trust level to create tags is 3" do
         before do
-          SiteSetting.create_tag_allowed_groups = "1|3|#{Group::AUTO_GROUPS[:trust_level_3]}"
+          SiteSetting.tag_topic_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_3]}"
+          SiteSetting.create_tag_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_3]}"
         end
 
         describe "#can_see_tag?" do
@@ -3754,7 +3755,7 @@ RSpec.describe Guardian do
           it "returns false if trust level is too low" do
             expect(
               Guardian.new(
-                Fabricate(:user, trust_level: 0, refresh_auto_groups: true),
+                Fabricate(:user, trust_level: 2, refresh_auto_groups: true),
               ).can_tag_topics?,
             ).to be_falsey
           end
@@ -3762,12 +3763,18 @@ RSpec.describe Guardian do
           it "returns true if trust level is high enough" do
             expect(
               Guardian.new(
-                Fabricate(:user, trust_level: 1, refresh_auto_groups: true),
+                Fabricate(:user, trust_level: 3, refresh_auto_groups: true),
+              ).can_tag_topics?,
+            ).to be_truthy
+
+            expect(
+              Guardian.new(
+                Fabricate(:user, trust_level: 4, refresh_auto_groups: true),
               ).can_tag_topics?,
             ).to be_truthy
           end
 
-          it "returns true for staff" do
+          it "always returns true for staff" do
             expect(Guardian.new(admin).can_tag_topics?).to be_truthy
             expect(Guardian.new(moderator).can_tag_topics?).to be_truthy
           end


### PR DESCRIPTION
There appears to be a regression from https://github.com/discourse/discourse/pull/25273 when we converted 

`min_trust_level_to_tag_topics` -> `tag_topic_allowed_groups`

We used to allow staff to do everything, but with the allowed groups we omitted staff.