### PR TITLE
UX: when reopening collapsed composer, reset height

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1353,6 +1353,7 @@ export default class ComposerService extends Service {
       composerModel.composeState === Composer.DRAFT
     ) {
       this.close();
+
       composerModel = null;
     }
 
@@ -1373,6 +1374,13 @@ export default class ComposerService extends Service {
           composerModel.draftKey === opts.draftKey
         ) {
           composerModel.set("composeState", Composer.OPEN);
+
+          // reset height set from collapse() state
+          document.documentElement.style.setProperty(
+            "--composer-height",
+            this.get("model.composerHeight")
+          );
+
           if (!opts.action) {
             return;
           }
@@ -1415,7 +1423,6 @@ export default class ComposerService extends Service {
           await this.open(opts);
         }
       }
-
       await this._setModel(composerModel, opts);
     } finally {
       this.skipAutoSave = false;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1353,7 +1353,6 @@ export default class ComposerService extends Service {
       composerModel.composeState === Composer.DRAFT
     ) {
       this.close();
-
       composerModel = null;
     }
 
@@ -1423,6 +1422,7 @@ export default class ComposerService extends Service {
           await this.open(opts);
         }
       }
+
       await this._setModel(composerModel, opts);
     } finally {
       this.skipAutoSave = false;


### PR DESCRIPTION
Currently when you minimize the composer, the `--composer-height` value is set to `40px` — when reopening a draft, this value isn't reset, so the resumed composer is quite short. This resets the `--composer-height` to the last known height. 

Before:

https://github.com/discourse/discourse/assets/1681963/e19eb854-d08f-4bf4-8cb1-d72efbffe539

After:

https://github.com/discourse/discourse/assets/1681963/4560dbae-fdad-4c69-90e1-549642ccafc7

