### PR TITLE
DEV: Support running system tests using chromium and custom chromedriver

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -607,15 +607,8 @@ RSpec.configure do |config|
 
     driver = [:selenium]
     driver << :mobile if example.metadata[:mobile]
-    driver << (aarch64? ? :firefox : :chrome)
+    driver << :chrome
     driver << :headless unless ENV["SELENIUM_HEADLESS"] == "0"
-
-    if driver.include?(:firefox)
-      STDERR.puts(
-        "WARNING: Running system specs using the Firefox driver is not officially supported. Some tests will fail.",
-      )
-    end
-
     driven_by driver.join("_").to_sym
 
     setup_system_test
@@ -635,8 +628,7 @@ RSpec.configure do |config|
       lines << "~~~~~ END DRIVER LOGS ~~~~~"
     end
 
-    # The logs API isn’t available (yet?) with the Firefox driver
-    js_logs = aarch64? ? [] : page.driver.browser.logs.get(:browser)
+    js_logs = page.driver.browser.logs.get(:browser)
 
     # Recommended that this is not disabled, since it makes debugging
     # failed system tests a lot trickier.
@@ -954,10 +946,22 @@ def apply_base_chrome_options(options)
   if ENV["CHROME_DISABLE_FORCE_DEVICE_SCALE_FACTOR"].blank?
     options.add_argument("--force-device-scale-factor=1")
   end
-end
 
-def aarch64?
-  RUBY_PLATFORM == "aarch64-linux"
+  if ENV["DISCOURSE_SYSTEM_TEST_CHROMIUM"] == "1"
+    options.binary =
+      case RUBY_PLATFORM
+      when /linux/
+        "/usr/bin/chromium"
+      when /darwin/
+        "/Applications/Chromium.app/Contents/MacOS/Chromium"
+      else
+        "Running Discourse system test with Chromium on #{RUBY_PLATFORM} is not supported"
+      end
+  end
+
+  if (chromedriver_path = ENV["DISCOURSE_SYSTEM_TEST_CHROMEDRIVER_PATH"]).present?
+    Selenium::WebDriver::Chrome::Service.driver_path = chromedriver_path
+  end
 end
 
 class SpecSecureRandom


### PR DESCRIPTION
### Why this change?

Google does not yet publish binaries for chrome and chromedriver for
`linux/arm64`. In 484954ec4c5c585c16fb6e7c2a8d45bac49d6964, we attempted
to add support for running system tests on `linux/arm64` by switching to
Firefox but our system tests seem to make lots of assumptions about
running on chromium based browsers so there are some tests that don't work in Firefox.

This commit works around the lack of chrome and chromedriver binaries by
doing the following:

1. Adds a `DISCOURSE_SYSTEM_TEST_CHROMIUM` ENV variable which when set to
  `1` will allow us to run system tests using a chromium binary. Chromium
  binaries for `linux/arm64` are available and since Chrome is Chromium based, all of our 
  system tests "should pass" even when running against a Chromium binary. I don't expect 
  this to be perfect but I expect it to be better than running against Firefox. This change buys us time
  until Chrome finally ships binaries for `linux/arm64`.

2. Adds a `DISCOURSE_SYSTEM_TEST_CHROMEDRIVER_PATH` ENV variable to
   allow the chromedriver path to be configured. We need this because
   the [electron project](https://github.com/electron/electron/releases) actually
   releases chromewebdriver for `linux/arm64` so someone running
   `linux/arm64` can download the necessary chromedriver from the
   project instead of relying on selenium-manager.

This change is also important for us to support [discourse_test](https://github.com/discourse/discourse_docker/blob/main/image/discourse_test/Dockerfile) and [discourse_dev](https://github.com/discourse/discourse_docker/blob/main/image/discourse_dev/Dockerfile) images targeted at `linux/arm64`.