### PR TITLE
FIX: Prevent content layout shift on mobile when ?page=N

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -206,15 +206,18 @@ export default MountWidget.extend({
               return element.offsetTop + getOffsetTop(element.offsetParent);
             };
 
-            const top = getOffsetTop(refreshedElem) - offsetCalculator();
-            window.scrollTo({ top });
+            window.scrollTo({
+              top: getOffsetTop(refreshedElem) - offsetCalculator(),
+            });
 
             // This seems weird, but somewhat infrequently a rerender
             // will cause the browser to scroll to the top of the document
             // in Chrome. This makes sure the scroll works correctly if that
             // happens.
             schedule("afterRender", () => {
-              window.scrollTo({ top });
+              window.scrollTo({
+                top: getOffsetTop(refreshedElem) - offsetCalculator(),
+              });
             });
           });
         };


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/25034

We were noticing a similar layout shift on mobile when ?page=N. It turns out there is an additional 100px worth of elements added after loading which didn't seem to be the case on desktop, so the `top` needs to be recalculated each time we attempt to scroll.

Before:
https://github.com/discourse/discourse/assets/1555215/f89aa082-d7f3-4726-b99d-a58d5f0a03b9


After:
https://github.com/discourse/discourse/assets/1555215/8d13fd15-a932-4982-9456-5fb5c72c862b

(Github seems to be weirding out on video attachments, they used to work)

t/278973