### PR TITLE
FEATURE: Support category, float, group and tag input types

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/field.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/field.gjs
@@ -1,8 +1,12 @@
 import Component from "@glimmer/component";
 import BooleanField from "./types/boolean";
+import CategoryField from "./types/category";
 import EnumField from "./types/enum";
+import FloatField from "./types/float";
+import GroupField from "./types/group";
 import IntegerField from "./types/integer";
 import StringField from "./types/string";
+import TagField from "./types/tag";
 
 export default class SchemaThemeSettingField extends Component {
   get component() {
@@ -11,10 +15,18 @@ export default class SchemaThemeSettingField extends Component {
         return StringField;
       case "integer":
         return IntegerField;
+      case "float":
+        return FloatField;
       case "boolean":
         return BooleanField;
       case "enum":
         return EnumField;
+      case "category":
+        return CategoryField;
+      case "tag":
+        return TagField;
+      case "group":
+        return GroupField;
       default:
         throw new Error("unknown type");
     }

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
@@ -5,12 +5,7 @@ import { action } from "@ember/object";
 import CategoryChooser from "select-kit/components/category-chooser";
 
 export default class SchemaThemeSettingTypeCategory extends Component {
-  @tracked value;
-
-  constructor() {
-    super(...arguments);
-    this.value = this.args.value;
-  }
+  @tracked value = this.args.value;
 
   @action
   onInput(newVal) {

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import CategoryChooser from "select-kit/components/category-chooser";
+import { hash } from "@ember/helper";
+
+export default class SchemaThemeSettingTypeCategory extends Component {
+  @tracked value;
+
+  constructor() {
+    super(...arguments);
+    this.value = this.args.value;
+  }
+
+  @action
+  onInput(newVal) {
+    this.value = newVal;
+    this.args.onChange(newVal);
+  }
+
+  <template>
+    <CategoryChooser
+      @value={{this.value}}
+      @onChange={{this.onInput}}
+      @options={{hash allowUncategorized=false}}
+    />
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/category.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import CategoryChooser from "select-kit/components/category-chooser";
-import { hash } from "@ember/helper";
 
 export default class SchemaThemeSettingTypeCategory extends Component {
   @tracked value;

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/enum.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/enum.gjs
@@ -4,12 +4,7 @@ import { action } from "@ember/object";
 import ComboBox from "select-kit/components/combo-box";
 
 export default class SchemaThemeSettingTypeEnum extends Component {
-  @tracked value;
-
-  constructor() {
-    super(...arguments);
-    this.value = this.args.value;
-  }
+  @tracked value = this.args.value;
 
   get content() {
     return this.args.spec.choices.map((choice) => {

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/float.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/float.gjs
@@ -3,10 +3,10 @@ import { Input } from "@ember/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 
-export default class SchemaThemeSettingTypeInteger extends Component {
+export default class SchemaThemeSettingTypeFloat extends Component {
   @action
   onInput(event) {
-    this.args.onChange(parseInt(event.currentTarget.value, 10));
+    this.args.onChange(parseFloat(event.currentTarget.value));
   }
 
   <template>

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/float.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/float.gjs
@@ -10,6 +10,11 @@ export default class SchemaThemeSettingTypeFloat extends Component {
   }
 
   <template>
-    <Input @value={{@value}} {{on "input" this.onInput}} @type="number" />
+    <Input
+      @value={{@value}}
+      {{on "input" this.onInput}}
+      @type="number"
+      step="0.1"
+    />
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
@@ -5,16 +5,10 @@ import Group from "discourse/models/group";
 import GroupChooser from "select-kit/components/group-chooser";
 
 export default class SchemaThemeSettingTypeGroup extends Component {
-  @tracked value;
-  @tracked groups;
-
-  constructor() {
-    super(...arguments);
-    this.value = this.args.value;
-    Group.findAll().then((groups) => {
-      this.groups = groups;
-    });
-  }
+  @tracked value = this.args.value;
+  @tracked groups = Group.findAll().then((groups) => {
+    this.groups = groups;
+  });
 
   @action
   onInput(newVal) {

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import GroupChooser from "select-kit/components/group-chooser";
 import Group from "discourse/models/group";
+import GroupChooser from "select-kit/components/group-chooser";
 
 export default class SchemaThemeSettingTypeGroup extends Component {
   @tracked value;

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import Group from "discourse/models/group";
 import GroupChooser from "select-kit/components/group-chooser";
@@ -12,8 +13,8 @@ export default class SchemaThemeSettingTypeGroup extends Component {
 
   @action
   onInput(newVal) {
-    this.value = newVal;
-    this.args.onChange(newVal);
+    this.value = newVal[0];
+    this.args.onChange(newVal[0]);
   }
 
   <template>
@@ -21,6 +22,7 @@ export default class SchemaThemeSettingTypeGroup extends Component {
       @content={{this.groups}}
       @value={{this.value}}
       @onChange={{this.onInput}}
+      @options={{hash maximum=1}}
     />
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/group.gjs
@@ -1,0 +1,32 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import GroupChooser from "select-kit/components/group-chooser";
+import Group from "discourse/models/group";
+
+export default class SchemaThemeSettingTypeGroup extends Component {
+  @tracked value;
+  @tracked groups;
+
+  constructor() {
+    super(...arguments);
+    this.value = this.args.value;
+    Group.findAll().then((groups) => {
+      this.groups = groups;
+    });
+  }
+
+  @action
+  onInput(newVal) {
+    this.value = newVal;
+    this.args.onChange(newVal);
+  }
+
+  <template>
+    <GroupChooser
+      @content={{this.groups}}
+      @value={{this.value}}
+      @onChange={{this.onInput}}
+    />
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
@@ -5,12 +5,7 @@ import { action } from "@ember/object";
 import TagChooser from "select-kit/components/tag-chooser";
 
 export default class SchemaThemeSettingTypeTag extends Component {
-  @tracked value;
-
-  constructor() {
-    super(...arguments);
-    this.value = this.args.value;
-  }
+  @tracked value = this.args.value;
 
   @action
   onInput(newVal) {

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import TagChooser from "select-kit/components/tag-chooser";
-import { hash } from "@ember/helper";
 
 export default class SchemaThemeSettingTypeTag extends Component {
   @tracked value;

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tag.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import TagChooser from "select-kit/components/tag-chooser";
+import { hash } from "@ember/helper";
+
+export default class SchemaThemeSettingTypeTag extends Component {
+  @tracked value;
+
+  constructor() {
+    super(...arguments);
+    this.value = this.args.value;
+  }
+
+  @action
+  onInput(newVal) {
+    this.value = newVal;
+    this.args.onChange(newVal);
+  }
+
+  <template>
+    <TagChooser
+      @tags={{this.value}}
+      @onChange={{this.onInput}}
+      @options={{hash allowAny=false}}
+    />
+  </template>
+}

--- a/app/assets/javascripts/discourse/tests/fixtures/theme-setting-schema-data.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/theme-setting-schema-data.js
@@ -170,12 +170,24 @@ export default function schemaAndData(version = 1) {
         integer_field: {
           type: "integer",
         },
+        float_field: {
+          type: "float",
+        },
         boolean_field: {
           type: "boolean",
         },
         enum_field: {
           type: "enum",
           choices: ["nice", "awesome", "cool"]
+        },
+        category_field: {
+          type: "category",
+        },
+        group_field: {
+          type: "group",
+        },
+        tag_field: {
+          type: "tag",
         }
       },
     };

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -2,11 +2,11 @@ import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import schemaAndData from "discourse/tests/fixtures/theme-setting-schema-data";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import I18n from "discourse-i18n";
 import AdminSchemaThemeSettingEditor from "admin/components/schema-theme-setting/editor";
-import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 class TreeFromDOM {
   constructor() {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -571,8 +571,7 @@ module(
 
       await groupSelector.expand();
       await groupSelector.selectRowByValue(74);
-      await groupSelector.selectRowByValue(23);
-      assert.strictEqual(groupSelector.header().value(), "74,23");
+      assert.strictEqual(groupSelector.header().value(), "74");
 
       const tree = new TreeFromDOM();
       await click(tree.nodes[1].element);
@@ -580,13 +579,12 @@ module(
       assert.strictEqual(groupSelector.header().value(), null);
       await groupSelector.expand();
       await groupSelector.selectRowByValue(23);
-      await groupSelector.selectRowByValue(89);
-      assert.strictEqual(groupSelector.header().value(), "23,89");
+      assert.strictEqual(groupSelector.header().value(), "23");
 
       tree.refresh();
 
       await click(tree.nodes[0].element);
-      assert.strictEqual(groupSelector.header().value(), "74,23");
+      assert.strictEqual(groupSelector.header().value(), "74");
     });
 
     test("identifier field instantly updates in the navigation tree when the input field is changed", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -6,6 +6,7 @@ import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import I18n from "discourse-i18n";
 import AdminSchemaThemeSettingEditor from "admin/components/schema-theme-setting/editor";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 class TreeFromDOM {
   constructor() {
@@ -286,6 +287,47 @@ module(
       );
     });
 
+    test("input fields are rendered even if they're not present in the data", async function (assert) {
+      const schema = {
+        name: "something",
+        identifier: "id",
+        properties: {
+          id: {
+            type: "string",
+          },
+          name: {
+            type: "string",
+          },
+        },
+      };
+      const data = [
+        {
+          id: "bu1",
+          name: "Big U",
+        },
+        {
+          id: "fi2",
+        },
+      ];
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @schema={{schema}} @data={{data}} />
+      </template>);
+
+      const inputFields = new InputFieldsFromDOM();
+
+      assert.strictEqual(inputFields.count, 2);
+      assert.dom(inputFields.fields.id.inputElement).hasValue("bu1");
+      assert.dom(inputFields.fields.name.inputElement).hasValue("Big U");
+
+      const tree = new TreeFromDOM();
+      await click(tree.nodes[1].element);
+      inputFields.refresh();
+
+      assert.strictEqual(inputFields.count, 2);
+      assert.dom(inputFields.fields.id.inputElement).hasValue("fi2");
+      assert.dom(inputFields.fields.name.inputElement).hasNoValue();
+    });
+
     test("input fields for items at different levels", async function (assert) {
       const [schema, data] = schemaAndData(2);
       await render(<template>
@@ -363,6 +405,36 @@ module(
         .hasValue("922229");
     });
 
+    test("input fields of type float", async function (assert) {
+      const [schema, data] = schemaAndData(3);
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @schema={{schema}} @data={{data}} />
+      </template>);
+
+      const inputFields = new InputFieldsFromDOM();
+      assert
+        .dom(inputFields.fields.float_field.labelElement)
+        .hasText("float_field");
+      assert.dom(inputFields.fields.float_field.inputElement).hasValue("");
+
+      await fillIn(inputFields.fields.float_field.inputElement, "6934.24");
+
+      const tree = new TreeFromDOM();
+      await click(tree.nodes[1].element);
+
+      inputFields.refresh();
+
+      assert.dom(inputFields.fields.float_field.inputElement).hasValue("");
+
+      tree.refresh();
+      await click(tree.nodes[0].element);
+      inputFields.refresh();
+
+      assert
+        .dom(inputFields.fields.float_field.inputElement)
+        .hasValue("6934.24");
+    });
+
     test("input fields of type boolean", async function (assert) {
       const [schema, data] = schemaAndData(3);
       await render(<template>
@@ -416,6 +488,105 @@ module(
 
       await click(tree.nodes[0].element);
       assert.strictEqual(enumSelector.header().value(), "nice");
+    });
+
+    test("input fields of type category", async function (assert) {
+      const [schema, data] = schemaAndData(3);
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @schema={{schema}} @data={{data}} />
+      </template>);
+
+      const inputFields = new InputFieldsFromDOM();
+      const categorySelector = selectKit(
+        `${inputFields.fields.category_field.selector} .select-kit`
+      );
+
+      assert.strictEqual(categorySelector.header().value(), null);
+
+      await categorySelector.expand();
+      await categorySelector.selectRowByIndex(1);
+
+      const selectedCategoryId = categorySelector.header().value();
+      assert.ok(selectedCategoryId);
+
+      const tree = new TreeFromDOM();
+      await click(tree.nodes[1].element);
+      assert.strictEqual(categorySelector.header().value(), null);
+
+      tree.refresh();
+
+      await click(tree.nodes[0].element);
+      assert.strictEqual(categorySelector.header().value(), selectedCategoryId);
+    });
+
+    test("input fields of type tag", async function (assert) {
+      const [schema, data] = schemaAndData(3);
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @schema={{schema}} @data={{data}} />
+      </template>);
+
+      const inputFields = new InputFieldsFromDOM();
+      const tagSelector = selectKit(
+        `${inputFields.fields.tag_field.selector} .select-kit`
+      );
+
+      assert.strictEqual(tagSelector.header().value(), null);
+
+      await tagSelector.expand();
+      await tagSelector.selectRowByIndex(1);
+      await tagSelector.selectRowByIndex(3);
+
+      assert.strictEqual(tagSelector.header().value(), "gazelle,cat");
+
+      const tree = new TreeFromDOM();
+      await click(tree.nodes[1].element);
+      assert.strictEqual(tagSelector.header().value(), null);
+
+      tree.refresh();
+
+      await click(tree.nodes[0].element);
+      assert.strictEqual(tagSelector.header().value(), "gazelle,cat");
+    });
+
+    test("input fields of type group", async function (assert) {
+      pretender.get("/groups/search.json", () => {
+        return response(200, [
+          { id: 23, name: "testers" },
+          { id: 74, name: "devs" },
+          { id: 89, name: "customers" },
+        ]);
+      });
+
+      const [schema, data] = schemaAndData(3);
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @schema={{schema}} @data={{data}} />
+      </template>);
+
+      const inputFields = new InputFieldsFromDOM();
+      const groupSelector = selectKit(
+        `${inputFields.fields.group_field.selector} .select-kit`
+      );
+
+      assert.strictEqual(groupSelector.header().value(), null);
+
+      await groupSelector.expand();
+      await groupSelector.selectRowByValue(74);
+      await groupSelector.selectRowByValue(23);
+      assert.strictEqual(groupSelector.header().value(), "74,23");
+
+      const tree = new TreeFromDOM();
+      await click(tree.nodes[1].element);
+
+      assert.strictEqual(groupSelector.header().value(), null);
+      await groupSelector.expand();
+      await groupSelector.selectRowByValue(23);
+      await groupSelector.selectRowByValue(89);
+      assert.strictEqual(groupSelector.header().value(), "23,89");
+
+      tree.refresh();
+
+      await click(tree.nodes[0].element);
+      assert.strictEqual(groupSelector.header().value(), "74,23");
     });
 
     test("identifier field instantly updates in the navigation tree when the input field is changed", async function (assert) {


### PR DESCRIPTION
Continue from https://github.com/discourse/discourse/pull/25673 and https://github.com/discourse/discourse/pull/25811.

This PR adds support for category, float, group and tag types for schema theme settings.