### PR TITLE
Bump the moment-timezone version in package.json to reflect 2024a release of TZDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint-to-the-future-eslint": "^2.0.1",
     "magnific-popup": "1.1.0",
     "moment": "2.29.4",
-    "moment-timezone": "0.5.43",
+    "moment-timezone": "0.5.45",
     "patch-package": "^8.0.0",
     "pikaday": "1.8.2",
     "postinstall-postinstall": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9691,10 +9691,10 @@ mktemp@~0.4.0:
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==
 
-moment-timezone@0.5.43:
-  version "0.5.43"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
-  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+moment-timezone@0.5.45:
+  version "0.5.45"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
+  integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
Starting from March 1, 2024, Kazakhstan has switched to a unified UTC+5 timezone. As a result, Asia/Almaty switched from UTC+6 to UTC+5. This change has been reflected in the 2024a release of the TZ DB ([see relevant commit](https://github.com/eggert/tz/commit/95a16c87f21c4643055482429dad921357a630c9)), which was incorporated into moment-timezone [in the 0.5.45 version](https://github.com/moment/moment-timezone/releases/tag/0.5.45). The dataset update is the only major change in 0.5.45, and, as far as I understand, [0.5.44 didn't introduce any functional changes that could break things](https://github.com/moment/moment-timezone/releases/tag/0.5.44), so I presumed bumping up the version would suffice.