### PR TITLE
FIX: Dismissing unread not dismissing correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -201,7 +201,13 @@ export default class DiscoveryListController extends Controller {
   }
 
   @action
-  dismissRead(operationType, options) {
-    this.bulkSelectHelper.dismissRead(operationType, options);
+  dismissRead(dismissTopics) {
+    const operationType = dismissTopics ? "topics" : "posts";
+
+    this.bulkSelectHelper.dismissRead(operationType, {
+      categoryId: this.model.category?.id,
+      tagName: this.model.tag?.id,
+      includeSubcategories: this.model.noSubcategories,
+    });
   }
 }

--- a/spec/system/page_objects/components/topic_list_controls.rb
+++ b/spec/system/page_objects/components/topic_list_controls.rb
@@ -11,7 +11,7 @@ module PageObjects
             I18n.t("js.filters.new.title_with_count", count: count)
           end
 
-        has_css?(".nav-item_new", text: text)
+        has_css?(".nav-item_new", exact_text: text)
       end
 
       def has_unread?(count:)
@@ -22,7 +22,7 @@ module PageObjects
             I18n.t("js.filters.unread.title_with_count", count: count)
           end
 
-        has_css?(".nav-item_unread", text: text)
+        has_css?(".nav-item_unread", exact_text: text)
       end
 
       def dismiss_unread(untrack: false)


### PR DESCRIPTION
### Why this change?

This is a regression from introduced in
5c1147adf3339c89a3ccb69839b4a4c5fd75a2ab where dismissing unread topics
was changing the notification level of the topics instead of just
dismissing the unread posts.

### What does this change do?

1. Bring back the previous implementation of the action
2. Fix the system test that was supposed to catch the problem but did
   not.
