### PR TITLE
UX: Improve the identifier for categories typed prop in theme objects editor

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
@@ -44,8 +44,21 @@ export default class SchemaThemeSettingNewEditor extends Component {
     this.activeIndex = index;
   }
 
+  @action
   generateSchemaTitle(object, schema, index) {
-    return object[schema.identifier] || `${schema.name} ${index + 1}`;
+    let title;
+
+    if (schema.properties[schema.identifier]?.type === "categories") {
+      title = this.activeData[index][schema.identifier]
+        ?.map((categoryId) => {
+          return this.args.setting.metadata.categories[categoryId].name;
+        })
+        .join(", ");
+    } else {
+      title = object[schema.identifier];
+    }
+
+    return title || `${schema.name} ${index + 1}`;
   }
 
   get backButtonText() {

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/categories.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/types/categories.gjs
@@ -15,7 +15,10 @@ export default class SchemaThemeSettingTypeCategories extends SchemaThemeSetting
   type = "categories";
 
   onChange(categories) {
-    return categories.mapBy("id");
+    return categories.map((category) => {
+      this.args.setting.metadata.categories[category.id] ||= category;
+      return category.id;
+    });
   }
 
   <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-theme-setting/editor-test.gjs
@@ -838,6 +838,65 @@ module(
       );
     });
 
+    test("input field of type categories with schema's identifier set to categories field", async function (assert) {
+      const setting = ThemeSettings.create({
+        setting: "objects_setting",
+        objects_schema: {
+          name: "category",
+          identifier: "category",
+          properties: {
+            category: {
+              type: "categories",
+              required: true,
+            },
+          },
+        },
+        metadata: {
+          categories: {
+            6: {
+              id: 6,
+              name: "support",
+            },
+            7: {
+              id: 7,
+              name: "something",
+            },
+          },
+        },
+        value: [
+          {
+            category: [6, 7],
+          },
+        ],
+      });
+
+      await render(<template>
+        <AdminSchemaThemeSettingEditor @themeId="1" @setting={{setting}} />
+      </template>);
+
+      const tree = new TreeFromDOM();
+
+      assert.dom(tree.nodes[0].textElement).hasText("support, something");
+
+      const inputFields = new InputFieldsFromDOM();
+
+      const categorySelector = selectKit(
+        `${inputFields.fields.category.selector} .select-kit`
+      );
+
+      await categorySelector.expand();
+      await categorySelector.deselectItemByValue("6");
+      await categorySelector.collapse();
+
+      assert.dom(tree.nodes[0].textElement).hasText("something");
+
+      await click(TOP_LEVEL_ADD_BTN);
+
+      tree.refresh();
+
+      assert.dom(tree.nodes[1].textElement).hasText("category 2");
+    });
+
     test("input fields of type tags which is required", async function (assert) {
       const setting = ThemeSettings.create({
         setting: "objects_setting",


### PR DESCRIPTION
This commit changes the identifier displayed in the navigation tree of
the theme objects editor from the generic "category 1" to "<category
name>, <category 2 name>" when a property of typed categories is set as
the identifier.

Example:

For the following theme objects schema:

```
some_setting:
  type: objects
  default: []
  schema:
    name: <some scheme name>
    identifier: list_of_categories
    properties:
      list_of_categories:
        type: categories
```

If the `list_of_categories` property's value has been set to `category
1` and `category 2`, the navigation tree will display `category 1,
category 2` as the text to represent the object in the navigation tree.

### Recording

https://github.com/discourse/discourse/assets/4335742/39781b04-c44e-4b19-9dfe-073209999dd4

