### PR TITLE
FEATURE: after wizard admin is redirected to the guide page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bootstrap-mode-notice.hbs
+++ b/app/assets/javascripts/discourse/app/components/bootstrap-mode-notice.hbs
@@ -1,35 +1,5 @@
-<DButtonTooltip>
-  <:button>
-    <DButton
-      class="btn-default bootstrap-mode"
-      @label="bootstrap_mode"
-      @action={{this.routeToAdminGuide}}
-    >
-      {{#if this.showUserTip}}
-        <UserTip
-          @id="admin_guide"
-          @priority={{900}}
-          @titleText={{i18n "user_tips.admin_guide.title"}}
-          @contentHtml={{this.userTipContent}}
-          @showSkipButton={{true}}
-          @triggerSelector=".d-header-mode"
-        />
-      {{/if}}
-    </DButton>
-  </:button>
-
-  <:tooltip>
-    {{#unless this.showUserTip}}
-      <DTooltip @theme="user-tip" @icon="info-circle" @arrow={{true}}>
-        <div class="user-tip__container">
-          <div class="user-tip__title">
-            {{i18n "user_tips.admin_guide.title"}}
-          </div>
-          <div class="user-tip__content">
-            {{i18n "user_tips.admin_guide.content_no_url"}}
-          </div>
-        </div>
-      </DTooltip>
-    {{/unless}}
-  </:tooltip>
-</DButtonTooltip>
+<DButton
+  class="btn-default bootstrap-mode"
+  @label="bootstrap_mode"
+  @action={{this.routeToAdminGuide}}
+/>

--- a/app/assets/javascripts/discourse/app/components/bootstrap-mode-notice.js
+++ b/app/assets/javascripts/discourse/app/components/bootstrap-mode-notice.js
@@ -1,32 +1,15 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DiscourseURL from "discourse/lib/url";
-import getURL from "discourse-common/lib/get-url";
-import I18n from "discourse-i18n";
 
 export default class BootstrapModeNotice extends Component {
   @service siteSettings;
-  @service userTips;
-
-  @tracked showUserTip = this.userTips.canSeeUserTip("admin_guide");
 
   @action
   routeToAdminGuide() {
-    this.showUserTip = false;
     DiscourseURL.routeTo(
       `/t/-/${this.siteSettings.admin_quick_start_topic_id}`
     );
-  }
-
-  get adminGuideUrl() {
-    return getURL(`/t/-/${this.siteSettings.admin_quick_start_topic_id}`);
-  }
-
-  get userTipContent() {
-    return I18n.t("user_tips.admin_guide.content", {
-      admin_guide_url: this.adminGuideUrl,
-    });
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
+++ b/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import RouteTemplate from "ember-route-template";
+import DiscourseURL from "discourse/lib/url";
 import WizardCanvas from "discourse/static/wizard/components/wizard-canvas";
 import WizardStep from "discourse/static/wizard/components/wizard-step";
 import getUrl from "discourse-common/lib/get-url";
@@ -9,6 +10,7 @@ import getUrl from "discourse-common/lib/get-url";
 export default RouteTemplate(
   class extends Component {
     @service router;
+    @service siteSettings;
 
     <template>
       {{#if this.showCanvas}}
@@ -32,6 +34,16 @@ export default RouteTemplate(
       return this.step.id === "ready";
     }
 
+    #goHomeOrQuickStart() {
+      if (this.siteSettings.bootstrap_mode_enabled) {
+        DiscourseURL.routeTo(
+          `/t/${this.siteSettings.admin_quick_start_topic_id}`
+        );
+      } else {
+        this.router.transitionTo("discovery.latest");
+      }
+    }
+
     @action
     goNext(response) {
       const next = this.step.next;
@@ -41,7 +53,7 @@ export default RouteTemplate(
       } else if (response?.success && next) {
         this.router.transitionTo("wizard.step", next);
       } else if (response?.success) {
-        this.router.transitionTo("discovery.latest");
+        this.#goHomeOrQuickStart();
       }
     }
 
@@ -52,7 +64,7 @@ export default RouteTemplate(
 
     @action
     goHome() {
-      this.router.transitionTo("discovery.latest");
+      this.#goHomeOrQuickStart();
     }
   }
 );

--- a/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
+++ b/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import RouteTemplate from "ember-route-template";
 import DiscourseURL from "discourse/lib/url";
+import { defaultHomepage } from "discourse/lib/utilities";
 import WizardCanvas from "discourse/static/wizard/components/wizard-canvas";
 import WizardStep from "discourse/static/wizard/components/wizard-step";
 import getUrl from "discourse-common/lib/get-url";
@@ -40,7 +41,7 @@ export default RouteTemplate(
           `/t/${this.siteSettings.admin_quick_start_topic_id}`
         );
       } else {
-        this.router.transitionTo("discovery.latest");
+        this.router.transitionTo(`discovery.${defaultHomepage()}`);
       }
     }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -360,7 +360,6 @@ class User < ActiveRecord::Base
         post_menu: 3,
         topic_notification_levels: 4,
         suggested_topics: 5,
-        admin_guide: 6,
       )
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2037,11 +2037,6 @@ en:
         title: "Keep reading!"
         content: "Here are some topics we think you might like to read next."
 
-      admin_guide:
-        title: "Welcome to your new site!"
-        content: "<a href='%{admin_guide_url}'>Read the admin guide</a> to continue building your site and community."
-        content_no_url: "Read the admin guide to continue building your site and community."
-
     loading: "Loading…"
     errors:
       prev_page: "while trying to load"

--- a/db/migrate/20240422015830_remove_admin_guide_tooltip_from_seen_popups.rb
+++ b/db/migrate/20240422015830_remove_admin_guide_tooltip_from_seen_popups.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RemoveAdminGuideTooltipFromSeenPopups < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE user_options SET seen_popups = ARRAY_REMOVE(user_options2.seen_popups, 6)
+      FROM (SELECT user_id, seen_popups FROM user_options) AS user_options2
+      WHERE 6 = ANY (user_options.seen_popups)
+        AND user_options.user_id = user_options2.user_id
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -3,7 +3,7 @@ Congratulations, you are now the proud owner of your very own [Civilized Discour
 ![](https://www.discourse.org/images/welcome/welcome-to-discourse-hosting-690x314.jpg)
 
 # 1. Initial setup 
-Discourse is a powerful, versatile platform with many options.  To help you make sure you're covering all the bases as you get started with your new community, we provided some checklists and guidance below. If you haven't already, [complete the Setup Wizard](/wizard) which covers the essentials. 
+Discourse is a powerful, versatile platform with many options. To help you make sure you're covering all the bases as you get started with your new community, we provided some checklists and guidance in this Getting Started guide. The Getting started button at the top is only visible to you and will go away when you have invited more members ([if you prefer, you can remove it now](/admin/site_settings/category/all_results?filter=bootstrap)).
 
 You now also need to [test your email](#h-4-maintaining-your-discourse-server-14) to make sure it is configured correctly, otherwise new signups and notifications will not work. 
 

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -245,9 +245,6 @@
         },
         "suggested_topics": {
           "type": "integer"
-        },
-        "admin_guide": {
-          "type": "integer"
         }
       },
       "required": [
@@ -255,8 +252,7 @@
         "topic_timeline",
         "post_menu",
         "topic_notification_levels",
-        "suggested_topics",
-        "admin_guide"
+        "suggested_topics"
       ]
     },
     "groups": {

--- a/spec/system/page_objects/pages/wizard.rb
+++ b/spec/system/page_objects/pages/wizard.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Wizard < PageObjects::Pages::Base
+      def click_jump_in
+        find(".jump-in").click
+      end
+    end
+  end
+end

--- a/spec/system/user_tips_spec.rb
+++ b/spec/system/user_tips_spec.rb
@@ -53,15 +53,6 @@ describe "Homepage", type: :system do
       )
     end
 
-    it "shows the boostrapping tip to an admin user" do
-      SiteSetting.bootstrap_mode_enabled = true
-      expect(admin.user_option.seen_popups).to eq(nil)
-      sign_in admin
-      visit "/"
-
-      expect(page).to have_css(".fk-d-tooltip .user-tip__title", text: "Welcome to your new site!")
-    end
-
     it "shows a second notification once first is dismissed and user visits a topic" do
       sign_in user
       visit "/"

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe "Wizard", type: :system do
+  fab!(:admin)
+  fab!(:topic) { Fabricate(:topic, title: "admin guide with 15 chars") }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  let(:wizard_page) { PageObjects::Pages::Wizard.new }
+
+  before { sign_in(admin) }
+
+  it "redirects to latest when wizard is completed" do
+    visit("/wizard/steps/ready")
+    wizard_page.click_jump_in
+
+    expect(page).to have_current_path("/latest")
+  end
+
+  it "redirects to admin guide when wizard is completed and bootstrap" do
+    SiteSetting.bootstrap_mode_enabled = true
+    SiteSetting.admin_quick_start_topic_id = topic.id
+
+    visit("/wizard/steps/ready")
+    wizard_page.click_jump_in
+
+    expect(page).to have_current_path("/t/admin-guide-with-15-chars/#{topic.id}")
+  end
+end

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -16,7 +16,7 @@ describe "Wizard", type: :system do
     expect(page).to have_current_path("/latest")
   end
 
-  it "redirects to admin guide when wizard is completed and bootstrap" do
+  it "redirects to admin guide when wizard is completed and bootstrap mode is enabled" do
     SiteSetting.bootstrap_mode_enabled = true
     SiteSetting.admin_quick_start_topic_id = topic.id
 


### PR DESCRIPTION
After the wizard is completed, the admin should be redirected to the admin guide topic.

Also tooltip from "Getting started" button was removed.


https://github.com/discourse/discourse/assets/72780/acb4705c-bd06-40fc-912f-73315bc183c8

