### PR TITLE
DEV: Embed IDs in serializer for about page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/about.js
+++ b/app/assets/javascripts/discourse/app/routes/about.js
@@ -1,19 +1,34 @@
+import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
+import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
 export default DiscourseRoute.extend({
-  model() {
-    return ajax("/about.json").then((result) => {
-      const yearAgo = moment().locale("en").utc().subtract(1, "year");
-      result.about.admins = result.about.admins.filter(
-        (r) => moment(r.last_seen_at) > yearAgo
-      );
-      result.about.moderators = result.about.moderators.filter(
-        (r) => moment(r.last_seen_at) > yearAgo
-      );
-      return result.about;
+  site: service(),
+
+  async model() {
+    const result = await ajax("/about.json");
+    const users = Object.fromEntries(
+      result.users.map((user) => [user.id, user])
+    );
+    result.categories?.forEach((category) => {
+      this.site.updateCategory(category);
     });
+
+    const yearAgo = moment().utc().subtract(1, "year");
+    result.about.admins = result.about.admin_ids
+      .map((id) => users[id])
+      .filter((r) => moment(r.last_seen_at) > yearAgo);
+    result.about.moderators = result.about.moderator_ids
+      .map((id) => users[id])
+      .filter((r) => moment(r.last_seen_at) > yearAgo);
+    result.about.category_moderators?.forEach((obj) => {
+      obj.category = Category.findById(obj.category_id);
+      obj.moderators = obj.moderator_ids.map((id) => users[id]);
+    });
+
+    return result.about;
   },
 
   titleToken() {

--- a/app/assets/javascripts/discourse/tests/fixtures/about.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/about.js
@@ -1,5 +1,34 @@
 export default {
   "about.json": {
+    users: [
+      {
+        id: 1,
+        username: "sam",
+        name: "Sam Saffron",
+        avatar_template:
+          "/user_avatar/meta.discourse.org/sam/{size}/102149_2.png",
+        title: "co-founder",
+        last_seen_at: "2030-01-15T13:30:43.272Z",
+      },
+      {
+        id: 32,
+        username: "codinghorror",
+        name: "Jeff Atwood",
+        avatar_template:
+          "/user_avatar/meta.discourse.org/codinghorror/{size}/110067_2.png",
+        title: "co-founder",
+        last_seen_at: "2030-01-15T13:21:56.592Z",
+      },
+      {
+        id: 19,
+        username: "eviltrout",
+        name: "Robin Ward",
+        avatar_template:
+          "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
+        title: "co-founder",
+        last_seen_at: "2030-01-14T18:03:08.232Z",
+      },
+    ],
     about: {
       can_see_about_stats: true,
       stats: {
@@ -37,64 +66,8 @@ export default {
       locale: "en",
       version: "2.2.0.beta8",
       https: true,
-      admins: [
-        {
-          id: 1,
-          username: "sam",
-          name: "Sam Saffron",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/sam/{size}/102149_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-15T13:30:43.272Z",
-        },
-        {
-          id: 32,
-          username: "codinghorror",
-          name: "Jeff Atwood",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/codinghorror/{size}/110067_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-15T13:21:56.592Z",
-        },
-        {
-          id: 19,
-          username: "eviltrout",
-          name: "Robin Ward",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-14T18:03:08.232Z",
-        },
-      ],
-      moderators: [
-        {
-          id: 1,
-          username: "sam",
-          name: "Sam Saffron",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/sam/{size}/102149_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-15T13:30:43.272Z",
-        },
-        {
-          id: 32,
-          username: "codinghorror",
-          name: "Jeff Atwood",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/codinghorror/{size}/110067_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-15T13:21:56.592Z",
-        },
-        {
-          id: 19,
-          username: "eviltrout",
-          name: "Robin Ward",
-          avatar_template:
-            "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
-          title: "co-founder",
-          last_seen_at: "2030-01-14T18:03:08.232Z",
-        },
-      ],
+      admin_ids: [1, 32, 19],
+      moderator_ids: [1, 32, 19],
     },
   },
 };

--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -13,6 +13,10 @@ class About
       @category = category
       @moderators = moderators
     end
+
+    def parent_category
+      category.parent_category
+    end
   end
 
   include ActiveModel::Serialization

--- a/app/serializers/about_serializer.rb
+++ b/app/serializers/about_serializer.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
 class AboutSerializer < ApplicationSerializer
+  class CategoryAboutSerializer < CategoryBadgeSerializer
+    has_one :parent_category, serializer: CategoryBadgeSerializer, root: :categories
+  end
+
   class UserAboutSerializer < BasicUserSerializer
     attributes :title, :last_seen_at
   end
 
   class AboutCategoryModsSerializer < ApplicationSerializer
-    has_one :category, serializer: CategoryBadgeSerializer, embed: :objects
-    has_many :moderators, serializer: UserAboutSerializer, embed: :objects
+    has_one :category, serializer: CategoryAboutSerializer
+    has_many :moderators, serializer: UserAboutSerializer, root: :users
   end
 
-  has_many :moderators, serializer: UserAboutSerializer, embed: :objects
-  has_many :admins, serializer: UserAboutSerializer, embed: :objects
+  has_many :moderators, serializer: UserAboutSerializer, root: :users
+  has_many :admins, serializer: UserAboutSerializer, root: :users
   has_many :category_moderators, serializer: AboutCategoryModsSerializer, embed: :objects
 
   attributes :stats,


### PR DESCRIPTION
It used to embed the objects which could lead to duplicated objects when the same user or category was used multiple times (user was admin, moderator and category or category was parent for multiple categories).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
