### PR TITLE
DEV: Allow CSP nonce_placeholder to be generated outside Rails

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,9 +66,7 @@ module ApplicationHelper
   end
 
   def csp_nonce_placeholder
-    response.headers[
-      ::Middleware::CspScriptNonceInjector::PLACEHOLDER_HEADER
-    ] ||= "[[csp_nonce_placeholder_#{SecureRandom.hex}]]"
+    ContentSecurityPolicy.nonce_placeholder(response.headers)
   end
 
   def shared_session_key

--- a/lib/content_security_policy.rb
+++ b/lib/content_security_policy.rb
@@ -7,6 +7,12 @@ class ContentSecurityPolicy
     def policy(theme_id = nil, base_url: Discourse.base_url, path_info: "/")
       new.build(theme_id, base_url: base_url, path_info: path_info)
     end
+
+    def nonce_placeholder(response_headers)
+      response_headers[
+        ::Middleware::CspScriptNonceInjector::PLACEHOLDER_HEADER
+      ] ||= "[[csp_nonce_placeholder_#{SecureRandom.hex}]]"
+    end
   end
 
   def build(theme_id, base_url:, path_info: "/")


### PR DESCRIPTION
Sometimes we add scripts outside of Rails. This commit provides a way to generate a nonce placeholder even if you don't have access to an ApplicationController instance.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
