### PR TITLE
UX: Tweak the mention padding

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -32,8 +32,7 @@ a.hashtag {
   .d-icon,
   .hashtag-icon-placeholder {
     font-size: var(--font-down-2);
-    margin: 0 0.33em 0 0.1em;
-    vertical-align: inherit;
+    margin: 0 0.3em 0 0;
   }
 
   img.emoji {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -257,7 +257,7 @@ $hpad: 0.65em;
   font-size: 0.93em;
   font-weight: normal;
   color: var(--primary);
-  padding: 0.16em 0.4em 0.2em;
+  padding: 0.14em 0.34em 0.19em;
   background: var(--primary-low);
   border-radius: 0.6em;
   text-decoration: none;


### PR DESCRIPTION
…to prevent them from overlapping/touching when placed on consecutive lines of text

Before/After

<img width="296" alt="Screenshot 2024-04-03 at 16 43 39" src="https://github.com/discourse/discourse/assets/66961/70ea3aca-968e-43b4-a207-b469e9708be1"> <img width="296" alt="Screenshot 2024-04-03 at 16 44 29" src="https://github.com/discourse/discourse/assets/66961/48e37dd9-fd5a-4867-8b8f-5929b3ee7cd3">

(screenshot taken with Text Size set to "Smaller")