### PR TITLE
DEV: Return meaningful values from desktop noti enable/disable fns

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -111,7 +111,7 @@ export function unsubscribe(user, callback) {
   }
 
   keyValueStore.setItem(userSubscriptionKey(user), "");
-  navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
+  return navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
     serviceWorkerRegistration.pushManager
       .getSubscription()
       .then((subscription) => {

--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -84,8 +84,8 @@ export function subscribe(callback, applicationServerKey) {
     return;
   }
 
-  navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
-    serviceWorkerRegistration.pushManager
+  return navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
+    return serviceWorkerRegistration.pushManager
       .subscribe({
         userVisibleOnly: true,
         applicationServerKey: new Uint8Array(applicationServerKey.split("|")), // eslint-disable-line no-undef
@@ -95,10 +95,12 @@ export function subscribe(callback, applicationServerKey) {
         if (callback) {
           callback();
         }
+        return true;
       })
       .catch((e) => {
         // eslint-disable-next-line no-console
         console.error(e);
+        return false;
       });
   });
 }
@@ -132,5 +134,6 @@ export function unsubscribe(user, callback) {
     if (callback) {
       callback();
     }
+    return true;
   });
 }

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -119,9 +119,10 @@ export default class DesktopNotificationsService extends Service {
   disable() {
     if (this.isEnabledDesktop) {
       this.setNotificationsDisabled("disabled");
+      return true;
     }
     if (this.isEnabledPush) {
-      unsubscribePushNotification(this.currentUser, () => {
+      return unsubscribePushNotification(this.currentUser, () => {
         this.setIsEnabledPush("");
       });
     }
@@ -130,13 +131,14 @@ export default class DesktopNotificationsService extends Service {
   @action
   enable() {
     if (this.isPushNotificationsPreferred) {
-      subscribePushNotification(() => {
+      return subscribePushNotification(() => {
         this.setIsEnabledPush("subscribed");
       }, this.siteSettings.vapid_public_key_bytes);
     } else {
       this.setNotificationsDisabled("");
-      Notification.requestPermission(() => {
+      return Notification.requestPermission((permission) => {
         confirmNotification(this.siteSettings);
+        return permission === "granted";
       });
     }
   }


### PR DESCRIPTION
Currently we don't return whether or not the subscription to desktop notifications was successful or not. A plugin is using these fns and needs to know if the user actually accepted notifications (going from `default` -> `granted`) or denied.