### PR TITLE
DEV: allow developers to use HTTPS if they wish

### DIFF
--- a/config/initializers/100-session_store.rb
+++ b/config/initializers/100-session_store.rb
@@ -16,7 +16,7 @@ Rails.application.config.session_store(
 )
 
 Rails.application.config.to_prepare do
-  if Rails.env.development? && SiteSetting.force_https
+  if Rails.env.development? && SiteSetting.force_https && !ENV["DISCOURSE_DEV_ALLOW_HTTPS"]
     STDERR.puts
     STDERR.puts "WARNING: force_https is enabled in dev"
     STDERR.puts "It is very unlikely you are running HTTPS in dev."


### PR DESCRIPTION
Warning is getting tiring on local and I have https://l.discourse working just fine (tm)
