### PR TITLE
DEV: adds a has-preloaded-chat-channels body-class

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/above-site-header/chat-body-class.gjs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/above-site-header/chat-body-class.gjs
@@ -1,0 +1,13 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import bodyClass from "discourse/helpers/body-class";
+
+export default class ChatBodyClass extends Component {
+  @service chatStateManager;
+
+  <template>
+    {{#if this.chatStateManager.hasPreloadedChannels}}
+      {{bodyClass "has-preloaded-chat-channels"}}
+    {{/if}}
+  </template>
+}

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -52,9 +52,9 @@ module PageObjects
         drawer?(expectation: false, channel_id: channel_id, expanded: expanded)
       end
 
-      def visit_channel(channel, message_id: nil)
+      def visit_channel(channel, message_id: nil, with_preloaded_channels: true)
         visit(channel.url + (message_id ? "/#{message_id}" : ""))
-        has_finished_loading?
+        has_finished_loading?(with_preloaded_channels: with_preloaded_channels)
       end
 
       def visit_user_threads
@@ -106,8 +106,8 @@ module PageObjects
         has_css?("body.has-preloaded-chat-channels")
       end
 
-      def has_finished_loading?
-        has_preloaded_channels?
+      def has_finished_loading?(with_preloaded_channels: true)
+        has_preloaded_channels? if with_preloaded_channels
         has_no_css?(".chat-channel--not-loaded-once")
         has_no_css?(".chat-skeleton")
       end

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -102,7 +102,12 @@ module PageObjects
         visit("/chat/new-message?recipients=#{recipients}")
       end
 
+      def has_preloaded_channels?
+        has_css?("body.has-preloaded-chat-channels")
+      end
+
       def has_finished_loading?
+        has_preloaded_channels?
         has_no_css?(".chat-channel--not-loaded-once")
         has_no_css?(".chat-skeleton")
       end

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Visit channel", type: :system do
     end
 
     it "shows a not found page" do
-      chat.visit_channel(category_channel_1)
+      chat.visit_channel(category_channel_1, with_preloaded_channels: false)
 
       expect(page).to have_content(I18n.t("page_not_found.title"))
     end
@@ -33,7 +33,7 @@ RSpec.describe "Visit channel", type: :system do
   context "when chat enabled" do
     context "when anonymous" do
       it "redirects to homepage" do
-        chat.visit_channel(category_channel_1)
+        chat.visit_channel(category_channel_1, with_preloaded_channels: false)
 
         expect(page).to have_current_path("/latest")
       end
@@ -46,7 +46,7 @@ RSpec.describe "Visit channel", type: :system do
         before { current_user.user_option.update!(chat_enabled: false) }
 
         it "redirects to homepage" do
-          chat.visit_channel(category_channel_1)
+          chat.visit_channel(category_channel_1, with_preloaded_channels: false)
 
           expect(page).to have_current_path("/latest")
         end
@@ -56,7 +56,7 @@ RSpec.describe "Visit channel", type: :system do
         before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:staff] }
 
         it "redirects homepage" do
-          chat.visit_channel(category_channel_1)
+          chat.visit_channel(category_channel_1, with_preloaded_channels: false)
 
           expect(page).to have_current_path("/latest")
         end


### PR DESCRIPTION
This class should help makes tests more reliable by ensuring we are in a known state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
