### PR TITLE
DEV: Add `topic_embed_import_create_args` plugin modifier

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -81,6 +81,17 @@ class TopicEmbed < ActiveRecord::Base
         }
         create_args[:visible] = false if SiteSetting.import_embed_unlisted?
 
+        # always return `args` when using this modifier, e.g:
+        #
+        # plugin.register_modifier(:topic_embed_import_create_args) do |args|
+        #   args[:title] = "MODIFIED: #{args[:title]}"
+        #
+        #   args # returning args is important to prevent errors
+        # end
+        create_args =
+          DiscoursePluginRegistry.apply_modifier(:topic_embed_import_create_args, create_args) ||
+            create_args
+
         post = PostCreator.create(user, create_args)
         post.topic.topic_embed.update!(embed_content_cache: original_contents)
       end

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -245,6 +245,46 @@ RSpec.describe TopicEmbed do
           )
         expect(imported_post.cooked).to match(/onebox|iframe/)
       end
+
+      describe "topic_embed_import_create_args modifier" do
+        after { DiscoursePluginRegistry.clear_modifiers! }
+
+        it "can alter the args used to create the topic" do
+          plugin = Plugin::Instance.new
+          plugin.register_modifier(:topic_embed_import_create_args) do |args|
+            args[:title] = "MODIFIED: #{args[:title]}"
+
+            args
+          end
+
+          Jobs.run_immediately!
+          imported_post =
+            TopicEmbed.import(
+              user,
+              "http://eviltrout.com/abcd",
+              title,
+              "some random content",
+              category_id: category.id,
+            )
+          expect(imported_post.topic.title).to eq("MODIFIED: #{title}")
+        end
+
+        it "will revert to defaults if the modifier returns nil" do
+          plugin = Plugin::Instance.new
+          plugin.register_modifier(:topic_embed_import_create_args) { |args| nil }
+
+          Jobs.run_immediately!
+          imported_post =
+            TopicEmbed.import(
+              user,
+              "http://eviltrout.com/abcd",
+              title,
+              "some random content",
+              category_id: category.id,
+            )
+          expect(imported_post.topic.title).to eq(title)
+        end
+      end
     end
 
     context "when post creation supports markdown rendering" do
@@ -285,46 +325,6 @@ RSpec.describe TopicEmbed do
         post = TopicEmbed.import(user, url, title, no_para)
 
         expect(post.raw).to include("testing it")
-      end
-    end
-
-    describe "topic_embed_import_create_args modifier" do
-      after { DiscoursePluginRegistry.clear_modifiers! }
-
-      it "can alter the args used to create the topic" do
-        plugin = Plugin::Instance.new
-        plugin.register_modifier(:topic_embed_import_create_args) do |args|
-          args[:title] = "MODIFIED: #{args[:title]}"
-
-          args
-        end
-
-        Jobs.run_immediately!
-        imported_post =
-          TopicEmbed.import(
-            user,
-            "http://eviltrout.com/abcd",
-            title,
-            "some random content",
-            category_id: category.id,
-          )
-        expect(imported_post.topic.title).to eq("MODIFIED: #{title}")
-      end
-
-      it "will revert to defaults if the modifier returns nil" do
-        plugin = Plugin::Instance.new
-        plugin.register_modifier(:topic_embed_import_create_args) { |args| nil }
-
-        Jobs.run_immediately!
-        imported_post =
-          TopicEmbed.import(
-            user,
-            "http://eviltrout.com/abcd",
-            title,
-            "some random content",
-            category_id: category.id,
-          )
-        expect(imported_post.topic.title).to eq(title)
       end
     end
   end


### PR DESCRIPTION
This modifier allows a plugin to change the arguments used when creating a new topic for an imported article.

For example: let's say you want to prepend "Imported: " to the title of every imported topic. You could use this modifier like so:

```ruby
# In your plugin's code
plugin.register_modifier(:topic_embed_import_create_args) do |args|
  args[:title] = "Imported: #{args[:title]}"
  args
end
```

In this example, the modifier is prepending "Imported: " to the `title` in the `create_args` hash. This modified title would then be used when the new topic is created.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
