### PR TITLE
DEV: Restore RSpec 'documentation' output, but collapse in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        run: bin/rake plugin:turbo_spec['*','--verbose --format progress --use-runtime-info']
+        run: bin/rake plugin:turbo_spec['*','--verbose --format documentation --use-runtime-info']
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,11 +212,11 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: bin/turbo_rspec --use-runtime-info --verbose
+        run: bin/turbo_rspec --use-runtime-info --verbose --format documentation
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        run: bin/rake plugin:turbo_spec['*','--verbose --use-runtime-info']
+        run: bin/rake plugin:turbo_spec['*','--verbose --format progress --use-runtime-info']
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
@@ -246,7 +246,7 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose spec/system
+        run: RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation spec/system
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
@@ -254,7 +254,7 @@ jobs:
           CHECKOUT_TIMEOUT: 10
         run: |
           GLOBIGNORE="plugins/chat/*";
-          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose plugins/*/spec/system
+          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
         timeout-minutes: 30
 
@@ -262,7 +262,7 @@ jobs:
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
           CHECKOUT_TIMEOUT: 10
-        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose plugins/chat/spec/system
+        run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system
         timeout-minutes: 30
 
       - name: Theme System Tests
@@ -270,7 +270,7 @@ jobs:
         env:
           CHECKOUT_TIMEOUT: 10
         run: |
-          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --profile=50 --verbose tmp/themes/*/spec/system
+          RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --profile=50 --verbose --format documentation tmp/themes/*/spec/system
         shell: bash
         timeout-minutes: 30
 

--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -5,14 +5,14 @@ module TurboTests
   class DocumentationFormatter < ::TurboTests::BaseFormatter
     RSpec::Core::Formatters.register(self, :example_failed, :example_passed, :example_pending)
 
-    def start
-      super
+    def start(*args)
+      super(*args)
       output.puts "::group:: Verbose turbo_spec output" if ENV["GITHUB_ACTIONS"]
     end
 
-    def dump_summary
+    def dump_summary(*args)
       output.puts "::endgroup::" if ENV["GITHUB_ACTIONS"]
-      super
+      super(*args)
     end
 
     def example_passed(notification)

--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -3,14 +3,21 @@
 module TurboTests
   # An RSpec formatter that prepends the process id to all messages
   class DocumentationFormatter < ::TurboTests::BaseFormatter
-    RSpec::Core::Formatters.register(self, :example_failed, :example_passed, :example_pending)
+    RSpec::Core::Formatters.register(
+      self,
+      :example_failed,
+      :example_passed,
+      :example_pending,
+      :start,
+      :stop,
+    )
 
     def start(*args)
       super(*args)
       output.puts "::group:: Verbose turbo_spec output" if ENV["GITHUB_ACTIONS"]
     end
 
-    def dump_summary(*args)
+    def stop(*args)
       output.puts "::endgroup::" if ENV["GITHUB_ACTIONS"]
       super(*args)
     end

--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -5,6 +5,16 @@ module TurboTests
   class DocumentationFormatter < ::TurboTests::BaseFormatter
     RSpec::Core::Formatters.register(self, :example_failed, :example_passed, :example_pending)
 
+    def start
+      super
+      output.puts "::group:: Verbose turbo_spec output" if ENV["GITHUB_ACTIONS"]
+    end
+
+    def dump_summary
+      output.puts "::endgroup::" if ENV["GITHUB_ACTIONS"]
+      super
+    end
+
     def example_passed(notification)
       output.puts RSpec::Core::Formatters::ConsoleCodes.wrap(
                     output_example(notification.example),

--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -13,13 +13,11 @@ module TurboTests
     )
 
     def start(*args)
-      super(*args)
       output.puts "::group:: Verbose turbo_spec output" if ENV["GITHUB_ACTIONS"]
     end
 
     def stop(*args)
       output.puts "::endgroup::" if ENV["GITHUB_ACTIONS"]
-      super(*args)
     end
 
     def example_passed(notification)

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -48,6 +48,10 @@ module TurboTests
       end
     end
 
+    def start
+      delegate_to_formatters(:start, RSpec::Core::Notifications::NullNotification)
+    end
+
     def example_passed(example)
       delegate_to_formatters(:example_passed, example.notification)
 
@@ -82,6 +86,8 @@ module TurboTests
 
     def finish
       end_time = Time.now
+
+      delegate_to_formatters(:stop, RSpec::Core::Notifications::NullNotification)
 
       delegate_to_formatters(:start_dump, RSpec::Core::Notifications::NullNotification)
 

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -81,8 +81,6 @@ module TurboTests
 
       @reporter.add_formatter(Flaky::FailuresLoggerFormatter.new) if @retry_and_log_flaky_tests
 
-      @reporter.start
-
       subprocess_opts = { record_runtime: @use_runtime_info }
 
       start_multisite_subprocess(@files, **subprocess_opts)
@@ -90,6 +88,8 @@ module TurboTests
       tests_in_groups.each_with_index do |tests, process_id|
         start_regular_subprocess(tests, process_id + 1, **subprocess_opts)
       end
+
+      @reporter.start
 
       handle_messages
 

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -81,6 +81,8 @@ module TurboTests
 
       @reporter.add_formatter(Flaky::FailuresLoggerFormatter.new) if @retry_and_log_flaky_tests
 
+      @reporter.start
+
       subprocess_opts = { record_runtime: @use_runtime_info }
 
       start_multisite_subprocess(@files, **subprocess_opts)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
