### PR TITLE
DEV: Extract the query code from CategoryList.find_relevant_topics into a separate method

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -70,7 +70,7 @@ class CategoryList
 
   private
 
-  def find_relevant_topics
+  def all_relevant_topics
     @all_topics =
       Topic
         .secured(@guardian)
@@ -104,10 +104,12 @@ class CategoryList
     end
 
     @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user).includes(:last_poster)
+  end
 
+  def find_relevant_topics
     featured_topics_by_category_id = Hash.new { |h, k| h[k] = [] }
 
-    @all_topics.each do |t|
+    all_relevant_topics.each do |t|
       # hint for the serializer
       t.include_last_poster = true
       t.dismissed = dismissed_topic?(t)

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -70,7 +70,7 @@ class CategoryList
 
   private
 
-  def all_relevant_topics
+  def relevant_topics_query
     @all_topics =
       Topic
         .secured(@guardian)
@@ -109,7 +109,7 @@ class CategoryList
   def find_relevant_topics
     featured_topics_by_category_id = Hash.new { |h, k| h[k] = [] }
 
-    all_relevant_topics.each do |t|
+    relevant_topics_query.each do |t|
       # hint for the serializer
       t.include_last_poster = true
       t.dismissed = dismissed_topic?(t)


### PR DESCRIPTION
## Why this change?
The previous implementation of the method generated the query to find the relevant topics and iterated over the results processing them.

This behavior made difficult reusing or changing the query logic in classes extending CategoryList.

This commit extracts the query logic into another method called `all_relevant_topics` which can be reused or overwritten in descendant classes.

The commit does not add specs because no behavior was changed. The refactor only extracted the logic into another method. The existing tests cover the changes.
