### PR TITLE
FIX: ensures reply is unlocking body scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -21,7 +21,6 @@ export default class ChatMessageActionsMobile extends Component {
   @service capabilities;
 
   @tracked hasExpandedReply = false;
-  @tracked showFadeIn = false;
 
   get message() {
     return this.chat.activeMessage.model;
@@ -60,14 +59,14 @@ export default class ChatMessageActionsMobile extends Component {
 
   @action
   actAndCloseMenu(fnId) {
-    this.messageInteractor[fnId]();
     this.args.closeModal();
+    this.messageInteractor[fnId]();
   }
 
   @action
   openEmojiPicker(_, event) {
-    this.messageInteractor.openEmojiPicker(_, event);
     this.args.closeModal();
+    this.messageInteractor.openEmojiPicker(_, event);
   }
 
   <template>


### PR DESCRIPTION
Prior to this fix we were calling the action before closing the menu which could cause various callbacks, like the enable body scroll one, to not be called as some actions will do: `chat.activeMessage = null;` causing the message actions menu to be instantly destroyed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
