### PR TITLE
FIX: Anon users could not edit their own posts

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -640,16 +640,6 @@ class Guardian
   private
 
   def is_my_own?(obj)
-    # NOTE: This looks strange...but we are checking if someone is posting anonymously
-    # as a AnonymousUser model, _not_ as Guardian::AnonymousUser which is a different thing
-    # used when !authenticated?
-    if authenticated? && is_anonymous?
-      return(
-        SiteSetting.allow_anonymous_likes? && obj.class == PostAction && obj.is_like? &&
-          obj.user_id == @user.id
-      )
-    end
-
     return false if anonymous?
     return obj.user_id == @user.id if obj.respond_to?(:user_id) && obj.user_id && @user.id
     return obj.user == @user if obj.respond_to?(:user)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2505,10 +2505,7 @@ RSpec.describe Guardian do
   end
 
   describe "#can_delete_post_action?" do
-    before do
-      SiteSetting.allow_anonymous_posting = true
-      Guardian.any_instance.stubs(:anonymous?).returns(true)
-    end
+    before { SiteSetting.allow_anonymous_posting = true }
 
     context "with allow_anonymous_likes enabled" do
       before { SiteSetting.allow_anonymous_likes = true }


### PR DESCRIPTION
Followup 3094f32ff5c7dec5be7ff4f01e6a855987f8d778,
this fixes an issue with the logic in this commit where
we were returning false if any of the conditionals here
were false, regardless of the type of `obj`, where we should
have only done this if `obj` was a `PostAction`, which lead
us to return false in cases where we were checking if the
user could edit their own post as anon.
