### PR TITLE
UX: CSS for back to the forum link on the hamburger menu

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -348,6 +348,22 @@
   .sidebar-filter {
     width: calc(100% - 2.35rem);
   }
+
+  .sidebar-sections {
+    &__back-to-forum {
+      margin: 0 var(--d-sidebar-row-horizontal-padding) 0.5em
+        var(--d-sidebar-row-horizontal-padding);
+      color: var(--d-sidebar-link-color);
+      display: flex;
+      align-items: center;
+      svg {
+        margin-right: var(--d-sidebar-section-link-prefix-margin-right);
+        height: 0.75em;
+        width: 0.75em;
+        color: var(--d-sidebar-link-icon-color);
+      }
+    }
+  }
 }
 
 // Panel / user-notification-list styles. **not** menu panel sizing styles


### PR DESCRIPTION
Fix styles for back to the forum link on the hamburger menu.

Before:
<img width="411" alt="Screenshot 2024-03-11 at 9 10 14 AM" src="https://github.com/discourse/discourse/assets/72780/8ff859da-a45a-4d35-ad6d-0adcf21f54c7">

After
<img width="425" alt="Screenshot 2024-03-11 at 9 10 00 AM" src="https://github.com/discourse/discourse/assets/72780/06ea42fa-1363-47af-94bb-dcbf2f424816">

