### PR TITLE
Add import_embed_unlisted

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -79,6 +79,7 @@ class TopicEmbed < ActiveRecord::Base
           embed_url: url,
           embed_content_sha1: content_sha1,
         }
+        create_args[:visible] = false if SiteSetting.import_embed_unlisted?
 
         post = PostCreator.create(user, create_args)
         post.topic.topic_embed.update!(embed_content_cache: original_contents)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2357,6 +2357,7 @@ en:
     embed_set_canonical_url: "Set the canonical URL for embedded topics to the embedded content's URL."
     embed_truncate: "Shorten the contents of posts that are embedded from external sources. This setting ensures that only the initial part of content is displayed when a post from an external URL is embedded on your site. If you prefer to display full content from the external posts, you can disable this setting."
     embed_unlisted: "Embedded topics will be unlisted until a user replies."
+    import_embed_unlisted: "Imported embedded topics will be unlisted until a user replies. Overrides embed_unlisted."
     embed_support_markdown: "Support Markdown formatting for embedded posts."
     allowed_embed_selectors: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1104,7 +1104,8 @@ posting:
   embed_any_origin: false
   embed_topics_list: false
   embed_set_canonical_url: false
-  embed_unlisted: true
+  embed_unlisted: false
+  import_embed_unlisted: true
   embed_truncate: true
   embed_support_markdown: false
   allowed_embed_selectors: ""

--- a/lib/post_jobs_enqueuer.rb
+++ b/lib/post_jobs_enqueuer.rb
@@ -43,7 +43,7 @@ class PostJobsEnqueuer
 
   def make_visible
     return if @topic.private_message?
-    return unless SiteSetting.embed_unlisted?
+    return unless SiteSetting.embed_unlisted? || SiteSetting.import_embed_unlisted?
     return if @post.post_number == 1
     return if @topic.visible?
     return if @post.post_type != Post.types[:regular]

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -1494,6 +1494,23 @@ RSpec.describe PostCreator do
       expect(creator.errors).to be_blank
       expect(TopicEmbed.where(content_sha1: content_sha1).exists?).to eq(true)
     end
+
+    context "when embed_unlisted is true" do
+      before { SiteSetting.embed_unlisted = true }
+
+      it "unlists the topic" do
+        creator =
+          PostCreator.new(
+            user,
+            embed_url: embed_url,
+            title: "Reviews of Science Ovens",
+            raw: "Did you know that you can use microwaves to cook your dinner? Science!",
+          )
+        post = creator.create
+        expect(creator.errors).to be_blank
+        expect(post.topic).not_to be_visible
+      end
+    end
   end
 
   describe "read credit for creator" do


### PR DESCRIPTION
- Adds import_embed_unlisted (default true) for topics created for imported embeds.
- Change embed_unlisted default to false.

See further https://meta.discourse.org/t/unlisted-topics/298929
See also https://github.com/discourse/discourse/pull/24294