### PR TITLE
DEV: Apply `flex-direction: column` on `.d-header`

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -11,6 +11,7 @@
 .d-header {
   display: flex;
   align-items: center;
+  flex-direction: column;
   width: 100%;
   background-color: var(--header_background);
   box-shadow: var(--shadow-header);


### PR DESCRIPTION
This doesn't change anything in 99.9% of cases - by default d-header has only one child element `.wrap`.

There are only two themes that I'm aware of that add another child:
1. discourse-categories-navbar - which I'm currently updating to use the new header APIs, and where the column layout makes more sense
2. a private theme, which was recently updated to use those APIs and that works around the current layout by applying `flex-wrap: wrap` to d-header (I'll remove that override as it conflicts with this change)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
