### PR TITLE
UX: Include message when crawler content is omitted

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -126,7 +126,8 @@
     <link rel="next" href="<%= @list.more_topics_url -%>">
   <% end %>
 <% end %>
-
+<% else %>
+  <%= t(:crawler_content_hidden) %>
 <%- end %> <!-- include_crawler_content? -->
 
 <% if @rss %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -139,7 +139,9 @@
     </div>
   <% end %>
 
-  <%= build_plugin_html 'server:topic-show-after-posts-crawler' %>
+    <%= build_plugin_html 'server:topic-show-after-posts-crawler' %>
+  <% else %>
+    <%= t(:crawler_content_hidden) %>
   <% end %>
 
   <% content_for :head do %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -481,6 +481,7 @@ en:
   next_page: "next page →"
   prev_page: "← previous page"
   page_num: "Page %{num}"
+  crawler_content_hidden: "HTML content ommitted because you are logged in or using a modern mobile device."
   home_title: "Home"
   topics_in_category: "Topics in the '%{category}' category"
   rss_posts_in_topic: "RSS feed of '%{topic}'"


### PR DESCRIPTION
To improve performance, we omit the basic-HTML version of pages when users are logged in, or when they are using a modern mobile device. This can be confusing when analysing the SEO of sites, so this commit adds a short static message when content is omitted.

<img width="569" alt="SCR-20240322-oubp" src="https://github.com/discourse/discourse/assets/6270921/eab092f4-ecf1-4ec5-8917-314deb13d847">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
