### PR TITLE
FIX: check for `options` in `dismissRead`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/bulk-select-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/bulk-select-helper.js
@@ -54,7 +54,7 @@ export default class BulkSelectHelper {
 
     promise.then((result) => {
       if (result?.topic_ids) {
-        if (options.private_message_inbox) {
+        if (options?.private_message_inbox) {
           this.pmTopicTrackingState.removeTopics(result.topic_ids);
         } else {
           this.topicTrackingState.removeTopics(result.topic_ids);


### PR DESCRIPTION
Follow-up to 5c1147adf3339c89a3ccb69839b4a4c5fd75a2ab, from a public topic list `options` isn't passed and causes an error. The topics still end up dismissed, but the error prevents the modal from closing. 