### PR TITLE
FIX: checklist weren't working if there was an image URL

### DIFF
--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -124,10 +124,16 @@ export function checklistSyntax(elem, postDecorator) {
         // make the first run go to index = 0
         let nth = -1;
         let found = false;
+
         const newRaw = post.raw.replace(
-          /\[(\s|\_|\-|\x|\\?\*)?\]/gi,
+          /\[( |x)?\]/gi,
           (match, ignored, off) => {
             if (found) {
+              return match;
+            }
+
+            // skip empty image URLs - "![](https://example.com/image.jpg)"
+            if (off > 0 && post.raw[off - 1] === "!") {
               return match;
             }
 

--- a/plugins/checklist/assets/javascripts/lib/discourse-markdown/checklist.js
+++ b/plugins/checklist/assets/javascripts/lib/discourse-markdown/checklist.js
@@ -1,4 +1,4 @@
-const REGEX = /\[(\s?|x|X)\]/g;
+const REGEX = /\[( |x)?\]/gi;
 
 function getClasses(str) {
   switch (str) {

--- a/plugins/checklist/assets/stylesheets/checklist.scss
+++ b/plugins/checklist/assets/stylesheets/checklist.scss
@@ -22,7 +22,9 @@ span.chcklst-stroked {
 }
 
 span.chcklst-box {
-  cursor: pointer;
+  &:not(.permanent) {
+    cursor: pointer;
+  }
 
   &:before {
     display: inline-block;

--- a/plugins/checklist/test/javascripts/lib/checklist-test.js
+++ b/plugins/checklist/test/javascripts/lib/checklist-test.js
@@ -10,7 +10,10 @@ let currentRaw;
 
 async function prepare(raw) {
   const cooked = await cook(raw, {
-    siteSettings: { checklist_enabled: true },
+    siteSettings: {
+      checklist_enabled: true,
+      discourse_local_dates_enabled: true,
+    },
   });
 
   const widget = { attrs: {}, scheduleRerender() {} };
@@ -36,6 +39,23 @@ acceptance("discourse-checklist | checklist", function (needs) {
       { "Content-Type": "application/json" },
       { raw: currentRaw },
     ]);
+  });
+
+  test("does not clash with date-range bbcode", async function (assert) {
+    const [$elem, updated] = await prepare(`
+[date-range from=2024-03-22 to=2024-03-23]
+
+[ ] task 1
+[ ] task 2
+[x] task 3
+    `);
+
+    assert.equal($elem.find(".discourse-local-date").length, 2);
+    assert.equal($elem.find(".chcklst-box").length, 3);
+    $elem.find(".chcklst-box")[0].click();
+
+    const output = await updated;
+    assert.ok(output.includes("[x] task 1"));
   });
 
   test("does not check an image URL", async function (assert) {

--- a/plugins/checklist/test/javascripts/lib/checklist-test.js
+++ b/plugins/checklist/test/javascripts/lib/checklist-test.js
@@ -38,6 +38,19 @@ acceptance("discourse-checklist | checklist", function (needs) {
     ]);
   });
 
+  test("does not check an image URL", async function (assert) {
+    const [$elem, updated] = await prepare(`
+![](upload://zLd8FtsWc2ZSg3cZKIhwvhYxTcn.jpg)
+[] first
+[] second
+    `);
+
+    $elem.find(".chcklst-box")[0].click();
+
+    const output = await updated;
+    assert.ok(output.includes("[x] first"));
+  });
+
   test("make checkboxes readonly while updating", async function (assert) {
     const [$elem, updated] = await prepare(`
 [ ] first

--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js
@@ -115,7 +115,7 @@ function defaultDateConfig() {
 }
 
 function parseTagAttributes(tag) {
-  const matchString = tag.replace(/‘|’|„|“|«|»|”/g, '"');
+  const matchString = tag.replace(/[‘’„“«»”]/g, '"');
 
   return parseBBCodeTag(
     "[date date" + matchString + "]",
@@ -162,7 +162,9 @@ function addLocalRange(buffer, matches, state) {
     addSingleLocalDate(buffer, state, config);
   }
   if (config.range) {
-    closeBuffer(buffer, state, "→");
+    const token = new state.Token("text", "", 0);
+    token.content = "→";
+    buffer.push(token);
   }
   if (parsed.attrs.to) {
     [date, time] = parsed.attrs.to.split("T");


### PR DESCRIPTION
Exclude image URLs with empty alt text from checklist state changes. 

Adds a condition to skip `[]` preceded by `!`, preventing images from being misinterpreted as empty checklist items.

Internal - t/124499

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
