### PR TITLE
FIX: hide chat btn from user card when chat disabled

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -147,10 +147,10 @@ after_initialize do
 
   add_to_serializer(:user_card, :can_chat_user) do
     return false if !SiteSetting.chat_enabled
-    return false if scope.user.blank?
+    return false if scope.user.blank? || scope.user.id == object.id
+    return false if !scope.user.user_option.chat_enabled || !object.user_option.chat_enabled
 
-    scope.user.id != object.id && scope.can_direct_message? && object.user_option.chat_enabled? &&
-      Guardian.new(object).can_chat?
+    scope.can_direct_message? && Guardian.new(object).can_chat?
   end
 
   add_to_serializer(

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -149,7 +149,8 @@ after_initialize do
     return false if !SiteSetting.chat_enabled
     return false if scope.user.blank?
 
-    scope.user.id != object.id && scope.can_chat? && Guardian.new(object).can_chat?
+    scope.user.id != object.id && scope.can_direct_message? && object.user_option.chat_enabled? &&
+      Guardian.new(object).can_chat?
   end
 
   add_to_serializer(
@@ -166,7 +167,7 @@ after_initialize do
     :can_direct_message,
     include_condition: -> do
       return @can_direct_message if defined?(@can_direct_message)
-      @can_direct_message = SiteSetting.chat_enabled && scope.can_direct_message?
+      @can_direct_message = include_has_chat_enabled? && scope.can_direct_message?
     end,
   ) { true }
 

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -114,6 +114,24 @@ describe Chat do
           expect(serializer.can_chat_user).to eq(false)
         end
       end
+
+      context "when both users are in Chat.allowed_group_ids" do
+        before do
+          SiteSetting.chat_allowed_groups = group.id
+          GroupUser.create(user: target_user, group: group)
+          GroupUser.create(user: user, group: group)
+        end
+
+        it "returns false if current user has chat disabled" do
+          user.user_option.update!(chat_enabled: false)
+          expect(serializer.can_chat_user).to eq(false)
+        end
+
+        it "returns false if target user has chat disabled" do
+          target_user.user_option.update!(chat_enabled: false)
+          expect(serializer.can_chat_user).to eq(false)
+        end
+      end
     end
 
     context "when chat not enabled" do

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -124,7 +124,7 @@ describe Chat do
           GroupUser.create(user: user, group: group)
         end
 
-        it "returns true" do
+        it "returns true when both users are valid" do
           expect(serializer.can_chat_user).to eq(true)
         end
 

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -82,6 +82,7 @@ describe Chat do
 
       it "returns true if the target user and the guardian user is in the Chat.allowed_group_ids" do
         SiteSetting.chat_allowed_groups = group.id
+        SiteSetting.direct_message_enabled_groups = group.id
         GroupUser.create(user: target_user, group: group)
         GroupUser.create(user: user, group: group)
         expect(serializer.can_chat_user).to eq(true)
@@ -118,8 +119,13 @@ describe Chat do
       context "when both users are in Chat.allowed_group_ids" do
         before do
           SiteSetting.chat_allowed_groups = group.id
+          SiteSetting.direct_message_enabled_groups = group.id
           GroupUser.create(user: target_user, group: group)
           GroupUser.create(user: user, group: group)
+        end
+
+        it "returns true" do
+          expect(serializer.can_chat_user).to eq(true)
         end
 
         it "returns false if current user has chat disabled" do
@@ -129,6 +135,11 @@ describe Chat do
 
         it "returns false if target user has chat disabled" do
           target_user.user_option.update!(chat_enabled: false)
+          expect(serializer.can_chat_user).to eq(false)
+        end
+
+        it "returns false if user is not in dm allowed group" do
+          SiteSetting.direct_message_enabled_groups = 3
           expect(serializer.can_chat_user).to eq(false)
         end
       end


### PR DESCRIPTION
When the current user disables chat from within user preferences, the chat button still appears when clicking another user’s profile picture to open the user card. This is also the case when the current user has chat enabled but the target user has disabled chat.

#### Acceptance Criteria
- when a user disables chat in preferences, the chat button should not be displayed when opening a user card or visiting profiles of other users.
- when chat is enabled in preferences but another user disables chat, the chat button should not appear on their user card or profile

/t/124129

