### PR TITLE
FEATURE: Add page number to page titles for crawlers

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -239,7 +239,10 @@ class TopicView
       else
         title += I18n.t("inline_oneboxer.topic_page_title_post_number", post_number: @post_number)
       end
+    elsif @page > 1
+      title += " - #{I18n.t("page_num", num: @page)}"
     end
+
     if SiteSetting.topic_page_title_includes_category
       if @topic.category_id != SiteSetting.uncategorized_category_id && @topic.category_id &&
            @topic.category

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -797,6 +797,18 @@ RSpec.describe TopicView do
       end
     end
 
+    context "when a page number is specified" do
+      it "does not include the page number for first page" do
+        title = TopicView.new(topic.id, admin, page: 1).page_title
+        expect(title).to eq("#{topic.title}")
+      end
+
+      it "includes page number for subsequent pages" do
+        title = TopicView.new(topic.id, admin, page: 2).page_title
+        expect(title).to eq("#{topic.title} - #{I18n.t("page_num", num: 2)}")
+      end
+    end
+
     context "with uncategorized topic" do
       context "when topic_page_title_includes_category is false" do
         before { SiteSetting.topic_page_title_includes_category = false }


### PR DESCRIPTION
At the moment, all topic `?page=` views are served with exactly identical page titles. If you search for something which is mentioned many times in the same Discourse topic, this makes for some very hard-to-understand search results! All the result titles are exactly the same, with no indication of why there are multiple results showing.

This commit adds a `- Page #` suffix to the titles in this situation. This lines up with our existing strategy for topic-list pagination.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
