### PR TITLE
PERF: Remove unnecessary `<link rel="preload">`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,16 +151,10 @@ module ApplicationHelper
     nonce_attribute = "nonce=\"#{csp_nonce_placeholder}\""
 
     add_resource_preload_list(url, "script")
-    if GlobalSetting.preload_link_header
-      <<~HTML.html_safe
-        <script defer src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
-      HTML
-    else
-      <<~HTML.html_safe
-        <link rel="preload" href="#{url}" as="script" #{entrypoint_attribute} #{nonce_attribute}>
-        <script defer src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
-      HTML
-    end
+
+    <<~HTML.html_safe
+      <script defer src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
+    HTML
   end
 
   def add_resource_preload_list(resource_url, type)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ApplicationHelper do
   describe "preload_script" do
     def script_tag(url, entrypoint, nonce)
       <<~HTML
-          <link rel="preload" href="#{url}" as="script" data-discourse-entrypoint="#{entrypoint}" nonce="#{nonce}">
           <script defer src="#{url}" data-discourse-entrypoint="#{entrypoint}" nonce="#{nonce}"></script>
       HTML
     end


### PR DESCRIPTION
### Why this change?

According to https://web.dev/articles/preload-critical-assets,

> By preloading a certain resource, you are telling the browser that you would like to fetch it sooner than the browser would otherwise discover it because you are certain that it is important for the current page.

The preload resource hint is meant to tell the browser to fetch
resources that it would not discover upfront or early. However, we are
not using it the right way because we are literally adding the resource
hint right before a `<script>` tag which means the browser would have
discovered the resource even without the resource hint.

### What does this change do?

This commit removes the preload resource hint which are added right
before script tags since the optimization here is highly questionable at the expense of making 
our initial DOM larger.
