### PR TITLE
FIX: support [code] in blockquotes

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1212,6 +1212,11 @@ eviltrout</p>
       '<pre><code class="lang-auto">   s</code></pre>',
       "it doesn't trim leading whitespace"
     );
+    assert.cooked(
+      "> [code]\n> line 1\n> line 2\n> line 3\n> [/code]",
+      '<blockquote>\n<pre><code class="lang-auto">line 1\nline 2\nline 3</code></pre>\n</blockquote>',
+      "supports quoting a whole [code] block"
+    );
   });
 
   test("tags with arguments", function (assert) {


### PR DESCRIPTION
> [code]
> line1
> line2
> [/code]

would render as

| line1
| > line2

instead of the correct

| line1
| line2

That was due to the `bbcode-block` code using a `slice` to get the content of a block and not taking into account it being nested in a quote block for example.

The fix was to get the content using the `getLines` utils method.

Context: https://meta.discourse.org/t/markdown-bbcode-code-quote-bug/299047

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
