### PR TITLE
UX: Move "All Site Settings" link to top of admin sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -378,12 +378,6 @@ export const ADMIN_NAV_MAP = [
         label: "admin.advanced.sidebar_link.experimental",
         icon: "discourse-sparkles",
       },
-      {
-        name: "admin_all_site_settings",
-        route: "adminSiteSettings",
-        label: "admin.advanced.sidebar_link.all_site_settings",
-        icon: "cog",
-      },
     ],
   },
 ];

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -153,6 +153,12 @@ export function useAdminNavConfig(navMap) {
           label: "admin.dashboard.title",
           icon: "home",
         },
+        {
+          name: "admin_all_site_settings",
+          route: "adminSiteSettings",
+          label: "admin.advanced.sidebar_link.all_site_settings",
+          icon: "cog",
+        },
       ],
     },
   ];


### PR DESCRIPTION
We are still making improvements to the admin sidebar and
various parts of the admin section. For now, to make the
transition easier, we are moving this link to the top of the
sidebar so it's clear that admins can still get to all settings
if they need to.

![2024-03-22_12-42](https://github.com/discourse/discourse/assets/920448/c3c78349-99c2-4f4c-b2eb-091a51d27803)
