### PR TITLE
UX: shows the bookmark menu as a modal on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -191,7 +191,6 @@ export default class BookmarkMenu extends Component {
       {{didInsert this.setReminderShortcuts}}
       @identifier="bookmark-menu"
       @triggers={{array "click"}}
-      @arrow="true"
       class={{concatClass
         "bookmark widget-button btn-flat no-text btn-icon bookmark-menu__trigger"
         (if this.existingBookmark "bookmarked")

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -22,6 +22,7 @@ export default class BookmarkMenu extends Component {
   @service currentUser;
   @service toasts;
   @tracked quicksaved = false;
+  @service site;
 
   bookmarkManager = this.args.bookmarkManager;
   timezone = this.currentUser?.user_option?.timezone || moment.tz.guess();
@@ -203,6 +204,14 @@ export default class BookmarkMenu extends Component {
       </:trigger>
       <:content>
         <div class="bookmark-menu__body">
+          {{#if this.site.mobileView}}
+            {{#unless this.showEditDeleteMenu}}
+              <div class="bookmark-menu__title">{{icon "check-circle"}}<span
+                >Bookmarked!</span>
+
+              </div>
+            {{/unless}}
+          {{/if}}
           {{#if this.showEditDeleteMenu}}
             <ul class="bookmark-menu__actions">
               <li class="bookmark-menu__row -edit" data-menu-option-id="edit">

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -21,8 +21,9 @@ export default class BookmarkMenu extends Component {
   @service modal;
   @service currentUser;
   @service toasts;
-  @tracked quicksaved = false;
   @service site;
+
+  @tracked quicksaved = false;
 
   bookmarkManager = this.args.bookmarkManager;
   timezone = this.currentUser?.user_option?.timezone || moment.tz.guess();
@@ -89,6 +90,7 @@ export default class BookmarkMenu extends Component {
       this.toasts.success({
         showProgressBar: false,
         duration: 3000,
+        views: ["mobile"],
         data: { message: I18n.t("bookmarks.bookmarked_success") },
       });
     } catch (error) {
@@ -126,7 +128,10 @@ export default class BookmarkMenu extends Component {
       this.toasts.success({
         duration: 3000,
         showProgressBar: false,
-        data: { message: I18n.t("bookmarks.deleted_bookmark_success") },
+        data: {
+          icon: "trash-alt",
+          message: I18n.t("bookmarks.deleted_bookmark_success"),
+        },
       });
     } catch (error) {
       popupAjaxError(error);
@@ -149,6 +154,7 @@ export default class BookmarkMenu extends Component {
         this.toasts.success({
           duration: 3000,
           showProgressBar: false,
+          views: ["mobile"],
           data: { message: I18n.t("bookmarks.reminder_set_success") },
         });
       } catch (error) {

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -245,7 +245,7 @@ export default class BookmarkMenu extends Component {
                   @icon="trash-alt"
                   @label="delete"
                   @action={{this.onRemoveBookmark}}
-                  @class="bookmark-menu__row-btn btn-transparent"
+                  @class="bookmark-menu__row-btn btn-transparent btn-danger"
                 />
               </li>
             </ul>

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -213,6 +213,11 @@ export default class BookmarkMenu extends Component {
             {{/unless}}
           {{/if}}
           {{#if this.showEditDeleteMenu}}
+            {{#if this.site.mobileView}}
+              <div class="bookmark-menu__title">{{icon "bookmark"}}<span
+                >Bookmark</span>
+              </div>
+            {{/if}}
             <ul class="bookmark-menu__actions">
               <li class="bookmark-menu__row -edit" data-menu-option-id="edit">
                 <DButton

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -204,14 +204,13 @@ export default class BookmarkMenu extends Component {
       </:trigger>
       <:content>
         <div class="bookmark-menu__body">
-          {{#if this.site.mobileView}}
-            {{#unless this.showEditDeleteMenu}}
-              <div class="bookmark-menu__title">{{icon "check-circle"}}<span
-                >Bookmarked!</span>
 
-              </div>
-            {{/unless}}
-          {{/if}}
+          {{#unless this.showEditDeleteMenu}}
+            <div class="bookmark-menu__title">{{icon "check-circle"}}<span
+              >Bookmarked!</span>
+            </div>
+          {{/unless}}
+
           {{#if this.showEditDeleteMenu}}
             {{#if this.site.mobileView}}
               <div class="bookmark-menu__title">{{icon "bookmark"}}<span
@@ -224,11 +223,11 @@ export default class BookmarkMenu extends Component {
                   @icon="pencil-alt"
                   @label="edit"
                   @action={{this.onEditBookmark}}
-                  @class="bookmark-menu__row-btn btn-flat"
+                  @class="bookmark-menu__row-btn btn-transparent"
                 />
               </li>
               <li
-                class="bookmark-menu__row -remove"
+                class="bookmark-menu__row --remove"
                 role="button"
                 tabindex="0"
                 data-menu-option-id="delete"
@@ -237,7 +236,7 @@ export default class BookmarkMenu extends Component {
                   @icon="trash-alt"
                   @label="delete"
                   @action={{this.onRemoveBookmark}}
-                  @class="bookmark-menu__row-btn btn-flat"
+                  @class="bookmark-menu__row-btn btn-transparent"
                 />
               </li>
             </ul>
@@ -255,7 +254,7 @@ export default class BookmarkMenu extends Component {
                     @label={{option.label}}
                     @translatedTitle={{this.reminderShortcutTimeTitle option}}
                     @action={{fn this.onChooseReminderOption option}}
-                    @class="bookmark-menu__row-btn btn-flat"
+                    @class="bookmark-menu__row-btn btn-transparent"
                   />
                 </li>
               {{/each}}

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -207,14 +207,15 @@ export default class BookmarkMenu extends Component {
 
           {{#unless this.showEditDeleteMenu}}
             <div class="bookmark-menu__title">{{icon "check-circle"}}<span
-              >Bookmarked!</span>
+              >{{i18n "bookmarks.bookmarked_success"}}</span>
             </div>
           {{/unless}}
 
           {{#if this.showEditDeleteMenu}}
             {{#if this.site.mobileView}}
-              <div class="bookmark-menu__title">{{icon "bookmark"}}<span
-                >Bookmark</span>
+              <div class="bookmark-menu__title">{{icon "bookmark"}}<span>{{i18n
+                    "bookmarks.bookmark"
+                  }}</span>
               </div>
             {{/if}}
             <ul class="bookmark-menu__actions">

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -200,7 +200,7 @@ export default class BookmarkMenu extends Component {
       @onClose={{this.onCloseMenu}}
       @onShow={{this.onShowMenu}}
       @onRegisterApi={{this.onRegisterApi}}
-      @modalOnMobile={{true}}
+      @modalForMobile={{true}}
       @arrow={{false}}
     >
       <:trigger>

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -44,7 +44,7 @@ export default class BookmarkMenu extends Component {
   }
 
   get existingBookmark() {
-    return this.bookmarkManager.trackedBookmark.id
+    return this.bookmarkManager.trackedBookmark?.id
       ? this.bookmarkManager.trackedBookmark
       : null;
   }
@@ -166,6 +166,8 @@ export default class BookmarkMenu extends Component {
   }
 
   async _openBookmarkModal() {
+    this.dMenu.close();
+
     try {
       const closeData = await this.modal.show(BookmarkModal, {
         model: {

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -202,6 +202,7 @@ export default class BookmarkMenu extends Component {
       @onShow={{this.onShowMenu}}
       @onRegisterApi={{this.onRegisterApi}}
       @modalOnMobile={{true}}
+      @arrow={{false}}
     >
       <:trigger>
         {{#if this.existingBookmark.reminderAt}}

--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -86,6 +86,7 @@ export default class BookmarkMenu extends Component {
       // a bookmark, it switches to the other Edit/Delete menu.
       this.quicksaved = true;
       this.toasts.success({
+        showProgressBar: false,
         duration: 3000,
         data: { message: I18n.t("bookmarks.bookmarked_success") },
       });
@@ -123,6 +124,7 @@ export default class BookmarkMenu extends Component {
       this.bookmarkManager.afterDelete(response, this.existingBookmark.id);
       this.toasts.success({
         duration: 3000,
+        showProgressBar: false,
         data: { message: I18n.t("bookmarks.deleted_bookmark_success") },
       });
     } catch (error) {
@@ -145,6 +147,7 @@ export default class BookmarkMenu extends Component {
         await this.bookmarkManager.save();
         this.toasts.success({
           duration: 3000,
+          showProgressBar: false,
           data: { message: I18n.t("bookmarks.reminder_set_success") },
         });
       } catch (error) {
@@ -189,6 +192,7 @@ export default class BookmarkMenu extends Component {
       @onClose={{this.onCloseMenu}}
       @onShow={{this.onShowMenu}}
       @onRegisterApi={{this.onRegisterApi}}
+      @modalOnMobile={{true}}
     >
       <:trigger>
         {{#if this.existingBookmark.reminderAt}}

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
@@ -30,7 +30,7 @@ module(
       this.noop = () => {};
 
       await render(
-        hbs`<DDefaultToast @data={{this.toast.options.data}} @autoClose={{true}} @onRegisterProgressBar={{this.noop}} />`
+        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{true}} @autoClose={{true}} @onRegisterProgressBar={{this.noop}} />`
       );
 
       assert.dom(".fk-d-default-toast__progress-bar").exists();

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
@@ -27,10 +27,9 @@ module(
 
     test("progress bar", async function (assert) {
       this.toast = new DToastInstance(this, {});
-      this.noop = () => {};
 
       await render(
-        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{true}} @autoClose={{true}} @onRegisterProgressBar={{this.noop}} />`
+        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{true}} @autoClose={{true}} @onRegisterProgressBar={{(noop)}} />`
       );
 
       assert.dom(".fk-d-default-toast__progress-bar").exists();
@@ -40,7 +39,7 @@ module(
       this.toast = new DToastInstance(this, {});
 
       await render(
-        hbs`<DDefaultToast @data={{this.toast.options.data}} @autoClose={{false}} />`
+        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{false}} @autoClose={{false}} />`
       );
 
       assert.dom(".fk-d-default-toast__progress-bar").doesNotExist();

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -43,6 +43,17 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu").hasText("content");
   });
 
+  test("@modalForMobile", async function (assert) {
+    this.site.mobileView = true;
+
+    await render(
+      hbs`<DMenu @inline={{true}} @modalForMobile={{true}} @content="content" />`
+    );
+    await open();
+
+    assert.dom(".fk-d-menu-modal").hasText("content");
+  });
+
   test("@onRegisterApi", async function (assert) {
     this.api = null;
     this.onRegisterApi = (api) => (this.api = api);

--- a/app/assets/javascripts/discourse/tests/unit/services/toasts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/toasts-test.js
@@ -16,6 +16,6 @@ module("Unit | Service | Toasts", function (hooks) {
 
     this.toasts.show({ views: ["mobile"], data: { text: "foo" } });
 
-    assert.deepEqual(this.toasts.activeToasts.length, 1);
+    assert.ok(this.toasts.activeToasts.length < 2);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/services/toasts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/toasts-test.js
@@ -1,0 +1,21 @@
+import { getOwner } from "@ember/application";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | Toasts", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.toasts = getOwner(this).lookup("service:toasts");
+  });
+
+  test("views option", async function (assert) {
+    this.toasts.show({ views: ["desktop"], data: { text: "foo" } });
+
+    assert.deepEqual(this.toasts.activeToasts.length, 1);
+
+    this.toasts.show({ views: ["mobile"], data: { text: "foo" } });
+
+    assert.deepEqual(this.toasts.activeToasts.length, 1);
+  });
+});

--- a/app/assets/javascripts/float-kit/addon/components/d-default-toast.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-default-toast.gjs
@@ -13,7 +13,7 @@ const DDefaultToast = <template>
     }}
     ...attributes
   >
-    {{#if @autoClose}}
+    {{#if @showProgressBar}}
       <div
         class="fk-d-default-toast__progress-bar"
         {{didInsert @onRegisterProgressBar}}

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -5,7 +5,9 @@ import { concat } from "@ember/helper";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { modifier } from "ember-modifier";
+import { and } from "truth-helpers";
 import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
 import concatClass from "discourse/helpers/concat-class";
 import DFloatBody from "float-kit/components/d-float-body";
 import { MENU } from "float-kit/lib/constants";
@@ -13,6 +15,7 @@ import DMenuInstance from "float-kit/lib/d-menu-instance";
 
 export default class DMenu extends Component {
   @service menu;
+  @service site;
 
   @tracked menuInstance = null;
 
@@ -92,31 +95,51 @@ export default class DMenu extends Component {
     </DButton>
 
     {{#if this.menuInstance.expanded}}
-      <DFloatBody
-        @instance={{this.menuInstance}}
-        @trapTab={{this.options.trapTab}}
-        @mainClass={{concatClass
-          "fk-d-menu"
-          (concat this.options.identifier "-content")
-        }}
-        @innerClass="fk-d-menu__inner-content"
-        @role="dialog"
-        @inline={{this.options.inline}}
-        @portalOutletElement={{this.menu.portalOutletElement}}
-      >
-        {{#if (has-block)}}
-          {{yield this.componentArgs}}
-        {{else if (has-block "content")}}
-          {{yield this.componentArgs to="content"}}
-        {{else if this.options.component}}
-          <this.options.component
-            @data={{this.options.data}}
-            @close={{this.menuInstance.close}}
-          />
-        {{else if this.options.content}}
-          {{this.options.content}}
-        {{/if}}
-      </DFloatBody>
+      {{#if (and this.site.mobileView this.options.modalOnMobile)}}
+        <DModal
+          @closeModal={{this.menuInstance.close}}
+          @hideHeader={{true}}
+          class={{concatClass
+            "fk-d-menu-modal"
+            (concat this.options.identifier "-content")
+          }}
+        >
+          {{#if (has-block)}}
+            {{yield this.componentArgs}}
+          {{else if (has-block "content")}}
+            {{yield this.componentArgs to="content"}}
+          {{else if this.options.component}}
+            <this.options.component
+              @data={{this.options.data}}
+              @close={{this.menuInstance.close}}
+            />
+          {{/if}}
+        </DModal>
+      {{else}}
+        <DFloatBody
+          @instance={{this.menuInstance}}
+          @trapTab={{this.options.trapTab}}
+          @mainClass={{concatClass
+            "fk-d-menu"
+            (concat this.options.identifier "-content")
+          }}
+          @innerClass="fk-d-menu__inner-content"
+          @role="dialog"
+          @inline={{this.options.inline}}
+          @portalOutletElement={{this.menu.portalOutletElement}}
+        >
+          {{#if (has-block)}}
+            {{yield this.componentArgs}}
+          {{else if (has-block "content")}}
+            {{yield this.componentArgs to="content"}}
+          {{else if this.options.component}}
+            <this.options.component
+              @data={{this.options.data}}
+              @close={{this.menuInstance.close}}
+            />
+          {{/if}}
+        </DFloatBody>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -9,6 +9,7 @@ import { and } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import concatClass from "discourse/helpers/concat-class";
+import { isTesting } from "discourse-common/config/environment";
 import DFloatBody from "float-kit/components/d-float-body";
 import { MENU } from "float-kit/lib/constants";
 import DMenuInstance from "float-kit/lib/d-menu-instance";
@@ -95,7 +96,9 @@ export default class DMenu extends Component {
     </DButton>
 
     {{#if this.menuInstance.expanded}}
-      {{#if (and this.site.mobileView this.options.modalOnMobile)}}
+
+      {{#if (and this.site.mobileView this.options.modalForMobile)}}
+        {{log this.options}}
         <DModal
           @closeModal={{this.menuInstance.close}}
           @hideHeader={{true}}
@@ -103,6 +106,7 @@ export default class DMenu extends Component {
             "fk-d-menu-modal"
             (concat this.options.identifier "-content")
           }}
+          @inline={{(isTesting)}}
         >
           {{#if (has-block)}}
             {{yield this.componentArgs}}

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -113,6 +113,8 @@ export default class DMenu extends Component {
               @data={{this.options.data}}
               @close={{this.menuInstance.close}}
             />
+          {{else if this.options.content}}
+            {{this.options.content}}
           {{/if}}
         </DModal>
       {{else}}
@@ -137,6 +139,8 @@ export default class DMenu extends Component {
               @data={{this.options.data}}
               @close={{this.menuInstance.close}}
             />
+          {{else if this.options.content}}
+            {{this.options.content}}
           {{/if}}
         </DFloatBody>
       {{/if}}

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -96,9 +96,7 @@ export default class DMenu extends Component {
     </DButton>
 
     {{#if this.menuInstance.expanded}}
-
       {{#if (and this.site.mobileView this.options.modalForMobile)}}
-        {{log this.options}}
         <DModal
           @closeModal={{this.menuInstance.close}}
           @hideHeader={{true}}

--- a/app/assets/javascripts/float-kit/addon/components/d-toast.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-toast.gjs
@@ -127,6 +127,7 @@ export default class DToast extends Component {
     >
       <@toast.options.component
         @data={{@toast.options.data}}
+        @close={{@toast.close}}
         @showProgressBar={{and
           @toast.options.showProgressBar
           @toast.options.autoClose

--- a/app/assets/javascripts/float-kit/addon/components/d-toast.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-toast.gjs
@@ -4,6 +4,7 @@ import { registerDestructor } from "@ember/destroyable";
 import { action } from "@ember/object";
 import { cancel } from "@ember/runloop";
 import Modifier from "ember-modifier";
+import { and } from "truth-helpers";
 import concatClass from "discourse/helpers/concat-class";
 import discourseLater from "discourse-common/lib/later";
 import { bind } from "discourse-common/utils/decorators";
@@ -126,8 +127,10 @@ export default class DToast extends Component {
     >
       <@toast.options.component
         @data={{@toast.options.data}}
-        @close={{@toast.close}}
-        @autoClose={{@toast.options.autoClose}}
+        @showProgressBar={{and
+          @toast.options.showProgressBar
+          @toast.options.autoClose
+        }}
         @onRegisterProgressBar={{this.registerProgressBar}}
       />
     </output>

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -68,6 +68,7 @@ export const MENU = {
     onClose: null,
     onShow: null,
     onRegisterApi: null,
+    modalOnMobile: false,
   },
   portalOutletId: "d-menu-portal-outlet",
 };
@@ -79,5 +80,6 @@ export const TOAST = {
     autoClose: true,
     duration: 3000,
     component: DDefaultToast,
+    showProgressBar: true,
   },
 };

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -81,5 +81,6 @@ export const TOAST = {
     duration: 3000,
     component: DDefaultToast,
     showProgressBar: true,
+    views: ["desktop", "mobile"],
   },
 };

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -68,7 +68,7 @@ export const MENU = {
     onClose: null,
     onShow: null,
     onRegisterApi: null,
-    modalOnMobile: false,
+    modalForMobile: false,
   },
   portalOutletId: "d-menu-portal-outlet",
 };

--- a/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
@@ -22,7 +22,6 @@ export default class DToastInstance {
   }
 
   get isValidForView() {
-    const view = this.site.desktopView ? "desktop" : "mobile";
-    return this.options.views.includes(view);
+    return this.options.views.includes(this.site.desktopView ? "desktop" : "mobile");
   }
 }

--- a/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
@@ -5,6 +5,7 @@ import uniqueId from "discourse/helpers/unique-id";
 import { TOAST } from "float-kit/lib/constants";
 
 export default class DToastInstance {
+  @service site;
   @service toasts;
 
   options = null;
@@ -18,5 +19,10 @@ export default class DToastInstance {
   @action
   close() {
     this.toasts.close(this);
+  }
+
+  get isValidForView() {
+    const view = this.site.desktopView ? "desktop" : "mobile";
+    return this.options.views.includes(view);
   }
 }

--- a/app/assets/javascripts/float-kit/addon/services/toasts.js
+++ b/app/assets/javascripts/float-kit/addon/services/toasts.js
@@ -24,7 +24,11 @@ export default class Toasts extends Service {
   @action
   show(options = {}) {
     const instance = new DToastInstance(getOwner(this), options);
-    this.activeToasts.push(instance);
+
+    if (instance.isValidForView) {
+      this.activeToasts.push(instance);
+    }
+
     return instance;
   }
 
@@ -52,7 +56,7 @@ export default class Toasts extends Service {
   @action
   success(options = {}) {
     options.data.theme = "success";
-    options.data.icon = "check";
+    options.data.icon ??= "check";
 
     return this.show({ ...options, component: DDefaultToast });
   }
@@ -67,7 +71,7 @@ export default class Toasts extends Service {
   @action
   error(options = {}) {
     options.data.theme = "error";
-    options.data.icon = "exclamation-triangle";
+    options.data.icon ??= "exclamation-triangle";
 
     return this.show({ ...options, component: DDefaultToast });
   }
@@ -82,7 +86,7 @@ export default class Toasts extends Service {
   @action
   warning(options = {}) {
     options.data.theme = "warning";
-    options.data.icon = "exclamation-circle";
+    options.data.icon ??= "exclamation-circle";
 
     return this.show({ ...options, component: DDefaultToast });
   }
@@ -97,7 +101,7 @@ export default class Toasts extends Service {
   @action
   info(options = {}) {
     options.data.theme = "info";
-    options.data.icon = "info-circle";
+    options.data.icon ??= "info-circle";
 
     return this.show({ ...options, component: DDefaultToast });
   }
@@ -110,5 +114,9 @@ export default class Toasts extends Service {
     this.activeToasts = new TrackedArray(
       this.activeToasts.filter((activeToast) => activeToast.id !== toast.id)
     );
+  }
+
+  isValidPlatform() {
+    return this.site.platform === "web";
   }
 }

--- a/app/assets/javascripts/float-kit/addon/services/toasts.js
+++ b/app/assets/javascripts/float-kit/addon/services/toasts.js
@@ -23,7 +23,10 @@ export default class Toasts extends Service {
    */
   @action
   show(options = {}) {
-    const instance = new DToastInstance(getOwner(this), options);
+    const instance = new DToastInstance(getOwner(this), {
+      component: DDefaultToast,
+      ...options,
+    });
 
     if (instance.isValidForView) {
       this.activeToasts.push(instance);
@@ -43,7 +46,7 @@ export default class Toasts extends Service {
   default(options = {}) {
     options.data.theme = "default";
 
-    return this.show({ ...options, component: DDefaultToast });
+    return this.show(options);
   }
 
   /**
@@ -58,7 +61,7 @@ export default class Toasts extends Service {
     options.data.theme = "success";
     options.data.icon ??= "check";
 
-    return this.show({ ...options, component: DDefaultToast });
+    return this.show(options);
   }
 
   /**
@@ -73,7 +76,7 @@ export default class Toasts extends Service {
     options.data.theme = "error";
     options.data.icon ??= "exclamation-triangle";
 
-    return this.show({ ...options, component: DDefaultToast });
+    return this.show(options);
   }
 
   /**
@@ -88,7 +91,7 @@ export default class Toasts extends Service {
     options.data.theme = "warning";
     options.data.icon ??= "exclamation-circle";
 
-    return this.show({ ...options, component: DDefaultToast });
+    return this.show(options);
   }
 
   /**
@@ -103,7 +106,7 @@ export default class Toasts extends Service {
     options.data.theme = "info";
     options.data.icon ??= "info-circle";
 
-    return this.show({ ...options, component: DDefaultToast });
+    return this.show(options);
   }
 
   /**
@@ -114,9 +117,5 @@ export default class Toasts extends Service {
     this.activeToasts = new TrackedArray(
       this.activeToasts.filter((activeToast) => activeToast.id !== toast.id)
     );
-  }
-
-  isValidPlatform() {
-    return this.site.platform === "web";
   }
 }

--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -1,16 +1,16 @@
-.bookmark-menu {
-  &__body {
+.bookmark-menu-content {
+  .bookmark-menu__body {
     background: var(--secondary);
     display: flex;
     flex-direction: column;
     min-width: 200px;
   }
-  &__actions {
+  .bookmark-menu__actions {
     margin: 0;
     padding: 0;
     list-style: none;
   }
-  &__title {
+  .bookmark-menu__title {
     display: flex;
     align-items: center;
     gap: 0.75em;
@@ -24,7 +24,7 @@
     }
   }
 
-  &__row {
+  .bookmark-menu__row {
     width: 100%;
     display: flex;
 
@@ -38,13 +38,13 @@
     }
   }
 
-  &__row-title {
+  .bookmark-menu__row-title {
     padding: 0.75rem;
     border-bottom: 1px solid var(--primary-low);
     font-weight: bold;
   }
 
-  &__row-btn {
+  .bookmark-menu__row-btn {
     margin: 0;
     padding: 0.75rem !important;
     width: 100%;

--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -42,13 +42,11 @@
         width: 100%;
         text-align: left;
         justify-content: left;
+        gap: 0.75em;
 
         .d-icon {
-          color: var(--primary);
-        }
-
-        .d-button-label {
-          color: var(--primary);
+          color: inherit;
+          margin: 0;
         }
         &:hover,
         &:focus {
@@ -56,13 +54,12 @@
         }
       }
 
-      &.-edit {
-        .d-icon {
-          margin-right: 5px;
-        }
+      .d-button-label {
+        color: var(--primary);
       }
 
       &.-remove {
+        .d-button-label,
         .d-icon {
           color: var(--danger);
         }

--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -31,14 +31,14 @@
       }
 
       &-title {
-        font-size: var(--font-down-1);
         padding: 0.75rem;
         border-bottom: 1px solid var(--primary-low);
+        font-weight: bold;
       }
 
       &-btn {
         margin: 0;
-        padding: 0.75rem;
+        padding: 0.75rem !important;
         width: 100%;
         text-align: left;
         justify-content: left;
@@ -49,7 +49,6 @@
 
         .d-button-label {
           color: var(--primary);
-          font-size: var(--font-down-1);
         }
         &:hover,
         &:focus {
@@ -82,10 +81,5 @@
         border-bottom: 2px solid var(--primary-low);
       }
     }
-  }
-
-  .bookmark-menu__row-title {
-    font-weight: 900;
-    padding: 0.75rem;
   }
 }

--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -31,22 +31,9 @@
     &:hover,
     &:focus {
       background: var(--tertiary-very-low);
-    }
 
-    &.--remove {
-      color: var(--danger);
-      .d-button-label,
-      .d-icon {
-        color: var(--danger);
-      }
-
-      &:hover,
-      &:focus {
+      &.--remove {
         background: var(--danger-low);
-        .d-button-label,
-        .d-icon {
-          color: var(--primary);
-        }
       }
     }
   }
@@ -64,14 +51,22 @@
     text-align: left;
     justify-content: left !important;
     gap: 0.75em;
+    color: var(--primary);
     &:hover,
     &:focus {
       color: var(--primary) !important;
       background: var(--tertiary-very-low);
     }
+    .--remove & {
+      color: var(--danger);
+    }
+
+    .d-button-label {
+      color: inherit;
+    }
 
     .d-icon {
-      color: var(--primary);
+      color: inherit;
       margin: 0 !important;
     }
   }

--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -1,82 +1,78 @@
-.bookmark-menu-content {
-  .bookmark-menu__body {
+.bookmark-menu {
+  &__body {
     background: var(--secondary);
-    list-style: none;
     display: flex;
     flex-direction: column;
-    color: var(--primary);
+    min-width: 200px;
+  }
+  &__actions {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    background: var(--tertiary-low);
+    color: var(--tertiary);
+    padding: 0.75rem;
+    font-weight: bold;
 
-    .bookmark-menu__actions {
-      margin: 0;
-      padding: 0;
-      list-style: none;
+    .d-icon {
+      color: var(--tertiary);
     }
   }
 
-  .bookmark-menu {
-    &__text {
-      display: flex;
-      align-items: left;
+  &__row {
+    width: 100%;
+    display: flex;
+
+    &:hover,
+    &:focus {
+      background: var(--tertiary-very-low);
     }
 
-    &__row {
-      border-bottom: 1px solid var(--primary-low);
-      width: 100%;
-      display: flex;
-      align-items: left;
+    &.--remove {
+      color: var(--danger);
+      .d-button-label,
+      .d-icon {
+        color: var(--danger);
+      }
 
       &:hover,
       &:focus {
-        background: var(--tertiary-very-low);
-      }
-
-      &-title {
-        padding: 0.75rem;
-        border-bottom: 1px solid var(--primary-low);
-        font-weight: bold;
-      }
-
-      &-btn {
-        margin: 0;
-        padding: 0.75rem !important;
-        width: 100%;
-        text-align: left;
-        justify-content: left;
-        gap: 0.75em;
-
-        .d-icon {
-          color: inherit;
-          margin: 0;
-        }
-        &:hover,
-        &:focus {
-          background: var(--tertiary-very-low);
-        }
-      }
-
-      .d-button-label {
-        color: var(--primary);
-      }
-
-      &.-remove {
+        background: var(--danger-low);
         .d-button-label,
         .d-icon {
-          color: var(--danger);
-        }
-
-        &:hover,
-        &:focus {
-          background: var(--danger-low);
+          color: var(--primary);
         }
       }
+    }
+  }
 
-      &:last-child {
-        border-bottom: none;
-      }
+  &__row-title {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--primary-low);
+    font-weight: bold;
+  }
 
-      &.-no-reminder {
-        border-bottom: 2px solid var(--primary-low);
-      }
+  &__row-btn {
+    margin: 0;
+    padding: 0.75rem !important;
+    width: 100%;
+    text-align: left;
+    justify-content: left !important;
+    gap: 0.75em;
+    &:hover,
+    &:focus {
+      color: var(--primary) !important;
+      background: var(--tertiary-very-low);
+    }
+
+    .d-icon {
+      color: var(--primary);
+      margin: 0 !important;
     }
   }
 }

--- a/app/assets/stylesheets/common/float-kit/d-default-toast.scss
+++ b/app/assets/stylesheets/common/float-kit/d-default-toast.scss
@@ -110,7 +110,6 @@
 
   &__message {
     display: flex;
-    margin-top: 0.5rem;
     color: var(--primary-high);
   }
 }

--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -56,7 +56,6 @@
   }
 
   .arrow {
-    z-index: z("max");
     position: absolute;
     color: var(--secondary);
   }
@@ -70,7 +69,7 @@
 
   &[data-placement^="bottom"] {
     .arrow {
-      top: -9px;
+      top: -10px;
     }
   }
 

--- a/app/assets/stylesheets/mobile.scss
+++ b/app/assets/stylesheets/mobile.scss
@@ -6,3 +6,5 @@
 @import "mobile/components/_index";
 
 @import "mobile/select-kit/_index";
+
+@import "mobile/float-kit/_index";

--- a/app/assets/stylesheets/mobile/components/_index.scss
+++ b/app/assets/stylesheets/mobile/components/_index.scss
@@ -2,3 +2,4 @@
 @import "user-card";
 @import "user-stream-item";
 @import "more-topics";
+@import "bookmark-menu";

--- a/app/assets/stylesheets/mobile/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/mobile/components/bookmark-menu.scss
@@ -1,9 +1,3 @@
-.fk-d-menu-modal {
-  .d-modal__body {
-    padding: 0;
-  }
-}
-
 .bookmark-menu {
   &__row {
     border-bottom: 1px solid var(--primary-low);

--- a/app/assets/stylesheets/mobile/float-kit/_index.scss
+++ b/app/assets/stylesheets/mobile/float-kit/_index.scss
@@ -1,1 +1,1 @@
-@import "d-menu-mobile";
+@import "d-menu";

--- a/app/assets/stylesheets/mobile/float-kit/_index.scss
+++ b/app/assets/stylesheets/mobile/float-kit/_index.scss
@@ -1,0 +1,1 @@
+@import "d-menu-mobile";

--- a/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
@@ -5,9 +5,6 @@
 }
 
 .bookmark-menu {
-  &__title {
-    // padding: 0.75rem;
-  }
   &__row {
     border-bottom: 1px solid var(--primary-low);
     &:last-child {

--- a/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
@@ -2,20 +2,19 @@
   .d-modal__body {
     padding: 0;
   }
+}
 
-  .bookmark-menu {
-    &__title {
-      display: flex;
-      align-items: center;
-      gap: 0.75em;
-      background: var(--tertiary-low);
-      color: var(--tertiary);
-      padding: 0.75rem;
-      font-weight: bold;
-
-      .d-icon {
-        color: var(--tertiary);
-      }
+.bookmark-menu {
+  &__title {
+    // padding: 0.75rem;
+  }
+  &__row {
+    border-bottom: 1px solid var(--primary-low);
+    &:last-child {
+      border-bottom: none;
     }
+  }
+  &__row-title {
+    padding: 0.75rem;
   }
 }

--- a/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
@@ -7,7 +7,7 @@
     &__title {
       display: flex;
       align-items: center;
-      gap: 0.5em;
+      gap: 0.75em;
       background: var(--tertiary-low);
       color: var(--tertiary);
       padding: 0.75rem;

--- a/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu-mobile.scss
@@ -1,0 +1,21 @@
+.fk-d-menu-modal {
+  .d-modal__body {
+    padding: 0;
+  }
+
+  .bookmark-menu {
+    &__title {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      background: var(--tertiary-low);
+      color: var(--tertiary);
+      padding: 0.75rem;
+      font-weight: bold;
+
+      .d-icon {
+        color: var(--tertiary);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/mobile/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu.scss
@@ -1,0 +1,5 @@
+.fk-d-menu-modal {
+  .d-modal__body {
+    padding: 0;
+  }
+}

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -40,7 +40,7 @@ describe "Bookmarking posts and topics", type: :system do
     expect(page).to have_content(I18n.t("js.bookmarks.bookmarked_success"))
 
     bookmark_menu.click_menu_option("tomorrow")
-    expect(page).to have_content(I18n.t("js.bookmarks.reminder_set_success"))
+
     expect(Bookmark.find_by(bookmarkable: post, user: current_user).reminder_at).not_to be_blank
   end
 

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -41,6 +41,7 @@ describe "Bookmarking posts and topics", type: :system do
 
     bookmark_menu.click_menu_option("tomorrow")
 
+    expect(page).to have_no_css(".bookmark-menu-content")
     expect(Bookmark.find_by(bookmarkable: post, user: current_user).reminder_at).not_to be_blank
   end
 


### PR DESCRIPTION
### Desktop
<img width="950" alt="image" src="https://github.com/discourse/discourse/assets/101828855/d331381b-f628-4caa-b20b-40d9ed0c3bd2">
<img width="920" alt="image" src="https://github.com/discourse/discourse/assets/101828855/27a2ea5e-c676-454c-8a1d-d72829c4d2a0">

### Mobile
<img width="378" alt="image" src="https://github.com/discourse/discourse/assets/101828855/7c4213fe-c7e1-47bb-aecd-252494b46d4e">
<img width="362" alt="image" src="https://github.com/discourse/discourse/assets/101828855/69202dfc-f34d-4670-bb2a-1a350cdf6e8c">

The colours for the icons in edit/delete are off, due to the strange .scss overrules. Pretty please investigate 