### PR TITLE
FEATURE: Add recover api scopes

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -34,6 +34,9 @@ class ApiKeyScope < ActiveRecord::Base
           delete: {
             actions: %w[topics#destroy],
           },
+          recover: {
+            actions: %w[topics#recover],
+          },
           read: {
             actions: %w[topics#show topics#feed topics#posts topics#show_by_external_id],
             params: %i[topic_id external_id],
@@ -60,6 +63,9 @@ class ApiKeyScope < ActiveRecord::Base
           },
           delete: {
             actions: %w[posts#destroy],
+          },
+          recover: {
+            actions: %w[posts#recover],
           },
           list: {
             actions: %w[posts#latest],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5037,11 +5037,13 @@ en:
               write: Create a new topic or post to an existing one.
               update: Update a topic. Change the title, category, tags, status, archetype, featured_link etc.
               delete: Delete a topic.
+              recover: Recover a topic.
               read_lists: Read topic lists like top, new, latest, etc. RSS is also supported.
               status: "Update a topic's status. Status: closed, archive, visible, pinned. Enabled: true, false. Specify a category_id here and in the request payload to only allow status changes on topics in that category."
             posts:
               edit: Edit any post or a specific one.
               delete: Delete a post.
+              recover: Recover a post.
               list: List latest posts and private posts. RSS is also supported.
             tags:
               list: List tags.

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -478,6 +478,7 @@ RSpec.describe Admin::ApiController do
           "/t/:slug/:topic_id/last (GET)",
           "/t/:topic_id/posts (GET)",
           "/latest.rss (GET)",
+          "/t/:topic_id/recover (PUT)",
         ]
 
         topic_routes.each do |route|
@@ -486,6 +487,9 @@ RSpec.describe Admin::ApiController do
 
         expect(scopes["posts"].any? { |h| h["urls"].include?("/posts (GET)") }).to be_truthy
         expect(scopes["posts"].any? { |h| h["urls"].include?("/private-posts (GET)") }).to be_truthy
+        expect(
+          scopes["posts"].any? { |h| h["urls"].include?("/posts/:post_id/recover (PUT)") },
+        ).to be_truthy
 
         expect(scopes["users"].find { _1["key"] == "update" }["urls"]).to contain_exactly(
           "/users/:username (PUT)",


### PR DESCRIPTION
This commit adds two new api scopes. One for recovering topics, and the
other for recovering posts.