### PR TITLE
DEV: Allow user api key scope for notifications#totals

### DIFF
--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -10,6 +10,7 @@ class UserApiKeyScope < ActiveRecord::Base
     notifications: [
       RouteMatcher.new(methods: :post, actions: "message_bus"),
       RouteMatcher.new(methods: :get, actions: "notifications#index"),
+      RouteMatcher.new(methods: :get, actions: "notifications#totals"),
       RouteMatcher.new(methods: :put, actions: "notifications#mark_read"),
     ],
     session_info: [

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -626,4 +626,28 @@ RSpec.describe NotificationsController do
       end
     end
   end
+
+  context "with user api keys" do
+    fab!(:user)
+    let(:user_api_key) do
+      UserApiKey.create!(
+        application_name: "my app",
+        client_id: "",
+        scopes: ["notifications"].map { |name| UserApiKeyScope.new(name: name) },
+        user_id: user.id,
+      )
+    end
+
+    before { SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_0] }
+
+    it "allows access to notifications#totals" do
+      get "/notifications/totals.json", headers: { "User-Api-Key": user_api_key.key }
+      expect(response.status).to eq(200)
+    end
+
+    it "allows access to notifications#index" do
+      get "/notifications.json", headers: { "User-Api-Key": user_api_key.key }
+      expect(response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
The `/notifications/totals` route is a stripped down version of `notifications#index`. This just allows the mobile app to use this new route.

Followup to https://github.com/discourse/discourse/pull/26106 