### PR TITLE
DEV: Move `noResults` to search service

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.hbs
@@ -54,7 +54,6 @@
   {{#if @inlineResults}}
     <SearchMenu::Results
       @loading={{this.loading}}
-      @noResults={{this.noResults}}
       @invalidTerm={{this.invalidTerm}}
       @suggestionKeyword={{this.suggestionKeyword}}
       @suggestionResults={{this.suggestionResults}}
@@ -70,7 +69,6 @@
     <MenuPanel @panelClass="search-menu-panel">
       <SearchMenu::Results
         @loading={{this.loading}}
-        @noResults={{this.noResults}}
         @invalidTerm={{this.invalidTerm}}
         @suggestionKeyword={{this.suggestionKeyword}}
         @suggestionResults={{this.suggestionResults}}

--- a/app/assets/javascripts/discourse/app/components/search-menu.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu.js
@@ -36,7 +36,6 @@ export default class SearchMenu extends Component {
   @service appEvents;
 
   @tracked loading = false;
-  @tracked noResults = false;
   @tracked
   inPMInboxContext = this.search.searchContext?.type === "private_messages";
   @tracked typeFilter = DEFAULT_TYPE_FILTER;
@@ -215,7 +214,7 @@ export default class SearchMenu extends Component {
 
     const matchSuggestions = this.matchesSuggestions();
     if (matchSuggestions) {
-      this.noResults = true;
+      this.search.noResults = true;
       this.search.results = {};
       this.loading = false;
       this.suggestionResults = [];
@@ -253,7 +252,7 @@ export default class SearchMenu extends Component {
             this.suggestionResults = result.users;
             this.suggestionKeyword = "@";
           } else {
-            this.noResults = true;
+            this.search.noResults = true;
             this.suggestionKeyword = false;
           }
         });
@@ -266,14 +265,14 @@ export default class SearchMenu extends Component {
     this.suggestionKeyword = false;
 
     if (!this.search.activeGlobalSearchTerm) {
-      this.noResults = false;
+      this.search.noResults = false;
       this.search.results = {};
       this.loading = false;
       this.invalidTerm = false;
     } else if (
       !isValidSearchTerm(this.search.activeGlobalSearchTerm, this.siteSettings)
     ) {
-      this.noResults = true;
+      this.search.noResults = true;
       this.search.results = {};
       this.loading = false;
       this.invalidTerm = true;
@@ -298,7 +297,7 @@ export default class SearchMenu extends Component {
               });
             }
 
-            this.noResults = results.resultTypes.length === 0;
+            this.search.noResults = results.resultTypes.length === 0;
             this.search.results = results;
           }
         })
@@ -339,7 +338,7 @@ export default class SearchMenu extends Component {
 
   @action
   triggerSearch() {
-    this.noResults = false;
+    this.search.noResults = false;
 
     if (this.includesTopics) {
       if (this.search.contextType === "topic") {

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.js
@@ -28,7 +28,7 @@ export default class Results extends Component {
   }
 
   get noTopicResults() {
-    return this.args.searchTopics && this.args.noResults;
+    return this.args.searchTopics && this.search.noResults;
   }
 
   get termTooShort() {

--- a/app/assets/javascripts/discourse/app/services/search.js
+++ b/app/assets/javascripts/discourse/app/services/search.js
@@ -14,6 +14,7 @@ export default class Search extends Service {
   @tracked inTopicContext = false;
   @tracked visible = false;
   @tracked results = {};
+  @tracked noResults = false;
 
   // only relative for the widget search menu
   searchContextEnabled = false; // checkbox to scope search


### PR DESCRIPTION
This PR moves the handling of the search menu's `noResults` property to the search service. This makes it easier for external plugins when adding tweaks to Discourse's search menu (such as with [Discourse AI's quick semantic search feature](https://github.com/discourse/discourse-ai/pull/501))

This is necessary because the normal searches are triggered immediately (debounced) when being typed. This at times causes the `noResults` to property to be marked as true. However, when a plugin handles its own `searchTermChanged` action that does in fact have searches, the results are prevented from being shown because of `noResults` being `true`. Moving `noResults` to the search service, allows plugins to conditionally set the `noResults` property based on its results.

In short, moving the property to the service should result in no behaviour changes in core, but it helps allow plugins to work with the search menu better.