### PR TITLE
FIX: Improve handling of 'PublicExceptions' when bootstrap_error_pages enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -643,8 +643,8 @@ class ApplicationController < ActionController::Base
     store_preloaded("customHTML", custom_html_json)
     store_preloaded("banner", banner_json)
     store_preloaded("customEmoji", custom_emoji)
-    store_preloaded("isReadOnly", @readonly_mode.to_s)
-    store_preloaded("isStaffWritesOnly", @staff_writes_only_mode.to_s)
+    store_preloaded("isReadOnly", get_or_check_readonly_mode.to_json)
+    store_preloaded("isStaffWritesOnly", get_or_check_staff_writes_only_mode.to_json)
     store_preloaded("activatedThemes", activated_themes_json)
   end
 

--- a/lib/read_only_mixin.rb
+++ b/lib/read_only_mixin.rb
@@ -32,6 +32,16 @@ module ReadOnlyMixin
     end
   end
 
+  def get_or_check_readonly_mode
+    check_readonly_mode if @readonly_mode.nil?
+    @readonly_mode
+  end
+
+  def get_or_check_staff_writes_only_mode
+    check_readonly_mode if @readonly_mode.nil?
+    @readonly_mode
+  end
+
   def add_readonly_header
     response.headers["Discourse-Readonly"] = "true" if @readonly_mode
   end

--- a/spec/system/bootstrap_error_pages_spec.rb
+++ b/spec/system/bootstrap_error_pages_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe "bootstrap_error_pages", type: :system do
+  before { SiteSetting.bootstrap_error_pages = true }
+
+  it "boots ember for non-existent route" do
+    visit "/foobar"
+    expect(page).not_to have_css("body.no-ember")
+    expect(page).to have_css("#site-logo")
+    expect(page).to have_css("div.page-not-found")
+  end
+
+  it "boots ember for non-existent topic" do
+    visit "/t/999999999999"
+    expect(page).not_to have_css("body.no-ember")
+    expect(page).to have_css("#site-logo")
+    expect(page).to have_css("div.page-not-found")
+  end
+end


### PR DESCRIPTION
- Fix the readonly mode checking to avoid empty strings being passed (the `check_readonly_mode` before_action will not execute in the case of these re-dispatched exceptions)

Partial backport of bca855f2396998943d52545fd9d59dc0d3da3183