### PR TITLE
DEV: Drop fast_xs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,6 @@ gem "message_bus"
 
 gem "rails_multisite"
 
-gem "fast_xs", platform: :ruby
-
 gem "fastimage"
 
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,6 @@ GEM
     faraday-retry (2.2.0)
       faraday (~> 2.0)
     fast_blank (1.0.1)
-    fast_xs (0.8.0)
     fastimage (2.3.0)
     ffi (1.16.3)
     fspath (3.1.2)
@@ -582,7 +581,6 @@ DEPENDENCIES
   faraday
   faraday-retry
   fast_blank
-  fast_xs
   fastimage
   gc_tracer
   highline


### PR DESCRIPTION
### Why this change?

This gem was added close to 10 years ago to speed up the generation of
RSS feeds. However, RSS feeds generation do not even call `String#to_xs`
anymore and the `fast_xs` gem does not install on macOS without using
the following workaround:

`bundle config build.fast_xs
--with-cflags=\"-Wno-incompatible-pointer-types\"`

Therefore, we have decided to drop the gem.
