### PR TITLE
DEV: Fix turbo_rspec formatters by sending real 'Start' notification

### DIFF
--- a/lib/turbo_tests/documentation_formatter.rb
+++ b/lib/turbo_tests/documentation_formatter.rb
@@ -13,6 +13,7 @@ module TurboTests
     )
 
     def start(*args)
+      super(*args)
       output.puts "::group:: Verbose turbo_spec output" if ENV["GITHUB_ACTIONS"]
     end
 

--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -49,7 +49,7 @@ module TurboTests
     end
 
     def start
-      delegate_to_formatters(:start, RSpec::Core::Notifications::NullNotification)
+      delegate_to_formatters(:start, RSpec::Core::Notifications::StartNotification.new)
     end
 
     def example_passed(example)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
