### PR TITLE
UX: make first admin a moderator to review user approvals.

### DIFF
--- a/app/jobs/regular/enable_bootstrap_mode.rb
+++ b/app/jobs/regular/enable_bootstrap_mode.rb
@@ -12,6 +12,9 @@ module Jobs
       user = User.find_by(id: args[:user_id])
       return if !user.is_singular_admin?
 
+      user.grant_moderation!
+      StaffActionLogger.new(Discourse.system_user).log_grant_moderation(user)
+
       # let's enable bootstrap mode settings
       if SiteSetting.default_trust_level == TrustLevel[0]
         SiteSetting.set_and_log("default_trust_level", TrustLevel[1])
@@ -19,6 +22,10 @@ module Jobs
 
       if SiteSetting.default_email_digest_frequency == 10_080
         SiteSetting.set_and_log("default_email_digest_frequency", 1440)
+      end
+
+      if SiteSetting.pending_users_reminder_delay_minutes == 480
+        SiteSetting.set_and_log("pending_users_reminder_delay_minutes", 5)
       end
 
       SiteSetting.set_and_log("bootstrap_mode_enabled", true)

--- a/app/jobs/scheduled/disable_bootstrap_mode.rb
+++ b/app/jobs/scheduled/disable_bootstrap_mode.rb
@@ -12,6 +12,10 @@ module Jobs
         return
       end
 
+      if SiteSetting.pending_users_reminder_delay_minutes == 5
+        SiteSetting.set_and_log("pending_users_reminder_delay_minutes", 480)
+      end
+
       if SiteSetting.default_trust_level == TrustLevel[1]
         SiteSetting.set_and_log("default_trust_level", TrustLevel[0])
       end

--- a/spec/jobs/disable_bootstrap_mode_spec.rb
+++ b/spec/jobs/disable_bootstrap_mode_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Jobs::DisableBootstrapMode do
       SiteSetting.bootstrap_mode_enabled = true
       SiteSetting.default_trust_level = TrustLevel[1]
       SiteSetting.default_email_digest_frequency = 1440
+      SiteSetting.pending_users_reminder_delay_minutes = 5
     end
 
     it "does not execute if bootstrap mode is already disabled" do
@@ -18,21 +19,21 @@ RSpec.describe Jobs::DisableBootstrapMode do
 
     it "turns off bootstrap mode if bootstrap_mode_min_users is set to 0" do
       SiteSetting.bootstrap_mode_min_users = 0
-      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(3)
+      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(4)
       Jobs::DisableBootstrapMode.new.execute(user_id: admin.id)
     end
 
     it "does not amend setting that is not in bootstrap state" do
       SiteSetting.bootstrap_mode_min_users = 0
       SiteSetting.default_trust_level = TrustLevel[3]
-      StaffActionLogger.any_instance.expects(:log_site_setting_change).twice
+      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(3)
       Jobs::DisableBootstrapMode.new.execute(user_id: admin.id)
     end
 
     it "successfully turns off bootstrap mode" do
       SiteSetting.bootstrap_mode_min_users = 5
       6.times { Fabricate(:user) }
-      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(3)
+      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(4)
       Jobs::DisableBootstrapMode.new.execute(user_id: admin.id)
     end
   end

--- a/spec/jobs/enable_bootstrap_mode_spec.rb
+++ b/spec/jobs/enable_bootstrap_mode_spec.rb
@@ -26,13 +26,14 @@ RSpec.describe Jobs::EnableBootstrapMode do
 
     it "does not amend setting that is not in default state" do
       SiteSetting.default_trust_level = TrustLevel[3]
-      StaffActionLogger.any_instance.expects(:log_site_setting_change).twice
+      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(3)
       Jobs::EnableBootstrapMode.new.execute(user_id: admin.id)
     end
 
     it "successfully turns on bootstrap mode" do
-      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(3)
+      StaffActionLogger.any_instance.expects(:log_site_setting_change).times(4)
       Jobs::EnableBootstrapMode.new.execute(user_id: admin.id)
+      expect(admin.reload.moderator).to be_truthy
     end
   end
 end

--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "notifications" do
                          type: :string,
                        },
                        post_number: {
-                         type: %i[string null],
+                         type: %i[integer null],
                        },
                        topic_id: {
                          type: %i[integer null],

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe CategoriesController do
           expect(category.category_groups.map { |g| [g.group_id, g.permission_type] }.sort).to eq(
             [[Group[:everyone].id, readonly], [Group[:staff].id, create_post]],
           )
-          expect(UserHistory.count).to eq(4) # 1 + 3 (bootstrap mode)
+          expect(UserHistory.count).to eq(6) # 1 + 5 (bootstrap mode)
         end
       end
     end
@@ -764,7 +764,7 @@ RSpec.describe CategoriesController do
                 },
               }
           expect(response.status).to eq(200)
-          expect(UserHistory.count).to eq(5) # 2 + 3 (bootstrap mode)
+          expect(UserHistory.count).to eq(7) # 2 + 5 (bootstrap mode)
         end
 
         it "updates per-category settings correctly" do


### PR DESCRIPTION
Previously, when the new site was created and after the first admin login, no one will receive notifications to review the user approval queue since only the moderators would receive the PMs about it. Also, this PR will change the "pending_users_reminder_delay_minutes" site setting to 5 minutes while the site is in bootstrap mode.