### PR TITLE
FIX: two skip links should not have the same ID

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -10,7 +10,7 @@
     {{this.primaryGroup}}"
 >
   <section class="user-main">
-    <a href="#user-content" id="skip-link" class="skip-link__user-nav">
+    <a href="#user-content" id="user-nav-skip-link" class="skip-link__user-nav">
       {{i18n "skip_user_nav"}}
     </a>
     <section

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -772,6 +772,7 @@ textarea {
   }
 }
 
+a#user-nav-skip-link,
 a#skip-link {
   padding: 0.25em 0.5em;
   position: fixed;


### PR DESCRIPTION
We have two skip links on this page, one to skip the site nav, and another to skip the profile nav. They should not use the same ID, which is against HTML spec 

https://meta.discourse.org/t/300012