### PR TITLE
FEATURE: User Notifications Links Page

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/linked-consolidated.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/linked-consolidated.js
@@ -4,8 +4,9 @@ import I18n from "discourse-i18n";
 
 export default class extends NotificationTypeBase {
   get linkHref() {
-    // Linking here for now until we have a proper new page for "linked" in the profile
-    return userPath(`${this.currentUser.username}/notifications`);
+    return userPath(
+      `${this.currentUser.username}/notifications/links?acting_username=${this.notification.data.username}`
+    );
   }
 
   get description() {

--- a/app/assets/javascripts/discourse/app/models/user-action.js
+++ b/app/assets/javascripts/discourse/app/models/user-action.js
@@ -19,6 +19,7 @@ const UserActionTypes = {
   edits: 11,
   messages_sent: 12,
   messages_received: 13,
+  links: 17,
 };
 const InvertedActionTypes = {};
 

--- a/app/assets/javascripts/discourse/app/routes/app-route-map.js
+++ b/app/assets/javascripts/discourse/app/routes/app-route-map.js
@@ -140,6 +140,7 @@ export default function () {
           this.route("likesReceived", { path: "likes-received" });
           this.route("mentions");
           this.route("edits");
+          this.route("links");
         }
       );
 

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-links.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-links.js
@@ -1,0 +1,11 @@
+import UserAction from "discourse/models/user-action";
+import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import I18n from "discourse-i18n";
+
+export default UserActivityStreamRoute.extend({
+  userActionType: UserAction.TYPES["links"],
+
+  titleToken() {
+    return I18n.t("user_action_groups.17");
+  },
+});

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -53,6 +53,15 @@
       <span>{{i18n "user_action_groups.11"}}</span>
     </DNavigationItem>
 
+    <DNavigationItem
+      @route="userNotifications.links"
+      @ariaCurrentContext="subNav"
+      class="user-nav__notifications-links"
+    >
+      {{d-icon "link"}}
+      <span>{{i18n "user_action_groups.17"}}</span>
+    </DNavigationItem>
+
     <PluginOutlet
       @name="user-notifications-bottom"
       @connectorTagName="li"

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/linked-consolidated-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/linked-consolidated-test.js
@@ -43,7 +43,7 @@ module("Unit | Notification Types | linked-consolidated", function (hooks) {
     );
     assert.strictEqual(
       director.linkHref,
-      "/u/eviltrout/notifications",
+      "/u/eviltrout/notifications/links?acting_username=liker439",
       "links to the notifications page of the user"
     );
   });

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -22,6 +22,7 @@ class UserAction < ActiveRecord::Base
   GOT_PRIVATE_MESSAGE = 13
   SOLVED = 15
   ASSIGNED = 16
+  LINKED = 17
 
   ORDER =
     Hash[
@@ -38,6 +39,7 @@ class UserAction < ActiveRecord::Base
         EDIT,
         SOLVED,
         ASSIGNED,
+        LINKED,
       ].each_with_index.to_a.flatten
     ]
 
@@ -60,6 +62,7 @@ class UserAction < ActiveRecord::Base
         got_private_message: 13,
         solved: 15,
         assigned: 16,
+        linked: 17,
       )
   end
 

--- a/app/services/user_action_manager.rb
+++ b/app/services/user_action_manager.rb
@@ -104,6 +104,8 @@ class UserActionManager
         UserAction::MENTION
       when Notification.types[:edited]
         UserAction::EDIT
+      when Notification.types[:linked]
+        UserAction::LINKED
       end
 
     # skip any invalid items, eg failed to save post and so on

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1049,6 +1049,7 @@ en:
       "13": "Inbox"
       "14": "Pending"
       "15": "Drafts"
+      "17": "Links"
 
     categories:
       categories_label: "categories"


### PR DESCRIPTION
This change creates a new user notifications page for showing your posts
that have been linked to.

This page is also needed for consolidated link notifications so that
when you click on the notification it will take you to this new page
showing you the link notifications from a specific user.

Follow up to: 72ac675e4ed498d4a961470358b7f807fa7f4a36
