### PR TITLE
A11Y: Add button role to the reply-to-tab anchor on desktop

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -163,6 +163,7 @@ createWidget("reply-to-tab", {
     };
 
     if (!this.attrs.mobileView) {
+      result["role"] = "button";
       result["aria-controls"] = `embedded-posts__top--${attrs.post_number}`;
       result["aria-expanded"] = this.attrs.repliesAbove.length
         ? "true"


### PR DESCRIPTION

![image](https://github.com/discourse/discourse/assets/1681963/25ec9477-c7d3-44a1-8fce-aafdb209c1f2)


This isn't navigating somewhere else, but shows/hides content, so `role="button"` would be appropriate here. The mobile behavior functions as an anchor link rather than expanding content, so that will remain unchanged. 