### PR TITLE
DEV: Fix state leak in test causing flaky tests

### DIFF
--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1166,6 +1166,8 @@ RSpec.describe CategoriesController do
 
       expect(response.parsed_body["categories"].length).to eq(1)
       expect(response.parsed_body["categories"][0]["custom_fields"]).to eq("bob" => "marley")
+    ensure
+      Site.reset_preloaded_category_custom_fields
     end
 
     context "without include_ancestors" do


### PR DESCRIPTION
Why this change?

The test registers a category custom field to preload but doesn't remove
it at the end of the test causing a state leak which can result in other
tests failing.
