### PR TITLE
DEV: Set `samesite=lax` on cookies set by client-side

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/cookie.js
+++ b/app/assets/javascripts/discourse/app/lib/cookie.js
@@ -36,6 +36,7 @@ function cookie(key, value, options) {
       options.path ? "; path=" + options.path : "",
       options.domain ? "; domain=" + options.domain : "",
       options.secure ? "; secure" : "",
+      ";samesite=Lax",
     ].join(""));
   }
 


### PR DESCRIPTION
Chrome's default is already Lax, so this change is a no-op there.

Firefox will soon be follow them, and has started warning about cookies with no samesite attribute. That's the motivation for this commit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
