### PR TITLE
FIX: Bookmark clock icon not showing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/modal/bookmark.js
@@ -177,6 +177,7 @@ export default class BookmarkModal extends Component {
   onTimeSelected(type, time) {
     this.bookmark.selectedReminderType = type;
     this.bookmark.selectedDatetime = time;
+    this.bookmark.reminderAt = time;
 
     // If the type is custom, we need to wait for the user to click save, as
     // they could still be adjusting the date and time

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -29,7 +29,7 @@ describe "Bookmarking posts and topics", type: :system do
 
     expect(bookmark_menu).to be_open
     expect(page).to have_content(I18n.t("js.bookmarks.bookmarked_success"))
-    expect(topic_page).to have_post_bookmarked(post)
+    expect(topic_page).to have_post_bookmarked(post, with_reminder: false)
     expect(Bookmark.find_by(bookmarkable: post, user: current_user)).to be_truthy
   end
 
@@ -41,6 +41,7 @@ describe "Bookmarking posts and topics", type: :system do
 
     bookmark_menu.click_menu_option("tomorrow")
 
+    expect(topic_page).to have_post_bookmarked(post, with_reminder: true)
     expect(page).to have_no_css(".bookmark-menu-content")
     expect(Bookmark.find_by(bookmarkable: post, user: current_user).reminder_at).not_to be_blank
   end
@@ -49,7 +50,7 @@ describe "Bookmarking posts and topics", type: :system do
     visit_topic_and_open_bookmark_menu(post)
     bookmark_menu.click_menu_option("custom")
     bookmark_modal.select_preset_reminder(:tomorrow)
-    expect(topic_page).to have_post_bookmarked(post)
+    expect(topic_page).to have_post_bookmarked(post, with_reminder: true)
     expect(Bookmark.find_by(bookmarkable: post, user: current_user).reminder_at).not_to be_blank
   end
 
@@ -70,7 +71,7 @@ describe "Bookmarking posts and topics", type: :system do
     )
     bookmark_modal.select_auto_delete_preference(Bookmark.auto_delete_preferences[:clear_reminder])
     bookmark_modal.save
-    expect(topic_page).to have_post_bookmarked(post_2)
+    expect(topic_page).to have_post_bookmarked(post_2, with_reminder: false)
     topic_page.click_post_action_button(post_2, :bookmark)
     bookmark_menu.click_menu_option("edit")
     expect(bookmark_modal).to have_open_options_panel

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -68,12 +68,12 @@ module PageObjects
         end
       end
 
-      def has_post_bookmarked?(post)
-        is_post_bookmarked(post, bookmarked: true)
+      def has_post_bookmarked?(post, with_reminder: false)
+        is_post_bookmarked(post, bookmarked: true, with_reminder: with_reminder)
       end
 
-      def has_no_post_bookmarked?(post)
-        is_post_bookmarked(post, bookmarked: false)
+      def has_no_post_bookmarked?(post, with_reminder: false)
+        is_post_bookmarked(post, bookmarked: false, with_reminder: with_reminder)
       end
 
       def expand_post_actions(post)
@@ -238,9 +238,10 @@ module PageObjects
         "#topic-footer-button-#{button}"
       end
 
-      def is_post_bookmarked(post, bookmarked:)
+      def is_post_bookmarked(post, bookmarked:, with_reminder: false)
         within post_by_number(post) do
-          page.public_send(bookmarked ? :has_css? : :has_no_css?, ".bookmark.bookmarked")
+          css_class = ".bookmark.bookmarked#{with_reminder ? ".with-reminder" : ""}"
+          page.public_send(bookmarked ? :has_css? : :has_no_css?, css_class)
         end
       end
     end


### PR DESCRIPTION
When choosing the "Custom..." option in the new bookmark
menu and then choosing a date + time in the modal for the
reminder, the bookmark icon on the post was not updating to
show the one with the clock to indicate the reminder.

This was just a data syncing issue between BookmarkFormData
and what the modal sets. Ideally all this would be refactored
because the data flow is messy...but hard to find time for
that right now.

Followup 67a8080e338aa62afbd02efc98178b4a67751775
