### PR TITLE
feat: export calendar to office365

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
@@ -29,6 +29,18 @@
           {{i18n "download_calendar.save_google"}}
         </label>
       </div>
+      <div class="office365">
+        <label class="radio" for="office365">
+          <RadioButton
+            id="office365"
+            @name="select-calendar"
+            @value="office365"
+            @selection={{this.selectedCalendar}}
+            @onChange={{fn this.selectCalendar "office365"}}
+          />
+          {{i18n "download_calendar.save_office365"}}
+        </label>
+      </div>
     </div>
 
     <div class="control-group remember">

--- a/app/assets/javascripts/discourse/app/components/modal/download-calendar.js
+++ b/app/assets/javascripts/discourse/app/components/modal/download-calendar.js
@@ -2,7 +2,11 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { downloadGoogle, downloadIcs } from "discourse/lib/download-calendar";
+import {
+  downloadGoogle,
+  downloadIcs,
+  downloadOffice365,
+} from "discourse/lib/download-calendar";
 
 export default class downloadCalendar extends Component {
   @service currentUser;
@@ -25,11 +29,16 @@ export default class downloadCalendar extends Component {
         this.args.model.calendar.dates,
         this.args.model.calendar.recurrenceRule
       );
-    } else {
+    } else if (this.selectedCalendar === "google") {
       downloadGoogle(
         this.args.model.calendar.title,
         this.args.model.calendar.dates,
         this.args.model.calendar.recurrenceRule
+      );
+    } else if (this.selectedCalendar === "office365") {
+      downloadOffice365(
+        this.args.model.calendar.title,
+        this.args.model.calendar.dates
       );
     }
     this.args.closeModal();

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@glimmer/syntax": "^0.89.0",
     "@highlightjs/cdn-assets": "^11.9.0",
+    "calendar-link": "^2.6.0",
     "discourse-hbr": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
     "ember-route-template": "^1.0.3",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4348,6 +4348,7 @@ en:
       title: "Download calendar"
       save_ics: "Download .ics file"
       save_google: "Add to Google calendar"
+      save_office365: "Add to Office365"
       remember: "Don’t ask me again"
       remember_explanation: "(you can change this preference in your user prefs)"
       download: "Download"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,6 +4465,14 @@ calculate-cache-key-for-tree@^2.0.0:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+calendar-link@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/calendar-link/-/calendar-link-2.6.0.tgz#47cec3d9a2d0c13ac87f732898867e92ea423c98"
+  integrity sha512-ypgYoFBz2w0WkJV1m6LoO31i8F5te3/rsTdJp/ONacVmr+C4Ny7rHhvwmIZS3yrbG2abbcohn2D8DZbcFZvwfA==
+  dependencies:
+    dayjs "^1.9.3"
+    query-string "^6.13.6"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -5175,6 +5183,11 @@ date-fns@^2.30.0:
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+dayjs@^1.9.3:
+  version "1.11.10"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
 debug@2.6.9, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -7012,6 +7025,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
 
 finalhandler@1.1.2:
   version "1.1.2"
@@ -10743,6 +10761,16 @@ qs@^6.4.0:
   dependencies:
     side-channel "^1.0.4"
 
+query-string@^6.13.6:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
+  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
@@ -11726,6 +11754,11 @@ spawn-command@0.0.2:
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
   integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11798,6 +11831,11 @@ streamx@^2.13.0, streamx@^2.15.0:
     queue-tick "^1.0.1"
   optionalDependencies:
     bare-events "^2.2.0"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-template@~0.2.0, string-template@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This pull request primarily introduces support for Office365 calendar downloads in the discourse application. The changes include UI updates to enable Office365 selection, backend logic to handle Office365 calendar downloads, and necessary package updates to facilitate these changes.

User Interface Updates:
* [`app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs`](diffhunk://#diff-e0be11226ca268a06c05eb21e38a7138447bef0d5cdb9e3e9a9587cbacadd298R32-R43): Added a new radio button for Office365 calendar selection in the download calendar modal.
* [`config/locales/client.en.yml`](diffhunk://#diff-d311cd526428b83a1ebb9ed9b457fb210800cc5f0e8188af7de7b5ce86aa5315R4351): Added a new locale string to support the Office365 option in the download calendar modal.

Backend Logic Updates:
* [`app/assets/javascripts/discourse/app/components/modal/download-calendar.js`](diffhunk://#diff-9eed0a6fd9ae2c9478debdc640dbc4e1cd1d0cab06a5de99f07058b83c450fdfL5-R9): Updated the download logic to include a case for Office365. [[1]](diffhunk://#diff-9eed0a6fd9ae2c9478debdc640dbc4e1cd1d0cab06a5de99f07058b83c450fdfL5-R9) [[2]](diffhunk://#diff-9eed0a6fd9ae2c9478debdc640dbc4e1cd1d0cab06a5de99f07058b83c450fdfL28-R42)
* [`app/assets/javascripts/discourse/app/lib/download-calendar.js`](diffhunk://#diff-58543c104cd39bd6280807cb984b737bc65cad0276f786351d2c9463369f9e2fR1): Added import statements for Office365, updated the `downloadCalendar` function to include a case for Office365, and added a new `downloadOffice365` function. The `downloadGoogle` function was also refactored to use the `google` function from the `calendar-link` package. [[1]](diffhunk://#diff-58543c104cd39bd6280807cb984b737bc65cad0276f786351d2c9463369f9e2fR1) [[2]](diffhunk://#diff-58543c104cd39bd6280807cb984b737bc65cad0276f786351d2c9463369f9e2fR23-R25) [[3]](diffhunk://#diff-58543c104cd39bd6280807cb984b737bc65cad0276f786351d2c9463369f9e2fL42-R75) [[4]](diffhunk://#diff-58543c104cd39bd6280807cb984b737bc65cad0276f786351d2c9463369f9e2fL98-L103)

Package Updates:
* [`app/assets/javascripts/discourse/package.json`](diffhunk://#diff-1376082b8aec42e0602ca199899b0cb67cc78be8a1af980f5715e258b0c36f9dR21): Added the `calendar-link` package to the dependencies.