### PR TITLE
FIX: only show edit history when navigating via edit notification for posts which have revisions and can have its edit history viewed

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -172,11 +172,10 @@ export default Controller.extend(bufferedProperty("model"), {
 
   _showRevision(postNumber, revision) {
     const post = this.model.get("postStream").postForPostNumber(postNumber);
-    if (!post) {
-      return;
-    }
 
-    schedule("afterRender", () => this.send("showHistory", post, revision));
+    if (post && post.version > 1 && post.can_view_edit_history) {
+      schedule("afterRender", () => this.send("showHistory", post, revision));
+    }
   },
 
   showCategoryChooser: not("model.isPrivateMessage"),

--- a/app/assets/javascripts/discourse/tests/acceptance/edit-notification-click-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/edit-notification-click-test.js
@@ -1,59 +1,129 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import topicFixtures from "discourse/tests/fixtures/topic";
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { cloneJSON } from "discourse-common/lib/object";
 
-acceptance("Edit Notification Click", function (needs) {
-  needs.user();
-  needs.pretender((server, helper) => {
-    server.get("/posts/133/revisions/1.json", () => {
-      return helper.response({
-        created_at: "2021-07-30T11:19:59.549Z",
-        post_id: 133,
-        previous_hidden: false,
-        current_hidden: false,
-        first_revision: 2,
-        previous_revision: null,
-        current_revision: 2,
-        next_revision: null,
-        last_revision: 2,
-        current_version: 2,
-        version_count: 2,
-        username: "velesin",
-        display_username: "velesin",
-        avatar_template: "/letter_avatar_proxy/v4/letter/j/13edae/{size}.png",
-        edit_reason: null,
-        body_changes: {
-          inline:
-            '<div class="inline-diff"><p>Hello world this is a test</p><p class="diff-ins">another edit!</p></div>',
-          side_by_side:
-            '<div class="revision-content"><p>Hello world this is a test</p></div><div class="revision-content"><p>Hello world this is a test</p><p class="diff-ins">This is an edit!</p></div>',
-          side_by_side_markdown:
-            '<table class="markdown"><tr><td class="diff-del">Hello world this is a test</td><td class="diff-ins">Hello world this is a test<ins>\n\nThis is an edit!</ins></td></tr></table>',
-        },
-        title_changes: null,
-        user_changes: null,
-        wiki: false,
-        can_edit: true,
+const revisionResponse = {
+  created_at: "2021-07-30T11:19:59.549Z",
+  post_id: 133,
+  previous_hidden: false,
+  current_hidden: false,
+  first_revision: 2,
+  previous_revision: null,
+  current_revision: 2,
+  next_revision: null,
+  last_revision: 2,
+  current_version: 2,
+  version_count: 2,
+  username: "velesin",
+  display_username: "velesin",
+  avatar_template: "/letter_avatar_proxy/v4/letter/j/13edae/{size}.png",
+  edit_reason: null,
+  body_changes: {
+    inline:
+      '<div class="inline-diff"><p>Hello world this is a test</p><p class="diff-ins">another edit!</p></div>',
+    side_by_side:
+      '<div class="revision-content"><p>Hello world this is a test</p></div><div class="revision-content"><p>Hello world this is a test</p><p class="diff-ins">This is an edit!</p></div>',
+    side_by_side_markdown:
+      '<table class="markdown"><tr><td class="diff-del">Hello world this is a test</td><td class="diff-ins">Hello world this is a test<ins>\n\nThis is an edit!</ins></td></tr></table>',
+  },
+  title_changes: null,
+  user_changes: null,
+  wiki: false,
+  can_edit: true,
+};
+acceptance(
+  "Edit Notification Click - when post revisions are present",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      const topicRef = "/t/130.json";
+      const topicResponse = cloneJSON(topicFixtures[topicRef]);
+      const originalPost = topicResponse.post_stream.posts[0];
+      originalPost.version = 2;
+      server.get(topicRef, () => helper.response(topicResponse));
+
+      server.get(`/posts/${originalPost.id}/revisions/1.json`, () => {
+        return helper.response(revisionResponse);
       });
     });
-  });
 
-  test("history modal is shown when navigating from a non-topic page", async function (assert) {
-    await visit("/");
-    await click(".header-dropdown-toggle.current-user");
-    await click(".notification.edited a");
-    const [v1, v2] = queryAll(".history-modal .revision-content");
+    test("history modal is shown when navigating from a non-topic page", async function (assert) {
+      await visit("/");
+      await click(".header-dropdown-toggle.current-user");
+      await click(".notification.edited a");
+      const [v1, v2] = queryAll(".history-modal .revision-content");
 
-    assert.strictEqual(
-      v1.textContent.trim(),
-      "Hello world this is a test",
-      "history modal for the edited post is shown"
-    );
+      assert.strictEqual(
+        v1.textContent.trim(),
+        "Hello world this is a test",
+        "history modal for the edited post is shown"
+      );
 
-    assert.strictEqual(
-      v2.textContent.trim(),
-      "Hello world this is a testThis is an edit!",
-      "history modal for the edited post is shown"
-    );
-  });
-});
+      assert.strictEqual(
+        v2.textContent.trim(),
+        "Hello world this is a testThis is an edit!",
+        "history modal for the edited post is shown"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Edit Notification Click - when post has no revisions",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      const topicRef = "/t/130.json";
+      const topicResponse = cloneJSON(topicFixtures[topicRef]);
+      const originalPost = topicResponse.post_stream.posts[0];
+      originalPost.version = 1;
+      originalPost.can_view_edit_history = true;
+      server.get(topicRef, () => helper.response(topicResponse));
+      server.get(`/posts/${originalPost.id}/revisions/1.json`, () => {
+        return helper.response(revisionResponse);
+      });
+    });
+
+    test("history modal is not shown when navigating from a non-topic page", async function (assert) {
+      await visit("/");
+      await click(".header-dropdown-toggle.current-user");
+      await click(".notification.edited a");
+      assert
+        .dom(".history-modal")
+        .doesNotExist(
+          "history modal should not open for post on its first version"
+        );
+    });
+  }
+);
+
+acceptance(
+  "Edit Notification Click - when post edit history cannot be viewed",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      const topicRef = "/t/130.json";
+      const topicResponse = cloneJSON(topicFixtures[topicRef]);
+      const originalPost = topicResponse.post_stream.posts[0];
+      originalPost.version = 2;
+      originalPost.can_view_edit_history = false;
+      server.get(topicRef, () => helper.response(topicResponse));
+      server.get(`/posts/${originalPost.id}/revisions/1.json`, () => {
+        return helper.response(revisionResponse);
+      });
+    });
+
+    test("history modal is not shown when navigating from a non-topic page", async function (assert) {
+      await visit("/");
+      await click(".header-dropdown-toggle.current-user");
+      await click(".notification.edited a");
+      assert
+        .dom(".history-modal")
+        .doesNotExist(
+          "history modal should not open for post which cannot have edit history viewed"
+        );
+    });
+  }
+);


### PR DESCRIPTION
Replaces https://github.com/discourse/discourse/pull/26412.

Adds checks to ensure that history modal does not display for a post without revisions or cannot have its history viewed, after navigating to the post from an edit notification. These checks align with the conditions needed to show the [`post-edits-indicator`](https://github.com/discourse/discourse/blob/c34f8b65cb5579c5461f33cdf461370bb4342828/app/assets/javascripts/discourse/app/widgets/post-edits-indicator.js#L64-L68) that appears in the top right of the post, and to click and show its edit history.

Previously, if the post does not have any revisions (https://meta.discourse.org/t/notification-for-after-a-topic-is-posted-using-schedule-publishing-shows-nothing-but-a-spinner/297147), the history modal would open and display an infinitely loading spinner as the request returns an error and we do not handle it explicitly with an error dialog.

When the post has no revisions:

https://github.com/discourse/discourse/assets/133760061/00f7d160-125e-45b2-82b9-b030b98c1678

When the post has revisions:

https://github.com/discourse/discourse/assets/133760061/8087a7b7-6cf0-46ce-bf93-b4cab6f8d09a

