### PR TITLE
DEV: Replace Category.findById with Category.asyncFindByIds in easy cases

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/multi-cache.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/multi-cache.js
@@ -22,6 +22,7 @@ export class MultiCache {
     this.fetchTimes = [this.fetchTimes[this.fetchTimes.length - 1], new Date()];
 
     const notFound = [];
+    ids = ids.uniq();
 
     for (const id of ids) {
       if (!this.values.has(id)) {

--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -190,26 +190,27 @@ export default class History extends Component {
     );
   }
 
-  revert(post, postVersion) {
-    post
-      .revertToRevision(postVersion)
-      .then((result) => {
-        this.refresh(post.id, postVersion);
-        if (result.topic) {
-          post.set("topic.slug", result.topic.slug);
-          post.set("topic.title", result.topic.title);
-          post.set("topic.fancy_title", result.topic.fancy_title);
-        }
-        if (result.category_id) {
-          post.set("topic.category", Category.findById(result.category_id));
-        }
-        this.args.closeModal();
-      })
-      .catch((e) => {
-        if (e.jqXHR.responseJSON?.errors?.[0]) {
-          this.dialog.alert(e.jqXHR.responseJSON.errors[0]);
-        }
-      });
+  async revert(post, postVersion) {
+    try {
+      const result = await post.revertToRevision(postVersion);
+      this.refresh(post.id, postVersion);
+      if (result.topic) {
+        post.set("topic.slug", result.topic.slug);
+        post.set("topic.title", result.topic.title);
+        post.set("topic.fancy_title", result.topic.fancy_title);
+      }
+      if (result.category_id) {
+        post.set(
+          "topic.category",
+          await Category.asyncFindById(result.category_id)
+        );
+      }
+      this.args.closeModal();
+    } catch (e) {
+      if (e.jqXHR.responseJSON?.errors?.[0]) {
+        this.dialog.alert(e.jqXHR.responseJSON.errors[0]);
+      }
+    }
   }
 
   get editButtonLabel() {

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -150,6 +150,10 @@ export default class Category extends RestModel {
     return categories;
   }
 
+  static async asyncFindById(id) {
+    return (await Category.asyncFindByIds([id]))[0];
+  }
+
   static findBySlugAndParent(slug, parentCategory) {
     if (this.slugEncoded()) {
       slug = encodeURI(slug);

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -450,7 +450,7 @@ export default class Group extends RestModel {
     });
   }
 
-  findPosts(opts) {
+  async findPosts(opts) {
     opts = opts || {};
     const type = opts.type || "posts";
     const data = {};
@@ -463,13 +463,16 @@ export default class Group extends RestModel {
       data.category_id = parseInt(opts.categoryId, 10);
     }
 
-    return ajax(`/groups/${this.name}/${type}.json`, { data }).then((posts) => {
-      return posts.map((p) => {
-        p.user = User.create(p.user);
-        p.topic = Topic.create(p.topic);
-        p.category = Category.findById(p.category_id);
-        return EmberObject.create(p);
-      });
+    const posts = await ajax(`/groups/${this.name}/${type}.json`, { data });
+    const categories = await Category.asyncFindByIds(
+      posts.map((p) => p.category_id)
+    );
+
+    return posts.map((p) => {
+      p.user = User.create(p.user);
+      p.topic = Topic.create(p.topic);
+      p.category = categories[p.category_id];
+      return EmberObject.create(p);
     });
   }
 


### PR DESCRIPTION
We want to use asyncFindByIds, because, if the category doesn't exist locally, it allows us to fetch it.
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
