### PR TITLE
DEV: Promote block problem checks to ProblemCheck

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -70,14 +70,14 @@ class ProblemCheck
 
   private
 
-  def problem(override_key = nil)
+  def problem(override_key = nil, override_data = {})
     [
       Problem.new(
         message ||
           I18n.t(
             override_key || translation_key,
             base_path: Discourse.base_path,
-            **translation_data.symbolize_keys,
+            **override_data.merge(translation_data).symbolize_keys,
           ),
         priority: self.config.priority,
         identifier:,

--- a/app/services/problem_check/sidekiq_check.rb
+++ b/app/services/problem_check/sidekiq_check.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ProblemCheck::SidekiqCheck < ProblemCheck
+  self.priority = "low"
+
+  def call
+    return problem("dashboard.sidekiq_warning") if jobs_in_queue? && !jobs_performed_recently?
+    return problem("dashboard.queue_size_warning", queue_size: Jobs.queued) if massive_queue?
+
+    no_problem
+  end
+
+  private
+
+  def massive_queue?
+    Jobs.queued >= 100_000
+  end
+
+  def jobs_in_queue?
+    Jobs.queued > 0
+  end
+
+  def jobs_performed_recently?
+    Jobs.last_job_performed_at.present? && Jobs.last_job_performed_at > 2.minutes.ago
+  end
+end

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -22,15 +22,6 @@ RSpec.describe AdminDashboardData do
         expect(problems).not_to include(I18n.t("errors.messages.invalid"))
       end
     end
-
-    describe "adding new checks" do
-      it "calls the passed block" do
-        AdminDashboardData.add_problem_check { "a problem was found" }
-
-        problems = AdminDashboardData.fetch_problems
-        expect(problems.map(&:to_s)).to include("a problem was found")
-      end
-    end
   end
 
   describe "adding scheduled checks" do
@@ -89,40 +80,6 @@ RSpec.describe AdminDashboardData do
       expect(described_class.problem_message_check(key)).to eq(
         I18n.t(key, base_path: Discourse.base_path),
       )
-    end
-  end
-
-  describe "sidekiq_check" do
-    subject(:check) { described_class.new.sidekiq_check }
-
-    it "returns nil when sidekiq processed a job recently" do
-      Jobs.stubs(:last_job_performed_at).returns(1.minute.ago)
-      Jobs.stubs(:queued).returns(0)
-      expect(check).to be_nil
-    end
-
-    it "returns nil when last job processed was a long time ago, but no jobs are queued" do
-      Jobs.stubs(:last_job_performed_at).returns(7.days.ago)
-      Jobs.stubs(:queued).returns(0)
-      expect(check).to be_nil
-    end
-
-    it "returns nil when no jobs have ever been processed, but no jobs are queued" do
-      Jobs.stubs(:last_job_performed_at).returns(nil)
-      Jobs.stubs(:queued).returns(0)
-      expect(check).to be_nil
-    end
-
-    it "returns a string when no jobs were processed recently and some jobs are queued" do
-      Jobs.stubs(:last_job_performed_at).returns(20.minutes.ago)
-      Jobs.stubs(:queued).returns(1)
-      expect(check).to_not be_nil
-    end
-
-    it "returns a string when no jobs have ever been processed, and some jobs are queued" do
-      Jobs.stubs(:last_job_performed_at).returns(nil)
-      Jobs.stubs(:queued).returns(1)
-      expect(check).to_not be_nil
     end
   end
 end

--- a/spec/services/problem_check/sidekiq_check_spec.rb
+++ b/spec/services/problem_check/sidekiq_check_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::SidekiqCheck do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    context "when Sidekiq processed a job recently" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(1.minute.ago)
+        Jobs.stubs(:queued).returns(1)
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when last job processed was a long time ago, but no jobs are queued" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(7.days.ago)
+        Jobs.stubs(:queued).returns(0)
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when no jobs have ever been processed, but no jobs are queued" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(nil)
+        Jobs.stubs(:queued).returns(0)
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when no jobs were processed recently and some jobs are queued" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(20.minutes.ago)
+        Jobs.stubs(:queued).returns(1)
+      end
+
+      it do
+        expect(check).to have_a_problem.with_priority("low").with_message(
+          'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by Sidekiq. Please ensure at least one Sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.',
+        )
+      end
+    end
+
+    context "when no jobs have ever been processed, and some jobs are queued" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(nil)
+        Jobs.stubs(:queued).returns(1)
+      end
+
+      it do
+        expect(check).to have_a_problem.with_priority("low").with_message(
+          'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by Sidekiq. Please ensure at least one Sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.',
+        )
+      end
+    end
+
+    context "when there's a massive pile-up in the queue" do
+      before do
+        Jobs.stubs(:last_job_performed_at).returns(1.second.ago)
+        Jobs.stubs(:queued).returns(100_000)
+      end
+
+      it do
+        expect(check).to have_a_problem.with_priority("low").with_message(
+          "The number of queued jobs is 100000, which is high. This could indicate a problem with the Sidekiq process(es), or you may need to add more Sidekiq workers.",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

In #26122 we promoted all problem checks defined as class methods on `AdminDashboardData` to their own first-class `ProblemCheck` instances.

This PR continues that by promoting problem checks that are implemented as blocks as well. This includes updating a couple plugins that have problem checks. (See below.)

### Plugin updates

**Do not merge until these plugins have had their problem checks promoted.**

- [x] https://github.com/discourse/discourse-chat-integration/pull/190
- [x] https://github.com/discourse/discourse-encrypt/pull/308
