### PR TITLE
DEV: Launch Chromium instead of Chrome on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -340,7 +340,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
+        browser: ["Chromium", "Firefox ESR", "Firefox Evergreen"]
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}


### PR DESCRIPTION
In
https://github.com/discourse/discourse_docker/commit/e6ffa64d9d7622327b134c8397f59edf832e4299,
we started shipping Chromium instead of Chrome.
