### PR TITLE
FEATURE: Add site setting to automatically disable failing social logins

### DIFF
--- a/app/jobs/regular/run_problem_check.rb
+++ b/app/jobs/regular/run_problem_check.rb
@@ -14,8 +14,10 @@ module Jobs
       identifier = args[:check_identifier].to_sym
 
       check = ProblemCheck[identifier]
+      tracker = ProblemCheckTracker[identifier]
 
-      problems = check.call
+      problems = check.call(tracker)
+
       raise RetrySignal if problems.present? && retry_count < check.max_retries
 
       if problems.present?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1838,6 +1838,8 @@ en:
     allow_new_registrations: "Allow new user registrations. Uncheck this to prevent anyone from creating a new account."
     enable_signup_cta: "Show a notice to returning anonymous users prompting them to sign up for an account."
 
+    disable_failing_social_logins: "Automatically disable social login methods that have failed their health check 3 times in a row."
+
     enable_google_oauth2_logins: "Enable Google Oauth2 authentication. This is the method of authentication that Google currently supports. Requires key and secret. See <a href='https://meta.discourse.org/t/15858' target='_blank'>Configuring Google login for Discourse</a>."
     google_oauth2_client_id: "The unique client ID provided by your Google application, used for the authentication process."
     google_oauth2_client_secret: "Client secret of your Google application."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -425,6 +425,8 @@ login:
   enable_signup_cta:
     client: true
     default: true
+  disable_failing_social_logins:
+    default: false
   enable_google_oauth2_logins:
     default: false
   google_oauth2_client_id: ""

--- a/lib/auth/twitter_authenticator.rb
+++ b/lib/auth/twitter_authenticator.rb
@@ -5,6 +5,10 @@ class Auth::TwitterAuthenticator < Auth::ManagedAuthenticator
     "twitter"
   end
 
+  def disable
+    SiteSetting.set_and_log(:enable_twitter_logins, false)
+  end
+
   def enabled?
     SiteSetting.enable_twitter_logins
   end

--- a/lib/problem_check.rb
+++ b/lib/problem_check.rb
@@ -21,6 +21,13 @@ class ProblemCheck
   #
   config_accessor :retry_after, default: 30.seconds, instance_writer: false
 
+  # How many consecutive times the check can fail without notifying admins.
+  # This can be used to give some leeway for transient problems. Note that
+  # retries are not counted. So a check that ultimately fails after e.g. two
+  # retries is counted as one "blip".
+  #
+  config_accessor :max_blips, default: 0, instance_writer: false
+
   def self.[](key)
     key = key.to_sym
 
@@ -45,11 +52,11 @@ class ProblemCheck
   end
   delegate :scheduled?, to: :class
 
-  def self.call
-    new.call
+  def self.call(tracker)
+    new.call(tracker)
   end
 
-  def call
+  def call(_tracker)
     raise NotImplementedError
   end
 

--- a/lib/problem_check/group_email_credentials.rb
+++ b/lib/problem_check/group_email_credentials.rb
@@ -9,7 +9,7 @@
 class ProblemCheck::GroupEmailCredentials < ProblemCheck
   self.perform_every = 30.minutes
 
-  def call
+  def call(_tracker)
     [*smtp_errors, *imap_errors]
   end
 

--- a/lib/problem_check/twitter_login.rb
+++ b/lib/problem_check/twitter_login.rb
@@ -2,13 +2,16 @@
 
 class ProblemCheck::TwitterLogin < ProblemCheck
   self.priority = "high"
-
-  # TODO: Implement.
   self.perform_every = 24.hours
+  self.max_blips = 3
 
-  def call
+  def call(tracker)
     return no_problem if !authenticator.enabled?
     return no_problem if authenticator.healthy?
+
+    if SiteSetting.disable_failing_social_logins? && self.class.max_blips >= tracker.blips
+      authenticator.disable
+    end
 
     problem
   end

--- a/spec/jobs/run_problem_check_spec.rb
+++ b/spec/jobs/run_problem_check_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::RunProblemCheck do
+  before { Fabricate(:problem_check_tracker, identifier: "test_check") }
+
   after do
     Discourse.redis.flushdb
 
@@ -14,7 +16,7 @@ RSpec.describe Jobs::RunProblemCheck do
           self.perform_every = 30.minutes
           self.max_retries = 0
 
-          def call
+          def call(_tracker)
             [
               ProblemCheck::Problem.new("Big problem"),
               ProblemCheck::Problem.new(
@@ -43,7 +45,7 @@ RSpec.describe Jobs::RunProblemCheck do
           self.perform_every = 30.minutes
           self.max_retries = 0
 
-          def call
+          def call(_tracker)
             [
               ProblemCheck::Problem.new(
                 "Yuge problem",
@@ -76,7 +78,7 @@ RSpec.describe Jobs::RunProblemCheck do
           self.perform_every = 30.minutes
           self.max_retries = 2
 
-          def call
+          def call(_tracker)
             [ProblemCheck::Problem.new("Yuge problem")]
           end
         end
@@ -106,7 +108,7 @@ RSpec.describe Jobs::RunProblemCheck do
           self.perform_every = 30.minutes
           self.max_retries = 1
 
-          def call
+          def call(_tracker)
             [ProblemCheck::Problem.new("Yuge problem")]
           end
         end
@@ -131,7 +133,7 @@ RSpec.describe Jobs::RunProblemCheck do
         Class.new(ProblemCheck) do
           self.max_retries = 1
 
-          def call
+          def call(_tracker)
             raise StandardError.new("Something went wrong")
           end
         end

--- a/spec/lib/problem_check/twitter_login_spec.rb
+++ b/spec/lib/problem_check/twitter_login_spec.rb
@@ -2,36 +2,38 @@
 
 RSpec.describe ProblemCheck::TwitterLogin do
   let(:problem_check) { described_class.new }
+  let(:tracker) { Fabricate(:problem_check_tracker, identifier: "twitter_login", blips: blips) }
 
-  let(:authenticator) { mock("Auth::TwitterAuthenticator") }
+  let!(:authenticator) { Auth::TwitterAuthenticator.new }
+  let(:blips) { 0 }
 
-  before { Auth::TwitterAuthenticator.stubs(:new).returns(authenticator) }
+  before do
+    SiteSetting.enable_twitter_logins = true
+
+    Auth::TwitterAuthenticator.stubs(:new).returns(authenticator)
+  end
 
   describe "#call" do
     context "when Twitter authentication isn't enabled" do
-      before { authenticator.stubs(:enabled?).returns(false) }
+      before { SiteSetting.enable_twitter_logins = false }
 
-      it { expect(problem_check.call).to be_empty }
+      it { expect(problem_check.call(tracker)).to be_empty }
     end
 
     context "when Twitter authentication appears to work" do
-      before do
-        authenticator.stubs(:enabled?).returns(true)
-        authenticator.stubs(:healthy?).returns(true)
-      end
+      before { authenticator.stubs(:healthy?).returns(true) }
 
-      it { expect(problem_check.call).to be_empty }
+      it { expect(problem_check.call(tracker)).to be_empty }
     end
 
     context "when Twitter authentication appears not to work" do
       before do
-        authenticator.stubs(:enabled?).returns(true)
         authenticator.stubs(:healthy?).returns(false)
         Discourse.stubs(:base_path).returns("foo.bar")
       end
 
       it do
-        expect(problem_check.call).to contain_exactly(
+        expect(problem_check.call(tracker)).to contain_exactly(
           have_attributes(
             identifier: :twitter_login,
             priority: "high",
@@ -39,6 +41,33 @@ RSpec.describe ProblemCheck::TwitterLogin do
               'Twitter login appears to not be working at the moment. Check the credentials in <a href="foo.bar/admin/site_settings/category/login?filter=twitter">the Site Settings</a>.',
           ),
         )
+      end
+    end
+
+    context "when Twitter authentication seems to be permanently broken" do
+      before do
+        authenticator.stubs(:healthy?).returns(false)
+        Discourse.stubs(:base_path).returns("foo.bar")
+      end
+
+      let(:blips) { 3 }
+
+      context "when configured to disable broken social login methods" do
+        before { SiteSetting.disable_failing_social_logins = true }
+
+        it do
+          expect { problem_check.call(tracker) }.to change {
+            SiteSetting.enable_twitter_logins
+          }.from(true).to(false)
+        end
+      end
+
+      context "when configured to not disable  broken social login methods" do
+        before { SiteSetting.disable_failing_social_logins = false }
+
+        it do
+          expect { problem_check.call(tracker) }.not_to change { SiteSetting.enable_twitter_logins }
+        end
       end
     end
   end


### PR DESCRIPTION
### What is this change?

This is Part 2 mentioned in #25830. It adds a site setting that, when enabled, will turn off failing social logins methods after their health check fails three consecutive times, i.e. after 3 "blips".

### Small note

It might be worth noting, if configuring both `max_retries` and `max_blips` that job retries are still considered part of a single problem check. So a check that fails after 2 retries still only counts as one "blip". This is intentional.