### PR TITLE
DEV: Use has_many and ArraySerializer for SidebarSectionsSerializer

### DIFF
--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -11,7 +11,14 @@ class SidebarSectionsController < ApplicationController
         .includes(:sidebar_urls)
         .where("public OR user_id = ?", current_user.id)
         .order("(public IS TRUE) DESC, title ASC")
-        .map { |section| SidebarSectionSerializer.new(section, root: false) }
+
+    sections =
+      ActiveModel::ArraySerializer.new(
+        sections,
+        each_serializer: SidebarSectionSerializer,
+        scope: guardian,
+        root: "sidebar_sections",
+      )
 
     render json: sections
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -188,6 +188,13 @@ class Site
     query
   end
 
+  def anonymous_sidebar_sections
+    SidebarSection
+      .public_sections
+      .includes(:sidebar_urls)
+      .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
+  end
+
   def archetypes
     Archetype.list.reject { |t| t.id == Archetype.private_message }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -367,6 +367,13 @@ class User < ActiveRecord::Base
     custom_fields_clean? || SiteSetting.disable_watched_word_checking_in_user_fields
   end
 
+  def all_sidebar_sections
+    sidebar_sections
+      .or(SidebarSection.public_sections)
+      .includes(:sidebar_urls)
+      .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
+  end
+
   def secured_sidebar_category_ids(user_guardian = nil)
     user_guardian ||= guardian
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -80,19 +80,14 @@ class CurrentUserSerializer < BasicUserSerializer
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
 
   has_one :user_option, embed: :object, serializer: CurrentUserOptionSerializer
+  has_many :all_sidebar_sections,
+           embed: :object,
+           key: :sidebar_sections,
+           serializer: SidebarSectionSerializer
 
   def initialize(object, options = {})
     super
     options[:include_status] = true
-  end
-
-  def sidebar_sections
-    SidebarSection
-      .public_sections
-      .or(SidebarSection.where(user_id: object.id))
-      .includes(:sidebar_urls)
-      .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
-      .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end
 
   def groups

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -53,6 +53,7 @@ class SiteSerializer < ApplicationSerializer
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
   has_many :user_fields, embed: :objects, serializer: UserFieldSerializer
   has_many :auth_providers, embed: :objects, serializer: AuthProviderSerializer
+  has_many :anonymous_sidebar_sections, embed: :objects, serializer: SidebarSectionSerializer
 
   def user_themes
     cache_fragment("user_themes") do
@@ -292,14 +293,6 @@ class SiteSerializer < ApplicationSerializer
     scope.anonymous? && SiteSetting.tagging_enabled &&
       SiteSetting.default_navigation_menu_tags.present? &&
       anonymous_default_navigation_menu_tags.present?
-  end
-
-  def anonymous_sidebar_sections
-    SidebarSection
-      .public_sections
-      .includes(:sidebar_urls)
-      .order("(section_type IS NOT NULL) DESC, (public IS TRUE) DESC")
-      .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end
 
   def include_anonymous_sidebar_sections?

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -330,7 +330,7 @@ RSpec.describe CurrentUserSerializer do
 
           expect(serialized[:sidebar_sections].count).to eq(2)
 
-          expect(serialized[:sidebar_sections].last.links.map { |link| link.id }).to eq(
+          expect(serialized[:sidebar_sections].last[:links].map { |link| link.id }).to eq(
             [custom_sidebar_section_link_1.linkable.id],
           )
         end.count
@@ -344,7 +344,7 @@ RSpec.describe CurrentUserSerializer do
 
           expect(serialized[:sidebar_sections].count).to eq(2)
 
-          expect(serialized[:sidebar_sections].last.links.map { |link| link.id }).to eq(
+          expect(serialized[:sidebar_sections].last[:links].map { |link| link.id }).to eq(
             [custom_sidebar_section_link_1.linkable.id, custom_sidebar_section_link_2.linkable.id],
           )
         end.count

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe SiteSerializer do
 
     it "includes only public sidebar sections serialised object when user is anonymous" do
       serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-      expect(serialized[:anonymous_sidebar_sections].map(&:title)).to eq(
+      expect(serialized[:anonymous_sidebar_sections].map { |section| section[:title] }).to eq(
         ["Community", "Public section"],
       )
     end
@@ -237,7 +237,7 @@ RSpec.describe SiteSerializer do
 
           expect(serialized[:anonymous_sidebar_sections].count).to eq(2)
 
-          expect(serialized[:anonymous_sidebar_sections].last.links.map { |link| link.id }).to eq(
+          expect(serialized[:anonymous_sidebar_sections].last[:links].map { |link| link.id }).to eq(
             [public_section_link.linkable.id],
           )
         end.count
@@ -253,7 +253,7 @@ RSpec.describe SiteSerializer do
 
           expect(serialized[:anonymous_sidebar_sections].count).to eq(2)
 
-          expect(serialized[:anonymous_sidebar_sections].last.links.map { |link| link.id }).to eq(
+          expect(serialized[:anonymous_sidebar_sections].last[:links].map { |link| link.id }).to eq(
             [
               public_section_link.linkable.id,
               public_section_link_2.linkable.id,


### PR DESCRIPTION
Otherwise embedded objects don't get passed to the root.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
