### PR TITLE
FEATURE: optionally show "Powered by Discourse" link to discourse.org

### DIFF
--- a/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
+++ b/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
@@ -1,0 +1,24 @@
+import Component from "@glimmer/component";
+import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class PoweredByDiscourse extends Component {
+  get encodedDomain() {
+    return btoa(window.location.hostname);
+  }
+
+  <template>
+    <a
+      class="powered-by-discourse"
+      href="https://discover.discourse.org/powered-by/{{this.encodedDomain}}"
+      nofollow="true"
+    >
+      <span class="powered-by-discourse__content">
+        <span class="powered-by-discourse__logo">
+          {{icon "fab-discourse"}}
+        </span>
+        <span>{{i18n "powered_by_discourse"}}</span>
+      </span>
+    </a>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
+++ b/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
@@ -2,7 +2,7 @@ import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
 const PoweredByDiscourse = <template>
-  <a class="powered-by-discourse" href="https://discourse.org" nofollow="true">
+  <a class="powered-by-discourse" href="https://discourse.org">
     <span class="powered-by-discourse__content">
       <span class="powered-by-discourse__logo">
         {{icon "fab-discourse"}}

--- a/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
+++ b/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
@@ -1,24 +1,15 @@
-import Component from "@glimmer/component";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
-export default class PoweredByDiscourse extends Component {
-  get encodedDomain() {
-    return btoa(window.location.hostname);
-  }
-
-  <template>
-    <a
-      class="powered-by-discourse"
-      href="https://discover.discourse.org/powered-by/{{this.encodedDomain}}"
-      nofollow="true"
-    >
-      <span class="powered-by-discourse__content">
-        <span class="powered-by-discourse__logo">
-          {{icon "fab-discourse"}}
-        </span>
-        <span>{{i18n "powered_by_discourse"}}</span>
+const PoweredByDiscourse = <template>
+  <a class="powered-by-discourse" href="https://discourse.org" nofollow="true">
+    <span class="powered-by-discourse__content">
+      <span class="powered-by-discourse__logo">
+        {{icon "fab-discourse"}}
       </span>
-    </a>
-  </template>
-}
+      <span>{{i18n "powered_by_discourse"}}</span>
+    </span>
+  </a>
+</template>;
+
+export default PoweredByDiscourse;

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -59,6 +59,11 @@ export default Controller.extend({
     return this.capabilities.isAppWebview || this.capabilities.isiOSPWA;
   },
 
+  @discourseComputed
+  showPoweredBy() {
+    return this.showFooter && this.siteSettings.show_powered_by;
+  },
+
   _mainOutletAnimate() {
     document.body.classList.remove("sidebar-animate");
   },

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -61,7 +61,7 @@ export default Controller.extend({
 
   @discourseComputed
   showPoweredBy() {
-    return this.showFooter && this.siteSettings.show_powered_by;
+    return this.showFooter && this.siteSettings.enable_powered_by_discourse;
   },
 
   _mainOutletAnimate() {

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -87,6 +87,10 @@
     </div>
 
     <PluginOutlet @name="after-main-outlet" />
+
+    {{#if this.showPoweredBy}}
+      <PoweredByDiscourse />
+    {{/if}}
   </div>
 
   <PluginOutlet

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -28,6 +28,7 @@
 @import "navs";
 @import "offline-indicator";
 @import "pick-files-button";
+@import "powered-by-discourse";
 @import "relative-time-picker";
 @import "add-pm-participants";
 @import "download-calendar";

--- a/app/assets/stylesheets/common/components/powered-by-discourse.scss
+++ b/app/assets/stylesheets/common/components/powered-by-discourse.scss
@@ -1,0 +1,73 @@
+.powered-by-discourse {
+  .admin-area &,
+  .has-full-page-chat &,
+  .static-login &,
+  .invite-page & {
+    display: none !important;
+  }
+  grid-area: below-content;
+  justify-self: start;
+  font-size: var(--font-down-1);
+  letter-spacing: 0.2px; // extra spacing makes small text easier to read
+  padding: 2px; // animated hover "border" width
+  background: var(--secondary);
+  border-radius: 0.75em;
+  transition: all 0.25s ease-in-out;
+  margin-bottom: 0.45em;
+  color: var(--primary-medium);
+
+  &:visited {
+    color: var(--primary-medium);
+  }
+
+  &__content {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    color: currentColor;
+    background: var(--secondary);
+    border-radius: 0.62em;
+    padding: 0.25em 0.65em 0.25em 0.5em;
+  }
+
+  .d-icon {
+    position: relative;
+    top: 0.05em; // vertical alignment
+  }
+
+  .discourse-no-touch & {
+    &:hover {
+      color: var(--primary-high);
+      @media (prefers-reduced-motion: no-preference) {
+        // secondary repeat is an intentional buffer
+        background: linear-gradient(
+          45deg,
+          var(--secondary),
+          var(--secondary),
+          var(--secondary),
+          var(--secondary),
+          var(--secondary),
+          #d0232b,
+          #f15d22,
+          #fff9ae,
+          #00a94f,
+          #00aeef
+        );
+        background-size: 300%;
+        animation: d-rainbow-shimmer 0.5s;
+        animation-fill-mode: forwards;
+        animation-timing-function: ease-in-out;
+        animation-delay: 0.15s; // avoid animating on passing hover
+      }
+    }
+
+    @keyframes d-rainbow-shimmer {
+      0% {
+        background-position: 0% 50%;
+      }
+      100% {
+        background-position: 100% 50%;
+      }
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4801,6 +4801,7 @@ en:
           copy: "Copy..."
           paste: "Paste..."
           save: "Save as..."
+    powered_by_discourse: "Powered by Discourse"
 
   # This section is exported to the javascript for i18n in the admin section
   admin_js:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2332,7 +2332,7 @@ en:
 
     share_anonymized_statistics: "Enable sharing of anonymized usage statistics with CDCK, Inc. (“Discourse”). When this setting is enabled, data concerning the usage of the site is collected and shared in anonymized form, ensuring no personal information is disclosed."
 
-    show_powered_by: "Show “Powered by Discourse” link to discourse.org at the bottom of most pages."
+    enable_powered_by_discourse: "Show “Powered by Discourse” link to discourse.org at the bottom of most pages."
 
     auto_handle_queued_age: "Automatically handle records that are waiting to be reviewed after this many days. Flags will be ignored. Queued posts and users will be rejected. Set to 0 to disable this feature."
     penalty_step_hours: "Default penalties for silencing or suspending users in hours. First offense defaults to the first value, second offense defaults to the second value, etc."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2332,6 +2332,8 @@ en:
 
     share_anonymized_statistics: "Enable sharing of anonymized usage statistics with CDCK, Inc. (“Discourse”). When this setting is enabled, data concerning the usage of the site is collected and shared in anonymized form, ensuring no personal information is disclosed."
 
+    show_powered_by: "Show “Powered by Discourse” link to discourse.org at the bottom of most pages."
+
     auto_handle_queued_age: "Automatically handle records that are waiting to be reviewed after this many days. Flags will be ignored. Queued posts and users will be rejected. Set to 0 to disable this feature."
     penalty_step_hours: "Default penalties for silencing or suspending users in hours. First offense defaults to the first value, second offense defaults to the second value, etc."
     penalty_include_post_message: "Automatically include offending post message in email message template when silencing or suspending a user"
@@ -2498,8 +2500,8 @@ en:
     watched_precedence_over_muted: "Notify me about topics in categories or tags I’m watching that also belong to one I have muted"
 
     company_name: "Name of your company or organization. If left blank, no boilerplate Terms of Service or Privacy Notice will be provided."
-    governing_law:  "Specify the jurisdiction that governs the legal aspects of the site, including Terms of Service and Privacy Policy. This is typically the country or state where the company operating the site is registered or conducts business."
-    city_for_disputes:  "Specify the city that will be used as the jurisdiction for resolving any disputes related to the use of this forum. This information is typically included in legal documents such as the forum's Terms of Service."
+    governing_law: "Specify the jurisdiction that governs the legal aspects of the site, including Terms of Service and Privacy Policy. This is typically the country or state where the company operating the site is registered or conducts business."
+    city_for_disputes: "Specify the city that will be used as the jurisdiction for resolving any disputes related to the use of this forum. This information is typically included in legal documents such as the forum's Terms of Service."
 
     shared_drafts_category: "Enable the Shared Drafts feature by designating a category for topic drafts. Topics in this category will be suppressed from topic lists for staff users."
     shared_drafts_min_trust_level: "Allow users to see and edit Shared Drafts."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2818,7 +2818,7 @@ uncategorized:
 
   share_anonymized_statistics: true
 
-  show_powered_by:
+  enable_powered_by_discourse:
     default: false
     client: true
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2818,6 +2818,10 @@ uncategorized:
 
   share_anonymized_statistics: true
 
+  show_powered_by:
+    default: false
+    client: true
+
   auto_handle_queued_age:
     default: 60
     min: 0

--- a/spec/system/powered_by_discourse_spec.rb
+++ b/spec/system/powered_by_discourse_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe "Powered by Discourse", type: :system do
+  it "appears when enabled" do
+    SiteSetting.show_powered_by = true
+
+    visit "/"
+    expect(page).to have_css(".powered-by-discourse")
+  end
+
+  it "does not appear on admin routes when enabled" do
+    SiteSetting.show_powered_by = true
+
+    visit "/admin"
+    expect(page).not_to have_css(".powered-by-discourse")
+  end
+
+  it "does not appear on login required route when enabled" do
+    SiteSetting.show_powered_by = true
+    SiteSetting.login_required = true
+
+    visit "/"
+    expect(page).not_to have_css(".powered-by-discourse")
+  end
+
+  it "does not appear when disabled" do
+    SiteSetting.show_powered_by = false
+
+    visit "/"
+    expect(page).not_to have_css(".powered-by-discourse")
+  end
+end

--- a/spec/system/powered_by_discourse_spec.rb
+++ b/spec/system/powered_by_discourse_spec.rb
@@ -2,21 +2,21 @@
 
 describe "Powered by Discourse", type: :system do
   it "appears when enabled" do
-    SiteSetting.show_powered_by = true
+    SiteSetting.enable_powered_by_discourse = true
 
     visit "/"
     expect(page).to have_css(".powered-by-discourse")
   end
 
   it "does not appear on admin routes when enabled" do
-    SiteSetting.show_powered_by = true
+    SiteSetting.enable_powered_by_discourse = true
 
     visit "/admin"
     expect(page).not_to have_css(".powered-by-discourse")
   end
 
   it "does not appear on login required route when enabled" do
-    SiteSetting.show_powered_by = true
+    SiteSetting.enable_powered_by_discourse = true
     SiteSetting.login_required = true
 
     visit "/"
@@ -24,7 +24,7 @@ describe "Powered by Discourse", type: :system do
   end
 
   it "does not appear when disabled" do
-    SiteSetting.show_powered_by = false
+    SiteSetting.enable_powered_by_discourse = false
 
     visit "/"
     expect(page).not_to have_css(".powered-by-discourse")


### PR DESCRIPTION
This adds a new site setting `enable_powered_by_discourse`, default false. 

When enabled, this will show a "Powered by Discourse" link to discourse.org at the bottom of most pages (admin, invites, full-page chat, login-required, and no-ember pages being the exceptions).

https://github.com/discourse/discourse/assets/1681963/9e771b44-bacf-446d-939f-5887143a693a

