### PR TITLE
FIX: correctly pass down calendar options

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/download-calendar.js
+++ b/app/assets/javascripts/discourse/app/components/modal/download-calendar.js
@@ -4,7 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { downloadGoogle, downloadIcs } from "discourse/lib/download-calendar";
 
-export default class downloadCalendar extends Component {
+export default class DownloadCalendar extends Component {
   @service currentUser;
 
   @tracked selectedCalendar = "ics";
@@ -23,13 +23,19 @@ export default class downloadCalendar extends Component {
       downloadIcs(
         this.args.model.calendar.title,
         this.args.model.calendar.dates,
-        this.args.model.calendar.recurrenceRule
+        {
+          recurrenceRule: this.args.model.calendar.recurrenceRule,
+        }
       );
     } else {
       downloadGoogle(
         this.args.model.calendar.title,
         this.args.model.calendar.dates,
-        this.args.model.calendar.recurrenceRule
+        {
+          recurrenceRule: this.args.model.calendar.recurrenceRule,
+          location: this.args.model.calendar.location,
+          details: this.args.model.calendar.details,
+        }
       );
     }
     this.args.closeModal();


### PR DESCRIPTION
Prior to this fix the options were not passed down when the user had no default calendar.

No test as it's mostly an interaction between discourse-calendar and core which is hard to test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
