### PR TITLE
FIX: active webhook types exclude inactive plugins

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -98,16 +98,23 @@ class WebHookEventType < ActiveRecord::Base
   def self.active
     ids_to_exclude = []
     unless defined?(SiteSetting.solved_enabled) && SiteSetting.solved_enabled
-      ids_to_exclude << TYPES[:solved_accept_unaccept]
+      ids_to_exclude.concat([TYPES[:solved_accepted_solution], TYPES[:solved_unaccepted_solution]])
     end
     unless defined?(SiteSetting.assign_enabled) && SiteSetting.assign_enabled
-      ids_to_exclude << TYPES[:assign_assign_unassign]
+      ids_to_exclude.concat([TYPES[:assign_assigned], TYPES[:assign_unassigned]])
     end
     unless defined?(SiteSetting.voting_enabled) && SiteSetting.voting_enabled
-      ids_to_exclude << TYPES[:voting_voted_unvoted]
+      ids_to_exclude.concat([TYPES[:voting_topic_upvote], TYPES[:voting_topic_unvote]])
     end
     unless defined?(SiteSetting.chat_enabled) && SiteSetting.chat_enabled
-      ids_to_exclude << TYPES[:chat_message]
+      ids_to_exclude.concat(
+        [
+          TYPES[:chat_message_created],
+          TYPES[:chat_message_edited],
+          TYPES[:chat_message_trashed],
+          TYPES[:chat_message_restored],
+        ],
+      )
     end
     self.where.not(id: ids_to_exclude)
   end

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe WebHookEventType do
+  describe "#active" do
+    it "returns only active types" do
+      core_event_types = WebHookEventType.active.map(&:name)
+      expect(core_event_types).to eq(
+        %w[
+          topic_created
+          topic_revised
+          topic_edited
+          topic_destroyed
+          topic_recovered
+          post_created
+          post_edited
+          post_destroyed
+          post_recovered
+          user_logged_in
+          user_logged_out
+          user_confirmed_email
+          user_created
+          user_approved
+          user_updated
+          user_destroyed
+          user_suspended
+          user_unsuspended
+          group_created
+          group_updated
+          group_destroyed
+          category_created
+          category_updated
+          category_destroyed
+          tag_created
+          tag_updated
+          tag_destroyed
+          reviewable_created
+          reviewable_updated
+          notification_created
+          user_badge_granted
+          user_badge_revoked
+          user_added_to_group
+          user_removed_from_group
+          post_liked
+          user_promoted
+        ],
+      )
+
+      SiteSetting.stubs(:solved_enabled).returns(true)
+      SiteSetting.stubs(:assign_enabled).returns(true)
+      SiteSetting.stubs(:voting_enabled).returns(true)
+      SiteSetting.stubs(:chat_enabled).returns(true)
+      plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
+      expect(plugins_event_types).to eq(
+        %w[
+          accepted_solution
+          unaccepted_solution
+          assigned
+          unassigned
+          topic_upvote
+          topic_unvote
+          chat_message_created
+          chat_message_edited
+          chat_message_trashed
+          chat_message_restored
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Bug introduced when webhooks were granularized in this PR - https://github.com/discourse/discourse/commit/c46811092994d456e7a67b33669b76e51aaa3668

Only active webhooks should be available when webhooks are configured.

https://meta.discourse.org/t/i18n-keys-showing-on-webhooks-edit-page/297701