### PR TITLE
UX: simplify styles for image uploader, add background to expand

### DIFF
--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.hbs
@@ -30,7 +30,7 @@
         @disabled={{this.loadingLightbox}}
         @action={{unless this.experimentalLightboxEnabled this.toggleLightbox}}
         data-lightbox-trigger={{if this.experimentalLightboxEnabled "true"}}
-        class="image-uploader-lightbox-btn no-text"
+        class="btn-default image-uploader-lightbox-btn no-text"
       />
     {{/if}}
 

--- a/app/assets/stylesheets/common/base/upload.scss
+++ b/app/assets/stylesheets/common/base/upload.scss
@@ -2,6 +2,14 @@
   background: var(--primary-medium) center;
   background-size: cover;
   position: relative;
+  max-width: 400px;
+  width: 100%;
+  height: 150px;
+  margin-bottom: 0.5em;
+
+  .meta {
+    display: none;
+  }
 
   .placeholder-overlay {
     background-size: contain;
@@ -19,28 +27,10 @@
     position: relative;
     display: flex;
     padding: 10px;
-
-    .btn {
-      margin-right: 5px;
-      padding: 7px 10px;
-    }
+    gap: 0.5em;
 
     .image-uploader-lightbox-btn {
-      background: none;
-      margin-right: 0;
       margin-left: auto;
-
-      .d-icon {
-        color: var(--primary-low);
-      }
-
-      &:hover {
-        background: none;
-
-        .d-icon {
-          color: var(--primary);
-        }
-      }
     }
   }
 }

--- a/app/assets/stylesheets/desktop/_index.scss
+++ b/app/assets/stylesheets/desktop/_index.scss
@@ -14,5 +14,4 @@
 @import "topic-post";
 @import "post-action-feedback";
 @import "topic";
-@import "upload";
 @import "user";

--- a/app/assets/stylesheets/desktop/upload.scss
+++ b/app/assets/stylesheets/desktop/upload.scss
@@ -1,6 +1,0 @@
-.uploaded-image-preview {
-  height: 270px;
-  width: 400px;
-  max-height: 150px;
-  margin-bottom: 10px;
-}

--- a/app/assets/stylesheets/mobile/_index.scss
+++ b/app/assets/stylesheets/mobile/_index.scss
@@ -32,6 +32,5 @@
 @import "topic-list";
 @import "topic-post";
 @import "topic";
-@import "upload";
 @import "user-badges";
 @import "user";

--- a/app/assets/stylesheets/mobile/upload.scss
+++ b/app/assets/stylesheets/mobile/upload.scss
@@ -1,3 +1,0 @@
-.uploaded-image-preview {
-  height: 150px;
-}


### PR DESCRIPTION
The expand button would disappear on hover for images with dark backgrounds, and it could be invisible on images with light backgrounds... so best to have a button background here. For the sake of consistency I just stuck with the `btn-default` styles. 

The mobile/desktop stylesheets were also very minimal, so I've cleaned up those styles and moved them to the /common stylesheet.


Before:
![image](https://github.com/discourse/discourse/assets/1681963/a8edaa32-1810-4cf9-aea7-0fe2c6cda796)


After:
![image](https://github.com/discourse/discourse/assets/1681963/56336c94-c69b-4bdf-a1be-7b6d8df8be3b)
