### PR TITLE
DEV: Use Nimbus font instead of Helvetica

### DIFF
--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -80,11 +80,11 @@ class LetterAvatar
         -fill
         #FFFFFFCC
         -font
-        Helvetica
+        NimbusSans-Regular
         -gravity
         Center
         -annotate
-        -0+26
+        -0+34
         #{letter}
         -depth
         8


### PR DESCRIPTION
To generate letter avatars, we’re currently using the ImageMagick suite and we’re using the Helvetica font family. However, that font isn’t shipped anymore in the latest stable version of Debian (Bookworm). Instead it seems to have been replaced by the Nimbus font. The rendering is extremely similar (not to say it’s the same thing) so it shouldn’t be noticeable.

That change is necessary for us to upgrade our docker images to Debian Bookworm.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
