### PR TITLE
DEV: Redo `DiscourseURL.isInternal()`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -286,27 +286,26 @@ const DiscourseURL = EmberObject.extend({
 
   // Determines whether a URL is internal or not
   isInternal(url) {
-    if (url && url.length) {
-      if (url.startsWith("//")) {
-        url = "http:" + url;
-      }
-      if (url.startsWith("#")) {
-        return true;
-      }
-      if (url.startsWith("/")) {
-        return true;
-      }
-      if (url.startsWith(this.origin())) {
-        return true;
-      }
-      if (url.replace(/^http/, "https").startsWith(this.origin())) {
-        return true;
-      }
-      if (url.replace(/^https/, "http").startsWith(this.origin())) {
-        return true;
-      }
+    if (!url?.length) {
+      return false;
     }
-    return false;
+
+    try {
+      const parsedUrl = new URL(url, this.origin);
+
+      if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+        return false;
+      }
+
+      const baseUrl = new URL(this.origin);
+
+      return (
+        parsedUrl.hostname === baseUrl.hostname &&
+        parsedUrl.pathname.startsWith(baseUrl.pathname)
+      );
+    } catch {
+      return false;
+    }
   },
 
   /**
@@ -388,8 +387,8 @@ const DiscourseURL = EmberObject.extend({
   },
 
   // This has been extracted so it can be tested.
-  origin() {
-    let prefix = getURL("/");
+  get origin() {
+    const prefix = getURL("/");
     return window.location.origin + (prefix === "/" ? "" : prefix);
   },
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -295,6 +295,15 @@ const DiscourseURL = EmberObject.extend({
     }
 
     if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      try {
+        const parsedUrl = new URL(url, this.origin);
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+
       return true;
     }
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -290,22 +290,19 @@ const DiscourseURL = EmberObject.extend({
       return false;
     }
 
-    try {
-      const parsedUrl = new URL(url, this.origin);
-
-      if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-        return false;
-      }
-
-      const baseUrl = new URL(this.origin);
-
-      return (
-        parsedUrl.hostname === baseUrl.hostname &&
-        parsedUrl.pathname.startsWith(baseUrl.pathname)
-      );
-    } catch {
-      return false;
+    if (url.startsWith("//")) {
+      url = "http:" + url;
     }
+
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      return true;
+    }
+
+    return (
+      url.startsWith(this.origin) ||
+      url.replace(/^http/, "https").startsWith(this.origin) ||
+      url.replace(/^https/, "http").startsWith(this.origin)
+    );
   },
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -294,24 +294,24 @@ const DiscourseURL = EmberObject.extend({
       url = "http:" + url;
     }
 
-    if (!url.startsWith("http://") && !url.startsWith("https://")) {
-      try {
-        const parsedUrl = new URL(url, this.origin);
-        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-          return false;
-        }
-      } catch {
-        return false;
-      }
-
-      return true;
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      return (
+        url.startsWith(this.origin) ||
+        url.replace(/^http/, "https").startsWith(this.origin) ||
+        url.replace(/^https/, "http").startsWith(this.origin)
+      );
     }
 
-    return (
-      url.startsWith(this.origin) ||
-      url.replace(/^http/, "https").startsWith(this.origin) ||
-      url.replace(/^https/, "http").startsWith(this.origin)
-    );
+    try {
+      const parsedUrl = new URL(url, this.origin);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    return true;
   },
 
   /**

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -81,7 +81,7 @@ module("Unit | Utility | click-track", function (hooks) {
       assert.true(false, "should not request a csrf token");
     });
 
-    sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+    sinon.stub(DiscourseURL, "origin").get(() => "http://discuss.domain.com");
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
@@ -101,7 +101,7 @@ module("Unit | Utility | click-track", function (hooks) {
   });
 
   test("does not track attachments", async function (assert) {
-    sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+    sinon.stub(DiscourseURL, "origin").get(() => "http://discuss.domain.com");
 
     pretender.post("/clicks/track", () => assert.true(false));
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -17,10 +17,6 @@ module("Unit | Utility | url", function (hooks) {
     sinon.stub(DiscourseURL, "origin").get(() => "http://eviltrout.com");
 
     assert.false(DiscourseURL.isInternal(null), "a blank URL is not internal");
-    assert.false(
-      DiscourseURL.isInternal("ftp::/test.com"),
-      "returns false for invalid URLs"
-    );
     assert.true(DiscourseURL.isInternal("/test"), "relative URLs are internal");
     assert.true(
       DiscourseURL.isInternal("docs"),
@@ -46,10 +42,6 @@ module("Unit | Utility | url", function (hooks) {
       DiscourseURL.isInternal("http://twitter.com"),
       "a different host is not internal"
     );
-    assert.false(
-      DiscourseURL.isInternal("ftp://eviltrout.com"),
-      "same host, different protocol is not internal"
-    );
   });
 
   test("isInternal with a HTTPS url", function (assert) {
@@ -57,6 +49,10 @@ module("Unit | Utility | url", function (hooks) {
     assert.true(
       DiscourseURL.isInternal("http://eviltrout.com/monocle"),
       "HTTPS urls match HTTP urls"
+    );
+    assert.true(
+      DiscourseURL.isInternal("https://eviltrout.com/monocle"),
+      "HTTPS urls match HTTPS urls"
     );
   });
 
@@ -73,6 +69,11 @@ module("Unit | Utility | url", function (hooks) {
     assert.true(
       DiscourseURL.isInternal("http://eviltrout.com/forum/moustache"),
       "a url on the same host and on the same folder is internal"
+    );
+    assert.true(DiscourseURL.isInternal("/test"), "relative URLs are internal");
+    assert.true(
+      DiscourseURL.isInternal("docs"),
+      "non-prefixed relative URLs are internal"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -43,6 +43,14 @@ module("Unit | Utility | url", function (hooks) {
       DiscourseURL.isInternal("http://twitter.com"),
       "a different host is not internal"
     );
+    assert.false(
+      DiscourseURL.isInternal("ftp://eviltrout.com"),
+      "a different protocol is not internal"
+    );
+    assert.false(
+      DiscourseURL.isInternal("ftp::/eviltrout.com"),
+      "an invalid URL is not internal"
+    );
   });
 
   test("isInternal with a HTTPS url", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -14,51 +14,63 @@ module("Unit | Utility | url", function (hooks) {
   setupTest(hooks);
 
   test("isInternal with a HTTP url", function (assert) {
-    sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com");
+    sinon.stub(DiscourseURL, "origin").get(() => "http://eviltrout.com");
 
-    assert.notOk(DiscourseURL.isInternal(null), "a blank URL is not internal");
-    assert.ok(DiscourseURL.isInternal("/test"), "relative URLs are internal");
-    assert.ok(
+    assert.false(DiscourseURL.isInternal(null), "a blank URL is not internal");
+    assert.false(
+      DiscourseURL.isInternal("ftp::/test.com"),
+      "returns false for invalid URLs"
+    );
+    assert.true(DiscourseURL.isInternal("/test"), "relative URLs are internal");
+    assert.true(
+      DiscourseURL.isInternal("docs"),
+      "non-prefixed relative URLs are internal"
+    );
+    assert.true(
       DiscourseURL.isInternal("//eviltrout.com"),
       "a url on the same host is internal (protocol-less)"
     );
-    assert.ok(
+    assert.true(
       DiscourseURL.isInternal("http://eviltrout.com/tophat"),
       "a url on the same host is internal"
     );
-    assert.ok(
+    assert.true(
       DiscourseURL.isInternal("https://eviltrout.com/moustache"),
       "a url on a HTTPS of the same host is internal"
     );
-    assert.notOk(
+    assert.false(
       DiscourseURL.isInternal("//twitter.com.com"),
       "a different host is not internal (protocol-less)"
     );
-    assert.notOk(
+    assert.false(
       DiscourseURL.isInternal("http://twitter.com"),
       "a different host is not internal"
+    );
+    assert.false(
+      DiscourseURL.isInternal("ftp://eviltrout.com"),
+      "same host, different protocol is not internal"
     );
   });
 
   test("isInternal with a HTTPS url", function (assert) {
-    sinon.stub(DiscourseURL, "origin").returns("https://eviltrout.com");
-    assert.ok(
+    sinon.stub(DiscourseURL, "origin").get(() => "https://eviltrout.com");
+    assert.true(
       DiscourseURL.isInternal("http://eviltrout.com/monocle"),
       "HTTPS urls match HTTP urls"
     );
   });
 
   test("isInternal on subfolder install", function (assert) {
-    sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com/forum");
-    assert.notOk(
+    sinon.stub(DiscourseURL, "origin").get(() => "http://eviltrout.com/forum");
+    assert.false(
       DiscourseURL.isInternal("http://eviltrout.com"),
       "the host root is not internal"
     );
-    assert.notOk(
+    assert.false(
       DiscourseURL.isInternal("http://eviltrout.com/tophat"),
       "a url on the same host but on a different folder is not internal"
     );
-    assert.ok(
+    assert.true(
       DiscourseURL.isInternal("http://eviltrout.com/forum/moustache"),
       "a url on the same host and on the same folder is internal"
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -22,6 +22,7 @@ module("Unit | Utility | url", function (hooks) {
       DiscourseURL.isInternal("docs"),
       "non-prefixed relative URLs are internal"
     );
+    assert.true(DiscourseURL.isInternal("#foo"), "anchor URLs are internal");
     assert.true(
       DiscourseURL.isInternal("//eviltrout.com"),
       "a url on the same host is internal (protocol-less)"
@@ -75,6 +76,7 @@ module("Unit | Utility | url", function (hooks) {
       DiscourseURL.isInternal("docs"),
       "non-prefixed relative URLs are internal"
     );
+    assert.true(DiscourseURL.isInternal("#foo"), "anchor URLs are internal");
   });
 
   test("userPath", function (assert) {


### PR DESCRIPTION
Simplify the implementation and make it return `true` for prefix-less relative urls, like `docs`