### PR TITLE
UX: fix overflow of long site text site names in the header

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -60,6 +60,7 @@
     min-width: var(--d-logo-height);
     a,
     a:visited {
+      min-width: 0;
       color: var(--header_primary);
     }
 
@@ -75,6 +76,10 @@
     width: auto;
     max-width: 100%;
     object-fit: contain;
+  }
+
+  .home-logo-wrapper-outlet {
+    overflow: hidden;
   }
 
   #site-text-logo {


### PR DESCRIPTION
I think this may have broken when the home-logo-wrapper-outlet was introduced? the additional wrapper means we need a little more CSS. 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/b80ecbe4-ee02-445c-892f-28d02efde6ed)

After:
![image](https://github.com/discourse/discourse/assets/1681963/6e6a979b-e3a8-4706-a4d0-f6bb840a1314)
