### PR TITLE
FEATURE: Merge user associated accounts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2931,6 +2931,7 @@ en:
         updating_site_settings: "Updating site settings…"
         updating_user_stats: "Updating user stats…"
         merging_user_attributes: "Merging user attributes…"
+        merging_user_associated_accounts: "Merging user associated accounts…"
         updating_user_ids: "Updating user ids…"
         deleting_source_user: "Deleting source user…"
   user:

--- a/spec/fabricators/user_associated_account_fabricator.rb
+++ b/spec/fabricators/user_associated_account_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator(:user_associated_account) do
+  provider_name "meecrosof"
+  provider_uid { sequence(:key) { |i| "#{i + 1}" } }
+  user
+  info { |attrs| { name: attrs[:user].username, email: attrs[:user].email } }
+end

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -1084,6 +1084,44 @@ RSpec.describe UserMerger do
     end
   end
 
+  context "with user associated accounts (UAAs)" do
+    context "when only merging account has UAAs" do
+      it "transfers the source user UAA to the target" do
+        source_uaa = Fabricate(:user_associated_account, user: source_user)
+
+        merge_users!
+
+        expect(source_uaa.reload.user).to eq(target_user)
+      end
+    end
+
+    context "when both accounts have UAAs" do
+      context "when both accounts' UAAs have different provider_names" do
+        it "transfers the source user UAA to the target and keeps both" do
+          source_uaa = Fabricate(:user_associated_account, user: source_user, provider_name: "x")
+          target_uaa = Fabricate(:user_associated_account, user: target_user, provider_name: "y")
+
+          merge_users!
+
+          expect(target_uaa.reload.user).to eq(target_user)
+          expect(source_uaa.reload.user).to eq(target_user)
+        end
+      end
+
+      context "when both accounts' UAAs have same provider_names" do
+        it "keeps only the target UAA" do
+          source_uaa = Fabricate(:user_associated_account, user: source_user, provider_name: "x")
+          target_uaa = Fabricate(:user_associated_account, user: target_user, provider_name: "x")
+
+          merge_users!
+
+          expect(target_uaa.reload.user).to eq(target_user)
+          expect(source_uaa.reload.user).to eq(nil)
+        end
+      end
+    end
+  end
+
   it "updates users" do
     walter.update!(approved_by: source_user)
     upload = Fabricate(:upload)


### PR DESCRIPTION
When merging users from /admin/users/:user_id, we currently don't merge user_associated_accounts. Sometimes this could lock users out of their accounts if local_logins are disabled, and the secondary email is tied to the main account.

This PR ensures user_associated_accounts are merged, and on conflict
- keeps the target_user's associated account
- sets user_id: nil for the source_user's conflicted user_associated_account