### PR TITLE
FIX: do not autofocus input on edit in mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
@@ -13,6 +13,7 @@ export default class ChatChannelComposer extends Service {
   @service loadingSlider;
   @service capabilities;
   @service appEvents;
+  @service site;
 
   @tracked textarea;
   @tracked scrollable;
@@ -48,7 +49,10 @@ export default class ChatChannelComposer extends Service {
     this.chat.activeMessage = null;
     message.editing = true;
     message.channel.draft = message;
-    this.focus({ refreshHeight: true, ensureAtEnd: true });
+
+    if (this.site.desktopView) {
+      this.focus({ refreshHeight: true, ensureAtEnd: true });
+    }
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/services/chat-thread-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-thread-composer.js
@@ -8,6 +8,7 @@ export default class ChatThreadComposer extends Service {
   @service chat;
   @service capabilities;
   @service appEvents;
+  @service site;
 
   @tracked textarea;
   @tracked scrollable;
@@ -43,7 +44,10 @@ export default class ChatThreadComposer extends Service {
     this.chat.activeMessage = null;
     message.editing = true;
     message.thread.draft = message;
-    this.focus({ refreshHeight: true, ensureAtEnd: true });
+
+    if (this.site.desktopView) {
+      this.focus({ refreshHeight: true, ensureAtEnd: true });
+    }
   }
 
   @action


### PR DESCRIPTION
Prior to this fix we would autofocus the chat input when editing a message. This was causing rendering issues (the body would scroll towards the top, leaving a large blank space between content and keyboard), especially on iOS, due to the fact that's it's not a trusted event and won't show the keyboard. Given it's not opening the keyboard anyways there's not reason to autofocus the keyboard.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
