### PR TITLE
Load synchronously in setup-tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/load-faker.js
+++ b/app/assets/javascripts/discourse/app/lib/load-faker.js
@@ -5,10 +5,17 @@ Plugins & themes are unable to async-import npm modules directly.
 This wrapper provides them with a way to use fakerjs, while keeping the `import()` in core's codebase.
 */
 export default async function loadFaker() {
-  faker = await import("@faker-js/faker");
+  faker ??= await import("@faker-js/faker");
   return faker;
 }
 
+export function setLoadedFaker(module) {
+  faker = module;
+}
+
 export function getLoadedFaker() {
+  if (!faker) {
+    throw "Faker has not been loaded yet. Ensure `setLoadedFaker()` or `loadFaker()` have been called first";
+  }
   return faker;
 }

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -48,7 +48,8 @@ import { setupS3CDN, setupURL } from "discourse-common/lib/get-url";
 import { buildResolver } from "discourse-common/resolver";
 import Application from "../app";
 import { loadSprites } from "../lib/svg-sprite-loader";
-import loadFaker from "discourse/lib/load-faker";
+import * as FakerModule from "@faker-js/faker";
+import { setLoadedFaker } from "discourse/lib/load-faker";
 
 const Plugin = $.fn.modal;
 const Modal = Plugin.Constructor;
@@ -228,7 +229,7 @@ function writeSummaryLine(message) {
   }
 }
 
-export default async function setupTests(config) {
+export default function setupTests(config) {
   disableCloaking();
 
   setupDeprecationCounter(QUnit);
@@ -434,7 +435,7 @@ export default async function setupTests(config) {
     );
   }
 
-  await loadFaker(); // so that we can use it synchronously in tests
+  setLoadedFaker(FakerModule);
 
   if (!hasPluginJs && !hasThemeJs) {
     configureRaiseOnDeprecation();


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
