### PR TITLE
FIX: Ensure header topic info updates immediately when navigating away

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -96,6 +96,13 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
     }
   },
 
+  init() {
+    this._super(...arguments);
+    this.appEvents.on("discourse:focus-changed", this, "gotFocus");
+    this.appEvents.on("post:highlight", this, "_highlightPost");
+    this.appEvents.on("header:update-topic", this, "_updateTopic");
+  },
+
   didInsertElement() {
     this._super(...arguments);
 
@@ -106,9 +113,16 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
       ".cooked a, a.track-link",
       (e) => ClickTrack.trackClick(e, getOwner(this))
     );
-    this.appEvents.on("discourse:focus-changed", this, "gotFocus");
-    this.appEvents.on("post:highlight", this, "_highlightPost");
-    this.appEvents.on("header:update-topic", this, "_updateTopic");
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+
+    // this happens after route exit, stuff could have trickled in
+    this._hideTopicInHeader();
+    this.appEvents.off("discourse:focus-changed", this, "gotFocus");
+    this.appEvents.off("post:highlight", this, "_highlightPost");
+    this.appEvents.off("header:update-topic", this, "_updateTopic");
   },
 
   willDestroyElement() {
@@ -121,12 +135,6 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
     $(this.element).off("click.discourse-redirect", ".cooked a, a.track-link");
 
     this.resetExamineDockCache();
-
-    // this happens after route exit, stuff could have trickled in
-    this._hideTopicInHeader();
-    this.appEvents.off("discourse:focus-changed", this, "gotFocus");
-    this.appEvents.off("post:highlight", this, "_highlightPost");
-    this.appEvents.off("header:update-topic", this, "_updateTopic");
   },
 
   gotFocus(hasFocus) {


### PR DESCRIPTION
Changing an `@tracked` value in a `willDestroyElement` hook will not immediately trigger a re-render. Instead, it seems to update on the next natural runloop iteration, which may be significantly later depending on what else is happening.

Instead, these kinds of 'data' changes should be made based on the lifecycle of the component instance (init / willDestroy). Making changes to tracked properties here does seem to cause immediate invalidation & re-render.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
