### PR TITLE
FEATURE: Allow specific groups to view raw email

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -130,7 +130,7 @@ export default function transformPost(
     postType === postTypes.small_action || post.action_code === "split_topic";
   postAtts.canBookmark = !!currentUser;
   postAtts.canManage = currentUser && currentUser.get("canManageTopic");
-  postAtts.canViewRawEmail = currentUser && currentUser.staff;
+  postAtts.canViewRawEmail = currentUser && currentUser.can_view_raw_email;
   postAtts.canArchiveTopic = !!details.can_archive_topic;
   postAtts.canCloseTopic = !!details.can_close_topic;
   postAtts.canSplitMergeTopic = !!details.can_split_merge_topic;

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -75,7 +75,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_experimental_topic_bulk_actions?,
              :use_experimental_topic_bulk_actions?,
              :use_admin_sidebar,
-             :glimmer_header_enabled?
+             :glimmer_header_enabled?,
+             :can_view_raw_email
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -315,5 +316,9 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def use_experimental_topic_bulk_actions?
     scope.user.in_any_groups?(SiteSetting.experimental_topic_bulk_actions_enabled_groups_map)
+  end
+
+  def can_view_raw_email
+    scope.user.in_any_groups?(SiteSetting.view_raw_email_allowed_groups_map)
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2554,6 +2554,7 @@ en:
 
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
+    view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1423,6 +1423,12 @@ email:
     default: 10
     hidden: true
   require_change_email_confirmation: false
+  view_raw_email_allowed_groups:
+    type: group_list
+    list_type: compact
+    default: "1|2"
+    allow_any: false
+    refresh: true
 
 files:
   max_image_size_kb:

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -358,7 +358,7 @@ module PostGuardian
   end
 
   def can_view_raw_email?(post)
-    post && is_staff?
+    post && @user.in_any_groups?(SiteSetting.view_raw_email_allowed_groups_map)
   end
 
   def can_unhide?(post)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2701,6 +2701,17 @@ RSpec.describe PostsController do
         expect(response.status).to eq(403)
       end
 
+      it "can view raw email if the user is in the allowed group" do
+        sign_in(user)
+        SiteSetting.view_raw_email_allowed_groups = "trust_level_0"
+
+        get "/posts/#{post.id}/raw-email.json"
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        expect(json["raw_email"]).to eq("email_content")
+      end
+
       it "can view raw email" do
         sign_in(moderator)
 


### PR DESCRIPTION
When a post is created by an incoming email, we show
an envelope icon on it which then opens a modal with the
raw email contents. Previously this was staff (admin+mod)
only, but now this commit adds the `view_raw_email_allowed_groups`
site setting, so any group can be added to give users permission
to see this.