### PR TITLE
FIX: Avoid sending user emails if @ mentioning a staged user in a topic

### DIFF
--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -100,7 +100,13 @@ class NotificationEmailer
       user = notification.user
       return unless user.active? || user.staged?
       return if SiteSetting.must_approve_users? && !user.approved? && !user.staged?
-      return if user.staged? && (type == :user_linked || type == :user_quoted)
+      if user.staged? &&
+           (
+             type == :user_linked || type == :user_quoted || type == :user_mentioned ||
+               type == :group_mentioned
+           )
+        return
+      end
 
       return unless EMAILABLE_POST_TYPES.include?(post_type)
 

--- a/spec/services/notification_emailer_spec.rb
+++ b/spec/services/notification_emailer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe NotificationEmailer do
       notification_type: Notification.types[type],
       topic: topic,
       post_number: post.post_number,
+      skip_send_email: true,
     )
   end
 
@@ -42,7 +43,7 @@ RSpec.describe NotificationEmailer do
       it "enqueues a job if the user is staged for non-linked and non-quoted types" do
         notification.user.staged = true
 
-        if type == :user_linked || type == :user_quoted
+        if type == :user_linked || type == :user_quoted || type == :user_mentioned || type == :group_mentioned
           expect_not_enqueued_with(job: :user_email, args: { type: type }) do
             NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
@@ -59,7 +60,7 @@ RSpec.describe NotificationEmailer do
         notification.user.staged = true
         SiteSetting.must_approve_users = true
 
-        if type == :user_linked || type == :user_quoted
+        if type == :user_linked || type == :user_quoted || type == :user_mentioned || type == :group_mentioned
           expect_not_enqueued_with(job: :user_email, args: { type: type }) do
             NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
@@ -281,7 +282,7 @@ RSpec.describe NotificationEmailer do
     let(:no_delay) { true }
     let(:type) { :user_quoted }
 
-    after { DiscoursePluginRegistry.reset! }
+    after { DiscoursePluginRegistry.reset_register! :email_notification_filters }
 
     it "sends email when all filters return true" do
       plugin.register_email_notification_filter { |_| true }
@@ -298,6 +299,24 @@ RSpec.describe NotificationEmailer do
 
       expect_not_enqueued_with(job: :user_email, args: { type: type }) do
         NotificationEmailer.process_notification(notification, no_delay: no_delay)
+      end
+    end
+  end
+
+  context "with a staged user" do
+    context "when notification is mentioned or group_mentioned type" do
+      it "doesn't enqueue the job to send user email" do
+        staged_user = Fabricate(:staged)
+        mentioned = create_notification(:mentioned, staged_user)
+        group_mentioned = create_notification(:group_mentioned, staged_user)
+
+        expect_not_enqueued_with(job: :user_email) do
+          NotificationEmailer.process_notification(mentioned, no_delay: Time.zone.now)
+        end
+
+        expect_not_enqueued_with(job: :user_email) do
+          NotificationEmailer.process_notification(group_mentioned, no_delay: Time.zone.now)
+        end
       end
     end
   end

--- a/spec/services/notification_emailer_spec.rb
+++ b/spec/services/notification_emailer_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe NotificationEmailer do
       it "enqueues a job if the user is staged for non-linked and non-quoted types" do
         notification.user.staged = true
 
-        if type == :user_linked || type == :user_quoted || type == :user_mentioned || type == :group_mentioned
+        if type == :user_linked || type == :user_quoted || type == :user_mentioned ||
+             type == :group_mentioned
           expect_not_enqueued_with(job: :user_email, args: { type: type }) do
             NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
@@ -60,7 +61,8 @@ RSpec.describe NotificationEmailer do
         notification.user.staged = true
         SiteSetting.must_approve_users = true
 
-        if type == :user_linked || type == :user_quoted || type == :user_mentioned || type == :group_mentioned
+        if type == :user_linked || type == :user_quoted || type == :user_mentioned ||
+             type == :group_mentioned
           expect_not_enqueued_with(job: :user_email, args: { type: type }) do
             NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe PostAlerter do
       expect(Notification.where(user_id: pm.user_id).count).to eq(1)
     end
 
-    it "notifies about private message even if direct mention" do
+    it "prioritises 'private_message' type even if direct mention" do
       pm = Fabricate(:topic, archetype: "private_message", category_id: nil)
       op =
         Fabricate(:post, topic: pm, user: pm.user, raw: "Hello @#{user.username}, nice to meet you")


### PR DESCRIPTION
Some cases, unknowingly mentioning a staged user would invite them into topics, sending them an email about it.

This commit makes sure that staged users do not get emails when they are mentioned.

This commit also highlights via tests (`prioritises 'private_message' type`) that a mentioned staged user in a PM would receive a `private_message` type notification even if they are mentioned. Therefore this means the user will receive the email due to being in a PM, not because they were mentioned. This is existing behaviour, so only test description was changed.

/t/122323