### PR TITLE
DEV: Remove href/auto-route attrs from buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-header/dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/dropdown.gjs
@@ -42,8 +42,6 @@ export default class Dropdown extends Component {
         class="button icon btn-flat"
         aria-expanded={{@active}}
         aria-haspopup="true"
-        href={{@href}}
-        data-auto-route="true"
         title={{i18n @title}}
         aria-label={{i18n @title}}
         id={{@iconId}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-header/user-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-header/user-dropdown.gjs
@@ -37,12 +37,10 @@ export default class UserDropdown extends Component {
         class="icon btn-flat"
         aria-haspopup="true"
         aria-expanded={{@active}}
-        href={{this.currentUser.path}}
         aria-label={{i18n
           "user.account_possessive"
           name=(or this.currentUser.name this.currentUser.username)
         }}
-        data-auto-route="true"
         {{on "click" this.click}}
       >
         <Notifications @active={{@active}} />

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -187,11 +187,9 @@ createWidget(
             attributes: {
               "aria-haspopup": true,
               "aria-expanded": attrs.active,
-              href: attrs.user.path,
               "aria-label": I18n.t("user.account_possessive", {
                 name: attrs.user.name || attrs.user.username,
               }),
-              "data-auto-route": true,
             },
           },
           this.attach("header-notifications", attrs)
@@ -222,8 +220,6 @@ createWidget(
             attributes: {
               "aria-expanded": attrs.active,
               "aria-haspopup": true,
-              href: attrs.href,
-              "data-auto-route": true,
               title,
               "aria-label": title,
               id: attrs.iconId,


### PR DESCRIPTION
Those apply only to `a` elements

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
