### PR TITLE
A11Y: improve markup of 404 page search form

### DIFF
--- a/app/assets/stylesheets/common/base/not-found.scss
+++ b/app/assets/stylesheets/common/base/not-found.scss
@@ -53,3 +53,11 @@
     flex-basis: 100%;
   }
 }
+
+.page-not-found-search {
+  label {
+    color: var(--primary);
+    font-size: var(--font-up-3);
+    margin-bottom: 0.5em;
+  }
+}

--- a/app/views/exceptions/not_found.html.erb
+++ b/app/views/exceptions/not_found.html.erb
@@ -21,13 +21,11 @@
 <%- unless @hide_search%>
   <div class="row">
     <div class="page-not-found-search">
-      <h2><%= t 'page_not_found.search_title' %></h2>
-      <p>
-        <form action='<%= path "/search" %>' id='discourse-search'>
-          <input type="text" name="q" value="<%= @slug %>">
-          <button class="btn btn-primary"><%= t 'page_not_found.search_button' %></button>
-        </form>
-      </p>
+      <form action='<%= path "/search" %>' id='discourse-search'>
+        <label for="search-input"><%= t 'page_not_found.search_title' %></label>
+        <input type="text" id="search-input" name="q" value="<%= @slug %>">
+        <button class="btn btn-primary"><%= t 'page_not_found.search_button' %></button>
+      </form>
     </div>
   </div>
 


### PR DESCRIPTION
* Associates the input label with the input using `for`
* Drops `H2`, which can't shouldn't be within a label tag
* Removes the `p` which was used for spacing rather than any semantic meaning 