### PR TITLE
UX: hide "powered by" from account activation page

### DIFF
--- a/app/assets/stylesheets/common/components/powered-by-discourse.scss
+++ b/app/assets/stylesheets/common/components/powered-by-discourse.scss
@@ -2,7 +2,8 @@
   .admin-area &,
   .has-full-page-chat &,
   .static-login &,
-  .invite-page & {
+  .invite-page &,
+  .account-activation-page & {
     display: none !important;
   }
   grid-area: below-content;


### PR DESCRIPTION
"Powered by Discourse" looks out of place here:

![image](https://github.com/discourse/discourse/assets/1681963/94d98251-68ca-484e-b601-9645481fd4d5)
