### PR TITLE
Allow redirect when downloading maxmind database

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -42,7 +42,7 @@ class DiscourseIpInfo
         max_file_size: 100.megabytes,
         tmp_file_name: "#{name}.gz",
         validate_uri: false,
-        follow_redirect: false,
+        follow_redirect: true,
       )
 
     filename = File.basename(gz_file.path)


### PR DESCRIPTION
Per https://dev.maxmind.com/geoip/release-notes/2024#presigned-urls-for-database-downloads 

MaxMind users who download databases should make sure that their HTTP client follows redirects and there are no proxy or firewall settings that would block requests to the host we are redirecting to.

See https://meta.discourse.org/t/fail-to-download-maxmind-db-with-valid-key-can-download-the-db-from-inside-containerr/300590/4 and https://meta.discourse.org/t/maxmind-r2-presigned-urls/298941/2

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
