### PR TITLE
FIX: remove "fake" mentions from extract_mentions

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -461,18 +461,14 @@ module PrettyText
   end
 
   def self.extract_mentions(cooked)
-    mentions = []
-
-    cooked
-      .css(".mention, .mention-group")
-      .each do |e|
-        if (name = e.inner_text)
-          if name[0] == "@"
-            name = name[1..-1]
-            mentions << User.normalize_username(name)
+    mentions =
+      cooked
+        .css(".mention, .mention-group")
+        .filter_map do |e|
+          if (name = e.inner_text)
+            User.normalize_username(name[1..-1]) if name[0] == "@"
           end
         end
-      end
 
     mentions =
       DiscoursePluginRegistry.apply_modifier(:pretty_text_extract_mentions, mentions, cooked)

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -461,16 +461,18 @@ module PrettyText
   end
 
   def self.extract_mentions(cooked)
-    mentions =
-      cooked
-        .css(".mention, .mention-group")
-        .map do |e|
-          if (name = e.inner_text)
+    mentions = []
+
+    cooked
+      .css(".mention, .mention-group")
+      .each do |e|
+        if (name = e.inner_text)
+          if name[0] == "@"
             name = name[1..-1]
-            name = User.normalize_username(name)
-            name
+            mentions << User.normalize_username(name)
           end
         end
+      end
 
     mentions =
       DiscoursePluginRegistry.apply_modifier(:pretty_text_extract_mentions, mentions, cooked)

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -569,13 +569,13 @@ RSpec.describe PrettyText do
           <a class="mention" href="/u/test">@test</a>,
           <a class="mention-group" href="/g/test-group">@test-group</a>,
           <a class="custom-mention" href="/custom-mention">@test-custom</a>,
+          <a class="mention" href="/u/test1">test1</a>,
           this is a test
         </p>
         HTML
 
         extracted_mentions = PrettyText.extract_mentions(Nokogiri::HTML5.fragment(cooked_html))
-        expect(extracted_mentions).to include("test", "test-group")
-        expect(extracted_mentions).not_to include("test-custom")
+        expect(extracted_mentions).to contain_exactly("test", "test-group")
 
         Plugin::Instance
           .new


### PR DESCRIPTION
```
<a class="mention" href="/u/test1">bsam</a>
```

Is not a mention of the user sam. We expect an @ in front always.
