### PR TITLE
FEATURE: Add thread support to the chat message mover

### DIFF
--- a/plugins/chat/lib/chat/message_mover.rb
+++ b/plugins/chat/lib/chat/message_mover.rb
@@ -21,13 +21,11 @@
 # messages into a new channel. Remaining messages that referenced moved ones
 # have their in_reply_to_id cleared so the data makes sense.
 #
-# Threads are even more complex. No threads are preserved when moving messages
-# into a new channel, they end up as just a flat series of messages that are
-# not in a chain. If the original message of a thread and N other messages
-# in that thread, then any messages left behind just get placed into a new
-# thread. Message moving will be disabled in the thread UI, its too complicated
-# to have end users reason about for now, and we may want a standalone
-# "Move Thread" UI later on.
+# The service supports moving threads. If any of the selected messages is the
+# original message of a thread, the entire thread with all its replies will be
+# moved to the destination channel. Moving individual messages out of a thread
+# is still disabled.
+
 module Chat
   class MessageMover
     class NoMessagesFound < StandardError

--- a/plugins/chat/lib/chat/message_mover.rb
+++ b/plugins/chat/lib/chat/message_mover.rb
@@ -164,8 +164,6 @@ module Chat
               cooked: source_message.cooked,
               cooked_version: source_message.cooked_version,
               thread_id: new_thread_id,
-              created_at: source_message.created_at,
-              updated_at: source_message.updated_at,
             )
 
           DB.exec(

--- a/plugins/chat/spec/lib/chat/message_mover_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_mover_spec.rb
@@ -162,28 +162,23 @@ describe Chat::MessageMover do
         message3.update!(thread: thread)
       end
 
-      it "does not preserve thread_ids" do
+      it "creates a new thread_id for the moved messages" do
         move!
         moved_messages =
           Chat::Message
             .where(chat_channel: destination_channel)
             .order("created_at ASC, id ASC")
             .last(3)
+        moved_thread_ids = moved_messages.pluck(:thread_id).uniq
 
-        expect(moved_messages.pluck(:thread_id).uniq).to eq([nil])
+        expect(moved_thread_ids.size).to eq(1)
+        expect(moved_thread_ids.first).not_to be_nil
+        expect(moved_thread_ids.first).not_to eq(thread.id)
       end
 
       it "deletes the empty thread" do
         move!
         expect(Chat::Thread.exists?(id: thread.id)).to eq(false)
-      end
-
-      it "clears in_reply_to_id for remaining messages when the messages they were replying to are moved but leaves the thread_id" do
-        message3.update!(in_reply_to: message2)
-        message2.update!(in_reply_to: message1)
-        move!([message2.id])
-        expect(message3.reload.in_reply_to_id).to eq(nil)
-        expect(message3.reload.thread).to eq(thread)
       end
 
       it "updates the tracking to the last non-deleted channel message for users whose last_read_message_id was the moved message" do
@@ -212,7 +207,7 @@ describe Chat::MessageMover do
       end
 
       context "when a thread original message is moved" do
-        it "creates a new thread for the messages left behind in the old channel" do
+        it "moves the entire thread to the new channel" do
           message4 =
             Fabricate(
               :chat_message,
@@ -228,39 +223,53 @@ describe Chat::MessageMover do
               message: "the fifth message",
               thread: thread,
             )
-          expect { move! }.to change { Chat::Thread.count }.by(1)
-          new_thread = Chat::Thread.last
-          expect(message4.reload.thread_id).to eq(new_thread.id)
-          expect(message5.reload.thread_id).to eq(new_thread.id)
-          expect(new_thread.channel).to eq(source_channel)
-          expect(new_thread.original_message).to eq(message4)
+
+          expect { move! }.to change {
+            Chat::Message.where(chat_channel: destination_channel).count
+          }.by(5)
+
+          moved_messages =
+            Chat::Message
+              .where(chat_channel: destination_channel)
+              .order("created_at ASC, id ASC")
+              .last(5)
+
+          expect(moved_messages.map(&:thread_id).uniq.size).to eq(1)
+          expect(moved_messages.map(&:chat_channel_id).uniq).to eq([destination_channel.id])
         end
       end
 
       context "when multiple thread original messages are moved" do
-        it "works the same as when one is" do
+        it "moves the entire threads to the new channel" do
           message4 =
             Fabricate(:chat_message, chat_channel: source_channel, message: "the fourth message")
           message5 =
             Fabricate(
               :chat_message,
               chat_channel: source_channel,
-              in_reply_to: message5,
+              in_reply_to: message4,
               message: "the fifth message",
             )
           other_thread =
             Fabricate(:chat_thread, channel: source_channel, original_message: message4)
           message4.update!(thread: other_thread)
           message5.update!(thread: other_thread)
-          expect { move!([message1.id, message4.id]) }.to change { Chat::Thread.count }.by(2)
 
-          new_threads = Chat::Thread.order(:created_at).last(2)
-          expect(message3.reload.thread_id).to eq(new_threads.first.id)
-          expect(message5.reload.thread_id).to eq(new_threads.second.id)
-          expect(new_threads.first.channel).to eq(source_channel)
-          expect(new_threads.second.channel).to eq(source_channel)
-          expect(new_threads.first.original_message).to eq(message2)
-          expect(new_threads.second.original_message).to eq(message5)
+          expect { move!([message1.id, message4.id]) }.to change {
+            Chat::Message.where(chat_channel: destination_channel).count
+          }.by(5)
+
+          moved_messages =
+            Chat::Message
+              .where(chat_channel: destination_channel)
+              .order("created_at ASC, id ASC")
+              .last(5)
+
+          moved_thread_ids = moved_messages.map(&:thread_id).uniq
+          expect(moved_thread_ids.size).to eq(2)
+          moved_thread_ids.each do |thread_id|
+            expect(Chat::Thread.find(thread_id).channel_id).to eq(destination_channel.id)
+          end
         end
       end
     end

--- a/plugins/chat/spec/system/move_message_to_channel_spec.rb
+++ b/plugins/chat/spec/system/move_message_to_channel_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "Move message to channel", type: :system do
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+  let(:thread_page) { PageObjects::Pages::ChatThread.new }
 
   before { chat_system_bootstrap }
 
@@ -64,10 +65,17 @@ RSpec.describe "Move message to channel", type: :system do
     end
 
     context "when category channel" do
-      fab!(:channel_1) { Fabricate(:chat_channel) }
-      fab!(:channel_2) { Fabricate(:chat_channel) }
+      fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
+      fab!(:channel_2) { Fabricate(:chat_channel, threading_enabled: true) }
       fab!(:message_1) do
         Fabricate(:chat_message, chat_channel: channel_1, user: current_admin_user)
+      end
+      fab!(:thread) do
+        chat_thread_chain_bootstrap(
+          channel: channel_1,
+          users: [Fabricate(:user), Fabricate(:user)],
+          messages_count: 3,
+        )
       end
 
       before do
@@ -89,6 +97,28 @@ RSpec.describe "Move message to channel", type: :system do
         chat_page.visit_channel(channel_1)
 
         expect(channel_page.messages).to have_deleted_message(message_1)
+      end
+
+      it "moves the thread" do
+        chat_page.visit_channel(channel_1)
+        channel_page.messages.select(thread.original_message)
+        channel_page.selection_management.move
+        find(".chat-modal-move-message-to-channel__channel-chooser").click
+        find("[data-value='#{channel_2.id}']").click
+        click_button(I18n.t("js.chat.move_to_channel.confirm_move"))
+
+        expect(page).to have_current_path(chat.channel_path(channel_2.slug, channel_2.id))
+        expect(channel_page.messages).to have_message(text: thread.original_message.message)
+
+        chat_page.visit_thread(channel_2.threads.first)
+        chat_page.find(".chat-message .chat-message-thread-indicator").click
+        thread.replies.each do |reply|
+          expect(thread_page.messages).to have_message(text: reply.message)
+        end
+
+        chat_page.visit_channel(channel_1)
+
+        expect(channel_page.messages).to have_deleted_message(thread.original_message)
       end
     end
   end

--- a/plugins/chat/spec/system/move_message_to_channel_spec.rb
+++ b/plugins/chat/spec/system/move_message_to_channel_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Move message to channel", type: :system do
 
         chat_page.visit_channel(channel_1)
 
-        expect(channel_page.messages).to have_deleted_message(thread.original_message)
+        expect(channel_page.messages).to have_no_message(text: thread.original_message.message)
       end
     end
   end


### PR DESCRIPTION
When selecting messages to move to a new channel, if any of the selected messages is the original message of a thread, the entire thread, including all its replies, will be moved to the destination channel