### PR TITLE
DEV: Add missing svg icons to the svg_sprite list

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -164,6 +164,7 @@ module SvgSprite
         italic
         key
         keyboard
+        language
         layer-group
         link
         list
@@ -197,6 +198,7 @@ module SvgSprite
         random
         redo
         reply
+        robot
         rocket
         search
         search-plus


### PR DESCRIPTION
they are used since https://github.com/discourse/discourse/pull/26047 and were causing warnings