### PR TITLE
UX: Change default action label from "Message" to "Send Message" when sending a message

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2481,7 +2481,7 @@ en:
       reply: "Reply"
       cancel: "Cancel"
       create_topic: "Create Topic"
-      create_pm: "Message"
+      create_pm: "Send Message"
       create_whisper: "Whisper"
       create_shared_draft: "Create Shared Draft"
       edit_shared_draft: "Edit Shared Draft"


### PR DESCRIPTION
To keep things clear and consistent with how messaging actions are typically labeled, it's better and more common to default to "Send Message" rather than just "Message." This helps users understand exactly what the button does without any confusion.

ChatGPT
![image](https://github.com/discourse/discourse/assets/37538241/3b10296f-a066-4272-be8e-91ebac46060e)

Gmail
<img width="126" alt="image" src="https://github.com/discourse/discourse/assets/37538241/f4f50c4a-29ea-4297-8672-4991ad84a322">

Facebook
![image](https://github.com/discourse/discourse/assets/37538241/bb713bbd-8cf4-425a-b1b2-12de9f447ffc)

Twitter
![image](https://github.com/discourse/discourse/assets/37538241/ad2e9bb0-158e-4d4f-ad8f-10da4b92cf02)

LinkedIn
<img width="197" alt="image" src="https://github.com/discourse/discourse/assets/37538241/52871b87-d304-423e-b018-5cea8c69dae9">
