### PR TITLE
FIX: add home-logo outlet args to non glimmer version

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
@@ -78,10 +78,7 @@ export default class HomeLogo extends Component {
   }
 
   <template>
-    <PluginOutlet
-      @name="home-logo"
-      @outletArgs={{hash minimized=@minimized}}
-    >
+    <PluginOutlet @name="home-logo" @outletArgs={{hash minimized=@minimized}}>
       <div class={{concatClass (if @minimized "title--minimized") "title"}}>
         <a href={{this.href}} {{on "click" this.click}}>
           {{#if @minimized}}

--- a/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
@@ -80,7 +80,7 @@ export default class HomeLogo extends Component {
   <template>
     <PluginOutlet
       @name="home-logo"
-      @outletArgs={{hash minimized=@minimized href=this.href}}
+      @outletArgs={{hash minimized=@minimized}}
     >
       <div class={{concatClass (if @minimized "title--minimized") "title"}}>
         <a href={{this.href}} {{on "click" this.click}}>

--- a/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo-wrapper-outlet.js
@@ -5,7 +5,7 @@ registerWidgetShim(
   "home-logo-wrapper-outlet",
   "div.home-logo-wrapper-outlet",
   hbs`<PluginOutlet @name="home-logo-wrapper">
-    <PluginOutlet @name="home-logo" @outletArgs>
+    <PluginOutlet @name="home-logo" @outletArgs={{hash minimized=@data.topic}}>
       <MountWidget @widget="home-logo" @args={{@data}} />
     </PluginOutlet>
   </PluginOutlet>`


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
