### PR TITLE
FIX: Descriptions not showing for some site setting types

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/category-list.gjs
@@ -51,8 +51,8 @@ export default class CategoryList extends Component {
         @onChange={{this.onChangeSelectedCategories}}
       />
 
-      <SiteSettingsDescription @description={{this.setting.description}} />
-      <SettingValidationMessage @message={{this.validationMessage}} />
+      <SiteSettingsDescription @description={{@setting.description}} />
+      <SettingValidationMessage @message={{@validationMessage}} />
     </div>
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/site-settings/file-size-restriction.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/file-size-restriction.gjs
@@ -29,6 +29,6 @@ export default class FileSizeRestriction extends Component {
     />
 
     <SettingValidationMessage @message={{this.validationMessage}} />
-    <SiteSettingsDescription @description={{this.setting.description}} />
+    <SiteSettingsDescription @description={{@setting.description}} />
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/site-settings/file-types-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/file-types-list.gjs
@@ -146,7 +146,7 @@ export default class FileTypesList extends Component {
       class="btn file-types-list__button document"
     />
 
-    <SettingValidationMessage @message={{this.validationMessage}} />
-    <SiteSettingsDescription @description={{this.setting.description}} />
+    <SettingValidationMessage @message={{@validationMessage}} />
+    <SiteSettingsDescription @description={{@setting.description}} />
   </template>
 }


### PR DESCRIPTION
Descriptions for the `category-list`, `file-size-restriction` and `file-types-list` site/theme settings aren't rendered due to a bug that was introduced when those components were migrated to Glimmer components. This PR fixes the bug which is that arguments passed to .gjs components should be accessed as `@argument` and not `this.arugment` inside the `<template>` tag.