### PR TITLE
UX: Chat avatar is-online styling

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -162,13 +162,12 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
 }
 
 .avatar {
-  border: 1px solid transparent;
-  padding: 0;
   box-sizing: border-box;
 
   .is-online & {
-    border: 1px solid var(--secondary);
-    box-shadow: 0px 0px 0px 1px var(--success);
+    padding: 2px;
+    box-shadow: inset 0px 0px 0px 1px var(--success),
+      inset 0px 0px 0px 2px var(--secondary);
   }
 }
 

--- a/plugins/chat/assets/stylesheets/common/chat-channel-icon.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-icon.scss
@@ -4,8 +4,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
     background: rgba(var(--primary-rgb), 0.1);
     box-sizing: border-box;
@@ -19,13 +19,11 @@
     }
   }
 
-  &.--avatar {
-    .chat-user-avatar {
-      .avatar {
-        .chat-channel-row & {
-          width: var(--channel-list-avatar-size);
-          height: var(--channel-list-avatar-size);
-        }
+  .chat-user-avatar {
+    .avatar {
+      .chat-channel-row & {
+        width: var(--channel-list-avatar-size);
+        height: var(--channel-list-avatar-size);
       }
     }
   }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
@@ -68,14 +68,6 @@
   position: relative;
 }
 
-.chat-channel-title .chat-user-avatar {
-  font-size: var(--font-up-1);
-
-  + .chat-channel-title__usernames {
-    margin-left: 0.5rem;
-  }
-}
-
 .chat-channel-title__restricted-category-icon {
   background-color: var(--secondary);
   position: absolute;

--- a/plugins/chat/assets/stylesheets/common/chat-user-avatar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-user-avatar.scss
@@ -3,26 +3,15 @@
   display: flex;
   align-items: center;
 
-  .chat-message-container:not(.has-reply) & {
-    width: var(--message-left-width);
-    flex-shrink: 0;
-  }
-
   &.is-online {
-    .chat-user-avatar__container .avatar {
-      box-shadow: 0px 0px 0px 1px var(--success);
-      border: 1px solid var(--secondary);
-      padding: 0;
+    .avatar {
+      padding: 2px;
+      box-shadow: inset 0px 0px 0px 1px var(--success),
+        inset 0px 0px 0px 2px var(--secondary);
     }
   }
 
   &__container {
-    padding: 1px; // for is-online box-shadow effect, preventing cutoff
-
-    .avatar {
-      padding: 1px; // for is-online box-shadow effect, preventing shift
-    }
-
     .chat-user-presence-flair {
       box-sizing: border-box;
       position: absolute;
@@ -44,6 +33,11 @@
         bottom: -1px;
       }
     }
+  }
+
+  .chat-message-container:not(.has-reply) & {
+    width: var(--message-left-width);
+    flex-shrink: 0;
   }
 
   .chat-channel-title & {


### PR DESCRIPTION
Working with a transparent border to prevent size-shifts for is-online and not-online avatars, often causes misalignments which require separate attention, and creates a visual distinction in perceived size.

A better approach is to use  inset box-shadows for both the green circle, as for the white padding, which means the size of the avatar box never changes, and so can never cause jumps. This also makes the size look visually more correct between an online and offline avatar.

BEFORE – AFTER
<img width="538" alt="image" src="https://github.com/discourse/discourse/assets/101828855/3ecc6673-22d3-48cb-99d2-6695779bac47">

<img width="938" alt="image" src="https://github.com/discourse/discourse/assets/101828855/b560b476-0e95-4695-a194-08e4a15ddc59">

<img width="899" alt="image" src="https://github.com/discourse/discourse/assets/101828855/1f9a11fa-e5df-46ac-a3d0-066ffe7d142f">


