### PR TITLE
UX: Emoji alignment fixes, followup to #26491

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -62,14 +62,12 @@
     }
 
     .sidebar-section-link-content-text {
-      align-items: center;
-      display: inline-flex;
-
       @include ellipsis;
 
       .emoji {
         width: 15px;
         height: 15px;
+        vertical-align: baseline;
       }
 
       .badge-category__wrapper {

--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -13,5 +13,6 @@
   .emoji {
     height: 1em;
     width: 1em;
+    vertical-align: baseline;
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-message-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-info.scss
@@ -7,7 +7,7 @@
 
 .chat-message-info__username {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
 
   & + .chat-message-info__bot-indicator,
   & + .chat-message-info__date {
@@ -61,8 +61,8 @@
   margin-inline: 0.33rem;
 
   .emoji {
-    width: 16px;
-    height: 16px;
+    width: 15px;
+    height: 15px;
   }
 }
 

--- a/plugins/chat/assets/stylesheets/common/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/sidebar-extensions.scss
@@ -152,12 +152,6 @@
     }
   }
 
-  .sidebar-section-link-content-text {
-    .user-status-message {
-      margin-left: 0.33em;
-    }
-  }
-
   .sidebar-section-link--active {
     background: var(--primary-low);
   }


### PR DESCRIPTION
Before / After

Sidebar
<img width="176" alt="Screenshot 2024-04-12 at 10 25 54" src="https://github.com/discourse/discourse/assets/66961/8f5944f6-9bb4-4f60-adc3-1eb650a34052"> <img width="205" alt="Screenshot 2024-04-12 at 10 23 04" src="https://github.com/discourse/discourse/assets/66961/532b2b44-d493-4b11-9639-6d981e5e6f04">

Sidebar
<img width="257" alt="Screenshot 2024-04-12 at 10 25 59" src="https://github.com/discourse/discourse/assets/66961/c2719e6b-13ad-47ec-a057-05ea7060f7f5"> <img width="273" alt="Screenshot 2024-04-12 at 10 23 11" src="https://github.com/discourse/discourse/assets/66961/c359dba5-7fcf-4f4b-93ad-3d04d89682e9">

Sidebar user status
<img width="225" alt="Screenshot 2024-04-12 at 10 26 05" src="https://github.com/discourse/discourse/assets/66961/1bf33cb5-7140-4684-9f3c-e6715b77b528"> <img width="238" alt="Screenshot 2024-04-12 at 10 23 23" src="https://github.com/discourse/discourse/assets/66961/4b1b27ff-b97e-43ff-ac60-50912454dfb0">

Header
<img width="241" alt="Screenshot 2024-04-12 at 10 26 10" src="https://github.com/discourse/discourse/assets/66961/c5d45c2b-cd25-4488-a01b-a139155486f8"> <img width="245" alt="Screenshot 2024-04-12 at 10 23 28" src="https://github.com/discourse/discourse/assets/66961/db1b7c5e-0ffc-4f6a-85e1-7e233a4e6259">

Message
<img width="169" alt="Screenshot 2024-04-12 at 10 26 15" src="https://github.com/discourse/discourse/assets/66961/f7f5506f-6447-42f9-bf85-983209d1b07d"> <img width="192" alt="Screenshot 2024-04-12 at 10 23 32" src="https://github.com/discourse/discourse/assets/66961/8bee6a6b-1501-406e-9f2f-e80d3c8d2592">
