### PR TITLE
FIX: Add content-type header to rate limiter error

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -218,6 +218,7 @@ class Middleware::RequestTracker
         Error code: #{error_code}.
       TEXT
       headers = {
+        "Content-Type" => "text/plain",
         "Retry-After" => available_in.to_s,
         "Discourse-Rate-Limit-Error-Code" => error_code,
       }


### PR DESCRIPTION
It's best to always set a content-type header and one was missing here.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
