### PR TITLE
FEATURE: filter additional keywords for the sidebar

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-sidebar-experiment.js
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-sidebar-experiment.js
@@ -12,7 +12,7 @@ import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
 
 // TODO (martin) (2024-02-01) Remove this experimental UI.
 export default class AdminConfigAreaSidebarExperiment extends Component {
-  @service adminSidebarExperimentStateManager;
+  @service adminSidebarStateManager;
   @service toasts;
   @service router;
   @tracked editedNavConfig;
@@ -46,7 +46,7 @@ export default class AdminConfigAreaSidebarExperiment extends Component {
 
   @action
   loadDefaultNavConfig() {
-    const savedConfig = this.adminSidebarExperimentStateManager.navConfig;
+    const savedConfig = this.adminSidebarStateManager.navConfig;
     this.editedNavConfig = savedConfig
       ? JSON.stringify(savedConfig, null, 2)
       : this.defaultAdminNav;
@@ -116,7 +116,7 @@ export default class AdminConfigAreaSidebarExperiment extends Component {
   }
 
   #saveConfig(config) {
-    this.adminSidebarExperimentStateManager.navConfig = config;
+    this.adminSidebarStateManager.navConfig = config;
     resetPanelSections(
       ADMIN_PANEL,
       useAdminNavConfig(config),

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -14,6 +14,7 @@ import PluginCommitHash from "./plugin-commit-hash";
 export default class AdminPluginsListItem extends Component {
   @service session;
   @service currentUser;
+  @service sidebarState;
 
   @action
   async togglePluginEnabled(plugin) {
@@ -30,8 +31,20 @@ export default class AdminPluginsListItem extends Component {
     }
   }
 
+  get isFiltered() {
+    if (!this.sidebarState.filter) {
+      return false;
+    }
+    return this.args.plugin.nameTitleized
+      .toLowerCase()
+      .match(this.sidebarState.filter);
+  }
+
   <template>
-    <tr data-plugin-name={{@plugin.name}}>
+    <tr
+      data-plugin-name={{@plugin.name}}
+      class={{if this.isFiltered "filtered"}}
+    >
       <td class="admin-plugins-list__row">
         <div class="admin-plugins-list__name-with-badges">
           <div class="admin-plugins-list__name">

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -43,9 +43,12 @@ export default class AdminPluginsListItem extends Component {
   <template>
     <tr
       data-plugin-name={{@plugin.name}}
-      class={{if this.isFiltered "filtered"}}
+      class={{concat
+        "admin-plugins-list__row"
+        (if this.isFiltered "-filtered")
+      }}
     >
-      <td class="admin-plugins-list__row">
+      <td class="admin-plugins-list__name-details">
         <div class="admin-plugins-list__name-with-badges">
           <div class="admin-plugins-list__name">
             {{#if @plugin.linkUrl}}

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -31,7 +31,7 @@ export default class AdminPluginsListItem extends Component {
     }
   }
 
-  get isFiltered() {
+  get isAdminSearchFiltered() {
     if (!this.sidebarState.filter) {
       return false;
     }
@@ -43,7 +43,7 @@ export default class AdminPluginsListItem extends Component {
       data-plugin-name={{@plugin.name}}
       class={{concat
         "admin-plugins-list__row"
-        (if this.isFiltered "-filtered")
+        (if this.isAdminSearchFiltered "-admin-search-filtered")
       }}
     >
       <td class="admin-plugins-list__name-details">

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -35,9 +35,7 @@ export default class AdminPluginsListItem extends Component {
     if (!this.sidebarState.filter) {
       return false;
     }
-    return this.args.plugin.nameTitleized
-      .toLowerCase()
-      .match(this.sidebarState.filter);
+    return this.args.plugin.nameTitleizedLower.match(this.sidebarState.filter);
   }
 
   <template>

--- a/app/assets/javascripts/admin/addon/models/admin-plugin.js
+++ b/app/assets/javascripts/admin/addon/models/admin-plugin.js
@@ -1,4 +1,4 @@
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { capitalize } from "@ember/string";
 import I18n from "discourse-i18n";
 
@@ -53,6 +53,7 @@ export default class AdminPlugin {
     return "plugins";
   }
 
+  @cached
   get nameTitleized() {
     // The category name is better in a lot of cases, as it's a human-inputted
     // translation, and we can handle things like SAML instead of showing them
@@ -77,6 +78,11 @@ export default class AdminPlugin {
     }
 
     return name;
+  }
+
+  @cached
+  get nameTitleizedLower() {
+    this.nameTitleized.toLowerCase();
   }
 
   get author() {

--- a/app/assets/javascripts/admin/addon/models/admin-plugin.js
+++ b/app/assets/javascripts/admin/addon/models/admin-plugin.js
@@ -82,7 +82,7 @@ export default class AdminPlugin {
 
   @cached
   get nameTitleizedLower() {
-    this.nameTitleized.toLowerCase();
+    return this.nameTitleized.toLowerCase();
   }
 
   get author() {

--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -7,7 +7,9 @@ import I18n from "discourse-i18n";
 export default class AdminRoute extends DiscourseRoute {
   @service sidebarState;
   @service siteSettings;
+  @service store;
   @service currentUser;
+  @service adminSidebarExperimentStateManager;
   @tracked initialSidebarState;
 
   titleToken() {
@@ -23,6 +25,12 @@ export default class AdminRoute extends DiscourseRoute {
 
     this.controllerFor("application").setProperties({
       showTop: false,
+    });
+
+    this.store.findAll("plugin").then((plugins) => {
+      this.adminSidebarExperimentStateManager.keywords[
+        "admin_installed_plugins"
+      ] = plugins.map((plugin) => plugin.name.toLowerCase());
     });
   }
 

--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -28,8 +28,9 @@ export default class AdminRoute extends DiscourseRoute {
       showTop: false,
     });
 
-    this.adminSidebarStateManager.keywords.admin_installed_plugins =
-      PreloadStore.get("visiblePlugins").mapBy("name");
+    this.adminSidebarStateManager.keywords.admin_installed_plugins = {
+      navigation: PreloadStore.get("visiblePlugins").mapBy("name"),
+    };
   }
 
   deactivate(transition) {

--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -28,9 +28,12 @@ export default class AdminRoute extends DiscourseRoute {
       showTop: false,
     });
 
-    this.adminSidebarStateManager.keywords.admin_installed_plugins = {
-      navigation: PreloadStore.get("visiblePlugins").mapBy("name"),
-    };
+    const visiblePlugins = PreloadStore.get("visiblePlugins");
+    if (visiblePlugins) {
+      this.adminSidebarStateManager.keywords.admin_installed_plugins = {
+        navigation: visiblePlugins.mapBy("name"),
+      };
+    }
   }
 
   deactivate(transition) {

--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
+import PreloadStore from "discourse/lib/preload-store";
 import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
@@ -9,7 +10,7 @@ export default class AdminRoute extends DiscourseRoute {
   @service siteSettings;
   @service store;
   @service currentUser;
-  @service adminSidebarExperimentStateManager;
+  @service adminSidebarStateManager;
   @tracked initialSidebarState;
 
   titleToken() {
@@ -27,11 +28,8 @@ export default class AdminRoute extends DiscourseRoute {
       showTop: false,
     });
 
-    this.store.findAll("plugin").then((plugins) => {
-      this.adminSidebarExperimentStateManager.keywords[
-        "admin_installed_plugins"
-      ] = plugins.map((plugin) => plugin.name.toLowerCase());
-    });
+    this.adminSidebarStateManager.keywords.admin_installed_plugins =
+      PreloadStore.get("visiblePlugins").mapBy("name");
   }
 
   deactivate(transition) {

--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-experiment-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-experiment-state-manager.js
@@ -1,7 +1,9 @@
+import { tracked } from "@glimmer/tracking";
 import Service from "@ember/service";
 import KeyValueStore from "discourse/lib/key-value-store";
 
 export default class AdminSidebarExperimentStateManager extends Service {
+  @tracked keywords = {};
   STORE_NAMESPACE = "discourse_admin_sidebar_experiment_";
 
   store = new KeyValueStore(this.STORE_NAMESPACE);

--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
@@ -1,9 +1,10 @@
 import { tracked } from "@glimmer/tracking";
 import Service from "@ember/service";
+import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import KeyValueStore from "discourse/lib/key-value-store";
 
-export default class AdminSidebarExperimentStateManager extends Service {
-  @tracked keywords = {};
+export default class AdminSidebarStateManager extends Service {
+  @tracked keywords = new TrackedObject();
   STORE_NAMESPACE = "discourse_admin_sidebar_experiment_";
 
   store = new KeyValueStore(this.STORE_NAMESPACE);

--- a/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
@@ -31,7 +31,9 @@ export default class SidebarApiSection extends Component {
     return this.section.links.filter((link) => {
       return (
         link.text.toString().toLowerCase().match(this.sidebarState.filter) ||
-        link.keywords.some((keyword) => keyword.match(this.sidebarState.filter))
+        link.keywords.navigation.some((keyword) =>
+          keyword.match(this.sidebarState.filter)
+        )
       );
     });
   }

--- a/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
@@ -27,8 +27,14 @@ export default class SidebarApiSection extends Component {
     if (this.section.text.toLowerCase().match(this.sidebarState.filter)) {
       return this.section.links;
     }
+
     return this.section.links.filter((link) => {
-      return link.text.toString().toLowerCase().match(this.sidebarState.filter);
+      return (
+        link.text.toString().toLowerCase().match(this.sidebarState.filter) ||
+        link.keywords?.some((keyword) =>
+          keyword.match(this.sidebarState.filter)
+        )
+      );
     });
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-section.js
@@ -31,9 +31,7 @@ export default class SidebarApiSection extends Component {
     return this.section.links.filter((link) => {
       return (
         link.text.toString().toLowerCase().match(this.sidebarState.filter) ||
-        link.keywords?.some((keyword) =>
-          keyword.match(this.sidebarState.filter)
-        )
+        link.keywords.some((keyword) => keyword.match(this.sidebarState.filter))
       );
     });
   }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -16,10 +16,16 @@ export function clearAdditionalAdminSidebarSectionLinks() {
 }
 
 class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
-  constructor({ adminSidebarNavLink, router }) {
+  constructor({
+    adminSidebarNavLink,
+    adminSidebarExperimentStateManager,
+    router,
+  }) {
     super(...arguments);
     this.router = router;
     this.adminSidebarNavLink = adminSidebarNavLink;
+    this.adminSidebarExperimentStateManager =
+      adminSidebarExperimentStateManager;
   }
 
   get name() {
@@ -80,14 +86,27 @@ class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
 
     return this.adminSidebarNavLink.route;
   }
+  get keywords() {
+    return (
+      this.adminSidebarExperimentStateManager.keywords[
+        this.adminSidebarNavLink.name
+      ] || []
+    );
+  }
 }
 
-function defineAdminSection(adminNavSectionData, router) {
+function defineAdminSection(
+  adminNavSectionData,
+  adminSidebarExperimentStateManager,
+  router
+) {
   const AdminNavSection = class extends BaseCustomSidebarSection {
     constructor() {
       super(...arguments);
       this.adminNavSectionData = adminNavSectionData;
       this.hideSectionHeader = adminNavSectionData.hideSectionHeader;
+      this.adminSidebarExperimentStateManager =
+        adminSidebarExperimentStateManager;
     }
 
     get sectionLinks() {
@@ -113,6 +132,8 @@ function defineAdminSection(adminNavSectionData, router) {
         (sectionLinkData) =>
           new SidebarAdminSectionLink({
             adminSidebarNavLink: sectionLinkData,
+            adminSidebarExperimentStateManager:
+              this.adminSidebarExperimentStateManager,
             router,
           })
       );
@@ -256,7 +277,11 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const navConfig = useAdminNavConfig(navMap);
 
     return navConfig.map((adminNavSectionData) => {
-      return defineAdminSection(adminNavSectionData, router);
+      return defineAdminSection(
+        adminNavSectionData,
+        this.adminSidebarExperimentStateManager,
+        router
+      );
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -16,11 +16,7 @@ export function clearAdditionalAdminSidebarSectionLinks() {
 }
 
 class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
-  constructor({
-    adminSidebarNavLink,
-    adminSidebarExperimentStateManager,
-    router,
-  }) {
+  constructor({ adminSidebarNavLink, adminSidebarStateManager, router }) {
     super(...arguments);
     this.router = router;
     this.adminSidebarNavLink = adminSidebarNavLink;
@@ -96,7 +92,7 @@ class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
 
 function defineAdminSection(
   adminNavSectionData,
-  adminSidebarExperimentStateManager,
+  adminSidebarStateManager,
   router
 ) {
   const AdminNavSection = class extends BaseCustomSidebarSection {
@@ -130,8 +126,7 @@ function defineAdminSection(
         (sectionLinkData) =>
           new SidebarAdminSectionLink({
             adminSidebarNavLink: sectionLinkData,
-            adminSidebarExperimentStateManager:
-              this.adminSidebarExperimentStateManager,
+            adminSidebarStateManager: this.adminSidebarStateManager,
             router,
           })
       );
@@ -228,7 +223,7 @@ function pluginAdminRouteLinks() {
         routeModels: plugin.admin_route.use_new_show_route
           ? [plugin.admin_route.location]
           : [],
-        label: pluginAdminRoute.label,
+        label: plugin.admin_route.label,
         icon: "cog",
       };
     });

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -83,8 +83,9 @@ class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
   }
   get keywords() {
     return (
-      this.adminSidebarStateManager.keywords[this.adminSidebarNavLink.name] ||
-      []
+      this.adminSidebarStateManager.keywords[this.adminSidebarNavLink.name] || {
+        navigation: [],
+      }
     );
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -83,7 +83,6 @@ class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
   }
   get keywords() {
     return (
-      this.adminSidebarNavLink.keywords ||
       this.adminSidebarStateManager.keywords[this.adminSidebarNavLink.name] ||
       []
     );
@@ -266,6 +265,14 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         icon: "list",
       });
     }
+
+    navMap.forEach((section) =>
+      section.links.forEach((link) => {
+        if (link.keywords) {
+          this.adminSidebarStateManager.keywords[link.name] = link.keywords;
+        }
+      })
+    );
 
     const navConfig = useAdminNavConfig(navMap);
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
@@ -42,7 +42,7 @@ acceptance("Admin - Plugins", function (needs) {
 
     assert
       .dom(
-        "table.admin-plugins-list tr .admin-plugins-list__row .admin-plugins-list__name-with-badges .admin-plugins-list__name"
+        "table.admin-plugins-list .admin-plugins-list__row .admin-plugins-list__name-details .admin-plugins-list__name-with-badges .admin-plugins-list__name"
       )
       .hasText("Some Test Plugin", "displays the plugin in the table");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -13,10 +13,14 @@ acceptance("Admin Sidebar - Sections", function (needs) {
   });
 
   needs.hooks.beforeEach(() => {
-    PreloadStore.store("enabledPluginAdminRoutes", [
+    PreloadStore.store("visiblePlugins", [
       {
-        location: "index",
-        label: "admin.plugins.title",
+        name: "plugin title",
+        admin_route: {
+          location: "index",
+          label: "admin.plugins.title",
+          enabled: true,
+        },
       },
     ]);
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -87,7 +87,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-plugins'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_plugin_index\"]"
+        ".sidebar-section[data-section-name='admin-nav-section-plugins'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_installed_plugins\"]"
       ),
       "the admin plugin route is added to the plugins section"
     );

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -9,16 +9,16 @@
 
   .admin-plugins-list {
     @media screen and (min-width: 550px) {
-      tr {
+      .admin-plugins-list__row {
         grid-template-columns: 0.25fr repeat(4, 1fr);
       }
     }
     @include breakpoint(mobile-extra-large) {
-      tr {
+      .admin-plugins-list__row {
         grid-template-columns: 0.25fr repeat(3, 1fr);
       }
       .admin-plugins-list {
-        &__row {
+        &__name-details {
           grid-column-start: 2;
           grid-column-end: -1;
         }
@@ -41,7 +41,7 @@
       }
     }
 
-    tr.filtered {
+    .admin-plugins-list__row-filtered {
       background-color: var(--primary-low);
     }
 

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -41,6 +41,10 @@
       }
     }
 
+    tr.filtered {
+      background-color: var(--primary-low);
+    }
+
     &__author {
       font-size: var(--font-down-2);
       padding: 0 0 0.25em 0;

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -41,7 +41,7 @@
       }
     }
 
-    .admin-plugins-list__row-filtered {
+    .admin-plugins-list__row-admin-search-filtered {
       background-color: var(--primary-low);
     }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -673,8 +673,18 @@ class ApplicationController < ActionController::Base
 
       # Used to show plugin-specific admin routes in the sidebar.
       store_preloaded(
-        "enabledPluginAdminRoutes",
-        MultiJson.dump(Discourse.plugins_sorted_by_name.filter_map(&:admin_route)),
+        "visiblePlugins",
+        MultiJson.dump(
+          Discourse
+            .plugins_sorted_by_name(enabled_only: false)
+            .map do |plugin|
+              {
+                name: plugin.name.downcase,
+                admin_route: plugin.admin_route,
+                enabled: plugin.enabled?,
+              }
+            end,
+        ),
       )
     end
   end

--- a/plugins/chat/spec/requests/application_controller_spec.rb
+++ b/plugins/chat/spec/requests/application_controller_spec.rb
@@ -18,20 +18,28 @@ RSpec.describe ApplicationController do
   end
 
   context "when user is admin" do
-    it "has correctly loaded preloaded data for enabledPluginAdminRoutes" do
+    it "has correctly loaded preloaded data for visiblePlugins" do
       sign_in(admin)
       get "/latest"
-      expect(JSON.parse(preloaded_json["enabledPluginAdminRoutes"])).to include(
-        { "label" => "chat.admin.title", "location" => "chat", "use_new_show_route" => false },
+      expect(JSON.parse(preloaded_json["visiblePlugins"])).to include(
+        {
+          "name" => "chat",
+          "admin_route" => {
+            "label" => "chat.admin.title",
+            "location" => "chat",
+            "use_new_show_route" => false,
+          },
+          "enabled" => true,
+        },
       )
     end
   end
 
   context "when user is not admin" do
-    it "does not include preloaded data for enabledPluginAdminRoutes" do
+    it "does not include preloaded data for visiblePlugins" do
       sign_in(user)
       get "/latest"
-      expect(preloaded_json["enabledPluginAdminRoutes"]).to eq(nil)
+      expect(preloaded_json["visiblePlugins"]).to eq(nil)
     end
   end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1295,7 +1295,7 @@ RSpec.describe ApplicationController do
             "topicTrackingStates",
             "topicTrackingStateMeta",
             "fontMap",
-            "enabledPluginAdminRoutes",
+            "visiblePlugins",
           ],
         )
       end
@@ -1309,9 +1309,9 @@ RSpec.describe ApplicationController do
         )
       end
 
-      it "has correctly loaded enabledPluginAdminRoutes" do
+      it "has correctly loaded visiblePlugins" do
         get "/latest"
-        expect(JSON.parse(preloaded_json["enabledPluginAdminRoutes"])).to eq([])
+        expect(JSON.parse(preloaded_json["visiblePlugins"])).to eq([])
       end
     end
   end

--- a/spec/system/admin_plugins_list_spec.rb
+++ b/spec/system/admin_plugins_list_spec.rb
@@ -17,7 +17,9 @@ describe "Admin Plugins List", type: :system, js: true do
     visit "/admin/plugins"
 
     plugin_row =
-      find(".admin-plugins-list tr[data-plugin-name=\"spoiler-alert\"] td.admin-plugins-list__row")
+      find(
+        ".admin-plugins-list tr[data-plugin-name=\"spoiler-alert\"] td.admin-plugins-list__name-details",
+      )
     expect(plugin_row).to have_css(
       ".admin-plugins-list__name-with-badges .admin-plugins-list__name",
       text: "Spoiler Alert",

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -92,4 +92,17 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(links.count).to eq(3)
     expect(links.map(&:text)).to eq(["Appearance", "Preview Summary", "Server Setup"])
   end
+
+  it "accepts hidden keywords like installed plugin names for filter" do
+    Discourse.instance_variable_set(
+      "@plugins",
+      Plugin::Instance.find_all("#{Rails.root}/spec/fixtures/plugins"),
+    )
+
+    visit("/admin")
+    filter.filter("csp_extension")
+    links = page.all(".sidebar-section-link-content-text")
+    expect(links.count).to eq(1)
+    expect(links.map(&:text)).to eq(["Installed"])
+  end
 end


### PR DESCRIPTION
With the new admin sidebar restructure, we have a link to "Installed plugins". We would like to ensure that when the admin is searching for a plugin name like "akismet" or "automation" this link will be visible. 

Also when entering the plugins page, related plugins should be highlighted.

Demo


https://github.com/discourse/discourse/assets/72780/c30f6501-73dc-4371-a7f1-844390a420eb


