### PR TITLE
UX: add title attribute to composer preview image controls

### DIFF
--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -82,7 +82,7 @@ function buildScaleButton(selectedScale, scale) {
   const activeScaleClass = selectedScale === scale ? " active" : "";
   return `<span title="
             ${I18n.t("composer.image_scale_button", { percent: scale })}" 
-            class='scale-btn${activeScaleClass}' data-scale='${scale}'
+            class="scale-btn${activeScaleClass}" data-scale="${scale}"
           >
             ${scale}%
           </span>`;

--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -82,7 +82,7 @@ function buildScaleButton(selectedScale, scale) {
   const activeScaleClass = selectedScale === scale ? " active" : "";
   return `<span title="
             ${I18n.t("composer.image_scale_button", { percent: scale })}" 
-            class="scale-btn${activeScaleClass}" data-scale="${scale}"
+            class='scale-btn${activeScaleClass}' data-scale='${scale}'
           >
             ${scale}%
           </span>`;
@@ -96,12 +96,9 @@ function buildImageShowAltTextControls(altText) {
     >
       <svg aria-hidden="true" class="fa d-icon d-icon-pencil svg-icon svg-string"><use href="#pencil-alt"></use></svg>
     </span>
-
     <span class="alt-text" 
       aria-label="${I18n.t("composer.image_alt_text.aria_label")}"
-    >
-      ${altText}
-    </span>
+    >${altText}</span>
   </span>
   `;
 }
@@ -124,6 +121,7 @@ function buildImageDeleteButton() {
   return `
   <span class="delete-image-button" 
     title="${I18n.t("composer.delete_image_button")}" 
+    aria-label="${I18n.t("composer.delete_image_button")}"
   >
     <svg class="fa d-icon d-icon-trash-alt svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
       <use href="#far-trash-alt"></use>

--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -80,27 +80,28 @@ function rule(state) {
 
 function buildScaleButton(selectedScale, scale) {
   const activeScaleClass = selectedScale === scale ? " active" : "";
-  return (
-    "<span class='scale-btn" +
-    activeScaleClass +
-    "' data-scale='" +
-    scale +
-    "'>" +
-    scale +
-    "%</span>"
-  );
+  return `<span title="
+            ${I18n.t("composer.image_scale_button", { percent: scale })}" 
+            class='scale-btn${activeScaleClass}' data-scale='${scale}'
+          >
+            ${scale}%
+          </span>`;
 }
 
 function buildImageShowAltTextControls(altText) {
   return `
   <span class="alt-text-readonly-container">
-  <span class="alt-text-edit-btn">
-  <svg aria-hidden="true" class="fa d-icon d-icon-pencil svg-icon svg-string"><use href="#pencil-alt"></use></svg>
-</span>
+    <span class="alt-text-edit-btn" 
+      title="${I18n.t("composer.image_alt_text.title")}" 
+    >
+      <svg aria-hidden="true" class="fa d-icon d-icon-pencil svg-icon svg-string"><use href="#pencil-alt"></use></svg>
+    </span>
 
-  <span class="alt-text" aria-label="${I18n.t(
-    "composer.image_alt_text.aria_label"
-  )}">${altText}</span>
+    <span class="alt-text" 
+      aria-label="${I18n.t("composer.image_alt_text.aria_label")}"
+    >
+      ${altText}
+    </span>
   </span>
   `;
 }
@@ -121,13 +122,14 @@ function buildImageEditAltTextControls(altText) {
 
 function buildImageDeleteButton() {
   return `
-  <span class="delete-image-button" aria-label="${I18n.t(
-    "composer.delete_image_button"
-  )}">
-  <svg class="fa d-icon d-icon-trash-alt svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
-  <use href="#far-trash-alt"></use>
-  </svg>
-   </span>
+  <span class="delete-image-button" 
+    title="${I18n.t("composer.delete_image_button")}" 
+    aria-label="${I18n.t("composer.delete_image_button")}"
+  >
+    <svg class="fa d-icon d-icon-trash-alt svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
+      <use href="#far-trash-alt"></use>
+    </svg>
+  </span>
   `;
 }
 

--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -124,7 +124,6 @@ function buildImageDeleteButton() {
   return `
   <span class="delete-image-button" 
     title="${I18n.t("composer.delete_image_button")}" 
-    aria-label="${I18n.t("composer.delete_image_button")}"
   >
     <svg class="fa d-icon d-icon-trash-alt svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
       <use href="#far-trash-alt"></use>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2588,7 +2588,9 @@ en:
 
       image_alt_text:
         aria_label: Alt text for image
+        title: "Add image description"
 
+      image_scale_button: "Scale image to %{percent}%"
       delete_image_button: Delete Image
       toggle_image_grid: Toggle image grid
 


### PR DESCRIPTION
This adds a title attribute to provide some more detail while hovering these controls:

![image](https://github.com/discourse/discourse/assets/1681963/5d3d3acb-a319-4a98-bf3d-f07bd0be6517)

![image](https://github.com/discourse/discourse/assets/1681963/a56b4089-2c82-43c4-9145-822bae0551d7)

Suggested in https://meta.discourse.org/t/100-75-50-next-to-images-in-preview-window/299883