### PR TITLE
renamed upgrade to update

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -131,7 +131,7 @@ If you'd like to enable *replying* to topics via email, [see this howto](https:/
 
 - [Our Docker container install](https://github.com/discourse/discourse/blob/main/docs/INSTALL.md) is the only one we officially support. It guarantees easy updates, and all recommended optimizations from the Discourse team.
 
-- You should get an email notification when new versions of Discourse are released. To update your instance via our easy one click upgrade process, visit [/admin/upgrade](/admin/upgrade).
+- You should get an email notification when new versions of Discourse are released. To update your instance via our easy one click process, visit [/admin/update](/admin/update).
 
 ### Optional things you might eventually want to set up
 [] [Automatic daily backups](https://meta.discourse.org/t/configure-automatic-backups-for-discourse/14855)


### PR DESCRIPTION
The "upgrade"page has been renamed to "update". See for context: https://meta.discourse.org/t/new-change-upgrade-page-is-now-the-update-page/302276?u=tobiaseigen

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
