### PR TITLE
FIX: ensures we close modal on reaction

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -64,6 +64,12 @@ export default class ChatMessageActionsMobile extends Component {
   }
 
   @action
+  react(name, operation) {
+    this.args.closeModal();
+    this.messageInteractor.react(name, operation);
+  }
+
+  @action
   openEmojiPicker(_, event) {
     this.args.closeModal();
     this.messageInteractor.openEmojiPicker(_, event);
@@ -115,7 +121,7 @@ export default class ChatMessageActionsMobile extends Component {
                 {{#each this.messageInteractor.emojiReactions as |reaction|}}
                   <ChatMessageReaction
                     @reaction={{reaction}}
-                    @onReaction={{this.messageInteractor.react}}
+                    @onReaction={{this.react}}
                     @message={{this.message}}
                     @showCount={{false}}
                   />


### PR DESCRIPTION
It's important to close the modal or we will just remove it from screen without calling callbacks, which will cause the body to be locked on iOS.

It's hard to test this behavior, as it only happens on iOS and the modal will disappear anyways, it's only a matter of ensuring it's closed correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
