### PR TITLE
FIX: Broken translation in tags input field objects setting editor

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tags.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/tags.gjs
@@ -36,8 +36,8 @@ export default class SchemaThemeSettingTypeTags extends Component {
       (this.min && this.value.length < this.min) ||
       (this.required && (!this.value || this.value.length === 0))
     ) {
-      return I18n.t("admin.customize.theme.schema.fields.tags.at_least_tag", {
-        count: this.min,
+      return I18n.t("admin.customize.theme.schema.fields.tags.at_least", {
+        count: this.min || 1,
       });
     }
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -736,6 +736,10 @@ module(
             required_tags: {
               type: "tags",
               required: true,
+            },
+            required_tags_with_validations: {
+              type: "tags",
+              required: true,
               validations: {
                 min: 2,
                 max: 3,
@@ -745,7 +749,8 @@ module(
         },
         value: [
           {
-            required_tags: ["gazelle", "cat"],
+            required_tags: ["gazelle"],
+            required_tags_with_validations: ["gazelle", "cat"],
           },
         ],
       });
@@ -756,8 +761,8 @@ module(
 
       const inputFields = new InputFieldsFromDOM();
 
-      const tagSelector = selectKit(
-        `${inputFields.fields.required_tags.selector} .select-kit`
+      let tagSelector = selectKit(
+        `${inputFields.fields.required_tags_with_validations.selector} .select-kit`
       );
 
       assert.strictEqual(tagSelector.header().value(), "gazelle,cat");
@@ -778,11 +783,13 @@ module(
 
       inputFields.refresh();
 
-      assert.dom(inputFields.fields.required_tags.errorElement).hasText(
-        I18n.t("admin.customize.theme.schema.fields.tags.at_least_tag", {
-          count: 2,
-        })
-      );
+      assert
+        .dom(inputFields.fields.required_tags_with_validations.errorElement)
+        .hasText(
+          I18n.t("admin.customize.theme.schema.fields.tags.at_least", {
+            count: 2,
+          })
+        );
 
       await tagSelector.expand();
       await tagSelector.selectRowByIndex(1);
@@ -791,9 +798,27 @@ module(
 
       inputFields.refresh();
 
+      assert
+        .dom(inputFields.fields.required_tags_with_validations.errorElement)
+        .hasText(
+          I18n.t("admin.customize.theme.schema.fields.tags.at_least", {
+            count: 2,
+          })
+        );
+
+      tagSelector = selectKit(
+        `${inputFields.fields.required_tags.selector} .select-kit`
+      );
+
+      await tagSelector.expand();
+      await tagSelector.deselectItemByName("gazelle");
+      await tagSelector.collapse();
+
+      inputFields.refresh();
+
       assert.dom(inputFields.fields.required_tags.errorElement).hasText(
-        I18n.t("admin.customize.theme.schema.fields.tags.at_least_tag", {
-          count: 2,
+        I18n.t("admin.customize.theme.schema.fields.tags.at_least", {
+          count: 1,
         })
       );
     });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5653,7 +5653,7 @@ en:
             fields:
               required: "*required"
               tags:
-                at_least_tag:
+                at_least:
                   one: "at least %{count} tag is required"
                   other: "at least %{count} tags are required"
               string:


### PR DESCRIPTION
## Why this change?

When a property of `type: tags` is required, we should be displaying the
"at least 1 tag is required" validation error message when there are no
tags selected in the `TagChooser` compoment. However, we were passing
`this.min` as the `count` attribute when generating the translation
string which is incorrect as `this.min` is not always set.
