### PR TITLE
FIX: prevents showing discard modal on re-edit

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -841,6 +841,16 @@ export default Controller.extend(bufferedProperty("model"), {
         opts.destinationCategoryId = topic.get("destination_category_id");
       }
 
+      // Reopen the composer if we're editing the same post
+      const editingExisting =
+        post.id === composerModel?.post?.id &&
+        opts?.action === Composer.EDIT &&
+        composerModel?.draftKey === opts.draftKey;
+      if (editingExisting) {
+        composerModel.set("composeState", Composer.OPEN);
+        return;
+      }
+
       // Cancel and reopen the composer for the first post
       if (editingFirst) {
         composer.cancelComposer(opts).then(() => composer.open(opts));

--- a/spec/system/composer/discard_draft_spec.rb
+++ b/spec/system/composer/discard_draft_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe "Composer - discard draft modal", type: :system do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:topic_1) { Fabricate(:topic) }
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  before { sign_in(current_user) }
+
+  context "when editing different post" do
+    fab!(:post_1) { Fabricate(:post, topic: topic_1, user: current_user) }
+    fab!(:post_2) { Fabricate(:post, topic: topic_1, user: current_user) }
+
+    it "shows the discard modal" do
+      topic_page.visit_topic(post_1.topic)
+      topic_page.click_post_action_button(post_1, :edit)
+
+      composer.fill_content("a b c d e f g")
+      composer.minimize
+      topic_page.click_post_action_button(post_2, :edit)
+
+      expect(discard_draft_modal).to be_open
+    end
+  end
+
+  context "when re-editing the first post" do
+    fab!(:post_1) { Fabricate(:post, topic: topic_1, user: current_user) }
+
+    it "doesn’t show the discard modal" do
+      topic_page.visit_topic(post_1.topic)
+      topic_page.click_post_action_button(post_1, :edit)
+
+      composer.fill_content("a b c d e f g")
+      composer.minimize
+      topic_page.click_post_action_button(post_1, :edit)
+
+      expect(discard_draft_modal).to be_closed
+      expect(composer).to be_opened
+
+      topic_page.click_post_action_button(post_1, :edit)
+
+      expect(discard_draft_modal).to be_closed
+      expect(composer).to be_opened
+    end
+  end
+
+  context "when re-editing the second post" do
+    fab!(:post_1) { Fabricate(:post, topic: topic_1, user: current_user) }
+    fab!(:post_2) { Fabricate(:post, topic: topic_1, user: current_user) }
+
+    it "doesn’t show the discard modal" do
+      topic_page.visit_topic(post_1.topic)
+      topic_page.click_post_action_button(post_2, :edit)
+
+      composer.fill_content("a b c d e f g")
+      composer.minimize
+      topic_page.click_post_action_button(post_2, :edit)
+
+      expect(discard_draft_modal).to be_closed
+      expect(composer).to be_opened
+
+      topic_page.click_post_action_button(post_2, :edit)
+
+      expect(discard_draft_modal).to be_closed
+      expect(composer).to be_opened
+    end
+  end
+end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -34,6 +34,11 @@ module PageObjects
         self
       end
 
+      def minimize
+        find("#{COMPOSER_ID} .toggle-minimize").click
+        self
+      end
+
       def append_content(content)
         current_content = composer_input.value
         composer_input.set(current_content + content)

--- a/spec/system/page_objects/modals/discard_draft.rb
+++ b/spec/system/page_objects/modals/discard_draft.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module PageObjects
+  module Modals
+    class DiscardDraft < PageObjects::Modals::Base
+      MODAL_SELECTOR = ".discard-draft-modal"
+
+      def open?
+        has_css?(".modal.d-modal#{MODAL_SELECTOR}")
+      end
+
+      def closed?
+        has_no_css?(".modal.d-modal#{MODAL_SELECTOR}")
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -90,6 +90,8 @@ module PageObjects
           post_by_number(post).find(".post-controls .create-flag").click
         when :copy_link
           post_by_number(post).find(".post-controls .post-action-menu__copy-link").click
+        when :edit
+          post_by_number(post).find(".post-controls .edit").click
         end
       end
 


### PR DESCRIPTION
This commit will now change two behaviors:

- If composer is already opened on a specific post and we click on edit again for the same post, we will do nothing and not show the discard draft modal
- if composer is shrinked and we click on edit for the same currently edited post, we will just open the composer and not show the discard draft modal