### PR TITLE
FIX: correct params for "show top replies" in topic map

### DIFF
--- a/app/assets/javascripts/discourse/app/components/summary-box.hbs
+++ b/app/assets/javascripts/discourse/app/components/summary-box.hbs
@@ -1,5 +1,5 @@
 <div class="summary-box__container">
-  {{#if this.topRepliesSummaryEnabled}}
+  {{#if @topic.has_summary}}
     <p>{{html-safe this.topRepliesSummaryInfo}}</p>
   {{/if}}
   <div class="summarization-buttons">
@@ -23,8 +23,7 @@
         />
       {{/if}}
     {{/if}}
-
-    {{#if this.topRepliesSummaryEnabled}}
+    {{#if @topic.has_summary}}
       <DButton
         @action={{if @postStream.summary @cancelFilter @showTopReplies}}
         @translatedTitle={{this.topRepliesTitle}}

--- a/app/assets/javascripts/discourse/app/components/summary-box.js
+++ b/app/assets/javascripts/discourse/app/components/summary-box.js
@@ -40,7 +40,7 @@ export default class SummaryBox extends Component {
   }
 
   get topRepliesSummaryEnabled() {
-    return this.args.topic.has_summary;
+    return this.args.topic.postStream.summary;
   }
 
   get topRepliesSummaryInfo() {


### PR DESCRIPTION
This is a follow-up to edbd44e737753eb4e9bd91c7da1836954e0627db

I think these just got mixed up and the top replies mode ended up broken... 



When entering a topic, it appears that "show top replies" is already enabled, but it is not:
![image](https://github.com/discourse/discourse/assets/1681963/51c5187b-d566-4834-9994-b3372dfd33cc)

The fix gets this back to the correct state:
![image](https://github.com/discourse/discourse/assets/1681963/58177598-86b9-496c-a48e-8a05c92a6705)
