### PR TITLE
FIX: correctly unshrink composer when re-editing post

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -847,7 +847,7 @@ export default Controller.extend(bufferedProperty("model"), {
         opts?.action === Composer.EDIT &&
         composerModel?.draftKey === opts.draftKey;
       if (editingExisting) {
-        composerModel.set("composeState", Composer.OPEN);
+        composer.unshrink();
         return;
       }
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1559,7 +1559,6 @@ export default class ComposerService extends Service {
       });
     }
 
-    const defaultComposerHeight = this._getDefaultComposerHeight();
 
     this.set("model.composerHeight", defaultComposerHeight);
     document.documentElement.style.setProperty(
@@ -1695,6 +1694,14 @@ export default class ComposerService extends Service {
     }).finally(() => {
       this.skipAutoSave = false;
     });
+  }
+
+  unshrink() {
+    this.model.set("composeState", Composer.OPEN);
+    document.documentElement.style.setProperty(
+      "--composer-height",
+      this.model.composerHeight
+    );
   }
 
   shrink() {

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1559,6 +1559,7 @@ export default class ComposerService extends Service {
       });
     }
 
+    const defaultComposerHeight = this._getDefaultComposerHeight();
 
     this.set("model.composerHeight", defaultComposerHeight);
     document.documentElement.style.setProperty(


### PR DESCRIPTION
Prior to this fix we were manually expanding the composer but not setting the correct height. This commit adds a new `unshrink` function on the composer service to correctly set the state and the height on the composer model.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
