### PR TITLE
UX: Make input sizing consistent across all browsers

### DIFF
--- a/app/assets/stylesheets/common/font-variables.scss
+++ b/app/assets/stylesheets/common/font-variables.scss
@@ -30,7 +30,7 @@
 
   // inputs/textareas in iOS need to be at least 16px to avoid triggering zoom on focus
   // with base at 15px, the below gives 16.05px
-  --font-size-ios-input: 1.07em;
+  --font-size-input: max(1em, 16px);
 
   // Common line-heights
   --line-height-small: 1;

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -115,8 +115,6 @@ $hpad: 0.65em;
   box-sizing: border-box;
   padding: $vpad $hpad;
   font-size: var(--font-size-input);
-  padding-top: $vpad * 0.8; // TODO... what's this for?
-  padding-bottom: $vpad * 0.8; // TODO... what's this for?
 }
 
 @mixin sticky {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -114,11 +114,9 @@ $hpad: 0.65em;
   line-height: normal;
   box-sizing: border-box;
   padding: $vpad $hpad;
-  .ios-device & {
-    font-size: var(--font-size-ios-input);
-    padding-top: $vpad * 0.8;
-    padding-bottom: $vpad * 0.8;
-  }
+  font-size: var(--font-size-input);
+  padding-top: $vpad * 0.8; // TODO... what's this for?
+  padding-bottom: $vpad * 0.8; // TODO... what's this for?
 }
 
 @mixin sticky {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -9,16 +9,14 @@ body {
   background-color: var(--secondary);
 }
 
-.ios-device {
-  textarea {
-    background-color: var(--secondary);
-    font-size: var(--font-size-ios-input);
-    -webkit-tap-highlight-color: transparent;
-  }
+textarea {
+  background-color: var(--secondary); // TODO: why was this iOS-only
+  font-size: var(--font-size-ios-input);
+  -webkit-tap-highlight-color: transparent;
+}
 
-  input#reply-title {
-    -webkit-tap-highlight-color: transparent;
-  }
+input#reply-title {
+  -webkit-tap-highlight-color: transparent;
 }
 
 blockquote {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -10,13 +10,7 @@ body {
 }
 
 textarea {
-  background-color: var(--secondary); // TODO: why was this iOS-only
-  font-size: var(--font-size-ios-input);
-  -webkit-tap-highlight-color: transparent;
-}
-
-input#reply-title {
-  -webkit-tap-highlight-color: transparent;
+  font-size: var(--font-size-input);
 }
 
 blockquote {


### PR DESCRIPTION
Previously we had an iOS-specific sizing rule which would increase inputs to `1.07em`, which would bring them over the 16px 'zoom on focus' threshold in some (but technically, not all) situations.

This commit does two things:

1. Updates the sizing rule from `1.07em` to `max(1em, 16px)`. Essentially: use the cascaded font size, unless it is smaller than 16px

2. Applies that sizing rule on all platforms. This will make Discourse design/theming more consistent across different devices