### PR TITLE
DEV: Make problem check registration more explicit

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -28,6 +28,37 @@ class ProblemCheck
   #
   config_accessor :max_blips, default: 0, instance_writer: false
 
+  # Problem check classes need to be registered here in order to be enabled.
+  #
+  # Note: This list must come after the `config_accessor` declarations.
+  #
+  CORE_PROBLEM_CHECKS = [
+    ProblemCheck::EmailPollingErroredRecently,
+    ProblemCheck::FacebookConfig,
+    ProblemCheck::FailingEmails,
+    ProblemCheck::ForceHttps,
+    ProblemCheck::GithubConfig,
+    ProblemCheck::GoogleAnalyticsVersion,
+    ProblemCheck::GoogleOauth2Config,
+    ProblemCheck::GroupEmailCredentials,
+    ProblemCheck::HostNames,
+    ProblemCheck::ImageMagick,
+    ProblemCheck::MissingMailgunApiKey,
+    ProblemCheck::OutOfDateThemes,
+    ProblemCheck::RailsEnv,
+    ProblemCheck::Ram,
+    ProblemCheck::S3BackupConfig,
+    ProblemCheck::S3Cdn,
+    ProblemCheck::S3UploadConfig,
+    ProblemCheck::SidekiqCheck,
+    ProblemCheck::SubfolderEndsInSlash,
+    ProblemCheck::TranslationOverrides,
+    ProblemCheck::TwitterConfig,
+    ProblemCheck::TwitterLogin,
+    ProblemCheck::UnreachableThemes,
+    ProblemCheck::WatchedWords,
+  ].freeze
+
   def self.[](key)
     key = key.to_sym
 
@@ -35,7 +66,7 @@ class ProblemCheck
   end
 
   def self.checks
-    descendants
+    CORE_PROBLEM_CHECKS | DiscoursePluginRegistry.problem_checks
   end
 
   def self.scheduled

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -121,6 +121,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :post_strippers
 
+  define_filtered_register :problem_checks
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -317,6 +317,10 @@ class Plugin::Instance
     Site.preloaded_category_custom_fields << field
   end
 
+  def register_problem_check(klass)
+    DiscoursePluginRegistry.register_problem_check(klass, self)
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       UserLookup.lookup_columns << column

--- a/spec/jobs/run_problem_checks_spec.rb
+++ b/spec/jobs/run_problem_checks_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::RunProblemChecks do
-  before do
+  around do |example|
     ProblemCheck::ScheduledCheck =
       Class.new(ProblemCheck) do
         self.perform_every = 30.minutes
@@ -10,9 +10,14 @@ RSpec.describe Jobs::RunProblemChecks do
       end
 
     ProblemCheck::NonScheduledCheck = Class.new(ProblemCheck) { def call = [] }
-  end
 
-  after do
+    stub_const(
+      ProblemCheck,
+      "CORE_PROBLEM_CHECKS",
+      [ProblemCheck::ScheduledCheck, ProblemCheck::NonScheduledCheck],
+      &example
+    )
+
     Discourse.redis.flushdb
     AdminDashboardData.reset_problem_checks
 


### PR DESCRIPTION
### What is this change?

Previously the problem check registry simply looked at the subclasses of `ProblemCheck`. This was causing some confusion in environments where eager loading is not enabled, as the registry would appear empty as a result of the classes never being referenced (and thus never loaded.)

This PR changes the approach to a more explicit one. I followed other implementations (bookmarkable and hashtag autocomplete.) As a bonus, this now has a neat plugin entry point as well.

### Plugins to update

- [ ] https://github.com/discourse/discourse-chat-integration/pull/191
- [ ] https://github.com/discourse/discourse-encrypt/pull/310