### PR TITLE
DEV: add topic-area-bottom plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -502,6 +502,11 @@
             {{/if}}
           </ConditionalLoadingSpinner>
 
+          <PluginOutlet
+            @name="topic-area-bottom"
+            @connectorTagName="div"
+            @outletArgs={{hash model=this.model}}
+          />
         </section>
       </div>
 


### PR DESCRIPTION
Using this for an experimental component, `this.model.postStream.loadingFilter` can be used to show/hide the outlet's content when the topic is loading