### PR TITLE
UX: always show image controls on touch devices

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -166,8 +166,8 @@
   --resizer-height: 1.75em;
   position: relative;
   display: inline-block;
-  .desktop-view & {
-    // need the extra space on mobile because controls are always visible
+  .discourse-no-touch & {
+    // on hover-capable devices we position the controls within the padding
     padding-bottom: var(--resizer-height);
     margin-bottom: calc(var(--resizer-height) * -1);
   }
@@ -178,7 +178,6 @@
 
   &:hover {
     .button-wrapper {
-      pointer-events: auto;
       opacity: 1;
     }
   }
@@ -198,11 +197,9 @@
     transition: all 0.25s;
     z-index: 1; // needs to be higher than image
     background: var(--secondary); // for when images are wider than controls
-    pointer-events: none; // the controls shouldn't be usable while invisible
 
     &[editing] {
       opacity: 1;
-      pointer-events: auto;
     }
 
     .scale-btn-container,
@@ -313,9 +310,8 @@
   }
 }
 
-.mobile-view .d-editor-preview .image-wrapper .button-wrapper {
+.discourse-touch .d-editor-preview .image-wrapper .button-wrapper {
   opacity: 1;
-  pointer-events: auto;
 }
 
 // d-editor bar button sizing


### PR DESCRIPTION
This switches the composer preview image hover controls to always be visible on *touch* devices, not just mobile. 

This also reverts 84882ad25fa38c55fb4a6b83940133fd64c06694 — the idea there was that pointer-events (clicks) should be disabled if the controls aren't visible, but too many mobile devices do a simultaneous "hover + tap" state for that to work. Tapping triggers the hover, and therefore the controls were interactive even before they're visible. 

I considered some alternate approaches, like adding JS click observers and the like... but hovering (double tapping) to find invisible controls just isn't great experience on a touch device. So we should always show these, and if we're unhappy with how they look on touch we can come up with a different design. 


Before (iPad):
![image](https://github.com/discourse/discourse/assets/1681963/d128a60e-84c0-41de-ac7b-57500c701dea)


After (iPad):
![image](https://github.com/discourse/discourse/assets/1681963/5b058238-39f0-4e4c-8463-4da3dafee6da)
