### PR TITLE
UX: fix chat navbar header alignment

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -23,12 +23,4 @@
     left: 0.25rem;
     width: calc(100% - 0.5rem);
   }
-
-  .c-navbar__title {
-    .c-routes-direct-messages &,
-    .c-routes-channels &,
-    .c-routes-threads & {
-      padding-left: 1.25rem;
-    }
-  }
 }


### PR DESCRIPTION
Removing the padding here which causes a misalignment

<img width="414" alt="image" src="https://github.com/discourse/discourse/assets/101828855/f8902fa0-1027-40ac-8246-334ae74464a0">