### PR TITLE
DEV: Move automation dependencies to core's Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -264,3 +264,7 @@ gem "net-http"
 gem "cgi", ">= 0.3.6", require: false
 
 gem "tzinfo-data"
+
+# dependencies for the automation plugin
+gem "iso8601"
+gem "rrule"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       progress (~> 3.0, >= 3.0.1)
     image_size (3.4.0)
     in_threads (1.6.0)
+    iso8601 (0.13.0)
     jmespath (1.6.2)
     json (2.7.2)
     json-schema (4.3.0)
@@ -366,6 +367,8 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
+    rrule (0.6.0)
+      activesupport (>= 2.3)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -580,6 +583,7 @@ DEPENDENCIES
   htmlentities
   http_accept_language
   image_optim
+  iso8601
   json
   json_schemer
   listen
@@ -637,6 +641,7 @@ DEPENDENCIES
   rinku
   rotp
   rqrcode
+  rrule
   rspec
   rspec-html-matchers
   rspec-rails

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -7,9 +7,6 @@
 # authors: jjaffeux
 # url: https://github.com/discourse/discourse/tree/main/plugins/automation
 
-gem "iso8601", "0.13.0"
-gem "rrule", "0.4.4"
-
 enabled_site_setting :discourse_automation_enabled
 
 register_asset "stylesheets/common/discourse-automation.scss"


### PR DESCRIPTION
Moving the automation plugin dependencies to core allows us to receive automatic notifications about new releases for those gems.

Internal topic: t/112693/54.