### PR TITLE
DEV: Add query parameter to get all categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -46,6 +46,7 @@ class CategoriesController < ApplicationController
       parent_category_id: params[:parent_category_id],
       include_topics: include_topics(parent_category),
       include_subcategories: include_subcategories,
+      all: ActiveModel::Type::Boolean.new.cast(params[:all]),
       tag: params[:tag],
       page: params[:page],
     }


### PR DESCRIPTION
The previous implementation of the categories endpoint could return up to 5 subcategories for each parent category, which may not fit all use cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
