### PR TITLE
DEV: Add the ability for problem checks to specify "max blips"

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -21,6 +21,13 @@ class ProblemCheck
   #
   config_accessor :retry_after, default: 30.seconds, instance_writer: false
 
+  # How many consecutive times the check can fail without notifying admins.
+  # This can be used to give some leeway for transient problems. Note that
+  # retries are not counted. So a check that ultimately fails after e.g. two
+  # retries is counted as one "blip".
+  #
+  config_accessor :max_blips, default: 0, instance_writer: false
+
   def self.[](key)
     key = key.to_sym
 

--- a/app/models/problem_check_tracker.rb
+++ b/app/models/problem_check_tracker.rb
@@ -27,6 +27,12 @@ class ProblemCheckTracker < ActiveRecord::Base
   def check
     ProblemCheck[identifier]
   end
+
+  private
+
+  def sound_the_alarm?
+    blips > check.max_blips
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
### What is this change?

This was originally introduced in https://github.com/discourse/discourse/pull/26071, but that PR was closed, because the requirements changed. This PR lifts only the relevant parts, since they are a prerequisite for the new admin notice system.