### PR TITLE
DEV: Fix syntax for Link entity header for `experimental_preconnect_link_header`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1108,9 +1108,9 @@ class ApplicationController < ActionController::Base
         next if url.blank?
         base_url = URI.join(url, "/").to_s.chomp("/")
 
-        links.push("<#{base_url}>; rel=preconnect;")
+        links.push("<#{base_url}>; rel=preconnect")
         # Not all browsers support the preconnect resource hint so we are adding dns-prefetch as the fallback
-        links.push("<#{base_url}>; rel=dns-prefetch;")
+        links.push("<#{base_url}>; rel=dns-prefetch")
       end
     end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1200,7 +1200,7 @@ RSpec.describe ApplicationController do
         expect(response.status).to eq(200)
 
         expect(response.headers["Link"]).to include(
-          "<https://cdn.example.com>; rel=preconnect;, <https://cdn.example.com>; rel=dns-prefetch;",
+          "<https://cdn.example.com>; rel=preconnect, <https://cdn.example.com>; rel=dns-prefetch",
         )
       end
 
@@ -1212,7 +1212,7 @@ RSpec.describe ApplicationController do
         expect(response.status).to eq(200)
 
         expect(response.headers["Link"]).to include(
-          "<https://s3.some-cdn.com>; rel=preconnect;, <https://s3.some-cdn.com>; rel=dns-prefetch;",
+          "<https://s3.some-cdn.com>; rel=preconnect, <https://s3.some-cdn.com>; rel=dns-prefetch",
         )
       end
     end


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link, the
syntax for multiple links is something like

```
Link: <https://one.example.com>; rel="preconnect", <https://two.example.com>; rel="preconnect", <https://three.example.com>; rel="preconnect"
```

There should be no trailing `;` before the `,`.
