### PR TITLE
FIX: Show max tag error and prevent search

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -67,6 +67,29 @@ module(
       );
     });
 
+    test("disables search and shows limit when max_tags_per_topic is zero", async function (assert) {
+      this.set("value", ["cat", "kit"]);
+      this.siteSettings.max_tags_per_topic = 0;
+
+      await render(hbs`<MiniTagChooser @value={{this.value}} />`);
+
+      assert.strictEqual(this.subject.header().value(), "cat,kit");
+      await this.subject.expand();
+
+      const error = query(".select-kit-error").innerText;
+      assert.strictEqual(
+        error,
+        I18n.t("select_kit.max_content_reached", {
+          count: 0,
+        })
+      );
+      await this.subject.fillInFilter("dawg");
+      assert.notOk(
+        exists(".select-kit-collection .select-kit-row"),
+        "it doesn’t show any options"
+      );
+    });
+
     test("required_tag_group", async function (assert) {
       this.set("value", ["foo", "bar"]);
 

--- a/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
@@ -70,6 +70,13 @@ export default MultiSelectComponent.extend(TagsMixin, {
   }),
 
   search(filter) {
+    const maximum = this.selectKit.options.maximum;
+    if (maximum === 0) {
+      const key = "select_kit.max_content_reached";
+      this.addError(I18n.t(key, { count: maximum }));
+      return [];
+    }
+
     const data = {
       q: filter || "",
       limit: this.maxTagSearchResults,

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -371,7 +371,9 @@ export default Component.extend(
     },
 
     addError(error) {
-      this.errorsCollection.pushObject(error);
+      if (!this.errorsCollection.includes(error)) {
+        this.errorsCollection.pushObject(error);
+      }
 
       this._safeAfterRender(() => this.popper && this.popper.update());
     },
@@ -646,6 +648,12 @@ export default Component.extend(
       return Promise.resolve(this.search(filter))
         .then((result) => {
           if (this.isDestroyed || this.isDestroying) {
+            return [];
+          }
+
+          if (this.selectKit.options.maximum === 0) {
+            this.set("selectKit.isLoading", false);
+            this.set("selectKit.hasNoContent", false);
             return [];
           }
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      STRING = "3.3.0.beta1"
+      STRING = "3.3.0.beta2-dev"
 
       PARTS = STRING.split(".")
       private_constant :PARTS

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      STRING = "3.3.0.beta2-dev"
+      STRING = "3.3.0.beta1"
 
       PARTS = STRING.split(".")
       private_constant :PARTS


### PR DESCRIPTION
Currently when `max_tags_per_topic` is zero, it fails silently. 

This change highlights the limit below the tag picker, and also prevents search when max is 0. It continues to allow users to remove existing tags if the max is changed to 0.

I considered removing the tag picker when the value is 0 and there are no existing tags, but it becomes non-obvious to the user why the tag picker is gone. So showing the red 'error' provides a better clue. Language-wise it sounds a bit funny, but after thinking a bit, I think it works alright.

Related: https://meta.discourse.org/t/max-tags-per-topic-failing-silently/142241

Some screenshots

### Existing tag, but max changed to 0
<img width="459" alt="Screenshot 2024-03-19 at 12 04 42 PM" src="https://github.com/discourse/discourse/assets/1555215/1174a518-6f8e-47d9-8f16-52480629087e">

### Composer
<img width="767" alt="Screenshot 2024-03-19 at 12 05 16 PM" src="https://github.com/discourse/discourse/assets/1555215/54f1bbc2-0e4b-46c1-b345-af9a367859b7">

### Topic tag picker when 0 tags doesn't search
<img width="764" alt="Screenshot 2024-03-19 at 12 10 46 PM" src="https://github.com/discourse/discourse/assets/1555215/f9a2ea1d-3351-4d31-840b-3abe09cd8a24">

