### PR TITLE
DEV: Modifier for Chat::Mailer to skip summary email for users

### DIFF
--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -7,7 +7,7 @@ module Chat
 
       users_with_unprocessed_unread_mentions.find_each do |user|
         # Apply modifier to `true` -- this allows other plugins to block the chat summary email send
-        next if !DiscoursePluginRegistry.apply_modifier(:chat_mailer_summary_user, true, user)
+        next if !DiscoursePluginRegistry.apply_modifier(:send_chat_mailer_summary_user, true, user)
 
         # user#memberships_with_unread_messages is a nested array that looks like [[membership_id, unread_message_id]]
         # Find the max unread id per membership.

--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -7,7 +7,9 @@ module Chat
 
       users_with_unprocessed_unread_mentions.find_each do |user|
         # Apply modifier to `true` -- this allows other plugins to block the chat summary email send
-        next if !DiscoursePluginRegistry.apply_modifier(:send_chat_mailer_summary_user, true, user)
+        if !DiscoursePluginRegistry.apply_modifier(:chat_mailer_send_summary_to_user, true, user)
+          next
+        end
 
         # user#memberships_with_unread_messages is a nested array that looks like [[membership_id, unread_message_id]]
         # Find the max unread id per membership.

--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -6,6 +6,9 @@ module Chat
       return unless SiteSetting.chat_enabled
 
       users_with_unprocessed_unread_mentions.find_each do |user|
+        # Apply modifier to `true` -- this allows other plugins to block the chat summary email send
+        next if !DiscoursePluginRegistry.apply_modifier(:chat_mailer_summary_user, true, user)
+
         # user#memberships_with_unread_messages is a nested array that looks like [[membership_id, unread_message_id]]
         # Find the max unread id per membership.
         membership_and_max_unread_mention_ids =

--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -235,13 +235,13 @@ describe Chat::Mailer do
       assert_only_queued_once
     end
 
-    context "with chat_mailer_summary_user modifier" do
+    context "with send_chat_mailer_summary_user modifier" do
       let(:modifier_block) { Proc.new { |_| false } }
       it "skips when modifier evaluates to false" do
         SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
 
         plugin_instance = Plugin::Instance.new
-        plugin_instance.register_modifier(:chat_mailer_summary_user, &modifier_block)
+        plugin_instance.register_modifier(:send_chat_mailer_summary_user, &modifier_block)
 
         described_class.send_unread_mentions_summary
 
@@ -249,7 +249,7 @@ describe Chat::Mailer do
       ensure
         DiscoursePluginRegistry.unregister_modifier(
           plugin_instance,
-          :chat_mailer_summary_user,
+          :send_chat_mailer_summary_user,
           &modifier_block
         )
       end

--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -235,13 +235,13 @@ describe Chat::Mailer do
       assert_only_queued_once
     end
 
-    context "with send_chat_mailer_summary_user modifier" do
+    context "with chat_mailer_send_summary_to_user modifier" do
       let(:modifier_block) { Proc.new { |_| false } }
       it "skips when modifier evaluates to false" do
         SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
 
         plugin_instance = Plugin::Instance.new
-        plugin_instance.register_modifier(:send_chat_mailer_summary_user, &modifier_block)
+        plugin_instance.register_modifier(:chat_mailer_send_summary_to_user, &modifier_block)
 
         described_class.send_unread_mentions_summary
 
@@ -249,7 +249,7 @@ describe Chat::Mailer do
       ensure
         DiscoursePluginRegistry.unregister_modifier(
           plugin_instance,
-          :send_chat_mailer_summary_user,
+          :chat_mailer_send_summary_to_user,
           &modifier_block
         )
       end

--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -235,6 +235,26 @@ describe Chat::Mailer do
       assert_only_queued_once
     end
 
+    context "with chat_mailer_summary_user modifier" do
+      let(:modifier_block) { Proc.new { |_| false } }
+      it "skips when modifier evaluates to false" do
+        SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+
+        plugin_instance = Plugin::Instance.new
+        plugin_instance.register_modifier(:chat_mailer_summary_user, &modifier_block)
+
+        described_class.send_unread_mentions_summary
+
+        assert_summary_skipped
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :chat_mailer_summary_user,
+          &modifier_block
+        )
+      end
+    end
+
     describe "update the user membership after we send the email" do
       before { Jobs.run_immediately! }
 


### PR DESCRIPTION
This adds a plugin modifier to block sending chat summary email to certain users via another plugin.