### PR TITLE
UX: chat thread last replied user avatar

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channel-icon/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channel-icon/index.gjs
@@ -52,7 +52,7 @@ export default class ChatChannelIcon extends Component {
       <div class="chat-channel-icon">
         <div class="chat-channel-icon --avatar">
           <ChatUserAvatar
-            @user={{@thread.originalMessage.user}}
+            @user={{@thread.preview.lastReplyUser}}
             @interactive={{true}}
             @showPresence={{false}}
           />


### PR DESCRIPTION
Within My Threads on mobile we should show the last replied user avatar rather than original poster avatar.