### PR TITLE
DEV: Switch to Chromium in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Set working directory owner
         run: chown root:root .
 
+      - name: Remove Chrome
+        continue-on-error: true
+        run: apt remove -y google-chrome-stable
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
@@ -127,7 +131,7 @@ jobs:
         if: matrix.target == 'themes' && matrix.build_type == 'system'
         run: bin/rake themes:clone_all_official
 
-      - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
+      - name: Add hosts to /etc/hosts, otherwise Chromium cannot reach minio
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: |
           echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
@@ -340,7 +344,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
+        browser: ["Chromium", "Firefox ESR", "Firefox Evergreen"]
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -127,12 +127,23 @@ class Reporter extends TapReporter {
 module.exports = {
   test_page: "tests/index.html?hidepassed",
   disable_watching: true,
-  launch_in_ci: ["Chrome"],
-  // launch_in_dev: ["Chrome"] // Ember-CLI always launches testem in 'CI' mode
+  launch_in_ci: [process.env.TESTEM_DEFAULT_BROWSER || "Chrome"],
   tap_failed_tests_only: false,
   parallel: -1,
   browser_start_timeout: 120,
   browser_args: {
+    Chromium: [
+      // --no-sandbox is needed when running Chromium inside a container
+      process.env.CI ? "--no-sandbox" : null,
+      "--headless=new",
+      "--disable-dev-shm-usage",
+      "--disable-software-rasterizer",
+      "--mute-audio",
+      "--remote-debugging-port=4201",
+      "--window-size=1440,900",
+      "--enable-precise-memory-info",
+      "--js-flags=--max_old_space_size=4096",
+    ].filter(Boolean),
     Chrome: [
       // --no-sandbox is needed when running Chrome inside a container
       process.env.CI ? "--no-sandbox" : null,


### PR DESCRIPTION
This PR switches to using Chromium in our CI jobs instead of Chrome.
