### PR TITLE
FEATURE: Buttons to add and remove objects for schema theme settings

### DIFF
--- a/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
+++ b/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
@@ -64,6 +64,12 @@
           font-weight: bold;
         }
       }
+
+      .schema-theme-setting-editor__tree-add-button {
+        &.--child {
+          margin-left: 0.5em;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Continue from https://github.com/discourse/discourse/pull/25673.

This feature adds new buttons for schema theme settings that add/remove objects from lists. Screenshot:

<img src="https://github.com/discourse/discourse/assets/17474474/38bcf34c-3f7a-4d37-82ce-96f961b672d2" width="600">
