### PR TITLE
DEV: Add API scopes for post revisions

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -71,6 +71,20 @@ class ApiKeyScope < ActiveRecord::Base
             actions: %w[posts#latest],
           },
         },
+        revisions: {
+          read: {
+            actions: %w[posts#latest_revision posts#revisions],
+            params: %i[post_id],
+          },
+          modify: {
+            actions: %w[posts#hide_revision posts#show_revision posts#revert],
+            params: %i[post_id],
+          },
+          permanently_delete: {
+            actions: %w[posts#permanently_delete_revisions],
+            params: %i[post_id],
+          },
+        },
         tags: {
           list: {
             actions: %w[tags#index],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5058,6 +5058,10 @@ en:
               delete: Delete a post.
               recover: Recover a post.
               list: List latest posts and private posts. RSS is also supported.
+            revisions:
+              read: "Get the latest or a specific revision."
+              modify: "Hide, show, or revert revisions."
+              permanently_delete: "Permanently delete a revision."
             tags:
               list: List tags.
             tag_groups:

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -450,6 +450,7 @@ RSpec.describe Admin::ApiController do
           "users",
           "email",
           "posts",
+          "revisions",
           "tags",
           "tag_groups",
           "uploads",
@@ -489,6 +490,12 @@ RSpec.describe Admin::ApiController do
         expect(scopes["posts"].any? { |h| h["urls"].include?("/private-posts (GET)") }).to be_truthy
         expect(
           scopes["posts"].any? { |h| h["urls"].include?("/posts/:post_id/recover (PUT)") },
+        ).to be_truthy
+
+        expect(
+          scopes["revisions"].any? do |h|
+            h["urls"].include?("/posts/:post_id/revisions/permanently_delete (DELETE)")
+          end,
         ).to be_truthy
 
         expect(scopes["users"].find { _1["key"] == "update" }["urls"]).to contain_exactly(


### PR DESCRIPTION
This commit adds API scopes for reading, modifying, and deleting post
revisions.
