### PR TITLE
FIX: 404 when visiting theme setting objects editor for theme component

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,6 +261,7 @@ Discourse::Application.routes.draw do
         get "components/:id" => "themes#index"
         get "themes/:id/export" => "themes#export"
         get "themes/:id/schema/:setting_name" => "themes#schema"
+        get "components/:id/schema/:setting_name" => "themes#schema"
 
         # They have periods in their URLs often:
         get "site_texts" => "site_texts#index"

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -1437,4 +1437,23 @@ RSpec.describe Admin::ThemesController do
       end
     end
   end
+
+  describe "#schema" do
+    fab!(:theme)
+    fab!(:theme_component) { Fabricate(:theme, component: true) }
+
+    before { sign_in(admin) }
+
+    it "returns 200 when customizing a theme's setting of objects type" do
+      get "/admin/customize/themes/#{theme.id}/schema/some_setting_name"
+
+      expect(response.status).to eq(200)
+    end
+
+    it "returns 200 when customizing a theme component's setting of objects type" do
+      get "/admin/customize/components/#{theme_component.id}/schema/some_setting_name"
+
+      expect(response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
This commit fixes a bug where the server returns a 404 response code if
a user visits the URL to edit a objects type theme setting directly.
