### PR TITLE
FIX: Update Discobot's `UserProfile#bio_raw` when default locale changes

### DIFF
--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -227,5 +227,17 @@ after_initialize do
     end
   end
 
+  self.on(:site_setting_changed) do |name, old_value, new_value|
+    next if name.to_s != "default_locale"
+    next if !SiteSetting.discourse_narrative_bot_enabled
+
+    profile = UserProfile.find_by(user_id: DiscourseNarrativeBot::BOT_USER_ID)
+
+    next if profile.blank?
+
+    new_bio = I18n.with_locale(new_value) { I18n.t("discourse_narrative_bot.bio") }
+    profile.update!(bio_raw: new_bio)
+  end
+
   PostGuardian.prepend(DiscourseNarrativeBot::PostGuardianExtension)
 end

--- a/plugins/discourse-narrative-bot/spec/lib/site_setting_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/lib/site_setting_spec.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe "Plugin specs" do
+RSpec.describe SiteSetting do
   let(:narrative_bot) { ::DiscourseNarrativeBot::Base.new }
   let(:discobot_user) { narrative_bot.discobot_user }
 
   before { SiteSetting.discourse_narrative_bot_enabled = true }
+
   it "should update bot's `UserProfile#bio_raw` when `default_locale` site setting is changed" do
     expect(discobot_user.user_profile.bio_raw).to eq(
       I18n.with_locale(:en) { I18n.t("discourse_narrative_bot.bio") },
     )
 
-    SiteSetting.default_locale = "zn_CN"
+    SiteSetting.default_locale = "zh_CN"
 
-    expect(discobot_user.user_profile.bio_raw).to eq(
+    expect(discobot_user.user_profile.reload.bio_raw).to eq(
       I18n.with_locale(:zh_CN) { I18n.t("discourse_narrative_bot.bio") },
     )
   end


### PR DESCRIPTION
Why this change?

When a site's default locale is changed, Discobot's `UserProfile#bio_raw` is not
changed and we have gotten reports about this.

What does this change do?

This change adds a `DiscourseEvent.on(:site_setting_changed)` callback
which watches for changes to the `default_locale` site setting and
updates Discobot's `UserProfile#bio_raw` when it changes.