### PR TITLE
A11Y: topic map aria-controls needs an ID 

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map.gjs
@@ -25,7 +25,8 @@ export default class TopicMap extends Component {
       />
     </section>
     {{#unless this.collapsed}}
-      <section class="topic-map-expanded">
+      {{! The ID is required for aria-controls, the class is legacy }}
+      <section class="topic-map-expanded" id="topic-map-expanded">
         <TopicMapExpanded @postAttrs={{@postAttrs}} />
       </section>
     {{/unless}}

--- a/app/assets/javascripts/discourse/app/components/topic-map.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map.gjs
@@ -25,8 +25,8 @@ export default class TopicMap extends Component {
       />
     </section>
     {{#unless this.collapsed}}
-      {{! The ID is required for aria-controls, the class is legacy }}
-      <section class="topic-map-expanded" id="topic-map-expanded">
+      {{! The ID is required for aria-controls}}
+      <section class="topic-map-expanded" id="topic-map-expanded-content">
         <TopicMapExpanded @postAttrs={{@postAttrs}} />
       </section>
     {{/unless}}

--- a/app/assets/javascripts/discourse/app/components/topic-map.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map.gjs
@@ -25,8 +25,10 @@ export default class TopicMap extends Component {
       />
     </section>
     {{#unless this.collapsed}}
-      {{! The ID is required for aria-controls}}
-      <section class="topic-map-expanded" id="topic-map-expanded-content">
+      <section
+        class="topic-map-expanded"
+        id="topic-map-expanded__aria-controls"
+      >
         <TopicMapExpanded @postAttrs={{@postAttrs}} />
       </section>
     {{/unless}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -17,7 +17,7 @@ export default class TopicMapSummary extends Component {
         : "topic.collapse_details",
       icon: this.args.collapsed ? "chevron-down" : "chevron-up",
       ariaExpanded: this.args.collapsed ? "false" : "true",
-      ariaControls: "topic-map-expanded",
+      ariaControls: "topic-map-expanded-content",
       action: this.args.toggleMap,
     };
   }

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -17,7 +17,7 @@ export default class TopicMapSummary extends Component {
         : "topic.collapse_details",
       icon: this.args.collapsed ? "chevron-down" : "chevron-up",
       ariaExpanded: this.args.collapsed ? "false" : "true",
-      ariaControls: "topic-map-expanded-content",
+      ariaControls: "topic-map-expanded__aria-controls",
       action: this.args.toggleMap,
     };
   }


### PR DESCRIPTION
The topic map expansion button correctly has `aria-controls` but there's no corresponding ID. 

This updates the ID to correspond with its purpose. I considered duplicating the class name as the ID and adding a comment... but I think this naming convention achieves a similar goal. 