### PR TITLE
FIX: <td> spacing on expanded table

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1743,6 +1743,10 @@ iframe {
       z-index: 1;
       background-color: var(--secondary);
     }
+
+    td {
+      padding: 5px 6px 5px 3px;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

### Before
![image](https://github.com/discourse/discourse/assets/2790986/008c06d5-3f0c-4d2c-bef9-1ccc51f9339c)

### After
![image](https://github.com/discourse/discourse/assets/2790986/e70153c1-888a-4223-a70b-fc4708b3502e)


Mentioned on [Meta](https://meta.discourse.org/t/expanded-table-view-missing-padding-on-td-elements/298019)

