### PR TITLE
FEATURE: ignore manually deactivated users when purging

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/site-setting-filter.js
+++ b/app/assets/javascripts/discourse/app/lib/site-setting-filter.js
@@ -78,10 +78,12 @@ export default class SiteSettingFilter {
             setting.includes(filter) ||
             setting.replace(/_/g, " ").includes(filter) ||
             item.get("description").toLowerCase().includes(filter) ||
-            (item.get("keywords") || "")
-              .replace(/_/g, " ")
-              .toLowerCase()
-              .includes(filter.replace(/_/g, " ")) ||
+            (item.get("keywords") || []).any((keyword) =>
+              keyword
+                .replace(/_/g, " ")
+                .toLowerCase()
+                .includes(filter.replace(/_/g, " "))
+            ) ||
             (item.get("value") || "").toString().toLowerCase().includes(filter);
           if (!filterResult && fuzzyRegex && fuzzyRegex.test(setting)) {
             // Tightens up fuzzy search results a bit.

--- a/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
@@ -21,7 +21,7 @@ export default {
         preview: null,
         secret: false,
         type: "username",
-        keywords: "blah blah",
+        keywords: ["blah blah"],
       },
       {
         setting: "logo",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2024,7 +2024,7 @@ class User < ActiveRecord::Base
 
     User
       .joins(
-        "LEFT JOIN user_histories ON user_histories.target_user_id = users.id AND action = #{UserHistory.actions[:deactivate_user]} AND acting_user_id != #{Discourse.system_user.id}",
+        "LEFT JOIN user_histories ON user_histories.target_user_id = users.id AND action = #{UserHistory.actions[:deactivate_user]} AND acting_user_id > 0",
       )
       .where(active: false)
       .where("users.created_at < ?", SiteSetting.purge_unactivated_users_grace_period_days.days.ago)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2673,6 +2673,14 @@ en:
       user_api_key_allowed_groups: "min_trust_level_for_user_api_key"
       tag_topic_allowed_groups: "min_trust_level_to_tag_topics"
       profile_background_allowed_groups: "min_trust_level_to_allow_profile_background"
+      clean_up_inactive_users_after_days:
+        - "deactivated"
+        - "inactive"
+        - "unactivated"
+      purge_unactivated_users_grace_period_days:
+        - "deactivated"
+        - "inactive"
+        - "unactivated"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -260,7 +260,7 @@ module SiteSettingExtension
   end
 
   def keywords(setting)
-    I18n.t("site_settings.keywords.#{setting}", default: "")
+    Array.wrap(I18n.t("site_settings.keywords.#{setting}", default: ""))
   end
 
   def placeholder(setting)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1848,7 +1848,7 @@ RSpec.describe User do
       )
     end
 
-    it "should only remove old, unactivated users" do
+    it "should only remove old, unactivated users that haven't been manually deactivated" do
       User.purge_unactivated
       expect(User.real.all).to match_array(
         [

--- a/spec/system/admin_site_setting_search_spec.rb
+++ b/spec/system/admin_site_setting_search_spec.rb
@@ -33,6 +33,13 @@ describe "Admin Site Setting Search", type: :system do
       expect(settings_page).to have_search_result("anonymous_posting_allowed_groups")
     end
 
+    it "finds the associated site setting when many keywords" do
+      settings_page.visit
+      settings_page.type_in_search("deactivated")
+      expect(settings_page).to have_search_result("clean_up_inactive_users_after_days")
+      expect(settings_page).to have_search_result("purge_unactivated_users_grace_period_days")
+    end
+
     it "can search for previous site setting without underscores" do
       settings_page.visit
       settings_page.type_in_search("anonymous posting min")


### PR DESCRIPTION
When a user is manually deactivated, they should not be deleted by our background job that purges inactive users.

In addition, site settings keywords should accept an array of keywords.

