### PR TITLE
FIX: allow direct message when max dm users set to 1

### DIFF
--- a/plugins/chat/app/services/chat/create_direct_message_channel.rb
+++ b/plugins/chat/app/services/chat/create_direct_message_channel.rb
@@ -33,7 +33,6 @@ module Chat
            class_name: Chat::DirectMessageChannel::CanCommunicateAllPartiesPolicy
     model :direct_message, :fetch_or_create_direct_message
     model :channel, :fetch_or_create_channel
-    step :validate_user_count
     step :set_optional_name
     step :update_memberships
     step :recompute_users_count
@@ -71,12 +70,6 @@ module Chat
 
     def fetch_user_comm_screener(target_users:, guardian:)
       UserCommScreener.new(acting_user: guardian.user, target_user_ids: target_users.map(&:id))
-    end
-
-    def validate_user_count(target_users:)
-      if target_users.length > SiteSetting.chat_max_direct_message_users
-        fail!("should have less than #{SiteSetting.chat_max_direct_message_users} elements")
-      end
     end
 
     def actor_allows_dms(user_comm_screener:)

--- a/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe Chat::CreateDirectMessageChannel do
           expect { result }.to change { Chat::UserChatChannelMembership.count }.by(4)
           expect(result).to be_a_success
         end
+
+        it "succeeds when target_usernames is equal to max direct users" do
+          SiteSetting.chat_max_direct_message_users = 2
+
+          expect { result }.to change { Chat::UserChatChannelMembership.count }.by(3) # current user + user_1 + user_2
+          expect(result).to be_a_success
+        end
       end
 
       context "when there is an existing direct message channel for the target users" do
@@ -165,9 +172,9 @@ RSpec.describe Chat::CreateDirectMessageChannel do
     end
 
     context "when target_usernames exceeds chat_max_direct_message_users" do
-      before { SiteSetting.chat_max_direct_message_users = 2 }
+      before { SiteSetting.chat_max_direct_message_users = 1 }
 
-      it { is_expected.to fail_a_step(:validate_user_count) }
+      it { is_expected.to fail_a_policy(:satisfies_dms_max_users_limit) }
     end
 
     context "when the current user cannot make direct messages" do


### PR DESCRIPTION
#### Why this change?

When the site setting for `chat_max_direct_message_users` is set to 1, it is expected that users can have a 1:1 chat with other users. However, since the current user is counting as 1 user it makes starting a new chat impossible.

This change hands this validation off to `DirectMessageChannel::MaxUsersExcessPolicy` which handles the count correctly by filtering out the current user.