### PR TITLE
FIX: Avoid syncing user bookmarks for users that are getting destroyed

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -85,7 +85,9 @@ class PostDestroyer
 
     DiscourseEvent.trigger(:post_destroyed, @post, @opts, @user)
     WebHook.enqueue_post_hooks(:post_destroyed, @post, payload)
-    Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: @topic.id) if @topic
+    if @topic && !@opts[:skip_bookmark_sync]
+      Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: @topic.id)
+    end
 
     if is_first_post
       UserProfile.remove_featured_topic_from_all_profiles(@topic)

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -512,6 +512,12 @@ RSpec.describe PostDestroyer do
       expect_job_enqueued(job: :sync_topic_user_bookmarked, args: { topic_id: post2.topic_id })
     end
 
+    it "skips the SyncTopicUserBookmarked job when the option to skip is passed in" do
+      post2 = create_post
+      PostDestroyer.new(post2.user, post2, skip_bookmark_sync: true).destroy
+      expect_not_enqueued_with(job: :sync_topic_user_bookmarked, args: { topic_id: post2.topic_id })
+    end
+
     it "skips post revise validations when post is marked for deletion by the author" do
       SiteSetting.min_first_post_length = 100
       post =


### PR DESCRIPTION
When a user is destroyed, it first gets its `Bookmark`s deleted, then its `Post`s.

In the `PostDestroyer`, the `SyncTopicUserBookmarked` job gets called to make sure orphan bookmarks are deleted if the post is a topic. However, this job is not needed when a user is getting destroyed.

This PR adds an `opt` that indicates to `PostDestroyer` that this job doesn't need to be scheduled.