### PR TITLE
FIX: Add the ident to fix user status styling in posts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-status-message.js
+++ b/app/assets/javascripts/discourse/app/lib/user-status-message.js
@@ -16,6 +16,7 @@ export class UserStatusMessage {
     this.html = this.#statusHtml(status, opts);
     this.content = this.#tooltipHtml(status);
     this.tooltipInstance = this.tooltip.register(this.html, {
+      identifier: "user-status-message-tooltip",
       content: this.content,
     });
   }

--- a/app/assets/stylesheets/common/components/user-status-message.scss
+++ b/app/assets/stylesheets/common/components/user-status-message.scss
@@ -1,7 +1,4 @@
 [data-content][data-identifier="user-status-message-tooltip"] {
-  display: flex;
-  align-items: center;
-
   .emoji {
     width: 1em;
     height: 1em;


### PR DESCRIPTION
Before / After

<img width="116" alt="Screenshot 2024-04-10 at 01 26 08" src="https://github.com/discourse/discourse/assets/66961/898da7a8-75ac-4908-bc61-f8ea5232f4cf"> <img width="116" alt="Screenshot 2024-04-10 at 01 21 16" src="https://github.com/discourse/discourse/assets/66961/dd00c9da-7fd2-4351-b4cf-2cfc46edb966">
