### PR TITLE
Revert "UX: Make input sizing consistent across all browsers (#26159)"

### DIFF
--- a/app/assets/stylesheets/common/font-variables.scss
+++ b/app/assets/stylesheets/common/font-variables.scss
@@ -30,7 +30,7 @@
 
   // inputs/textareas in iOS need to be at least 16px to avoid triggering zoom on focus
   // with base at 15px, the below gives 16.05px
-  --font-size-input: max(1em, 16px);
+  --font-size-ios-input: 1.07em;
 
   // Common line-heights
   --line-height-small: 1;

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -114,7 +114,11 @@ $hpad: 0.65em;
   line-height: normal;
   box-sizing: border-box;
   padding: $vpad $hpad;
-  font-size: var(--font-size-input);
+  .ios-device & {
+    font-size: var(--font-size-ios-input);
+    padding-top: $vpad * 0.8;
+    padding-bottom: $vpad * 0.8;
+  }
 }
 
 @mixin sticky {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -9,8 +9,16 @@ body {
   background-color: var(--secondary);
 }
 
-textarea {
-  font-size: var(--font-size-input);
+.ios-device {
+  textarea {
+    background-color: var(--secondary);
+    font-size: var(--font-size-ios-input);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  input#reply-title {
+    -webkit-tap-highlight-color: transparent;
+  }
 }
 
 blockquote {


### PR DESCRIPTION
This reverts commit d0d4a363d4801a274caad50ffa509fc64740f238. This causes issues for people that have specified explicit font sizes in their browser - reverting while we investigate. https://meta.discourse.org/t/300374

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
