### PR TITLE
DEV: Remove `experimental_objects_type_for_theme_settings` site setting

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -354,12 +354,9 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def schema
-    raise Discourse::InvalidAccess if !SiteSetting.experimental_objects_type_for_theme_settings
   end
 
   def objects_setting_metadata
-    raise Discourse::InvalidAccess if !SiteSetting.experimental_objects_type_for_theme_settings
-
     theme = Theme.find_by(id: params[:id])
     raise Discourse::InvalidParameters.new(:id) unless theme
 

--- a/app/models/theme_setting.rb
+++ b/app/models/theme_setting.rb
@@ -11,7 +11,6 @@ class ThemeSetting < ActiveRecord::Base
   MAXIMUM_JSON_VALUE_SIZE_BYTES = 0.5 * 1024 * 1024 # 0.5 MB
 
   validates_presence_of :name, :theme
-  before_validation :objects_type_enabled
   validates :data_type, inclusion: { in: TYPES_ENUM.values }
   validate :json_value_size, if: -> { self.data_type == TYPES_ENUM[:objects] }
   validates :name, length: { maximum: 255 }
@@ -48,13 +47,6 @@ class ThemeSetting < ActiveRecord::Base
   end
 
   private
-
-  def objects_type_enabled
-    if self.data_type == ThemeSetting.types[:objects] &&
-         !SiteSetting.experimental_objects_type_for_theme_settings
-      self.data_type = nil
-    end
-  end
 
   def json_value_size
     if json_value.to_json.size > MAXIMUM_JSON_VALUE_SIZE_BYTES

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2366,9 +2366,6 @@ developer:
     list_type: compact
     allow_any: false
     refresh: true
-  experimental_objects_type_for_theme_settings:
-    default: false
-    hidden: true
 
 navigation:
   navigation_menu:

--- a/db/migrate/20240404034232_remove_experimental_objects_type_for_theme_settings.rb
+++ b/db/migrate/20240404034232_remove_experimental_objects_type_for_theme_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveExperimentalObjectsTypeForThemeSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'experimental_objects_type_for_theme_settings'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/lib/theme_settings_manager/objects_spec.rb
+++ b/spec/lib/theme_settings_manager/objects_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe ThemeSettingsManager::Objects do
     theme.settings
   end
 
-  before { SiteSetting.experimental_objects_type_for_theme_settings = true }
-
   it "can store a list of objects" do
     new_value = [
       {

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ThemeField do
   before do
     SvgSprite.clear_plugin_svg_sprite_cache!
     ThemeJavascriptCompiler.disable_terser!
-    SiteSetting.experimental_objects_type_for_theme_settings = true
   end
 
   after { ThemeJavascriptCompiler.enable_terser! }

--- a/spec/models/theme_setting_spec.rb
+++ b/spec/models/theme_setting_spec.rb
@@ -4,28 +4,7 @@ RSpec.describe ThemeSetting do
   fab!(:theme)
 
   context "for validations" do
-    it "should be invalid when setting data_type to objects and `experimental_objects_type_for_theme_settings` is disabled" do
-      SiteSetting.experimental_objects_type_for_theme_settings = false
-
-      theme_setting =
-        ThemeSetting.new(name: "test", data_type: ThemeSetting.types[:objects], theme:)
-
-      expect(theme_setting.valid?).to eq(false)
-      expect(theme_setting.errors[:data_type]).to contain_exactly("is not included in the list")
-    end
-
-    it "should be valid when setting data_type to objects and `experimental_objects_type_for_theme_settings` is enabled" do
-      SiteSetting.experimental_objects_type_for_theme_settings = true
-
-      theme_setting =
-        ThemeSetting.new(name: "test", data_type: ThemeSetting.types[:objects], theme:)
-
-      expect(theme_setting.valid?).to eq(true)
-    end
-
     it "should be invalid when json_value size is greater than the maximum allowed size" do
-      SiteSetting.experimental_objects_type_for_theme_settings = true
-
       json_value = { "key" => "value" }
       bytesize = json_value.to_json.bytesize
 

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -1064,8 +1064,6 @@ RSpec.describe Admin::ThemesController do
       end
 
       it "should return the right error when value used to update a theme setting of `objects` typed is invalid" do
-        SiteSetting.experimental_objects_type_for_theme_settings = true
-
         field =
           theme.set_field(
             target: :settings,
@@ -1091,8 +1089,6 @@ RSpec.describe Admin::ThemesController do
       end
 
       it "should be able to update a theme setting of `objects` typed" do
-        SiteSetting.experimental_objects_type_for_theme_settings = true
-
         field =
           theme.set_field(
             target: :settings,
@@ -1351,8 +1347,6 @@ RSpec.describe Admin::ThemesController do
       theme.settings
     end
 
-    before { SiteSetting.experimental_objects_type_for_theme_settings = true }
-
     it "returns 404 if user is not an admin" do
       get "/admin/themes/#{theme.id}/objects_setting_metadata/objects_with_categories.json"
 
@@ -1373,14 +1367,6 @@ RSpec.describe Admin::ThemesController do
 
     context "when user is an admin" do
       before { sign_in(admin) }
-
-      it "returns 403 if `experimental_objects_type_for_theme_settings` site setting is not enabled" do
-        SiteSetting.experimental_objects_type_for_theme_settings = false
-
-        get "/admin/themes/#{theme.id}/objects_setting_metadata/objects_with_categories.json"
-
-        expect(response.status).to eq(403)
-      end
 
       it "returns 400 if the `id` param is not the id of a valid theme" do
         get "/admin/themes/some_invalid_id/objects_setting_metadata/objects_with_categories.json"

--- a/spec/serializers/theme_objects_setting_metadata_serializer_spec.rb
+++ b/spec/serializers/theme_objects_setting_metadata_serializer_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe ThemeObjectsSettingMetadataSerializer do
     theme.settings
   end
 
-  before { SiteSetting.experimental_objects_type_for_theme_settings = true }
-
   describe "#property_descriptions" do
     let(:objects_setting_locale) do
       theme.set_field(

--- a/spec/serializers/theme_settings_serializer_spec.rb
+++ b/spec/serializers/theme_settings_serializer_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe ThemeSettingsSerializer do
     theme.settings
   end
 
-  before { SiteSetting.experimental_objects_type_for_theme_settings = true }
-
   describe "#objects_schema" do
     it "should include the attribute when theme setting is typed objects" do
       payload = ThemeSettingsSerializer.new(theme_setting[:objects_setting]).as_json

--- a/spec/system/admin_editing_objects_typed_theme_setting_spec.rb
+++ b/spec/system/admin_editing_objects_typed_theme_setting_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Admin editing objects type theme setting", type: :system do
   end
 
   before do
-    SiteSetting.experimental_objects_type_for_theme_settings = true
     objects_setting
     sign_in(admin)
   end


### PR DESCRIPTION
### Why this change?

Objects type for theme settings is no longer considered experimental so
we are dropping the site setting.
