### PR TITLE
FIX: Allow deleting avatars from the selectable avatars setting

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/uploaded-image-list.hbs
+++ b/app/assets/javascripts/admin/addon/components/modal/uploaded-image-list.hbs
@@ -8,6 +8,9 @@
       {{#each this.images as |image|}}
         <a href class="selectable-avatar" {{on "click" (fn this.remove image)}}>
           {{bound-avatar-template image "huge"}}
+          <span class="selectable-avatar__remove">{{d-icon
+              "times-circle"
+            }}</span>
         </a>
       {{else}}
         <p>{{i18n "admin.site_settings.uploaded_image_list.empty"}}</p>

--- a/app/assets/javascripts/admin/addon/components/modal/uploaded-image-list.js
+++ b/app/assets/javascripts/admin/addon/components/modal/uploaded-image-list.js
@@ -9,7 +9,8 @@ export default class UploadedImageList extends Component {
     : [];
 
   @action
-  remove(url) {
+  remove(url, event) {
+    event.preventDefault();
     this.images.removeObject(url);
   }
 

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -911,13 +911,26 @@
   .selectable-avatar {
     margin: 5px;
     display: inline-block;
+    position: relative;
     .avatar {
       cursor: pointer;
       width: 60px;
       height: 60px;
-      &:hover {
-        box-shadow: 0 0 10px var(--primary);
+    }
+    &:hover {
+      .selectable-avatar__remove {
+        visibility: visible;
       }
+    }
+    &__remove {
+      visibility: hidden;
+      color: var(--primary-high);
+      position: absolute;
+      bottom: 0px;
+      width: 100%;
+      left: 0px;
+      text-align: center;
+      font-size: var(--font-up-2);
     }
   }
 }

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -45,7 +45,7 @@ class Admin::SiteSettingsController < Admin::AdminController
     when :file_size_restriction
       value = value.tr("^0-9", "").to_i
     when :uploaded_image_list
-      value = Upload.get_from_urls(value.split("|")).to_a
+      value = value.blank? ? "" : Upload.get_from_urls(value.split("|")).to_a
     end
 
     value = Upload.get_from_url(value) || "" if SiteSetting.type_supervisor.get_type(id) == :upload

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -269,6 +269,13 @@ RSpec.describe Admin::SiteSettingsController do
         expect(SiteSetting.title).to eq("")
       end
 
+      it "allows value to be a blank string for selectable_avatars" do
+        SiteSetting.selectable_avatars = [Fabricate(:image_upload)]
+        put "/admin/site_settings/selectable_avatars.json", params: { selectable_avatars: "" }
+        expect(response.status).to eq(200)
+        expect(SiteSetting.selectable_avatars).to eq([])
+      end
+
       it "sanitizes integer values" do
         put "/admin/site_settings/suggested_topics.json", params: { suggested_topics: "1,000" }
 


### PR DESCRIPTION
Fixes two issues:

- frontend was reloading the page when clicking-to-remove avatar
- backend wasn't allowing resetting the setting by deleting all avatars

