### PR TITLE
DEV: adds details/location options to downloadCalendar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -2116,12 +2116,12 @@ class PluginApi {
    *       endsAt: "2021-10-12T16:00:00.000Z",
    *     },
    *   ],
-   *   "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR"
+   *   { recurrenceRule: "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR", location: "Paris", details: "Foo" }
    * );
    * ```
    */
-  downloadCalendar(title, dates, recurrenceRule = null) {
-    downloadCalendar(title, dates, recurrenceRule);
+  downloadCalendar(title, dates, options = {}) {
+    downloadCalendar(title, dates, options);
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/unit/lib/download-calendar-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/download-calendar-test.js
@@ -62,7 +62,7 @@ END:VCALENDAR`
           endsAt: "2021-10-12T16:00:00.000Z",
         },
       ],
-      "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR"
+      { recurrenceRule: "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR" }
     );
     assert.equal(
       data,
@@ -109,11 +109,53 @@ END:VCALENDAR`
           endsAt: "2021-10-12T16:00:00.000Z",
         },
       ],
-      "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR"
+      { recurrenceRule: "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR" }
     );
     assert.ok(
       window.open.calledWith(
         "https://www.google.com/calendar/event?action=TEMPLATE&text=event&dates=20211012T150000Z%2F20211012T160000Z&recur=RRULE%3AFREQ%3DDAILY%3BBYDAY%3DMO%2CTU%2CWE%2CTH%2CFR",
+        "_blank",
+        "noopener",
+        "noreferrer"
+      )
+    );
+  });
+
+  test("correct location for Google when location given", function (assert) {
+    downloadGoogle(
+      "event",
+      [
+        {
+          startsAt: "2021-10-12T15:00:00.000Z",
+          endsAt: "2021-10-12T16:00:00.000Z",
+        },
+      ],
+      { location: "Paris" }
+    );
+    assert.ok(
+      window.open.calledWith(
+        "https://www.google.com/calendar/event?action=TEMPLATE&text=event&dates=20211012T150000Z%2F20211012T160000Z&location=Paris",
+        "_blank",
+        "noopener",
+        "noreferrer"
+      )
+    );
+  });
+
+  test("correct details for Google when details given", function (assert) {
+    downloadGoogle(
+      "event",
+      [
+        {
+          startsAt: "2021-10-12T15:00:00.000Z",
+          endsAt: "2021-10-12T16:00:00.000Z",
+        },
+      ],
+      { details: "Cool" }
+    );
+    assert.ok(
+      window.open.calledWith(
+        "https://www.google.com/calendar/event?action=TEMPLATE&text=event&dates=20211012T150000Z%2F20211012T160000Z&details=Cool",
         "_blank",
         "noopener",
         "noreferrer"


### PR DESCRIPTION
This will now be used for google calendars to pre-fill the associated fields in: https://calendar.google.com/calendar/u/0/r/eventedit

Used in: https://github.com/discourse/discourse-calendar/pull/549
