### PR TITLE
FIX: `ThemeSettingsObjectValidator` not allowing URL paths for string

### DIFF
--- a/lib/theme_settings_object_validator.rb
+++ b/lib/theme_settings_object_validator.rb
@@ -163,7 +163,7 @@ class ThemeSettingsObjectValidator
         return false
       end
 
-      if validations&.dig(:url) && !value.match?(URI.regexp)
+      if validations&.dig(:url) && !UrlHelper.relaxed_parse(value)
         add_error(property_name, :string_value_not_valid_url)
         return false
       end

--- a/spec/lib/theme_settings_object_validator_spec.rb
+++ b/spec/lib/theme_settings_object_validator_spec.rb
@@ -359,6 +359,38 @@ RSpec.describe ThemeSettingsObjectValidator do
         expect(errors["/string_property"].full_messages).to contain_exactly("must be a string")
       end
 
+      it "should not return an empty hash when string property satsify url validation" do
+        schema = {
+          name: "section",
+          properties: {
+            string_property: {
+              type: "string",
+              validations: {
+                url: true,
+              },
+            },
+          },
+        }
+
+        expect(
+          described_class.new(
+            schema: schema,
+            object: {
+              string_property: "https://www.example.com",
+            },
+          ).validate,
+        ).to eq({})
+
+        expect(
+          described_class.new(
+            schema: schema,
+            object: {
+              string_property: "/some-path/to/some-where",
+            },
+          ).validate,
+        ).to eq({})
+      end
+
       it "should return the right hash of error messages when string property does not statisfy url validation" do
         schema = {
           name: "section",


### PR DESCRIPTION
### Why this change?

Prior this change, we were using `URI.regexp` which was too strict as it
doesn't allow a URL path.

### What does this change do?

Just parse the string using `URI.parse` and if it doesn't raise an error
we consider the string to be a valid URL