### PR TITLE
UX: catch and show errors from fetching latest revision in history modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 import { sanitizeAsync } from "discourse/lib/text";
 import Category from "discourse/models/category";
 import Post from "discourse/models/post";
@@ -171,11 +172,16 @@ export default class History extends Component {
 
   refresh(postId, postVersion) {
     this.loading = true;
-    Post.loadRevision(postId, postVersion).then((result) => {
-      this.postRevision = result;
-      this.loading = false;
-      this.initialLoad = false;
-    });
+    Post.loadRevision(postId, postVersion)
+      .then((result) => {
+        this.postRevision = result;
+        this.loading = false;
+        this.initialLoad = false;
+      })
+      .catch((error) => {
+        popupAjaxError(error);
+        this.args.closeModal();
+      });
   }
 
   hide(postId, postVersion) {

--- a/app/assets/javascripts/discourse/tests/acceptance/history-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/history-test.js
@@ -101,3 +101,26 @@ acceptance("History Modal - anonymous", function (needs) {
       );
   });
 });
+
+acceptance("History Modal - when server error is raised", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/posts/419/revisions/latest.json", () => {
+      return helper.response(404, { errors: ["some error message"] });
+    });
+  });
+
+  test("shows error message in alert dialog", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("article[data-post-id='419'] .edits button");
+
+    assert
+      .dom(".dialog-body")
+      .exists("displays a dialog to show error message")
+      .containsText("some error message");
+    assert
+      .dom(".history-modal")
+      .doesNotExist("should close the history modal upon error");
+    await click(".dialog-footer .btn-primary");
+    assert.dom(".dialog-body").doesNotExist();
+  });
+});


### PR DESCRIPTION
Displays an error message instead of showing a infinitely loading spinner in history modal when error occurs on the server request. This happens either:
1. when there's no post revisions to fetch (as was the case for https://meta.discourse.org/t/notification-for-after-a-topic-is-posted-using-schedule-publishing-shows-nothing-but-a-spinner/297147); or
2. when the post is already hidden and the user does not have sufficient permissions to view hidden posts.

Example of what this looks like in action:

https://github.com/discourse/discourse/assets/133760061/6552aae5-b5d5-4b67-9c99-d876e344671f

--
This is probably a marginal improvement on UX since it simply acknowledges the error more explicitly but the user can't really resolve the root error. For the cases observed where this happens (in the notifications list), it would be better to not send notifications where the click action navigates to the history modal, or figure out how to capture more data related to editing a topic that can be stored in a post revision. 