### PR TITLE
FEATURE: Add message to bulk close topics

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
+import { on } from "@ember/modifier";
 import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
 import { Promise } from "rsvp";
@@ -10,6 +11,7 @@ import DModal from "discourse/components/d-modal";
 import RadioButton from "discourse/components/radio-button";
 import { topicLevels } from "discourse/lib/notification-levels";
 import Topic from "discourse/models/topic";
+import autoFocus from "discourse/modifiers/auto-focus";
 import htmlSafe from "discourse-common/helpers/html-safe";
 import i18n from "discourse-common/helpers/i18n";
 import CategoryChooser from "select-kit/components/category-chooser";
@@ -30,6 +32,7 @@ export default class BulkTopicActions extends Component {
   @tracked loading;
   @tracked errors;
   @tracked isSilent = false;
+  @tracked closeNote = null;
 
   notificationLevelId = null;
 
@@ -82,6 +85,10 @@ export default class BulkTopicActions extends Component {
 
     if (this.isSilent) {
       operation = { type: "silent_close" };
+    }
+
+    if (this.isCloseAction && this.closeNote) {
+      operation["message"] = this.closeNote;
     }
 
     const tasks = topicChunks.map((topics) => async () => {
@@ -246,6 +253,17 @@ export default class BulkTopicActions extends Component {
     return this.args.model.action === "update-category";
   }
 
+  @computed("action")
+  get isCloseAction() {
+    return this.args.model.action === "close";
+  }
+
+  @action
+  updateCloseNote(event) {
+    event.preventDefault();
+    this.closeNote = event.target.value;
+  }
+
   get notificationLevels() {
     return topicLevels.map((level) => ({
       id: level.id.toString(),
@@ -321,6 +339,23 @@ export default class BulkTopicActions extends Component {
               this.activeComponent
               onRegisterAction=this.registerCustomAction
             }}
+          {{/if}}
+
+          {{#if this.isCloseAction}}
+            <div class="control-group assign-status">
+              <label>
+                {{i18n "discourse_assign.assign_modal.note_label"}}&nbsp;<span
+                  class="label-optional"
+                >{{i18n "discourse_assign.assign_modal.optional_label"}}</span>
+              </label>
+
+              <textarea
+                id="bulk-close-note"
+                {{on "input" this.updateCloseNote}}
+                {{!-- {{on "keydown" this.handleTextAreaKeydown}} --}}
+                {{autoFocus}}
+              >{{this.closeNote}}</textarea>
+            </div>
           {{/if}}
         </ConditionalLoadingSection>
       </:body>

--- a/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -352,7 +352,6 @@ export default class BulkTopicActions extends Component {
               <textarea
                 id="bulk-close-note"
                 {{on "input" this.updateCloseNote}}
-                {{!-- {{on "keydown" this.handleTextAreaKeydown}} --}}
                 {{autoFocus}}
               >{{this.closeNote}}</textarea>
             </div>

--- a/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -342,11 +342,11 @@ export default class BulkTopicActions extends Component {
           {{/if}}
 
           {{#if this.isCloseAction}}
-            <div class="control-group assign-status">
+            <div class="bulk-close-note-section">
               <label>
-                {{i18n "discourse_assign.assign_modal.note_label"}}&nbsp;<span
+                {{i18n "topic_bulk_actions.close_topics.note"}}&nbsp;<span
                   class="label-optional"
-                >{{i18n "discourse_assign.assign_modal.optional_label"}}</span>
+                >{{i18n "topic_bulk_actions.close_topics.optional"}}</span>
               </label>
 
               <textarea

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -230,6 +230,9 @@
   #bulk-topics-cancel {
     margin-left: auto;
   }
+  .bulk-close-note-section {
+    margin-top: 1em;
+  }
 }
 
 .d-modal.edit-slow-mode-modal {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1010,6 +1010,7 @@ class TopicsController < ApplicationController
           :group,
           :category_id,
           :notification_level_id,
+          :message,
           *DiscoursePluginRegistry.permitted_bulk_action_parameters,
           tags: [],
         )

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3028,6 +3028,8 @@ en:
     topic_bulk_actions:
       close_topics:
         name: "Close Topics"
+        note: "Note"
+        optional: (optional)
       archive_topics:
         name: "Archive Topics"
       unlist_topics:

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -165,7 +165,7 @@ class TopicsBulkAction
   def close
     topics.each do |t|
       if guardian.can_moderate?(t)
-        t.update_status("closed", true, @user)
+        t.update_status("closed", true, @user, { message: @operation[:message] })
         @changed_ids << t.id
       end
     end
@@ -174,7 +174,7 @@ class TopicsBulkAction
   def silent_close
     topics.each do |t|
       if guardian.can_moderate?(t)
-        t.update_status("autoclosed", true, @user)
+        t.update_status("autoclosed", true, @user, { message: @operation[:message] })
         @changed_ids << t.id
       end
     end

--- a/spec/system/page_objects/components/topic_list_header.rb
+++ b/spec/system/page_objects/components/topic_list_header.rb
@@ -50,6 +50,10 @@ module PageObjects
         find("#topic-bulk-action-options__silent").click
       end
 
+      def fill_in_close_note(message)
+        find("#bulk-close-note").set(message)
+      end
+
       def click_dismiss_read_confirm
         find("#dismiss-read-confirm").click
       end

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -100,13 +100,11 @@ describe "Topic bulk select", type: :system do
 
       # Fill in message
       topic_list_header.fill_in_close_note("My message")
-      sleep(10)
       topic_list_header.click_bulk_topics_confirm
 
       # Check that the topic now has the message
       visit("/t/#{topic.slug}/#{topic.id}")
       expect(topic_page).to have_content("My message")
-      sleep(10)
     end
 
     it "works with keyboard shortcuts" do

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -88,6 +88,27 @@ describe "Topic bulk select", type: :system do
       expect(topic_list).to have_no_unread_badge(topics.first)
     end
 
+    it "closes topics with message" do
+      # Bulk close the topic with a message
+      sign_in(admin)
+      visit("/latest")
+      topic = topics.first
+      topic_list_header.click_bulk_select_button
+      topic_list.click_topic_checkbox(topics.first)
+      topic_list_header.click_bulk_select_topics_dropdown
+      topic_list_header.click_close_topics_button
+
+      # Fill in message
+      topic_list_header.fill_in_close_note("My message")
+      sleep(10)
+      topic_list_header.click_bulk_topics_confirm
+
+      # Check that the topic now has the message
+      visit("/t/#{topic.slug}/#{topic.id}")
+      expect(topic_page).to have_content("My message")
+      sleep(10)
+    end
+
     it "works with keyboard shortcuts" do
       sign_in(admin)
       visit("/latest")


### PR DESCRIPTION
This will allow you to type a single message when bulk closing topics
that will be applied to every topic, that way they all have the same
message.
