### PR TITLE
FIX: messages are already reversed

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -416,11 +416,8 @@ export default class ChatChannel extends Component {
     }
 
     schedule("afterRender", () => {
-      const messages = this.scrollable.querySelectorAll(
-        ".chat-message-container"
-      );
-      let lastFullyVisibleMessageNode = Array.from(messages)
-        .reverse()
+      const lastFullyVisibleMessageNode = this.scrollable
+        .querySelectorAll(".chat-message-container")
         .find((item) => checkMessageBottomVisibility(this.scrollable, item));
 
       if (!lastFullyVisibleMessageNode) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -416,9 +416,15 @@ export default class ChatChannel extends Component {
     }
 
     schedule("afterRender", () => {
-      const lastFullyVisibleMessageNode = this.scrollable
+      let lastFullyVisibleMessageNode = null;
+
+      this.scrollable
         .querySelectorAll(".chat-message-container")
-        .find((item) => checkMessageBottomVisibility(this.scrollable, item));
+        .forEach((item) => {
+          if (checkMessageBottomVisibility(this.scrollable, item)) {
+            lastFullyVisibleMessageNode = item;
+          }
+        });
 
       if (!lastFullyVisibleMessageNode) {
         return;


### PR DESCRIPTION
This is reverting part of https://github.com/discourse/discourse/commit/08ff0bac297dede8144f83a0b0aa3fc530943bcf to only have the call on exit channel. This was causing incorrect unread update. I will refactor this in another commit.