### PR TITLE
DEV: Use Chrome in system specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,9 +61,10 @@ jobs:
       - name: Set working directory owner
         run: chown root:root .
 
-      - name: Remove Chrome
+      - name: Remove Chromium
         continue-on-error: true
-        run: apt remove -y google-chrome-stable
+        if: matrix.build_type == 'system'
+        run: apt remove -y chromium-driver chromium
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The version of Chromium we have in our images (120) is relatively unstable and our system specs break regularly.

This PR makes sure Chrome is used instead for system specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
