### PR TITLE
FIX: code "block" detection before showing autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -241,8 +241,8 @@ export default Component.extend(ComposerUploadUppy, {
         key: "@",
         transformComplete: (v) => v.username || v.name,
         afterComplete: this._afterMentionComplete,
-        triggerRule: (textarea) =>
-          !inCodeBlock(textarea.value, caretPosition(textarea)),
+        triggerRule: async (textarea) =>
+          !(await inCodeBlock(textarea.value, caretPosition(textarea))),
         onClose: destroyUserStatuses,
       });
     }

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -532,10 +532,6 @@ export default Component.extend(TextareaTextManipulation, {
       },
 
       onKeyUp: (text, cp) => {
-        if (inCodeBlock(text, cp)) {
-          return false;
-        }
-
         const matches =
           /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
             text.substring(0, cp)
@@ -639,8 +635,8 @@ export default Component.extend(TextareaTextManipulation, {
           });
       },
 
-      triggerRule: (textarea) =>
-        !inCodeBlock(textarea.value, caretPosition(textarea)),
+      triggerRule: async (textarea) =>
+        !(await inCodeBlock(textarea.value, caretPosition(textarea))),
     });
   },
 

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -17,8 +17,9 @@ import discourseLater from "discourse-common/lib/later";
 
 export const SKIP = "skip";
 export const CANCELLED_STATUS = "__CANCELLED";
-const allowedLettersRegex = /[\s\t\[\{\(\/]/;
-let _autoCompletePopper;
+
+const ALLOWED_LETTERS_REGEXP = /[\s[{(/]/;
+let _autoCompletePopper, _inputTimeout;
 
 const keys = {
   backSpace: 8,
@@ -46,15 +47,13 @@ const keys = {
   z: 90,
 };
 
-let inputTimeout;
-
 export default function (options) {
   if (this.length === 0) {
     return;
   }
 
   if (options === "destroy" || options.updateData) {
-    cancel(inputTimeout);
+    cancel(_inputTimeout);
 
     this[0].removeEventListener("keydown", handleKeyDown);
     this[0].removeEventListener("keyup", handleKeyUp);
@@ -242,7 +241,7 @@ export default function (options) {
           // the time autocomplete was first displayed and the time of completion
           // Specifically this may happen due to uploads which inject a placeholder
           // which is later replaced with a different length string.
-          let pos = guessCompletePosition({ completeTerm: true });
+          let pos = await guessCompletePosition({ completeTerm: true });
 
           if (
             pos.completeStart !== undefined &&
@@ -374,26 +373,31 @@ export default function (options) {
     } else {
       selectedOption = -1;
     }
-    ul.find("li").click(function ({ originalEvent }) {
+    ul.find("li").click(async function ({ originalEvent }) {
+      // this is required to prevent the default behaviour when clicking on a <a> tag
+      originalEvent.preventDefault();
+
       selectedOption = ul.find("li").index(this);
       // hack for Gboard, see meta.discourse.org/t/-/187009/24
       if (autocompleteOptions == null) {
         const opts = { ...options, _gboard_hack_force_lookup: true };
-        const forcedAutocompleteOptions = dataSource(prevTerm, opts);
-        forcedAutocompleteOptions?.then((data) => {
+        const data = await dataSource(prevTerm, opts);
+        if (data) {
           updateAutoComplete(data);
-          completeTerm(autocompleteOptions[selectedOption], originalEvent);
+          await completeTerm(
+            autocompleteOptions[selectedOption],
+            originalEvent
+          );
           if (!options.single) {
             me.focus();
           }
-        });
+        }
       } else {
-        completeTerm(autocompleteOptions[selectedOption], originalEvent);
+        await completeTerm(autocompleteOptions[selectedOption], originalEvent);
         if (!options.single) {
           me.focus();
         }
       }
-      return false;
     });
 
     if (options.appendSelector) {
@@ -537,19 +541,20 @@ export default function (options) {
     closeAutocomplete();
   });
 
-  function checkTriggerRule(opts) {
-    return options.triggerRule ? options.triggerRule(me[0], opts) : true;
+  async function checkTriggerRule(opts) {
+    const shouldTrigger = await options.triggerRule?.(me[0], opts);
+    return shouldTrigger ?? true;
   }
 
-  function handleKeyUp(e) {
+  async function handleKeyUp(e) {
     if (options.debounced) {
       discourseDebounce(this, performAutocomplete, e, INPUT_DELAY);
     } else {
-      performAutocomplete(e);
+      await performAutocomplete(e);
     }
   }
 
-  function performAutocomplete(e) {
+  async function performAutocomplete(e) {
     if ([keys.esc, keys.enter].includes(e.which)) {
       return true;
     }
@@ -572,9 +577,10 @@ export default function (options) {
     if (completeStart === null && cp > 0) {
       if (key === options.key) {
         let prevChar = me.val().charAt(cp - 2);
+        const shouldTrigger = await checkTriggerRule();
         if (
-          checkTriggerRule() &&
-          (!prevChar || allowedLettersRegex.test(prevChar))
+          shouldTrigger &&
+          (!prevChar || ALLOWED_LETTERS_REGEXP.test(prevChar))
         ) {
           completeStart = cp - 1;
           updateAutoComplete(dataSource("", options));
@@ -586,13 +592,12 @@ export default function (options) {
     }
   }
 
-  function guessCompletePosition(opts) {
+  async function guessCompletePosition(opts) {
     let prev, stopFound, term;
     let prevIsGood = true;
     let element = me[0];
-    let backSpace = opts && opts.backSpace;
-    let completeTermOption = opts && opts.completeTerm;
-
+    let backSpace = opts?.backSpace;
+    let completeTermOption = opts?.completeTerm;
     let caretPos = caretPosition(element);
 
     if (backSpace) {
@@ -612,15 +617,15 @@ export default function (options) {
 
       if (stopFound) {
         prev = element.value[caretPos - 1];
+        const shouldTrigger = await checkTriggerRule({ backSpace });
 
         if (
-          checkTriggerRule({ backSpace }) &&
-          (prev === undefined || allowedLettersRegex.test(prev))
+          shouldTrigger &&
+          (prev === undefined || ALLOWED_LETTERS_REGEXP.test(prev))
         ) {
           start = caretPos;
           term = element.value.substring(caretPos + 1, initialCaretPos);
           end = caretPos + term.length;
-
           break;
         }
       }
@@ -633,7 +638,7 @@ export default function (options) {
     return { completeStart: start, completeEnd: end, term };
   }
 
-  function handleKeyDown(e) {
+  async function handleKeyDown(e) {
     let i, term, total, userToComplete;
     let cp;
 
@@ -644,8 +649,8 @@ export default function (options) {
     if (options.allowAny) {
       // saves us wiring up a change event as well
 
-      cancel(inputTimeout);
-      inputTimeout = discourseLater(function () {
+      cancel(_inputTimeout);
+      _inputTimeout = discourseLater(() => {
         if (inputSelectedItems.length === 0) {
           inputSelectedItems.push("");
         }
@@ -669,7 +674,7 @@ export default function (options) {
     }
 
     if (completeStart === null && e.which === keys.backSpace && options.key) {
-      let position = guessCompletePosition({ backSpace: true });
+      let position = await guessCompletePosition({ backSpace: true });
       completeStart = position.completeStart;
 
       if (position.completeEnd) {
@@ -716,7 +721,7 @@ export default function (options) {
             selectedOption >= 0 &&
             (userToComplete = autocompleteOptions[selectedOption])
           ) {
-            completeTerm(userToComplete, e);
+            await completeTerm(userToComplete, e);
           } else {
             // We're cancelling it, really.
             return true;

--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -140,12 +140,8 @@ export function setupHashtagAutocomplete(
   );
 }
 
-export function hashtagTriggerRule(textarea) {
-  if (inCodeBlock(textarea.value, caretPosition(textarea))) {
-    return false;
-  }
-
-  return true;
+export async function hashtagTriggerRule(textarea) {
+  return !(await inCodeBlock(textarea.value, caretPosition(textarea)));
 }
 
 function _setup(
@@ -168,7 +164,8 @@ function _setup(
       }
       return _searchGeneric(term, siteSettings, contextualHashtagConfiguration);
     },
-    triggerRule: (textarea, opts) => hashtagTriggerRule(textarea, opts),
+    triggerRule: async (textarea, opts) =>
+      await hashtagTriggerRule(textarea, opts),
   });
 }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { test } from "qunit";
 import {
@@ -6,6 +6,8 @@ import {
   exists,
   normalizeHtml,
   query,
+  simulateKey,
+  simulateKeys,
   visible,
 } from "discourse/tests/helpers/qunit-helpers";
 
@@ -16,12 +18,13 @@ acceptance("Emoji", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
-    await fillIn(".d-editor-input", "this is an emoji :blonde_woman:");
+    await simulateKeys(query(".d-editor-input"), "a :blonde_wo\t");
+
     assert.ok(visible(".d-editor-preview"));
     assert.strictEqual(
       normalizeHtml(query(".d-editor-preview").innerHTML.trim()),
       normalizeHtml(
-        `<p>this is an emoji <img src="/images/emoji/twitter/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"></p>`
+        `<p>a <img src="/images/emoji/twitter/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"></p>`
       )
     );
   });
@@ -30,13 +33,13 @@ acceptance("Emoji", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
-    await fillIn(".d-editor-input", "this is an emoji :blonde_woman:t5:");
+    await simulateKeys(query(".d-editor-input"), "a :blonde_woman:t5:");
 
     assert.ok(visible(".d-editor-preview"));
     assert.strictEqual(
       normalizeHtml(query(".d-editor-preview").innerHTML.trim()),
       normalizeHtml(
-        `<p>this is an emoji <img src="/images/emoji/twitter/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"></p>`
+        `<p>a <img src="/images/emoji/twitter/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"></p>`
       )
     );
   });
@@ -49,13 +52,13 @@ acceptance("Emoji", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
-    await fillIn(".d-editor-input", ":s");
-    await triggerKeyEvent(".d-editor-input", "keyup", "ArrowDown"); // ensures a keyup is triggered
+    const editor = query(".d-editor-input");
+
+    await simulateKeys(editor, ":s");
 
     assert.notOk(exists(".autocomplete.ac-emoji"));
 
-    await fillIn(".d-editor-input", ":sw");
-    await triggerKeyEvent(".d-editor-input", "keyup", "ArrowDown"); // ensures a keyup is triggered
+    await simulateKey(editor, "w");
 
     assert.ok(exists(".autocomplete.ac-emoji"));
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtag-autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtag-autocomplete-test.js
@@ -2,14 +2,13 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
-  emulateAutocomplete,
+  query,
+  simulateKeys,
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("#hashtag autocompletion in composer", function (needs) {
   needs.user();
-  needs.settings({
-    tagging_enabled: true,
-  });
+  needs.settings({ tagging_enabled: true });
   needs.pretender((server, helper) => {
     server.get("/hashtags", () => {
       return helper.response({
@@ -56,8 +55,7 @@ acceptance("#hashtag autocompletion in composer", function (needs) {
   test(":emoji: unescape in autocomplete search results", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
-
-    await emulateAutocomplete(".d-editor-input", "abc #o");
+    await simulateKeys(query(".d-editor-input"), "abc #o");
 
     assert.dom(".hashtag-autocomplete__option").exists({ count: 3 });
     assert

--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -1,6 +1,5 @@
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest as emberSetupRenderingTest } from "ember-qunit";
-import $ from "jquery";
 import QUnit, { test } from "qunit";
 import { autoLoadModules } from "discourse/instance-initializers/auto-load-modules";
 import { AUTO_GROUPS } from "discourse/lib/constants";
@@ -48,8 +47,6 @@ export function setupRenderingTest(hooks) {
 
     autoLoadModules(this.owner, this.registry);
     this.owner.lookup("service:store");
-
-    $.fn.autocomplete = function () {};
   });
 }
 

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -1,9 +1,9 @@
 import { run } from "@ember/runloop";
 import {
-  fillIn,
   getApplication,
   settled,
   triggerKeyEvent,
+  typeIn,
 } from "@ember/test-helpers";
 import { isEmpty } from "@ember/utils";
 import { setupApplicationTest } from "ember-qunit";
@@ -610,14 +610,31 @@ export async function paste(element, text, otherClipboardData = {}) {
   return e;
 }
 
-export async function emulateAutocomplete(inputSelector, text) {
-  await triggerKeyEvent(inputSelector, "keydown", "Backspace");
-  await fillIn(inputSelector, `${text} `);
-  await triggerKeyEvent(inputSelector, "keyup", "Backspace");
+export async function simulateKey(element, key) {
+  if (key === "\b") {
+    await triggerKeyEvent(element, "keydown", "Backspace");
 
-  await triggerKeyEvent(inputSelector, "keydown", "Backspace");
-  await fillIn(inputSelector, text);
-  await triggerKeyEvent(inputSelector, "keyup", "Backspace");
+    const pos = element.selectionStart;
+    element.value = element.value.slice(0, pos - 1) + element.value.slice(pos);
+    element.selectionStart = pos - 1;
+    element.selectionEnd = pos - 1;
+
+    await triggerKeyEvent(element, "keyup", "Backspace");
+  } else if (key === "\t") {
+    await triggerKeyEvent(element, "keydown", "Tab");
+    await triggerKeyEvent(element, "keyup", "Tab");
+  } else if (key === "\r") {
+    await triggerKeyEvent(element, "keydown", "Enter");
+    await triggerKeyEvent(element, "keyup", "Enter");
+  } else {
+    await typeIn(element, key);
+  }
+}
+
+export async function simulateKeys(element, keys) {
+  for (let key of keys) {
+    await simulateKey(element, key);
+  }
 }
 
 // The order of attributes can vary in different browsers. When comparing

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -219,34 +219,16 @@ module("Unit | Utilities", function (hooks) {
     );
   });
 
-  test("inCodeBlock", function (assert) {
-    const texts = [
-      // CLOSED CODE BLOCKS:
-      "000\n\n    111\n\n000",
-      "000 `111` 000",
-      "000\n```\n111\n```\n000",
-      "000\n[code]111[/code]\n000",
-      // OPEN CODE BLOCKS:
-      "000\n\n    111",
-      "000 `111",
-      "000\n```\n111",
-      "000\n[code]111",
-      // COMPLEX TEST:
-      "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`111",
-      // INDENTED OPEN CODE BLOCKS:
-      // - Using tab
-      "000\n\t```111\n\t111\n\t111```\n000",
-      // - Using spaces
-      `000\n  \`\`\`111\n  111\n  111\`\`\`\n000`,
-    ];
+  test("inCodeBlock", async function (assert) {
+    const text =
+      "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`000";
 
-    texts.forEach((text) => {
-      for (let i = 0; i < text.length; ++i) {
-        if (text[i] === "0" || text[i] === "1") {
-          assert.strictEqual(inCodeBlock(text, i), text[i] === "1");
-        }
+    for (let i = 0; i < text.length; ++i) {
+      if (text[i] === "0" || text[i] === "1") {
+        let inCode = await inCodeBlock(text, i);
+        assert.strictEqual(inCode, text[i] === "1");
       }
-    });
+    }
   });
 
   test("mergeSortedLists", function (assert) {

--- a/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
+++ b/plugins/chat/test/javascripts/acceptance/user-status-on-mentions-test.js
@@ -3,10 +3,10 @@ import { skip, test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
-  emulateAutocomplete,
   loggedInUser,
   publishToMessageBus,
   query,
+  simulateKeys,
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Chat | User status on mentions", function (needs) {
@@ -321,7 +321,7 @@ acceptance("Chat | User status on mentions", function (needs) {
   }
 
   async function typeWithAutocompleteAndSend(text) {
-    await emulateAutocomplete(".chat-composer__input", text);
+    await simulateKeys(query(".chat-composer__input"), text);
     await click(".autocomplete.ac-user .selected");
     await click(".chat-composer-button.-send");
   }


### PR DESCRIPTION
**TL;DR:** Refactor autocomplete to use async markdown parsing for code block detection.

Previously, the `inCodeBlock` function in `discourse/app/lib/utilities.js` used regular expressions to determine if a given position in the text was inside a code block. This approach had some limitations and could lead to incorrect behavior in certain edge cases.

This commit refactors `inCodeBlock` to use a more robust algorithm that leverages Discourse's markdown parsing library. 

The new approach works as follows:

1. Check if the text contains any code block markers using a regular expression.
   If not, return `false` since the cursor can't be in a code block.
1. If potential code blocks exist, find a unique marker character that doesn't appear in the text.
1. Insert the unique marker character into the text at the cursor position.
1. Parse the modified text using Discourse's markdown parser, which converts the markdown into a tree of tokens.
1. Traverse the token tree to find the token that contains the unique marker character.
1. Check if the token's type is one of the types representing code blocks ("code_inline", "code_block", or "fence").
   If so, return `true`, indicating that the cursor is inside a code block. 
   Otherwise, return `false`.

This algorithm provides a more accurate way to determine the cursor's position in relation to code blocks, accounting for the various ways code blocks can be represented in markdown.

To accommodate this change, the autocomplete `triggerRule` option is now an async function. 

The autocomplete logic in `composer-editor.js`, `d-editor.js`, and `hashtag-autocomplete.js` has been updated to handle the async nature of `inCodeBlock`.

Additionally, many of the tests have been refactored to handle async behavior. The test helpers now simulate typing and autocomplete selection in a more realistic, step-by-step manner. This should make the tests more robust and reflective of real-world usage.

This is a significant refactor that touches multiple parts of the codebase, but it should lead to more accurate and reliable autocomplete behavior, especially when dealing with code blocks in the editor.

> Written by an 🤖 LLM. Edited by a 🧑‍💻 human.