### PR TITLE
FIX: Serialize categories for bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import Bookmark from "discourse/models/bookmark";
+import Site from "discourse/models/site";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
@@ -38,6 +39,10 @@ export default DiscourseRoute.extend({
         if (!response.user_bookmark_list) {
           return { bookmarks: [] };
         }
+
+        response.user_bookmark_list.categories?.forEach((category) =>
+          Site.current().updateCategory(category)
+        );
 
         const bookmarks = response.user_bookmark_list.bookmarks.map(
           controller.transform

--- a/app/models/user_bookmark_list.rb
+++ b/app/models/user_bookmark_list.rb
@@ -36,4 +36,16 @@ class UserBookmarkList
     @has_more = (@page.to_i + 1) * @per_page < query.count
     @bookmarks
   end
+
+  def categories
+    @categories ||=
+      @bookmarks
+        .map do |bm|
+          category = bm.bookmarkable.try(:category) || bm.bookmarkable.try(:topic)&.category
+          [category&.parent_category, category]
+        end
+        .flatten
+        .compact
+        .uniq
+  end
 end

--- a/app/serializers/user_bookmark_list_serializer.rb
+++ b/app/serializers/user_bookmark_list_serializer.rb
@@ -3,6 +3,8 @@
 class UserBookmarkListSerializer < ApplicationSerializer
   attributes :more_bookmarks_url, :bookmarks
 
+  has_many :categories, serializer: CategoryBadgeSerializer, embed: :objects
+
   def bookmarks
     object.bookmarks.map do |bm|
       bm.registered_bookmarkable.serializer.new(
@@ -16,5 +18,9 @@ class UserBookmarkListSerializer < ApplicationSerializer
 
   def include_more_bookmarks_url?
     @include_more_bookmarks_url ||= object.has_more
+  end
+
+  def include_categories?
+    scope.can_lazy_load_categories?
   end
 end

--- a/app/services/post_bookmarkable.rb
+++ b/app/services/post_bookmarkable.rb
@@ -12,7 +12,7 @@ class PostBookmarkable < BaseBookmarkable
   end
 
   def self.preload_associations
-    [{ topic: %i[tags category] }, :user]
+    [{ topic: [:tags, { category: :parent_category }] }, :user]
   end
 
   def self.list_query(user, guardian)

--- a/app/services/topic_bookmarkable.rb
+++ b/app/services/topic_bookmarkable.rb
@@ -12,7 +12,7 @@ class TopicBookmarkable < BaseBookmarkable
   end
 
   def self.preload_associations
-    [:category, :tags, { first_post: :user }]
+    [{ category: :parent_category }, :tags, { first_post: :user }]
   end
 
   def self.perform_custom_preload!(topic_bookmarks, guardian)

--- a/spec/serializers/user_bookmark_list_serializer_spec.rb
+++ b/spec/serializers/user_bookmark_list_serializer_spec.rb
@@ -29,5 +29,16 @@ RSpec.describe UserBookmarkListSerializer do
         %w[UserTestBookmarkSerializer UserTopicBookmarkSerializer UserPostBookmarkSerializer],
       )
     end
+
+    it "serializes categories" do
+      topic_category = Fabricate(:category)
+      topic_bookmark.bookmarkable.update!(category: topic_category)
+      post_category = Fabricate(:category)
+      post_bookmark.bookmarkable.topic.update!(category: post_category)
+
+      serializer = run_serializer
+
+      expect(serializer.categories).to contain_exactly(topic_category, post_category)
+    end
   end
 end


### PR DESCRIPTION
This is necessary when "lazy load categories" feature is enabled to make sure the categories are rendered for topics and posts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
