### PR TITLE
FIX: `maxmind:refresh` does not respect `refresh_maxmind_db_during_precompile_days`

### DIFF
--- a/lib/tasks/maxminddb.rake
+++ b/lib/tasks/maxminddb.rake
@@ -34,6 +34,7 @@ def copy_maxmind(from_path, to_path)
     from = File.join(from_path, "#{name}.mmdb")
     to = File.join(to_path, "#{name}.mmdb")
     FileUtils.cp(from, to, preserve: true)
+    FileUtils.touch(to)
   end
 end
 


### PR DESCRIPTION
### Why this change?

We currently support `GlobalSetting.refresh_maxmind_db_during_precompile_days` which
should cache the maxmind databases on disk for the configured number of
days before it downloads the databases from maxmind again via the API.
This was previously added to help us avoid hitting the API rate limit from maxmind.
However, there is a bug in the `copy_maxmind` method of the Rake task when we copied the latest
downloaded database to the cache directory. In particular, `FileUtils.cp` was called with
`preserve: true` which would preserve the modified time of the file
being copied. This is problematic because downloading the database from
maxmind on 2 April 2024 can give us a file with an mtime of 29 March
2024. If `GlobalSetting.refresh_maxmind_db_during_precompile_days` is
set to `2` for example, the cache will never be used since we will
think that the file has been downloaded for more than 2 days in our
checks when the `maxmind:refresh` rake task is ran again.

### What is the fix here?

While we want to preserve the owner and group of the file, we do not
want to preserve the modified time and hence we will call
`FileUtils.touch` when copying the file.
