### PR TITLE
UX: Fix styling for focused row

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -367,23 +367,19 @@ export default Component.extend({
   @bind
   _onTitleFocus() {
     if (this.element && !this.isDestroying && !this.isDestroyed) {
-      this._mainLinkElement().classList.add("focused");
+      this.element.classList.add("selected");
     }
   },
 
   @bind
   _onTitleBlur() {
     if (this.element && !this.isDestroying && !this.isDestroyed) {
-      this._mainLinkElement().classList.remove("focused");
+      this.element.classList.remove("selected");
     }
   },
 
   _shouldFocusLastVisited() {
     return this.site.desktopView && this.focusLastVisitedTopic;
-  },
-
-  _mainLinkElement() {
-    return this.element.querySelector(".main-link");
   },
 
   _titleElement() {

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -246,10 +246,8 @@
       pointer-events: none;
     }
 
-    &.focused {
-      box-shadow: inset 3px 0 0 var(--tertiary);
-    }
-    /* we have a custom focus indicator so we can remove the native one */
+    // we have a custom focus indicator via .selected
+    // we can remove the native one
     .title:focus {
       outline: none;
     }


### PR DESCRIPTION
Previously, we had two styles for selected/focused topic in the topic list. This was most noticeable when using the bulk select feature:

focus state (when returning to the list from a topic, the topic is marked as focused)
<img width="678" alt="image" src="https://github.com/discourse/discourse/assets/368961/54bbc5ee-b456-492f-aa51-a52eeb2a344c">
selected (when using keyboard navigation)
<img width="692" alt="image" src="https://github.com/discourse/discourse/assets/368961/ca5b9fa3-108f-46f6-aec0-ae2b1a66599b">

This change makes it so that both states look like the second screenshot. It's more consistent, and avoids the selected line hugging the text. 
