### PR TITLE
FEATURE: clear sidebar admin filter with ESC

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
@@ -12,6 +12,11 @@ import { bind } from "discourse-common/utils/decorators";
 export default class Filter extends Component {
   @service sidebarState;
 
+  constructor() {
+    super(...arguments);
+    document.documentElement.addEventListener("keydown", this.handleKeydown);
+  }
+
   get shouldDisplay() {
     return this.sidebarState.currentPanel.filterable;
   }
@@ -23,6 +28,15 @@ export default class Filter extends Component {
   @bind
   teardown() {
     this.sidebarState.clearFilter();
+    document.documentElement.removeEventListener("keydown", this.handleKeydown);
+  }
+
+  @bind
+  handleKeydown(event) {
+    if (event.key === "Escape" && this.sidebarState.filter.length > 0) {
+      event.stopPropagation();
+      this.sidebarState.filter = "";
+    }
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
@@ -12,11 +12,6 @@ import { bind } from "discourse-common/utils/decorators";
 export default class Filter extends Component {
   @service sidebarState;
 
-  constructor() {
-    super(...arguments);
-    document.documentElement.addEventListener("keydown", this.handleKeydown);
-  }
-
   get shouldDisplay() {
     return this.sidebarState.currentPanel.filterable;
   }
@@ -28,19 +23,16 @@ export default class Filter extends Component {
   @bind
   teardown() {
     this.sidebarState.clearFilter();
-    document.documentElement.removeEventListener("keydown", this.handleKeydown);
-  }
-
-  @bind
-  handleKeydown(event) {
-    if (event.key === "Escape" && this.sidebarState.filter.length > 0) {
-      event.stopPropagation();
-      this.sidebarState.filter = "";
-    }
   }
 
   @action
   setFilter(event) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      return this.sidebarState.filter.length > 0
+        ? (this.sidebarState.filter = "")
+        : event.target.blur();
+    }
     this.sidebarState.filter = event.target.value.toLowerCase();
   }
 
@@ -57,7 +49,7 @@ export default class Filter extends Component {
           class="sidebar-filter__input"
           placeholder={{i18n "sidebar.filter"}}
           @value={{this.sidebarState.filter}}
-          {{on "input" this.setFilter}}
+          {{on "keydown" this.setFilter}}
         />
         {{#if this.displayClearFilter}}
           <DButton @action={{this.clearFilter}} class="sidebar-filter__clear">

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -86,7 +86,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       "advanced section is displayed"
     );
 
-    await triggerKeyEvent("#main-outlet", "keydown", "Escape");
+    await triggerKeyEvent(".sidebar-filter__input", "keydown", "Escape");
     assert.ok(
       exists(".sidebar-section[data-section-name='admin-plugins']"),
       "plugins section is displayed"

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -64,6 +64,29 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       exists(".sidebar-section[data-section-name='admin-security']"),
       "security settings section is displayed"
     );
+    assert.ok(
+      exists(".sidebar-section[data-section-name='admin-plugins']"),
+      "plugins section is displayed"
+    );
+    assert.ok(
+      exists(".sidebar-section[data-section-name='admin-advanced']"),
+      "advanced section is displayed"
+    );
+  });
+
+  test("filter sections and clear filter with ESC", async function (assert) {
+    await visit("/admin");
+    await fillIn(".sidebar-filter__input", "advanced");
+    assert.notOk(
+      exists(".sidebar-section[data-section-name='admin-plugins']"),
+      "plugins section is hidden"
+    );
+    assert.ok(
+      exists(".sidebar-section[data-section-name='admin-advanced']"),
+      "advanced section is displayed"
+    );
+
+    await triggerKeyEvent("#main-outlet", "keydown", "Escape");
     assert.ok(
       exists(".sidebar-section[data-section-name='admin-plugins']"),
       "plugins section is displayed"


### PR DESCRIPTION
Allow the sidebar filter to be cleared by hitting ESC.

Demo
https://github.com/discourse/discourse/assets/72780/769794f9-98fa-400a-9326-6c463ed3196c


