### PR TITLE
FIX: don't purge users who were deactivated by the system

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2020,7 +2020,7 @@ class User < ActiveRecord::Base
 
     User
       .joins(
-        "LEFT JOIN user_histories ON user_histories.target_user_id = users.id AND action = #{UserHistory.actions[:deactivate_user]} AND acting_user_id > 0",
+        "LEFT JOIN user_histories ON user_histories.target_user_id = users.id AND action = #{UserHistory.actions[:deactivate_user]} AND acting_user_id IS NOT NULL",
       )
       .where(active: false)
       .where("users.created_at < ?", SiteSetting.purge_unactivated_users_grace_period_days.days.ago)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1857,6 +1857,7 @@ RSpec.describe User do
           unactivated_old_with_human_pm,
           unactivated_old_with_post,
           unactivated_by_admin,
+          unactivated_by_system,
           admin,
         ],
       )


### PR DESCRIPTION
In a previous PR, we skipped users deactivated by admins from being automatically purged - https://github.com/discourse/discourse/pull/26478.

However, users deactivated by `discourse-auto-deactivate` plugin are deactivated by the system user. Those users should not be purged as well.

https://github.com/discourse/discourse-auto-deactivate/blob/main/plugin.rb#L62
