### PR TITLE
FIX: prevents body scroll to hide sticky elements

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/body-scroll-lock.js
+++ b/app/assets/javascripts/discourse/app/lib/body-scroll-lock.js
@@ -45,7 +45,6 @@ let locks = [];
 let locksIndex = /* @__PURE__ */ new Map();
 let documentListenerAdded = false;
 let initialClientY = -1;
-let previousBodyOverflowSetting;
 let htmlStyle;
 let bodyStyle;
 let previousBodyPaddingRight;
@@ -89,19 +88,11 @@ const setOverflowHidden = (options) => {
       }px`;
     }
   }
-  if (previousBodyOverflowSetting === void 0) {
-    previousBodyOverflowSetting = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-  }
 };
 const restoreOverflowSetting = () => {
   if (previousBodyPaddingRight !== void 0) {
     document.body.style.paddingRight = previousBodyPaddingRight;
     previousBodyPaddingRight = void 0;
-  }
-  if (previousBodyOverflowSetting !== void 0) {
-    document.body.style.overflow = previousBodyOverflowSetting;
-    previousBodyOverflowSetting = void 0;
   }
 };
 const setPositionFixed = () =>
@@ -119,17 +110,6 @@ const setPositionFixed = () =>
       $body.style.left = `${-scrollX}px`;
       $body.style.width = "100%";
       $body.style.height = "auto";
-      $body.style.overflow = "hidden";
-      setTimeout(
-        () =>
-          window.requestAnimationFrame(() => {
-            const bottomBarHeight = innerHeight - window.innerHeight;
-            if (bottomBarHeight && scrollY >= innerHeight) {
-              $body.style.top = -(scrollY + bottomBarHeight) + "px";
-            }
-          }),
-        300
-      );
     }
   });
 const restorePositionSetting = () => {


### PR DESCRIPTION
Applying `overflow: hidden` was not playing well with sticky elements (like the header for example). It appears that we don't really need this to achieve our goal so Im removing this part of body scroll lock for now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
