### PR TITLE
FIX: Fetch categories for "+subcategories" option

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -398,6 +398,7 @@ export default class Category extends RestModel {
       include_ancestors: opts.includeAncestors,
       prioritized_category_id: opts.prioritizedCategoryId,
       limit: opts.limit,
+      page: opts.page,
     };
 
     const result = (CATEGORY_ASYNC_SEARCH_CACHE[JSON.stringify(data)] ||=

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -521,6 +521,7 @@ export default {
           notification_level: null,
           background_url: null,
           has_children: true,
+          subcategory_count: 2,
         },
         {
           id: 1002,

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -112,7 +112,7 @@ export default class CategoryRow extends Component {
         hideParent: !!this.parentCategory,
         topicCount: this.topicCount,
         subcategoryCount: this.args.item?.categories
-          ? this.args.item.categories.length - 1
+          ? this.category.subcategories_count
           : 0,
       })
     );

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -111,8 +111,8 @@ export default class CategoryRow extends Component {
           this.allowUncategorizedTopics || this.allowUncategorized,
         hideParent: !!this.parentCategory,
         topicCount: this.topicCount,
-        subcategoryCount: this.args.item?.categories
-          ? this.category.subcategories_count
+        subcategoryCount: this.args.item?.category
+          ? this.category.subcategory_count
           : 0,
       })
     );

--- a/app/assets/javascripts/select-kit/addon/components/category-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-selector.js
@@ -80,6 +80,7 @@ export default MultiSelectComponent.extend({
       if (this.site.lazy_load_categories) {
         await Category.asyncSearch("", {
           parentCategoryId: categories[0].id,
+          limit: 100,
         });
       }
 
@@ -92,7 +93,9 @@ export default MultiSelectComponent.extend({
             // that parseInt still returns a valid ID in order to generate the
             // label
             id: `${categories[0].id}+subcategories`,
-            categories: categories[0].descendants,
+            // We limit to the first 100 subcategories because a large number
+            // of categories selected would break the UI
+            categories: categories[0].descendants.slice(0, 100),
           })
         );
       }
@@ -101,7 +104,7 @@ export default MultiSelectComponent.extend({
     return categories;
   },
 
-  select(value, item) {
+  async select(value, item) {
     if (item.categories) {
       this.selectKit.change(
         makeArray(this.value).concat(item.categories.mapBy("id")),

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -367,7 +367,7 @@ class CategoriesController < ApplicationController
         if params[:limit].present?
           params[:limit].to_i.clamp(1, MAX_CATEGORIES_LIMIT)
         else
-          CategoriesController::MAX_CATEGORIES_LIMIT
+          MAX_CATEGORIES_LIMIT
         end
       )
     page = [1, params[:page].to_i].max

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -21,7 +21,8 @@ class CategoriesController < ApplicationController
 
   SYMMETRICAL_CATEGORIES_TO_TOPICS_FACTOR = 1.5
   MIN_CATEGORIES_TOPICS = 5
-  MAX_CATEGORIES_LIMIT = 25
+  DEFAULT_CATEGORIES_LIMIT = 25
+  MAX_CATEGORIES_LIMIT = 100
 
   def redirect
     return if handle_permalink("/category/#{params[:path]}")
@@ -404,7 +405,7 @@ class CategoriesController < ApplicationController
         )
         .joins("LEFT JOIN topics t on t.id = categories.topic_id")
         .select("categories.*, t.slug topic_slug")
-        .limit(limit || MAX_CATEGORIES_LIMIT)
+        .limit(limit || DEFAULT_CATEGORIES_LIMIT)
 
     if Site.preloaded_category_custom_fields.present?
       Category.preload_custom_fields(categories, Site.preloaded_category_custom_fields)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -227,7 +227,7 @@ class Category < ActiveRecord::Base
                 :subcategory_list,
                 :notification_level,
                 :has_children,
-                :subcategories_count
+                :subcategory_count
 
   # Allows us to skip creating the category definition topic in tests.
   attr_accessor :skip_category_definition
@@ -246,7 +246,7 @@ class Category < ActiveRecord::Base
       end
 
     # Load subcategory counts (used to fill has_children property)
-    subcategories_count =
+    subcategory_count =
       Category
         .secured(guardian)
         .where.not(parent_category_id: nil)
@@ -261,9 +261,9 @@ class Category < ActiveRecord::Base
       category.permission = CategoryGroup.permission_types[:full] if guardian.is_admin? ||
         allowed_topic_create_ids&.include?(category[:id])
 
-      category.has_children = subcategories_count.key?(category[:id])
+      category.has_children = subcategory_count.key?(category[:id])
 
-      category.subcategories_count = subcategories_count[category[:id]] if category.has_children
+      category.subcategory_count = subcategory_count[category[:id]] if category.has_children
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -247,12 +247,7 @@ class Category < ActiveRecord::Base
 
     # Load subcategory counts (used to fill has_children property)
     subcategory_count =
-      Category
-        .secured(guardian)
-        .where.not(parent_category_id: nil)
-        .group(:parent_category_id)
-        .pluck(:parent_category_id, "COUNT(*)")
-        .to_h
+      Category.secured(guardian).where.not(parent_category_id: nil).group(:parent_category_id).count
 
     # Update category attributes
     categories.each do |category|

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -20,6 +20,7 @@ class BasicCategorySerializer < ApplicationSerializer
              :can_edit,
              :topic_template,
              :has_children,
+             :subcategories_count,
              :sort_order,
              :sort_ascending,
              :show_subcategory_list,

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -20,7 +20,7 @@ class BasicCategorySerializer < ApplicationSerializer
              :can_edit,
              :topic_template,
              :has_children,
-             :subcategories_count,
+             :subcategory_count,
              :sort_order,
              :sort_ascending,
              :show_subcategory_list,

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -84,7 +84,7 @@
             "null"
           ]
         },
-        "subcategories_count": {
+        "subcategory_count": {
           "type": [
             "integer",
             "null"
@@ -293,7 +293,7 @@
         "can_edit",
         "topic_template",
         "has_children",
-        "subcategories_count",
+        "subcategory_count",
         "sort_order",
         "sort_ascending",
         "show_subcategory_list",

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -84,6 +84,12 @@
             "null"
           ]
         },
+        "subcategories_count": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "sort_order": {
           "type": [
             "string",
@@ -287,6 +293,7 @@
         "can_edit",
         "topic_template",
         "has_children",
+        "subcategories_count",
         "sort_order",
         "sort_ascending",
         "show_subcategory_list",

--- a/spec/requests/api/schemas/json/category_list_response.json
+++ b/spec/requests/api/schemas/json/category_list_response.json
@@ -78,6 +78,12 @@
                 "has_children": {
                   "type": "boolean"
                 },
+                "subcategories_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
                 "sort_order": {
                   "type": [
                     "string",
@@ -194,6 +200,7 @@
                 "can_edit",
                 "topic_template",
                 "has_children",
+                "subcategories_count",
                 "sort_order",
                 "sort_ascending",
                 "show_subcategory_list",

--- a/spec/requests/api/schemas/json/category_list_response.json
+++ b/spec/requests/api/schemas/json/category_list_response.json
@@ -78,7 +78,7 @@
                 "has_children": {
                   "type": "boolean"
                 },
-                "subcategories_count": {
+                "subcategory_count": {
                   "type": [
                     "integer",
                     "null"
@@ -200,7 +200,7 @@
                 "can_edit",
                 "topic_template",
                 "has_children",
-                "subcategories_count",
+                "subcategory_count",
                 "sort_order",
                 "sort_ascending",
                 "show_subcategory_list",

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -87,7 +87,7 @@
             "null"
           ]
         },
-        "subcategories_count": {
+        "subcategory_count": {
           "type": [
             "integer",
             "null"
@@ -297,7 +297,7 @@
         "topic_template",
         "form_template_ids",
         "has_children",
-        "subcategories_count",
+        "subcategory_count",
         "sort_order",
         "sort_ascending",
         "show_subcategory_list",

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -87,6 +87,12 @@
             "null"
           ]
         },
+        "subcategories_count": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "sort_order": {
           "type": [
             "string",
@@ -291,6 +297,7 @@
         "topic_template",
         "form_template_ids",
         "has_children",
+        "subcategories_count",
         "sort_order",
         "sort_ascending",
         "show_subcategory_list",

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -607,6 +607,12 @@
             "has_children": {
               "type": "boolean"
             },
+            "subcategories_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "sort_order": {
               "type": [
                 "string",
@@ -744,6 +750,7 @@
             "notification_level",
             "topic_template",
             "has_children",
+            "subcategories_count",
             "sort_order",
             "sort_ascending",
             "show_subcategory_list",

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -607,7 +607,7 @@
             "has_children": {
               "type": "boolean"
             },
-            "subcategories_count": {
+            "subcategory_count": {
               "type": [
                 "integer",
                 "null"
@@ -750,7 +750,7 @@
             "notification_level",
             "topic_template",
             "has_children",
-            "subcategories_count",
+            "subcategory_count",
             "sort_order",
             "sort_ascending",
             "show_subcategory_list",

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1115,6 +1115,7 @@ RSpec.describe CategoriesController do
         expect(serialized["notification_level"]).to eq(CategoryUser.default_notification_level)
         expect(serialized["permission"]).to eq(nil)
         expect(serialized["has_children"]).to eq(false)
+        expect(serialized["subcategory_count"]).to eq(nil)
       end
 
       it "does not return hidden category" do
@@ -1168,6 +1169,7 @@ RSpec.describe CategoriesController do
       expect(category["notification_level"]).to eq(NotificationLevels.all[:regular])
       expect(category["permission"]).to eq(CategoryGroup.permission_types[:full])
       expect(category["has_children"]).to eq(true)
+      expect(category["subcategory_count"]).to eq(1)
     end
 
     context "with a read restricted child category" do
@@ -1179,6 +1181,7 @@ RSpec.describe CategoriesController do
         get "/categories/find.json", params: { ids: [category.id] }
         category = response.parsed_body["categories"].first
         expect(category["has_children"]).to eq(true)
+        expect(category["subcategory_count"]).to eq(1)
       end
 
       it "indicates to a normal user that the category has no child" do
@@ -1187,6 +1190,7 @@ RSpec.describe CategoriesController do
         get "/categories/find.json", params: { ids: [category.id] }
         category = response.parsed_body["categories"].first
         expect(category["has_children"]).to eq(false)
+        expect(category["subcategory_count"]).to eq(nil)
       end
     end
   end
@@ -1415,6 +1419,7 @@ RSpec.describe CategoriesController do
       expect(category["notification_level"]).to eq(NotificationLevels.all[:regular])
       expect(category["permission"]).to eq(CategoryGroup.permission_types[:full])
       expect(category["has_children"]).to eq(true)
+      expect(category["subcategory_count"]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Selecting the +subcategories option does not work sometimes when "lazy load categories" is enabled because the subcategories may not be fetched. This ensures that subcategories are loaded by requesting them before being used.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
