### PR TITLE
UX: Convert `mention` style to inline

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -33,6 +33,7 @@ a.hashtag {
   .hashtag-icon-placeholder {
     font-size: var(--font-down-2);
     margin: 0 0.33em 0 0.1em;
+    vertical-align: inherit;
   }
 
   img.emoji {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -257,7 +257,7 @@ $hpad: 0.65em;
   font-size: 0.93em;
   font-weight: normal;
   color: var(--primary);
-  padding: 0.159em 0.4em;
+  padding: 0.16em 0.4em 0.2em;
   background: var(--primary-low);
   border-radius: 0.6em;
   text-decoration: none;

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -253,12 +253,13 @@ $hpad: 0.65em;
 }
 
 @mixin mention() {
-  display: inline-block; // https://bugzilla.mozilla.org/show_bug.cgi?id=1656119
+  display: inline;
   font-size: 0.93em;
   font-weight: normal;
   color: var(--primary);
-  padding: 0 0.4em 0.07em;
+  padding: 0.159em 0.4em;
   background: var(--primary-low);
   border-radius: 0.6em;
   text-decoration: none;
+  text-wrap: nowrap;
 }


### PR DESCRIPTION
Works around a webkit bug (?) and makes more sense for elements that are mostly text and displayed _inline_ with text content.

Before / After
<img width="709" alt="Screenshot 2024-03-22 at 10 45 55" src="https://github.com/discourse/discourse/assets/66961/cea8a6fb-f0ca-4c82-a1a9-673a04d71950">
<img width="709" alt="Screenshot 2024-03-22 at 10 46 04" src="https://github.com/discourse/discourse/assets/66961/e0bb05be-7cc3-4a11-8c1b-2511169e56dc">


The recent webkit bug/behavior of unstable inline-block layout:

<img width="35" alt="image" src="https://github.com/discourse/discourse/assets/66961/d64165f3-89ca-4374-9302-e4145cd3ccaf">


Tested on Chromium and in macOS Safari, with 3 different text sizes in the Interface settings