### PR TITLE
DEV: Drop gc_tracer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -198,8 +198,6 @@ gem "puma", require: false
 
 gem "rbtrace", require: false, platform: :mri
 
-gem "gc_tracer", require: false, platform: :mri
-
 # required for feed importing and embedding
 gem "ruby-readability", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
     fastimage (2.3.0)
     ffi (1.16.3)
     fspath (3.1.2)
-    gc_tracer (1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (4.26.1-aarch64-linux)
@@ -584,7 +583,6 @@ DEPENDENCIES
   fast_blank
   fast_xs
   fastimage
-  gc_tracer
   highline
   htmlentities
   http_accept_language


### PR DESCRIPTION
Why this change?

This gem is failing to install cleanly on macOS and the following
workaround is required:

`bundle config build.gc_tracer
--with-cflags=\"-Wno-incompatible-pointer-types\"`

Instead of requiring this workaround, we have decided to drop `gc_tracer`
because it isn't a gem that is used anymore.
