### PR TITLE
PERF: introduce a basic api key serializer

### DIFF
--- a/app/controllers/admin/api_controller.rb
+++ b/app/controllers/admin/api_controller.rb
@@ -13,12 +13,16 @@ class Admin::ApiController < Admin::AdminController
     keys =
       ApiKey
         .where(hidden: false)
-        .includes(:user, :api_key_scopes)
+        .includes(:user)
         .order("revoked_at DESC NULLS FIRST, created_at DESC")
         .offset(offset)
         .limit(limit)
 
-    render_json_dump(keys: serialize_data(keys, ApiKeySerializer), offset: offset, limit: limit)
+    render_json_dump(
+      keys: serialize_data(keys, BasicApiKeySerializer),
+      offset: offset,
+      limit: limit,
+    )
   end
 
   def show

--- a/app/serializers/basic_api_key_serializer.rb
+++ b/app/serializers/basic_api_key_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BasicApiKeySerializer < ApplicationSerializer
+  attributes :id, :truncated_key, :description, :created_at, :last_used_at, :revoked_at
+
+  has_one :user, serializer: BasicUserSerializer, embed: :objects
+end


### PR DESCRIPTION
For better performances when listing all the API keys.

Loading all the "api key scopes" is slow and not required when showing the list of all the api keys.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
