### PR TITLE
DEV: Change QUnit reporters to dot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,12 +213,12 @@ jobs:
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
-        run: QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_PARALLEL=3 bin/rake plugin:qunit['*','1200000']
+        run: QUNIT_REPORTER_FORMAT=dot QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_PARALLEL=3 bin/rake plugin:qunit['*','1200000']
         timeout-minutes: 30
 
       - name: Theme QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'themes'
-        run: DISCOURSE_DEV_DB=discourse_test QUNIT_PARALLEL=3 bin/rake themes:qunit_all_official
+        run: QUNIT_REPORTER_FORMAT=dot DISCOURSE_DEV_DB=discourse_test QUNIT_PARALLEL=3 bin/rake themes:qunit_all_official
         timeout-minutes: 15
 
       - uses: actions/upload-artifact@v4
@@ -382,7 +382,7 @@ jobs:
 
       - name: Core QUnit
         working-directory: ./app/assets/javascripts/discourse
-        run: yarn ember exam --path /tmp/emberbuild --load-balance --parallel=5 --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
+        run: yarn ember exam --path /tmp/emberbuild --load-balance --parallel=5 --reporter=dot --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
         timeout-minutes: 15
 
       - uses: actions/upload-artifact@v4

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -132,6 +132,7 @@ task "qunit:test", %i[timeout qunit_path filter] do |_, args|
       cmd += ["--load-balance", "--parallel", parallel] if parallel
       cmd += ["--filter", filter] if filter
       cmd << "--write-execution-file" if ENV["QUNIT_WRITE_EXECUTION_FILE"]
+      cmd << "--reporter=#{ENV["QUNIT_REPORTER_FORMAT"]}" if ENV["QUNIT_REPORTER_FORMAT"]
     end
 
     # Print out all env for debugging purposes


### PR DESCRIPTION
This is so the CI output on GitHub actions isn't showing
tons and tons of unnecessary log data every time you want
to see the important thing, which is the actual test failure.

![2024-03-26_16-27](https://github.com/discourse/discourse/assets/920448/f72c2b1c-dd5d-490e-8fc0-4ed45ab4aaf6)
![2024-03-26_16-13](https://github.com/discourse/discourse/assets/920448/d8a6b958-e4a4-496e-b28a-be489302dd91)

