### PR TITLE
FIX: `DiscourseIpInfo.mmdb_download` incorrectly joining URLs

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -27,7 +27,7 @@ class DiscourseIpInfo
   def self.mmdb_download(name)
     url =
       if GlobalSetting.maxmind_mirror_url.present?
-        URI.join(GlobalSetting.maxmind_mirror_url, "#{name}.tar.gz").to_s
+        File.join(GlobalSetting.maxmind_mirror_url, "#{name}.tar.gz").to_s
       else
         if GlobalSetting.maxmind_license_key.blank?
           STDERR.puts "MaxMind IP database updates require a license"

--- a/lib/discourse_ip_info_spec.rb
+++ b/lib/discourse_ip_info_spec.rb
@@ -3,9 +3,20 @@
 RSpec.describe DiscourseIpInfo do
   describe ".mmdb_download" do
     it "should download the MaxMind databases from the right URL when `maxmind_mirror_url` global setting has been configured" do
-      global_setting :maxmind_mirror_url, "https://example.com/mirror/"
+      global_setting :maxmind_mirror_url, "https://b.www.example.com/mirror"
 
-      stub_request(:get, "https://example.com/mirror/GeoLite2-City.tar.gz").to_return(
+      stub_request(:get, "https://b.www.example.com/mirror/GeoLite2-City.tar.gz").to_return(
+        status: 200,
+        body: "",
+      )
+
+      described_class.mmdb_download("GeoLite2-City")
+    end
+
+    it "should download the MaxMind databases from the right URL when `maxmind_mirror_url` global setting has been configured and has a trailing slash" do
+      global_setting :maxmind_mirror_url, "https://b.www.example.com/mirror/"
+
+      stub_request(:get, "https://b.www.example.com/mirror/GeoLite2-City.tar.gz").to_return(
         status: 200,
         body: "",
       )


### PR DESCRIPTION
This commit changes `DiscourseIpInfo.mmdb_download` to use `File.join`
instead of `URI.join` when `GlobalSetting.maxmind_mirror_url` has been
configured. This is necessary because `URI.join` does not work the way I
expect it to work when I implemented it previously.

`URI.join("http://www.example.com/mirror", "test.tar.gz")` results in
`http://www.example.com/test.tar.gz` instead of our expected
`http://www.exmaple.com/mirror/test.tar.gz`. For our simple use case
here, `File.join` is sufficient.
