### PR TITLE
FIX: ignore SVGs when regenerating missing optimized images

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -353,7 +353,16 @@ def regenerate_missing_optimized
 
         if File.exist?(original) && File.size(original) > 0
           FileUtils.mkdir_p(File.dirname(thumbnail))
-          OptimizedImage.resize(original, thumbnail, optimized_image.width, optimized_image.height)
+          if upload.extension == "svg"
+            FileUtils.cp(original, thumbnail)
+          else
+            OptimizedImage.resize(
+              original,
+              thumbnail,
+              optimized_image.width,
+              optimized_image.height,
+            )
+          end
           putc "#"
         else
           missing_uploads << original


### PR DESCRIPTION
When running `rake uploads:regenerate_missing_optimized`, a `Discourse::InvalidAccess` will be raised if an SVG file is being processed as `OptimizedImage.prepend_decoder!` doesn't support the svg extension. This commit simply copies the original SVG file as the thumbnail, just like currently `OptimizedImage.create_for` does.