### PR TITLE
FIX: resets pending automations only if necessary

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -162,7 +162,6 @@ module DiscourseAutomation
     end
 
     def reset!
-      pending_automations.delete_all
       pending_pms.delete_all
       scriptable&.on_reset&.call(self)
     end

--- a/plugins/automation/lib/discourse_automation/triggers/point_in_time.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/point_in_time.rb
@@ -3,11 +3,17 @@
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::POINT_IN_TIME) do
   field :execute_at, component: :date_time, required: true
 
-  on_update do |automation, metadata|
-    # prevents creating a new pending automation on save when date is expired
-    execute_at = metadata.dig("execute_at", "value")
-    if execute_at && execute_at > Time.zone.now
-      automation.pending_automations.create!(execute_at: execute_at)
+  on_update do |automation, fields, previous_fields|
+    execute_at = fields.dig("execute_at", "value")
+    previous_execute_at = previous_fields&.dig("execute_at", "value")
+
+    if execute_at != previous_execute_at
+      automation.pending_automations.destroy_all
+
+      # prevents creating a new pending automation on save when date is expired
+      if execute_at && execute_at > Time.zone.now
+        automation.pending_automations.create!(execute_at: execute_at)
+      end
     end
   end
 end

--- a/plugins/automation/spec/triggers/point_in_time_spec.rb
+++ b/plugins/automation/spec/triggers/point_in_time_spec.rb
@@ -40,4 +40,49 @@ describe "PointInTime" do
       end
     end
   end
+
+  context "when updating automation" do
+    fab!(:automation) do
+      Fabricate(:automation, trigger: DiscourseAutomation::Triggers::POINT_IN_TIME, script: "test")
+    end
+
+    before do
+      DiscourseAutomation::Scriptable.add("test") do
+        triggerables [DiscourseAutomation::Triggers::POINT_IN_TIME]
+        field :test, component: :text
+      end
+
+      automation.upsert_field!(
+        "execute_at",
+        "date_time",
+        { value: 2.hours.from_now },
+        target: "trigger",
+      )
+
+      automation.upsert_field!("test", "text", { value: "something" }, target: "script")
+    end
+
+    context "when execute_at changes" do
+      it "resets the pending automations" do
+        expect {
+          automation.upsert_field!(
+            "execute_at",
+            "date_time",
+            { value: 3.hours.from_now },
+            target: "trigger",
+          )
+        }.to change { DiscourseAutomation::PendingAutomation.last.execute_at }
+        expect(DiscourseAutomation::PendingAutomation.count).to eq(1)
+      end
+    end
+
+    context "when a field other than execute_at changes" do
+      it "doesn't reset the pending automations" do
+        expect {
+          automation.upsert_field!("test", "text", { value: "somethingelse" }, target: "script")
+        }.to_not change { DiscourseAutomation::PendingAutomation.last.execute_at }
+        expect(DiscourseAutomation::PendingAutomation.count).to eq(1)
+      end
+    end
+  end
 end

--- a/plugins/automation/spec/triggers/recurring_spec.rb
+++ b/plugins/automation/spec/triggers/recurring_spec.rb
@@ -58,7 +58,7 @@ describe "Recurring" do
     end
   end
 
-  context "updating automation with recurring trigger" do
+  context "when updating automation" do
     fab!(:automation) do
       Fabricate(:automation, trigger: DiscourseAutomation::Triggers::RECURRING, script: "test")
     end


### PR DESCRIPTION
Prior to this fix, any change to an automation would reset `pending_automations`, now we only do it if any value related to recurrence (start_date, interval, frequency, execute_at...) has been changed.

It means that any trigger creating `pending_automations` now needs to manage them in the `on_update` callback.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
