### PR TITLE
FIX: Hide footgun max_notifications_per_user site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -727,6 +727,7 @@ users:
     client: true
   max_notifications_per_user:
     default: 10000
+    hidden: true
   gravatar_name:
     default: Gravatar
     client: true


### PR DESCRIPTION
It's not really intentional to have regular admins change
this in all but pathological cases. It deletes all notifications
over this threshold for users without warning. If admins
really want to turn this on, they can do it via the app.yml file
