### PR TITLE
UX: use flex gap to space topic map summary buttons

### DIFF
--- a/app/assets/stylesheets/common/base/topic-summary.scss
+++ b/app/assets/stylesheets/common/base/topic-summary.scss
@@ -1,6 +1,7 @@
 .topic-map .toggle-summary {
   .summarization-buttons {
     display: flex;
+    gap: 0.5em;
   }
 
   .ai-summary {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -318,10 +318,6 @@ pre.codeblock-buttons:hover {
     }
   }
 
-  .toggle-summary .summarization-buttons .top-replies {
-    margin-left: 10px;
-  }
-
   .toggle-summary .summary-box {
     margin-top: 10px;
   }

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -198,10 +198,6 @@ a.reply-to-tab {
   .toggle-summary {
     .summarization-buttons {
       flex-direction: column;
-
-      .top-replies {
-        margin-top: 10px;
-      }
     }
   }
 }


### PR DESCRIPTION
There's some left margin on the top replies button to distance it from the AI summary button, but this creates a misalignment when the AI summary is disabled. 

Switching to flex gap here means the space will only be applied when both buttons are present. 

Before

![image](https://github.com/discourse/discourse/assets/1681963/47387310-9242-488a-9b21-2ccd880d95a9)



After

![image](https://github.com/discourse/discourse/assets/1681963/94096011-9ea4-4f8b-b584-10941b2756d6)
