### PR TITLE
DEV: Add form template support for composer's `openNewTopic` action

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -16,6 +16,7 @@
   @onExpandPopupMenuOptions={{action "onExpandPopupMenuOptions"}}
   @onPopupMenuAction={{this.onPopupMenuAction}}
   @popupMenuOptions={{this.popupMenuOptions}}
+  @formTemplateId={{this.composer.formTemplateId}}
   @formTemplateIds={{this.formTemplateIds}}
   @formTemplateInitialValues={{@formTemplateInitialValues}}
   @onSelectFormTemplate={{@onSelectFormTemplate}}

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -244,7 +244,7 @@ export default Component.extend(TextareaTextManipulation, {
         return this._selectedFormTemplateId;
       }
 
-      return this.formTemplateIds?.[0];
+      return this.formTemplateId || this.formTemplateIds?.[0];
     },
 
     set(key, value) {

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1288,6 +1288,7 @@ export default class ComposerService extends Service {
    @param {Boolean} [opts.disableScopedCategory]
    @param {Number} [opts.categoryId] Sets `scopedCategoryId` and `categoryId` on the Composer model
    @param {Number} [opts.prioritizedCategoryId]
+   @param {Number} [opts.formTemplateId]
    @param {String} [opts.draftSequence]
    @param {Boolean} [opts.skipDraftCheck]
    @param {Boolean} [opts.skipJumpOnSave] Option to skip navigating to the post when saved in this composer session
@@ -1440,6 +1441,7 @@ export default class ComposerService extends Service {
     body,
     category,
     tags,
+    formTemplate,
     preferDraft = false,
   } = {}) {
     if (preferDraft && this.currentUser.has_topic_draft) {
@@ -1448,6 +1450,7 @@ export default class ComposerService extends Service {
       return this.open({
         prioritizedCategoryId: category?.id,
         topicCategoryId: category?.id,
+        formTemplateId: formTemplate?.id,
         topicTitle: title,
         topicBody: body,
         topicTags: tags,
@@ -1532,6 +1535,15 @@ export default class ComposerService extends Service {
 
     if (opts.topicBody) {
       this.model.set("reply", opts.topicBody);
+    }
+
+    if (
+      opts.formTemplateId &&
+      this.model
+        .get("category.form_template_ids")
+        ?.includes(opts.formTemplateId)
+    ) {
+      this.model.set("formTemplateId", opts.formTemplateId);
     }
 
     if (opts.prependText && !this.model.reply?.includes(opts.prependText)) {


### PR DESCRIPTION
The Composer service's `openNewTopic` action allows us to open the composer with certain topic properties pre-filled/selected. Currently, it supports setting properties such as `title`, `body`, `category` and `tags`.

This PR is intended to add support for form templates to `openNewTopic`.