### PR TITLE
DEV: Allow overriding sidebar icon for "My Posts"

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -51,6 +51,7 @@ export const REPLACEMENTS = {
   "notification.reaction": "bell",
   "notification.votes_released": "plus",
   "notification.chat_quoted": "quote-right",
+  "sidebar.my_posts": "user",
 };
 
 export function replaceIcon(source, destination) {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -98,11 +98,11 @@ export default class MyPostsSectionLink extends BaseSectionLink {
     return this.draftCount > 0;
   }
 
-  get defaultPrefixValue() {
+  get prefixValue() {
     if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
       return "pencil-alt";
     }
-    return "user";
+    return "sidebar.my_posts";
   }
 
   get suffixCSSClass() {


### PR DESCRIPTION
This sidebar link uses the "user" icon by default. For themes/plugins that may want to override only this icon, we need to add a unique name here so it that it can be replaced for this use case specifically.

See meta internal topic t/285750
