### PR TITLE
FEATURE: allow re-scoping chat user search via a plugin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,12 +259,19 @@ class User < ActiveRecord::Base
           )
         end
 
-  scope :human_users, -> { where("users.id > 0") }
+  scope :human_users,
+        ->(allowed_bot_user_ids: nil) do
+          if allowed_bot_user_ids.present?
+            where("users.id > 0 OR users.id IN (?)", allowed_bot_user_ids)
+          else
+            where("users.id > 0")
+          end
+        end
 
   # excluding fake users like the system user or anonymous users
   scope :real,
-        -> do
-          human_users.where(
+        ->(allowed_bot_user_ids: nil) do
+          human_users(allowed_bot_user_ids: allowed_bot_user_ids).where(
             "NOT EXISTS(
                      SELECT 1
                      FROM anonymous_users a

--- a/plugins/chat/app/services/chat/search_chatable.rb
+++ b/plugins/chat/app/services/chat/search_chatable.rb
@@ -103,16 +103,10 @@ module Chat
         user_search = user_search.search
       end
 
-      scopes = DiscoursePluginRegistry.apply_modifier(:chat_search_users_scopes, [:real], guardian)
+      allowed_bot_user_ids =
+        DiscoursePluginRegistry.apply_modifier(:chat_allowed_bot_user_ids, [], guardian)
 
-      scopes.each do |scope, args, kwargs|
-        kwargs ||= {}
-        args ||= []
-
-        # guard so plugins do not break search
-        user_search = user_search.send(scope, *args, **kwargs) if user_search.respond_to?(scope)
-      end
-
+      user_search = user_search.real(allowed_bot_user_ids: allowed_bot_user_ids)
       user_search = user_search.includes(:user_option)
 
       if context.excluded_memberships_channel_id

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe Chat::SearchChatable do
 
           expect(result.users).to_not include(current_user)
         end
+
+        context "when chat_allowed_bot_user_ids modifier exists" do
+          fab!(:bot_1) { Fabricate(:user, id: -500) }
+          fab!(:bot_2) { Fabricate(:user, id: -501) }
+
+          it "alters the users returned" do
+            modifier_block = Proc.new { [bot_2.id] }
+            plugin_instance = Plugin::Instance.new
+            plugin_instance.register_modifier(:chat_allowed_bot_user_ids, &modifier_block)
+
+            expect(result.users).to_not include(bot_1)
+            expect(result.users).to include(bot_2)
+          ensure
+            DiscoursePluginRegistry.unregister_modifier(
+              plugin_instance,
+              :chat_allowed_bot_user_ids,
+              &modifier_block
+            )
+          end
+        end
       end
 
       context "when not including users" do

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Chat::SearchChatable do
 
             expect(result.users).to_not include(bot_1)
             expect(result.users).to include(bot_2)
+            expect(result.users).to include(current_user, sam, charlie, alain)
           ensure
             DiscoursePluginRegistry.unregister_modifier(
               plugin_instance,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1781,6 +1781,17 @@ RSpec.describe User do
     end
   end
 
+  describe "real users" do
+    it "should find system user if you allow it" do
+      ids =
+        User
+          .real(allowed_bot_user_ids: [Discourse.system_user.id])
+          .where(id: Discourse.system_user.id)
+          .pluck(:id)
+      expect(ids).to eq([Discourse.system_user.id])
+    end
+  end
+
   describe "#purge_unactivated" do
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:unactivated) { Fabricate(:user, active: false) }


### PR DESCRIPTION
This enables the following in Discourse AI

```ruby
 plugin.register_modifier(:chat_allowed_bot_user_ids) do |user_ids, guardian|
  if guardian.user
    mentionables = AiPersona.mentionables(user: guardian.user)
    allowed_bot_ids = mentionables.map { |mentionable| mentionable[:user_id] }
    user_ids.concat(allowed_bot_ids)
  end
  user_ids
end
```

some bots that are id < 0 need to be discoverable in search otherwise people can not talk to them. 
