### PR TITLE
DEV: Use `-prod` flag when building production assets

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -21,7 +21,8 @@ task "assets:precompile:build" do
       compile_command = "NODE_OPTIONS='--max-old-space-size=2048' #{compile_command}"
     end
 
-    compile_command = "EMBER_ENV=production #{compile_command}" if ENV["EMBER_ENV"].nil?
+    ember_env = ENV["EMBER_ENV"] || "production"
+    compile_command = "#{compile_command} -prod" if ember_env == "production"
 
     only_ember_precompile_build_remaining = (ARGV.last == "assets:precompile:build")
     only_assets_precompile_remaining = (ARGV.last == "assets:precompile")


### PR DESCRIPTION
We were previously using the `EMBER_ENV=production` environment variable, which appears to produce the same output. But, some parts of ember-cli don't seem to support it, which leads to a confusing 'Environment: development' being printed on the console.

This commit adds `-prod` by default, which is the more common way to invoke ember-cli for production builds.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
