### PR TITLE
UX: Don't hide new navigation item in experimental new new view

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.js
@@ -32,14 +32,14 @@ export default Component.extend({
     return contentFilterType === filterType;
   },
 
-  @discourseComputed("content.count")
-  isHidden(count) {
+  @discourseComputed("content.count", "content.name")
+  isHidden(count, name) {
     return (
       !this.active &&
       this.currentUser &&
+      !this.currentUser.new_new_view_enabled &&
       this.currentUser.trust_level > 0 &&
-      (this.content.get("name") === "new" ||
-        this.content.get("name") === "unread") &&
+      (name === "new" || name === "unread") &&
       count < 1
     );
   },

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe "Dismissing New", type: :system do
       expect(topic_list_controls).to have_new(count: 0)
 
       using_session(:tab_1) { expect(topic_list_controls).to have_new(count: 0) }
+
+      topic_list_controls.click_latest
+
+      expect(topic_list_controls).to have_new(count: 0)
     end
 
     it "displays confirmation modal with preselected options" do

--- a/spec/system/page_objects/components/topic_list_controls.rb
+++ b/spec/system/page_objects/components/topic_list_controls.rb
@@ -36,6 +36,11 @@ module PageObjects
         click_button("dismiss-new-top")
         self
       end
+
+      def click_latest
+        find(".nav-item_latest").click
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
### Why this change?

Before this change, the new navigation item in the topic list will be
hidden when there are no new or unread topics for the user. We have
started to find this behaviour confusing UX wise so we decided to stop
hiding it.
