### PR TITLE
FIX: lookbehind assertions aren't available in < iOS 16.4

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -443,7 +443,7 @@ function findToken(tokens, marker, level = 0) {
   return token?.children ? findToken(token.children, marker, level + 1) : token;
 }
 
-const CODE_MARKERS_REGEX = /    |```|~~~|(?<!`)`(?!`)|\[code\]/;
+const CODE_MARKERS_REGEX = /    |```|~~~|[^`]`[^`]|\[code\]/;
 const CODE_TOKEN_TYPES = ["code_inline", "code_block", "fence"];
 
 export async function inCodeBlock(text, pos) {


### PR DESCRIPTION
This would generate an error and prevent the page from loading on "older" iOSes 😬 

_NOTE: no test added/changed, since the behaviour is the same, just using different "technique"._