### PR TITLE
DEV: Fix migration that adds index to `incoming_emails` `topic_id`

### DIFF
--- a/db/migrate/20240304030429_topic_id_on_incoming_email_index.rb
+++ b/db/migrate/20240304030429_topic_id_on_incoming_email_index.rb
@@ -2,7 +2,12 @@
 class TopicIdOnIncomingEmailIndex < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
-  def change
+  def up
+    remove_index :incoming_emails, :topic_id, if_exists: true
     add_index :incoming_emails, :topic_id, algorithm: :concurrently
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end


### PR DESCRIPTION
Why this change?

Follow up to f880f1a42ffc39cd65eeaf318682b166290fd1d4. When adding an
index concurrently where the database transaction is disabled, we have
to ensure that we drop the index first if it exists because an invalid
index can be created if the migration has failed before.