### PR TITLE
DEV: remove various unused CSS

### DIFF
--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -1,12 +1,10 @@
 .admin-reports,
-.dashboard,
 .dashboard-next {
   &.admin-contents {
     margin: 10px 0 0 0;
   }
 }
 
-.dashboard,
 .dashboard-next {
   .navigation {
     display: flex;

--- a/app/assets/stylesheets/mobile/dashboard.scss
+++ b/app/assets/stylesheets/mobile/dashboard.scss
@@ -1,4 +1,3 @@
-.dashboard,
 .dashboard-next {
   .activity-metrics .counters-list {
     font-size: var(--font-down-1);

--- a/app/assets/stylesheets/mobile/directory.scss
+++ b/app/assets/stylesheets/mobile/directory.scss
@@ -22,8 +22,3 @@
     padding: 5px;
   }
 }
-
-.edit-user-directory-columns-modal .modal-inner-container {
-  width: 90%;
-  min-width: unset;
-}

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -134,9 +134,3 @@ blockquote {
 #main {
   position: relative;
 }
-
-// Styles used before the user is logged into discourse. For example, activating
-// their account or changing their email.
-#simple-container {
-  width: 90%;
-}


### PR DESCRIPTION
1. `.dashboard` refers to the legacy dashboard that no longer exists
2. `.edit-user-directory-columns-modal .modal-inner-container` style for old modals, no longer needed
3. `#simple-container` this old width restriction is no longer needed