### PR TITLE
FIX: Correctly re-attach allowed images in activity summary e-mail

### DIFF
--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -218,7 +218,9 @@ module Email
       end
 
       result["X-Discourse-Post-Id"] = @opts[:post_id].to_s if @opts[:post_id]
+      result["X-Discourse-Post-Ids"] = @opts[:post_ids].join(",") if @opts[:post_ids].present?
       result["X-Discourse-Topic-Id"] = @opts[:topic_id].to_s if @opts[:topic_id]
+      result["X-Discourse-Topic-Ids"] = @opts[:topic_ids].join(",") if @opts[:topic_ids].present?
 
       # at this point these have been filtered by the recipient's guardian for visibility,
       # see UserNotifications#send_notification_email

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -253,6 +253,9 @@ module Email
       if post.present?
         @stripped_secure_upload_shas = style.stripped_upload_sha_map.values
         add_attachments(post)
+      elsif @email_type == :digest
+        @stripped_secure_upload_shas = style.stripped_upload_sha_map.values
+        digest_posts.each { |p| add_attachments(p) }
       end
 
       # Suppress images from short emails
@@ -346,6 +349,10 @@ module Email
     end
 
     private
+
+    def digest_posts
+      Post.where(id: header_value("X-Discourse-Post-Ids")&.split(","))
+    end
 
     def add_attachments(post)
       max_email_size = SiteSetting.email_total_attachment_size_limit_kb.kilobytes

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -640,6 +640,15 @@ RSpec.describe Email::Sender do
           expect(message.to_s.scan(/cid:[\w\-@.]+/).uniq.length).to eq(2)
         end
 
+        it "attaches allowed images from posts in the activity summary" do
+          message.header["X-Discourse-Post-Id"] = nil
+          message.header["X-Discourse-Post-Ids"] = "#{reply.id}"
+          Email::Sender.new(message, :digest).send
+          expect(message.attachments.map(&:filename)).to include(
+            *[image, @secure_image].map(&:original_filename),
+          )
+        end
+
         it "does not attach images that are not marked as secure, in the case of a non-secure upload copied to a PM" do
           SiteSetting.login_required = false
           @secure_image.update_secure_status(override: false)


### PR DESCRIPTION
### What is the problem?

For e-mails, secure uploads redacts all secure images, and later uses the access control post to re-attached allowed ones. We pass the ID of this post through the `X-Discourse-Post-Id` header. As the name suggests, this assumes there's only ever one access control post. This is not true for activity summary e-mails, as they summarize across posts.

### How does this fix it?

Add a new header, `X-Discourse-Post-Ids`, which is used the same way as the old header, but also works for the case where an e-mail is associated with multiple posts.