### PR TITLE
DEV: Use Category.findById instead of Array.find

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -90,10 +90,7 @@ export default Controller.extend({
         return;
       }
       const model = this.model;
-      const parentCategory = this.site.categories.findBy(
-        "id",
-        parseInt(model.parent_category_id, 10)
-      );
+      const parentCategory = Category.findById(model.parent_category_id);
 
       this.set("saving", true);
       const previousParentCategory = model.get("parentCategory");

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -12,6 +12,7 @@ import { propertyNotEqual } from "discourse/lib/computed";
 import { QUOTE_REGEXP } from "discourse/lib/quote";
 import { prioritizeNameFallback } from "discourse/lib/settings";
 import { emailValid, escapeExpression } from "discourse/lib/utilities";
+import Category from "discourse/models/category";
 import Draft from "discourse/models/draft";
 import RestModel from "discourse/models/rest";
 import Site from "discourse/models/site";
@@ -253,7 +254,7 @@ export default class Composer extends RestModel {
 
   @discourseComputed("categoryId")
   category(categoryId) {
-    return categoryId ? this.site.categories.findBy("id", categoryId) : null;
+    return categoryId ? Category.findById(categoryId) : null;
   }
 
   @discourseComputed("category.minimumRequiredTags")
@@ -760,7 +761,7 @@ export default class Composer extends RestModel {
 
     // If the user didn't change the template, clear it
     if (oldCategoryId) {
-      const oldCat = this.site.categories.findBy("id", oldCategoryId);
+      const oldCat = Category.findById(oldCategoryId);
       if (oldCat && oldCat.topic_template === reply) {
         reply = "";
       }
@@ -770,7 +771,7 @@ export default class Composer extends RestModel {
       return;
     }
 
-    const category = this.site.categories.findBy("id", categoryId);
+    const category = Category.findById(categoryId);
     if (category) {
       this.set("reply", category.topic_template || "");
     }
@@ -1184,9 +1185,7 @@ export default class Composer extends RestModel {
 
         // Update topic_count for the category
         const postCategoryId = parseInt(createdPost.category, 10) || 1;
-        const category = this.site.categories.find(
-          (x) => x.id === postCategoryId
-        );
+        const category = Category.findById(postCategoryId);
 
         category?.incrementProperty("topic_count");
       }

--- a/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
@@ -2,6 +2,7 @@ import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { cook, emojiUnescape, excerpt } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
+import Category from "discourse/models/category";
 import {
   NEW_PRIVATE_MESSAGE_KEY,
   NEW_TOPIC_KEY,
@@ -78,9 +79,7 @@ export default class UserDraftsStream extends RestModel {
             }
             draft.title = emojiUnescape(escapeExpression(draft.title));
             if (draft.data.categoryId) {
-              draft.category =
-                this.site.categories.findBy("id", draft.data.categoryId) ||
-                null;
+              draft.category = Category.findById(draft.data.categoryId) || null;
             }
             this.content.push(UserDraft.create(draft));
           });

--- a/app/assets/javascripts/discourse/app/routes/about.js
+++ b/app/assets/javascripts/discourse/app/routes/about.js
@@ -1,4 +1,5 @@
 import { ajax } from "discourse/lib/ajax";
+import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
@@ -24,7 +25,7 @@ export default DiscourseRoute.extend({
       const { category_moderators: categoryModerators } = result.about;
       if (categoryModerators && categoryModerators.length) {
         categoryModerators.forEach((obj, index) => {
-          const category = this.site.categories.findBy("id", obj.category_id);
+          const category = Category.findById(obj.category_id);
           result.about.category_moderators[index].category = category;
         });
       }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -30,6 +30,7 @@ import {
 } from "discourse/lib/uploads";
 import DiscourseURL from "discourse/lib/url";
 import { escapeExpression, modKeysPressed } from "discourse/lib/utilities";
+import Category from "discourse/models/category";
 import Composer, {
   CREATE_TOPIC,
   NEW_TOPIC_KEY,
@@ -1322,17 +1323,14 @@ export default class ComposerService extends Service {
 
     // Scope the categories drop down to the category we opened the composer with.
     if (opts.categoryId && !opts.disableScopedCategory) {
-      const category = this.site.categories.findBy("id", opts.categoryId);
+      const category = Category.findById(opts.categoryId);
       if (category) {
         this.set("scopedCategoryId", opts.categoryId);
       }
     }
 
     if (opts.prioritizedCategoryId) {
-      const category = this.site.categories.findBy(
-        "id",
-        opts.prioritizedCategoryId
-      );
+      const category = Category.findById(opts.prioritizedCategoryId);
 
       if (category) {
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);

--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/create-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/create-channel.js
@@ -8,6 +8,7 @@ import { isBlank, isPresent } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
 import { escapeExpression } from "discourse/lib/utilities";
+import Category from "discourse/models/category";
 import discourseDebounce from "discourse-common/lib/debounce";
 import I18n from "discourse-i18n";
 
@@ -67,9 +68,7 @@ export default class ChatModalCreateChannel extends Component {
 
   @action
   onCategoryChange(categoryId) {
-    const category = categoryId
-      ? this.site.categories.findBy("id", categoryId)
-      : null;
+    const category = categoryId ? Category.findById(categoryId) : null;
     this.#updatePermissionsHint(category);
 
     const name = this.name || category?.name || "";


### PR DESCRIPTION
Category.findById uses a Map to look up categories by ID which makes it
faster and preferable over Site.categories.find.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
