### PR TITLE
FIX: store registration ip address when creating user via SSO

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -256,6 +256,7 @@ class DiscourseConnect < DiscourseConnectBase
           name: resolve_name,
           username: resolve_username,
           ip_address: ip_address,
+          registration_ip_address: ip_address,
         }
 
         if SiteSetting.allow_user_locale && locale && LocaleSiteSetting.valid_value?(locale)

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -694,6 +694,26 @@ RSpec.describe DiscourseConnect do
     expect(user.username).to eq short_username
   end
 
+  it "stores registration ip address if it's present" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.registration_ip_address).to eq ip_address
+  end
+
+  it "does not store registration ip address if it's not present" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(nil)
+
+    expect(user.registration_ip_address).to eq nil
+  end
+
   it "can fill in data on way back" do
     sso = make_sso
 


### PR DESCRIPTION
This commit makes sure that `user.registration_ip_address` is stored at the time of user account creation via DiscourseConnect SSO. Note that `sync_sso` requests will not save ip_address because ip_address will be nil in that case.