### PR TITLE
DEV: Delete old enable_bookmarks_with_reminders setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -338,10 +338,6 @@ basic:
     default: "14"
     allow_any: false
     refresh: true
-  enable_bookmarks_with_reminders:
-    client: true
-    default: true
-    hidden: true
   push_notifications_prompt:
     default: true
     client: true

--- a/db/migrate/20200409033412_create_bookmarks_from_post_action_bookmarks.rb
+++ b/db/migrate/20200409033412_create_bookmarks_from_post_action_bookmarks.rb
@@ -2,7 +2,20 @@
 
 class CreateBookmarksFromPostActionBookmarks < ActiveRecord::Migration[6.0]
   def up
-    SiteSetting.enable_bookmarks_with_reminders = true
+    bookmarks_with_reminders_val =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'enable_bookmarks_with_reminders'",
+      )
+
+    if bookmarks_with_reminders_val.present?
+      DB.exec("UPDATE site_settings SET value = 't' WHERE name = 'enable_bookmarks_with_reminders'")
+    else
+      # data_type 5 is boolean
+      DB.exec(<<~SQL)
+        INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('enable_bookmarks_with_reminders', 't', 5, NOW(), NOW())
+      SQL
+    end
 
     bookmarks_to_create = []
     loop do

--- a/db/migrate/20240301033753_delete_old_bookmark_reminder_setting.rb
+++ b/db/migrate/20240301033753_delete_old_bookmark_reminder_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DeleteOldBookmarkReminderSetting < ActiveRecord::Migration[7.0]
+  def up
+    DB.exec("DELETE FROM site_settings WHERE name = 'enable_bookmarks_with_reminders'")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This setting has not been used for a long time, get rid
of it and also update the historical migration to not
rely on the SiteSetting model.
