### PR TITLE
DEV: Add skip_email_bulk_invites hidden site setting

### DIFF
--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -24,6 +24,8 @@ module Jobs
       @current_user = User.find_by(id: args[:current_user_id])
       raise Discourse::InvalidParameters.new(:current_user_id) unless @current_user
 
+      @skip_email = SiteSetting.skip_email_bulk_invites
+
       @guardian = Guardian.new(@current_user)
 
       process_invites(@invites)
@@ -168,7 +170,12 @@ module Jobs
             user.save!
           end
 
-          invite_opts = { email: email, topic: topic, group_ids: groups.map(&:id) }
+          invite_opts = {
+            email: email,
+            topic: topic,
+            group_ids: groups.map(&:id),
+            skip_email: @skip_email,
+          }
 
           if @invites.length > Invite::BULK_INVITE_EMAIL_LIMIT
             invite_opts[:emailed_status] = Invite.emailed_status_types[:bulk_pending]

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2858,6 +2858,10 @@ uncategorized:
     default: 50000
     hidden: true
 
+  skip_email_bulk_invites:
+    default: false
+    hidden: true
+
   max_api_invites:
     default: 200
     hidden: true

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -141,5 +141,14 @@ RSpec.describe Jobs::BulkInvite do
         expect(Jobs::ProcessBulkInviteEmails.jobs.size).to eq(1)
       end
     end
+
+    it "does not send an invite email when skip_email_bulk_invites is true" do
+      SiteSetting.skip_email_bulk_invites = true
+
+      described_class.new.execute(current_user_id: admin.id, invites: invites)
+
+      invite = Invite.last
+      expect(invite.emailed_status).to eq(Invite.emailed_status_types[:not_required])
+    end
   end
 end


### PR DESCRIPTION
This adds a hidden site setting of `skip_email_bulk_invites`

If set to `true`, the `BulkInvite` job will pass the value to `Invite`, meaning the generated invite wont trigger an email notification being sent to the newly invited user.

(This is useful if you want to manage the sending of the invite emails outside of Discourse.)
