### PR TITLE
FEATURE: Show additional filter links in admin sidebar for no results

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
@@ -4,6 +4,7 @@ import { Input } from "@ember/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import DButton from "discourse/components/d-button";
 import TextField from "discourse/components/text-field";
 import i18n from "discourse-common/helpers/i18n";
@@ -35,6 +36,9 @@ export default class AdminSiteSettingsFilterControls extends Component {
 
   @action
   runInitialFilter() {
+    if (this.args.initialFilter !== this.filter) {
+      this.filter = this.args.initialFilter;
+    }
     this.onChangeFilter();
   }
 
@@ -42,6 +46,7 @@ export default class AdminSiteSettingsFilterControls extends Component {
     <div
       class="admin-controls admin-site-settings-filter-controls"
       {{didInsert this.runInitialFilter}}
+      {{didUpdate this.runInitialFilter @initialFilter}}
     >
       <div class="controls">
         <div class="inline-form">

--- a/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
@@ -4,6 +4,7 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
   queryParams = {
     order: { refreshModel: true },
     asc: { refreshModel: true },
+    username: { refreshModel: true },
   };
 
   // TODO: this has been introduced to fix a bug in admin-users-list-show
@@ -20,6 +21,7 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
         controller.setProperties({
           order: transition.to.queryParams.order,
           asc: transition.to.queryParams.asc,
+          listFilter: transition.to.queryParams.username,
           query: params.filter,
           refreshing: false,
         });

--- a/app/assets/javascripts/discourse/app/components/sidebar/filter-no-results.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/filter-no-results.gjs
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import i18n from "discourse-common/helpers/i18n";
+import getURL from "discourse-common/lib/get-url";
+import I18n from "discourse-i18n";
 
 export default class FilterNoResulsts extends Component {
   @service sidebarState;
@@ -13,16 +16,28 @@ export default class FilterNoResulsts extends Component {
     return this.sidebarState.currentPanel.filterable;
   }
 
+  get noResultsDescription() {
+    const params = {
+      filter: this.sidebarState.filter,
+      settings_filter_url: getURL(
+        `/admin/site_settings/category/all_results?filter=${this.sidebarState.filter}`
+      ),
+      user_list_filter_url: getURL(
+        `/admin/users/list/active?username=${this.sidebarState.filter}`
+      ),
+    };
+    return htmlSafe(I18n.t("sidebar.no_results.description", params));
+  }
+
   <template>
     {{#if this.shouldDisplay}}
       <div class="sidebar-no-results">
-        <div class="sidebar-no-results__title">{{i18n
+        <h4 class="sidebar-no-results__title">{{i18n
             "sidebar.no_results.title"
-          }}</div>
-        <div class="sidebar-no-results__description">{{i18n
-            "sidebar.no_results.description"
-            filter=this.sidebarState.filter
-          }}</div>
+          }}</h4>
+        <p
+          class="sidebar-no-results__description"
+        >{{this.noResultsDescription}}</p>
       </div>
     {{/if}}
   </template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4759,7 +4759,7 @@ en:
       clear_filter: "Clear filter"
       no_results:
         title: "No results"
-        description: "We couldn’t find anything matching ‘%{filter}’.<br><br>Did you want to <a href=\"%{settings_filter_url}\">search site settings</a> or the <a href=\"%{user_list_filter_url}\">admin user list?</a>"
+        description: "We couldn’t find anything matching ‘%{filter}’.<br><br>Did you want to <a class=\"sidebar-additional-filter-settings\" href=\"%{settings_filter_url}\">search site settings</a> or the <a class=\"sidebar-additional-filter-users\" href=\"%{user_list_filter_url}\">admin user list?</a>"
 
     welcome_topic_banner:
       title: "Create your Welcome Topic"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4759,7 +4759,7 @@ en:
       clear_filter: "Clear filter"
       no_results:
         title: "No results"
-        description: "We couldn’t find anything matching ‘%{filter}’"
+        description: "We couldn’t find anything matching ‘%{filter}’.<br><br>Did you want to <a href=\"%{settings_filter_url}\">search site settings</a> or the <a href=\"%{user_list_filter_url}\">admin user list?</a>"
 
     welcome_topic_banner:
       title: "Create your Welcome Topic"

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -101,6 +101,36 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(links.map(&:text)).to eq(["Appearance", "Preview Summary", "Server Setup"])
   end
 
+  it "allows further filtering of site settings or users if links do not show results" do
+    visit("/admin")
+    filter.filter("user locale")
+    find(".sidebar-additional-filter-settings").click
+    expect(page).to have_current_path(
+      "/admin/site_settings/category/all_results?filter=user%20locale",
+    )
+    expect(page).to have_content(I18n.t("site_settings.allow_user_locale"))
+
+    filter.filter("log_search_queries")
+    find(".sidebar-additional-filter-settings").click
+    expect(page).to have_current_path(
+      "/admin/site_settings/category/all_results?filter=log_search_queries",
+    )
+    expect(page).to have_content(I18n.t("site_settings.log_search_queries"))
+
+    user_1 = Fabricate(:user, username: "moltisanti", name: "Christopher Moltisanti")
+    user_2 = Fabricate(:user, username: "bevelaqua", name: "Matthew Bevelaqua")
+
+    filter.filter("bevelaqua")
+    find(".sidebar-additional-filter-users").click
+    expect(page).to have_current_path("/admin/users/list/active?username=bevelaqua")
+    within(".users-list-container") { expect(page).to have_content("bevelaqua") }
+
+    filter.filter("moltisanti")
+    find(".sidebar-additional-filter-users").click
+    expect(page).to have_current_path("/admin/users/list/active?username=moltisanti")
+    within(".users-list-container") { expect(page).to have_content("moltisanti") }
+  end
+
   it "allows sections to be expanded" do
     visit("/admin")
     sidebar.toggle_all_sections


### PR DESCRIPTION
When the user sees no results in their admin sidebar query,
we are adding two additional links:

* "Search site settings" - Navigates to the site settings page
  with the filter prefilled in the search
* "Admin user list" - Navigates to the user list with the filter
  prefilled in the username search

This will bridge the gap until we have a full admin-wide search.
