### PR TITLE
FIX: Ensure `Theme#settings` are instances of `ThemeSettings`

### DIFF
--- a/app/assets/javascripts/admin/addon/adapters/theme.js
+++ b/app/assets/javascripts/admin/addon/adapters/theme.js
@@ -1,8 +1,8 @@
 import RestAdapter from "discourse/adapters/rest";
-import ThemeSettings from "admin/models/theme-settings";
 
 export default class Theme extends RestAdapter {
   jsonMode = true;
+
   basePath() {
     return "/admin/";
   }
@@ -22,13 +22,6 @@ export default class Theme extends RestAdapter {
       let mappedParents = theme.get("parent_themes") || [];
       mappedParents = mappedParents.map((t) => map[t.id]);
       theme.set("parentThemes", mappedParents);
-
-      if (theme.settings) {
-        theme.set(
-          "settings",
-          theme.settings.map((setting) => ThemeSettings.create(setting))
-        );
-      }
     });
 
     return results;

--- a/app/assets/javascripts/admin/addon/models/theme.js
+++ b/app/assets/javascripts/admin/addon/models/theme.js
@@ -5,6 +5,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import RestModel from "discourse/models/rest";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
+import ThemeSettings from "admin/models/theme-settings";
 
 const THEME_UPLOAD_VAR = 2;
 const FIELDS_IDS = [0, 1, 5];
@@ -14,6 +15,16 @@ export const COMPONENTS = "components";
 const SETTINGS_TYPE_ID = 5;
 
 class Theme extends RestModel {
+  static munge(json) {
+    if (json.settings) {
+      json.settings = json.settings.map((setting) =>
+        ThemeSettings.create(setting)
+      );
+    }
+
+    return json;
+  }
+
   @or("default", "user_selectable") isActive;
   @gt("remote_theme.commits_behind", 0) isPendingUpdates;
   @gt("editedFields.length", 0) hasEditedFields;

--- a/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
@@ -1,9 +1,31 @@
 import { getOwner } from "@ember/application";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import ThemeSettings from "admin/models/theme-settings";
 
 module("Unit | Model | theme", function (hooks) {
   setupTest(hooks);
+
+  test("create munges settings property to ThemeSettings instances", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+
+    const theme = store.createRecord("theme", {
+      settings: [
+        { id: 1, name: "setting1" },
+        { id: 2, name: "setting2" },
+      ],
+    });
+
+    assert.ok(
+      theme.settings[0] instanceof ThemeSettings,
+      "should be an instance of ThemeSettings"
+    );
+
+    assert.ok(
+      theme.settings[1] instanceof ThemeSettings,
+      "should be an instance of ThemeSettings"
+    );
+  });
 
   test("can add an upload correctly", function (assert) {
     const store = getOwner(this).lookup("service:store");


### PR DESCRIPTION
### Why this change?

Instead of dealing with a generic object for `Theme#settings`, we want
to always be dealing with `ThemeSettings` objects. Previously, we
converted the generic objects to `ThemeSettings` objects in the theme's
adapter `afterFindAll` function. This is not correct because updating
or saving the theme individually reverted the `Theme#settings` back to an
array of generic object.

To fix this problem, the proper way with our REST models is to overwrite
the static `munge` method and create `ThemeSettings` instances there.
