### PR TITLE
DEV: Skip babel for qunit and sinon

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -228,6 +228,14 @@ module.exports = function (defaults) {
         ],
       },
     },
+    skipBabel: [
+      {
+        package: "qunit",
+      },
+      {
+        package: "sinon",
+      },
+    ],
   });
 
   return mergeTrees([appTree, mergeTrees(extraPublicTrees)]);


### PR DESCRIPTION
Skipping babel for qunit is part of the default embroider blueprint. Adding these doesn't seem to have a measurable effect on build time, but it does stop this message from being printed in the build log:

```
The code generator has deoptimised the styling of /Users/david/discourse/discourse/node_modules/sinon/pkg/sinon-esm.js as it exceeds the max of 500KB
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
