### PR TITLE
DEV: Expose extra data from themes

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -90,6 +90,8 @@ class Theme < ActiveRecord::Base
           )
         end
 
+  delegate :remote_url, to: :remote_theme, private: true, allow_nil: true
+
   def notify_color_change(color, scheme: nil)
     scheme ||= color.color_scheme
     changed_colors << color if color
@@ -947,6 +949,18 @@ class Theme < ActiveRecord::Base
     end
 
     [content, Digest::SHA1.hexdigest(content)]
+  end
+
+  def repository_url
+    return unless remote_url
+    remote_url.gsub(
+      %r{([^@]+@)?(http(s)?://)?(?<host>[^:/]+)[:/](?<path>((?!\.git).)*)(\.git)?(?<rest>.*)},
+      '\k<host>/\k<path>\k<rest>',
+    )
+  end
+
+  def user_selectable_count
+    UserOption.where(theme_ids: [id]).count
   end
 
   private

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1433,4 +1433,66 @@ HTML
       expect(Theme.lookup_field(theme_1.id, :translations, :fr)).to eq(en_field.value_baked)
     end
   end
+
+  describe "#repository_url" do
+    subject(:repository_url) { theme.repository_url }
+
+    context "when theme is not a remote one" do
+      it "returns nothing" do
+        expect(repository_url).to be_blank
+      end
+    end
+
+    context "when theme is a remote one" do
+      let!(:remote_theme) { theme.create_remote_theme(remote_url: remote_url) }
+
+      context "when URL is a SSH one" do
+        let(:remote_url) { "git@github.com:discourse/graceful.git" }
+
+        it "normalizes it" do
+          expect(repository_url).to eq "github.com/discourse/graceful"
+        end
+      end
+
+      context "when URL is a HTTPS one" do
+        let(:remote_url) { "https://github.com/discourse/graceful.git" }
+
+        it "normalizes it" do
+          expect(repository_url).to eq "github.com/discourse/graceful"
+        end
+      end
+
+      context "when URL is a HTTP one" do
+        let(:remote_url) { "http://github.com/discourse/graceful" }
+
+        it "normalizes it" do
+          expect(repository_url).to eq "github.com/discourse/graceful"
+        end
+      end
+
+      context "when URL contains query params" do
+        let(:remote_url) { "http://github.com/discourse/graceful.git?param_id=1" }
+
+        it "keeps the query params" do
+          expect(repository_url).to eq "github.com/discourse/graceful?param_id=1"
+        end
+      end
+    end
+  end
+
+  describe "#user_selectable_count" do
+    subject(:count) { theme.user_selectable_count }
+
+    let!(:users) { Fabricate.times(5, :user) }
+    let!(:another_theme) { Fabricate(:theme) }
+
+    before do
+      users.take(3).each { _1.user_option.update!(theme_ids: [theme.id]) }
+      users.slice(3..4).each { _1.user_option.update!(theme_ids: [another_theme.id]) }
+    end
+
+    it "returns how many users are currently using the theme" do
+      expect(count).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
This PR exposes a normalized repository URL and how many users are using a given theme.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
