### PR TITLE
FIX: Load category info for about page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/about.js
+++ b/app/assets/javascripts/discourse/app/routes/about.js
@@ -1,35 +1,17 @@
 import { ajax } from "discourse/lib/ajax";
-import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
 export default DiscourseRoute.extend({
   model() {
     return ajax("/about.json").then((result) => {
-      let activeAdmins = [];
-      let activeModerators = [];
       const yearAgo = moment().locale("en").utc().subtract(1, "year");
-      result.about.admins.forEach((r) => {
-        if (moment(r.last_seen_at) > yearAgo) {
-          activeAdmins.push(r);
-        }
-      });
-      result.about.moderators.forEach((r) => {
-        if (moment(r.last_seen_at) > yearAgo) {
-          activeModerators.push(r);
-        }
-      });
-      result.about.admins = activeAdmins;
-      result.about.moderators = activeModerators;
-
-      const { category_moderators: categoryModerators } = result.about;
-      if (categoryModerators && categoryModerators.length) {
-        categoryModerators.forEach((obj, index) => {
-          const category = Category.findById(obj.category_id);
-          result.about.category_moderators[index].category = category;
-        });
-      }
-
+      result.about.admins = result.about.admins.filter(
+        (r) => moment(r.last_seen_at) > yearAgo
+      );
+      result.about.moderators = result.about.moderators.filter(
+        (r) => moment(r.last_seen_at) > yearAgo
+      );
       return result.about;
     });
   },

--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -7,10 +7,10 @@ class About
 
   class CategoryMods
     include ActiveModel::Serialization
-    attr_reader :category_id, :moderators
+    attr_reader :category, :moderators
 
-    def initialize(category_id, moderators)
-      @category_id = category_id
+    def initialize(category, moderators)
+      @category = category
       @moderators = moderators
     end
   end
@@ -85,9 +85,10 @@ class About
       ORDER BY c.position
     SQL
 
+    cats = Category.where(id: results.map(&:category_id)).index_by(&:id)
     mods = User.where(id: results.map(&:user_ids).flatten.uniq).index_by(&:id)
 
-    results.map { |row| CategoryMods.new(row.category_id, mods.values_at(*row.user_ids)) }
+    results.map { |row| CategoryMods.new(cats[row.category_id], mods.values_at(*row.user_ids)) }
   end
 
   def category_mods_limit

--- a/app/serializers/about_serializer.rb
+++ b/app/serializers/about_serializer.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 class AboutSerializer < ApplicationSerializer
+  class CategoryAboutSerializer < ApplicationSerializer
+    attributes :id, :name, :color, :slug, :parent_category_id
+  end
+
   class UserAboutSerializer < BasicUserSerializer
     attributes :title, :last_seen_at
   end
 
   class AboutCategoryModsSerializer < ApplicationSerializer
-    attributes :category_id
-
+    has_one :category, serializer: CategoryAboutSerializer, embed: :objects
     has_many :moderators, serializer: UserAboutSerializer, embed: :objects
   end
 

--- a/spec/models/about_spec.rb
+++ b/spec/models/about_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe About do
 
     it "lists moderators of the category that the current user can see" do
       results = About.new(private_cat_moderator).category_moderators
-      expect(results.map(&:category_id)).to contain_exactly(public_cat.id, private_cat.id)
+      expect(results.map(&:category).map(&:id)).to contain_exactly(public_cat.id, private_cat.id)
       expect(results.map(&:moderators).flatten.map(&:id).uniq).to contain_exactly(
         public_cat_moderator.id,
         common_moderator.id,
@@ -97,7 +97,7 @@ RSpec.describe About do
 
       [public_cat_moderator, user, nil].each do |u|
         results = About.new(u).category_moderators
-        expect(results.map(&:category_id)).to contain_exactly(public_cat.id)
+        expect(results.map(&:category).map(&:id)).to contain_exactly(public_cat.id)
         expect(results.map(&:moderators).flatten.map(&:id)).to eq(
           [public_cat_moderator.id, common_moderator.id, common_moderator_2.id],
         )


### PR DESCRIPTION
Load a basic category object instead of just the category ID. This makes the about page self contained (it does not require additional category info from the `Site` object).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
