### PR TITLE
FIX: prevents mobile DMenu modal to lock scroll

### DIFF
--- a/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
@@ -7,6 +7,8 @@ import FloatKitInstance from "float-kit/lib/float-kit-instance";
 
 export default class DMenuInstance extends FloatKitInstance {
   @service menu;
+  @service site;
+  @service modal;
 
   constructor(owner, trigger, options = {}) {
     super(...arguments);
@@ -16,6 +18,15 @@ export default class DMenuInstance extends FloatKitInstance {
     this.id = trigger.id || guidFor(trigger);
     this.trigger = trigger;
     this.setupListeners();
+  }
+
+  @action
+  close() {
+    if (this.site.mobileView && this.options.modalForMobile) {
+      this.modal.close();
+    }
+
+    super.close(...arguments);
   }
 
   @action

--- a/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-toast-instance.js
@@ -22,6 +22,8 @@ export default class DToastInstance {
   }
 
   get isValidForView() {
-    return this.options.views.includes(this.site.desktopView ? "desktop" : "mobile");
+    return this.options.views.includes(
+      this.site.desktopView ? "desktop" : "mobile"
+    );
   }
 }


### PR DESCRIPTION
The bug was due to the fact that the `<DModal />` is displayed inside a if block, when the condition was false to close the menu, the modal was just hidden without calling callbacks. The fix ensures we are correctly calling `modal.close()` before in this case.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
