### PR TITLE
DEV: Add a test to ensure that our SMTP settings are correct

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -247,6 +247,33 @@ class GlobalSetting
     define_singleton_method(name) { default } unless self.respond_to? name
   end
 
+  def self.smtp_settings
+    if GlobalSetting.smtp_address
+      settings = {
+        address: GlobalSetting.smtp_address,
+        port: GlobalSetting.smtp_port,
+        domain: GlobalSetting.smtp_domain,
+        user_name: GlobalSetting.smtp_user_name,
+        password: GlobalSetting.smtp_password,
+        enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
+        open_timeout: GlobalSetting.smtp_open_timeout,
+        read_timeout: GlobalSetting.smtp_read_timeout,
+      }
+
+      if settings[:password] || settings[:user_name]
+        settings[:authentication] = GlobalSetting.smtp_authentication
+      end
+
+      settings[
+        :openssl_verify_mode
+      ] = GlobalSetting.smtp_openssl_verify_mode if GlobalSetting.smtp_openssl_verify_mode
+
+      settings[:tls] = true if GlobalSetting.smtp_force_tls
+      settings.compact
+      settings
+    end
+  end
+
   class BaseProvider
     def self.coerce(setting)
       return setting == "true" if setting == "true" || setting == "false"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,29 +24,8 @@ Discourse::Application.configure do
 
   config.log_level = :info
 
-  if GlobalSetting.smtp_address
-    settings = {
-      address: GlobalSetting.smtp_address,
-      port: GlobalSetting.smtp_port,
-      domain: GlobalSetting.smtp_domain,
-      user_name: GlobalSetting.smtp_user_name,
-      password: GlobalSetting.smtp_password,
-      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
-      open_timeout: GlobalSetting.smtp_open_timeout,
-      read_timeout: GlobalSetting.smtp_read_timeout,
-    }
-
-    if settings[:password] || settings[:user_name]
-      settings[:authentication] = GlobalSetting.smtp_authentication
-    end
-
-    settings[
-      :openssl_verify_mode
-    ] = GlobalSetting.smtp_openssl_verify_mode if GlobalSetting.smtp_openssl_verify_mode
-
-    settings[:tls] = true if GlobalSetting.smtp_force_tls
-
-    config.action_mailer.smtp_settings = settings.compact
+  if (smtp_settings = GlobalSetting.smtp_settings).present?
+    config.action_mailer.smtp_settings = smtp_settings
   else
     config.action_mailer.delivery_method = :sendmail
     config.action_mailer.sendmail_settings = { arguments: "-i" }

--- a/spec/integration/smtp_spec.rb
+++ b/spec/integration/smtp_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "SMTP Settings Integration" do
+  before do
+    @original_action_mailer_smtp_settings = ActionMailer::Base.smtp_settings
+    @original_action_mailer_delivery_method = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = :smtp
+  end
+
+  after do
+    ActionMailer::Base.smtp_settings = @original_action_mailer_smtp_settings
+    ActionMailer::Base.delivery_method = @original_action_mailer_delivery_method
+  end
+
+  it "should send out the email successfully using the SMTP settings" do
+    global_setting :smtp_address, "some.host"
+    global_setting :smtp_port, 12_345
+
+    ActionMailer::Base.smtp_settings = GlobalSetting.smtp_settings
+
+    message = TestMailer.send_test("some_email")
+
+    expect do Email::Sender.new(message, :test_message).send end.to raise_error(
+      StandardError,
+      /some.host/,
+    )
+  end
+end


### PR DESCRIPTION
### Why this change?

This is a follow up to 897be75941eb95b89e885e4b447ddf0c75eb81ff.

When updating `net-smtp` from `0.4.x` to `0.5.x`, our test suite passed
but the error `ArgumentError: SMTP-AUTH requested but missing user name`
was being thrown in production leading to emails being failed to send
out via SMTP.

This commit adds a test to ensure that our production SMTP settings will
at least attemp to connect to an SMTP server.
