### PR TITLE
DEV: Always eager load problem checks

### DIFF
--- a/config/initializers/000-zeitwerk.rb
+++ b/config/initializers/000-zeitwerk.rb
@@ -54,3 +54,12 @@ Rails.autoloaders.main.ignore(
   "lib/i18n/backend",
   "lib/unicorn_logstash_patch.rb",
 )
+
+# Always load problem checks. Problem checks are registered when their classes are
+# loaded, which means if we're not eager loading, the registry would be empty.
+#
+if !Rails.application.config.eager_load
+  Rails.application.config.to_prepare do
+    Rails.autoloaders.main.eager_load_dir("#{Rails.root}/app/services/problem_check")
+  end
+end


### PR DESCRIPTION
### What is this change?

Currently you need to use `DISCOURSE_ZEITWERK_EAGER_LOAD=1` to have the problem checks registered when doing local development. (This is because they get registered when `ProblemCheck` is subclassed.) But this is pretty bad DX, so this PR adds a condition to the Zeitwerk initializer telling it to always eager load the problem check classes.