### PR TITLE
FIX: disable storing invalid post and topic timing when sent from client

### DIFF
--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -308,7 +308,14 @@ class TopicUser < ActiveRecord::Base
     UPDATE_TOPIC_USER_SQL = <<~SQL
       UPDATE topic_users
       SET
-        last_read_post_number = GREATEST(:post_number, tu.last_read_post_number),
+        last_read_post_number =
+          LEAST(
+            CASE WHEN :whisperer
+              THEN highest_staff_post_number
+              ELSE highest_post_number END
+            ,
+            GREATEST(:post_number, tu.last_read_post_number)
+          ),
         total_msecs_viewed = LEAST(tu.total_msecs_viewed + :msecs,86400000),
         notification_level =
            case when tu.notifications_reason_id is null and (tu.total_msecs_viewed + :msecs) >
@@ -357,6 +364,7 @@ class TopicUser < ActiveRecord::Base
         msecs: msecs,
         tracking: notification_levels[:tracking],
         threshold: SiteSetting.default_other_auto_track_topics_after_msecs,
+        whisperer: user.whisperer?,
       }
 
       rows = DB.query(UPDATE_TOPIC_USER_SQL, args)

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe PostTiming do
 
       (2..5).each { |i| Fabricate(:post, topic: post.topic, post_number: i) }
       user2 = Fabricate(:coding_horror, created_at: 1.day.ago)
+      Topic.reset_highest(post.topic.id)
 
       PostActionCreator.like(user2, post)
 

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -228,6 +228,12 @@ RSpec.describe TopicUser do
         today = Time.zone.now
         freeze_time Time.zone.now
 
+        # ensure data model is correct for the test
+        # logging an update to a row that does not exist
+        # is not supported
+        _post1 = Fabricate(:post, topic: topic)
+        _post2 = Fabricate(:post, topic: topic)
+
         TopicUser.update_last_read(user, topic.id, 1, 1, 0)
 
         tomorrow = 1.day.from_now


### PR DESCRIPTION
This ensures we only ever store correct post and topic timing when the client
notifies.

Previous to this change we would blindly trust the client.

Additionally this has error correction code that will correct the last seen
post number when you visit a topic with incorrect timings.
