### PR TITLE
FIX: Don't put non-category in Site.categories

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -57,7 +57,6 @@ export function translateResults(results, opts) {
 
   results.categories = results.categories
     .map(function (category) {
-      Site.current().updateCategory(category);
       return Category.list().findBy("id", category.id || category.model.id);
     })
     .compact();


### PR DESCRIPTION
This 'category' variable isn't a serialized category - at least when doing a category/tag search.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
