### PR TITLE
DEV: Enable lazy_load_categories in tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -3,6 +3,7 @@ import { NOTIFICATION_TYPES } from "./concerns/notification-types";
 export default {
   "site.json": {
     site: {
+      lazy_load_categories: true,
       default_archetype: "regular",
       shared_drafts_category_id: 24,
       notification_types: NOTIFICATION_TYPES,

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1,5 +1,6 @@
 import Pretender from "pretender";
 import User from "discourse/models/user";
+import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import getURL from "discourse-common/lib/get-url";
 import { cloneJSON } from "discourse-common/lib/object";
 
@@ -527,6 +528,23 @@ export function applyDefaultHandlers(pretender) {
   pretender.post("/categories", () =>
     response(fixturesByUrl["/c/11/show.json"])
   );
+
+  pretender.get("/categories/find", () => {
+    return response({ categories: siteFixtures["site.json"].site.categories });
+  });
+
+  pretender.get("/categories/search", (request) => {
+    if (request.queryParams.include_ancestors) {
+      return response({
+        categories: siteFixtures["site.json"].site.categories,
+        ancestors: siteFixtures["site.json"].site.categories,
+      });
+    } else {
+      return response({
+        categories: siteFixtures["site.json"].site.categories,
+      });
+    }
+  });
 
   pretender.get("/c/testing/find_by_slug.json", () =>
     response(fixturesByUrl["/c/11/show.json"])

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2349,7 +2349,7 @@ developer:
     allow_any: false
     refresh: true
   lazy_load_categories_groups:
-    default: ""
+    default: "0"
     type: group_list
     list_type: compact
   warn_critical_js_deprecations:


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
