### PR TITLE
FIX: wait for the end of search requests

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/multi-select.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.hbs
@@ -42,7 +42,7 @@
     {{/each}}
 
     {{#if this.selectKit.filter}}
-      {{#if this.selectKit.hasNoContent}}
+      {{#if (and this.selectKit.hasNoContent (not this.selectKit.isLoading))}}
         <span class="no-content" role="alert">
           {{i18n "select_kit.no_content"}}
         </span>

--- a/app/assets/javascripts/select-kit/addon/components/single-select.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/single-select.hbs
@@ -28,7 +28,7 @@
     {{/each}}
 
     {{#if this.selectKit.filter}}
-      {{#if this.selectKit.hasNoContent}}
+      {{#if (and this.selectKit.hasNoContent (not this.selectKit.isLoading))}}
         <span class="no-content" role="alert">
           {{i18n "select_kit.no_content"}}
         </span>


### PR DESCRIPTION
Prior to this fix, if you were following this series of events:
- type something in a select-kit filter with async search
- query starts
- type something again
- first query finished with no results
- second query starts
- :boom: we would show a no content found for a split second
- second query finishes
- we display a list of results

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
