### PR TITLE
DEV: Add Google-InspectionTool as a crawler user agent

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1928,7 +1928,7 @@ security:
     list_type: compact
   crawler_user_agents:
     hidden: true
-    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse"
+    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse|google-inspectiontool"
     type: list
     list_type: compact
   browser_update_user_agents:


### PR DESCRIPTION
This user-agent is sent when URLs are inspected via the UI of Google's search console. It makes sense for us to serve it the same content as other bots, including GoogleBot.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
