### PR TITLE
UX: wrap `small-user-list-content` for many users case

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -537,6 +537,7 @@ aside.quote {
 .small-user-list {
   .small-user-list-content {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     justify-content: flex-end;
   }


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/26337

This needs to wrap for the case of many users:

Before:

![image](https://github.com/discourse/discourse/assets/1681963/b761293d-f47c-401f-b8f8-549b14a8ce93)


After:

![image](https://github.com/discourse/discourse/assets/1681963/d5ea3c1f-5b42-4791-98b9-09c5320fd237)
