### PR TITLE
UX: prevent toasts from covering header

### DIFF
--- a/app/assets/stylesheets/common/float-kit/d-toasts.scss
+++ b/app/assets/stylesheets/common/float-kit/d-toasts.scss
@@ -8,7 +8,7 @@
   --transform-y: 0;
 
   position: fixed;
-  top: 5px;
+  top: calc(var(--header-offset) + 0.33rem);
   right: 5px;
   z-index: z("max");
   display: flex;


### PR DESCRIPTION
This change prevents toast notifications from blocking the header and user navigation on both desktop and mobile.

Mobile (after change):
<img width="372" alt="desktop-toast-position" src="https://github.com/discourse/discourse/assets/2257978/a2317523-cd5c-4df2-b108-96bf5e8d1086">


Desktop (after change):
<img width="356" alt="mobile-toast-bookmark-1" src="https://github.com/discourse/discourse/assets/2257978/8b53e50e-95b7-466d-94e1-3e6a20ce7bf8">

<img width="354" alt="mobile-toast-bookmark-2" src="https://github.com/discourse/discourse/assets/2257978/44b95087-eeb0-4c12-a2e2-7e8013ffb5e7">
