### PR TITLE
FIX: Use user's locale for chat push notifications

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -66,11 +66,14 @@ module Jobs
             translation_args,
           )
 
+        translated_title =
+          I18n.with_locale(user.effective_locale) { I18n.t(translation_key, translation_args) }
+
         payload = {
           username: @creator.username,
           notification_type: ::Notification.types[:chat_message],
           post_url: @chat_message.url,
-          translated_title: ::I18n.t(translation_key, translation_args),
+          translated_title: translated_title,
           tag: ::Chat::Notifier.push_notification_tag(:message, @chat_channel.id),
           excerpt: @chat_message.push_notification_excerpt,
         }


### PR DESCRIPTION
It was reported by a customer that chat push notifications are not localized correctly. I believe this will fix the issue!