### PR TITLE
FEATURE: Simplify crawler content for non-canonical post URLs

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -59,7 +59,7 @@
         <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
       <% end %>
 
-      <% @topic_view.posts.each do |post| %>
+      <% @topic_view.crawler_posts.each do |post| %>
         <% if (u = post.user) && !post.hidden && post.cooked && !post.cooked.strip.empty? %>
           <div id='post_<%= post.post_number %>' <%= post.is_first_post? ? "" : "itemprop='comment' itemscope itemtype='http://schema.org/Comment'".html_safe %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>
@@ -128,16 +128,21 @@
       <% end %>
     </div>
 
-  <% if @topic_view.prev_page || @topic_view.next_page %>
-    <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
-      <% if @topic_view.prev_page %>
-        <span itemprop='name'><%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev', itemprop: 'url' %></span>
-      <% end %>
-      <% if @topic_view.next_page %>
-        <span itemprop='name'><b><%= link_to t(:next_page), @topic_view.next_page_path, rel: 'next', itemprop: 'url' %></b></span>
-      <% end %>
-    </div>
-  <% end %>
+    <% if @topic_view.crawler_only_one_post? || @topic_view.prev_page || @topic_view.next_page %>
+      <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
+        <% if @topic_view.crawler_only_one_post? %>
+          <span itemprop='name'>
+            <%= link_to t(:show_post_in_topic), "#{@topic_view.current_page_path}#post_#{@topic_view.crawler_posts.first&.post_number}", itemprop: 'url' %></span>
+        <% else %>
+          <% if @topic_view.prev_page %>
+            <span itemprop='name'><%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev', itemprop: 'url' %></span>
+          <% end %>
+          <% if @topic_view.next_page %>
+            <span itemprop='name'><b><%= link_to t(:next_page), @topic_view.next_page_path, rel: 'next', itemprop: 'url' %></b></span>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
 
     <%= build_plugin_html 'server:topic-show-after-posts-crawler' %>
   <% else %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -128,9 +128,9 @@
       <% end %>
     </div>
 
-    <% if @topic_view.crawler_only_one_post? || @topic_view.prev_page || @topic_view.next_page %>
+    <% if @topic_view.single_post_request? || @topic_view.prev_page || @topic_view.next_page %>
       <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
-        <% if @topic_view.crawler_only_one_post? %>
+        <% if @topic_view.single_post_request? %>
           <span itemprop='name'>
             <%= link_to t(:show_post_in_topic), "#{@topic_view.current_page_path}#post_#{@topic_view.crawler_posts.first&.post_number}", itemprop: 'url' %></span>
         <% else %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -132,7 +132,8 @@
       <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
         <% if @topic_view.single_post_request? %>
           <span itemprop='name'>
-            <%= link_to t(:show_post_in_topic), "#{@topic_view.current_page_path}#post_#{@topic_view.crawler_posts.first&.post_number}", itemprop: 'url' %></span>
+            <%= link_to t(:show_post_in_topic), "#{@topic_view.current_page_path}#post_#{@topic_view.crawler_posts.first&.post_number}", itemprop: 'url' %>
+          </span>
         <% else %>
           <% if @topic_view.prev_page %>
             <span itemprop='name'><%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev', itemprop: 'url' %></span>
@@ -153,7 +154,7 @@
     <%= auto_discovery_link_tag(@topic_view, {action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, rel: 'alternate nofollow', title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
     <%= raw crawlable_meta_data(title: @topic_view.title, description: @topic_view.summary(strip_images: true), image: @topic_view.image_url, read_time: @topic_view.read_time, like_count: @topic_view.like_count, ignore_canonical: true, published_time: @topic_view.published_time, breadcrumbs: @breadcrumbs, tags: @tags.map(&:name)) %>
 
-    <% if @topic_view.prev_page || @topic_view.next_page %>
+    <% if !@topic_view.single_post_request? && (@topic_view.prev_page || @topic_view.next_page)  %>
       <% if @topic_view.prev_page %>
         <link rel="prev" href="<%= @topic_view.prev_page_path -%>">
       <% end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -480,6 +480,7 @@ en:
   is_invalid: "seems unclear, is it a complete sentence?"
   next_page: "next page →"
   prev_page: "← previous page"
+  show_post_in_topic: "show post in topic"
   page_num: "Page %{num}"
   crawler_content_hidden: "HTML content omitted because you are logged in or using a modern mobile device."
   home_title: "Home"

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -167,7 +167,7 @@ class TopicView
   end
 
   def current_page_path
-    "#{relative_url}#{"?page=#{@page}" if @page > 0}"
+    "#{relative_url}#{"?page=#{@page}" if @page > 1}"
   end
 
   def contains_gaps?

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -268,14 +268,14 @@ class TopicView
   end
 
   def crawler_posts
-    if crawler_only_one_post?
+    if single_post_request?
       [desired_post]
     else
       posts
     end
   end
 
-  def crawler_only_one_post?
+  def single_post_request?
     @post_number && @post_number != 1
   end
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -163,9 +163,11 @@ class TopicView
       topic_embed = topic.topic_embed
       return topic_embed.embed_url if topic_embed
     end
-    path = relative_url.dup
-    path << ((@page > 1) ? "?page=#{@page}" : "")
-    path
+    current_page_path
+  end
+
+  def current_page_path
+    "#{relative_url}#{"?page=#{@page}" if @page > 0}"
   end
 
   def contains_gaps?
@@ -263,6 +265,18 @@ class TopicView
     @desired_post = posts.detect { |p| p.post_number == @post_number }
     @desired_post ||= posts.first
     @desired_post
+  end
+
+  def crawler_posts
+    if crawler_only_one_post?
+      [desired_post]
+    else
+      posts
+    end
+  end
+
+  def crawler_only_one_post?
+    @post_number && @post_number != 1
   end
 
   def summary(opts = {})

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -167,7 +167,11 @@ class TopicView
   end
 
   def current_page_path
-    "#{relative_url}#{"?page=#{@page}" if @page > 1}"
+    if @page > 1
+      "#{relative_url}?page=#{@page}"
+    else
+      relative_url
+    end
   end
 
   def contains_gaps?

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "topics/show.html.erb" do
 
   it "uses subfolder-safe category url" do
     set_subfolder "/subpath"
-    topic_view = OpenStruct.new(topic: topic, posts: [])
+    topic_view = OpenStruct.new(topic: topic, posts: [], crawler_posts: [])
     topic_view.stubs(:summary).returns("")
     view.stubs(:crawler_layout?).returns(false)
     assign(:topic_view, topic_view)
@@ -21,7 +21,7 @@ RSpec.describe "topics/show.html.erb" do
   end
 
   it "add nofollow to RSS alternate link for topic" do
-    topic_view = OpenStruct.new(topic: topic, posts: [])
+    topic_view = OpenStruct.new(topic: topic, posts: [], crawler_posts: [])
     topic_view.stubs(:summary).returns("")
     view.stubs(:crawler_layout?).returns(false)
     view.stubs(:url_for).returns("https://www.example.com/test.rss")


### PR DESCRIPTION
When crawlers visit a post-specific URL like `/t/-/{topic-id}/{post-number}`, we use the canonical to direct them to the appropriate crawler-optimised paginated view (e.g. `?page=3`).

However, analysis of google results shows that the post-specific URLs are still being included in the index. Google doesn't tell us exactly why this is happening. However, as a general rule, 'A large portion of the duplicate page's content should be present on the canonical version'.

In our previous implementation, this wasn't 100% true all the time. That's because a request for a post-specific URL would include posts 'surrounding' that post, and won't exactly conform to the page boundaries which are used in the canonical version of the page. Essentially: in some cases, the content of the post-specific pages would include many posts which were not present on the canonical paginated version.

This commit aims to resolve that problem by simplifying the implementation. Instead of rendering posts surrounding the target post_number, we will only render the target post, and include a link to 'show post in topic'. With this new implementation, 100% of the post-specific page content will be present on the canonical paginated version, which will hopefully mean google reduces their  indexing of the non-canonical post-specific pages.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
