### PR TITLE
DEV: Set category on embeddable-host component instead of rest object

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embeddable-host.hbs
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.hbs
@@ -53,7 +53,7 @@
   </td>
   <td>
     <div class="label">{{i18n "admin.embedding.category"}}</div>
-    {{category-badge this.host.category allowUncategorized=true}}
+    {{category-badge this.category allowUncategorized=true}}
   </td>
   <td class="controls">
     <DButton @icon="pencil-alt" @action={{this.edit}} />

--- a/app/assets/javascripts/admin/addon/components/embeddable-host.js
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.js
@@ -28,7 +28,7 @@ export default class EmbeddableHost extends Component.extend(
     const categoryId = host.category_id || this.site.uncategorized_category_id;
     const category = Category.findById(categoryId);
 
-    host.set("category", category);
+    this.set("category", category);
   }
 
   @discourseComputed("buffered.host", "host.isSaving")
@@ -60,7 +60,7 @@ export default class EmbeddableHost extends Component.extend(
     host
       .save(props)
       .then(() => {
-        host.set("category", Category.findById(this.categoryId));
+        this.set("category", Category.findById(this.categoryId));
         this.set("editToggled", false);
       })
       .catch(popupAjaxError);


### PR DESCRIPTION
The rest object doesn't need the whole serialized category.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
