### PR TITLE
FIX: do not increment reply count manually

### DIFF
--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -93,7 +93,7 @@ module Chat
           type: :update_thread_original_message,
           original_message_id: thread.original_message_id,
           thread_id: thread.id,
-          channe_id: thread.channel.id,
+          channel_id: thread.channel.id,
           preview: preview.as_json,
         },
       )

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -93,6 +93,7 @@ module Chat
           type: :update_thread_original_message,
           original_message_id: thread.original_message_id,
           thread_id: thread.id,
+          channe_id: thread.channel.id,
           preview: preview.as_json,
         },
       )

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -92,6 +92,7 @@ module Chat
         {
           type: :update_thread_original_message,
           original_message_id: thread.original_message_id,
+          thread_id: thread.id,
           preview: preview.as_json,
         },
       )

--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -61,13 +61,19 @@ export default class UserThreads extends Component {
 
     this.messageBus.subscribe(
       `/chat/${channel.id}`,
-      (data) => this.onMessage(data, channel),
+      this.onMessage,
       channel.channelMessageBusLastId
     );
   }
 
-  onMessage(data, channel) {
+  onMessage(data) {
     if (data.type === "update_thread_original_message") {
+      const channel = this.trackedChannels[data.channel_id];
+
+      if (!channel) {
+        return;
+      }
+
       const thread = channel.threadsManager.threads.find(
         (t) => t.id === data.thread_id
       );

--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -9,16 +9,30 @@ import List from "discourse/plugins/chat/discourse/components/chat/list";
 import ThreadIndicator from "discourse/plugins/chat/discourse/components/chat-message-thread-indicator";
 import ThreadTitle from "discourse/plugins/chat/discourse/components/thread-title";
 import ThreadPreview from "discourse/plugins/chat/discourse/components/user-threads/preview";
+import ChatThreadPreview from "discourse/plugins/chat/discourse/models/chat-thread-preview";
 
 export default class UserThreads extends Component {
   @service chat;
   @service chatApi;
   @service chatChannelsManager;
+  @service messageBus;
   @service site;
+
+  trackedChannels = {};
 
   @cached
   get threadsCollection() {
     return this.chatApi.userThreads(this.handleLoadedThreads);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+
+    Object.keys(this.trackedChannels).forEach((id) => {
+      this.messageBus.unsubscribe(`/chat/${id}`, this.onMessage);
+    });
+
+    this.trackedChannels = {};
   }
 
   @bind
@@ -32,8 +46,36 @@ export default class UserThreads extends Component {
         thread.tracking.mentionCount = tracking.mention_count;
         thread.tracking.unreadCount = tracking.unread_count;
       }
+
+      this.trackChannel(thread.channel);
       return thread;
     });
+  }
+
+  trackChannel(channel) {
+    if (this.trackedChannels[channel.id]) {
+      return;
+    }
+
+    this.trackedChannels[channel.id] = channel;
+
+    this.messageBus.subscribe(
+      `/chat/${channel.id}`,
+      (data) => this.onMessage(data, channel),
+      channel.channelMessageBusLastId
+    );
+  }
+
+  onMessage(data, channel) {
+    if (data.type === "update_thread_original_message") {
+      const thread = channel.threadsManager.threads.find(
+        (t) => t.id === data.thread_id
+      );
+
+      if (thread) {
+        thread.preview = ChatThreadPreview.create(data.preview);
+      }
+    }
   }
 
   <template>

--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/index.gjs
@@ -66,6 +66,7 @@ export default class UserThreads extends Component {
     );
   }
 
+  @bind
   onMessage(data) {
     if (data.type === "update_thread_original_message") {
       const channel = this.trackedChannels[data.channel_id];

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
@@ -1,6 +1,5 @@
 import { tracked } from "@glimmer/tracking";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
-import User from "discourse/models/user";
 
 export default class ChatThreadPreview {
   static create(args = {}) {

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
@@ -37,16 +37,4 @@ export default class ChatThreadPreview {
   get otherParticipantCount() {
     return this.participantCount - this.participantUsers.length;
   }
-
-  updateFromMessageObject(messageObject) {
-    const user = User.create(messageObject.user);
-    if (!this.participantUsers.find((u) => u.id === user.id)) {
-      this.participantUsers.push(user);
-      this.participantCount += 1;
-    }
-    this.lastReplyAt = messageObject.created_at;
-    this.lastReplyId = messageObject.id;
-    this.lastReplyExcerpt = messageObject.excerpt;
-    this.lastReplyUser = user;
-  }
 }

--- a/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-thread-preview.js
@@ -44,7 +44,6 @@ export default class ChatThreadPreview {
       this.participantUsers.push(user);
       this.participantCount += 1;
     }
-    this.replyCount += 1;
     this.lastReplyAt = messageObject.created_at;
     this.lastReplyId = messageObject.id;
     this.lastReplyExcerpt = messageObject.excerpt;

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -267,7 +267,6 @@ export default class ChatSubscriptionsManager extends Service {
                   busData.thread_id,
                   busData.message.created_at
                 );
-                thread.preview.updateFromMessageObject(busData.message);
                 thread.tracking.unreadCount++;
                 this._updateActiveLastViewedAt(channel);
               }

--- a/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
+++ b/plugins/chat/spec/system/reply_to_message/smoke_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe "Reply to message - smoke", type: :system do
       end
 
       thread_page.send_message("user1reply")
-      expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(1)
+
       expect(thread_page.messages).to have_message(text: "user1reply")
+      expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(1)
 
       using_session(:user_2) do |session|
         expect(thread_page.messages).to have_message(text: "user1reply")
@@ -50,7 +51,7 @@ RSpec.describe "Reply to message - smoke", type: :system do
 
       expect(thread_page.messages).to have_message(text: "user1reply")
       expect(thread_page.messages).to have_message(text: "user2reply")
-      expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(3)
+      expect(channel_page.message_thread_indicator(original_message)).to have_reply_count(2)
     end
   end
 end

--- a/plugins/chat/spec/system/user_threads_spec.rb
+++ b/plugins/chat/spec/system/user_threads_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe "User threads", type: :system do
     it "updates the thread when another user replies" do
       chat_thread_chain_bootstrap(channel: channel_1, users: [current_user, Fabricate(:user)])
       thread = channel_1.threads.last
-      message = thread.original_message
       last_user = Fabricate(:user)
 
       chat_page.visit_user_threads
@@ -126,7 +125,6 @@ RSpec.describe "User threads", type: :system do
       last_message = Fabricate(:chat_message, thread: thread, user: last_user, use_service: true)
 
       indicator = PageObjects::Components::Chat::ThreadIndicator.new(".c-user-thread")
-
       expect(indicator).to have_reply_count(4)
       expect(indicator).to have_participant(last_user)
       expect(indicator).to have_excerpt(last_message.excerpt)


### PR DESCRIPTION
That could cause flakeyness in specs depending in which timing message bus would arrive and it's not necessary as it should be update with `handleThreadOriginalMessageUpdate`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
