### PR TITLE
DEV: Introduce `maxmind_mirror_url` GlobalSetting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -295,7 +295,13 @@ maxmind_backup_path =
 
 # register an account at: https://www.maxmind.com/en/geolite2/signup
 # then head to profile and get your license key
-maxmind_license_key=
+maxmind_license_key =
+
+# Configures a URL mirror to download the MaxMind databases from.
+# When set, the file path will be appended to the mirror's URL.
+# If the mirror URL is https://some.url.com/maxmind/mirror for example, the
+# GeoLite2-City database file will be downloaded from https://some.url.com/maxmind/mirror/GeoLite2-City.tar.gz
+maxmind_mirror_url =
 
 # when enabled the following headers will be added to every response:
 # (note, if measurements do not exist for the header they will be omitted)

--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -25,16 +25,18 @@ class DiscourseIpInfo
   end
 
   def self.mmdb_download(name)
-    if GlobalSetting.maxmind_license_key.blank?
-      STDERR.puts "MaxMind IP database updates require a license"
-      STDERR.puts "Please set DISCOURSE_MAXMIND_LICENSE_KEY to one you generated at https://www.maxmind.com"
-      return
-    end
-
-    FileUtils.mkdir_p(path)
-
     url =
-      "https://download.maxmind.com/app/geoip_download?license_key=#{GlobalSetting.maxmind_license_key}&edition_id=#{name}&suffix=tar.gz"
+      if GlobalSetting.maxmind_mirror_url.present?
+        URI.join(GlobalSetting.maxmind_mirror_url, "#{name}.tar.gz").to_s
+      else
+        if GlobalSetting.maxmind_license_key.blank?
+          STDERR.puts "MaxMind IP database updates require a license"
+          STDERR.puts "Please set DISCOURSE_MAXMIND_LICENSE_KEY to one you generated at https://www.maxmind.com"
+          return
+        end
+
+        "https://download.maxmind.com/app/geoip_download?license_key=#{GlobalSetting.maxmind_license_key}&edition_id=#{name}&suffix=tar.gz"
+      end
 
     gz_file =
       FileHelper.download(

--- a/lib/discourse_ip_info_spec.rb
+++ b/lib/discourse_ip_info_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseIpInfo do
+  describe ".mmdb_download" do
+    it "should download the MaxMind databases from the right URL when `maxmind_mirror_url` global setting has been configured" do
+      global_setting :maxmind_mirror_url, "https://example.com/mirror/"
+
+      stub_request(:get, "https://example.com/mirror/GeoLite2-City.tar.gz").to_return(
+        status: 200,
+        body: "",
+      )
+
+      described_class.mmdb_download("GeoLite2-City")
+    end
+  end
+end


### PR DESCRIPTION
### Why this change?

This allows downloading the MaxMind databases from a mirror in cases
where downloading directly from MaxMind's API endpoint is problematic
due to API limits.
