### PR TITLE
EXPERIMENTAL: preconnect and dns-prefetch resource hints for CDN domains

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -390,7 +390,7 @@ log_line_max_chars = 160000
 # this value is included when generating static asset URLs.
 # Updating the value will allow site operators to invalidate all asset urls
 # to recover from configuration issues which may have been cached by CDNs/browsers.
-asset_url_salt = 
+asset_url_salt =
 
 # disable service-worker caching. An 'offline' page will still be used as an offline fallback.
 # This flag is for a temporary experiment, and may be removed at any time

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2368,6 +2368,9 @@ developer:
   experimental_objects_type_for_theme_settings:
     default: false
     hidden: true
+  experimental_preconnect_link_header:
+    default: false
+    hidden: true
 
 navigation:
   navigation_menu:

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1188,8 +1188,36 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe "preload Link header" do
-    context "with GlobalSetting.preload_link_header" do
+  describe "Link header" do
+    describe "when `experimental_preconnect_link_header` site setting is enabledd" do
+      before { SiteSetting.experimental_preconnect_link_header = true }
+
+      it "should include the `preconnect` and `dns-prefetch` resource hints in the Link header when `GlobalSetting.cdn_url is configured`" do
+        global_setting :cdn_url, "https://cdn.example.com/something"
+
+        get "/latest"
+
+        expect(response.status).to eq(200)
+
+        expect(response.headers["Link"]).to include(
+          "<https://cdn.example.com>; rel=preconnect;, <https://cdn.example.com>; rel=dns-prefetch;",
+        )
+      end
+
+      it "should include the `preconnect` and `dns-prefetch` resource hints in the Link header when `SiteSetting.s3_cdn_url is configured`" do
+        SiteSetting.s3_cdn_url = "https://s3.some-cdn.com/something"
+
+        get "/latest"
+
+        expect(response.status).to eq(200)
+
+        expect(response.headers["Link"]).to include(
+          "<https://s3.some-cdn.com>; rel=preconnect;, <https://s3.some-cdn.com>; rel=dns-prefetch;",
+        )
+      end
+    end
+
+    context "when `GlobalSetting.preload_link_header` is enabled" do
       before { global_setting :preload_link_header, true }
 
       it "should have the Link header with assets on full page requests" do
@@ -1203,7 +1231,7 @@ RSpec.describe ApplicationController do
       end
     end
 
-    context "without GlobalSetting.preload_link_header" do
+    context "when `GlobalSetting.preload_link_header` is disabled" do
       before { global_setting :preload_link_header, false }
 
       it "shouldn't have the Link header with assets on full page requests" do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1189,7 +1189,7 @@ RSpec.describe ApplicationController do
   end
 
   describe "Link header" do
-    describe "when `experimental_preconnect_link_header` site setting is enabledd" do
+    describe "when `experimental_preconnect_link_header` site setting is enabled" do
       before { SiteSetting.experimental_preconnect_link_header = true }
 
       it "should include the `preconnect` and `dns-prefetch` resource hints in the Link header when `GlobalSetting.cdn_url is configured`" do


### PR DESCRIPTION
### Why this change?

In https://web.dev/articles/preconnect-and-dns-prefetch, it describes
how hinting to the browser to preconnect to domains which we will
eventually use the connection for can help improve the time it takes to
load a page.

We are putting this behind an experimental flag so that we can test and
profile this in a production environment.

### What does this change introduce?

Introduce a hidden experimental `experimental_preconnect_link_header`
site setting which when enabled will add the `preconnect` and
`dns-prefetch` resource hints to the response headers for full page load
requests.
