### PR TITLE
DEV: Send proper 'stop' notification in turbo_rspec

### DIFF
--- a/lib/turbo_tests/reporter.rb
+++ b/lib/turbo_tests/reporter.rb
@@ -87,7 +87,7 @@ module TurboTests
     def finish
       end_time = Time.now
 
-      delegate_to_formatters(:stop, RSpec::Core::Notifications::NullNotification)
+      delegate_to_formatters(:stop, RSpec::Core::Notifications::ExamplesNotification.new(self))
 
       delegate_to_formatters(:start_dump, RSpec::Core::Notifications::NullNotification)
 


### PR DESCRIPTION
Doesn't actually seem to be used by any of our formatters, but let's send the proper data anyway for future-proofing. Followup to ff6cb1bc059d880368480a847b50f4aceb1e48a1 and 8098876bfaf2a2f28c22d16b5856c4be43fcf32b

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
