### PR TITLE
improved description of personal_message_enabled_groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1745,7 +1745,7 @@ en:
     custom_summarization_allowed_groups: "Groups allowed to summarize contents using the `summarization_strategy`."
 
     enable_personal_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
-    personal_message_enabled_groups: "Allow users in these groups to create personal messages. IMPORTANT: 1) all users can reply to messages. 2) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 3) Admins and mods can always send messages. 4) Group interaction settings override this setting for messaging specific groups. Admins and moderators can always create personal messages."
+    personal_message_enabled_groups: "Allow users in these groups to CREATE personal messages. IMPORTANT: 1) all users can REPLY to messages. 2) Admins and mods can CREATE messages to any user. 3) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 4) Group interaction settings override this setting for messaging specific groups."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"
     enable_chunked_encoding: "Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed"
     long_polling_base_url: "Base URL used for long polling (when a CDN is serving dynamic content, be sure to set this to origin pull) eg: http://origin.site.com"


### PR DESCRIPTION
Made another effort to improve the description of the personal_message_enabled _groups site setting, to clarify who can already create and reply to messages no matter which groups are specified in this setting.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
