### PR TITLE
FIX: Ensure `showPoweredBy` updates when dependent properties change

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -59,8 +59,7 @@ export default Controller.extend({
     return this.capabilities.isAppWebview || this.capabilities.isiOSPWA;
   },
 
-  @discourseComputed
-  showPoweredBy() {
+  get showPoweredBy() {
     return this.showFooter && this.siteSettings.enable_powered_by_discourse;
   },
 


### PR DESCRIPTION
`@discourseComputed` with no dependent keys will never be re-evaluated. We could add the correct dependent keys, but then we'd have to add `@dependentKeyCompat` to make it work with the native `showFooter` getter.

So... better to fully modernize it to be a native getter with autotracking 🎉

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
