### PR TITLE
Fix: allow staff and `direct message enabled groups` to create personal chats

### DIFF
--- a/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
+++ b/plugins/chat/app/serializers/chat/chatable_user_serializer.rb
@@ -5,7 +5,7 @@ module Chat
     attributes :can_chat, :has_chat_enabled
 
     def can_chat
-      SiteSetting.chat_enabled && object.guardian.can_chat? && object.guardian.can_direct_message?
+      SiteSetting.chat_enabled && object.guardian.can_chat? && scope.can_create_direct_message?
     end
 
     def has_chat_enabled

--- a/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe Chat::ChatableUserSerializer do
   end
 
   context "when staff creates direct messages" do
-    let(:admin) { Fabricate(:admin) }
+    fab!(:admin)
     subject(:serializer) { described_class.new(user, scope: Guardian.new(admin), root: false) }
+
     before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4] }
 
     it "can chat" do

--- a/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_user_serializer_spec.rb
@@ -54,4 +54,19 @@ RSpec.describe Chat::ChatableUserSerializer do
       expect(serializer.as_json[:can_chat]).to eq(false)
     end
   end
+
+  context "when staff creates direct messages" do
+    let(:admin) { Fabricate(:admin) }
+    subject(:serializer) { described_class.new(user, scope: Guardian.new(admin), root: false) }
+    before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4] }
+
+    it "can chat" do
+      expect(serializer.as_json[:can_chat]).to eq(true)
+    end
+
+    it "can't chat if user has chat disabled" do
+      user.user_option.update!(chat_enabled: false)
+      expect(serializer.as_json[:has_chat_enabled]).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
As an admin, I am unable to create personal chats with other users.

![image](https://github.com/discourse/discourse/assets/51732678/da04af6c-0134-45c4-b1a6-ecd6cbd16fa9)

However, according to the site settings, staff members should always have the ability to create personal chats.

![image](https://github.com/discourse/discourse/assets/51732678/88bd0a5f-ad33-47ac-9086-58b2f74924be)

## Steps to reproduce:

1. Set `chat allowed groups` to TL0 & `direct message enabled groups` to moderators
2. As an admin, attempt to create a personal chat with a TL1 user.

## Fix

This issue is related to PR https://github.com/discourse/discourse/pull/26010 

https://github.com/discourse/discourse/blob/df373d90fe9460b49aaa771e138aebf3f768c803/plugins/chat/app/serializers/chat/chatable_user_serializer.rb#L8

When a user attempts to create a personal chat, we should not verify whether the target user has the ability to create personal chats. Instead, as specified in the site settings, we should verify whether the **current user** has the ability to create personal chats.

As long as the current user is a member of the direct message enabled groups or is a staff member, they should be able to create a personal chat.