### PR TITLE
DEV: Include group_name in push notification payload for group mentions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -167,6 +167,7 @@ async function onNotification(data, siteSettings, user, appEvents) {
       site_title: siteSettings.title,
       topic: data.topic_title,
       username: formatUsername(data.username),
+      group_name: data.group_name,
     });
 
   const notificationBody = data.excerpt;

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -40,8 +40,8 @@ class PostAlerter
             ),
         username: username || post.username,
         post_url: post_url,
-        group_name: group_name,
       }
+      payload[:group_name] = group_name if group_name.present?
 
       DiscourseEvent.trigger(:pre_notification_alert, user, payload)
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -13,7 +13,14 @@ class PostAlerter
     post
   end
 
-  def self.create_notification_alert(user:, post:, notification_type:, excerpt: nil, username: nil)
+  def self.create_notification_alert(
+    user:,
+    post:,
+    notification_type:,
+    excerpt: nil,
+    username: nil,
+    group_name: nil
+  )
     return if user.suspended?
 
     if post_url = post.url
@@ -33,6 +40,7 @@ class PostAlerter
             ),
         username: username || post.username,
         post_url: post_url,
+        group_name: group_name,
       }
 
       DiscourseEvent.trigger(:pre_notification_alert, user, payload)
@@ -655,19 +663,28 @@ class PostAlerter
         post: original_post,
         notification_type: type,
         username: original_username,
+        group_name: group&.name,
       )
     end
 
     created.id ? created : nil
   end
 
-  def create_notification_alert(user:, post:, notification_type:, excerpt: nil, username: nil)
+  def create_notification_alert(
+    user:,
+    post:,
+    notification_type:,
+    excerpt: nil,
+    username: nil,
+    group_name: nil
+  )
     self.class.create_notification_alert(
       user: user,
       post: post,
       notification_type: notification_type,
       excerpt: excerpt,
       username: username,
+      group_name: group_name,
     )
   end
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -58,6 +58,7 @@ class PushNotificationPusher
       site_title: SiteSetting.title,
       topic: payload[:topic_title],
       username: payload[:username],
+      group_name: payload[:group_name],
     )
   end
 


### PR DESCRIPTION
Customer translation wants group_mention text to be 
> "User mentioned admins in 'topic title'" 

rather than 

> "User mentioned you in 'topic title'"

This adds the data for the translations to include group name :)