### PR TITLE
DEV: Modifier to add params to TopicsController redirect

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1255,7 +1255,19 @@ class TopicsController < ApplicationController
       raise(SiteSetting.detailed_404 ? ex : Discourse::NotFound)
     end
 
-    opts = params.slice(:page, :print, :filter_top_level_replies, :preview_theme_id)
+    # Allow plugins to append allowed query parameters, so they aren't scrubbed on redirect to proper topic URL
+    additional_allowed_query_parameters =
+      DiscoursePluginRegistry.apply_modifier(
+        :redirect_to_correct_topic_additional_query_parameters,
+        [],
+      )
+
+    opts =
+      params.slice(
+        *%i[page print filter_top_level_replies preview_theme_id].concat(
+          additional_allowed_query_parameters,
+        ),
+      )
     opts.delete(:page) if params[:page] == 0
 
     url = topic.relative_url


### PR DESCRIPTION
This PR creates an extension point for plugins to add query parameters to an array, to not be scrubbed when the topics controller redirects to the most "proper" topic URL. We have all sorts of topic urls supported, but topics controller redirects to the standard version. In the redirect we scrub query params. A customer wants a specific param retained and this allows for the addition!