### PR TITLE
DEV: correctly check for latest

### DIFF
--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -152,9 +152,7 @@ RSpec.describe "Navigation", type: :system do
       chat_page.open
       chat_page.minimize_full_page
 
-      expect(page).to have_current_path(
-        chat.channel_path(category_channel.slug, category_channel.id),
-      )
+      expect(page).to have_current_path("/latest")
     end
   end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -35,8 +35,9 @@ module PageObjects
         find(".chat-header-icon").has_link?(href: href)
       end
 
-      def open
+      def open(with_preloaded_channels: true)
         visit("/chat")
+        has_finished_loading?(with_preloaded_channels: with_preloaded_channels)
       end
 
       def open_new_message(ensure_open: true)


### PR DESCRIPTION
This was not testing the right path, and was still green most of the times because we were not waiting for channels to be preloaded in this case.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
