### PR TITLE
FEATURE: move back to the forum link above the filter

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
@@ -1,3 +1,4 @@
+<Sidebar::BackToForum />
 <Sidebar::Filter />
 {{#each this.sections as |sectionConfig|}}
   <Sidebar::ApiSection

--- a/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import { defaultHomepage } from "discourse/lib/utilities";
+import dIcon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class BackToForum extends Component {
+  @service sidebarState;
+
+  get shouldDisplay() {
+    return this.sidebarState.currentPanel.filterable;
+  }
+
+  get homepage() {
+    return `discovery.${defaultHomepage()}`;
+  }
+
+  <template>
+    {{#if this.shouldDisplay}}
+      <LinkTo @route={{this.homepage}} class="sidebar-sections__back-to-forum">
+        {{dIcon "arrow-left"}}
+
+        <span>{{i18n "admin.back_to_forum"}}</span>
+      </LinkTo>
+    {{/if}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
+import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
 import { defaultHomepage } from "discourse/lib/utilities";
 import dIcon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
@@ -9,7 +10,7 @@ export default class BackToForum extends Component {
   @service sidebarState;
 
   get shouldDisplay() {
-    return this.sidebarState.currentPanel.filterable;
+    return this.sidebarState.currentPanel.key === ADMIN_PANEL;
   }
 
   get homepage() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -5,7 +5,6 @@ import BaseCustomSidebarPanel from "discourse/lib/sidebar/base-custom-sidebar-pa
 import BaseCustomSidebarSection from "discourse/lib/sidebar/base-custom-sidebar-section";
 import BaseCustomSidebarSectionLink from "discourse/lib/sidebar/base-custom-sidebar-section-link";
 import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
-import { defaultHomepage } from "discourse/lib/utilities";
 import { getOwnerWithFallback } from "discourse-common/lib/get-owner";
 import I18n from "discourse-i18n";
 
@@ -111,12 +110,6 @@ export function useAdminNavConfig(navMap) {
       name: "root",
       hideSectionHeader: true,
       links: [
-        {
-          name: "back_to_forum",
-          route: `discovery.${defaultHomepage()}`,
-          label: "admin.back_to_forum",
-          icon: "arrow-left",
-        },
         {
           name: "admin_dashboard",
           route: "admin.dashboard",

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -116,6 +116,19 @@
 
       transition-delay: 0s;
     }
+    &__back-to-forum {
+      margin: 0 var(--d-sidebar-row-horizontal-padding) 1em
+        var(--d-sidebar-row-horizontal-padding);
+      color: var(--d-sidebar-link-color);
+      display: flex;
+      align-items: center;
+      svg {
+        margin-right: var(--d-sidebar-section-link-prefix-margin-right);
+        height: 0.75em;
+        width: 0.75em;
+        color: var(--d-sidebar-link-icon-color);
+      }
+    }
   }
   .sidebar-footer-wrapper {
     .btn-flat.add-section {

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -20,7 +20,7 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(sidebar).to be_visible
     expect(sidebar).to have_no_section("community")
     expect(page).to have_no_css(".admin-main-nav")
-    sidebar.click_link_in_section("admin-nav-section-root", "back_to_forum")
+    filter.click_back_to_forum
     expect(page).to have_current_path("/latest")
     expect(sidebar).to have_no_section("admin-nav-section-root")
   end
@@ -44,7 +44,7 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
       sidebar_dropdown.click
       expect(sidebar).to have_no_section("community")
       expect(page).to have_no_css(".admin-main-nav")
-      sidebar.click_link_in_section("admin-nav-section-root", "back_to_forum")
+      filter.click_back_to_forum
       expect(page).to have_current_path("/latest")
       sidebar_dropdown.click
       expect(sidebar).to have_no_section("admin-nav-section-root")
@@ -84,6 +84,7 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     links = page.all(".sidebar-section-link-content-text")
     expect(links.count).to eq(all_links_count)
     expect(page).to have_no_css(".sidebar-no-results")
+    expect(page).to have_css(".sidebar-sections__back-to-forum")
 
     # When match section title, display all links
     filter.filter("Backups")

--- a/spec/system/page_objects/components/filter.rb
+++ b/spec/system/page_objects/components/filter.rb
@@ -12,6 +12,11 @@ module PageObjects
         page.find(".sidebar-filter__clear").click
         self
       end
+
+      def click_back_to_forum
+        page.find(".sidebar-sections__back-to-forum").click
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
Before, the `back to forum` link was part of experimental admin navigation. It means that the link could be filtered out.

Because it is essential navigation, it should not be part of sidebar links and should be moved above the filter.

https://github.com/discourse/discourse/assets/72780/12f6e2b4-20e6-439e-8448-e06530342b37


