### PR TITLE
DEV: Silence the output of migration specs

### DIFF
--- a/spec/generator/site_setting_move_to_groups_migrations_generator_spec.rb
+++ b/spec/generator/site_setting_move_to_groups_migrations_generator_spec.rb
@@ -8,13 +8,15 @@ RSpec.describe SiteSettingMoveToGroupsMigrationGenerator, type: :generator do
   it "generates the correct migration for TrustLevelSetting" do
     freeze_time DateTime.parse("2010-01-01 12:00")
 
-    described_class.start(
-      %w[min_trust_level_to_allow_invite allow_invite_groups],
-      destination_root: "#{Rails.root}/tmp",
-    )
+    silence_stdout do
+      described_class.start(
+        %w[min_trust_level_to_allow_invite allow_invite_groups],
+        destination_root: "#{Rails.root}/tmp",
+      )
+    end
+
     file_path =
       "#{Rails.root}/tmp/db/migrate/20100101120000_fill_allow_invite_groups_based_on_deprecated_setting.rb"
-
     expected_content = <<~EXPECTED_CONTENT
       # frozen_string_literal: true
 
@@ -50,13 +52,15 @@ RSpec.describe SiteSettingMoveToGroupsMigrationGenerator, type: :generator do
   it "generates the correct migration for TrustLevelAndStaffSetting" do
     freeze_time DateTime.parse("2010-01-01 12:00")
 
-    described_class.start(
-      %w[min_trust_level_to_allow_invite_tl_and_staff allow_invite_groups],
-      destination_root: "#{Rails.root}/tmp",
-    )
+    silence_stdout do
+      described_class.start(
+        %w[min_trust_level_to_allow_invite_tl_and_staff allow_invite_groups],
+        destination_root: "#{Rails.root}/tmp",
+      )
+    end
+
     file_path =
       "#{Rails.root}/tmp/db/migrate/20100101120000_fill_allow_invite_groups_based_on_deprecated_setting.rb"
-
     expected_content = <<~EXPECTED_CONTENT
       # frozen_string_literal: true
 
@@ -106,18 +110,24 @@ RSpec.describe SiteSettingMoveToGroupsMigrationGenerator, type: :generator do
   end
 
   it "raises an error when old name is incorrect" do
-    expect { described_class.start(%w[wrong_name allow_invite_groups]) }.to raise_error(
-      ArgumentError,
-    )
+    silence_stdout do
+      expect { described_class.start(%w[wrong_name allow_invite_groups]) }.to raise_error(
+        ArgumentError,
+      )
+    end
   end
 
   it "raises an error when new name is incorrect" do
-    expect { described_class.start(%w[min_trust_level_to_allow_invite wrong_name]) }.to raise_error(
-      ArgumentError,
-    )
+    silence_stdout do
+      expect {
+        described_class.start(%w[min_trust_level_to_allow_invite wrong_name])
+      }.to raise_error(ArgumentError)
+    end
   end
 
   it "raises an error when old setting is incorrect type" do
-    expect { described_class.start(%w[title allow_invite_groups]) }.to raise_error(ArgumentError)
+    silence_stdout do
+      expect { described_class.start(%w[title allow_invite_groups]) }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/generator/site_setting_rename_migrations_generator_spec.rb
+++ b/spec/generator/site_setting_rename_migrations_generator_spec.rb
@@ -7,9 +7,15 @@ require "generators/site_setting_rename_migration/site_setting_rename_migration_
 RSpec.describe SiteSettingRenameMigrationGenerator, type: :generator do
   it "generates the correct migration" do
     freeze_time DateTime.parse("2010-01-01 12:00")
-    described_class.start(%w[site_description contact_email], destination_root: "#{Rails.root}/tmp")
-    file_path = "#{Rails.root}/tmp/db/migrate/20100101120000_rename_site_description_setting.rb"
 
+    silence_stdout do
+      described_class.start(
+        %w[site_description contact_email],
+        destination_root: "#{Rails.root}/tmp",
+      )
+    end
+
+    file_path = "#{Rails.root}/tmp/db/migrate/20100101120000_rename_site_description_setting.rb"
     expected_content = <<~EXPECTED_CONTENT
       # frozen_string_literal: true
 
@@ -29,10 +35,16 @@ RSpec.describe SiteSettingRenameMigrationGenerator, type: :generator do
   end
 
   it "raises an error when old name is incorrect" do
-    expect { described_class.start(%w[wrong_name contact_email]) }.to raise_error(ArgumentError)
+    silence_stdout do
+      expect { described_class.start(%w[wrong_name contact_email]) }.to raise_error(ArgumentError)
+    end
   end
 
   it "raises an error when new name is incorrect" do
-    expect { described_class.start(%w[site_description wrong_name]) }.to raise_error(ArgumentError)
+    silence_stdout do
+      expect { described_class.start(%w[site_description wrong_name]) }.to raise_error(
+        ArgumentError,
+      )
+    end
   end
 end

--- a/spec/migrations/update_category_setting_approval_values_spec.rb
+++ b/spec/migrations/update_category_setting_approval_values_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe UpdateCategorySettingApprovalValues do
       end
 
       it "backfills with false (new default)" do
-        expect { described_class.new.up }.to change { category.reload.require_topic_approval }.from(
-          nil,
-        ).to(false)
+        silence_stdout do
+          expect { described_class.new.up }.to change {
+            category.reload.require_topic_approval
+          }.from(nil).to(false)
+        end
       end
     end
 
@@ -29,9 +31,11 @@ RSpec.describe UpdateCategorySettingApprovalValues do
       let(:category) { Fabricate(:category) }
 
       it "backfills with the custom field value" do
-        expect { described_class.new.up }.to change { category.reload.category_setting }.from(
-          nil,
-        ).to(have_attributes(require_topic_approval: true))
+        silence_stdout do
+          expect { described_class.new.up }.to change { category.reload.category_setting }.from(
+            nil,
+          ).to(have_attributes(require_topic_approval: true))
+        end
       end
     end
 
@@ -45,9 +49,11 @@ RSpec.describe UpdateCategorySettingApprovalValues do
       end
 
       it "backfills with the custom field value" do
-        expect { described_class.new.up }.to change {
-          category.category_setting.reload.require_topic_approval
-        }.from(false).to(true)
+        silence_stdout do
+          expect { described_class.new.up }.to change {
+            category.category_setting.reload.require_topic_approval
+          }.from(false).to(true)
+        end
       end
     end
   end


### PR DESCRIPTION
(plus fix the typo in the filename)