### PR TITLE
FIX: prevents open to happen too early

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -198,7 +198,9 @@ export default Component.extend(
       this.appEvents.on("keyboard-visibility-change", this, this._updatePopper);
 
       if (this.selectKit.options.expandedOnInsert) {
-        this._open();
+        next(() => {
+          this._open();
+        });
       }
     },
 


### PR DESCRIPTION
In discourse-assign the assign menu in the modal is using this `expandedOnInsert` option and  was sometimes not opening correctly resulting in a broken state until you click two times on it. This should prevent this issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
