### PR TITLE
UX: Keep input headings consistently bold

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -303,7 +303,7 @@
       label:not(.checkbox-label) {
         width: auto;
         text-align: left;
-        font-weight: normal;
+        font-weight: bold;
       }
 
       .instructions {


### PR DESCRIPTION
Before|After
-|-
<img width="593" alt="image" src="https://github.com/discourse/discourse/assets/37538241/5d00892a-5fa9-423b-a446-309840a217b2">|<img width="601" alt="image" src="https://github.com/discourse/discourse/assets/37538241/8d266761-7124-4ad1-b5de-c09a6c93102b">