### PR TITLE
FIX: Error encountered when adding child object in object setting editor

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
@@ -69,7 +69,9 @@ export default class SchemaThemeSettingEditor extends Component {
         index,
         schema,
         object,
-        text: object[schema.identifier] || `${schema.name} ${index + 1}`,
+        text:
+          object[schema.identifier] ||
+          this.defaultSchemaIdentifier(schema.name, index),
         parentTree: tree,
       });
 
@@ -84,7 +86,7 @@ export default class SchemaThemeSettingEditor extends Component {
           const subtree = new Tree();
           subtree.propertyName = childObjectsProperty.name;
           subtree.schema = childObjectsProperty.schema;
-          subtree.data = data[index][childObjectsProperty.name];
+          subtree.data = data[index][childObjectsProperty.name] ||= [];
 
           data[index][childObjectsProperty.name]?.forEach(
             (childObj, childIndex) => {
@@ -232,6 +234,7 @@ export default class SchemaThemeSettingEditor extends Component {
     const data = this.activeNode.parentTree.data;
     data.splice(this.activeIndex, 1);
     this.tree.nodes = this.tree.nodes.filter((n, i) => i !== this.activeIndex);
+
     if (data.length > 0) {
       this.activeIndex = Math.max(this.activeIndex - 1, 0);
     } else if (this.history.length > 0) {
@@ -257,10 +260,14 @@ export default class SchemaThemeSettingEditor extends Component {
     return descriptions[key];
   }
 
+  defaultSchemaIdentifier(schemaName, index) {
+    return `${schemaName} ${index + 1}`;
+  }
+
   createNodeFromSchema(schema, tree) {
     const object = {};
     const index = tree.nodes.length;
-    const defaultName = `${schema.name} ${index + 1}`;
+    const defaultName = this.defaultSchemaIdentifier(schema.name, index);
 
     if (schema.identifier) {
       object[schema.identifier] = defaultName;

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -25,7 +25,7 @@ class TreeFromDOM {
 
       const children = [
         ...queryAll(
-          `.schema-theme-setting-editor__tree-node.--child[data-test-parent-index="${index}"]:not(.--heading)`
+          `.schema-theme-setting-editor__tree-node.--child[data-test-parent-index="${index}"]`
         ),
       ].map((child) => {
         return {
@@ -822,6 +822,70 @@ module(
       assert.strictEqual(tree.nodes.length, 5);
       assert.dom(tree.nodes[2].textElement).hasText("level1 3");
       assert.dom(tree.nodes[3].textElement).hasText("level1 4");
+    });
+
+    test("adding an object to a child list of objects when an object has multiple objects properties", async function (assert) {
+      const setting = ThemeSettings.create({
+        setting: "objects_setting",
+        objects_schema: {
+          name: "something",
+          properties: {
+            title: {
+              type: "string",
+            },
+            links: {
+              type: "objects",
+              schema: {
+                name: "link",
+                properties: {
+                  url: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+            chairs: {
+              type: "objects",
+              schema: {
+                name: "chair",
+                properties: {
+                  name: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+        },
+        value: [
+          {
+            title: "some title",
+          },
+        ],
+      });
+
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @themeId="1" @setting={{setting}} />
+      </template>);
+
+      const tree = new TreeFromDOM();
+
+      await click(tree.nodes[0].addButtons[0]);
+
+      tree.refresh();
+
+      assert.dom(tree.nodes[0].children[0].textElement).hasText("link 1");
+
+      await click(tree.nodes[0].addButtons[1]);
+      tree.refresh();
+
+      assert.dom(tree.nodes[0].children[1].textElement).hasText("chair 1");
+
+      await click(tree.nodes[0].children[0].element);
+
+      const inputFields = new InputFieldsFromDOM();
+
+      assert.dom(inputFields.fields.url.labelElement).hasText("url");
     });
 
     test("adding an object to a child list of objects", async function (assert) {


### PR DESCRIPTION
### Why this change?

If an object doesn't have any child objects for a particular property
and we try to add one through the editor, an error will be raised.

```
Cannot read properties of undefined (reading 'push')
    at SchemaThemeSettingEditor.addItem (editor.js:190:1)
```

### Recording

#### Before 


![Kapture 2024-03-20 at 15 17 21](https://github.com/discourse/discourse/assets/4335742/c47367f6-ff21-4353-a3fd-09c26732947a)

#### After

![Kapture 2024-03-20 at 15 17 47](https://github.com/discourse/discourse/assets/4335742/685aa1b8-606d-47d4-adf3-52a5afcd23be)
