### PR TITLE
UX: add optional grid-area below-content

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -607,7 +607,10 @@ textarea {
   box-sizing: border-box;
   width: 100%;
   display: grid;
-  grid-template-areas: "sidebar content";
+  grid-template-areas:
+    "sidebar content"
+    "sidebar below-content";
+  grid-template-rows: 1fr auto;
   grid-template-columns: 0 minmax(0, 1fr); // 0 column width needs to be set for CSS transitions
   gap: 0;
 


### PR DESCRIPTION
This grants the ability to add more content below `content` without interfering with footers and other page elements, with the added bonus of having anything within `below-content` automatically pushed to the bottom of the content area.

This is utilized by adding content to the `after-main-outlet` plugin outlet, and applying CSS like:

```css
.my-div {
  grid-area: below-content;
}
```


For example, this "powered by Discourse" badge:

![image](https://github.com/discourse/discourse/assets/1681963/f95d81c8-2ae8-4738-9e5c-8fd573e43f15)

when no content is added to `below-content`, the grid remains unchanged because the `1fr` on the first row tells the first row to occupy all available space:

![image](https://github.com/discourse/discourse/assets/1681963/2bd0db8f-8138-4aa4-8e30-4ed3dfe32f1a)
