### PR TITLE
DEV: early hints around_action -> after_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,7 @@ class ApplicationController < ActionController::Base
   after_action :add_noindex_header_to_non_canonical, if: :spa_boot_request?
   after_action :set_cross_origin_opener_policy_header, if: :spa_boot_request?
   after_action :clean_xml, if: :is_feed_response?
-  around_action :add_early_hint_header, if: -> { spa_boot_request? }
+  after_action :add_early_hint_header, if: -> { spa_boot_request? }
 
   HONEYPOT_KEY ||= "HONEYPOT_KEY"
   CHALLENGE_KEY ||= "CHALLENGE_KEY"
@@ -1100,11 +1100,7 @@ class ApplicationController < ActionController::Base
   # to cache a response header from the app and use that to send an Early Hint response to future clients.
   # See 'early_hint_header_mode' and 'early_hint_header_name' Global Setting descriptions for more info.
   def add_early_hint_header
-    return yield if GlobalSetting.early_hint_header_mode.nil?
-
-    @asset_preload_links = []
-
-    yield
+    return if GlobalSetting.early_hint_header_mode.nil?
 
     links = []
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,8 +158,10 @@ module ApplicationHelper
   end
 
   def add_resource_preload_list(resource_url, type)
-    @asset_preload_links ||= []
-    @asset_preload_links << %Q(<#{resource_url}>; rel="preload"; as="#{type}")
+    links =
+      controller.instance_variable_get(:@asset_preload_links) ||
+        controller.instance_variable_set(:@asset_preload_links, [])
+    links << %Q(<#{resource_url}>; rel="preload"; as="#{type}")
   end
 
   def discourse_csrf_tags

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,9 +158,8 @@ module ApplicationHelper
   end
 
   def add_resource_preload_list(resource_url, type)
-    if !@asset_preload_links.nil?
-      @asset_preload_links << %Q(<#{resource_url}>; rel="preload"; as="#{type}")
-    end
+    @asset_preload_links ||= []
+    @asset_preload_links << %Q(<#{resource_url}>; rel="preload"; as="#{type}")
   end
 
   def discourse_csrf_tags

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -132,43 +132,31 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "add_resource_preload_list" do
-    it "adds resources to the preload list when it's available" do
-      @asset_preload_links = []
+    it "adds resources to the preload list" do
       add_resource_preload_list("/assets/start-discourse.js", "script")
       add_resource_preload_list("/assets/discourse.css", "style")
 
-      expect(@asset_preload_links.size).to eq(2)
-    end
-
-    it "doesn't add resources to the preload list when it's not available" do
-      @asset_preload_links = nil
-      add_resource_preload_list("/assets/start-discourse.js", "script")
-      add_resource_preload_list("/assets/discourse.css", "style")
-
-      expect(@asset_preload_links).to eq(nil)
+      expect(controller.instance_variable_get(:@asset_preload_links).size).to eq(2)
     end
 
     it "adds resources to the preload list when preload_script is called" do
-      @asset_preload_links = []
       helper.preload_script("start-discourse")
 
-      expect(@asset_preload_links.size).to eq(1)
+      expect(controller.instance_variable_get(:@asset_preload_links).size).to eq(1)
     end
 
     it "adds resources to the preload list when discourse_stylesheet_link_tag is called" do
-      @asset_preload_links = []
       helper.discourse_stylesheet_link_tag(:desktop)
 
-      expect(@asset_preload_links.size).to eq(1)
+      expect(controller.instance_variable_get(:@asset_preload_links).size).to eq(1)
     end
 
     it "adds resources as the correct type" do
-      @asset_preload_links = []
       helper.discourse_stylesheet_link_tag(:desktop)
       helper.preload_script("start-discourse")
 
-      expect(@asset_preload_links[0]).to match(/as="style"/)
-      expect(@asset_preload_links[1]).to match(/as="script"/)
+      expect(controller.instance_variable_get(:@asset_preload_links)[0]).to match(/as="style"/)
+      expect(controller.instance_variable_get(:@asset_preload_links)[1]).to match(/as="script"/)
     end
   end
 


### PR DESCRIPTION
Using around_action means `add_early_hint_header` is in the stack for every request, and gets included in the backtrace of any errors.

We can manage with an after_action instead, which avoids adding to the stack depth (and avoids people blaming me for unrelated application errors 😉)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
