### PR TITLE
FEATURE: mandatory fields for group site setting

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/group-list.hbs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/group-list.hbs
@@ -2,6 +2,7 @@
   @value={{this.settingValue}}
   @choices={{this.groupChoices}}
   @settingName="name"
+  @mandatoryValues={{this.setting.mandatory_values}}
   @nameProperty={{this.nameProperty}}
   @valueProperty={{this.valueProperty}}
   @onChange={{this.onChangeGroupListSetting}}

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
@@ -102,6 +102,6 @@ module("Integration | Component | group-list site-setting", function (hooks) {
     await subject.expand();
     await subject.selectRowByValue("2");
 
-    assert.dom(".selected-content div").hasClass("disabled");
+    assert.dom(".selected-content button").hasClass("disabled");
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
@@ -57,4 +57,51 @@ module("Integration | Component | group-list site-setting", function (hooks) {
       "it allows to select a setting from the list of choices"
     );
   });
+
+  test("mandatory values", async function (assert) {
+    this.site.groups = [
+      {
+        id: 1,
+        name: "Donuts",
+      },
+      {
+        id: 2,
+        name: "Cheese cake",
+      },
+    ];
+
+    this.set(
+      "setting",
+      EmberObject.create({
+        allowsNone: undefined,
+        category: "foo",
+        default: "",
+        description: "Choose groups",
+        overridden: false,
+        placeholder: null,
+        preview: null,
+        secret: false,
+        setting: "foo_bar",
+        type: "group_list",
+        validValues: undefined,
+        mandatory_values: "1",
+        value: "1",
+      })
+    );
+
+    await render(hbs`<SiteSetting @setting={{this.setting}} />`);
+
+    const subject = selectKit(".list-setting");
+
+    assert.strictEqual(
+      subject.header().value(),
+      "1",
+      "it selects the setting's value"
+    );
+
+    await subject.expand();
+    await subject.selectRowByValue("2");
+
+    assert.dom(".selected-content div").hasClass("disabled");
+  });
 });

--- a/app/assets/javascripts/select-kit/addon/components/multi-select.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.hbs
@@ -26,6 +26,7 @@
               this.selectKit.options.selectedChoiceComponent
               item=item
               selectKit=this.selectKit
+              mandatoryValues=@mandatoryValues
             }}
           {{/each}}
         </div>

--- a/app/assets/javascripts/select-kit/addon/components/selected-choice.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/selected-choice.hbs
@@ -1,18 +1,22 @@
-<button
-  {{on "click" (fn this.selectKit.deselect this.item)}}
-  aria-label={{i18n "select_kit.delete_item" name=this.itemName}}
-  data-value={{this.itemValue}}
-  data-name={{this.itemName}}
-  type="button"
-  id="{{this.id}}-choice"
-  class="btn btn-default selected-choice {{this.extraClass}}"
->
-  {{d-icon "times"}}
-  {{#if (has-block)}}
-    {{yield}}
-  {{else}}
-    <span class="d-button-label">
-      {{this.itemName}}
-    </span>
-  {{/if}}
-</button>
+{{#if this.readOnly}}
+  <div class="btn btn-default disabled">{{this.itemName}}</div>
+{{else}}
+  <button
+    {{on "click" (fn this.selectKit.deselect this.item)}}
+    aria-label={{i18n "select_kit.delete_item" name=this.itemName}}
+    data-value={{this.itemValue}}
+    data-name={{this.itemName}}
+    type="button"
+    id="{{this.id}}-choice"
+    class="btn btn-default selected-choice {{this.extraClass}}"
+  >
+    {{d-icon "times"}}
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      <span class="d-button-label">
+        {{this.itemName}}
+      </span>
+    {{/if}}
+  </button>
+{{/if}}

--- a/app/assets/javascripts/select-kit/addon/components/selected-choice.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/selected-choice.hbs
@@ -1,5 +1,8 @@
 {{#if this.readOnly}}
-  <div class="btn btn-default disabled">{{this.itemName}}</div>
+  <button
+    class="btn btn-default disabled"
+    title={{I18n "admin.site_settings.mandatory_group"}}
+  >{{this.itemName}}</button>
 {{else}}
   <button
     {{on "click" (fn this.selectKit.deselect this.item)}}

--- a/app/assets/javascripts/select-kit/addon/components/selected-choice.js
+++ b/app/assets/javascripts/select-kit/addon/components/selected-choice.js
@@ -23,4 +23,8 @@ export default Component.extend(UtilsMixin, {
   itemName: computed("item", function () {
     return this.getName(this.item);
   }),
+
+  readOnly: computed("item", function () {
+    return this.get("mandatoryValues")?.split("|")?.includes(this.item.id);
+  }),
 });

--- a/app/assets/javascripts/select-kit/addon/components/selected-choice.js
+++ b/app/assets/javascripts/select-kit/addon/components/selected-choice.js
@@ -24,7 +24,11 @@ export default Component.extend(UtilsMixin, {
     return this.getName(this.item);
   }),
 
+  mandatoryValuesArray: computed("item", function () {
+    return this.get("mandatoryValues")?.split("|") || [];
+  }),
+
   readOnly: computed("item", function () {
-    return this.get("mandatoryValues")?.split("|")?.includes(this.item.id);
+    return this.mandatoryValuesArray.includes(this.item.id);
   }),
 });

--- a/app/assets/stylesheets/common/select-kit/multi-select.scss
+++ b/app/assets/stylesheets/common/select-kit/multi-select.scss
@@ -35,6 +35,11 @@
       border-bottom: 1px solid var(--primary-low);
       padding: 0.25em 0.25em 0 0.25em;
 
+      .disabled {
+        margin: 0 0.25em 0.25em 0;
+        align-content: center;
+      }
+
       .selected-choice {
         margin: 0 0.25em 0.25em 0;
         font-size: var(--font-down-1);

--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -5,7 +5,11 @@ class SiteSettingsTask
     site_settings = SiteSetting.all_settings(include_hidden: include_hidden)
     h = {}
     site_settings.each do |site_setting|
-      next if site_setting[:default] == site_setting[:value] if !include_defaults
+      default = site_setting[:default]
+      if site_setting[:mandatory_values]
+        default = (site_setting[:mandatory_values].split("|") | default.split("|")).join("|")
+      end
+      next if default == site_setting[:value] if !include_defaults
       h.store(site_setting[:setting].to_s, site_setting[:value])
     end
     h

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6673,6 +6673,7 @@ en:
           add_document_types: "Documents"
           add_types_title: "Allow extensions %{types}"
           add_types_toast: "%{types} file types added"
+        mandatory_group: "Group is mandatory"
 
       badges:
         title: Badges

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1745,7 +1745,7 @@ en:
     custom_summarization_allowed_groups: "Groups allowed to summarize contents using the `summarization_strategy`."
 
     enable_personal_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
-    personal_message_enabled_groups: "Allow users in these groups to create personal messages. IMPORTANT: 1) all users can reply to messages. 2) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 3) Admins and mods can always send messages. 4) Group interaction settings override this setting for messaging specific groups."
+    personal_message_enabled_groups: "Allow users in these groups to create personal messages. IMPORTANT: 1) all users can reply to messages. 2) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 3) Admins and mods can always send messages. 4) Group interaction settings override this setting for messaging specific groups. Admins and moderators can always create personal messages."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"
     enable_chunked_encoding: "Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed"
     long_polling_base_url: "Base URL used for long polling (when a CDN is serving dynamic content, be sure to set this to origin pull) eg: http://origin.site.com"
@@ -2070,35 +2070,35 @@ en:
     edit_all_post_groups: "Allow users in this group to edit other users' posts"
 
     min_trust_to_create_topic: "The minimum trust level required to create a new topic."
-    create_topic_allowed_groups: "Groups that are allowed to create new topics."
+    create_topic_allowed_groups: "Groups that are allowed to create new topics. Admins and moderators can always create topics."
     allow_flagging_staff: "If enabled, users can flag posts from staff accounts."
 
     min_trust_to_edit_wiki_post: "The minimum trust level required to edit post marked as wiki."
-    edit_wiki_post_allowed_groups: "Groups that are allowed to edit posts marked as wiki."
+    edit_wiki_post_allowed_groups: "Groups that are allowed to edit posts marked as wiki. Admins and moderators can always edit posts marked as wiki."
 
     min_trust_to_edit_post: "The minimum trust level required to edit posts."
-    edit_post_allowed_groups: "Groups that are allowed to edit posts."
+    edit_post_allowed_groups: "Groups that are allowed to edit posts. Admins and moderators can always edit posts."
 
     min_trust_to_allow_self_wiki: "The minimum trust level required to make user's own post wiki."
-    self_wiki_allowed_groups: "Groups where users can make their own post wiki."
+    self_wiki_allowed_groups: "Groups where users can make their own post wiki. Admins and moderators can always make their own post wiki."
 
     min_trust_to_send_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages."
     min_trust_to_send_email_messages: "The minimum trust level required to send personal messages via email."
-    send_email_messages_allowed_groups: "Groups that are allowed to send personal messages via email."
+    send_email_messages_allowed_groups: "Groups that are allowed to send personal messages via email. Admins and moderators can always send personal messages via email."
     min_trust_to_flag_posts: "The minimum trust level required to flag posts"
-    flag_post_allowed_groups: "Groups that are allowed to flag posts."
+    flag_post_allowed_groups: "Groups that are allowed to flag posts. Admins and moderators can always flag posts."
     min_trust_to_post_links: "The minimum trust level required to include links in posts"
     post_links_allowed_groups: "Groups that are allowed to include links in posts. Admins and moderators are always allowed to post links."
     min_trust_to_post_embedded_media: "The minimum trust level required to embed media items in a post"
-    embedded_media_post_allowed_groups: "The users in these groups are allowed to embed media items in a post"
+    embedded_media_post_allowed_groups: "The users in these groups are allowed to embed media items in a post. Admins and moderators can always embed media items."
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"
-    profile_background_allowed_groups: "Groups that are allowed to upload a profile background."
+    profile_background_allowed_groups: "Groups that are allowed to upload a profile background. Admins and moderators can always upload a profile background."
     min_trust_level_to_allow_user_card_background: "The minimum trust level required to upload a user card background"
-    user_card_background_allowed_groups: "Groups that are allowed to upload a user card background."
+    user_card_background_allowed_groups: "Groups that are allowed to upload a user card background. Admins and moderators can always upload a user card background."
     min_trust_level_to_allow_invite: "The minimum trust level required to invite users"
-    invite_allowed_groups: "Groups that are allowed to invite users."
+    invite_allowed_groups: "Groups that are allowed to invite users. Admins and moderators can always invite users."
     min_trust_level_to_allow_ignore: "The minimum trust level required to ignore users"
-    ignore_allowed_groups: "Groups that are allowed to ignore other users."
+    ignore_allowed_groups: "Groups that are allowed to ignore other users. Admins and moderators can always ignore other users."
     allowed_link_domains: "Domains that users may link to even if they don't have the appropriate trust level to post links"
 
     newuser_max_links: "How many links a new user can add to a post."
@@ -2112,7 +2112,7 @@ en:
     here_mention: "Name used for a @mention to allow privileged users to notify up to 'max_here_mentioned' people participating in the topic. Must not be an existing username."
     max_here_mentioned: "Maximum number of mentioned people by @here."
     min_trust_level_for_here_mention: "The minimum trust level allowed to mention @here."
-    here_mention_allowed_groups: "Groups that are allowed to mention @here."
+    here_mention_allowed_groups: "Groups that are allowed to mention @here. Admins and moderators can always mention @here."
 
     create_thumbnails: "Create thumbnails and lightbox images that are too large to fit in a post."
 
@@ -2264,7 +2264,7 @@ en:
     log_mail_processing_failures: "Log all email processing failures to <a href='%{base_path}/logs' target='_blank'>/logs</a>"
     email_in: "Allow users to post new topics via email. After enabling this setting, you will be able to configure incoming email addresses for groups and categories."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."
-    email_in_allowed_groups: "Groups that are allowed to post new topics via email."
+    email_in_allowed_groups: "Groups that are allowed to post new topics via email. Admins and moderators can always post new topics via email."
 
     email_in_authserv_id: "The identifier of the service doing authentication checks on incoming emails. See <a href='https://meta.discourse.org/t/134358'>https://meta.discourse.org/t/134358</a> for instructions on how to configure this."
     email_in_spam_header: "Selects the specific email header to use for identifying spam. This option can be X-Spam-Flag, X-Spam-Status, or X-SES-Spam-Verdict, and the email is tagged as spam based on the header's value. For instance, if the chosen setting is X-Spam-Flag, an email with this header value set to YES would be classified as spam."
@@ -2453,9 +2453,9 @@ en:
 
     approve_post_count: "The amount of posts from a new or basic user that must be approved"
     approve_unless_trust_level: "Posts created by users below this trust level must be approved"
-    approve_unless_allowed_groups: "Posts created by users not in these groups must be approved"
+    approve_unless_allowed_groups: "Posts created by users not in these groups must be approved. Posts created by admins and moderators are always approved."
     approve_new_topics_unless_trust_level: "New topics created by users below this trust level must be approved"
-    approve_new_topics_unless_allowed_groups: "New topics created by users not in these groups must be approved"
+    approve_new_topics_unless_allowed_groups: "New topics created by users not in these groups must be approved. Topics created by admins and moderators are always approved."
     approve_unless_staged: "New topics and posts created by staged users must be approved"
     notify_about_queued_posts_after: "If there are posts that have been waiting to be reviewed for more than this many hours, send a notification to all moderators. Set to 0 to disable these notifications."
     reviewable_revision_reasons: "List of reasons that can be selected when rejecting a reviewable queued post with a revision. Other is always available as well, which allows for a custom reason to be entered."
@@ -2478,7 +2478,7 @@ en:
     returning_user_notice_tl: "Minimum trust level required to see returning user post notices."
     returning_users_days: "How many days should pass before a user is considered to be returning."
     review_media_unless_trust_level: "Staff will review posts of users with lower trust levels if they contain embedded media."
-    skip_review_media_groups: "Users who are not in any of these groups will have their posts sent to staff for review if the post contains embedded media."
+    skip_review_media_groups: "Users who are not in any of these groups will have their posts sent to staff for review if the post contains embedded media. Posts created by admins and moderators are always allowed."
     blur_tl0_flagged_posts_media: "Blur flagged posts images to hide potentially NSFW content."
     enable_page_publishing: "Allow staff members to publish topics to new URLs with their own styling."
     show_published_pages_login_required: "Anonymous users can see published pages, even when login is required."
@@ -2541,7 +2541,8 @@ en:
       <b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub
     user_api_key_allowed_groups: |
       Group membership required for generation of user API keys.<br>
-      <b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub
+      <b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub.<br>
+       Admins and moderators can always create user API keys.
     allowed_user_api_auth_redirects: "Allowed URL for authentication redirect for user API keys. Wildcard symbol * can be used to match any part of it (e.g. www.example.com/*)."
     allowed_user_api_push_urls: "Allowed URLs for server push to user API"
     revoke_user_api_keys_unused_days: "Number of days since a user API key was last used before it is automatically revoked (0 for never)"
@@ -2549,7 +2550,7 @@ en:
 
     tagging_enabled: "Enable tags on topics? See the <a href='https://meta.discourse.org/t/admin-guide-to-tags-in-discourse/121041'>Admin guide to tags on Meta</a> for more information."
     min_trust_to_create_tag: "The minimum trust level required to create a tag."
-    create_tag_allowed_groups: "Groups that are allowed to create tags."
+    create_tag_allowed_groups: "Groups that are allowed to create tags. Admins and moderators can always create tags."
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
     enable_max_tags_per_email_subject: "Use max_tags_per_email_subject when generating the subject of an email"
     max_tags_per_email_subject: "The maximum tags that can be in the subject of an email"
@@ -2561,7 +2562,7 @@ en:
     tag_style: "Define the visual appearance of tag badges on the site. This setting allows you to customize how tags are visually represented across all areas of the site, enhancing layout consistency and user accessibility."
     pm_tags_allowed_for_groups: "Allow members of included groups to tag any personal message"
     min_trust_level_to_tag_topics: "Minimum trust level required to tag topics"
-    tag_topic_allowed_groups: "Groups that are allowed to tag topics."
+    tag_topic_allowed_groups: "Groups that are allowed to tag topics. Admins and moderators can always tag topics."
     suppress_overlapping_tags_in_list: "If tags match exact words in topic titles, don't show the tag"
     remove_muted_tags_from_latest: "Don't show topics tagged only with muted tags in the latest topic list."
     force_lowercase_tags: "Force all new tags to be entirely lowercase."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -876,11 +876,11 @@ posting:
   enable_system_message_replies:
     default: true
   personal_message_enabled_groups:
-    default: "3|11" # auto group trust_level_1
+    default: "11" # auto group trust_level_1
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   editing_grace_period: 300
   editing_grace_period_max_diff: 100
   editing_grace_period_max_diff_high_trust: 400
@@ -973,11 +973,11 @@ posting:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   here_mention_allowed_groups:
-    default: "3|12" # auto group staff and trust_level_2
+    default: "12" # auto group trust_level_2
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   title_max_word_length:
     default: 30
     locale_default:
@@ -1082,21 +1082,21 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   approve_unless_allowed_groups:
-    default: "3|10" # auto groups staff and trust_level_0
+    default: "10" # auto groups trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   approve_new_topics_unless_trust_level:
     default: 0
     enum: "TrustLevelSetting"
     hidden: true
   approve_new_topics_unless_allowed_groups:
-    default: "3|10" # auto groups staff and trust_level_0
+    default: "10" # auto groups trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   approve_suspect_users:
     default: true
   approve_unless_staged:
@@ -1167,11 +1167,11 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   skip_review_media_groups:
-    default: "3|10" # auto groups staff and trust_level_0
+    default: "10" # auto groups trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   blur_tl0_flagged_posts_media:
     default: true
     client: true
@@ -1285,11 +1285,11 @@ email:
     enum: "TrustLevelSetting"
     hidden: true
   email_in_allowed_groups:
-    default: "3|12" # auto group staff and trust_level_2
+    default: "12" # auto group trust_level_2
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   email_in_authserv_id:
     default: ""
   email_in_spam_header:
@@ -1719,88 +1719,89 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   create_topic_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_edit_wiki_post:
     default: 1
     enum: "TrustLevelSetting"
     hidden: true
   edit_wiki_post_allowed_groups:
-    default: "3|11" # auto group staff and trust_level_1
+    default: "11" # auto group trust_level_1
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_edit_post:
     default: 0
     enum: "TrustLevelSetting"
     hidden: true
   edit_post_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_allow_self_wiki:
     default: 3
     enum: "TrustLevelSetting"
     hidden: true
   self_wiki_allowed_groups:
-    default: "3|13" # auto group staff and trust_level_3
+    default: "13" # auto group trust_level_3
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_send_email_messages:
     default: "4"
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   send_email_messages_allowed_groups:
-    default: "1|3|14" # auto group admin, staff, and trust_level_4
+    default: "14" # auto group trust_level_4
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_flag_posts:
     default: 1
     enum: "TrustLevelSetting"
     hidden: true
   flag_post_allowed_groups:
-    default: "3|11" # auto group staff and trust_level_1
+    default: "11" # auto group trust_level_1
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_post_links:
     default: 0
     enum: "TrustLevelSetting"
     hidden: true
   post_links_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_to_post_embedded_media:
     default: 0
     enum: "TrustLevelSetting"
     hidden: true
   embedded_media_post_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_level_to_allow_profile_background:
     default: 0
     client: true
     enum: "TrustLevelSetting"
     hidden: true
   profile_background_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
@@ -1810,7 +1811,8 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   user_card_background_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
@@ -1819,22 +1821,22 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   invite_allowed_groups:
-    default: "3|12" # auto group staff and trust_level_2
+    default: "12" # auto group trust_level_2
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_level_to_allow_ignore:
     default: 2
     enum: "TrustLevelSetting"
     client: true
     hidden: true
   ignore_allowed_groups:
-    default: "3|12" # auto group staff and trust_level_2
+    default: "12" # auto group trust_level_2
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   allow_flagging_staff: true
   send_tl1_welcome_message: true
   send_tl2_promotion_message: true
@@ -3038,11 +3040,11 @@ user_api:
     enum: "TrustLevelSetting"
     hidden: true
   user_api_key_allowed_groups:
-    default: "3|10" # auto group staff and trust_level_0
+    default: "10" # auto group trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   allowed_user_api_push_urls:
     default: ""
     type: list
@@ -3091,23 +3093,23 @@ tags:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   create_tag_allowed_groups:
-    default: "1|3|13" # auto group admin, staff, and trust_level_3
+    default: "13" # auto group trust_level_3
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
-    validator: "AtLeastOneGroupValidator"
   min_trust_level_to_tag_topics:
     default: "0"
     enum: "TrustLevelAndStaffSetting"
     client: true
     hidden: true
   tag_topic_allowed_groups:
-    default: "1|3|10" # auto group admin, staff, and trust_level_0
+    default: "10" # auto trust_level_0
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true
     client: true
-    validator: "AtLeastOneGroupValidator"
   max_tag_search_results:
     client: true
     default: 5

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -876,7 +876,7 @@ posting:
   enable_system_message_replies:
     default: true
   personal_message_enabled_groups:
-    default: "11" # auto group trust_level_1
+    default: "1|2|11" # auto group admins, moderators, trust_level_1
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -973,7 +973,7 @@ posting:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   here_mention_allowed_groups:
-    default: "12" # auto group trust_level_2
+    default: "1|2|12" # auto group admins, moderators, trust_level_2
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1082,7 +1082,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   approve_unless_allowed_groups:
-    default: "10" # auto groups trust_level_0
+    default: "1|2|10" # auto groups admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1092,7 +1092,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   approve_new_topics_unless_allowed_groups:
-    default: "10" # auto groups trust_level_0
+    default: "1|2|10" # auto groups admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1167,7 +1167,7 @@ posting:
     enum: "TrustLevelSetting"
     hidden: true
   skip_review_media_groups:
-    default: "10" # auto groups trust_level_0
+    default: "1|2|10" # auto groups admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1285,7 +1285,7 @@ email:
     enum: "TrustLevelSetting"
     hidden: true
   email_in_allowed_groups:
-    default: "12" # auto group trust_level_2
+    default: "1|2|12" # auto group admins, moderators, trust_level_2
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1719,7 +1719,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   create_topic_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1729,7 +1729,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   edit_wiki_post_allowed_groups:
-    default: "11" # auto group trust_level_1
+    default: "1|2|11" # auto group admins, moderators, trust_level_1
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1739,7 +1739,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   edit_post_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1749,7 +1749,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   self_wiki_allowed_groups:
-    default: "13" # auto group trust_level_3
+    default: "1|2|13" # auto group admins, moderators, trust_level_3
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1759,7 +1759,7 @@ trust:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   send_email_messages_allowed_groups:
-    default: "14" # auto group trust_level_4
+    default: "1|2|14" # auto group admins, moderators, trust_level_4
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1769,7 +1769,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   flag_post_allowed_groups:
-    default: "11" # auto group trust_level_1
+    default: "1|2|11" # auto group admins, moderators, trust_level_1
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1779,7 +1779,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   post_links_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1789,7 +1789,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   embedded_media_post_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1800,7 +1800,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   profile_background_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1811,7 +1811,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   user_card_background_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1821,7 +1821,7 @@ trust:
     enum: "TrustLevelSetting"
     hidden: true
   invite_allowed_groups:
-    default: "12" # auto group trust_level_2
+    default: "1|2|12" # auto group admins, moderators, trust_level_2
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -1832,7 +1832,7 @@ trust:
     client: true
     hidden: true
   ignore_allowed_groups:
-    default: "12" # auto group trust_level_2
+    default: "1|2|12" # auto group admins, moderators, trust_level_2
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -3040,7 +3040,7 @@ user_api:
     enum: "TrustLevelSetting"
     hidden: true
   user_api_key_allowed_groups:
-    default: "10" # auto group trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -3093,7 +3093,7 @@ tags:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   create_tag_allowed_groups:
-    default: "13" # auto group trust_level_3
+    default: "1|2|13" # auto group admins, moderators, trust_level_3
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
@@ -3104,7 +3104,7 @@ tags:
     client: true
     hidden: true
   tag_topic_allowed_groups:
-    default: "10" # auto trust_level_0
+    default: "1|2|10" # auto group admins, moderators, trust_level_0
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -624,8 +624,7 @@ class Guardian
     return false if !authenticated?
     return false if User.where(username_lower: SiteSetting.here_mention).exists?
 
-    @user.in_any_groups?(SiteSetting.here_mention_allowed_groups_map) ||
-      @user.has_trust_level_or_staff?(SiteSetting.min_trust_level_for_here_mention)
+    @user.in_any_groups?(SiteSetting.here_mention_allowed_groups_map)
   end
 
   def can_lazy_load_categories?

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -370,6 +370,12 @@ module SiteSettingExtension
     sanitize_override = val.is_a?(String) && client_settings.include?(name)
 
     sanitized_val = sanitize_override ? sanitize_field(val) : val
+
+    if mandatory_values[name.to_sym]
+      sanitized_val =
+        (mandatory_values[name.to_sym].split("|") | sanitized_val.to_s.split("|")).join("|")
+    end
+
     provider.save(name, sanitized_val, type)
     current[name] = type_supervisor.to_rb_value(name, sanitized_val)
 
@@ -559,13 +565,9 @@ module SiteSettingExtension
           return false if !plugin.configurable? && plugin.enabled_site_setting == name
         end
 
-        value =
-          if (c = current[name]).nil?
-            refresh!
-            current[name]
-          else
-            c
-          end
+        refresh! if current[name].nil?
+        value = current[name]
+
         if mandatory_values[name]
           return (mandatory_values[name].split("|") | value.to_s.split("|")).join("|")
         end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Guardian do
   fab!(:trust_level_1)
   fab!(:trust_level_2)
   fab!(:trust_level_3)
-  fab!(:trust_level_4)
+  fab!(:trust_level_4) { Fabricate(:trust_level_4, refresh_auto_groups: true) }
   fab!(:another_admin) { Fabricate(:admin) }
   fab!(:coding_horror) { Fabricate(:coding_horror, refresh_auto_groups: true) }
 
@@ -3794,13 +3794,9 @@ RSpec.describe Guardian do
           SiteSetting.create_tag_allowed_groups = Group::AUTO_GROUPS[:admins]
         end
 
-        it "returns false if not admin" do
-          expect(Guardian.new(trust_level_4).can_create_tag?).to eq(false)
-          expect(Guardian.new(moderator).can_create_tag?).to eq(false)
-        end
-
-        it "returns true if admin" do
+        it "returns true if admin or moderator" do
           expect(Guardian.new(admin).can_create_tag?).to be_truthy
+          expect(Guardian.new(moderator).can_create_tag?).to be_truthy
         end
       end
     end
@@ -4362,12 +4358,12 @@ RSpec.describe Guardian do
       expect(admin.guardian.can_mention_here?).to eq(true)
     end
 
-    it "works with admin" do
+    it "works with admin or moderator" do
       SiteSetting.min_trust_level_for_here_mention = "admin"
       SiteSetting.here_mention_allowed_groups = Group::AUTO_GROUPS[:admins]
 
       expect(trust_level_4.guardian.can_mention_here?).to eq(false)
-      expect(moderator.guardian.can_mention_here?).to eq(false)
+      expect(moderator.guardian.can_mention_here?).to eq(true)
       expect(admin.guardian.can_mention_here?).to eq(true)
     end
   end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -859,16 +859,24 @@ RSpec.describe SiteSettingExtension do
 
   describe "mandatory_values for group list settings" do
     it "adds mandatory values" do
-      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|13")
+      expect(SiteSetting.embedded_media_post_allowed_groups).to eq("1|2|10")
 
-      SiteSetting.create_tag_allowed_groups = 14
-      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|14")
+      SiteSetting.embedded_media_post_allowed_groups = 14
+      expect(SiteSetting.embedded_media_post_allowed_groups).to eq("1|2|14")
 
-      SiteSetting.create_tag_allowed_groups = "13|14"
-      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|13|14")
+      SiteSetting.embedded_media_post_allowed_groups = ""
+      expect(SiteSetting.embedded_media_post_allowed_groups).to eq("1|2")
 
-      SiteSetting.create_tag_allowed_groups = ""
-      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2")
+      test_provider = SiteSetting.provider
+      SiteSetting.provider = SiteSettings::DbProvider.new(SiteSetting)
+      SiteSetting.embedded_media_post_allowed_groups = "13|14"
+      expect(SiteSetting.embedded_media_post_allowed_groups).to eq("1|2|13|14")
+      expect(SiteSetting.find_by(name: "embedded_media_post_allowed_groups").value).to eq(
+        "1|2|13|14",
+      )
+    ensure
+      SiteSetting.find_by(name: "embedded_media_post_allowed_groups").destroy
+      SiteSetting.provider = test_provider
     end
   end
 

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -857,6 +857,21 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe "mandatory_values for group list settings" do
+    it "adds mandatory values" do
+      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|13")
+
+      SiteSetting.create_tag_allowed_groups = 14
+      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|14")
+
+      SiteSetting.create_tag_allowed_groups = "13|14"
+      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2|13|14")
+
+      SiteSetting.create_tag_allowed_groups = ""
+      expect(SiteSetting.create_tag_allowed_groups).to eq("1|2")
+    end
+  end
+
   describe "_map extension for list settings" do
     it "handles splitting group_list settings" do
       SiteSetting.personal_message_enabled_groups = "1|2"

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Admin::SiteSettingsController do
 
         expect(response.status).to eq(422)
         expect(SiteSetting.personal_message_enabled_groups).to eq(
-          Group::AUTO_GROUPS[:trust_level_4],
+          "1|2|#{Group::AUTO_GROUPS[:trust_level_4]}",
         )
       end
 


### PR DESCRIPTION
Automatically add `moderators` and `admins` auto groups to specific site settings.

In the new group-based permissions systems, we just want to check the user’s groups since it more accurately reflects reality

Demo
<img width="1089" alt="Screenshot 2024-04-12 at 9 55 09 AM" src="https://github.com/discourse/discourse/assets/72780/4b28b620-4758-4abe-aec2-45798da6c96c">

Affected settings:
- tag_topic_allowed_groups
- create_tag_allowed_groups
- send_email_messages_allowed_groups
- personal_message_enabled_groups
- here_mention_allowed_groups
- approve_unless_allowed_groups
- approve_new_topics_unless_allowed_groups
- skip_review_media_groups
- email_in_allowed_groups
- create_topic_allowed_groups
- edit_wiki_post_allowed_groups
- edit_post_allowed_groups
- self_wiki_allowed_groups
- flag_post_allowed_groups
- post_links_allowed_groups
- embedded_media_post_allowed_groups
- profile_background_allowed_groups
- user_card_background_allowed_groups
- invite_allowed_groups
- ignore_allowed_groups
- user_api_key_allowed_groups

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
