### PR TITLE
Revert "Build(deps): Bump net-smtp from 0.4.0.1 to 0.5.0 (#26381)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.1)
     nokogiri (1.16.3-aarch64-linux)


### PR DESCRIPTION
This reverts commit 260b2a7450f75646f7c659ef41fa004ae51ec54d.

I believe this is causing errors: `SMTP-AUTH requested but missing user name`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
