### PR TITLE
FEATURE: `noAutoClass` option for DButton component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -5,7 +5,6 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";
 import GlimmerComponentWithDeprecatedParentView from "discourse/components/glimmer-component-with-deprecated-parent-view";
-import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse-common/helpers/d-icon";
 import deprecated from "discourse-common/lib/deprecated";
 import I18n from "discourse-i18n";

--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -31,6 +31,22 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
     }
   }
 
+  get buttonClasses() {
+    if (this.args.noAutoClass) {
+      return this.args.class || "";
+    }
+
+    let classes = [
+      this.args.isLoading ? "is-loading" : "",
+      this.btnLink ? "btn-link" : "btn",
+      this.noText ? "no-text" : "",
+      this.btnType || "",
+      this.args.class || "",
+    ];
+
+    return classes.join(" ");
+  }
+
   get forceDisabled() {
     return !!this.args.isLoading;
   }
@@ -154,14 +170,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
   <template>
     {{! template-lint-disable no-pointer-down-event-binding }}
     <this.wrapperElement
-      {{! For legacy compatibility. Prefer passing class as attributes. }}
-      class={{concatClass
-        @class
-        (if @isLoading "is-loading")
-        (if this.btnLink "btn-link" "btn")
-        (if this.noText "no-text")
-        this.btnType
-      }}
+      class={{this.buttonClasses}}
       {{! For legacy compatibility. Prefer passing these as html attributes. }}
       id={{@id}}
       form={{@form}}

--- a/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
@@ -11,7 +11,7 @@ import closeOnClickOutside from "../../modifiers/close-on-click-outside";
 import HamburgerDropdown from "../sidebar/hamburger-dropdown";
 
 const CLOSE_ON_CLICK_SELECTORS =
-  "a[href], .sidebar-section-header-button, .sidebar-section-link-button, .sidebar-section-link";
+  "a[href], .sidebar-section-header-button, .--link-button, .sidebar-section-link";
 
 export default class HamburgerDropdownWrapper extends Component {
   @action

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
@@ -39,6 +39,7 @@
               @action={{@moreButtonAction}}
               @icon={{@moreButtonIcon}}
               @text={{@moreButtonText}}
+              @name="customize"
             />
           </div>
         {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
@@ -4,12 +4,18 @@
 
 <li class="sidebar-section-link-wrapper">
   <DButton
-    @icon="ellipsis-v"
-    @action={{this.toggleSectionLinks}}
-    @label="sidebar.more"
-    class="btn-flat sidebar-more-section-links-details-summary"
     aria-expanded={{if this.open "true" "false"}}
-  />
+    class="sidebar-section-link sidebar-row sidebar-more-section-links-details-summary --link-button"
+    @noAutoClass={{true}}
+    @action={{this.toggleSectionLinks}}
+  >
+    <span class="sidebar-section-link-prefix icon">
+      {{d-icon "ellipsis-v"}}
+    </span>
+    <span class="sidebar-section-link-content-text">
+      {{i18n "sidebar.more"}}
+    </span>
+  </DButton>
 </li>
 
 {{#if this.open}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -50,7 +50,7 @@ export default class SidebarMoreSectionLinks extends Component {
     if (this.open) {
       const isLinkClick =
         event.target.className.includes("sidebar-section-link") ||
-        event.target.className.includes("sidebar-section-link-button");
+        event.target.className.includes("--link-button");
 
       if (isLinkClick || this.#isOutsideDetailsClick(event)) {
         this.open = false;

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
@@ -2,7 +2,7 @@
   <DButton
     class="sidebar-section-link sidebar-row --link-button"
     @noAutoClass={{true}}
-    @action={{@action}}
+    {{on "click" @action}}
   >
     <span class="sidebar-section-link-prefix icon">
       {{d-icon @icon}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
@@ -1,8 +1,8 @@
 <div class="sidebar-section-link-wrapper">
-  <button
-    type="button"
-    class="btn btn-flat sidebar-section-link-button sidebar-row"
-    {{on "click" @action}}
+  <DButton
+    class="sidebar-section-link sidebar-row --link-button"
+    @noAutoClass={{true}}
+    @action={{@action}}
   >
     <span class="sidebar-section-link-prefix icon">
       {{d-icon @icon}}
@@ -11,5 +11,5 @@
     <span class="sidebar-section-link-content-text">
       {{@text}}
     </span>
-  </button>
+  </DButton>
 </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
@@ -1,7 +1,8 @@
-<div class="sidebar-section-link-wrapper">
+<div class="sidebar-section-link-wrapper" data-list-item-name={{@name}}>
   <DButton
     class="sidebar-section-link sidebar-row --link-button"
     @noAutoClass={{true}}
+    data-link-name={{@name}}
     {{on "click" @action}}
   >
     <span class="sidebar-section-link-prefix icon">

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.hbs
@@ -7,7 +7,6 @@
     <span class="sidebar-section-link-prefix icon">
       {{d-icon @icon}}
     </span>
-
     <span class="sidebar-section-link-content-text">
       {{@text}}
     </span>

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -357,7 +357,7 @@ createWidget("hamburger-dropdown-wrapper", {
   click(event) {
     if (
       event.target.closest(".sidebar-section-header-button") ||
-      event.target.closest(".sidebar-section-link-button") ||
+      event.target.closest(".--link-button") ||
       event.target.closest(".sidebar-section-link")
     ) {
       this.sendWidgetAction("toggleHamburger");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -295,7 +295,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.strictEqual(
       query(
-        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary .sidebar-section-link-content-text"
       ).textContent.trim(),
       I18n.t("sidebar.more"),
       "displays the right count as users link is currently active"
@@ -404,7 +404,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.strictEqual(
       query(
-        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary .sidebar-section-link-content-text"
       ).textContent.trim(),
       I18n.t("sidebar.more"),
       "displays the right count as groups link is currently active"

--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -1,30 +1,3 @@
-.btn-flat.sidebar-more-section-links-details-summary {
-  &:focus-within,
-  &:active,
-  &:hover {
-    background: var(--d-sidebar-highlight-background);
-    svg.d-icon {
-      color: var(--d-sidebar-highlight-color);
-    }
-  }
-
-  height: var(--d-sidebar-row-height);
-  color: var(--d-sidebar-link-color);
-  display: flex;
-  list-style: none;
-  box-sizing: border-box;
-  width: 100%;
-  padding: 0 var(--d-sidebar-row-horizontal-padding);
-  justify-content: left;
-
-  .d-icon {
-    width: var(--d-sidebar-section-link-prefix-width);
-    margin-right: var(--d-sidebar-section-link-prefix-margin-right);
-    color: var(--d-sidebar-link-icon-color);
-    font-size: var(--font-down-1);
-  }
-}
-
 .sidebar-more-section-links-details-content {
   background-color: var(--d-sidebar-background);
   transition: background-color 0.25s;

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -83,24 +83,9 @@
     }
   }
 
-  .sidebar-section-link-button {
-    color: var(--d-sidebar-link-color);
-    background-color: var(--secondary);
-    width: 100%;
-    justify-content: flex-start;
-
-    &:hover {
-      color: var(--d-sidebar-link-color);
-      background-color: var(--primary-low);
-
-      .d-icon {
-        color: var(--d-sidebar-link-icon-color);
-      }
-    }
-
-    .d-icon {
-      color: var(--d-sidebar-link-icon-color);
-    }
+  .--link-button {
+    border: none;
+    background: inherit;
   }
 
   .sidebar-section-link[data-link-name="personal-messages-sent"],

--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -83,7 +83,7 @@ describe "Homepage", type: :system do
         expect(page).to have_css(".new-home", text: "Hi friends!")
         expect(page).to have_no_css(".list-container")
 
-        find("#sidebar-section-content-community .sidebar-section-link:first-child").click
+        find("#sidebar-section-content-community li:first-child").click
         expect(page).to have_css(".list-container")
 
         find("#site-logo").click

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -18,7 +18,7 @@ module PageObjects
         end
 
         def has_no_customize_community_section_button?
-          community_section.has_no_button?(class: "--link-button")
+          community_section.has_no_button?('[data-list-item-name="customize"]')
         end
 
         def click_customize_community_section_button

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -18,7 +18,7 @@ module PageObjects
         end
 
         def has_no_customize_community_section_button?
-          community_section.has_no_button?(class: "sidebar-section-link-button")
+          community_section.has_no_button?(class: "--link-button")
         end
 
         def click_customize_community_section_button


### PR DESCRIPTION
Often when styling `.btn` in themes, some styles get applied in undesirable places: 

![image](https://github.com/discourse/discourse/assets/1681963/43f03bd0-da3f-4738-adea-6f4b95f7773f)

![image](https://github.com/discourse/discourse/assets/1681963/64ecfee8-042f-47dc-9713-fb012299fe49)


This PR gives the option of passing `noAutoClass` to `DButton` to exclude various automatically appended class names. 

This is useful for situations where you'd still like to use `DButton` but don't want buttons to have default button styles applied. 

I've applied this to two common scenarios — the "more" and "customize this section" buttons in the sidebar. These are technically buttons, but should not be styled along with other buttons when a theme uses the `.btn` class. 

This also simplifies our default CSS, because we no longer have to override our own button styles. 

