### PR TITLE
FIX: Bug in desktopNotifications service not allowing unsubscription

### DIFF
--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -1,6 +1,7 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import Service, { service } from "@ember/service";
+import { Promise } from "rsvp";
 import {
   confirmNotification,
   context,
@@ -116,15 +117,28 @@ export default class DesktopNotificationsService extends Service {
 
   @action
   disable() {
+    const promises = [];
     if (this.isEnabledDesktop) {
-      this.setNotificationsDisabled(DISABLED);
-      return true;
+      promises.push(
+        new Promise((resolve) => {
+          this.setNotificationsDisabled(DISABLED);
+          resolve(true);
+        })
+      );
     }
+
     if (this.isEnabledPush) {
-      return unsubscribePushNotification(this.currentUser, () => {
-        this.setIsEnabledPush("");
-      });
+      promises.push(
+        new Promise((resolve) => {
+          unsubscribePushNotification(this.currentUser, () => {
+            this.setIsEnabledPush("");
+            resolve(true);
+          });
+        })
+      );
     }
+
+    return Promise.all(promises);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -1,7 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import Service, { service } from "@ember/service";
-import { Promise } from "rsvp";
 import {
   confirmNotification,
   context,
@@ -116,29 +115,17 @@ export default class DesktopNotificationsService extends Service {
   }
 
   @action
-  disable() {
-    const promises = [];
+  async disable() {
     if (this.isEnabledDesktop) {
-      promises.push(
-        new Promise((resolve) => {
-          this.setNotificationsDisabled(DISABLED);
-          resolve(true);
-        })
-      );
+      this.setNotificationsDisabled(DISABLED);
     }
-
     if (this.isEnabledPush) {
-      promises.push(
-        new Promise((resolve) => {
-          unsubscribePushNotification(this.currentUser, () => {
-            this.setIsEnabledPush("");
-            resolve(true);
-          });
-        })
-      );
+      await unsubscribePushNotification(this.currentUser, () => {
+        this.setIsEnabledPush("");
+      });
     }
 
-    return Promise.all(promises);
+    return true;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -49,7 +49,7 @@ export default class DesktopNotificationsService extends Service {
 
   setNotificationsDisabled(value) {
     keyValueStore.setItem("notifications-disabled", value);
-    this.notificationsDisabled = value;
+    this.notificationsDisabled = value === DISABLED;
   }
 
   get isDeniedPermission() {


### PR DESCRIPTION
The variable `notificationsDisabled` here is whacky. Currently the values are either an empty string or `"disabled"`. this makes boolean comparison really tricky. I found a bug in the `disable` function where we don't unsubscribe from desktop notifications b/c an early return..

This makes `notificationsDisabled` a boolean so we can rely on it :)

____

Also.. I made the `disable` method on the service unsubscribe from push notifications channel as well as disabling incoming desktop notifications. This is a safer way to ensure notifications are actually disabled.