### PR TITLE
FEATURE: Increase default DiscourseConnect session length

### DIFF
--- a/lib/discourse_connect_base.rb
+++ b/lib/discourse_connect_base.rb
@@ -59,7 +59,7 @@ class DiscourseConnectBase
   ]
 
   def self.nonce_expiry_time
-    @nonce_expiry_time ||= 10.minutes
+    @nonce_expiry_time ||= 30.minutes
   end
 
   def self.nonce_expiry_time=(v)


### PR DESCRIPTION
For some identity providers, 10 minutes isn't much time for a user to complete authentication/registration on the identity provider. Increasing the default to 30 minutes should help in those situations. The nonce is still tied to a single browser session, so there is no material impact on security.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
