### PR TITLE
DEV: remove unneeded mobile /top buttons CSS, clean up

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -403,11 +403,8 @@
   display: flex;
   margin: 0.5em 0;
   flex-wrap: wrap;
-  font-size: var(--font-0-rem);
-
-  button {
-    margin-right: 0.5em;
-  }
+  font-size: var(--font-down-1);
+  gap: 0.5em;
 }
 
 div.education {

--- a/app/assets/stylesheets/mobile/_index.scss
+++ b/app/assets/stylesheets/mobile/_index.scss
@@ -5,7 +5,6 @@
 @import "admin_report";
 @import "admin_reports";
 @import "alert";
-@import "buttons";
 @import "compose";
 @import "dashboard";
 @import "dialog";

--- a/app/assets/stylesheets/mobile/buttons.scss
+++ b/app/assets/stylesheets/mobile/buttons.scss
@@ -1,3 +1,0 @@
-h3 .top-title-buttons button {
-  margin-top: 0.5em;
-}


### PR DESCRIPTION
These buttons are plenty large enough and don't need the extra margin here:

Before:
![image](https://github.com/discourse/discourse/assets/1681963/3cdc56d6-7315-4605-9f82-df8506e44d07)


After:
![image](https://github.com/discourse/discourse/assets/1681963/37344f0c-3b34-441c-ae6b-f9059222aee7)


They're now consistent with desktop:

![image](https://github.com/discourse/discourse/assets/1681963/07e149dc-9205-4c8a-9b58-a754dae1e7fb)
