### PR TITLE
FIX: Amend broken Mailgun API key check

### DIFF
--- a/app/services/problem_check/missing_mailgun_api_key.rb
+++ b/app/services/problem_check/missing_mailgun_api_key.rb
@@ -5,7 +5,7 @@ class ProblemCheck::MissingMailgunApiKey < ProblemCheck
 
   def call
     return no_problem if !SiteSetting.reply_by_email_enabled
-    return no_problem if !ActionMailer::Base.smtp_settings.dig(:address, "smtp.mailgun.org")
+    return no_problem if ActionMailer::Base.smtp_settings[:address] != "smtp.mailgun.org"
     return no_problem if SiteSetting.mailgun_api_key.present?
 
     problem

--- a/spec/services/problem_check/missing_mailgun_api_key_spec.rb
+++ b/spec/services/problem_check/missing_mailgun_api_key_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProblemCheck::MissingMailgunApiKey do
   describe ".call" do
     before do
       SiteSetting.stubs(reply_by_email_enabled: replies_enabled)
-      ActionMailer::Base.smtp_settings.stubs(dig: mailgun_address)
+      ActionMailer::Base.stubs(smtp_settings: { address: mailgun_address })
       SiteSetting.stubs(mailgun_api_key: api_key)
     end
 
@@ -28,7 +28,7 @@ RSpec.describe ProblemCheck::MissingMailgunApiKey do
 
     context "when using Mailgun without an API key" do
       let(:replies_enabled) { true }
-      let(:mailgun_address) { "foo" }
+      let(:mailgun_address) { "smtp.mailgun.org" }
       let(:api_key) { nil }
 
       it do


### PR DESCRIPTION
### What was happening?

This check was never used before. As part of the `ProblemCheck` migration this is now in use, which revealed a bug caused by an incorrect assumption about the shape of `ActionMailer::Base.smtp_settings`. This PR fixes that bug.