### PR TITLE
FIX: Load subcategories through CategoryList

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -140,7 +140,7 @@ class CategoryList
 
     query = self.class.order_categories(query)
 
-    if @guardian.can_lazy_load_categories?
+    if @guardian.can_lazy_load_categories? && @options[:parent_category_id].blank?
       page = [1, @options[:page].to_i].max
       query =
         query
@@ -154,7 +154,7 @@ class CategoryList
 
     @categories = query.to_a
 
-    if @guardian.can_lazy_load_categories?
+    if @guardian.can_lazy_load_categories? && @options[:parent_category_id].blank?
       categories_with_rownum =
         Category
           .secured(@guardian)

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -437,5 +437,13 @@ RSpec.describe CategoryList do
         category.id,
       )
     end
+
+    context "with parent_category_id" do
+      it "returns subcategories" do
+        category_list = CategoryList.new(Guardian.new(user), parent_category_id: category.id)
+
+        expect(category_list.categories.size).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
When "lazy load categories" is enabled and parent_category_id was set, the query fetching categories contained a contradiction filtering both by parent_category_id and parent_category_id = NULL.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
