### PR TITLE
FEATURE: Rate limit common AI bots crawlers by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1958,7 +1958,7 @@ security:
     list_type: compact
   crawler_user_agents:
     hidden: true
-    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse|google-inspectiontool"
+    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse|google-inspectiontool|gptbot|claudebot|anthropic-ai|brightbot"
     type: list
     list_type: compact
   browser_update_user_agents:
@@ -2006,7 +2006,7 @@ security:
     list_type: compact
   slow_down_crawler_user_agents:
     type: list
-    default: ""
+    default: "gptbot|claudebot|anthropic-ai|brightbot"
     list_type: compact
   slow_down_crawler_rate: 60
   content_security_policy:


### PR DESCRIPTION
This commit adds the most common AI bot crawlers seen
on our hosting (claudebot, gptbot, anthropic-ai, brightbot)
to our `slow_down_crawler_user_agents` and `crawler_user_agents`
site settings by default.

This means these AI bots will be rate limited by default instead
of site admins having to remember to do it for themselves.
