### PR TITLE
FIX: Prevent indexing of invitation codes by search engines

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -18,7 +18,7 @@ class RobotsTxtController < ApplicationController
     /*?*api_key*
   ]
 
-  DISALLOWED_WITH_HEADER_PATHS ||= %w[/badges /u/ /my /search /tag/*/l /g /t/*/*.rss /c/*.rss]
+  DISALLOWED_WITH_HEADER_PATHS ||= %w[/badges /invites/ /u/ /my /search /tag/*/l /g /t/*/*.rss /c/*.rss]
 
   def index
     if (overridden = SiteSetting.overridden_robots_txt.dup).present?


### PR DESCRIPTION
The invitation code should not be indexed by search engines.