### PR TITLE
FIX: missing IST KST and JST timezones in cooked posts

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js
@@ -1,5 +1,6 @@
 import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-block";
 
+moment.tz.link(["Asia/Kolkata|IST", "Asia/Seoul|KST", "Asia/Tokyo|JST"]);
 const timezoneNames = moment.tz.names();
 
 function addSingleLocalDate(buffer, state, config) {

--- a/plugins/discourse-local-dates/spec/integration/local_dates_spec.rb
+++ b/plugins/discourse-local-dates/spec/integration/local_dates_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe "Local Dates" do
 
     expect(cooked).to include('data-timezone="Asia/Calcutta"')
     expect(cooked).to include("05/08/2018 4:30:00 PM")
+
+    post = Fabricate(:post, raw: <<~MD)
+      [date=2018-05-08 time=22:00 format="L LTS" timezone="IST"]
+    MD
+
+    cooked = post.cooked
+
+    expect(cooked).to include('data-timezone="IST"')
+    expect(cooked).to include("05/08/2018 4:30:00 PM")
   end
 
   it "requires the right attributes to convert to a local date" do


### PR DESCRIPTION
In this PR we introduced 3 new timezones to UX - IST, KST and JST

https://github.com/discourse/discourse/pull/20114

However, the same has to be done in PrettyText so cooked posts respect those timezones.

<img width="1076" alt="Screenshot 2024-03-20 at 11 10 35 AM" src="https://github.com/discourse/discourse/assets/72780/b1a6bce1-d089-435f-b2b4-47506e4c36e8">

