### PR TITLE
DEV: Fix flaky system test

### DIFF
--- a/plugins/chat/spec/system/document_title_spec.rb
+++ b/plugins/chat/spec/system/document_title_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Document title", type: :system do
     it "shows the channel name in the document title" do
       chat_page.visit_channel(channel_1)
 
-      expect(page.title).to start_with("##{channel_1.title}")
+      expect(page).to have_title("##{channel_1.title}")
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe "Document title", type: :system do
     it "shows the channel name in the document title" do
       chat_page.visit_channel(channel_1)
 
-      expect(page.title).to start_with("#{channel_1.title(current_user)}")
+      expect(page).to have_title("#{channel_1.title(current_user)}")
     end
   end
 end


### PR DESCRIPTION
### Why this change?

`expect(page.title).to starts_with("...")` does not rely on capybara
waiters. This commit switches us to use `have_title` instead which will
rely on Capybara waiters.
