### PR TITLE
FEATURE: site setting to include post in penalty messages

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/penalize-user.js
+++ b/app/assets/javascripts/admin/addon/components/modal/penalize-user.js
@@ -19,6 +19,13 @@ export default class PenalizeUser extends Component {
   @tracked reason;
   @tracked message;
 
+  constructor() {
+    super(...arguments);
+    if (this.postEdit && this.siteSettings.penalty_include_post_message) {
+      this.message = `-------------------\n${this.postEdit}\n-------------------`;
+    }
+  }
+
   get modalTitle() {
     if (this.args.model.penaltyType === "suspend") {
       return "admin.user.suspend_modal_title";

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -128,7 +128,11 @@ acceptance("flagging", function (needs) {
     await selectKit(".reviewable-action-dropdown").expand();
     await click("[data-value='agree_and_silence']");
     assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
-
+    assert.equal(
+      query(".suspend-message").value,
+      "",
+      "penalty message is empty"
+    );
     const silenceUntilCombobox = selectKit(".silence-until .combobox");
     await silenceUntilCombobox.expand();
     await silenceUntilCombobox.selectRowByValue("tomorrow");
@@ -137,6 +141,21 @@ acceptance("flagging", function (needs) {
 
     await click(".perform-penalize");
     assert.ok(!exists(".d-modal__body"));
+  });
+
+  test("Message appears in penalty modal", async function (assert) {
+    this.siteSettings.penalty_include_post_message = true;
+    await visit("/t/internationalization-localization/280");
+    await openFlagModal();
+    await click("#radio_inappropriate");
+    await selectKit(".reviewable-action-dropdown").expand();
+    await click("[data-value='agree_and_silence']");
+    assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
+    assert.equal(
+      query(".suspend-message").value,
+      "-------------------\n<p>Any plans to support localization of UI elements, so that I (for example) could set up a completely German speaking forum?</p>\n-------------------",
+      "penalty message is prefilled with post text"
+    );
   });
 
   test("Can delete spammer from spam", async function (assert) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2334,6 +2334,7 @@ en:
 
     auto_handle_queued_age: "Automatically handle records that are waiting to be reviewed after this many days. Flags will be ignored. Queued posts and users will be rejected. Set to 0 to disable this feature."
     penalty_step_hours: "Default penalties for silencing or suspending users in hours. First offense defaults to the first value, second offense defaults to the second value, etc."
+    penalty_include_post_message: "Automatically include offending post message in email message template when silencing or suspending a user"
     svg_icon_subset: "Add additional FontAwesome 5 icons that you would like to include in your assets. Use prefix 'fa-' for solid icons, 'far-' for regular icons and 'fab-' for brand icons."
     max_prints_per_hour_per_user: "Maximum number of /print page impressions (set to 0 to disable printing)"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2827,6 +2827,10 @@ uncategorized:
     type: "list"
     list_type: "compact"
 
+  penalty_include_post_message:
+    default: false
+    client: true
+
   svg_icon_subset:
     default: ""
     type: "list"


### PR DESCRIPTION
Adds a site setting to include a post's content in penalty message. When silencing/suspending a user from a post, or a reviewable with a post, adds an option to include a post's content in the email message by default.