### PR TITLE
FEATURE: Add 'New users only' option to user_updated trigger

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -20,6 +20,10 @@ module DiscourseAutomation
     validates :script, presence: true
     validate :validate_trigger_fields
 
+    after_destroy do |automation|
+      UserCustomField.where(name: automation.new_user_custom_field_name).destroy_all
+    end
+
     attr_accessor :running_in_background
 
     def running_in_background!
@@ -161,6 +165,10 @@ module DiscourseAutomation
       pending_automations.delete_all
       pending_pms.delete_all
       scriptable&.on_reset&.call(self)
+    end
+
+    def new_user_custom_field_name
+      "automation_#{self.id}_new_user"
     end
 
     private

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -175,6 +175,9 @@ en:
             once_per_user:
               label: Once per user
               description: Will trigger only once per user
+            new_users_only:
+              label: New users only
+              description: Will trigger only for new users that join after this automation is enabled
         category_created_edited:
           fields:
             restricted_category:

--- a/plugins/automation/lib/discourse_automation/triggers/user_updated.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/user_updated.rb
@@ -8,6 +8,7 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::USER_UPDATED
   field :custom_fields, component: :custom_fields
   field :user_profile, component: :user_profile
   field :once_per_user, component: :boolean
+  field :new_users_only, component: :boolean
 
   validate do
     has_triggers = has_trigger_field?(:custom_fields) && has_trigger_field?(:user_profile)

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -208,6 +208,9 @@ after_initialize do
   register_topic_custom_field_type(DiscourseAutomation::AUTO_RESPONDER_TRIGGERED_IDS, [:integer])
 
   on(:user_updated) { |user| DiscourseAutomation::EventHandlers.handle_user_updated(user) }
+  on(:user_created) do |user|
+    DiscourseAutomation::EventHandlers.handle_user_updated(user, new_user: true)
+  end
 
   register_user_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])
   register_post_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -165,4 +165,21 @@ describe DiscourseAutomation::Automation do
       end
     end
   end
+
+  describe "after_destroy" do
+    fab!(:automation) { Fabricate(:automation, enabled: false) }
+    fab!(:automation2) { Fabricate(:automation, enabled: false) }
+
+    it "deletes user custom fields that indicate new users" do
+      user = Fabricate(:user)
+      user.custom_fields[automation.new_user_custom_field_name] = "1"
+      user.custom_fields[automation2.new_user_custom_field_name] = "1"
+      user.save_custom_fields
+
+      automation.destroy!
+      user.reload
+
+      expect(user.custom_fields).to eq({ automation2.new_user_custom_field_name => "1" })
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new option to the `user_updated` trigger of the automation plugin to only trigger an automation for new users that join after the automation is enabled.

Screenshot:

<img src="https://github.com/discourse/discourse/assets/17474474/730d70dd-0f2a-43c3-8efa-6d6fcaa9f0cd" width=600>