### PR TITLE
PERF: Replace posts reply_to_post_number index

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1353,10 +1353,10 @@ end
 #  index_posts_on_id_and_baked_version                    (id DESC,baked_version) WHERE (deleted_at IS NULL)
 #  index_posts_on_id_topic_id_where_not_deleted_or_empty  (id,topic_id) WHERE ((deleted_at IS NULL) AND (raw <> ''::text))
 #  index_posts_on_image_upload_id                         (image_upload_id)
-#  index_posts_on_reply_to_post_number                    (reply_to_post_number)
 #  index_posts_on_topic_id_and_created_at                 (topic_id,created_at)
 #  index_posts_on_topic_id_and_percent_rank               (topic_id,percent_rank)
 #  index_posts_on_topic_id_and_post_number                (topic_id,post_number) UNIQUE
+#  index_posts_on_topic_id_and_reply_to_post_number       (topic_id,reply_to_post_number)
 #  index_posts_on_topic_id_and_sort_order                 (topic_id,sort_order)
 #  index_posts_on_user_id_and_created_at                  (user_id,created_at)
 #  index_posts_user_and_likes                             (user_id,like_count DESC,created_at DESC) WHERE (post_number > 1)

--- a/db/migrate/20240327000440_replace_post_reply_index.rb
+++ b/db/migrate/20240327000440_replace_post_reply_index.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ReplacePostReplyIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS "index_posts_on_topic_id_and_reply_to_post_number"
+    SQL
+
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "index_posts_on_topic_id_and_reply_to_post_number"
+      ON "posts" ("topic_id", "reply_to_post_number")
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS "index_posts_on_reply_to_post_number"
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS "index_posts_on_reply_to_post_number"
+    SQL
+
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "index_posts_on_reply_to_post_number"
+      ON "posts" ("reply_to_post_number")
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS "index_posts_on_topic_id_and_reply_to_post_number"
+    SQL
+  end
+end


### PR DESCRIPTION
post_number is a sequence per topic, so it doesn't make sense to have an index on only reply_to_post_number without also including the topic_id.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
