### PR TITLE
FIX: Amend upload_reference.created_at dates for backfilled data

### DIFF
--- a/db/migrate/20240415052153_fixup_upload_reference_created_at.rb
+++ b/db/migrate/20240415052153_fixup_upload_reference_created_at.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class FixupUploadReferenceCreatedAt < ActiveRecord::Migration[7.0]
+  def up
+    ActiveRecord::Base.transaction do
+      # Target: Post
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = posts.created_at, updated_at = NOW()
+        FROM posts, uploads
+        WHERE upload_references.target_id = posts.id
+          AND upload_references.target_type = 'Post'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+
+      # Target: UserExport
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = user_exports.created_at, updated_at = NOW()
+        FROM user_exports, uploads
+        WHERE upload_references.target_id = user_exports.id
+          AND upload_references.target_type = 'UserExport'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+
+      # Target: UserAvatar
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = user_avatars.updated_at, updated_at = NOW()
+        FROM user_avatars, uploads
+        WHERE upload_references.target_id = user_avatars.id
+          AND upload_references.target_type = 'UserAvatar'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+
+      # Target: CustomEmoji
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = custom_emojis.created_at, updated_at = NOW()
+        FROM custom_emojis, uploads
+        WHERE upload_references.target_id = custom_emojis.id
+          AND upload_references.target_type = 'CustomEmoji'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+
+      # Target: ThemeSetting
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = theme_settings.created_at, updated_at = NOW()
+        FROM theme_settings, uploads
+        WHERE upload_references.target_id = theme_settings.id
+          AND upload_references.target_type = 'ThemeSetting'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+
+      # Target: SiteSetting
+      execute <<~SQL
+        UPDATE upload_references
+        SET created_at = site_settings.updated_at, updated_at = NOW()
+        FROM site_settings, uploads
+        WHERE upload_references.target_id = site_settings.id
+          AND upload_references.target_type = 'SiteSetting'
+          AND upload_references.upload_id = uploads.id
+          AND upload_references.created_at = uploads.created_at
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
When we created the upload_references table in 9db8f00b3dd6f2881adf1b786e29426889225e7a
we backfilled records based on existing references in various tables
into the upload_references table.

This does cause some issues with ordering when trying to figure out
where the upload was first referenced; this is because we used the
uploads.created_at value for the upload_references.created_at value
for all cases, so we've ended up with thousands of upload_references
all on the same created_at datetime.

The side effect of this is that when ordering by `upload_references.created_at, upload_references.id`,
upload references created in earlier migrations (e.g. the Post ones) have a higher
order preference than later ones (e.g. SiteSetting ones).

This commit fixes historical data where the upload_references.created_at
is equal to the uploads.created_at, by setting the created_at value to
the target table's created_at or updated_at value as the situation
dictates.

This does not cover all upload reference targets, only the ones
that still have some sort of reference table or column we can go off.
For example UserProfile used to be on profile_background_upload_id;
the user_profile record can be updated for any number of reasons so we
can't just use the user_profile.updated_at for example.

At any rate the most important or widely used references -- Post and SiteSetting -- are
covered.
