### PR TITLE
UX: disable the image preview controls while invisible

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -202,6 +202,7 @@
 
     &[editing] {
       opacity: 1;
+      pointer-events: auto;
     }
 
     .scale-btn-container,

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -178,6 +178,7 @@
 
   &:hover {
     .button-wrapper {
+      pointer-events: auto;
       opacity: 1;
     }
   }
@@ -185,12 +186,10 @@
   .button-wrapper {
     min-width: 10em;
     width: 100%;
-
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
     gap: 0 0.5em;
-
     position: absolute;
     height: calc(var(--resizer-height) + 0.5em);
     bottom: 0;
@@ -199,6 +198,7 @@
     transition: all 0.25s;
     z-index: 1; // needs to be higher than image
     background: var(--secondary); // for when images are wider than controls
+    pointer-events: none; // the controls shouldn't be usable while invisible
 
     &[editing] {
       opacity: 1;
@@ -314,6 +314,7 @@
 
 .mobile-view .d-editor-preview .image-wrapper .button-wrapper {
   opacity: 1;
+  pointer-events: auto;
 }
 
 // d-editor bar button sizing


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/accidentially-tapping-the-invisible-ai-caption-button/297455

This should make it harder to accidentally trigger the opacity-hidden hover buttons on touch devices.