### PR TITLE
FIX: Ensure custom composer button 'condition' is run correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -435,7 +435,7 @@ export default class ComposerService extends Service {
 
       return options.concat(
         customPopupMenuOptions
-          .map((option) => this._setupPopupMenuOption(option))
+          .map((option) => this._setupPopupMenuOption({ ...option }))
           .filter((o) => o)
       );
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1417,7 +1417,7 @@ acceptance("composer buttons API", function (needs) {
 
     await visit("/t/internationalization-localization/280");
 
-    await click("#topic-footer-buttons .btn.create");
+    await click(".post-controls button.reply");
     assert.dom(".d-editor-input").exists("the composer input is visible");
 
     const expectedName = "[en.some_label]";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1394,3 +1394,48 @@ acceptance("Composer - current time", function (needs) {
     );
   });
 });
+
+acceptance("composer buttons API", function (needs) {
+  needs.user();
+  needs.settings({
+    allow_uncategorized_topics: true,
+  });
+
+  test("buttons can be added conditionally", async function (assert) {
+    withPluginApi("0", (api) => {
+      api.addComposerToolbarPopupMenuOption({
+        action: (toolbarEvent) => {
+          toolbarEvent.applySurround("**", "**");
+        },
+        icon: "far-bold",
+        label: "some_label",
+        condition: (composer) => {
+          return composer.model.creatingTopic;
+        },
+      });
+    });
+
+    await visit("/t/internationalization-localization/280");
+
+    await click("#topic-footer-buttons .btn.create");
+    assert.dom(".d-editor-input").exists("the composer input is visible");
+
+    const expectedName = "[en.some_label]";
+    const dropdown = selectKit(".toolbar-popup-menu-options");
+    await dropdown.expand();
+
+    assert.false(
+      dropdown.rowByName(expectedName).exists(),
+      "custom button is not displayed for reply"
+    );
+
+    await visit("/latest");
+    await click("#create-topic");
+
+    await dropdown.expand();
+    assert.true(
+      dropdown.rowByName(expectedName).exists(),
+      "custom button is displayed for new topic"
+    );
+  });
+});


### PR DESCRIPTION
Previously we were only running the `condition` function once, and then overwriting it with a static boolean value. Future changes to composer attributes would not affect button visibility.

This commit fixes the issue and adds an acceptance test for the behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
