### PR TITLE
FIX: correctly strip unneeded csp directives under strict-dynamic

### DIFF
--- a/lib/content_security_policy/builder.rb
+++ b/lib/content_security_policy/builder.rb
@@ -76,7 +76,7 @@ class ContentSecurityPolicy
       sources = Array(sources).map { |s| normalize_source(s) }
 
       if SiteSetting.content_security_policy_strict_dynamic &&
-           %w[script-src worker-src].include?(directive.to_s)
+           %w[script_src worker_src].include?(directive.to_s)
         # Strip any sources which are ignored under strict-dynamic
         # If/when we make strict-dynamic the only option, we could print deprecation warnings
         # asking plugin/theme authors to remove the unnecessary config

--- a/spec/lib/content_security_policy/builder_spec.rb
+++ b/spec/lib/content_security_policy/builder_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe ContentSecurityPolicy::Builder do
   describe "#<<" do
     it "normalizes directive name" do
       builder << {
-        :script_src => ["symbol_underscore"],
-        :"script-src" => ["symbol_dash"],
-        "script_src" => ["string_underscore"],
-        "script-src" => ["string_dash"],
+        :script_src => ["'symbol_underscore'"],
+        :"script-src" => ["'symbol_dash'"],
+        "script_src" => ["'string_underscore'"],
+        "script-src" => ["'string_dash'"],
       }
 
       script_srcs = parse(builder.build)["script-src"]
 
       expect(script_srcs).to include(
-        *%w[symbol_underscore symbol_dash string_underscore symbol_underscore],
+        *%w['symbol_underscore' 'symbol_dash' 'string_underscore' 'symbol_underscore'],
       )
     end
 

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -396,6 +396,16 @@ RSpec.describe ContentSecurityPolicy do
     expect(parse(policy)["script-src"]).to include("'unsafe-eval'")
   end
 
+  it "strips unsupported values from setting" do
+    SiteSetting.content_security_policy_script_src =
+      "'unsafe-eval'|blob:|https://example.com/script.js"
+
+    script_src = parse(policy)["script-src"]
+    expect(script_src).to include("'unsafe-eval'")
+    expect(script_src).not_to include("blob:")
+    expect(script_src).not_to include("https://example.com/script.js")
+  end
+
   def parse(csp_string)
     csp_string
       .split(";")

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -647,14 +647,14 @@ RSpec.describe ApplicationController do
       get "/"
       script_src = parse(response.headers["Content-Security-Policy"])["script-src"]
 
-      expect(script_src).to_not include("'unsafe-inline'")
+      expect(script_src).to_not include("'unsafe-eval'")
 
-      SiteSetting.content_security_policy_script_src = "'unsafe-inline'"
+      SiteSetting.content_security_policy_script_src = "'unsafe-eval'"
 
       get "/"
       script_src = parse(response.headers["Content-Security-Policy"])["script-src"]
 
-      expect(script_src).to include("'unsafe-inline'")
+      expect(script_src).to include("'unsafe-eval'")
     end
 
     it "does not set CSP when responding to non-HTML" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
