### PR TITLE
FIX: `import:rebake_uncooked_*` jobs couldn't be run in parallel

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -772,8 +772,15 @@ def import_rebake_posts(posts)
   max_count = posts.count
   current_count = 0
 
-  posts.find_each(order: :desc) do |post|
-    post.rebake!
+  ids = posts.pluck(:id)
+  # work randomly so you can run this job from lots of consoles if needed
+  ids.shuffle!
+
+  ids.each do |id|
+    # may have been cooked in interim
+    post = posts.where(id: id).first
+    post.rebake! if post
+
     current_count += 1
     print "\r%7d / %7d" % [current_count, max_count]
   end


### PR DESCRIPTION
If those jobs were started multiple times each process would have rebaked the same posts.