### PR TITLE
FIX: Handle nil post_search_data for search result

### DIFF
--- a/lib/search/grouped_search_results.rb
+++ b/lib/search/grouped_search_results.rb
@@ -78,8 +78,10 @@ class Search
 
     def blurb(post)
       opts = { term: @blurb_term, blurb_length: @blurb_length }
+      post_search_data_version = post&.post_search_data&.version
 
-      if post.post_search_data.version >= SearchIndexer::MIN_POST_BLURB_INDEX_VERSION &&
+      if post_search_data_version.present? &&
+           post_search_data_version >= SearchIndexer::MIN_POST_BLURB_INDEX_VERSION &&
            !Search.segment_chinese? && !Search.segment_japanese?
         if use_pg_headlines_for_excerpt
           scrubbed_headline = post.headline.gsub(SCRUB_HEADLINE_REGEXP, '\1')


### PR DESCRIPTION
Since we are introducing new ways to search in Discourse, like the AI semantic search using embeddings, posts can be part of a search result list without having any search data.

Since the code path already handles this, we only need to add a safety check when accessing the post_search_data.