### PR TITLE
UX: update to variable text color for variable background

### DIFF
--- a/plugins/chat/app/views/user_notifications/chat_summary.html.erb
+++ b/plugins/chat/app/views/user_notifications/chat_summary.html.erb
@@ -14,7 +14,7 @@
       </td>
     </tr>
     <tr>
-      <td align="center" style="font-weight:bold;font-size:22px;color:#0a0a0a">
+      <td align="center" style="font-weight:bold;font-size:22px;color:#<%= @header_color -%>">
         <%= I18n.t("user_notifications.chat_summary.description", count: @messages.size) %>
       </td>
     </tr>


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/chat-email-notification-uses-hard-coded-text-color-in-title-but-not-in-background/304299

Since this section uses `@header_bgcolor` for the background, the text should dynamically update with `@header_color` to avoid situations where the text matches the background