### PR TITLE
DEV: Reduce the usage of "(s)" in strings

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1233,7 +1233,7 @@ en:
         description: "Skip new user onboarding tips and badges"
       reset_seen_user_tips: "Show user tips again"
       theme_default_on_all_devices: "Make this the default theme on all my devices"
-      color_scheme_default_on_all_devices: "Set default color scheme(s) on all my devices"
+      color_scheme_default_on_all_devices: "Set default color scheme on all my devices"
       color_scheme: "Color Scheme"
       color_schemes:
         default_description: "Theme default"
@@ -2836,7 +2836,7 @@ en:
           seen: I read
           unseen: I've not read
           wiki: are wiki
-          images: include image(s)
+          images: include images
           all_tags: All the above tags
         statuses:
           label: Where topics
@@ -4280,7 +4280,7 @@ en:
         filter_sidebar: "%{shortcut} Filter sidebar"
         help: "%{shortcut} Open keyboard help"
         toggle_bulk_select: "%{shortcut} Toggle bulk select"
-        dismiss: "%{shortcut} Dismiss selected topic(s)"
+        dismiss: "%{shortcut} Dismiss selected topics"
         x: "%{shortcut} Toggle selection (in bulk select mode)"
         log_out: "%{shortcut} Log Out"
       composing:
@@ -6574,7 +6574,7 @@ en:
           empty: "There are no pictures yet. Please upload one."
           upload:
             label: "Upload"
-            title: "Upload image(s)"
+            title: "Upload images"
         selectable_avatars:
           title: "List of avatars users can choose from"
         categories:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -399,7 +399,6 @@ en:
       one: "You have already sent %{count} invite in the last 24 hours, please wait %{time_left} before trying again."
       other: "You have already sent %{count} invites in the last 24 hours, please wait %{time_left} before trying again."
     confirm_email: "<p>You’re almost done! We sent an activation mail to your email address. Please follow the instructions in the mail to activate your account.</p><p>If it doesn’t arrive, check your spam folder.</p>"
-    cant_invite_to_group: "You are not allowed to invite users to specified group(s). Make sure you are owner of the group(s) you are trying to invite to."
     disabled_errors:
       discourse_connect_enabled: "Invites are disabled because DiscourseConnect is enabled."
       invalid_access: "You are not permitted to view the requested resource."
@@ -531,7 +530,6 @@ en:
   pm_reached_recipients_limit: "Sorry, you can't have more than %{recipients_limit} recipients in a message."
   removed_direct_reply_full_quotes: "Automatically removed quote of whole previous post."
   watched_words_auto_tag: "Automatically tagged topic"
-  secure_upload_not_allowed_in_public_topic: "Sorry, the following secure upload(s) cannot be used in a public topic: %{upload_filenames}."
   create_pm_on_existing_topic: "Sorry, you can't create a PM on an existing topic."
   slow_mode_enabled: "This topic is in slow mode."
 
@@ -2557,7 +2555,7 @@ en:
     tags_sort_alphabetically: "Show tags in alphabetical order. Default is to show in order of popularity."
     tags_listed_by_group: "List tags by tag group on the <a href='%{base_path}/tags' target='_blank'>Tags page</a>."
     tag_style: "Define the visual appearance of tag badges on the site. This setting allows you to customize how tags are visually represented across all areas of the site, enhancing layout consistency and user accessibility."
-    pm_tags_allowed_for_groups: "Allow members of included group(s) to tag any personal message"
+    pm_tags_allowed_for_groups: "Allow members of included groups to tag any personal message"
     min_trust_level_to_tag_topics: "Minimum trust level required to tag topics"
     tag_topic_allowed_groups: "Groups that are allowed to tag topics."
     suppress_overlapping_tags_in_list: "If tags match exact words in topic titles, don't show the tag"


### PR DESCRIPTION
It's mostly fine to use the plural form instead of writing something like "topic(s)" when one or more topics could be meant, but the actual count is not known.

This also removes some unused strings from the locale files.