### PR TITLE
FIX: Load categories with post revisions

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -74,9 +74,10 @@ export default class Post extends RestModel {
   }
 
   static loadRevision(postId, version) {
-    return ajax(`/posts/${postId}/revisions/${version}.json`).then((result) =>
-      EmberObject.create(result)
-    );
+    return ajax(`/posts/${postId}/revisions/${version}.json`).then((result) => {
+      result.categories?.forEach((c) => Site.current().updateCategory(c));
+      return EmberObject.create(result);
+    });
   }
 
   static hideRevision(postId, version) {

--- a/app/models/post_revision.rb
+++ b/app/models/post_revision.rb
@@ -28,6 +28,12 @@ class PostRevision < ActiveRecord::Base
     SQL
   end
 
+  def categories
+    return [] if modifications["category_id"].blank?
+
+    @categories ||= Category.where(id: modifications["category_id"])
+  end
+
   def hide!
     update_column(:hidden, true)
   end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -28,6 +28,8 @@ class PostRevisionSerializer < ApplicationSerializer
              :wiki,
              :can_edit
 
+  has_many :categories, serializer: BasicCategorySerializer, embed: :objects
+
   # Creates a field called field_name_changes with previous and
   # current members if a field has changed in this revision
   def self.add_compared_field(field)


### PR DESCRIPTION
When lazy load categories is enabled, categories should be loaded with post revisions because the categories may not be preloaded on the client side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
