### PR TITLE
FIX: ensures last read is updated on exit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -111,6 +111,7 @@ export default class ChatChannel extends Component {
     this.#cancelHandlers();
     removeOnPresenceChange(this.onPresenceChangeCallback);
     this.subscriptionManager.teardown();
+    this.updateLastReadMessage();
   }
 
   @action
@@ -415,15 +416,12 @@ export default class ChatChannel extends Component {
     }
 
     schedule("afterRender", () => {
-      let lastFullyVisibleMessageNode = null;
-
-      this.scrollable
-        .querySelectorAll(".chat-message-container")
-        .forEach((item) => {
-          if (checkMessageBottomVisibility(this.scrollable, item)) {
-            lastFullyVisibleMessageNode = item;
-          }
-        });
+      const messages = this.scrollable.querySelectorAll(
+        ".chat-message-container"
+      );
+      let lastFullyVisibleMessageNode = Array.from(messages)
+        .reverse()
+        .find((item) => checkMessageBottomVisibility(this.scrollable, item));
 
       if (!lastFullyVisibleMessageNode) {
         return;


### PR DESCRIPTION
Prior to this fix, the debounced update last read call, might be cancelled when exiting the channel. We now ensure we make one last attempt at updating last read state when exiting a channel.

Note this commit also attempts to optimise the fold detection by starting from bottom and stopping on first hit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
