### PR TITLE
PERF: Fix N+1 when loading categories with custom fields

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -410,6 +410,10 @@ class CategoriesController < ApplicationController
         .select("categories.*, t.slug topic_slug")
         .limit(limit || MAX_CATEGORIES_LIMIT)
 
+    if Site.preloaded_category_custom_fields.present?
+      Category.preload_custom_fields(categories, Site.preloaded_category_custom_fields)
+    end
+
     Category.preload_user_fields!(guardian, categories)
 
     # Prioritize categories that start with the term, then top-level


### PR DESCRIPTION
Follow up to commit a90b88af5618b99496ab14d8c6264785484e1f84.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
