### PR TITLE
UX: minor theme schema editor adjustments for mobile

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/field.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/field.gjs
@@ -46,7 +46,7 @@ export default class SchemaThemeSettingField extends Component {
   }
 
   <template>
-    <div class="schema-field" data-name={{@name}}>
+    <div class="schema-field" data-name={{@name}} data-type={{@spec.type}}>
       <label class="schema-field__label">{{@label}}{{if
           @spec.required
           "*"

--- a/app/assets/stylesheets/common/admin/schema_field.scss
+++ b/app/assets/stylesheets/common/admin/schema_field.scss
@@ -1,10 +1,21 @@
 .schema-field {
   margin-bottom: 1em;
   width: 100%;
-  min-width: 200px;
   display: grid;
   grid-template-columns: 25% 1fr;
   gap: 1em;
+
+  @include breakpoint(mobile-extra-large) {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    gap: 0;
+    &[data-type="boolean"] {
+      grid-template-columns: auto 1fr;
+      .schema-field__input {
+        order: -1;
+      }
+    }
+  }
 
   .schema-field__label {
     word-break: break-all;


### PR DESCRIPTION
this makes some minor adjustments to get the new schema editor workable on small mobile devices 

Before:

![image](https://github.com/discourse/discourse/assets/1681963/2d8e53e8-5ce1-4a46-badd-fe7fbc64363d)


After:

![image](https://github.com/discourse/discourse/assets/1681963/6e37d911-221c-4e27-bf96-dca84101736d)
