### PR TITLE
PERF: Enable brotli compression in nginx

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -50,6 +50,12 @@ server {
   access_log /var/log/nginx/access.log log_discourse;
 
   listen 80;
+
+  brotli on;
+  brotli_min_length 1000;
+  brotli_comp_level 5;
+  brotli_types application/json text/css text/javascript application/x-javascript application/javascript image/svg+xml application/wasm;
+
   gzip on;
   gzip_vary on;
   gzip_min_length 1000;


### PR DESCRIPTION
Why this change?

We have seen brotli getting higher compression ratios than gzip with
similar compression times. For dynamic content compression, the
compression time is important so we are setting to brotli quality=5 for
now based on a compression test I ran locally.

```
time brotli -f --quality=5 out.html --output=br_5
brotli -f --quality=5 out.html --output=br_5  0.01s user 0.01s system 65% cpu 0.020 total

time brotli -f --quality=5 out.html --output=br_5
brotli -f --quality=5 out.html --output=br_5  0.01s user 0.01s system 79% cpu 0.017 total

43K Mar 22 14:22 br_5
51K Mar 22 14:25 gzip_5
390K Mar 22 14:22 out.html
```

The gains are higher as the size of the response increases as well.