### PR TITLE
UX: First pass styling experimental objects typed setting editor

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show-schema.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show-schema.hbs
@@ -1,3 +1,12 @@
+<div class="customize-themes-show-schema__header row">
+  <h2>
+    {{i18n
+      "admin.customize.theme.schema.title"
+      (hash name=@model.setting.setting)
+    }}
+  </h2>
+</div>
+
 <SchemaThemeSetting::Editor
   @themeId={{@model.theme.id}}
   @setting={{@model.setting}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -1068,6 +1068,8 @@ a.inline-editable-field {
 @import "common/admin/admin_intro";
 @import "common/admin/admin_emojis";
 @import "common/admin/mini_profiler";
+@import "common/admin/schema_theme_setting_editor";
+@import "common/admin/customize_themes_show_schema";
 
 // EXPERIMENTAL: Revamped admin styles, probably can be split up later down the line.
 @import "common/admin/admin_revamp";

--- a/app/assets/stylesheets/common/admin/customize_themes_show_schema.scss
+++ b/app/assets/stylesheets/common/admin/customize_themes_show_schema.scss
@@ -1,0 +1,3 @@
+.customize-themes-show-schema__header {
+  margin-bottom: 1em;
+}

--- a/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
+++ b/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
@@ -1,0 +1,76 @@
+.schema-theme-setting-editor {
+  display: grid;
+  grid-template-columns: 0.2fr 0.8fr;
+
+  &__navigation {
+    margin-right: 2em;
+
+    ul {
+      list-style: none;
+    }
+
+    .schema-theme-setting-editor__tree {
+      margin: 0;
+
+      .schema-theme-setting-editor__tree-node--back-btn {
+        cursor: pointer;
+        width: 100%;
+        text-align: left;
+
+        .schema-theme-setting-editor__tree-node-text {
+          .d-icon {
+            margin-left: 0;
+            margin-right: 0.5em;
+          }
+        }
+      }
+
+      .schema-theme-setting-editor__tree-node-text {
+        padding: 0.5em;
+        color: var(--primary);
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        .d-icon {
+          margin-left: auto;
+          font-size: var(--font-down-3);
+          color: var(--primary-500);
+        }
+      }
+
+      .schema-theme-setting-editor__tree-node {
+        cursor: pointer;
+
+        &.--active {
+          > .schema-theme-setting-editor__tree-node-text {
+            background-color: var(--tertiary);
+            color: var(--secondary);
+
+            .d-icon {
+              color: var(--secondary);
+            }
+          }
+        }
+
+        &.--child {
+          margin-left: 0.5em;
+          border-left: 1.5px solid var(--primary-200);
+        }
+
+        &.--heading {
+          cursor: default;
+          margin-top: 0.5em;
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  &__fields {
+  }
+
+  &__footer {
+    margin-top: 0.5em;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5643,6 +5643,7 @@ en:
           inactive_filter: "Inactive"
           updates_available_filter: "Updates Available"
           schema:
+            title: "Edit %{name} setting"
             back_button: "Back to %{name}"
         colors:
           select_base:

--- a/spec/system/page_objects/pages/admin_objects_theme_setting_editor.rb
+++ b/spec/system/page_objects/pages/admin_objects_theme_setting_editor.rb
@@ -17,7 +17,11 @@ module PageObjects
       end
 
       def click_link(name)
-        find(".schema-editor-navigation .node", text: name).click
+        find(
+          ".schema-theme-setting-editor__navigation .schema-theme-setting-editor__tree-node",
+          text: name,
+        ).click
+
         self
       end
 


### PR DESCRIPTION
This is a first pass at styling the editor for creating/editing/updating
an objects typed theme setting. Only the desktop view is being
considered at the current moment.

The objects typed theme setting is still behind a feature flag at this moment so there is no need for us to get the styling perfect. The purpose of this PR is to get us to a state which we can quickly iterate with a designer on. 

### Recording

#### Light mode

![Kapture 2024-03-15 at 12 06 03](https://github.com/discourse/discourse/assets/4335742/a40aa8a6-ca55-46fe-a49f-21e5610bb53b)

#### Dark mode

![Kapture 2024-03-15 at 12 06 53](https://github.com/discourse/discourse/assets/4335742/9418de83-3198-42dc-9908-b890be0bfd74)

