### PR TITLE
DEV: Do not attempt to update polls if there are no polls before and after edit

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -70,6 +70,7 @@ after_initialize do
 
     validator = DiscoursePoll::PollsValidator.new(self)
     return unless (polls = validator.validate_polls)
+    return if polls.blank? && self.id.blank?
 
     if polls.present?
       validator = DiscoursePoll::PostValidator.new(self)
@@ -78,6 +79,8 @@ after_initialize do
 
     # are we updating a post?
     if self.id.present?
+      return if polls.blank? && ::Poll.where(post: self).empty?
+
       DiscoursePoll::PollsUpdater.update(self, polls)
     else
       self.extracted_polls = polls

--- a/plugins/poll/spec/lib/polls_updater_spec.rb
+++ b/plugins/poll/spec/lib/polls_updater_spec.rb
@@ -186,5 +186,27 @@ RSpec.describe DiscoursePoll::PollsUpdater do
         end
       end
     end
+
+    context "when no polls" do
+      it "does not attempt to update polls" do
+        DiscoursePoll::PollsUpdater.stubs(:update).raises(StandardError)
+        no_poll_post = Fabricate(:post)
+
+        raw = <<~RAW
+          no poll here, moving on
+        RAW
+
+        no_poll_post.raw = raw
+        expect(no_poll_post.valid?).to eq(true)
+      end
+
+      it "does not need to validate post" do
+        DiscoursePoll::PostValidator.stubs(:validate_post).raises(StandardError)
+        no_poll_post =
+          Post.new(user: user, topic: Fabricate(:topic), raw: "no poll here, meoving on")
+
+        expect(no_poll_post.valid?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
When `poll_enabled` is `true` (default is `true`), and a user attempts to update a post, the update **always** goes through the `PollsUpdater` even though the user has never created a poll, nor is removing an existing poll.

This is a problem because the PollUpdater includes a `post.save_custom_fields`, and it errors out, hiding the real problem when a user attempts to save a post that is invalid.

This PR prevents the PollUpdater from getting invoked if there are no polls at all getting created or already created.

Here's the erroneous message which is shown when there are no polls involved
```
activerecord (7.0.8.1) lib/active_record/validations.rb:80:in `raise_validation_error'
app/models/concerns/has_custom_fields.rb:286:in `save_custom_fields'
plugins/poll/lib/polls_updater.rb:110:in `block in update'
activerecord (7.0.8.1) lib/active_record/connection_adapters/abstract/database_statements.rb:314:in `transaction'
activerecord (7.0.8.1) lib/active_record/transactions.rb:209:in `transaction'
plugins/poll/lib/polls_updater.rb:8:in `update'
plugins/poll/plugin.rb:81:in `block (2 levels) in activate!'
activesupport (7.0.8.1) lib/active_support/callbacks.rb:400:in `block in make_lambda'
```