### PR TITLE
DEV: Promote inline problem checks to problem check classes

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -162,7 +162,7 @@ class StaticController < ApplicationController
 
               file&.read || ""
             rescue => e
-              AdminDashboardData.add_problem_message("dashboard.bad_favicon_url", 1800)
+              ProblemCheckTracker[:bad_favicon_url].problem!
               Rails.logger.debug("Failed to fetch favicon #{favicon.url}: #{e}\n#{e.backtrace}")
               ""
             ensure

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -90,24 +90,6 @@ class AdminDashboardData
     end
   end
 
-  ##
-  # We call this method in the class definition below
-  # so all of the problem checks in this class are registered on
-  # boot. These problem checks are run when the problems are loaded in
-  # the admin dashboard controller.
-  #
-  # This method also can be used in testing to reset checks between
-  # tests. It will also fire multiple times in development mode because
-  # classes are not cached.
-  def self.reset_problem_checks
-    @@problem_messages = %w[
-      dashboard.bad_favicon_url
-      dashboard.poll_pop3_timeout
-      dashboard.poll_pop3_auth_error
-    ]
-  end
-  reset_problem_checks
-
   def self.fetch_stats
     new.as_json
   end

--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -33,6 +33,7 @@ class ProblemCheck
   # Note: This list must come after the `config_accessor` declarations.
   #
   CORE_PROBLEM_CHECKS = [
+    ProblemCheck::BadFaviconUrl,
     ProblemCheck::EmailPollingErroredRecently,
     ProblemCheck::FacebookConfig,
     ProblemCheck::FailingEmails,
@@ -45,6 +46,8 @@ class ProblemCheck
     ProblemCheck::ImageMagick,
     ProblemCheck::MissingMailgunApiKey,
     ProblemCheck::OutOfDateThemes,
+    ProblemCheck::PollPop3Timeout,
+    ProblemCheck::PollPop3AuthError,
     ProblemCheck::RailsEnv,
     ProblemCheck::Ram,
     ProblemCheck::S3BackupConfig,

--- a/app/services/problem_check/bad_favicon_url.rb
+++ b/app/services/problem_check/bad_favicon_url.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProblemCheck::BadFaviconUrl < ProblemCheck::InlineProblemCheck
+  self.priority = "low"
+end

--- a/app/services/problem_check/inline_problem_check.rb
+++ b/app/services/problem_check/inline_problem_check.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProblemCheck::InlineProblemCheck < ProblemCheck
+  def call
+    # The logic of this problem check is performed inline, so this class is
+    # purely here to support its configuration.
+    #
+    no_problem
+  end
+end

--- a/app/services/problem_check/poll_pop3_auth_error.rb
+++ b/app/services/problem_check/poll_pop3_auth_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProblemCheck::PollPop3AuthError < ProblemCheck::InlineProblemCheck
+  self.priority = "low"
+end

--- a/app/services/problem_check/poll_pop3_timeout.rb
+++ b/app/services/problem_check/poll_pop3_timeout.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProblemCheck::PollPop3Timeout < ProblemCheck::InlineProblemCheck
+  self.priority = "low"
+end

--- a/spec/jobs/poll_mailbox_spec.rb
+++ b/spec/jobs/poll_mailbox_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe Jobs::PollMailbox do
 
         i18n_key = "dashboard.poll_pop3_auth_error"
 
-        expect(AdminDashboardData.problem_message_check(i18n_key)).to eq(
-          I18n.t(i18n_key, base_path: Discourse.base_path),
-        )
+        expect(ProblemCheckTracker[:poll_pop3_auth_error].blips).to eq(1)
       end
 
       it "logs an error on pop connection timeout error" do
@@ -59,9 +57,7 @@ RSpec.describe Jobs::PollMailbox do
 
         i18n_key = "dashboard.poll_pop3_timeout"
 
-        expect(AdminDashboardData.problem_message_check(i18n_key)).to eq(
-          I18n.t(i18n_key, base_path: Discourse.base_path),
-        )
+        expect(ProblemCheckTracker[:poll_pop3_timeout].blips).to eq(1)
       end
 
       it "logs an error when pop fails and continues with next message" do

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe StaticController do
         expect(response.media_type).to eq("image/png")
         expect(response.body.bytesize).to eq(upload.filesize)
       end
+
+      context "when favicon fails to load" do
+        before { FileHelper.stubs(:download).raises(SocketError) }
+
+        it "creates an admin notice" do
+          expect { get "/favicon/proxied" }.to change { AdminNotice.problem.count }.by(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What is this change?

This is the first in a series of PRs that aim to break down https://github.com/discourse/discourse/pull/26192 into more manageable chunks. Starting with this so I can convert an inline problem check in a plugin and get the plugin tests passing.
