### PR TITLE
UX: clean up tag info styles, remove mobile stylesheet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.hbs
@@ -49,23 +49,25 @@
             >{{d-icon "pencil-alt"}}</a>
           {{/if}}
         </div>
-        <div class="tag-description-wrapper">
-          <span>{{html-safe this.tagInfo.description}}</span>
-        </div>
+        {{#if this.tagInfo.description}}
+          <div class="tag-description-wrapper">
+            <span>{{html-safe this.tagInfo.description}}</span>
+          </div>
+        {{/if}}
       {{/if}}
     </div>
     <div class="tag-associations">
-      {{#if this.tagInfo.tag_group_names}}
+      {{~#if this.tagInfo.tag_group_names}}
         {{this.tagGroupsInfo}}
-      {{/if}}
-      {{#if this.tagInfo.categories}}
+      {{/if~}}
+      {{~#if this.tagInfo.categories}}
         {{this.categoriesInfo}}
         <br />
         {{#each this.tagInfo.categories as |category|}}
           {{category-link category}}
         {{/each}}
-      {{/if}}
-      {{#if this.nothingToShow}}
+      {{/if~}}
+      {{~#if this.nothingToShow}}
         {{#if this.tagInfo.category_restricted}}
           {{i18n "tagging.category_restricted"}}
         {{else}}
@@ -74,7 +76,7 @@
             {{html-safe (i18n "tagging.staff_info" basePath=(base-path))}}
           {{/if}}
         {{/if}}
-      {{/if}}
+      {{/if~}}
     </div>
     {{#if this.tagInfo.synonyms}}
       <div class="synonyms-list">
@@ -112,7 +114,7 @@
     {{#if this.editSynonymsMode}}
       <section class="add-synonyms field">
         <label for="add-synonyms">{{i18n "tagging.add_synonyms_label"}}</label>
-        <div>
+        <div class="add-synonyms__controls">
           <TagChooser
             @id="add-synonyms"
             @tags={{this.newSynonyms}}
@@ -123,22 +125,24 @@
             @unlimitedTagCount={{true}}
             @allowCreate={{true}}
           />
-          <DButton
-            @action={{action "addSynonyms"}}
-            @disabled={{this.addSynonymsDisabled}}
-            @icon="check"
-            class="ok"
-          />
+          {{#if this.newSynonyms}}
+            <DButton
+              @action={{action "addSynonyms"}}
+              @disabled={{this.addSynonymsDisabled}}
+              @icon="check"
+              class="ok"
+            />
+          {{/if}}
         </div>
       </section>
     {{/if}}
     {{#if this.canAdminTag}}
-      <section>
-        <PluginOutlet
-          @name="tag-custom-settings"
-          @outletArgs={{hash tag=this.tagInfo}}
-        />
-      </section>
+      <PluginOutlet
+        @name="tag-custom-settings"
+        @outletArgs={{hash tag=this.tagInfo}}
+        @connectorTagName="section"
+      />
+
       <div class="tag-actions">
         <DButton
           @action={{action "toggleEditControls"}}

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -317,31 +317,29 @@ header .discourse-tag {
 }
 
 section.tag-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
   margin: 1em 0;
   padding: 2em;
   border: 1px solid var(--primary-low);
 
-  .field {
-    margin: 0 0 0.5em;
-  }
-
-  .btn {
-    margin-right: 0.5em;
-  }
-
   .edit-tag-wrapper {
     display: flex;
-    flex-wrap: wrap;
-    margin-bottom: 1em;
-    #edit-name {
+    flex-direction: column;
+
+    #edit-name,
+    #edit-description {
       width: 100%;
+      margin-bottom: 0.5em;
     }
+
     #edit-description {
       height: 120px;
-      flex: 10 1 auto;
     }
     .edit-controls {
-      width: 100%;
+      display: flex;
+      gap: 0.5em;
     }
   }
 
@@ -381,34 +379,25 @@ section.tag-info {
     }
   }
 
-  .tag-description-wrapper {
-    margin-bottom: 1em;
-  }
-
-  .tag-associations {
-    margin-bottom: 1em;
-  }
-
   .tag-actions {
-    margin-top: 2em;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+  }
+
+  .tag-associations:empty {
+    display: none;
   }
 
   .add-synonyms {
-    margin-top: 1em;
-    div {
+    &__controls {
       display: flex;
-    }
-    .ok {
-      margin-left: 0.5em;
-      display: none;
-    }
-    .has-selection + .ok {
-      display: flex;
+      gap: 0.5em;
     }
   }
 
   .tag-list {
-    margin: 0.5em 0 1em;
+    margin: 0.5em 0 0;
     padding: 0;
     border: none;
     a {

--- a/app/assets/stylesheets/mobile/_index.scss
+++ b/app/assets/stylesheets/mobile/_index.scss
@@ -28,7 +28,6 @@
 @import "reviewables";
 @import "search";
 @import "sidebar";
-@import "tagging";
 @import "topic-list";
 @import "topic-post";
 @import "topic";

--- a/app/assets/stylesheets/mobile/tagging.scss
+++ b/app/assets/stylesheets/mobile/tagging.scss
@@ -1,9 +1,0 @@
-.edit-tag-wrapper {
-  flex-direction: column;
-  .edit-controls {
-    margin-bottom: 0.5em;
-  }
-}
-.tag-info .tag-actions {
-  display: flex;
-}


### PR DESCRIPTION
The mobile stylesheet was fairly minimal, so I moved the styles to common and cleaned up some minor issues I noticed along the way. 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/a1b5cf87-177c-47b8-97d6-3cee8cab3a4b)


After:


![image](https://github.com/discourse/discourse/assets/1681963/40635693-870c-47b2-8989-de2582b9807c)

Before:

![image](https://github.com/discourse/discourse/assets/1681963/80ad7cca-2011-4a39-8e5c-90e7946bd82d)


After (minor spacing consistencies):



![image](https://github.com/discourse/discourse/assets/1681963/071738d5-3cb8-4248-9603-f7173ef5d6ed)

