### PR TITLE
FIX: Ensure invalid timezone does not block critical emails

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -167,7 +167,7 @@ class UserNotifications < ActionMailer::Base
         reason: user_history.details,
       )
     else
-      silenced_till = user.silenced_till.in_time_zone(user.user_option.timezone)
+      silenced_till = user.silenced_till.in_time_zone(user.user_option.timezone.presence || "UTC")
       build_email(
         user.email,
         template: "user_notifications.account_silenced",
@@ -191,7 +191,7 @@ class UserNotifications < ActionMailer::Base
         reason: user_history.details,
       )
     else
-      suspended_till = user.suspended_till.in_time_zone(user.user_option.timezone)
+      suspended_till = user.suspended_till.in_time_zone(user.user_option.timezone.presence || "UTC")
       build_email(
         user.email,
         template: "user_notifications.account_suspended",

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1471,6 +1471,23 @@ RSpec.describe UserNotifications do
         expect(mail.body).to include(date)
       end
     end
+
+    context "when user timezone is invalid" do
+      before { user.user_option.timezone = "" }
+
+      it "doesn't raise error" do
+        expect { UserNotifications.account_silenced(user) }.not_to raise_error
+      end
+
+      it "adds the silenced_till date in UTC" do
+        date = "May 25, 2020, 12:00pm"
+        user.silenced_till = DateTime.parse(date)
+
+        mail = UserNotifications.account_silenced(user, { user_history: user_history })
+
+        expect(mail.body).to include(date)
+      end
+    end
   end
 
   describe ".account_suspended" do
@@ -1487,6 +1504,23 @@ RSpec.describe UserNotifications do
 
     context "when user doesn't have timezone set" do
       before { user.user_option.timezone = nil }
+
+      it "doesn't raise error" do
+        expect { UserNotifications.account_suspended(user) }.not_to raise_error
+      end
+
+      it "adds the suspended_till date in UTC" do
+        date = "May 25, 2020, 12:00pm"
+        user.suspended_till = DateTime.parse(date)
+
+        mail = UserNotifications.account_suspended(user, { user_history: user_history })
+
+        expect(mail.body).to include(date)
+      end
+    end
+
+    context "when user timezone is invalid" do
+      before { user.user_option.timezone = "" }
 
       it "doesn't raise error" do
         expect { UserNotifications.account_suspended(user) }.not_to raise_error


### PR DESCRIPTION
See https://meta.discourse.org/t/invalid-user-timezone-jams-up-their-mail/303306

This ensures that "account silenced" and "account suspended" emails don't fail to send if the user has an invalid timezone.
