### PR TITLE
FIX: build chat message excerpt for thread preview

### DIFF
--- a/plugins/chat/app/models/chat/null_message.rb
+++ b/plugins/chat/app/models/chat/null_message.rb
@@ -6,7 +6,7 @@ module Chat
       nil
     end
 
-    def excerpt(max_length: nil)
+    def build_excerpt
       nil
     end
 

--- a/plugins/chat/app/serializers/chat/thread_original_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_original_message_serializer.rb
@@ -12,6 +12,10 @@ module Chat
                :mentioned_users,
                :user
 
+    def excerpt
+      object.excerpt || object.build_excerpt
+    end
+
     def mentioned_users
       object
         .user_mentions

--- a/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_preview_serializer.rb
@@ -28,7 +28,7 @@ module Chat
     end
 
     def last_reply_excerpt
-      object.last_message.excerpt
+      object.last_message.excerpt || object.last_message.build_excerpt
     end
 
     def last_reply_user

--- a/plugins/chat/spec/models/chat/null_message_spec.rb
+++ b/plugins/chat/spec/models/chat/null_message_spec.rb
@@ -9,9 +9,9 @@ describe Chat::NullMessage do
     end
   end
 
-  describe "#excerpt" do
+  describe "#build_excerpt" do
     it "returns nil" do
-      expect(null_message.excerpt(max_length: 1)).to be_nil
+      expect(null_message.build_excerpt).to be_nil
     end
   end
 

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -137,6 +137,15 @@ describe "Thread indicator for chat messages", type: :system do
       ).to have_content(thread_excerpt(thread_1.last_message.reload))
     end
 
+    it "builds an excerpt for the last reply if it doesn’t have one" do
+      thread_1.last_message.update!(excerpt: nil)
+      chat_page.visit_channel(channel)
+
+      expect(
+        channel_page.message_thread_indicator(thread_1.original_message).excerpt,
+      ).to have_content(thread_1.last_message.build_excerpt)
+    end
+
     it "updates the last reply excerpt and participants when a new message is added to the thread" do
       new_user = Fabricate(:user)
       chat_system_user_bootstrap(user: new_user, channel: channel)

--- a/plugins/chat/spec/system/thread_list/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_list/full_page_spec.rb
@@ -111,6 +111,15 @@ describe "Thread list in side panel | full page", type: :system do
       )
     end
 
+    it "builds an excerpt for the original message if it doesn’t have one" do
+      thread_1.original_message.update!(excerpt: nil)
+      chat_page.visit_threads_list(channel)
+
+      expect(thread_list_page.item_by_id(thread_1.id)).to have_content(
+        thread_1.original_message.build_excerpt,
+      )
+    end
+
     it "doesn’t show the thread original message user avatar" do
       chat_page.visit_threads_list(channel)
 


### PR DESCRIPTION
Follow up to #26712 to account for older threads that don't have a persisted excerpt, as this was previously generated on every page load.

This change allows us to build the excerpt on the fly when none exists, fixing the issue of missing message excerpts for thread previews (within channel) and thread lists (on mobile/desktop).