### PR TITLE
UX: hide sidebar toggle on account created route

### DIFF
--- a/app/assets/stylesheets/common/base/activation.scss
+++ b/app/assets/stylesheets/common/base/activation.scss
@@ -11,6 +11,9 @@
       display: none;
     }
   }
+  .header-sidebar-toggle {
+    display: none;
+  }
   #main-outlet {
     padding: 0;
     height: 100%;


### PR DESCRIPTION
The sidebar is already hidden here, but the toggle isn't. This hides it.

Eventually we'll probably have a service that can handle this so it's not only CSS. 

Before:

![image](https://github.com/discourse/discourse/assets/1681963/16512a7b-bad4-4e1f-8e74-f9ac494c1ae4)

After:

![image](https://github.com/discourse/discourse/assets/1681963/a1021949-e7dd-47a4-9533-08f565e1339f)
