### PR TITLE
DEV: applies body-scroll-lock on select-kit

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
@@ -1,5 +1,11 @@
 {{#if this.collection.content.length}}
-  <ul class="select-kit-collection" aria-live="polite" role="menu">
+  <ul
+    class="select-kit-collection"
+    aria-live="polite"
+    role="menu"
+    {{did-insert this.lock}}
+    {{will-destroy this.unlock}}
+  >
     {{#each this.collection.content as |item index|}}
       {{component
         (component-for-row this.collection.identifier item this.selectKit)

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
@@ -1,5 +1,20 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+} from "discourse/lib/body-scroll-lock";
 
 export default Component.extend({
   tagName: "",
+
+  @action
+  lock(element) {
+    disableBodyScroll(element);
+  },
+
+  @action
+  unlock(element) {
+    enableBodyScroll(element);
+  },
 });


### PR DESCRIPTION
This will prevent any scrolling issues with sk when on mobile, especially on iOS and in modals.

Prior to this fix, scrolling could sometimes stop working in dropdowns.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
