### PR TITLE
DEV: set toast progress bar to false by default

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -88,7 +88,6 @@ export default class BookmarkMenu extends Component {
       // a bookmark, it switches to the other Edit/Delete menu.
       this.quicksaved = true;
       this.toasts.success({
-        showProgressBar: false,
         duration: 3000,
         views: ["mobile"],
         data: { message: I18n.t("bookmarks.bookmarked_success") },
@@ -127,7 +126,6 @@ export default class BookmarkMenu extends Component {
       this.bookmarkManager.afterDelete(response, this.existingBookmark.id);
       this.toasts.success({
         duration: 3000,
-        showProgressBar: false,
         data: {
           icon: "trash-alt",
           message: I18n.t("bookmarks.deleted_bookmark_success"),
@@ -153,7 +151,6 @@ export default class BookmarkMenu extends Component {
         await this.bookmarkManager.save();
         this.toasts.success({
           duration: 3000,
-          showProgressBar: false,
           views: ["mobile"],
           data: { message: I18n.t("bookmarks.reminder_set_success") },
         });

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-default-toast-test.js
@@ -29,7 +29,7 @@ module(
       this.toast = new DToastInstance(this, {});
 
       await render(
-        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{true}} @autoClose={{true}} @onRegisterProgressBar={{(noop)}} />`
+        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{true}} @onRegisterProgressBar={{(noop)}} />`
       );
 
       assert.dom(".fk-d-default-toast__progress-bar").exists();
@@ -39,7 +39,7 @@ module(
       this.toast = new DToastInstance(this, {});
 
       await render(
-        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{false}} @autoClose={{false}} />`
+        hbs`<DDefaultToast @data={{this.toast.options.data}} @showProgressBar={{false}} />`
       );
 
       assert.dom(".fk-d-default-toast__progress-bar").doesNotExist();

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -80,7 +80,7 @@ export const TOAST = {
     autoClose: true,
     duration: 3000,
     component: DDefaultToast,
-    showProgressBar: true,
+    showProgressBar: false,
     views: ["desktop", "mobile"],
   },
 };


### PR DESCRIPTION
This change disables the toast notification progress bar by default. It can be enabled for a specific toast by setting `autoClose: true` (it is true by default) and also `showProgressBar: true`.