### PR TITLE
FIX: Use ILIKE for searching categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -366,13 +366,7 @@ class CategoriesController < ApplicationController
 
     categories = Category.secured(guardian)
 
-    categories =
-      categories
-        .includes(:category_search_data)
-        .references(:category_search_data)
-        .where(
-          "category_search_data.search_data @@ #{Search.ts_query(term: term)}",
-        ) if term.present?
+    categories = categories.where("name ILIKE ?", "%#{term}%") if term.present?
 
     categories =
       (

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -366,7 +366,9 @@ class CategoriesController < ApplicationController
 
     categories = Category.secured(guardian)
 
-    categories = categories.where("name ILIKE ?", "%#{term}%") if term.present?
+    if term.present? && words = term.split
+      words.each { |word| categories = categories.where("name ILIKE ?", "%#{word}%") }
+    end
 
     categories =
       (

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1211,7 +1211,7 @@ RSpec.describe CategoriesController do
 
       queries = track_sql_queries { get "/categories/search.json", params: { term: "Notfoo" } }
 
-      expect(queries.length).to eq(5)
+      expect(queries.length).to eq(8)
 
       expect(response.parsed_body["categories"].length).to eq(1)
       expect(response.parsed_body["categories"][0]["custom_fields"]).to eq("bob" => "marley")
@@ -1247,10 +1247,11 @@ RSpec.describe CategoriesController do
       it "returns categories" do
         get "/categories/search.json", params: { term: "Foo" }
 
-        expect(response.parsed_body["categories"].size).to eq(2)
+        expect(response.parsed_body["categories"].size).to eq(3)
         expect(response.parsed_body["categories"].map { |c| c["name"] }).to contain_exactly(
           "Foo",
           "Foobar",
+          "Notfoo",
         )
       end
     end

--- a/spec/system/editing_sidebar_categories_navigation_spec.rb
+++ b/spec/system/editing_sidebar_categories_navigation_spec.rb
@@ -293,7 +293,15 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       modal.filter("category 2 subcategory subcategory")
 
       expect(modal).to have_categories(
-        [category2, category2_subcategory, category2_subcategory_subcategory],
+        [
+          category2,
+          category2_subcategory,
+          category2_subcategory_subcategory,
+          category,
+          category_subcategory2,
+          category_subcategory,
+          category_subcategory_subcategory2,
+        ],
       )
     end
   end

--- a/spec/system/editing_sidebar_categories_navigation_spec.rb
+++ b/spec/system/editing_sidebar_categories_navigation_spec.rb
@@ -293,15 +293,7 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       modal.filter("category 2 subcategory subcategory")
 
       expect(modal).to have_categories(
-        [
-          category2,
-          category2_subcategory,
-          category2_subcategory_subcategory,
-          category,
-          category_subcategory2,
-          category_subcategory,
-          category_subcategory_subcategory2,
-        ],
+        [category2, category2_subcategory, category2_subcategory_subcategory],
       )
     end
   end


### PR DESCRIPTION
Full text search does not return ideal results for category dropdown. Usually, in category dropdowns we want to search for categories as we type. For example, while typing "theme", the dropdown should show intermediary results for "t", "th", "the", "them" and finally "theme". For some of these substrings (like "the"), full text search does not return any results, which leads to an unpleasant user experience.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
