### PR TITLE
FIX: Ensure sitemaps include all topics with no duplicates

### DIFF
--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -62,7 +62,7 @@ class Sitemap < ActiveRecord::Base
     else
       offset = (name.to_i - 1) * max_page_size
 
-      indexable_topics.limit(max_page_size).offset(offset)
+      indexable_topics.order(id: :asc).limit(max_page_size).offset(offset)
     end
   end
 end


### PR DESCRIPTION
We were using `OFFSET`/`LIMIT` to query topics without an 'ORDER'. Without an explicit order, postgres makes no guarantees about which rows will be returned for each query. This commit adds `ORDER BY id ASC` so that our sitemaps behave consistently.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
