### PR TITLE
DEV: Remove assertion causing flaky test

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -69,8 +69,6 @@ describe "Admin Customize Themes", type: :system do
       expect(color_scheme_settings.find(".setting-value")).to have_content(color_scheme.name)
       expect(color_scheme_settings).not_to have_css(".submit-edit")
       expect(color_scheme_settings).not_to have_css(".cancel-edit")
-
-      expect(theme.reload.color_scheme_id).to eq(color_scheme.id)
     end
   end
 


### PR DESCRIPTION
Why this change?

Assertions against the database in a system test is not reliable because
the request sent from the client side may not have been processed when
the query to the database has been run.

The test was added to prevent a regression for 63119144ff481b1a18b69c0d638ece1b03c54766
but it turns out that the test will still prevent the regression even if
we do not assert against the state in the database.