### PR TITLE
FIX: in EmailSettingsValidator, unset smtp authentication when there's no user and password

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -84,7 +84,7 @@ task "emails:test", [:email] => [:environment] do |_, args|
       domain: smtp[:domain] || "localhost",
       username: smtp[:user_name],
       password: smtp[:password],
-      authentication: smtp[:authentication] || "plain",
+      authentication: smtp[:authentication],
     )
   rescue Exception => e
     if e.to_s.match(/execution expired/)


### PR DESCRIPTION
net-smtp 0.5.0 bails when authentication is set without username/password

followup-to: 7b8d60dc, 897be759

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
