### PR TITLE
Peg redis client to 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ gem "mail"
 gem "mini_mime"
 gem "mini_suffix"
 
-gem "redis"
+# config/initializers/006-mini_profiler.rb depends upon the RedisClient#call.
+# Rework this when upgrading to redis client 5.0 and above.
+gem "redis", "< 5.0"
 
 # This is explicitly used by Sidekiq and is an optional dependency.
 # We tell Sidekiq to use the namespace "sidekiq" which triggers this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,7 +636,7 @@ DEPENDENCIES
   rbtrace
   rchardet
   redcarpet
-  redis
+  redis (< 5.0)
   redis-namespace
   rinku
   rotp


### PR DESCRIPTION
Ok.

There was an initializer introduced in discourse/discourse#11088

```
Rack::MiniProfiler.counter_method(Redis::Client, :call) { 'redis' }
```

This now throws an error

```
gems/rack-mini-profiler-3.3.1/lib/mini_profiler/profiling_methods.rb:87:
in alias_method': undefined method call' for class `Redis::Client'
```

The error states that the method `def call` is no longer defined for `Redis::Client`. Which is accurate since that method was dropped in 5.0 via https://github.com/redis/redis-rb/commit/349ddb1daeed0ef1ee6e8a521238705ced010f27 ( redis/redis-rb#1120 )

This change ensures a known redis api

Other options are to change the interface used by discourse and `gem "redis", "> 5.0"`

/via https://github.com/MiniProfiler/rack-mini-profiler/issues/610

I currently do not use discourse, so testing would be appreciated.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
