### PR TITLE
FEATURE: Improve "+ subcategories" option

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-selector-test.js
@@ -49,8 +49,8 @@ module(
         "Parent Category × 95"
       );
       assert.equal(
-        this.subject.rowByIndex(1).el().innerText.replace("\n", " "),
-        "Parent Category + 2 subcategories"
+        this.subject.rowByIndex(1).el().innerText.replaceAll("\n", " "),
+        "Parent Category × 95 + 2 subcategories"
       );
     });
   }

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -111,6 +111,9 @@ export default class CategoryRow extends Component {
           this.allowUncategorizedTopics || this.allowUncategorized,
         hideParent: !!this.parentCategory,
         topicCount: this.topicCount,
+        subcategoryCount: this.args.item?.categories
+          ? this.args.item.categories.length - 1
+          : 0,
       })
     );
   }


### PR DESCRIPTION
This commit improves the "+ X subcategories" option that shows sometimes in the category selector. It used to show when there was a single match, but now it also shows up on exact matches even though there are multiple results.

It also makes it work when lazy_load_categories is enabled by searching the subcategories before rendering them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
