### PR TITLE
removed link to TOS from community guidelines

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4577,12 +4577,6 @@ en:
 
       This site is operated by your [friendly local staff](%{base_path}/about) and *you*, the community. If you have any further questions about how things should work here, open a new topic in %{feedback_category} and let’s discuss! If there’s a critical or urgent issue that can’t be handled by a meta topic or flag, contact us via the [staff page](%{base_path}/about).
 
-      <a name="tos"></a>
-
-      ## [Terms of Service](#tos)
-
-      Yes, legalese is boring, but we must protect ourselves &ndash; and by extension, you and your data &ndash; against unfriendly folks. We have a [Terms of Service](%{base_path}/tos) describing your (and our) behavior and rights related to content, privacy, and laws. To use this service, you must agree to abide by our [TOS](%{base_path}/tos).
-
   tos_topic:
     title: "Terms of Service"
     body: |


### PR DESCRIPTION
Not all sites will want to have a terms of service page, so we do not want to link to it from the community guidelines.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
