### PR TITLE
FIX: do not show threads with no replies

### DIFF
--- a/plugins/chat/app/serializers/chat/thread_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_serializer.rb
@@ -12,7 +12,8 @@ module Chat
                :meta,
                :reply_count,
                :current_user_membership,
-               :preview
+               :preview,
+               :last_message_id
 
     def initialize(object, opts)
       super(object, opts)

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -199,11 +199,11 @@ module Chat
         channel,
         message_instance.user,
         {
+          thread_id: thread&.id,
+          thread_replies_count: thread&.replies_count_cache || 0,
           context: {
             post_ids: contract.context_post_ids,
             topic_id: contract.context_topic_id,
-            thread_id: thread&.id,
-            thread_replies_count: thread&.replies_count_cache || 0,
           },
         },
       )

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -199,7 +199,7 @@ module Chat
         channel,
         message_instance.user,
         {
-          thread_id: thread&.id,
+          thread: thread,
           thread_replies_count: thread&.replies_count_cache || 0,
           context: {
             post_ids: contract.context_post_ids,

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -190,7 +190,7 @@ module Chat
       Chat::Publisher.publish_thread_created!(channel, reply, thread.id)
     end
 
-    def process(channel:, message_instance:, contract:, **)
+    def process(channel:, message_instance:, contract:, thread:, **)
       ::Chat::Publisher.publish_new!(channel, message_instance, contract.staged_id)
 
       DiscourseEvent.trigger(
@@ -198,7 +198,14 @@ module Chat
         message_instance,
         channel,
         message_instance.user,
-        { context: { post_ids: contract.context_post_ids, topic_id: contract.context_topic_id } },
+        {
+          context: {
+            post_ids: contract.context_post_ids,
+            topic_id: contract.context_topic_id,
+            thread_id: thread&.id,
+            thread_replies_count: thread&.replies_count_cache || 0,
+          },
+        },
       )
 
       if contract.process_inline

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread-list.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread-list.gjs
@@ -78,7 +78,11 @@ export default class ChatThreadList extends Component {
   @cached
   get sortedThreads() {
     return this.threadsManager.threads
-      .filter((thread) => !thread.originalMessage.deletedAt)
+      .filter(
+        (thread) =>
+          !thread.originalMessage.deletedAt &&
+          thread.originalMessage?.id !== thread.lastMessageId
+      )
       .sort((threadA, threadB) => {
         // If both are unread we just want to sort by last reply date + time descending.
         if (threadA.tracking.unreadCount && threadB.tracking.unreadCount) {

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread.js
@@ -26,6 +26,7 @@ export default class ChatThread {
   @tracked staged;
   @tracked channel;
   @tracked originalMessage;
+  @tracked lastMessageId;
   @tracked threadMessageBusLastId;
   @tracked replyCount;
   @tracked tracking;
@@ -48,6 +49,8 @@ export default class ChatThread {
     if (this.originalMessage) {
       this.originalMessage.thread = this;
     }
+
+    this.lastMessageId = args.last_message_id;
 
     this.title = args.title;
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -233,6 +233,8 @@ export default class ChatSubscriptionsManager extends Service {
       channel.threadsManager
         .find(busData.channel_id, busData.thread_id)
         .then((thread) => {
+          thread.lastMessageId = busData.message.id;
+
           if (busData.message.user.id === this.currentUser.id) {
             // Thread should no longer be considered unread.
             if (thread.currentUserMembership) {

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Chat::CreateMessage do
           channel,
           user,
           {
-            thread_id: anything,
+            thread: anything,
             thread_replies_count: anything,
             context: {
               post_ids: anything,
@@ -125,7 +125,7 @@ RSpec.describe Chat::CreateMessage do
             channel,
             user,
             {
-              thread_id: thread.id,
+              thread: thread,
               thread_replies_count: 1,
               context: {
                 post_ids: context_post_ids,

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -101,7 +101,14 @@ RSpec.describe Chat::CreateMessage do
           instance_of(Chat::Message),
           channel,
           user,
-          anything,
+          {
+            context: {
+              post_ids: anything,
+              topic_id: anything,
+              thread_id: anything,
+              thread_replies_count: anything,
+            },
+          },
         )
 
         result
@@ -117,7 +124,14 @@ RSpec.describe Chat::CreateMessage do
             instance_of(Chat::Message),
             channel,
             user,
-            { context: { post_ids: context_post_ids, topic_id: context_topic_id } },
+            {
+              context: {
+                post_ids: context_post_ids,
+                topic_id: context_topic_id,
+                thread_id: thread.id,
+                thread_replies_count: 1,
+              },
+            },
           )
 
           result

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -102,11 +102,11 @@ RSpec.describe Chat::CreateMessage do
           channel,
           user,
           {
+            thread_id: anything,
+            thread_replies_count: anything,
             context: {
               post_ids: anything,
               topic_id: anything,
-              thread_id: anything,
-              thread_replies_count: anything,
             },
           },
         )
@@ -125,11 +125,11 @@ RSpec.describe Chat::CreateMessage do
             channel,
             user,
             {
+              thread_id: thread.id,
+              thread_replies_count: 1,
               context: {
                 post_ids: context_post_ids,
                 topic_id: context_topic_id,
-                thread_id: thread.id,
-                thread_replies_count: 1,
               },
             },
           )

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -101,8 +101,10 @@ RSpec.describe Chat::CreateMessage do
           instance_of(Chat::Message),
           channel,
           user,
-          anything,
+          has_entries(thread: anything, thread_replies_count: anything, context: anything),
         )
+
+        result
       end
 
       context "when context given" do

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -101,17 +101,8 @@ RSpec.describe Chat::CreateMessage do
           instance_of(Chat::Message),
           channel,
           user,
-          {
-            thread: anything,
-            thread_replies_count: anything,
-            context: {
-              post_ids: anything,
-              topic_id: anything,
-            },
-          },
+          anything,
         )
-
-        result
       end
 
       context "when context given" do
@@ -124,14 +115,14 @@ RSpec.describe Chat::CreateMessage do
             instance_of(Chat::Message),
             channel,
             user,
-            {
-              thread: thread,
-              thread_replies_count: 1,
+            has_entries(
+              thread: anything,
+              thread_replies_count: anything,
               context: {
                 post_ids: context_post_ids,
                 topic_id: context_topic_id,
               },
-            },
+            ),
           )
 
           result

--- a/plugins/chat/spec/system/thread_list/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_list/full_page_spec.rb
@@ -61,6 +61,15 @@ describe "Thread list in side panel | full page", type: :system do
     end
   end
 
+  it "doesn’t list threads with no replies" do
+    thread = Fabricate(:chat_thread, channel: channel, use_service: true)
+
+    chat_page.visit_channel(channel)
+    channel_page.open_thread_list
+
+    expect(thread_list_page).to have_no_thread(thread)
+  end
+
   context "when there are threads that the user is participating in" do
     fab!(:thread_1) do
       chat_thread_chain_bootstrap(channel: channel, users: [current_user, other_user])


### PR DESCRIPTION
Prior to this fix if a user had started to reply to a message without actually sending a message, the thread would still be created and we would end up listing it in the threads list of a channel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
