### PR TITLE
FIX: Error not being raised for required typed categories property

### DIFF
--- a/lib/theme_settings_object_validator.rb
+++ b/lib/theme_settings_object_validator.rb
@@ -208,7 +208,7 @@ class ThemeSettingsObjectValidator
   end
 
   def is_property_present?(property_name)
-    if @object[property_name].nil?
+    if @object[property_name].blank?
       add_error(property_name, :required)
       false
     else

--- a/spec/lib/theme_settings_object_validator_spec.rb
+++ b/spec/lib/theme_settings_object_validator_spec.rb
@@ -1068,7 +1068,7 @@ RSpec.describe ThemeSettingsObjectValidator do
       end
     end
 
-    context "for category properties" do
+    context "for categories properties" do
       fab!(:category_1) { Fabricate(:category) }
       fab!(:category_2) { Fabricate(:category) }
 
@@ -1088,6 +1088,22 @@ RSpec.describe ThemeSettingsObjectValidator do
       it "should not return any error messages when the value is not present and it's not required in the schema" do
         schema = { name: "section", properties: { category_property: { type: "categories" } } }
         expect(described_class.new(schema: schema, object: {}).validate).to eq({})
+      end
+
+      it "should return the right hash of error messages when value of property is present but empty and it's required" do
+        schema = {
+          name: "section",
+          properties: {
+            category_property: {
+              type: "categories",
+              required: true,
+            },
+          },
+        }
+        errors = described_class.new(schema: schema, object: { category_property: [] }).validate
+
+        expect(errors.keys).to eq(["/category_property"])
+        expect(errors["/category_property"].full_messages).to contain_exactly("must be present")
       end
 
       it "should return the right hash of error messages when value of property is not present and it's required" do


### PR DESCRIPTION
### Why this change?

For a schema like this:

```
schema = {
  name: "section",
  properties: {
    category_property: {
      type: "categories",
      required: true,
    },
  },
}
```

When the value of the property is set to an empty array, we are not
raising an error which we should because the property is marked as
required.
