### PR TITLE
FIX: add support for query string in sidebar links to the homepage

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.js
@@ -228,10 +228,10 @@ class SectionLink {
   }
 
   #validInternal() {
-    const routeInfoHelper = new RouteInfoHelper(this.router, this.path);
+    const { route } = new RouteInfoHelper(this.router, this.path);
 
     return (
-      routeInfoHelper.route !== "unknown" ||
+      route !== "unknown" ||
       FULL_RELOAD_LINKS_REGEX.some((regex) => this.path.match(regex))
     );
   }

--- a/app/assets/javascripts/discourse/app/lib/homepage-router-overrides.js
+++ b/app/assets/javascripts/discourse/app/lib/homepage-router-overrides.js
@@ -32,21 +32,28 @@ export function homepageDestination() {
 }
 
 function rewriteIfNeeded(url, transition) {
-  const intentUrl = transition?.intent?.url;
-  if (
-    intentUrl?.startsWith(homepageDestination()) ||
-    (transition?.intent.name === `discovery.${defaultHomepage()}` &&
-      transition?.intent.queryParams[homepageRewriteParam])
-  ) {
-    const params = (intentUrl || url).split("?", 2)[1];
-    url = "/";
-    if (params) {
-      const searchParams = new URLSearchParams(params);
-      searchParams.delete(homepageRewriteParam);
-      if (searchParams.size) {
-        url += `?${searchParams.toString()}`;
+  const { intent } = transition || {};
+  const { url: intentUrl, name, queryParams } = intent || {};
+
+  const isHomepageUrl = intentUrl?.startsWith(homepageDestination());
+  const isHomepageRoute = name === `discovery.${defaultHomepage()}`;
+  const hasRewriteParam = queryParams?.[homepageRewriteParam];
+
+  if (isHomepageUrl || (isHomepageRoute && hasRewriteParam)) {
+    const urlParams = new URLSearchParams((intentUrl || url).split("?", 2)[1]);
+
+    if (queryParams) {
+      for (const [key, value] of Object.entries(queryParams)) {
+        if (value !== null && value !== undefined) {
+          urlParams.set(key, value);
+        }
       }
     }
+
+    urlParams.delete(homepageRewriteParam);
+
+    url = urlParams.size > 0 ? `/?${urlParams}` : "/";
   }
+
   return url;
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/section-link.js
@@ -1,6 +1,5 @@
 import { tracked } from "@glimmer/tracking";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
-import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class SectionLink {
   @tracked linkDragCss;
@@ -18,19 +17,13 @@ export default class SectionLink {
     this.text = name;
     this.value = value;
     this.section = section;
-    this.withAnchor = value.match(/#\w+$/gi);
+    this.withAnchor = /#\w+$/i.test(value);
 
     if (!this.externalOrFullReload) {
-      const routeInfoHelper = new RouteInfoHelper(router, value);
-
-      if (routeInfoHelper.route === "discovery.index") {
-        this.route = `discovery.${defaultHomepage()}`;
-      } else {
-        this.route = routeInfoHelper.route;
-      }
-
-      this.models = routeInfoHelper.models;
-      this.query = routeInfoHelper.query;
+      const { route, models, query } = new RouteInfoHelper(router, value);
+      this.route = route;
+      this.models = models;
+      this.query = query;
     }
   }
 

--- a/app/assets/javascripts/discourse/app/routes/discovery-index.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-index.js
@@ -8,12 +8,24 @@ export default class DiscoveryIndex extends DiscourseRoute {
   @service router;
 
   beforeModel(transition) {
-    const url = transition.intent.url;
-    const params = url?.split("?", 2)[1];
-    let destination = homepageDestination();
-    if (params) {
-      destination += `&${params}`;
+    const { intent } = transition || {};
+    const { url, queryParams } = intent || {};
+    const urlParams = new URLSearchParams(url?.split("?", 2)[1]);
+
+    if (queryParams) {
+      for (const [key, value] of Object.entries(queryParams)) {
+        if (value !== null && value !== undefined) {
+          urlParams.set(key, value);
+        }
+      }
     }
+
+    let destination = homepageDestination();
+
+    if (urlParams.size > 0) {
+      destination += `&${urlParams}`;
+    }
+
     this.router.transitionTo(destination);
   }
 }


### PR DESCRIPTION
If you add a link in your sidebar to `/?some=query-string` it would change it to `/latest?some=query-string` if `latest` is the homepage. That might break some 3rd party integrations.

Context: https://meta.discourse.org/t/299027

This is a draft since I'm not 100% sure it's the _right_ fix, considering how "hacky" the `DiscoveryIndex` route is 🤔 