### PR TITLE
FIX: improvements for the admin sidebar

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize.hbs
@@ -1,64 +1,66 @@
-<AdminNav>
-  {{#if this.currentUser.admin}}
-    <NavItem
-      @route="adminCustomizeThemes"
-      @label="admin.customize.theme.title"
-      class="admin-customize-themes"
-    />
-    <NavItem
-      @route="adminCustomize.colors"
-      @label="admin.customize.colors.title"
-      class="admin-customize-colors"
-    />
-    <NavItem
-      @route="adminSiteText"
-      @label="admin.site_text.title"
-      class="admin-customize-site-text"
-    />
-    <NavItem
-      @route="adminCustomizeEmailTemplates"
-      @label="admin.customize.email_templates.title"
-      class="admin-customize-email-templates"
-    />
-    <NavItem
-      @route="adminCustomizeEmailStyle"
-      @label="admin.customize.email_style.title"
-      class="admin-customize-email-styles"
-    />
-    <NavItem
-      @route="adminUserFields"
-      @label="admin.user_fields.title"
-      class="admin-customize-user-fields"
-    />
-    <NavItem
-      @route="adminEmojis"
-      @label="admin.emoji.title"
-      class="admin-customize-emojis"
-    />
-    <NavItem
-      @route="adminPermalinks"
-      @label="admin.permalink.title"
-      class="admin-customize-permalinks"
-    />
-    <NavItem
-      @route="adminEmbedding"
-      @label="admin.embedding.title"
-      class="admin-customize-embedding"
-    />
-    {{#if this.siteSettings.experimental_form_templates}}
+{{#unless this.currentUser.use_admin_sidebar}}
+  <AdminNav>
+    {{#if this.currentUser.admin}}
       <NavItem
-        @route="adminCustomizeFormTemplates"
-        @label="admin.form_templates.nav_title"
-        class="admin-customize-form-templates"
+        @route="adminCustomizeThemes"
+        @label="admin.customize.theme.title"
+        class="admin-customize-themes"
       />
+      <NavItem
+        @route="adminCustomize.colors"
+        @label="admin.customize.colors.title"
+        class="admin-customize-colors"
+      />
+      <NavItem
+        @route="adminSiteText"
+        @label="admin.site_text.title"
+        class="admin-customize-site-text"
+      />
+      <NavItem
+        @route="adminCustomizeEmailTemplates"
+        @label="admin.customize.email_templates.title"
+        class="admin-customize-email-templates"
+      />
+      <NavItem
+        @route="adminCustomizeEmailStyle"
+        @label="admin.customize.email_style.title"
+        class="admin-customize-email-styles"
+      />
+      <NavItem
+        @route="adminUserFields"
+        @label="admin.user_fields.title"
+        class="admin-customize-user-fields"
+      />
+      <NavItem
+        @route="adminEmojis"
+        @label="admin.emoji.title"
+        class="admin-customize-emojis"
+      />
+      <NavItem
+        @route="adminPermalinks"
+        @label="admin.permalink.title"
+        class="admin-customize-permalinks"
+      />
+      <NavItem
+        @route="adminEmbedding"
+        @label="admin.embedding.title"
+        class="admin-customize-embedding"
+      />
+      {{#if this.siteSettings.experimental_form_templates}}
+        <NavItem
+          @route="adminCustomizeFormTemplates"
+          @label="admin.form_templates.nav_title"
+          class="admin-customize-form-templates"
+        />
+      {{/if}}
     {{/if}}
-  {{/if}}
-  <NavItem
-    @route="adminWatchedWords"
-    @label="admin.watched_words.title"
-    class="admin-customize-watched-words"
-  />
-</AdminNav>
+    <NavItem
+      @route="adminWatchedWords"
+      @label="admin.watched_words.title"
+      class="admin-customize-watched-words"
+    />
+  </AdminNav>
+{{/unless}}
 
 <div class="admin-container">
   {{outlet}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -379,7 +379,7 @@ export const ADMIN_NAV_MAP = [
         icon: "discourse-sparkles",
       },
       {
-        name: "admin_experimental",
+        name: "admin_all_site_settings",
         route: "adminSiteSettings",
         label: "admin.advanced.sidebar_link.all_site_settings",
         icon: "cog",

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -378,6 +378,12 @@ export const ADMIN_NAV_MAP = [
         label: "admin.advanced.sidebar_link.experimental",
         icon: "discourse-sparkles",
       },
+      {
+        name: "admin_experimental",
+        route: "adminSiteSettings",
+        label: "admin.advanced.sidebar_link.all_site_settings",
+        icon: "cog",
+      },
     ],
   },
 ];

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5328,6 +5328,7 @@ en:
           other_options: "Other"
           search: "Search"
           experimental: "Experimental"
+          all_site_settings: "All Site Settings"
 
       navigation_menu:
         sidebar: "Sidebar"


### PR DESCRIPTION
- add all settings link
- hide the customize header menu when the admin sidebar

before:
<img width="1478" alt="Screenshot 2024-03-14 at 2 33 54 PM" src="https://github.com/discourse/discourse/assets/72780/c198e9a4-b074-4b3e-9fb4-b97996305ae0">


after:
<img width="1462" alt="Screenshot 2024-03-14 at 2 33 05 PM" src="https://github.com/discourse/discourse/assets/72780/76329721-6d04-4be7-9d35-1c43aeb01e38">

