### PR TITLE
FIX: Update category breadcrumbs more reliably

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -10,11 +10,11 @@ export default Component.extend({
   editingCategory: false,
   editingCategoryTab: null,
 
-  @discourseComputed("category.ancestors", "categories", "noSubcategories")
-  categoryBreadcrumbs(categoryAncestors, filteredCategories, noSubcategories) {
-    categoryAncestors = categoryAncestors || [];
-    const parentCategories = [undefined, ...categoryAncestors];
-    const categories = [...categoryAncestors, undefined];
+  @discourseComputed("category", "categories", "noSubcategories")
+  categoryBreadcrumbs(cat, filteredCategories, noSubcategories) {
+    const ancestors = cat?.ancestors || [];
+    const parentCategories = [undefined, ...ancestors];
+    const categories = [...ancestors, undefined];
     const zipped = parentCategories.map((x, i) => [x, categories[i]]);
 
     return zipped.map((record) => {

--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -11,29 +11,30 @@ export default Component.extend({
   editingCategoryTab: null,
 
   @discourseComputed("category", "categories", "noSubcategories")
-  categoryBreadcrumbs(cat, filteredCategories, noSubcategories) {
-    const ancestors = cat?.ancestors || [];
+  categoryBreadcrumbs(category, filteredCategories, noSubcategories) {
+    const ancestors = category?.ancestors || [];
     const parentCategories = [undefined, ...ancestors];
     const categories = [...ancestors, undefined];
-    const zipped = parentCategories.map((x, i) => [x, categories[i]]);
 
-    return zipped.map((record) => {
-      const [parentCategory, category] = record;
+    return parentCategories
+      .map((x, i) => [x, categories[i]])
+      .map((record) => {
+        const [parentCategory, subCategory] = record;
 
-      const options = filteredCategories.filter(
-        (c) =>
-          c.get("parentCategory.id") === (parentCategory && parentCategory.id)
-      );
+        const options = filteredCategories.filter(
+          (c) =>
+            c.get("parentCategory.id") === (parentCategory && parentCategory.id)
+        );
 
-      return {
-        category,
-        parentCategory,
-        options,
-        isSubcategory: !!parentCategory,
-        noSubcategories: !category && noSubcategories,
-        hasOptions: !parentCategory || parentCategory.has_children,
-      };
-    });
+        return {
+          category: subCategory,
+          parentCategory,
+          options,
+          isSubcategory: !!parentCategory,
+          noSubcategories: !subCategory && noSubcategories,
+          hasOptions: !parentCategory || parentCategory.has_children,
+        };
+      });
   },
 
   @discourseComputed("siteSettings.tagging_enabled", "editingCategory")

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -436,6 +436,7 @@ class CategoriesController < ApplicationController
 
     if include_ancestors
       ancestors = Category.secured(guardian).ancestors_of(categories.map(&:id))
+      Category.preload_user_fields!(guardian, ancestors)
       response[:ancestors] = serialize_data(ancestors, SiteCategorySerializer, scope: guardian)
     end
 


### PR DESCRIPTION
The breadcrumbs were updated everytime there were changes to the categories which was not efficient and caused unnecessary rerendering of the CategoryDrop elements when "lazy load categories" is enabled.

This commit also ensures that all category fields are serialized for ancestors too for the categories#search endpoint.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
