### PR TITLE
UX: fix chat title margin on drawer and side panel

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -72,10 +72,6 @@
     }
   }
 
-  .chat-drawer & {
-    padding-left: 1rem;
-  }
-
   .d-icon {
     vertical-align: middle;
   }

--- a/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
@@ -17,3 +17,7 @@
     padding: 0 1.5em 1em;
   }
 }
+
+#main-chat-outlet .chat-side-panel .c-navbar__title {
+  margin-left: 0;
+}


### PR DESCRIPTION
Fixes alignment issues within the drawer mode and chat sidebar panel on desktop.

Before:
<img width="330" alt="Screenshot 2024-03-14 at 1 01 52 PM" src="https://github.com/discourse/discourse/assets/2257978/3ffe41fb-e0b8-440c-a568-19a06fe890dc">

After:
<img width="304" alt="Screenshot 2024-03-14 at 1 01 29 PM" src="https://github.com/discourse/discourse/assets/2257978/9efd110d-80f6-44ad-aacc-6e8376d1c951">

Before:
<img width="201" alt="Screenshot 2024-03-14 at 1 02 37 PM" src="https://github.com/discourse/discourse/assets/2257978/45e9e3b9-3c71-4f12-b20f-8ac08ef38f5a">

After:
<img width="228" alt="Screenshot 2024-03-14 at 1 02 44 PM" src="https://github.com/discourse/discourse/assets/2257978/ebf03b78-e065-423c-921e-6a1c91d1aa78">
 