### PR TITLE
UX: Display JIT when user list is empty

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -77,8 +77,21 @@
             />
             <ConditionalLoadingSpinner @condition={{this.model.loadingMore}} />
           {{else}}
-            <div class="clearfix"></div>
-            <p>{{i18n "directory.no_results"}}</p>
+            <div class="empty-state">
+              <span class="empty-state-title">
+                {{i18n "directory.no_results.title"}}
+              </span>
+              <div class="empty-state-body">
+                {{i18n "directory.no_results.body"}}
+                {{#if this.currentUser.staff}}
+                  {{html-safe
+                    (i18n
+                      "directory.no_results.extra_body" basePath=(base-path)
+                    )
+                  }}
+                {{/if}}
+              </div>
+            </div>
           {{/if}}
         </ConditionalLoadingSpinner>
       </div>

--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -78,9 +78,6 @@
             <ConditionalLoadingSpinner @condition={{this.model.loadingMore}} />
           {{else}}
             <div class="empty-state">
-              <span class="empty-state-title">
-                {{i18n "directory.no_results.title"}}
-              </span>
               <div class="empty-state-body">
                 {{i18n "directory.no_results.body"}}
                 {{#if this.currentUser.staff}}

--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -79,14 +79,16 @@
           {{else}}
             <div class="empty-state">
               <div class="empty-state-body">
-                {{i18n "directory.no_results.body"}}
-                {{#if this.currentUser.staff}}
-                  {{html-safe
-                    (i18n
-                      "directory.no_results.extra_body" basePath=(base-path)
-                    )
-                  }}
-                {{/if}}
+                <p>
+                  {{i18n "directory.no_results.body"}}
+                  {{#if this.currentUser.staff}}
+                    {{html-safe
+                      (i18n
+                        "directory.no_results.extra_body" basePath=(base-path)
+                      )
+                    }}
+                  {{/if}}
+                </p>
               </div>
             </div>
           {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -763,7 +763,10 @@ en:
       topic_count_long: "Topics Created"
       post_count: "Replies"
       post_count_long: "Replies Posted"
-      no_results: "No results were found."
+      no_results:
+        title: "There are currently no members"
+        body: "A list of community members showing their activity will be shown here. For now the list is empty because your community is still brand new!"
+        extra_body: "Admins and moderators can see and manage users in <a href='%{basePath}/admin/users/'>User Admin</a>."
       days_visited: "Visits"
       days_visited_long: "Days Visited"
       posts_read: "Read"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -764,7 +764,6 @@ en:
       post_count: "Replies"
       post_count_long: "Replies Posted"
       no_results:
-        title: "There are currently no members"
         body: "A list of community members showing their activity will be shown here. For now the list is empty because your community is still brand new!"
         extra_body: "Admins and moderators can see and manage users in <a href='%{basePath}/admin/users/'>User Admin</a>."
       days_visited: "Visits"


### PR DESCRIPTION
### Before
![image](https://github.com/discourse/discourse/assets/2790986/3b9b4d37-d75e-4bb5-9ad6-f14b0234f651)


### After
Admins and mods
![image](https://github.com/discourse/discourse/assets/2790986/d8ee3806-4e47-41b1-b99d-9c3830c8df75)


Not admins or mods
![image](https://github.com/discourse/discourse/assets/2790986/5f60e96d-4f7b-4d3d-bd60-34e08910712f)

