### PR TITLE
UX: chat > deleted msg styling

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -4,7 +4,7 @@
   padding: 0;
 
   .chat-message-expand {
-    color: var(--primary-low-mid);
+    color: var(--primary-high);
     padding: 0.25em;
 
     .d-button-label {
@@ -172,7 +172,10 @@
     }
 
     &.-deleted {
-      background-color: var(--danger-medium);
+      background-color: var(--danger-low);
+      .chat-message-expand {
+        color: var(--danger);
+      }
     }
 
     &.-highlighted {


### PR DESCRIPTION
Improves the readability of a deleted chat message

### Before
![image](https://github.com/discourse/discourse/assets/101828855/2cddba0c-09e1-43e5-bf6e-9de38a7dbccc)
![image](https://github.com/discourse/discourse/assets/101828855/bd9cf011-adfb-48e9-af76-5c0ca008f759)

### After
<img width="556" alt="image" src="https://github.com/discourse/discourse/assets/101828855/51dc6ca7-ac66-41af-bdf4-d055635c6e6b">
<img width="555" alt="image" src="https://github.com/discourse/discourse/assets/101828855/86f0516f-a30b-48ad-8065-dee258c10ca5">

