### PR TITLE
DEV: Hide min_trust_level_to_allow_profile_background setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1778,6 +1778,7 @@ trust:
     default: 0
     client: true
     enum: "TrustLevelSetting"
+    hidden: true
   profile_background_allowed_groups:
     default: "3|10" # auto group staff and trust_level_0
     type: group_list


### PR DESCRIPTION
Followup to a57280cb175c6352c64bf8d7b3330b477222af4d,
it was an oversight
