### PR TITLE
DEV: supports inline for d-menu

### DIFF
--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -69,6 +69,7 @@ export const MENU = {
     onShow: null,
     onRegisterApi: null,
     modalForMobile: false,
+    inline: null,
   },
   portalOutletId: "d-menu-portal-outlet",
 };


### PR DESCRIPTION
`<DMenu @inline={{true}} ...>...</DMenu>` will render the body relative to the trigger instead of rendering it in a portal.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
