### PR TITLE
FIX: print view wasn't working

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -430,7 +430,11 @@ module ApplicationHelper
   end
 
   def include_crawler_content?
-    (crawler_layout? || !mobile_view? || !modern_mobile_device?) && !current_user
+    if current_user
+      params.key?(:print)
+    else
+      crawler_layout? || !mobile_view? || !modern_mobile_device?
+    end
   end
 
   def modern_mobile_device?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe ApplicationHelper do
       expect(helper.include_crawler_content?).to eq(false)
     end
 
+    it "sends crawler content to logged on users who wants to print" do
+      helper.stubs(:current_user).returns(Fabricate(:user))
+      helper.stubs(:params).returns(print: true)
+
+      expect(helper.include_crawler_content?).to eq(true)
+    end
+
     it "sends crawler content to old mobiles" do
       controller.stubs(:use_crawler_layout?).returns(false)
 


### PR DESCRIPTION
In e05628c0793567b581ca04cbae801a7d4a6e55ca we omitted the HTML view for logged in users but that view is used when printing.

This restore the HTML view when printing a topic page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
