### PR TITLE
FEATURE: the ability to expand/collapse all admin sections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/admin-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/admin-header.gjs
@@ -1,0 +1,28 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
+import BackToForum from "./back-to-forum";
+import Filter from "./filter";
+import ToggleAllSections from "./toggle-all-sections";
+
+export default class AdminHeader extends Component {
+  @service sidebarState;
+
+  get shouldDisplay() {
+    return this.sidebarState.isCurrentPanel(ADMIN_PANEL);
+  }
+
+  <template>
+    {{#if this.shouldDisplay}}
+      <div class="sidebar-admin-header">
+        <div class="sidebar-admin-header__row">
+          <BackToForum />
+          <ToggleAllSections @sections={{@sections}} />
+        </div>
+        <div class="sidebar-admin-header__row">
+          <Filter />
+        </div>
+      </div>
+    {{/if}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar/api-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-section.hbs
@@ -9,6 +9,7 @@
     @collapsable={{@collapsable}}
     @displaySection={{this.section.displaySection}}
     @hideSectionHeader={{this.section.hideSectionHeader}}
+    @collapsedByDefault={{this.section.collapsedByDefault}}
   >
     {{#each this.filteredLinks key="name" as |link|}}
       <Sidebar::SectionLink

--- a/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-sections.hbs
@@ -1,5 +1,4 @@
-<Sidebar::BackToForum />
-<Sidebar::Filter />
+<Sidebar::AdminHeader />
 {{#each this.sections as |sectionConfig|}}
   <Sidebar::ApiSection
     @sectionConfig={{sectionConfig}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
@@ -10,7 +10,7 @@ export default class BackToForum extends Component {
   @service sidebarState;
 
   get shouldDisplay() {
-    return this.sidebarState.currentPanel.key === ADMIN_PANEL;
+    return this.sidebarState.isCurrentPanel(ADMIN_PANEL);
   }
 
   get homepage() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
@@ -3,6 +3,7 @@
     data-section-name={{@sectionName}}
     class="sidebar-section-wrapper sidebar-section"
     ...attributes
+    {{did-insert this.setExpandedState}}
   >
     {{#unless @hideSectionHeader}}
       <div class="sidebar-section-header-wrapper sidebar-row">

--- a/app/assets/javascripts/discourse/app/components/sidebar/toggle-all-sections.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/toggle-all-sections.gjs
@@ -1,0 +1,53 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import { ADMIN_NAV_MAP } from "discourse/lib/sidebar/admin-nav-map";
+
+export default class ToggleAllSections extends Component {
+  @service sidebarState;
+  @service keyValueStore;
+  @tracked collapsedSections = this.sidebarState.collapsedSections;
+
+  get allSectionsExpanded() {
+    return ADMIN_NAV_MAP.every((adminNav) => {
+      return !this.collapsedSections.includes(
+        `sidebar-section-${this.sidebarState.currentPanel.key}-${adminNav.name}-collapsed`
+      );
+    });
+  }
+
+  get title() {
+    return this.allSectionsExpanded
+      ? "admin.collapse_all_sections"
+      : "admin.expand_all_sections";
+  }
+
+  get icon() {
+    return this.allSectionsExpanded
+      ? "discourse-chevron-collapse"
+      : "discourse-chevron-expand";
+  }
+
+  @action
+  toggleAllSections() {
+    const collapseOrExpand = this.allSectionsExpanded
+      ? this.sidebarState.collapseSection.bind(this)
+      : this.sidebarState.expandSection.bind(this);
+    ADMIN_NAV_MAP.forEach((adminNav) => {
+      collapseOrExpand(
+        `${this.sidebarState.currentPanel.key}-${adminNav.name}`
+      );
+    });
+  }
+
+  <template>
+    <DButton
+      @action={{this.toggleAllSections}}
+      @icon={{this.icon}}
+      @title={{this.title}}
+      class="btn-transparent sidebar-toggle-all-sections"
+    />
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -108,7 +108,7 @@ function defineAdminSection(
     }
 
     get name() {
-      return `admin-nav-section-${this.adminNavSectionData.name}`;
+      return `${ADMIN_PANEL}-${this.adminNavSectionData.name}`;
     }
 
     get title() {
@@ -134,6 +134,10 @@ function defineAdminSection(
 
     get displaySection() {
       return true;
+    }
+
+    get collapsedByDefault() {
+      return this.adminNavSectionData.name !== "root";
     }
   };
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section.js
@@ -38,6 +38,13 @@ export default class BaseCustomSidebarSection {
     return true;
   }
 
+  /**
+   * @returns {Boolean} Whether or not to collapse the entire section by default.
+   */
+  get collapsedByDefault() {
+    return false;
+  }
+
   _notImplemented() {
     throw "not implemented";
   }

--- a/app/assets/javascripts/discourse/app/services/sidebar-state.js
+++ b/app/assets/javascripts/discourse/app/services/sidebar-state.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
-import Service from "@ember/service";
+import { A } from "@ember/array";
+import Service, { service } from "@ember/service";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import {
   currentPanelKey,
@@ -13,11 +14,14 @@ import {
 
 @disableImplicitInjections
 export default class SidebarState extends Service {
+  @service keyValueStore;
   @tracked currentPanelKey = currentPanelKey;
   @tracked panels = panels;
   @tracked mode = COMBINED_MODE;
   @tracked displaySwitchPanelButtons = false;
   @tracked filter = "";
+  @tracked collapsedSections = A([]);
+
   previousState = {};
 
   constructor() {
@@ -61,6 +65,22 @@ export default class SidebarState extends Service {
       mode: this.mode,
       displaySwitchPanelButtons: this.displaySwitchPanelButtons,
     };
+  }
+
+  collapseSection(sectionKey) {
+    const collapsedSidebarSectionKey = `sidebar-section-${sectionKey}-collapsed`;
+    this.keyValueStore.setItem(collapsedSidebarSectionKey, true);
+    this.collapsedSections.pushObject(collapsedSidebarSectionKey);
+  }
+
+  expandSection(sectionKey) {
+    const collapsedSidebarSectionKey = `sidebar-section-${sectionKey}-collapsed`;
+    this.keyValueStore.setItem(collapsedSidebarSectionKey, false);
+    this.collapsedSections.removeObject(collapsedSidebarSectionKey);
+  }
+
+  isCurrentPanel(panel) {
+    return this.currentPanel.key === panel;
   }
 
   restorePreviousState() {

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -33,65 +33,54 @@ acceptance("Admin Sidebar - Sections", function (needs) {
     await visit("/admin");
 
     assert.ok(
-      exists(".sidebar-section[data-section-name='admin-nav-section-root']"),
+      exists(".sidebar-section[data-section-name='admin-root']"),
       "root section is displayed"
     );
     assert.ok(
-      exists(".sidebar-section[data-section-name='admin-nav-section-account']"),
+      exists(".sidebar-section[data-section-name='admin-account']"),
       "account section is displayed"
     );
     assert.ok(
-      exists(".sidebar-section[data-section-name='admin-nav-section-reports']"),
+      exists(".sidebar-section[data-section-name='admin-reports']"),
       "reports section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-community']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-community']"),
       "community section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-appearance']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-appearance']"),
       "appearance section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-email_settings']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-email_settings']"),
       "email settings section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-email_logs']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-email_logs']"),
       "email logs settings section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-security']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-security']"),
       "security settings section is displayed"
     );
     assert.ok(
-      exists(".sidebar-section[data-section-name='admin-nav-section-plugins']"),
+      exists(".sidebar-section[data-section-name='admin-plugins']"),
       "plugins section is displayed"
     );
     assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='admin-nav-section-advanced']"
-      ),
+      exists(".sidebar-section[data-section-name='admin-advanced']"),
       "advanced section is displayed"
     );
   });
 
   test("enabled plugin admin routes have links added", async function (assert) {
     await visit("/admin");
+    await click(".sidebar-toggle-all-sections");
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-plugins'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_installed_plugins\"]"
+        ".sidebar-section[data-section-name='admin-plugins'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_installed_plugins\"]"
       ),
       "the admin plugin route is added to the plugins section"
     );
@@ -99,6 +88,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
 
   test("Visit reports page", async function (assert) {
     await visit("/admin");
+    await click(".sidebar-toggle-all-sections");
     await click(".sidebar-section-link[data-link-name='admin_all_reports']");
 
     assert.strictEqual(count(".admin-reports-list__report"), 1);
@@ -170,28 +160,28 @@ acceptance("Admin Sidebar - Sections - Plugin API", function (needs) {
 
     assert.ok(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link\"]"
+        ".sidebar-section[data-section-name='admin-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link\"]"
       ),
       "link is appended to the root section"
     );
 
     assert.notOk(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_no_route_or_href\"]"
+        ".sidebar-section[data-section-name='admin-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_no_route_or_href\"]"
       ),
       "invalid link that has no route or href is not appended to the root section"
     );
 
     assert.notOk(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_no_label_or_text\"]"
+        ".sidebar-section[data-section-name='admin-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_no_label_or_text\"]"
       ),
       "invalid link that has no label or text is not appended to the root section"
     );
 
     assert.notOk(
       exists(
-        ".sidebar-section[data-section-name='admin-nav-section-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_invalid_label\"]"
+        ".sidebar-section[data-section-name='admin-root'] .sidebar-section-link-wrapper[data-list-item-name=\"admin_additional_root_test_section_link_invalid_label\"]"
       ),
       "invalid link with an invalid I18n key is not appended to the root section"
     );

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -91,6 +91,10 @@
   .badge-notification {
     vertical-align: text-bottom;
   }
+
+  .sidebar-filter {
+    width: calc(320px - 2 * var(--d-sidebar-row-horizontal-padding));
+  }
 }
 
 .search-menu .menu-panel {
@@ -345,14 +349,12 @@
     font-size: var(--font-down-1);
   }
 
-  .sidebar-filter {
-    width: calc(100% - 2.35rem);
+  .sidebar-admin-header__row {
+    width: calc(320px - 2 * var(--d-sidebar-row-horizontal-padding));
   }
 
   .sidebar-sections {
     &__back-to-forum {
-      margin: 0 var(--d-sidebar-row-horizontal-padding) 0.5em
-        var(--d-sidebar-row-horizontal-padding);
       color: var(--d-sidebar-link-color);
       display: flex;
       align-items: center;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -116,9 +116,8 @@
 
       transition-delay: 0s;
     }
+
     &__back-to-forum {
-      margin: 0 var(--d-sidebar-row-horizontal-padding) 1em
-        var(--d-sidebar-row-horizontal-padding);
       color: var(--d-sidebar-link-color);
       display: flex;
       align-items: center;
@@ -310,8 +309,8 @@
 }
 
 .sidebar-filter {
-  margin: 0 var(--d-sidebar-row-horizontal-padding) 0.5em
-    var(--d-sidebar-row-horizontal-padding);
+  margin-top: 1em;
+  margin-bottom: 1em;
   display: flex;
   border: 1px solid var(--primary-400);
   border-radius: var(--d-input-border-radius);
@@ -319,7 +318,7 @@
   justify-content: space-between;
   background: var(--secondary);
   width: calc(
-    var(--d-sidebar-width) - var(--d-sidebar-row-horizontal-padding) * 2
+    var(--d-sidebar-width) - 2 * var(--d-sidebar-row-horizontal-padding)
   );
 
   &:focus-within {
@@ -336,7 +335,7 @@
     &:focus-within {
       outline: 0;
     }
-    width: calc(100% - 2em);
+    width: 100%;
   }
 
   &__clear {
@@ -346,6 +345,7 @@
     background-color: var(--secondary);
   }
 }
+
 .sidebar-no-results {
   margin: 0.5em var(--d-sidebar-row-horizontal-padding) 0
     var(--d-sidebar-row-horizontal-padding);
@@ -358,4 +358,23 @@
 }
 .sidebar-section-wrapper + .sidebar-no-results {
   display: none;
+}
+
+.sidebar-admin-header__row {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 var(--d-sidebar-row-horizontal-padding) 0
+    var(--d-sidebar-row-horizontal-padding);
+  color: var(--d-sidebar-link-color);
+  width: calc(
+    var(--d-sidebar-width) - 2 * var(--d-sidebar-row-horizontal-padding) + 2px
+  );
+}
+
+.sidebar-toggle-all-sections.btn-transparent {
+  padding-right: 0;
+  color: var(--d-sidebar-link-color);
+  svg {
+    width: 0.75em;
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4817,6 +4817,8 @@ en:
       moderator: "Moderator"
       back_to_forum: "Back to Forum"
       filter_reports: Filter reports
+      expand_all_sections: "Expand all sections"
+      collapse_all_sections: "Collapse all sections"
 
       tags:
         remove_muted_tags_from_latest:

--- a/plugins/chat/spec/system/admin_sidebar_navigation_spec.rb
+++ b/plugins/chat/spec/system/admin_sidebar_navigation_spec.rb
@@ -13,11 +13,13 @@ describe "Admin Revamp | Sidebar Navigation | Plugin Links", type: :system do
 
   it "shows links to enabled plugin admin routes" do
     visit("/admin")
+    sidebar.toggle_all_sections
     expect(sidebar).to have_section_link("Chat", href: "/admin/plugins/chat")
   end
 
   it "does not duplicate links to enabled plugin admin routes when showing and hiding sidebar" do
     visit("/admin")
+    sidebar.toggle_all_sections
     expect(sidebar).to have_section_link("Chat", href: "/admin/plugins/chat", count: 1)
     find(".header-sidebar-toggle").click
     find(".header-sidebar-toggle").click
@@ -68,12 +70,12 @@ describe "Admin Revamp | Sidebar Navigation | Plugin Links", type: :system do
       admin.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => membership.chat_channel.id)
       chat_page.prefers_full_page
       visit("/admin")
-      expect(sidebar).to have_section("admin-nav-section-root")
+      expect(sidebar).to have_section("admin-root")
       chat_page.open_from_header
-      expect(sidebar).to have_no_section("admin-nav-section-root")
+      expect(sidebar).to have_no_section("admin-root")
       chat_page.minimize_full_page
       expect(chat_page).to have_drawer
-      expect(sidebar).to have_section("admin-nav-section-root")
+      expect(sidebar).to have_section("admin-root")
     end
   end
 end

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -40,6 +40,10 @@ module PageObjects
         def custom_section_modal_title
           find("#discourse-modal-title")
         end
+
+        def toggle_all_sections
+          find(".sidebar-toggle-all-sections").click
+        end
       end
     end
   end


### PR DESCRIPTION
By default, admin sections should be collapsed.
In addition, a button to expand/collapse all sections has been added.

https://github.com/discourse/discourse/assets/72780/c8dd400c-f970-4ab7-b89b-883fe8cc7624

<img width="419" alt="Screenshot 2024-03-26 at 3 53 23 PM" src="https://github.com/discourse/discourse/assets/72780/c10fa0f9-d3fb-4cd1-a152-35a624aba36a">

<img width="431" alt="Screenshot 2024-03-26 at 3 58 19 PM" src="https://github.com/discourse/discourse/assets/72780/214d941f-030f-42a0-8220-7be7eddedc48">

