### PR TITLE
FIX: Don't allow access to plugin page if plugin is not visible

### DIFF
--- a/app/controllers/admin/plugins_controller.rb
+++ b/app/controllers/admin/plugins_controller.rb
@@ -16,7 +16,7 @@ class Admin::PluginsController < Admin::StaffController
     # version of their plugin name for a route.
     plugin = Discourse.plugins_by_name["discourse-#{params[:plugin_id]}"] if !plugin
 
-    raise Discourse::NotFound if !plugin
+    raise Discourse::NotFound if !plugin&.visible?
 
     render_serialized(plugin, AdminPluginSerializer, root: nil)
   end

--- a/spec/requests/admin/plugins_controller_spec.rb
+++ b/spec/requests/admin/plugins_controller_spec.rb
@@ -85,14 +85,6 @@ RSpec.describe Admin::PluginsController do
         get "/admin/plugins/poll.json"
         expect(response.status).to eq(404)
       end
-
-      it "404s if the plugin is not configurable" do
-        poll = Discourse.plugins_by_name["poll"]
-        poll.stubs(:configurable?).returns(false)
-
-        get "/admin/plugins/poll.json"
-        expect(response.status).to eq(404)
-      end
     end
 
     context "when logged in as a moderator" do

--- a/spec/requests/admin/plugins_controller_spec.rb
+++ b/spec/requests/admin/plugins_controller_spec.rb
@@ -77,6 +77,22 @@ RSpec.describe Admin::PluginsController do
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
       end
+
+      it "404s if the plugin is not visible" do
+        poll = Discourse.plugins_by_name["poll"]
+        poll.stubs(:visible?).returns(false)
+
+        get "/admin/plugins/poll.json"
+        expect(response.status).to eq(404)
+      end
+
+      it "404s if the plugin is not configurable" do
+        poll = Discourse.plugins_by_name["poll"]
+        poll.stubs(:configurable?).returns(false)
+
+        get "/admin/plugins/poll.json"
+        expect(response.status).to eq(404)
+      end
     end
 
     context "when logged in as a moderator" do


### PR DESCRIPTION
Plugins that are hidden or disabled aren't shown in the plugins list at `/admin/plugins` because they cannot be changed. However, the `#show` route doesn't check for the plugin's state and responds with 200 and the plugin's info even if the plugin is hidden or disabled. This PR makes the `#show` route respond with 404 if the plugin is hidden or disabled.