### PR TITLE
PERF: Improve performance of `most_replied_to_users`

### DIFF
--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -81,6 +81,25 @@ class UserSummary
 
   REPLY_ACTIONS ||= [UserAction::RESPONSE, UserAction::QUOTE, UserAction::MENTION]
 
+  # new method
+  # def most_replied_to_users
+  #   replied_users = {}
+  
+  #   post_query
+  #     .joins("JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number")
+  #     .joins("JOIN topics ON replies.topic_id = topics.id AND topics.archetype <> 'private_message'")
+  #     .joins("AND replies.post_type IN (#{Topic.visible_post_types(@guardian&.user, include_moderator_actions: false).join(',')})")
+  #     .where("replies.user_id <> ?", @user.id)
+  #     .group("replies.user_id")
+  #     .order("COUNT(*) DESC")
+  #     .limit(MAX_SUMMARY_RESULTS)
+  #     .pluck("replies.user_id, COUNT(*)")
+  #     .each { |r| replied_users[r[0]] = r[1] }
+  
+  #   user_counts(replied_users)
+  # end
+
+  # old method
   def most_replied_to_users
     replied_users = {}
 

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -81,37 +81,24 @@ class UserSummary
 
   REPLY_ACTIONS ||= [UserAction::RESPONSE, UserAction::QUOTE, UserAction::MENTION]
 
-  # new method
-  # def most_replied_to_users
-  #   replied_users = {}
-  
-  #   post_query
-  #     .joins("JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number")
-  #     .joins("JOIN topics ON replies.topic_id = topics.id AND topics.archetype <> 'private_message'")
-  #     .joins("AND replies.post_type IN (#{Topic.visible_post_types(@guardian&.user, include_moderator_actions: false).join(',')})")
-  #     .where("replies.user_id <> ?", @user.id)
-  #     .group("replies.user_id")
-  #     .order("COUNT(*) DESC")
-  #     .limit(MAX_SUMMARY_RESULTS)
-  #     .pluck("replies.user_id, COUNT(*)")
-  #     .each { |r| replied_users[r[0]] = r[1] }
-  
-  #   user_counts(replied_users)
-  # end
-
-  # old method
   def most_replied_to_users
     replied_users = {}
 
     post_query
       .joins(
-        "JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number",
+        "JOIN posts replies ON posts.topic_id = replies.topic_id AND replies.reply_to_post_number = posts.post_number",
       )
-      .where("replies.user_id <> ?", @user.id)
-      .group("replies.user_id")
+      .joins(
+        "JOIN topics ON replies.topic_id = topics.id AND topics.archetype <> 'private_message'",
+      )
+      .joins(
+        "AND replies.post_type IN (#{Topic.visible_post_types(@guardian&.user, include_moderator_actions: false).join(",")})",
+      )
+      .where("replies.user_id <> posts.user_id")
+      .group("posts.user_id")
       .order("COUNT(*) DESC")
       .limit(MAX_SUMMARY_RESULTS)
-      .pluck("replies.user_id, COUNT(*)")
+      .pluck("posts.user_id, COUNT(*)")
       .each { |r| replied_users[r[0]] = r[1] }
 
     user_counts(replied_users)

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -86,19 +86,19 @@ class UserSummary
 
     post_query
       .joins(
-        "JOIN posts replies ON posts.topic_id = replies.topic_id AND replies.reply_to_post_number = posts.post_number",
+        "JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number",
       )
       .joins(
         "JOIN topics ON replies.topic_id = topics.id AND topics.archetype <> 'private_message'",
       )
       .joins(
-        "AND replies.post_type IN (#{Topic.visible_post_types(@guardian&.user, include_moderator_actions: false).join(",")})",
+        "AND replies.post_type IN (#{Topic.visible_post_types(@user, include_moderator_actions: false).join(",")})",
       )
       .where("replies.user_id <> posts.user_id")
-      .group("posts.user_id")
+      .group("replies.user_id")
       .order("COUNT(*) DESC")
       .limit(MAX_SUMMARY_RESULTS)
-      .pluck("posts.user_id, COUNT(*)")
+      .pluck("replies.user_id, COUNT(*)")
       .each { |r| replied_users[r[0]] = r[1] }
 
     user_counts(replied_users)

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -72,6 +72,8 @@ class PostCreator
         (opts[:embed_url].present? && SiteSetting.embed_unlisted?)
     )
 
+    puts "opts[:topic_id]: #{opts[:topic_id]}"
+    puts "opts[:reply]: #{opts[:reply_to_post_number]}"
     opts.delete(:reply_to_post_number) unless opts[:topic_id]
   end
 

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -72,8 +72,6 @@ class PostCreator
         (opts[:embed_url].present? && SiteSetting.embed_unlisted?)
     )
 
-    puts "opts[:topic_id]: #{opts[:topic_id]}"
-    puts "opts[:reply]: #{opts[:reply_to_post_number]}"
     opts.delete(:reply_to_post_number) unless opts[:topic_id]
   end
 

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -92,20 +92,15 @@ RSpec.describe UserSummary do
   end
 
   it "returns the most replied to users" do
-    topic = create_post(visible: true).topic
-    user = topic.user
-    reply = create_post(topic: topic, visible: true)
-    topic.posts.first.update!(post_replies: [PostReply.new(reply_post_id: reply.id)])
-    reply.update!(
-      raw: "show me what you can do",
-      reply_to_post_number: topic.posts.first.post_number,
-    )
+    topic = create_post.topic
+    post = create_post(topic: topic, user: topic.user)
+    reply = create_post(topic: topic, reply_to_post_number: post.post_number)
 
-    summary = UserSummary.new(user, Guardian.new(user))
-    most_replied_to_users = summary.most_replied_to_users
+    user_summary = UserSummary.new(topic.user, Guardian.new(topic.user))
+    most_replied_to_users = user_summary.most_replied_to_users
 
     expect(most_replied_to_users).to eq({
-      user.id => 1,
+      topic.user.id => 1,
     })
-  end
+end
 end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -99,8 +99,11 @@ RSpec.describe UserSummary do
     user_summary = UserSummary.new(topic.user, Guardian.new(topic.user))
     most_replied_to_users = user_summary.most_replied_to_users
 
-    expect(most_replied_to_users).to eq({
-      topic.user.id => 1,
-    })
-end
+    counts =
+      most_replied_to_users
+        .index_by { |user_with_count| user_with_count[:id] }
+        .transform_values { |c| c[:count] }
+
+    expect(counts).to eq({ topic.user.id => 1 })
+  end
 end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -90,4 +90,22 @@ RSpec.describe UserSummary do
     expect(summary.top_categories.first[:topic_count]).to eq(1)
     expect(summary.top_categories.first[:post_count]).to eq(1)
   end
+
+  it "returns the most replied to users" do
+    topic = create_post(visible: true).topic
+    user = topic.user
+    reply = create_post(topic: topic, visible: true)
+    topic.posts.first.update!(post_replies: [PostReply.new(reply_post_id: reply.id)])
+    reply.update!(
+      raw: "show me what you can do",
+      reply_to_post_number: topic.posts.first.post_number,
+    )
+
+    summary = UserSummary.new(user, Guardian.new(user))
+    most_replied_to_users = summary.most_replied_to_users
+
+    expect(most_replied_to_users).to eq({
+      user.id => 1,
+    })
+  end
 end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -92,11 +92,36 @@ RSpec.describe UserSummary do
   end
 
   it "returns the most replied to users" do
-    topic = create_post.topic
-    post = create_post(topic: topic, user: topic.user)
-    reply = create_post(topic: topic, reply_to_post_number: post.post_number)
+    topic1 = create_post.topic
+    topic1_post = create_post(topic: topic1)
+    topic1_reply =
+      create_post(topic: topic1, reply_to_post_number: topic1_post.post_number, user: topic1.user)
 
-    user_summary = UserSummary.new(topic.user, Guardian.new(topic.user))
+    # Create a second topic by the same user as topic1
+    topic2 = create_post(user: topic1.user).topic
+    topic2_post = create_post(topic: topic2)
+    topic2_reply =
+      create_post(topic: topic2, reply_to_post_number: topic2_post.post_number, user: topic2.user)
+
+    # Don't include replies to whispers
+    topic3 = create_post(user: topic1.user).topic
+    topic3_post = create_post(topic: topic3, post_type: Post.types[:whisper])
+    topic3_reply =
+      create_post(topic: topic3, reply_to_post_number: topic3_post.post_number, user: topic3.user)
+
+    # Don't include replies to private messages
+    replied_to_user = Fabricate(:user)
+    topic4 =
+      create_post(
+        user: topic1.user,
+        archetype: Archetype.private_message,
+        target_usernames: [replied_to_user.username],
+      ).topic
+    topic4_post = create_post(topic: topic4, user: replied_to_user)
+    topic4_reply =
+      create_post(topic: topic4, reply_to_post_number: topic4_post.post_number, user: topic4.user)
+
+    user_summary = UserSummary.new(topic1.user, Guardian.new(topic1.user))
     most_replied_to_users = user_summary.most_replied_to_users
 
     counts =
@@ -104,6 +129,6 @@ RSpec.describe UserSummary do
         .index_by { |user_with_count| user_with_count[:id] }
         .transform_values { |c| c[:count] }
 
-    expect(counts).to eq({ topic.user.id => 1 })
+    expect(counts).to eq({ topic1_post.user_id => 1, topic2_post.user_id => 1 })
   end
 end


### PR DESCRIPTION
This PR improves the performance of the `most_replied_to_users` method on the `UserSummary` model.

### Old Query
```ruby
    post_query
      .joins(
        "JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number",
      )
      # We are removing replies by @user, but we can simplify this by getting the using the user_id on the posts.
      .where("replies.user_id <> ?", @user.id)
      .group("replies.user_id")
      .order("COUNT(*) DESC")
      .limit(MAX_SUMMARY_RESULTS)
      .pluck("replies.user_id, COUNT(*)")
      .each { |r| replied_users[r[0]] = r[1] }
```
 
### Old Query with corrections

```ruby
post_query
  .joins(
    "JOIN posts replies ON posts.topic_id = replies.topic_id AND replies.reply_to_post_number = posts.post_number",
  )
  # Remove replies by @user but instead look on loaded posts (we do this so we don't count self replies)
  .where("replies.user_id <> posts.user_id")
  .group("replies.user_id")
  .order("COUNT(*) DESC")
  .limit(MAX_SUMMARY_RESULTS)
  .pluck("replies.user_id, COUNT(*)")
  .each { |r| replied_users[r[0]] = r[1] }
```

### New Query
```ruby
    post_query
      .joins(
        "JOIN posts replies ON posts.topic_id = replies.topic_id AND posts.reply_to_post_number = replies.post_number",
      )
      # Only include regular posts in our joins, this makes sure we don't have the bloat of loading private messages
      .joins(
        "JOIN topics ON replies.topic_id = topics.id AND topics.archetype <> 'private_message'",
      )
      # Only include visible post types, so exclude posts like whispers, etc
      .joins(
        "AND replies.post_type IN (#{Topic.visible_post_types(@user, include_moderator_actions: false).join(",")})",
      )
      .where("replies.user_id <> posts.user_id")
      .group("replies.user_id")
      .order("COUNT(*) DESC")
      .limit(MAX_SUMMARY_RESULTS)
      .pluck("replies.user_id, COUNT(*)")
      .each { |r| replied_users[r[0]] = r[1] }
```

# Conclusion

`most_replied_to_users` was untested, so I introduced a test for the logic, and have confirmed that it passes on both the new query **AND** the old query. 

Thank you @danielwaterworth for the debugging assistance.