### PR TITLE
FIX: Wait for async `Topic.apply_transformations` during `loadMore`

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -185,13 +185,13 @@ export default class TopicList extends RestModel {
 
       this.set("loadingMore", true);
 
-      return ajax({ url: moreUrl }).then((result) => {
+      return ajax({ url: moreUrl }).then(async (result) => {
         let topicsAdded = 0;
 
         if (result) {
           // the new topics loaded from the server
           const newTopics = TopicList.topicsFrom(this.store, result);
-          Topic.applyTransformations(newTopics);
+          await Topic.applyTransformations(newTopics);
 
           this.forEachNew(newTopics, (t) => {
             t.set("highlight", topicsAdded++ === 0);


### PR DESCRIPTION
`apply_transformations` is an async function, and plugins/themes using it expect their transformations to be applied before the loadMore logic continues. This should resolve issues with unencrypted topics when scrolling down topic lists in discourse-encrypt.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
