### PR TITLE
DEV: Convert `home-logo` widget to a glimmer component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/contents.gjs
@@ -7,6 +7,7 @@ import MountWidget from "../mount-widget";
 import PluginOutlet from "../plugin-outlet";
 import SidebarToggle from "./sidebar-toggle";
 import TopicInfo from "./topic/info";
+import HomeLogo from "./home-logo";
 
 export default class Contents extends Component {
   @service site;
@@ -28,10 +29,7 @@ export default class Contents extends Component {
 
       <div class="home-logo-wrapper-outlet">
         <PluginOutlet @name="home-logo-wrapper">
-          <MountWidget
-            @widget="home-logo"
-            @args={{hash minimized=this.topicPresent}}
-          />
+          <HomeLogo @minimized={{this.topicPresent}} />
         </PluginOutlet>
       </div>
 

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/contents.gjs
@@ -3,11 +3,10 @@ import { hash } from "@ember/helper";
 import { inject as service } from "@ember/service";
 import and from "truth-helpers/helpers/and";
 import BootstrapModeNotice from "../bootstrap-mode-notice";
-import MountWidget from "../mount-widget";
 import PluginOutlet from "../plugin-outlet";
+import HomeLogo from "./home-logo";
 import SidebarToggle from "./sidebar-toggle";
 import TopicInfo from "./topic/info";
-import HomeLogo from "./home-logo";
 
 export default class Contents extends Component {
   @service site;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -11,13 +11,12 @@ import getURL from "discourse-common/lib/get-url";
 import Logo from "./logo";
 
 export default class HomeLogo extends Component {
+  @service session;
   @service site;
   @service siteSettings;
 
   href = getURL("/");
-  session = Session.current();
-  darkModeAvailable = Session.current().darkModeAvailable;
-  title = this.siteSettings.title;
+  darkModeAvailable = this.session.darkModeAvailable;
 
   get showMobileLogo() {
     return this.site.mobileView && this.logoResolver("mobile_logo").length > 0;
@@ -56,7 +55,7 @@ export default class HomeLogo extends Component {
     // try dark logos first when color scheme is dark
     // this is independent of browser dark mode
     // hence the fallback to normal logos
-    if (Session.currentProp("defaultColorSchemeIsDark")) {
+    if (this.session.defaultColorSchemeIsDark) {
       return (
         this.siteSettings[`site_${name}_dark_url`] ||
         this.siteSettings[`site_${name}_url`] ||
@@ -75,7 +74,6 @@ export default class HomeLogo extends Component {
 
     e.preventDefault();
     DiscourseURL.routeToTag(e.target.closest("a"));
-    return false;
   }
 
   <template>
@@ -90,7 +88,7 @@ export default class HomeLogo extends Component {
             <Logo
               @key="logo-small"
               @url={{this.logoSmallUrl}}
-              @title={{this.title}}
+              @title={{this.siteSettings.title}}
               @darkUrl={{this.logoSmallUrlDark}}
             />
           {{else}}
@@ -100,19 +98,19 @@ export default class HomeLogo extends Component {
           <Logo
             @key="logo-mobile"
             @url={{this.mobileLogoUrl}}
-            @title={{this.title}}
+            @title={{this.siteSettings.title}}
             @darkUrl={{this.mobileLogoUrlDark}}
           />
         {{else if this.logoUrl}}
           <Logo
             @key="logo-big"
             @url={{this.logoUrl}}
-            @title={{this.title}}
+            @title={{this.siteSettings.title}}
             @darkUrl={{this.logoUrlDark}}
           />
         {{else}}
           <h1 id="site-text-logo" class="text-logo">
-            {{this.title}}
+            {{this.siteSettings.title}}
           </h1>
         {{/if}}
       </a>

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -79,6 +79,7 @@ export default class HomeLogo extends Component {
   }
 
   <template>
+    {{! template-lint-disable no-invalid-interactive }}
     <div
       class={{concatClass (if @minimized "title--minimized") "title"}}
       {{on "click" this.click}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -1,14 +1,13 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import concatClass from "discourse/helpers/concat-class";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL from "discourse/lib/url";
 import Session from "discourse/models/session";
-import getURL from "discourse-common/lib/get-url";
-import { concat, fn, hash } from "@ember/helper";
-import { action } from "@ember/object";
-import { inject as service } from "@ember/service";
 import icon from "discourse-common/helpers/d-icon";
+import getURL from "discourse-common/lib/get-url";
 import Logo from "./logo";
-import concatClass from "discourse/helpers/concat-class";
 
 export default class HomeLogo extends Component {
   @service site;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -5,7 +5,6 @@ import { inject as service } from "@ember/service";
 import concatClass from "discourse/helpers/concat-class";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL from "discourse/lib/url";
-import Session from "discourse/models/session";
 import icon from "discourse-common/helpers/d-icon";
 import getURL from "discourse-common/lib/get-url";
 import Logo from "./logo";

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import concatClass from "discourse/helpers/concat-class";
@@ -71,14 +72,17 @@ export default class HomeLogo extends Component {
     if (wantsNewWindow(e)) {
       return false;
     }
-    e.preventDefault();
 
+    e.preventDefault();
     DiscourseURL.routeToTag(e.target.closest("a"));
     return false;
   }
 
   <template>
-    <div class={{concatClass (if @minimized "title--minimized") "title"}}>
+    <div
+      class={{concatClass (if @minimized "title--minimized") "title"}}
+      {{on "click" this.click}}
+    >
       <a href={{this.href}} data-auto-route="true">
         {{#if @minimized}}
           {{#if this.logoSmallUrl}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -1,0 +1,117 @@
+import Component from "@glimmer/component";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
+import DiscourseURL from "discourse/lib/url";
+import Session from "discourse/models/session";
+import getURL from "discourse-common/lib/get-url";
+import { concat, fn, hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import icon from "discourse-common/helpers/d-icon";
+import Logo from "./logo";
+import concatClass from "discourse/helpers/concat-class";
+
+export default class HomeLogo extends Component {
+  @service site;
+  @service siteSettings;
+
+  href = getURL("/");
+  session = Session.current();
+  darkModeAvailable = Session.current().darkModeAvailable;
+  title = this.siteSettings.title;
+
+  get showMobileLogo() {
+    return this.site.mobileView && this.logoResolver("mobile_logo").length > 0;
+  }
+
+  get logoUrl() {
+    return this.logoResolver("logo");
+  }
+
+  get logoUrlDark() {
+    return this.logoResolver("logo", { dark: this.darkModeAvailable });
+  }
+
+  get logoSmallUrl() {
+    return this.logoResolver("logo_small");
+  }
+
+  get logoSmallUrlDark() {
+    return this.logoResolver("logo_small", { dark: this.darkModeAvailable });
+  }
+
+  get mobileLogoUrl() {
+    return this.logoResolver("mobile_logo");
+  }
+
+  get mobileLogoUrlDark() {
+    return this.logoResolver("mobile_logo", { dark: this.darkModeAvailable });
+  }
+
+  logoResolver(name, opts = {}) {
+    // get alternative logos for browser dark dark mode switching
+    if (opts.dark) {
+      return this.siteSettings[`site_${name}_dark_url`];
+    }
+
+    // try dark logos first when color scheme is dark
+    // this is independent of browser dark mode
+    // hence the fallback to normal logos
+    if (Session.currentProp("defaultColorSchemeIsDark")) {
+      return (
+        this.siteSettings[`site_${name}_dark_url`] ||
+        this.siteSettings[`site_${name}_url`] ||
+        ""
+      );
+    }
+
+    return this.siteSettings[`site_${name}_url`] || "";
+  }
+
+  @action
+  click(e) {
+    if (wantsNewWindow(e)) {
+      return false;
+    }
+    e.preventDefault();
+
+    DiscourseURL.routeToTag(e.target.closest("a"));
+    return false;
+  }
+
+  <template>
+    <div class={{concatClass (if @minimized "title--minimized") "title"}}>
+      <a href={{this.href}} data-auto-route="true">
+        {{#if @minimized}}
+          {{#if this.logoSmallUrl}}
+            <Logo
+              @key="logo-small"
+              @url={{this.logoSmallUrl}}
+              @title={{this.title}}
+              @darkUrl={{this.logoSmallUrlDark}}
+            />
+          {{else}}
+            {{icon "home"}}
+          {{/if}}
+        {{else if this.showMobileLogo}}
+          <Logo
+            @key="logo-mobile"
+            @url={{this.mobileLogoUrl}}
+            @title={{this.title}}
+            @darkUrl={{this.mobileLogoUrlDark}}
+          />
+        {{else if this.logoUrl}}
+          <Logo
+            @key="logo-big"
+            @url={{this.logoUrl}}
+            @title={{this.title}}
+            @darkUrl={{this.logoUrlDark}}
+          />
+        {{else}}
+          <h1 id="site-text-logo" class="text-logo">
+            {{this.title}}
+          </h1>
+        {{/if}}
+      </a>
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
@@ -1,10 +1,10 @@
 import getURL from "discourse-common/lib/get-url";
 import and from "truth-helpers/helpers/and";
+import notEq from "truth-helpers/helpers/not-eq";
 import eq from "truth-helpers/helpers/eq";
-import not from "truth-helpers/helpers/not";
 
-const LogoElement = <template>
-  {{#if (and @darkUrl (not (eq @url @darkUrl)))}}
+const Logo = <template>
+  {{#if (and @darkUrl (notEq @url @darkUrl))}}
     <picture>
       <source srcset={{getURL @darkUrl}} media="(prefers-color-scheme: dark)" />
       <img
@@ -26,4 +26,4 @@ const LogoElement = <template>
   {{/if}}
 </template>;
 
-export default LogoElement;
+export default Logo;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
@@ -1,0 +1,30 @@
+import { concat } from "@ember/helper";
+import getURL from "discourse-common/lib/get-url";
+import and from "truth-helpers/helpers/and";
+import not from "truth-helpers/helpers/not";
+import eq from "truth-helpers/helpers/eq";
+
+const LogoElement = <template>
+  {{#if (and @darkUrl (not (eq @url @darkUrl)))}}
+    <picture>
+      <source srcset={{getURL @darkUrl}} media="(prefers-color-scheme: dark)" />
+      <img
+        id="site-logo"
+        class={{@key}}
+        src={{getURL @url}}
+        width={{if (eq @key "logo-small") "36"}}
+        alt={{@title}}
+      />
+    </picture>
+  {{else}}
+    <img
+      id="site-logo"
+      class={{@key}}
+      src={{getURL @url}}
+      width={{if (eq @key "logo-small") "36"}}
+      alt={{@title}}
+    />
+  {{/if}}
+</template>;
+
+export default LogoElement;

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
@@ -1,8 +1,7 @@
-import { concat } from "@ember/helper";
 import getURL from "discourse-common/lib/get-url";
 import and from "truth-helpers/helpers/and";
-import not from "truth-helpers/helpers/not";
 import eq from "truth-helpers/helpers/eq";
+import not from "truth-helpers/helpers/not";
 
 const LogoElement = <template>
   {{#if (and @darkUrl (not (eq @url @darkUrl)))}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/logo.gjs
@@ -1,7 +1,7 @@
 import getURL from "discourse-common/lib/get-url";
 import and from "truth-helpers/helpers/and";
-import notEq from "truth-helpers/helpers/not-eq";
 import eq from "truth-helpers/helpers/eq";
+import notEq from "truth-helpers/helpers/not-eq";
 
 const Logo = <template>
   {{#if (and @darkUrl (notEq @url @darkUrl))}}

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -156,6 +156,7 @@ const DEPRECATED_HEADER_WIDGETS = [
   "header-icons",
   "header-topic-info",
   "header-notifications",
+  "home-logo",
 ];
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.

--- a/app/assets/javascripts/discourse/app/widgets/home-logo.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo.js
@@ -1,3 +1,4 @@
+// deprecated in favor of components/glimmer-header/home-logo.gjs
 import { h } from "virtual-dom";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -25,47 +25,43 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = bigLogo;
     this.siteSettings.site_logo_small_url = smallLogo;
     this.siteSettings.title = title;
-    const minimized = false;
 
-    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
-    assert.strictEqual(count(".title"), 1);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
-    assert.strictEqual(query("#site-logo").getAttribute("alt"), title);
+    await render(<template><HomeLogo @minimized={{false}} /></template>);
+    assert.dom(".title").exists({ count: 1 });
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", bigLogo);
+    assert.dom("#site-logo").hasAttribute("alt", title);
   });
 
   test("basics - minimized", async function (assert) {
     this.siteSettings.site_logo_url = bigLogo;
     this.siteSettings.site_logo_small_url = smallLogo;
     this.siteSettings.title = title;
-    const minimized = true;
 
-    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
-    assert.strictEqual(count("img.logo-small"), 1);
-    assert.strictEqual(query("img.logo-small").getAttribute("src"), smallLogo);
-    assert.strictEqual(query("img.logo-small").getAttribute("alt"), title);
-    assert.strictEqual(query("img.logo-small").getAttribute("width"), "36");
+    await render(<template><HomeLogo @minimized={{true}} /></template>);
+    assert.dom("img.logo-small").exists({ count: 1 });
+    assert.dom("img.logo-small").hasAttribute("src", smallLogo);
+    assert.dom("img.logo-small").hasAttribute("alt", title);
+    assert.dom("img.logo-small").hasAttribute("width", "36");
   });
 
   test("no logo", async function (assert) {
     this.siteSettings.site_logo_url = "";
     this.siteSettings.site_logo_small_url = "";
     this.siteSettings.title = title;
-    const minimized = false;
 
-    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
-    assert.strictEqual(count("h1#site-text-logo.text-logo"), 1);
-    assert.strictEqual(query("#site-text-logo").innerText, title);
+    await render(<template><HomeLogo @minimized={{false}} /></template>);
+    assert.dom("h1#site-text-logo.text-logo").exists({ count: 1 });
+    assert.dom("#site-text-logo").hasText(title, "has title as text logo");
   });
 
   test("no logo - minimized", async function (assert) {
     this.siteSettings.site_logo_url = "";
     this.siteSettings.site_logo_small_url = "";
     this.siteSettings.title = title;
-    const minimized = true;
 
-    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
-    assert.strictEqual(count(".d-icon-home"), 1);
+    await render(<template><HomeLogo @minimized={{true}} /></template>);
+    assert.dom(".d-icon-home").exists({ count: 1 });
   });
 
   test("mobile logo", async function (assert) {
@@ -74,8 +70,8 @@ module("Integration | Component | home-logo", function (hooks) {
     this.site.mobileView = true;
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-mobile"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), mobileLogo);
+    assert.dom("img#site-logo.logo-mobile").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", mobileLogo);
   });
 
   test("mobile without logo", async function (assert) {
@@ -83,8 +79,8 @@ module("Integration | Component | home-logo", function (hooks) {
     this.site.mobileView = true;
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", bigLogo);
   });
 
   test("logo with dark mode alternative", async function (assert) {
@@ -93,19 +89,18 @@ module("Integration | Component | home-logo", function (hooks) {
     this.session.set("darkModeAvailable", true);
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
-
-    assert.strictEqual(
-      query("picture source").getAttribute("media"),
-      prefersDark,
-      "includes dark mode media attribute"
-    );
-    assert.strictEqual(
-      query("picture source").getAttribute("srcset"),
-      darkLogo,
-      "includes dark mode alternative logo source"
-    );
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", bigLogo);
+    assert
+      .dom("picture source")
+      .hasAttribute("media", prefersDark, "includes dark mode media attribute");
+    assert
+      .dom("picture source")
+      .hasAttribute(
+        "srcset",
+        darkLogo,
+        "includes dark mode alternative logo source"
+      );
   });
 
   test("mobile logo with dark mode alternative", async function (assert) {
@@ -117,18 +112,18 @@ module("Integration | Component | home-logo", function (hooks) {
     this.site.mobileView = true;
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), mobileLogo);
 
-    assert.strictEqual(
-      query("picture source").getAttribute("media"),
-      prefersDark,
-      "includes dark mode media attribute"
-    );
-    assert.strictEqual(
-      query("picture source").getAttribute("srcset"),
-      darkLogo,
-      "includes dark mode alternative logo source"
-    );
+    assert.dom("#site-logo").hasAttribute("src", mobileLogo);
+    assert
+      .dom("picture source")
+      .hasAttribute("media", prefersDark, "includes dark mode media attribute");
+    assert
+      .dom("picture source")
+      .hasAttribute(
+        "srcset",
+        darkLogo,
+        "includes dark mode alternative logo source"
+      );
   });
 
   test("dark mode enabled but no dark logo set", async function (assert) {
@@ -137,9 +132,9 @@ module("Integration | Component | home-logo", function (hooks) {
     this.session.set("darkModeAvailable", true);
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
-    assert.ok(!exists("picture"), "does not include alternative logo");
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", bigLogo);
+    assert.dom("picture").doesNotExist("does not include alternative logo");
   });
 
   test("dark logo set but no dark mode", async function (assert) {
@@ -147,9 +142,9 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_logo_dark_url = darkLogo;
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
-    assert.ok(!exists("picture"), "does not include alternative logo");
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", bigLogo);
+    assert.dom("picture").doesNotExist("does not include alternative logo");
   });
 
   test("dark color scheme and dark logo set", async function (assert) {
@@ -158,13 +153,9 @@ module("Integration | Component | home-logo", function (hooks) {
     this.session.set("defaultColorSchemeIsDark", true);
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(
-      query("#site-logo").getAttribute("src"),
-      darkLogo,
-      "uses dark logo"
-    );
-    assert.ok(!exists("picture"), "does not add dark mode alternative");
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert.dom("#site-logo").hasAttribute("src", darkLogo, "uses dark logo");
+    assert.dom("picture").doesNotExist("does not add dark mode alternative");
   });
 
   test("dark color scheme and dark logo not set", async function (assert) {
@@ -173,11 +164,13 @@ module("Integration | Component | home-logo", function (hooks) {
     this.session.set("defaultColorSchemeIsDark", true);
 
     await render(<template><HomeLogo /></template>);
-    assert.strictEqual(count("img#site-logo.logo-big"), 1);
-    assert.strictEqual(
-      query("#site-logo").getAttribute("src"),
-      bigLogo,
-      "uses regular logo on dark scheme if no dark logo"
-    );
+    assert.dom("img#site-logo.logo-big").exists({ count: 1 });
+    assert
+      .dom("#site-logo")
+      .hasAttribute(
+        "src",
+        bigLogo,
+        "uses regular logo on dark scheme if no dark logo"
+      );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -1,10 +1,9 @@
-// deprecated in favor of discourse/tests/integration/components/home-logo-test.gjs
 import { getOwner } from "@ember/application";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import MountWidget from "discourse/components/mount-widget";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
+import HomeLogo from "discourse/components/glimmer-header/home-logo";
 
 const bigLogo = "/images/d-logo-sketch.png?test";
 const smallLogo = "/images/d-logo-sketch-small.png?test";
@@ -13,7 +12,7 @@ const darkLogo = "/images/d-logo-sketch.png?dark";
 const title = "Cool Forum";
 const prefersDark = "(prefers-color-scheme: dark)";
 
-module("Integration | Component | Widget | home-logo", function (hooks) {
+module("Integration | Component | home-logo", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.afterEach(function () {
@@ -26,12 +25,9 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = bigLogo;
     this.siteSettings.site_logo_small_url = smallLogo;
     this.siteSettings.title = title;
-    const args = { minimized: false };
+    const minimized = false;
 
-    await render(<template>
-      <MountWidget @widget="home-logo" @args={{args}} />
-    </template>);
-
+    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count(".title"), 1);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
@@ -44,10 +40,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.title = title;
     const args = { minimized: true };
 
-    await render(<template>
-      <MountWidget @widget="home-logo" @args={{args}} />
-    </template>);
-
+    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count("img.logo-small"), 1);
     assert.strictEqual(query("img.logo-small").getAttribute("src"), smallLogo);
     assert.strictEqual(query("img.logo-small").getAttribute("alt"), title);
@@ -60,10 +53,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.title = title;
     const args = { minimized: false };
 
-    await render(<template>
-      <MountWidget @widget="home-logo" @args={{args}} />
-    </template>);
-
+    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count("h1#site-text-logo.text-logo"), 1);
     assert.strictEqual(query("#site-text-logo").innerText, title);
   });
@@ -74,10 +64,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.title = title;
     const args = { minimized: true };
 
-    await render(<template>
-      <MountWidget @widget="home-logo" @args={{args}} />
-    </template>);
-
+    await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count(".d-icon-home"), 1);
   });
 
@@ -86,8 +73,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_small_url = smallLogo;
     this.site.mobileView = true;
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-mobile"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), mobileLogo);
   });
@@ -96,8 +82,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = bigLogo;
     this.site.mobileView = true;
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
   });
@@ -107,8 +92,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_dark_url = darkLogo;
     this.session.set("darkModeAvailable", true);
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
 
@@ -132,8 +116,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
 
     this.site.mobileView = true;
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(query("#site-logo").getAttribute("src"), mobileLogo);
 
     assert.strictEqual(
@@ -153,8 +136,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_dark_url = "";
     this.session.set("darkModeAvailable", true);
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
     assert.ok(!exists("picture"), "does not include alternative logo");
@@ -164,8 +146,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = bigLogo;
     this.siteSettings.site_logo_dark_url = darkLogo;
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(query("#site-logo").getAttribute("src"), bigLogo);
     assert.ok(!exists("picture"), "does not include alternative logo");
@@ -176,8 +157,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_dark_url = darkLogo;
     this.session.set("defaultColorSchemeIsDark", true);
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(
       query("#site-logo").getAttribute("src"),
@@ -192,8 +172,7 @@ module("Integration | Component | Widget | home-logo", function (hooks) {
     this.siteSettings.site_logo_dark_url = "";
     this.session.set("defaultColorSchemeIsDark", true);
 
-    await render(<template><MountWidget @widget="home-logo" /></template>);
-
+    await render(<template><HomeLogo /></template>);
     assert.strictEqual(count("img#site-logo.logo-big"), 1);
     assert.strictEqual(
       query("#site-logo").getAttribute("src"),

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -3,7 +3,6 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import HomeLogo from "discourse/components/glimmer-header/home-logo";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
 
 const bigLogo = "/images/d-logo-sketch.png?test";
 const smallLogo = "/images/d-logo-sketch-small.png?test";

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -1,9 +1,9 @@
 import { getOwner } from "@ember/application";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import HomeLogo from "discourse/components/glimmer-header/home-logo";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
-import HomeLogo from "discourse/components/glimmer-header/home-logo";
 
 const bigLogo = "/images/d-logo-sketch.png?test";
 const smallLogo = "/images/d-logo-sketch-small.png?test";
@@ -38,7 +38,7 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = bigLogo;
     this.siteSettings.site_logo_small_url = smallLogo;
     this.siteSettings.title = title;
-    const args = { minimized: true };
+    const minimized = true;
 
     await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count("img.logo-small"), 1);
@@ -51,7 +51,7 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = "";
     this.siteSettings.site_logo_small_url = "";
     this.siteSettings.title = title;
-    const args = { minimized: false };
+    const minimized = false;
 
     await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count("h1#site-text-logo.text-logo"), 1);
@@ -62,7 +62,7 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_logo_url = "";
     this.siteSettings.site_logo_small_url = "";
     this.siteSettings.title = title;
-    const args = { minimized: true };
+    const minimized = true;
 
     await render(<template><HomeLogo @minimized={{minimized}} /></template>);
     assert.strictEqual(count(".d-icon-home"), 1);


### PR DESCRIPTION
Part of the larger effort to upgrade the header from widgets to glimmer components: https://github.com/discourse/discourse/pull/25214
