### PR TITLE
FIX: Don't set smtp authentication type when there's no user or password

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
     nokogiri (1.16.3-aarch64-linux)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,11 +31,14 @@ Discourse::Application.configure do
       domain: GlobalSetting.smtp_domain,
       user_name: GlobalSetting.smtp_user_name,
       password: GlobalSetting.smtp_password,
-      authentication: GlobalSetting.smtp_authentication,
       enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
       open_timeout: GlobalSetting.smtp_open_timeout,
       read_timeout: GlobalSetting.smtp_read_timeout,
     }
+
+    if settings[:password] || settings[:user_name]
+      settings[:authentication] = GlobalSetting.smtp_authentication
+    end
 
     settings[
       :openssl_verify_mode


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
