### PR TITLE
UX: minor style adjustments for schema objects editor

### DIFF
--- a/app/assets/stylesheets/common/admin/schema_field.scss
+++ b/app/assets/stylesheets/common/admin/schema_field.scss
@@ -9,19 +9,13 @@
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
     gap: 0;
-    &[data-type="boolean"] {
-      grid-template-columns: auto 1fr;
-      .schema-field__input {
-        order: -1;
-      }
-    }
   }
 
   .schema-field__label {
     word-break: break-all;
   }
 
-  .schema-field__input:has(input[type="checkbox"]) {
+  &[data-type="boolean"] .schema-field__input {
     flex-direction: row;
   }
 
@@ -29,6 +23,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    min-width: 0;
 
     input {
       width: 100%;
@@ -52,6 +47,8 @@
     .schema-field__input-description {
       font-size: var(--font-down-1);
       color: var(--primary-medium);
+      min-width: 0;
+      overflow-wrap: break-word;
     }
   }
 
@@ -60,6 +57,7 @@
     flex-direction: row;
     margin-top: 0.2em;
     width: 100%;
+    gap: 0 0.5em;
 
     .schema-field__input-count {
       margin-left: auto;

--- a/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
+++ b/app/assets/stylesheets/common/admin/schema_theme_setting_editor.scss
@@ -3,7 +3,11 @@
   display: grid;
   grid-template-columns: minmax(10em, 0.3fr) 1fr;
   grid-template-rows: auto 1fr;
-  gap: 2em 5vw;
+  gap: 0 5vw;
+  @include breakpoint(mobile-extra-large) {
+    --schema-space: 0.33em;
+    gap: 0 1em;
+  }
 
   &__navigation {
     overflow: hidden;
@@ -112,7 +116,9 @@
         }
 
         &.--heading {
-          font-weight: bold;
+          .d-icon {
+            color: var(--primary-700);
+          }
           &:hover {
             background: var(--primary-very-low);
           }
@@ -121,6 +127,9 @@
         &.--child {
           margin-left: var(--schema-space);
           border-left: 1px solid var(--primary-200);
+          .schema-theme-setting-editor__tree-node-text {
+            color: var(--primary-800);
+          }
         }
       }
     }
@@ -130,11 +139,11 @@
       width: 100%;
       line-height: 1.4; // match li height
       justify-content: start;
+      padding: var(--schema-space);
 
       .d-icon {
         color: currentColor;
         font-size: var(--font-down-1);
-        margin-left: -0.35em; // optical alignment
       }
 
       &:hover {


### PR DESCRIPTION
This improves some styles for small screens...

Before:
![image](https://github.com/discourse/discourse/assets/1681963/54840df0-40fe-4d3b-a440-118650189b2a)


After:
![image](https://github.com/discourse/discourse/assets/1681963/724646e8-6a91-4945-bffe-cee9f8f1e859)
