### PR TITLE
UX: Tweak the checklist plugin css

### DIFF
--- a/plugins/checklist/assets/stylesheets/checklist.scss
+++ b/plugins/checklist/assets/stylesheets/checklist.scss
@@ -22,14 +22,9 @@ span.chcklst-stroked {
 }
 
 span.chcklst-box {
-  &:not(.permanent) {
-    cursor: pointer;
-  }
-
-  &:before {
-    display: inline-block;
-    vertical-align: middle;
-  }
+  cursor: pointer;
+  display: inline-flex;
+  vertical-align: text-bottom;
 
   &:not(.checked) {
     &.fa-square-o {
@@ -68,20 +63,18 @@ span.chcklst-box {
 ul li.has-checkbox {
   list-style-type: none;
   position: relative;
+}
 
-  .list-item-checkbox {
-    position: absolute;
-    left: -1.2em;
-  }
+ul:has(li.has-checkbox) {
+  padding-left: 0;
 }
 
 .fa-spin {
-  display: inline-block;
-  vertical-align: middle;
-  margin-bottom: 0.25em;
+  display: inline-flex;
+  vertical-align: text-bottom;
   animation: fa-spin 2s infinite linear;
-  width: 14px;
-  height: 17px;
+  width: 1em;
+  height: 1em;
 }
 
 @keyframes fa-spin {


### PR DESCRIPTION
1. Fixes alignment of checkboxes in posts (they now sit higher on the text line and toggling no longer results in a content shift)
2. Removes unused styles

Before / After
![Kapture 2024-04-09 at 15 33 57](https://github.com/discourse/discourse/assets/66961/30fdd07e-20d1-40df-95db-81d112b9f415) ![Kapture 2024-04-09 at 15 31 37](https://github.com/discourse/discourse/assets/66961/37ceeeb9-3762-45cf-af80-9e4de428590e)
