### PR TITLE
FIX: update topic property access in raw topic-status view

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-views/topic-status.js
+++ b/app/assets/javascripts/discourse/app/raw-views/topic-status.js
@@ -16,13 +16,13 @@ export default EmberObject.extend({
     const results = [];
 
     // TODO, custom statuses? via override?
-    if (topic.get("is_warning")) {
+    if (topic.is_warning) {
       results.push({ icon: "envelope", key: "warning" });
     }
 
-    if (topic.get("bookmarked")) {
-      const postNumbers = topic.get("bookmarked_post_numbers");
-      let url = topic.get("url");
+    if (topic.bookmarked) {
+      const postNumbers = topic.bookmarked_post_numbers;
+      let url = topic.url;
       let extraClasses = "";
       if (postNumbers && postNumbers[0] > 1) {
         url += "/" + postNumbers[0];
@@ -38,23 +38,23 @@ export default EmberObject.extend({
       });
     }
 
-    if (topic.get("closed") && topic.get("archived")) {
+    if (topic.closed && topic.archived) {
       results.push({ icon: "lock", key: "locked_and_archived" });
-    } else if (topic.get("closed")) {
+    } else if (topic.closed) {
       results.push({ icon: "lock", key: "locked" });
-    } else if (topic.get("archived")) {
+    } else if (topic.archived) {
       results.push({ icon: "lock", key: "archived" });
     }
 
-    if (topic.get("pinned")) {
+    if (topic.pinned) {
       results.push({ icon: "thumbtack", key: "pinned" });
     }
 
-    if (topic.get("unpinned")) {
+    if (topic.unpinned) {
       results.push({ icon: "thumbtack", key: "unpinned" });
     }
 
-    if (topic.get("invisible")) {
+    if (topic.invisible) {
       results.push({ icon: "far-eye-slash", key: "unlisted" });
     }
 


### PR DESCRIPTION
Building on the modernization efforts of PR #26342, this PR applies similar updates to topic property access in the topic-status raw view, shifting from Ember's .get to direct property access.