### PR TITLE
UX: bookmark button in topic footer should have btn-default class

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -31,6 +31,7 @@
         <BookmarkMenu
           @showLabel={{true}}
           @bookmarkManager={{this.topicBookmarkManager}}
+          @buttonClasses="btn-default"
         />
       {{else}}
         <DButton


### PR DESCRIPTION
All the other buttons here have this class, and without it styling may vary in undesired ways. 