### PR TITLE
DEV: Better error message when user is not allowed to user tags

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5142,6 +5142,7 @@ en:
     limited_to_one_tag_from_group: "The tags %{tags} cannot be used simultaneously. Please include only one of them."
     invalid_target_tag: "cannot be a synonym of a synonym"
     synonyms_exist: "is not allowed while synonyms exist"
+    user_not_permitted: "You're not allowed to tag topics"
   rss_by_tag: "Topics tagged %{tag}"
 
   finish_installation:

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -214,9 +214,11 @@ module DiscourseTagging
         new_tag_names: topic.tags.map(&:name),
       )
 
-      return true
+      true
+    else
+      topic.errors.add(:base, I18n.t("tags.user_not_permitted"))
+      false
     end
-    false
   end
 
   def self.validate_category_tags(guardian, model, category, tags = [])


### PR DESCRIPTION
When a topic fails to be created due to the user not having permission to add tags to the topic, the error message that you get is `There was an error tagging the topic` which is very generic and doesn't explain where/what the problem is. This PR adds a clearer error message for this scenario.