### PR TITLE
DEV: Avoid using `@tracked` as a decorator in RenderGlimmer object literal

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
+++ b/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
@@ -152,13 +152,13 @@ export default class RenderGlimmer {
     component.name = "Widgets/RenderGlimmer";
     setComponentTemplate(template, component);
 
-    this._componentInfo = {
+    this._componentInfo = new ComponentInfo({
       element,
       component,
-      @tracked data: this.data,
+      data: this.data,
       setWrapperElementAttrs: (attrs) =>
         this.updateElementAttrs(element, attrs),
-    };
+    });
 
     this.parentMountWidgetComponent.mountChildComponent(this._componentInfo);
   }
@@ -208,4 +208,15 @@ export function registerWidgetShim(name, tagName, template) {
   };
 
   createWidgetFrom(RenderGlimmerShim, name, {});
+}
+
+class ComponentInfo {
+  @tracked data;
+  element;
+  component;
+  setWrapperElementAttrs;
+
+  constructor(params) {
+    Object.assign(this, params);
+  }
 }


### PR DESCRIPTION
Decorators in object literals are non-standard, and we're working to remove them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
