### PR TITLE
DEV: Call `Site.reset_preloaded_category_custom_fields` in test setup

### DIFF
--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -392,7 +392,6 @@ RSpec.describe CategoryList do
     fab!(:category) { Fabricate(:category, user: admin) }
 
     before { category.upsert_custom_fields("bob" => "marley") }
-    after { Site.reset_preloaded_category_custom_fields }
 
     it "can preloads custom fields" do
       Site.preloaded_category_custom_fields << "bob"

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -138,8 +138,6 @@ RSpec.describe Site do
       categories = Site.new(Guardian.new).categories
 
       expect(categories.last[:custom_fields]["enable_marketplace"]).to eq("f")
-    ensure
-      Site.reset_preloaded_category_custom_fields
     end
 
     it "sets the can_edit field for categories correctly" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -116,6 +116,7 @@ module TestSetup
     NotificationEmailer.disable
     SiteIconManager.disable
     WordWatcher.disable_cache
+    Site.reset_preloaded_category_custom_fields
 
     SiteSetting.provider.all.each { |setting| SiteSetting.remove_override!(setting.name) }
 

--- a/spec/requests/api/site_spec.rb
+++ b/spec/requests/api/site_spec.rb
@@ -21,18 +21,14 @@ RSpec.describe "site" do
 
       produces "application/json"
       response "200", "success response" do
-        begin
-          Site.preloaded_category_custom_fields << "no_oddjob"
+        Site.preloaded_category_custom_fields << "no_oddjob"
 
-          expected_response_schema = load_spec_schema("site_response")
-          schema expected_response_schema
+        expected_response_schema = load_spec_schema("site_response")
+        schema expected_response_schema
 
-          it_behaves_like "a JSON endpoint", 200 do
-            let(:expected_response_schema) { expected_response_schema }
-            let(:expected_request_schema) { expected_request_schema }
-          end
-        ensure
-          Site.reset_preloaded_category_custom_fields
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
         end
       end
     end


### PR DESCRIPTION
This is a common source of flaky test so we should just reset it
instead of assuming test writers will reset it.
