### PR TITLE
UX: highlight code in `em` and `strong` blocks

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -2,7 +2,9 @@
 
 p > code,
 li > code,
-pre > code {
+pre > code,
+strong > code,
+em > code {
   color: var(--primary-very-high);
   background: var(--hljs-bg);
 }


### PR DESCRIPTION
Code within `em` or `strong` wasn't getting a background or color change:

![image](https://github.com/discourse/discourse/assets/1681963/4debd724-fe51-4ac3-a4ab-d1480126bf1b)

This fixes it. 