### PR TITLE
DEV: Allow RenderGlimmer to be used inside post-cooked-glued widgets

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
+++ b/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
@@ -178,7 +178,21 @@ export default class RenderGlimmer {
   }
 
   get parentMountWidgetComponent() {
-    return this.widget?._findView() || this._emberView;
+    if (this._emberView) {
+      return this._emberView;
+    }
+    // Work up parent widgets until we find one with a _emberView
+    // attribute. `.parentWidget` is the normal way to work up the tree,
+    // but we use `attrs._postCookedWidget` to handle the special case
+    // of widgets rendered inside post-cooked.
+    let widget = this.widget;
+    while (widget) {
+      const component = widget._emberView;
+      if (component) {
+        return component;
+      }
+      widget = widget.parentWidget || widget.attrs._postCookedWidget;
+    }
   }
 }
 

--- a/plugins/poll/assets/javascripts/discourse/initializers/extend-for-poll.js
+++ b/plugins/poll/assets/javascripts/discourse/initializers/extend-for-poll.js
@@ -120,6 +120,7 @@ function initializePolls(api) {
           groupableUserFields: (pollGroupableUserFields || "")
             .split("|")
             .filter(Boolean),
+          _postCookedWidget: helper.widget,
         };
         const glue = new WidgetGlue("discourse-poll", register, attrs);
         glue.appendTo(pollNode);


### PR DESCRIPTION
In this case, the top-level widget being glued must have a `_postCookedWidget` attribute.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
