### PR TITLE
FIX: relative picker was being reset on change

### DIFF
--- a/app/assets/javascripts/discourse/app/components/time-shortcut-picker.hbs
+++ b/app/assets/javascripts/discourse/app/components/time-shortcut-picker.hbs
@@ -1,5 +1,5 @@
 <TapTileGrid @activeTile={{this.selectedShortcut}} as |grid|>
-  {{#each this.options as |option|}}
+  {{#each this.options key="id" as |option|}}
     {{#unless option.hidden}}
       <TapTile
         @icon={{option.icon}}

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -116,6 +116,19 @@ describe "Bookmarking posts and topics", type: :system do
         expect(bookmark.reload.name).to eq("something important")
       end
     end
+
+    it "allows to set a relative time" do
+      bookmark = Fabricate(:bookmark, bookmarkable: topic, user: current_user)
+      topic_page.visit_topic(topic)
+      topic_page.click_topic_bookmark_button
+      bookmark_menu.click_menu_option("edit")
+      bookmark_modal.select_relative_time_duration(10)
+      bookmark_modal.select_relative_time_interval("days")
+
+      expect(bookmark_modal.custom_time_picker.value).to eq(
+        bookmark.reminder_at_in_zone(timezone).strftime("%H:%M"),
+      )
+    end
   end
 
   describe "editing existing bookmarks" do

--- a/spec/system/page_objects/modals/bookmark.rb
+++ b/spec/system/page_objects/modals/bookmark.rb
@@ -39,6 +39,16 @@ module PageObjects
         has_css?(".bookmark-options-panel")
       end
 
+      def select_relative_time_duration(duration)
+        find("#bookmark-relative-time-picker").fill_in(with: duration)
+      end
+
+      def select_relative_time_interval(interval)
+        select_kit = PageObjects::Components::SelectKit.new(".relative-time-intervals")
+        select_kit.expand
+        select_kit.select_row_by_value(interval)
+      end
+
       def select_auto_delete_preference(preference)
         select_kit = PageObjects::Components::SelectKit.new("#bookmark-auto-delete-preference")
         select_kit.expand


### PR DESCRIPTION
A change in relative picker was causing a serie of events which ultimately would cause the whole list of time options to be reset and re-rendered which would cause a new instance of the picker to be created, causing a reset.

The fix is using id in the each loop to help ember identify that it doesn’t have to re-render a specific component.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
