### PR TITLE
DEV: add "load-morphlex" wrapper...

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/load-morphlex.js
+++ b/app/assets/javascripts/discourse/app/lib/load-morphlex.js
@@ -1,0 +1,3 @@
+export default async function loadMorphlex() {
+  return await import("morphlex");
+}

--- a/app/assets/javascripts/discourse/app/lib/load-morphlex.js
+++ b/app/assets/javascripts/discourse/app/lib/load-morphlex.js
@@ -1,3 +1,7 @@
+/**
+Plugins & themes are unable to async-import npm modules directly.
+This wrapper provides them with a way to use morphlex, while keeping the `import()` in core's codebase.
+*/
 export default async function loadMorphlex() {
   return await import("morphlex");
 }

--- a/app/assets/javascripts/discourse/app/lib/load-morphlex.js
+++ b/app/assets/javascripts/discourse/app/lib/load-morphlex.js
@@ -1,4 +1,4 @@
-/**
+/*
 Plugins & themes are unable to async-import npm modules directly.
 This wrapper provides them with a way to use morphlex, while keeping the `import()` in core's codebase.
 */


### PR DESCRIPTION
... so plugins can import and use `morphlex`.

No tests because it's just adding a loading wrapper to be used by plugins.