### PR TITLE
FIX: return missing href attribute for topic map participants avatars

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
@@ -48,7 +48,7 @@ export default class TopicParticipant extends Component {
   }
 
   get userUrl() {
-    userPath(this.args.participant);
+    return userPath(this.args.participant.username);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-participant-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-participant-test.js
@@ -15,7 +15,7 @@ module("Integration | Component | topic-participant", function (hooks) {
 
     await render(hbs`<TopicMap::TopicParticipant @participant={{this.args}}/>`);
 
-    assert.dom("a.poster.trigger-user-card").exists();
+    assert.dom("a.poster.trigger-user-card").hasAttribute("href", "/u/test");
     assert.dom("span.post-count").doesNotExist();
     assert.dom(".avatar-flair").doesNotExist();
   });
@@ -34,7 +34,7 @@ module("Integration | Component | topic-participant", function (hooks) {
 
     await render(hbs`<TopicMap::TopicParticipant @participant={{this.args}}/>`);
 
-    assert.dom("a.poster.trigger-user-card").exists();
+    assert.dom("a.poster.trigger-user-card").hasAttribute("href", "/u/test");
     assert.dom("span.post-count").exists();
     assert.dom(".group-devs a.poster").exists();
     assert.dom(".avatar-flair.avatar-flair-devs").exists();


### PR DESCRIPTION
Discovered a regression where the href attribute was left empty when rendering a TopicParticipant. This PR fixes the bug and adds to the acceptance test covering the component. 