### PR TITLE
FEATURE: include themes and components keywords to the admin sidebar

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
@@ -20,9 +20,9 @@ export default class AdminSidebarStateManager extends Service {
       return;
     }
 
-    this.keywords[link_name].navigation = keywords.map((keyword) =>
-      keyword.toLowerCase()
-    );
+    this.keywords[link_name].navigation = this.keywords[
+      link_name
+    ].navigation.concat(keywords.map((keyword) => keyword.toLowerCase()));
   }
 
   get navConfig() {

--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
@@ -20,9 +20,13 @@ export default class AdminSidebarStateManager extends Service {
       return;
     }
 
-    this.keywords[link_name].navigation = this.keywords[
-      link_name
-    ].navigation.concat(keywords.map((keyword) => keyword.toLowerCase()));
+    this.keywords[link_name].navigation = [
+      ...new Set(
+        this.keywords[link_name].navigation.concat(
+          keywords.map((keyword) => keyword.toLowerCase())
+        )
+      ),
+    ];
   }
 
   get navConfig() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -286,11 +286,11 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     store.findAll("theme").then((themes) => {
       this.adminSidebarStateManager.setLinkKeywords(
         "admin_themes",
-        themes.content.filter((theme) => !theme.component).mapBy("name")
+        themes.content.rejectBy("component").mapBy("name")
       );
       this.adminSidebarStateManager.setLinkKeywords(
         "admin_components",
-        themes.content.filter((component) => component.component).mapBy("name")
+        themes.content.filterBy("component").mapBy("name")
       );
     });
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -270,7 +270,13 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const navMap = savedConfig || ADMIN_NAV_MAP;
 
     if (!session.get("safe_mode")) {
-      navMap.findBy("name", "plugins").links.push(...pluginAdminRouteLinks());
+      const pluginLinks = navMap.findBy("name", "plugins").links;
+      pluginAdminRouteLinks().forEach((pluginLink) => {
+        if (!pluginLinks.mapBy("name").includes(pluginLink.name)) {
+          pluginLinks.push(pluginLink);
+        }
+      });
+
       this.adminSidebarStateManager.setLinkKeywords(
         "admin_installed_plugins",
         installedPluginsLinkKeywords()

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -255,6 +255,7 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
     const siteSettings = getOwnerWithFallback(this).lookup(
       "service:site-settings"
     );
+    const store = getOwnerWithFallback(this).lookup("service:store");
     const router = getOwnerWithFallback(this).lookup("service:router");
     const session = getOwnerWithFallback(this).lookup("service:session");
     if (!currentUser.use_admin_sidebar) {
@@ -275,6 +276,17 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         installedPluginsLinkKeywords()
       );
     }
+
+    store.findAll("theme").then((themes) => {
+      this.adminSidebarStateManager.setLinkKeywords(
+        "admin_themes",
+        themes.content.filter((theme) => !theme.component).mapBy("name")
+      );
+      this.adminSidebarStateManager.setLinkKeywords(
+        "admin_components",
+        themes.content.filter((component) => component.component).mapBy("name")
+      );
+    });
 
     if (siteSettings.experimental_form_templates) {
       navMap.findBy("name", "appearance").links.push({

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -160,6 +160,24 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(links.map(&:text)).to eq(["Installed"])
   end
 
+  it "accepts components and themes keywords for filter" do
+    Fabricate(:theme, name: "Air theme", component: false)
+    Fabricate(:theme, name: "Kanban", component: true)
+
+    visit("/admin")
+    sidebar.toggle_all_sections
+
+    filter.filter("air")
+    links = page.all(".sidebar-section-link-content-text")
+    expect(links.count).to eq(1)
+    expect(links.map(&:text)).to eq(["Themes"])
+
+    filter.filter("kanban")
+    links = page.all(".sidebar-section-link-content-text")
+    expect(links.count).to eq(1)
+    expect(links.map(&:text)).to eq(["Components"])
+  end
+
   it "does not show the button to customize sidebar sections, that is only supported in the main panel" do
     visit("/")
     expect(sidebar).to have_add_section_button


### PR DESCRIPTION
Include themes and component keywords to make the filter more accurate.


https://github.com/discourse/discourse/assets/72780/4f4d4ff7-c2fe-4169-9f2b-f140e03c62c8

