### PR TITLE
FIX: Locale mismatch at theme translations picker

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -302,7 +302,11 @@ export default class AdminCustomizeThemesShowController extends Controller {
   }
 
   get locale() {
-    return this.get("model.locale") || this.siteSettings.default_locale;
+    return (
+      this.get("model.locale") ||
+      this.userLocale ||
+      this.siteSettings.default_locale
+    );
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
@@ -41,6 +41,7 @@ export default class AdminCustomizeThemesShowRoute extends Route {
       colorSchemes: parentController.get("model.extras.color_schemes"),
       editingName: false,
       editingThemeSetting: false,
+      userLocale: parentController.get("model.extras.locale"),
     });
 
     this.handleHighlight(model);

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -176,6 +176,7 @@ class Admin::ThemesController < Admin::AdminController
       themes: serialize_data(@themes, ThemeSerializer),
       extras: {
         color_schemes: serialize_data(@color_schemes, ColorSchemeSerializer),
+        locale: I18n.locale,
       },
     }
 

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -176,7 +176,7 @@ class Admin::ThemesController < Admin::AdminController
       themes: serialize_data(@themes, ThemeSerializer),
       extras: {
         color_schemes: serialize_data(@color_schemes, ColorSchemeSerializer),
-        locale: I18n.locale,
+        locale: current_user.effective_locale,
       },
     }
 

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -161,7 +161,6 @@ describe "Admin Customize Themes", type: :system do
       theme_translations_settings_editor.save
     end
 
-    # relates to https://meta.discourse.org/t/locale-mismatch-at-theme-translations/302879
     it "should match the current user locale translation" do
       SiteSetting.allow_user_locale = true
       SiteSetting.set_locale_from_accept_language_header = true

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -3,7 +3,7 @@
 describe "Admin Customize Themes", type: :system do
   fab!(:color_scheme)
   fab!(:theme)
-  fab!(:admin)
+  fab!(:admin) { Fabricate(:admin, locale: "en") }
 
   let(:admin_customize_themes_page) { PageObjects::Pages::AdminCustomizeThemes.new }
 
@@ -159,6 +159,35 @@ describe "Admin Customize Themes", type: :system do
 
       theme_translations_settings_editor.fill_in("Hello World in French")
       theme_translations_settings_editor.save
+    end
+
+    # relates to https://meta.discourse.org/t/locale-mismatch-at-theme-translations/302879
+    it "should match the current user locale translation" do
+      SiteSetting.allow_user_locale = true
+      SiteSetting.set_locale_from_accept_language_header = true
+      SiteSetting.default_locale = "fr"
+
+      theme.set_field(
+        target: :translations,
+        name: "en",
+        value: { en: { group: { hello: "Hello there!" } } }.deep_stringify_keys.to_yaml,
+      )
+      theme.set_field(
+        target: :translations,
+        name: "fr",
+        value: { fr: { group: { hello: "Bonjour!" } } }.deep_stringify_keys.to_yaml,
+      )
+      theme.save!
+
+      visit("/admin/customize/themes/#{theme.id}")
+
+      theme_translations_settings_editor =
+        PageObjects::Components::AdminThemeTranslationsSettingsEditor.new
+
+      expect(theme_translations_settings_editor.get_input_value).to have_content("Hello there!")
+
+      theme_translations_picker = PageObjects::Components::SelectKit.new(".translation-selector")
+      expect(theme_translations_picker.component.text).to eq("English (US)")
     end
   end
 end


### PR DESCRIPTION
Before, the theme translations picker value was set to the site's default locale, which mismatches from the user's locale.

This commit changes the picker value to the user locale.

relates to https://meta.discourse.org/t/locale-mismatch-at-theme-translations/302879

<details>
<summary>Before</summary>

<img width="1397" alt="Screenshot 2024-04-19 at 11 46 13" src="https://github.com/discourse/discourse/assets/70247653/0a4d2b65-e857-4ebf-a5b2-bf5f32f1e8f7">

_You can see in the left-right corner that the picker is not consistent_

</details>
<details>
<summary>Now</summary>

<img width="1399" alt="Screenshot 2024-04-19 at 11 42 54" src="https://github.com/discourse/discourse/assets/70247653/7cb2933c-55fa-4165-8e6f-6ed061d08890">


</details>

> [!NOTE]
> Is there a better way to get the user's locale session? I used ruby [I18n.locale](https://github.com/discourse/discourse/blob/a45b2b1124e71a1d9fd8af2b53f69efdf5dba2af/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js#L44) for [consistency](https://stackoverflow.com/questions/673905/how-can-i-determine-a-users-locale-within-the-browser). 
