### PR TITLE
DEV: Fix broken RunProblemCheck spec

### DIFF
--- a/spec/jobs/run_problem_check_spec.rb
+++ b/spec/jobs/run_problem_check_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Jobs::RunProblemCheck do
 
     it "schedules a retry" do
       expect_enqueued_with(
-        job: :problem_check,
+        job: :run_problem_check,
         args: {
           check_identifier: :test_check,
           retry_count: 1,
@@ -119,7 +119,7 @@ RSpec.describe Jobs::RunProblemCheck do
     end
 
     it "does not schedule a retry" do
-      expect_not_enqueued_with(job: :problem_check) do
+      expect_not_enqueued_with(job: :run_problem_check) do
         described_class.new.execute(check_identifier: :test_check, retry_count: 1)
       end
     end

--- a/spec/jobs/run_problem_checks_spec.rb
+++ b/spec/jobs/run_problem_checks_spec.rb
@@ -26,9 +26,12 @@ RSpec.describe Jobs::RunProblemChecks do
     end
 
     it "schedules the individual scheduled checks" do
-      expect_enqueued_with(job: :problem_check, args: { check_identifier: "scheduled_check" }) do
-        described_class.new.execute([])
-      end
+      expect_enqueued_with(
+        job: :run_problem_check,
+        args: {
+          check_identifier: "scheduled_check",
+        },
+      ) { described_class.new.execute([]) }
     end
   end
 


### PR DESCRIPTION
### What is this change?

The build is broken due to some changes not being staged when I pushed the previous PR. The assertions that check that a job has been scheduled needs to be updated to reflect the new name.