### PR TITLE
FEATURE: enable new admin sidebar by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2345,7 +2345,7 @@ developer:
   admin_sidebar_enabled_groups:
     type: group_list
     list_type: compact
-    default: ""
+    default: "1"
     allow_any: false
     refresh: true
   lazy_load_categories_groups:

--- a/db/migrate/20240327043323_disable_admin_sidebar_for_existing_sites.rb
+++ b/db/migrate/20240327043323_disable_admin_sidebar_for_existing_sites.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetAdminSidebarEnabledGroups < ActiveRecord::Migration[7.0]
+class DisableAdminSidebarForExistingSites < ActiveRecord::Migration[7.0]
   def up
     # keep old admin menu for existing sites
     execute <<~SQL if Migration::Helpers.existing_site?

--- a/db/migrate/20240327043323_set_admin_sidebar_enabled_groups.rb
+++ b/db/migrate/20240327043323_set_admin_sidebar_enabled_groups.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SetAdminSidebarEnabledGroups < ActiveRecord::Migration[7.0]
+  def up
+    # keep old admin menu for existing sites
+    execute <<~SQL if Migration::Helpers.existing_site?
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES('admin_sidebar_enabled_groups', 20, '-1', NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
By default, enable the new admin sidebar.
In addition, migration was created for old sites to keep the old admin panel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
