### PR TITLE
DEV: Document basic-info endpoint

### DIFF
--- a/spec/requests/api/schemas/json/site_basic_info_response.json
+++ b/spec/requests/api/schemas/json/site_basic_info_response.json
@@ -1,0 +1,47 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "logo_url": {
+      "type": "string"
+    },
+    "logo_small_url": {
+      "type": "string"
+    },
+    "apple_touch_icon_url": {
+      "type": "string"
+    },
+    "favicon_url": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "header_primary_color": {
+      "type": "string"
+    },
+    "header_background_color": {
+      "type": "string"
+    },
+    "login_required": {
+      "type": "boolean"
+    },
+    "mobile_logo_url": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "logo_url",
+    "logo_small_url",
+    "apple_touch_icon_url",
+    "favicon_url",
+    "title",
+    "description",
+    "header_primary_color",
+    "header_background_color",
+    "login_required",
+    "mobile_logo_url"
+  ]
+}

--- a/spec/requests/api/site_spec.rb
+++ b/spec/requests/api/site_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe "site" do
       end
     end
   end
+
+  path "/site/basic-info.json" do
+    get "Get site basic info" do
+      tags "Site"
+      operationId "getSiteBasicInfo"
+      description "Can be used to fetch basic info about a site"
+      consumes "application/json"
+      expected_request_schema = nil
+
+      produces "application/json"
+      response "200", "success response" do
+        expected_response_schema = load_spec_schema("site_basic_info_response")
+        schema expected_response_schema
+
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add the /site/basic-info.json endpoint to the api docs.

See: https://meta.discourse.org/t/302109
