### PR TITLE
DEV: Introduce second home-logo wrapper plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/home-logo.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL from "discourse/lib/url";
@@ -76,39 +77,41 @@ export default class HomeLogo extends Component {
   }
 
   <template>
-    <div class={{concatClass (if @minimized "title--minimized") "title"}}>
-      <a href={{this.href}} {{on "click" this.click}}>
-        {{#if @minimized}}
-          {{#if this.logoSmallUrl}}
+    <PluginOutlet @name="home-logo">
+      <div class={{concatClass (if @minimized "title--minimized") "title"}}>
+        <a href={{this.href}} {{on "click" this.click}}>
+          {{#if @minimized}}
+            {{#if this.logoSmallUrl}}
+              <Logo
+                @key="logo-small"
+                @url={{this.logoSmallUrl}}
+                @title={{this.siteSettings.title}}
+                @darkUrl={{this.logoSmallUrlDark}}
+              />
+            {{else}}
+              {{icon "home"}}
+            {{/if}}
+          {{else if this.showMobileLogo}}
             <Logo
-              @key="logo-small"
-              @url={{this.logoSmallUrl}}
+              @key="logo-mobile"
+              @url={{this.mobileLogoUrl}}
               @title={{this.siteSettings.title}}
-              @darkUrl={{this.logoSmallUrlDark}}
+              @darkUrl={{this.mobileLogoUrlDark}}
+            />
+          {{else if this.logoUrl}}
+            <Logo
+              @key="logo-big"
+              @url={{this.logoUrl}}
+              @title={{this.siteSettings.title}}
+              @darkUrl={{this.logoUrlDark}}
             />
           {{else}}
-            {{icon "home"}}
+            <h1 id="site-text-logo" class="text-logo">
+              {{this.siteSettings.title}}
+            </h1>
           {{/if}}
-        {{else if this.showMobileLogo}}
-          <Logo
-            @key="logo-mobile"
-            @url={{this.mobileLogoUrl}}
-            @title={{this.siteSettings.title}}
-            @darkUrl={{this.mobileLogoUrlDark}}
-          />
-        {{else if this.logoUrl}}
-          <Logo
-            @key="logo-big"
-            @url={{this.logoUrl}}
-            @title={{this.siteSettings.title}}
-            @darkUrl={{this.logoUrlDark}}
-          />
-        {{else}}
-          <h1 id="site-text-logo" class="text-logo">
-            {{this.siteSettings.title}}
-          </h1>
-        {{/if}}
-      </a>
-    </div>
+        </a>
+      </div>
+    </PluginOutlet>
   </template>
 }

--- a/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
@@ -4,5 +4,9 @@ import { registerWidgetShim } from "discourse/widgets/render-glimmer";
 registerWidgetShim(
   "home-logo-wrapper-outlet",
   "div.home-logo-wrapper-outlet",
-  hbs`<PluginOutlet @name="home-logo-wrapper"><MountWidget @widget="home-logo" @args={{@data}} /></PluginOutlet>`
+  hbs`<PluginOutlet @name="home-logo-wrapper">
+    <PluginOutlet @name="home-logo" @outletArgs>
+      <MountWidget @widget="home-logo" @args={{@data}} />
+    </PluginOutlet>
+  </PluginOutlet>`
 );


### PR DESCRIPTION
The `home-logo-wrapper` outlet is used by chat, which means it is unavailable for use by any other themes/plugins. This commit introduces a second nested outlet called `home-logo` which can be used to replace the logo without affecting chat's header logic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
