### PR TITLE
FIX: Let users reset their homepage choice if custom homepage is from…

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -241,10 +241,10 @@ class Theme < ActiveRecord::Base
     end
   end
 
-  def self.active_theme_and_component_ids
-    get_set_cache "active_theme_and_component_ids" do
+  def self.enabled_theme_and_component_ids
+    get_set_cache "enabled_theme_and_component_ids" do
       component_ids = []
-      theme_ids = Theme.user_selectable.pluck(:id)
+      theme_ids = Theme.user_selectable.where(enabled: true).pluck(:id)
       theme_ids.each do |id|
         component_ids += Theme.find(id).child_themes.where(enabled: true).pluck(:id)
       end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -250,7 +250,7 @@ class Theme < ActiveRecord::Base
           .joins(:child_theme)
           .where(themes: { enabled: true })
           .pluck(:child_theme_id)
-      (theme_ids + component_ids).uniq
+      (theme_ids | component_ids)
     end
   end
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -241,6 +241,18 @@ class Theme < ActiveRecord::Base
     end
   end
 
+  def self.active_theme_and_component_ids
+    get_set_cache "active_theme_and_component_ids" do
+      component_ids = []
+      theme_ids = Theme.user_selectable.pluck(:id)
+      theme_ids.each do |id|
+        component_ids += Theme.find(id).child_themes.where(enabled: true).pluck(:id)
+      end
+
+      (theme_ids + component_ids).uniq
+    end
+  end
+
   def self.allowed_remote_theme_ids
     return nil if GlobalSetting.allowed_theme_repos.blank?
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -243,12 +243,13 @@ class Theme < ActiveRecord::Base
 
   def self.enabled_theme_and_component_ids
     get_set_cache "enabled_theme_and_component_ids" do
-      component_ids = []
       theme_ids = Theme.user_selectable.where(enabled: true).pluck(:id)
-      theme_ids.each do |id|
-        component_ids += Theme.find(id).child_themes.where(enabled: true).pluck(:id)
-      end
-
+      component_ids =
+        ChildTheme
+          .where(parent_theme_id: theme_ids)
+          .joins(:child_theme)
+          .where(themes: { enabled: true })
+          .pluck(:child_theme_id)
       (theme_ids + component_ids).uniq
     end
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -324,7 +324,7 @@ class UserSerializer < UserCardSerializer
   end
 
   def can_pick_theme_with_custom_homepage
-    ThemeModifierHelper.new(theme_ids: Theme.user_theme_ids).custom_homepage
+    ThemeModifierHelper.new(theme_ids: Theme.active_theme_and_component_ids).custom_homepage
   end
 
   private

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -324,7 +324,7 @@ class UserSerializer < UserCardSerializer
   end
 
   def can_pick_theme_with_custom_homepage
-    ThemeModifierHelper.new(theme_ids: Theme.active_theme_and_component_ids).custom_homepage
+    ThemeModifierHelper.new(theme_ids: Theme.enabled_theme_and_component_ids).custom_homepage
   end
 
   private

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -466,6 +466,39 @@ HTML
     expect(Theme.user_theme_ids).to eq([])
   end
 
+  it "correctly caches active_theme_and_component_ids" do
+    Theme.destroy_all
+
+    theme2 = Fabricate(:theme)
+
+    expect(Theme.active_theme_and_component_ids).to eq([])
+
+    theme2.update!(user_selectable: true)
+
+    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+
+    theme2.update!(user_selectable: false)
+    theme2.set_default!
+    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+
+    child2 = Fabricate(:theme, component: true)
+    theme2.add_relative_theme!(:child, child2)
+    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id, child2.id)
+
+    child2.update!(enabled: false)
+    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+
+    theme3 = Fabricate(:theme, user_selectable: true)
+    child2.update!(enabled: true)
+
+    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id, child2.id, theme3.id)
+
+    theme2.destroy
+    theme3.destroy
+
+    expect(Theme.active_theme_and_component_ids).to eq([])
+  end
+
   it "correctly caches user_themes template" do
     Theme.destroy_all
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -501,10 +501,10 @@ HTML
 
     expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id, child2.id)
 
-    # theme2.destroy
-    # theme3.destroy
+    theme2.destroy
+    theme3.destroy
 
-    # expect(Theme.enabled_theme_and_component_ids).to eq([])
+    expect(Theme.enabled_theme_and_component_ids).to eq([])
   end
 
   it "correctly caches user_themes template" do

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -466,37 +466,45 @@ HTML
     expect(Theme.user_theme_ids).to eq([])
   end
 
-  it "correctly caches active_theme_and_component_ids" do
+  it "correctly caches enabled_theme_and_component_ids" do
     Theme.destroy_all
 
     theme2 = Fabricate(:theme)
 
-    expect(Theme.active_theme_and_component_ids).to eq([])
+    expect(Theme.enabled_theme_and_component_ids).to eq([])
 
     theme2.update!(user_selectable: true)
 
-    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id)
 
     theme2.update!(user_selectable: false)
     theme2.set_default!
-    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id)
 
     child2 = Fabricate(:theme, component: true)
     theme2.add_relative_theme!(:child, child2)
-    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id, child2.id)
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id, child2.id)
 
     child2.update!(enabled: false)
-    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id)
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id)
 
     theme3 = Fabricate(:theme, user_selectable: true)
     child2.update!(enabled: true)
 
-    expect(Theme.active_theme_and_component_ids).to contain_exactly(theme2.id, child2.id, theme3.id)
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(
+      theme2.id,
+      child2.id,
+      theme3.id,
+    )
 
-    theme2.destroy
-    theme3.destroy
+    theme3.update!(enabled: false)
 
-    expect(Theme.active_theme_and_component_ids).to eq([])
+    expect(Theme.enabled_theme_and_component_ids).to contain_exactly(theme2.id, child2.id)
+
+    # theme2.destroy
+    # theme3.destroy
+
+    # expect(Theme.enabled_theme_and_component_ids).to eq([])
   end
 
   it "correctly caches user_themes template" do


### PR DESCRIPTION
… a theme component

This is a followup to #26291. 

@nolosb noticed that when adding the custom homepage modifier via a theme component, the user preference was missing the "(default)" option in the dropdown, so the user couldn't reset back to the custom homepage. 

This PR fixes that issue by adding a new `enabled_theme_and_component_ids` method to the theme model and using it in the serializer. It also refactors the system spec to use the same test cases for both themes and components extending the connector. 