### PR TITLE
DEV: Remove minitest dependency to appease ruby-lsp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,6 @@ group :test do
   gem "capybara", require: false
   gem "webmock", require: false
   gem "fakeweb", require: false
-  gem "minitest", require: false
   gem "simplecov", require: false
   gem "selenium-webdriver", "~> 4.14", require: false
   gem "selenium-devtools", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,7 +602,6 @@ DEPENDENCIES
   mini_sql
   mini_suffix
   minio_runner
-  minitest
   mocha
   multi_json
   mustache

--- a/lib/tasks/emoji.rake
+++ b/lib/tasks/emoji.rake
@@ -475,12 +475,27 @@ def confirm_overwrite(path)
   STDIN.gets.chomp
 end
 
-class TestEmojiUpdate < Minitest::Test
+class TestEmojiUpdate
   def self.run_and_summarize
-    puts "Runnings tests..."
-    reporter = Minitest::SummaryReporter.new
-    TestEmojiUpdate.run(reporter)
-    puts reporter
+    puts "Running tests..."
+    instance = TestEmojiUpdate.new
+    instance.public_methods.each do |method|
+      next unless method.to_s.start_with? "test_"
+      print "Running #{method}..."
+      instance.public_send(method)
+      puts " ✅"
+    rescue StandardError => e
+      puts " ❌"
+      puts e.message.indent(2)
+    end
+  end
+
+  def assert_equal(a, b)
+    raise "Expected #{a.inspect} to equal #{b.inspect}" if a != b
+  end
+
+  def assert(a)
+    raise "Expected #{a.inspect} to be truthy" if !a
   end
 
   def image_path(style, name)


### PR DESCRIPTION
Having minitest as a direct dependency causes ruby-lsp to use it as our test runner (per https://github.com/Shopify/ruby-lsp/blob/d1da8858a1/lib/ruby_lsp/requests/support/dependency_detector.rb#L40-L55). This makes VSCode's test explorer incorrectly display Minitest 'run' buttons above all our tests.

We were only using it in `emoji.rake`... and that wasn't even working with the latest version of Minitest. This commit refactors `emoji.rake` to work without minitest, and removes the dependency.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
