### PR TITLE
DEV: Rename problem check jobs to avoid namespace clashes

### DIFF
--- a/app/jobs/scheduled/run_problem_checks.rb
+++ b/app/jobs/scheduled/run_problem_checks.rb
@@ -4,7 +4,7 @@ module Jobs
   # This job runs all of the scheduled problem checks for the admin dashboard
   # on a regular basis. To add a problem check, add a new class that inherits
   # the `ProblemCheck` base class.
-  class ProblemChecks < ::Jobs::Scheduled
+  class RunProblemChecks < ::Jobs::Scheduled
     sidekiq_options retry: false
 
     every 10.minutes
@@ -20,7 +20,7 @@ module Jobs
         end
 
       scheduled_checks.each do |check|
-        Jobs.enqueue(:problem_check, check_identifier: check.identifier.to_s)
+        Jobs.enqueue(:run_problem_check, check_identifier: check.identifier.to_s)
       end
     end
   end

--- a/spec/jobs/run_problem_check_spec.rb
+++ b/spec/jobs/run_problem_check_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-RSpec.describe Jobs::ProblemCheck do
+RSpec.describe Jobs::RunProblemCheck do
   after do
     Discourse.redis.flushdb
 
-    ::ProblemCheck.send(:remove_const, "TestCheck")
+    ProblemCheck.send(:remove_const, "TestCheck")
   end
 
   context "when there are problems" do
     before do
-      ::ProblemCheck::TestCheck =
-        Class.new(::ProblemCheck) do
+      ProblemCheck::TestCheck =
+        Class.new(ProblemCheck) do
           self.perform_every = 30.minutes
           self.max_retries = 0
 
           def call
             [
-              ::ProblemCheck::Problem.new("Big problem"),
-              ::ProblemCheck::Problem.new(
+              ProblemCheck::Problem.new("Big problem"),
+              ProblemCheck::Problem.new(
                 "Yuge problem",
                 priority: "high",
                 identifier: "config_is_a_mess",
@@ -38,19 +38,19 @@ RSpec.describe Jobs::ProblemCheck do
 
   context "with multiple problems with the same identifier" do
     before do
-      ::ProblemCheck::TestCheck =
-        Class.new(::ProblemCheck) do
+      ProblemCheck::TestCheck =
+        Class.new(ProblemCheck) do
           self.perform_every = 30.minutes
           self.max_retries = 0
 
           def call
             [
-              ::ProblemCheck::Problem.new(
+              ProblemCheck::Problem.new(
                 "Yuge problem",
                 priority: "high",
                 identifier: "config_is_a_mess",
               ),
-              ::ProblemCheck::Problem.new(
+              ProblemCheck::Problem.new(
                 "Nasty problem",
                 priority: "high",
                 identifier: "config_is_a_mess",
@@ -71,13 +71,13 @@ RSpec.describe Jobs::ProblemCheck do
 
   context "when there are retries remaining" do
     before do
-      ::ProblemCheck::TestCheck =
-        Class.new(::ProblemCheck) do
+      ProblemCheck::TestCheck =
+        Class.new(ProblemCheck) do
           self.perform_every = 30.minutes
           self.max_retries = 2
 
           def call
-            [::ProblemCheck::Problem.new("Yuge problem")]
+            [ProblemCheck::Problem.new("Yuge problem")]
           end
         end
     end
@@ -101,13 +101,13 @@ RSpec.describe Jobs::ProblemCheck do
 
   context "when there are no retries remaining" do
     before do
-      ::ProblemCheck::TestCheck =
-        Class.new(::ProblemCheck) do
+      ProblemCheck::TestCheck =
+        Class.new(ProblemCheck) do
           self.perform_every = 30.minutes
           self.max_retries = 1
 
           def call
-            [::ProblemCheck::Problem.new("Yuge problem")]
+            [ProblemCheck::Problem.new("Yuge problem")]
           end
         end
     end
@@ -127,8 +127,8 @@ RSpec.describe Jobs::ProblemCheck do
 
   context "when the check unexpectedly errors out" do
     before do
-      ::ProblemCheck::TestCheck =
-        Class.new(::ProblemCheck) do
+      ProblemCheck::TestCheck =
+        Class.new(ProblemCheck) do
           self.max_retries = 1
 
           def call

--- a/spec/jobs/run_problem_checks_spec.rb
+++ b/spec/jobs/run_problem_checks_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe Jobs::ProblemChecks do
+RSpec.describe Jobs::RunProblemChecks do
   before do
-    ::ProblemCheck::ScheduledCheck =
+    ProblemCheck::ScheduledCheck =
       Class.new(ProblemCheck) do
         self.perform_every = 30.minutes
 
         def call = []
       end
 
-    ::ProblemCheck::NonScheduledCheck = Class.new(ProblemCheck) { def call = [] }
+    ProblemCheck::NonScheduledCheck = Class.new(ProblemCheck) { def call = [] }
   end
 
   after do
@@ -39,7 +39,7 @@ RSpec.describe Jobs::ProblemChecks do
 
     it "does not schedule any check" do
       expect_not_enqueued_with(
-        job: :problem_check,
+        job: :run_problem_check,
         args: {
           check_identifier: "scheduled_check",
         },
@@ -52,7 +52,7 @@ RSpec.describe Jobs::ProblemChecks do
 
     it "does not schedule any check" do
       expect_not_enqueued_with(
-        job: :problem_check,
+        job: :run_problem_check,
         args: {
           check_identifier: "non_scheduled_check",
         },
@@ -62,7 +62,7 @@ RSpec.describe Jobs::ProblemChecks do
 
   it "does not schedule non-scheduled checks" do
     expect_not_enqueued_with(
-      job: :problem_check,
+      job: :run_problem_check,
       args: {
         check_identifier: "non_scheduled_check",
       },


### PR DESCRIPTION
### What is this change?

Doing the following renames:

- `Jobs::ProblemChecks` → `Jobs::RunProblemChecks`
- `Jobs::ProblemCheck` → `Jobs::RunProblemCheck`

This is to disambiguate the `ProblemCheck` class name, ease fuzzy finding, and avoid needing to use `::` in a bunch of places.

### Is it safe to just remove the old class definitions?

I tried this locally. After rebooting, the scheduler UI no longer had the old class name there, and instead had the new one. There is theoretically a chance that the main job enqueues the individual jobs the very second we deploy the code, but in that unlikely event, we can just let the job go to the morgue without anything bad happening.