### PR TITLE
FIX: Input fields not displaying when adding a object to empty setting

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
@@ -144,8 +144,9 @@ export default class SchemaThemeSettingNewEditor extends Component {
 
   get fields() {
     const list = [];
+    const activeObject = this.activeData[this.activeIndex];
 
-    if (this.activeData.length !== 0) {
+    if (activeObject) {
       for (const [name, spec] of Object.entries(this.activeSchema.properties)) {
         if (spec.type === "objects") {
           continue;
@@ -154,7 +155,7 @@ export default class SchemaThemeSettingNewEditor extends Component {
         list.push({
           name,
           spec,
-          value: this.activeData[this.activeIndex][name],
+          value: activeObject[name],
           description: this.fieldDescription(name),
           label: this.fieldLabel(name),
         });

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -1143,6 +1143,36 @@ module(
       assert.dom(inputFields.fields.text.inputElement).hasValue("Talk to us");
     });
 
+    test("adding an object to the root list of objects which is empty by default", async function (assert) {
+      const setting = ThemeSettings.create({
+        setting: "objects_setting",
+        objects_schema: {
+          name: "something",
+          properties: {
+            name: {
+              type: "string",
+            },
+          },
+        },
+        value: [],
+      });
+
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @themeId="1" @setting={{setting}} />
+      </template>);
+
+      assert.dom(TOP_LEVEL_ADD_BTN).hasText("something");
+      await click(TOP_LEVEL_ADD_BTN);
+
+      const tree = new TreeFromDOM();
+
+      assert.dom(tree.nodes[0].textElement).hasText("something 1");
+
+      const inputFields = new InputFieldsFromDOM();
+
+      assert.dom(inputFields.fields.name.labelElement).hasText("name");
+    });
+
     test("adding an object to the root list of objects", async function (assert) {
       const setting = schemaAndData(1);
 


### PR DESCRIPTION
### Why this change?

Prior to this change, the input fields were not displaying when adding
an object to a objects typed theme setting which has a default value of
`[]`. This is because the `fields` getter was not being recomputed.
