### PR TITLE
FIX: Serialize parent categories first

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -77,7 +77,7 @@ class TopicList
 
   def categories
     @categories ||=
-      topics.map { |t| [t.category&.parent_category, t.category] }.uniq.flatten.compact
+      topics.map { |t| [t.category&.parent_category, t.category] }.flatten.uniq.compact
   end
 
   def load_topics

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -727,9 +727,9 @@ class TopicView
   end
 
   def categories
-    categories = [category, category&.parent_category]
-    categories += suggested_topics.categories if suggested_topics
-    categories.compact.uniq
+    @categories ||= [category&.parent_category, category, suggested_topics&.categories].flatten
+      .uniq
+      .compact
   end
 
   protected


### PR DESCRIPTION
When categories are loaded by the frontend, the parent category is looked up by ID and the `parentCategory` is set with the result. If the categories returned are not in order, the parent category may miss.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
