### PR TITLE
DEV: ENV variable for brotli quality in assets:precompile rake task

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -196,7 +196,8 @@ end
 
 # different brotli versions use different parameters
 def brotli_command(path, max_compress)
-  compression_quality = max_compress ? "11" : "6"
+  compression_quality =
+    max_compress ? "11" : (ENV["DISCOURSE_ASSETS_PRECOMPILE_DEFAULT_BROTLI_QUALITY"] || "6")
   "brotli -f --quality=#{compression_quality} #{path} --output=#{path}.br"
 end
 


### PR DESCRIPTION
Why this change?

This ENV allows the brotli compression quality to be configurable such
that one can opt for a higher/lower level of compression based on their
preferences.
