### PR TITLE
FIX: correctly shows as disabled a user who can't chat

### DIFF
--- a/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
+++ b/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
@@ -5,7 +5,7 @@ module Chat
     attributes :can_chat, :has_chat_enabled
 
     def can_chat
-      SiteSetting.chat_enabled && scope.can_chat?
+      SiteSetting.chat_enabled && scope.can_chat? && scope.can_direct_message?
     end
 
     def has_chat_enabled

--- a/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
+++ b/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
@@ -5,7 +5,7 @@ module Chat
     attributes :can_chat, :has_chat_enabled
 
     def can_chat
-      SiteSetting.chat_enabled && scope.can_chat? && scope.can_direct_message?
+      SiteSetting.chat_enabled && object.guardian.can_chat? && object.guardian.can_direct_message?
     end
 
     def has_chat_enabled

--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -199,7 +199,7 @@ module Chat
           .where(id: scoped_channels)
           .includes(
             last_message: [:uploads],
-            chatable: [{ direct_message_users: [user: :user_option] }, :users],
+            chatable: [{ direct_message_users: [user: %i[user_option group_users]] }, :users],
           )
           .joins(
             "LEFT JOIN chat_messages last_message ON last_message.id = chat_channels.last_message_id",

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -25,7 +25,7 @@ module Chat
     end
 
     def can_create_direct_message?
-      is_staff? || @user.in_any_groups?(SiteSetting.direct_message_enabled_groups_map)
+      is_staff? || can_direct_message?
     end
 
     def hidden_tag_names

--- a/plugins/chat/spec/integration/outgoing_web_hooks_spec.rb
+++ b/plugins/chat/spec/integration/outgoing_web_hooks_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Outgoing chat webhooks" do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
   end
 
   describe "chat messages" do

--- a/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
@@ -3,7 +3,10 @@ RSpec.describe Chat::ChatableUserSerializer do
   fab!(:user)
   subject(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
 
-  before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+  before do
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
+  end
 
   it "serializes a user" do
     expect(serializer.as_json).to eq(
@@ -15,7 +18,7 @@ RSpec.describe Chat::ChatableUserSerializer do
         custom_fields: {
         },
         can_chat: false,
-        has_chat_enabled: false,
+        has_chat_enabled: true,
       },
     )
   end

--- a/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe Chat::ChatableUserSerializer do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user)
   subject(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
 
-  it "serializes a user" do
-    json = serializer.as_json
+  before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone] }
 
-    expect(json).to eq(
+  it "serializes a user" do
+    expect(serializer.as_json).to eq(
       {
         id: user.id,
         username: user.username,
@@ -18,5 +18,37 @@ RSpec.describe Chat::ChatableUserSerializer do
         has_chat_enabled: false,
       },
     )
+  end
+
+  context "when chat is disabled" do
+    before { SiteSetting.chat_enabled = false }
+
+    it "can't chat" do
+      expect(serializer.as_json[:can_chat]).to eq(false)
+    end
+  end
+
+  context "when user is not allowed to chat" do
+    before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_4] }
+
+    it "can't chat" do
+      expect(serializer.as_json[:can_chat]).to eq(false)
+    end
+  end
+
+  context "when user has chat disabled" do
+    before { user.user_option.update!(chat_enabled: false) }
+
+    it "has chat disabled" do
+      expect(serializer.as_json[:has_chat_enabled]).to eq(false)
+    end
+  end
+
+  context "when user can't use direct messages" do
+    before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4] }
+
+    it "can't chat" do
+      expect(serializer.as_json[:can_chat]).to eq(false)
+    end
   end
 end

--- a/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Chat::ChatableUserSerializer do
         avatar_template: user.avatar_template,
         custom_fields: {
         },
-        can_chat: false,
+        can_chat: true,
         has_chat_enabled: true,
       },
     )

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Channel - Info - Members page", type: :system do
   fab!(:channel_1) { Fabricate(:category_channel) }
 
   before do
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
     chat_system_bootstrap
     sign_in(current_user)
   end

--- a/plugins/chat/spec/system/chat_message_creator_spec.rb
+++ b/plugins/chat/spec/system/chat_message_creator_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Flag message", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   before do
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
     SiteSetting.chat_max_direct_message_users = 3
     chat_system_bootstrap
     sign_in(current_user)


### PR DESCRIPTION
Prior to this fix we were checking if user was not part of a group which allows to chat, but we were not checking if this user was part of groups who can use direct messages.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
