### PR TITLE
FIX: Automatic code highlighting not applied in fullscreen modal

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -35,7 +35,7 @@ export default async function highlightSyntax(elem, siteSettings, session) {
 
     let lang;
     for (const className of e.classList) {
-      const m = className.match(/^lang-(.+)$/);
+      const m = className.match(/^lang(?:uage)?-(.+)$/);
       if (m) {
         lang = m[1];
         break;

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -1,6 +1,7 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
+import highlightSyntax from "discourse/lib/highlight-syntax";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 
@@ -26,5 +27,35 @@ module("Integration | Component | highlighted-code", function (hooks) {
     await render(hbs`<HighlightedCode @lang="ruby" @code={{this.code}} />`);
 
     assert.strictEqual(query("code").innerText.trim(), LONG_CODE_BLOCK.trim());
+  });
+
+  test("highlighting code with lang=auto", async function (assert) {
+    this.set("code", "def test; end");
+
+    await render(hbs`<HighlightedCode @lang="auto" @code={{this.code}} />`);
+
+    const codeElement = query("code.hljs");
+
+    assert.ok(
+      !codeElement.classList.contains("lang-auto"),
+      "lang-auto is removed"
+    );
+    assert.ok(
+      Array.from(codeElement.classList).some((className) => {
+        return className.startsWith("language-");
+      }),
+      "language is detected"
+    );
+
+    await highlightSyntax(
+      codeElement.parentElement, // <pre>
+      this.siteSettings,
+      this.session
+    );
+
+    assert.ok(
+      codeElement.dataset.unknownHljsLang === undefined,
+      "language is found from language- class"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -36,8 +36,8 @@ module("Integration | Component | highlighted-code", function (hooks) {
 
     const codeElement = query("code.hljs");
 
-    assert.ok(
-      !codeElement.classList.contains("lang-auto"),
+    assert.notOk(
+      codeElement.classList.contains("lang-auto"),
       "lang-auto is removed"
     );
     assert.ok(
@@ -53,8 +53,8 @@ module("Integration | Component | highlighted-code", function (hooks) {
       this.session
     );
 
-    assert.ok(
-      codeElement.dataset.unknownHljsLang === undefined,
+    assert.notOk(
+      codeElement.dataset.unknownHljsLang,
       "language is found from language- class"
     );
   });


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/automatic-code-highlighting-broken-in-fullscreen-code-view/304879

This PR fixes the code highlighting not applied in the fullscreen modal.

#### Explanation
A `lang-auto` classname name is added to the  `<code>` element when no language is provided.
The library highlight.js can then guess the language.
If found,  `lang-auto` is removed, and a `language-<name>` class name is added (from the library).

After clicking on fullscreen, the current element classnames are used in the modal template (see [here](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/codeblock-buttons.js#L171-L176)).
Because no `lang-<name>` class name exists, the `lang` variable is always _undefined_, resulting in the highlighting being skipped.

#### Proposed fix

The `language-<name>` classname is used to retrieve the language name if no `lang-<name>` is present.

#### Screenshots

<details>
<summary>Before</summary>

![image](https://github.com/discourse/discourse/assets/360640/df74722d-ba94-459d-bc67-e9bdf84bab69)
</details>
<details>
<summary>After</summary>

![image](https://github.com/discourse/discourse/assets/360640/52f75c04-dec8-4e57-a62f-9bc0c6f14ca8)
</details>


