### PR TITLE
FIX: deleting a groups was throwing an error

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -144,13 +144,17 @@ export default Controller.extend({
       didConfirm: () => {
         model
           .destroy()
-          .then(() => this.router.transitionTo("groups.index"))
           .catch((error) => {
             // eslint-disable-next-line no-console
             console.error(error);
             this.dialog.alert(I18n.t("admin.groups.delete_failed"));
           })
-          .finally(() => this.set("destroying", false));
+          .then(() => {
+            this.router.transitionTo("groups.index");
+          })
+          .finally(() => {
+            this.set("destroying", false);
+          });
       },
       didCancel: () => this.set("destroying", false),
     });

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -64,6 +64,7 @@
               @icon="trash-alt"
               @label="admin.groups.delete"
               class="btn-danger"
+              data-test-selector="delete-group-button"
             />
           {{/if}}
         {{/if}}

--- a/spec/system/groups/group_spec.rb
+++ b/spec/system/groups/group_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe "Group", type: :system do
+  let(:group_page) { PageObjects::Pages::Group.new }
+  fab!(:admin)
+  fab!(:group)
+
+  before { sign_in(admin) }
+
+  describe "delete a group" do
+    it "redirects to groups index page" do
+      group_page.visit(group)
+
+      group_page.delete_group
+
+      expect(page).to have_current_path("/g")
+    end
+  end
+end

--- a/spec/system/page_objects/pages/group.rb
+++ b/spec/system/page_objects/pages/group.rb
@@ -17,6 +17,11 @@ module PageObjects
         self
       end
 
+      def delete_group
+        page.find("[data-test-selector='delete-group-button']").click
+        page.find(".dialog-footer .btn-danger").click
+      end
+
       def select_user_and_add(user)
         page.find(
           ".modal-container .user-chooser .multi-select-header .select-kit-header-wrapper",


### PR DESCRIPTION
The issue was that we were returning the transition as a result to the `then`. The fix was just to add `{ }`  for this to not be interpreted as an implicit return.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
