### PR TITLE
PERF: only allow one reviewable notification at a time

### DIFF
--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Jobs::NotifyReviewable < ::Jobs::Base
+  # this job can take a very long time if there are many mods
+  # do not swamp the queue with it
+  cluster_concurrency 1
+
   def execute(args)
     return unless reviewable = Reviewable.find_by(id: args[:reviewable_id])
 


### PR DESCRIPTION
This job may notify hundreds of mods and take quite a while to run.
