### PR TITLE
FIX: Ensure dnd icon is updated immediately in glimmer header

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import { getOwner, setOwner } from "@ember/application";
 import { A } from "@ember/array";
 import EmberObject, { computed, get, getProperties } from "@ember/object";
@@ -174,6 +175,8 @@ function userOption(userOptionKey) {
 export default class User extends RestModel.extend(Evented) {
   @service appEvents;
   @service userTips;
+
+  @tracked do_not_disturb_until;
 
   @userOption("mailing_list_mode") mailing_list_mode;
   @userOption("external_links_in_new_tab") external_links_in_new_tab;


### PR DESCRIPTION
Adds `@tracked` to the relevant property on the User model so that it is autotracked correctly via the function call `glimmer-header/user-dropdown/notifications#isInDoNotDisturb` -> `models/user#isInDoNotDisturb`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
