### PR TITLE
FIX: ensures we don't exit without pending automations

### DIFF
--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -31,7 +31,7 @@ module DiscourseAutomation
         if previous_start_date != start_date || previous_interval != interval ||
              previous_frequency != frequency
           automation.pending_automations.destroy_all
-        else
+        elsif automation.pending_automations.present?
           return
         end
 

--- a/plugins/automation/spec/triggers/recurring_spec.rb
+++ b/plugins/automation/spec/triggers/recurring_spec.rb
@@ -119,6 +119,16 @@ describe "Recurring" do
         }.to_not change { DiscourseAutomation::PendingAutomation.last.execute_at }
         expect(DiscourseAutomation::PendingAutomation.count).to eq(1)
       end
+
+      context "when there are no existing pending automations" do
+        before { automation.pending_automations.destroy_all }
+
+        it "creates a new one" do
+          expect {
+            automation.upsert_field!("test", "text", { value: "somethingelse" }, target: "script")
+          }.to change { DiscourseAutomation::PendingAutomation.count }.by(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This case is not supposed to happen but it seems safer to ensure this case will recreate pending automations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
