### PR TITLE
Revert "FIX: Post uploads setting access_control_post_id unnecessarily (#26627)"

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1093,28 +1093,11 @@ class Post < ActiveRecord::Base
       UploadReference.where(target: self).delete_all
       UploadReference.insert_all(upload_references) if upload_references.size > 0
 
-      # NOTE: The access_control_post_id needs to be set whenever a post is linked to an upload
-      # when secure uploads is enabled because it is later used for UploadSecurity checks.
-      # The caveat here is that access_control_post_id should only be set if this post is
-      # the first time the upload is referenced, otherwise we can end up hijacking upload
-      # ownership from other posts.
       if SiteSetting.secure_uploads?
-        uploads_in_post =
-          Upload
-            .joins(:upload_references)
-            .includes(:upload_references)
-            .where(id: upload_ids, access_control_post_id: nil)
-            .where("uploads.id NOT IN (SELECT upload_id FROM custom_emojis)")
-
-        access_control_will_change_upload_ids =
-          uploads_in_post.filter_map do |upl|
-            first_ref = upl.upload_references.min_by { |ur| [ur.created_at, ur.id] }
-            upl.id if first_ref.blank? || first_ref.target?(self)
-          end
-
-        Upload.where(id: access_control_will_change_upload_ids).update_all(
-          access_control_post_id: self.id,
-        )
+        Upload
+          .where(id: upload_ids, access_control_post_id: nil)
+          .where("id NOT IN (SELECT upload_id FROM custom_emojis)")
+          .update_all(access_control_post_id: self.id)
       end
     end
   end

--- a/app/models/upload_reference.rb
+++ b/app/models/upload_reference.rb
@@ -6,10 +6,6 @@ class UploadReference < ActiveRecord::Base
 
   delegate :to_markdown, to: :upload
 
-  def target?(target_to_check)
-    self.target_id == target_to_check.id && self.target_type == target_to_check.class.to_s
-  end
-
   def self.ensure_exist!(upload_ids: [], target: nil, target_type: nil, target_id: nil)
     if !target && !(target_type && target_id)
       raise "target OR target_type and target_id are required"

--- a/spec/integration/secure_uploads_spec.rb
+++ b/spec/integration/secure_uploads_spec.rb
@@ -40,7 +40,6 @@ describe "Secure uploads" do
 
   it "does not convert an upload to secure when it was first used in a site setting then in a post" do
     upload = create_upload
-    stub_presign_upload_get(upload)
     SiteSetting.favicon = upload
     expect(upload.reload.upload_references.count).to eq(1)
     create_post(
@@ -56,7 +55,6 @@ describe "Secure uploads" do
 
   it "does not convert an upload to insecure when it was first used in a secure post then a site setting" do
     upload = create_upload
-    stub_presign_upload_get(upload)
     create_post(
       title: "Secure upload post",
       raw: "This is a new post <img src=\"#{upload.url}\" />",

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1542,8 +1542,7 @@ RSpec.describe PostRevisor do
       end
 
       context "with secure uploads uploads" do
-        let!(:image5) { Fabricate(:secure_upload, access_control_post: post) }
-
+        let!(:image5) { Fabricate(:secure_upload) }
         before do
           Jobs.run_immediately!
           setup_s3


### PR DESCRIPTION
This reverts commit cdc8e9de1b8d269b7d1704b210462276042a8a38.

It's made things worse internally and on meta.
