### PR TITLE
PERF: omit HTML view from sessions by logged on users.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -436,7 +436,7 @@ module ApplicationHelper
   end
 
   def include_crawler_content?
-    crawler_layout? || !mobile_view? || !modern_mobile_device?
+    (crawler_layout? || !mobile_view? || !modern_mobile_device?) && !current_user
   end
 
   def modern_mobile_device?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe ApplicationHelper do
       HTML
     end
 
+    it "does not send crawler content to logged on users" do
+      controller.stubs(:use_crawler_layout?).returns(false)
+      helper.stubs(:current_user).returns(Fabricate(:user))
+
+      helper.request.user_agent = "Firefox"
+      expect(helper.include_crawler_content?).to eq(false)
+    end
+
     it "sends crawler content to old mobiles" do
       controller.stubs(:use_crawler_layout?).returns(false)
 


### PR DESCRIPTION
You need JS to log on to Discourse anyway, HTML only serves for debugging
purpose, no need to send it
