### PR TITLE
FIX: ensures last read is updated on new message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -491,7 +491,7 @@ export default class ChatChannel extends Component {
     } else {
       this.chatChannelScrollPositions.set(
         this.args.channel.id,
-        state.lastVisibleId
+        state.firstVisibleId
       );
     }
   }

--- a/plugins/chat/assets/javascripts/discourse/helpers/first-visible-message-id.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/first-visible-message-id.js
@@ -1,0 +1,20 @@
+import { checkMessageBottomVisibility } from "discourse/plugins/chat/discourse/lib/check-message-visibility";
+
+export default function firstVisibleMessageId(container) {
+  let _found;
+  const messages = container.querySelectorAll(
+    ":scope .chat-messages-container > [data-id]"
+  );
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+
+    if (checkMessageBottomVisibility(container, message)) {
+      _found = message;
+      break;
+    }
+  }
+
+  const id = _found?.dataset?.id;
+  return id ? parseInt(id, 10) : null;
+}

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
@@ -54,7 +54,7 @@ export default class ChatScrollableList extends Modifier {
     this.scrollTimer = discourseLater(() => {
       this.options.onScrollEnd?.(
         Object.assign(this.computeState(), {
-          lastVisibleId: firstVisibleMessageId(this.element),
+          firstVisibleId: firstVisibleMessageId(this.element),
         })
       );
     }, this.options.delay || 250);

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
@@ -3,7 +3,7 @@ import { cancel, throttle } from "@ember/runloop";
 import Modifier from "ember-modifier";
 import discourseLater from "discourse-common/lib/later";
 import { bind } from "discourse-common/utils/decorators";
-import { checkMessageBottomVisibility } from "discourse/plugins/chat/discourse/lib/check-message-visibility";
+import firstVisibleMessageId from "discourse/plugins/chat/discourse/helpers/first-visible-message-id";
 
 const UP = "up";
 const DOWN = "down";
@@ -136,21 +136,6 @@ export default class ChatScrollableList extends Modifier {
   }
 
   computeFirstVisibleMessageId() {
-    let firstVisibleMessage;
-    const messages = this.element.querySelectorAll(
-      ":scope .chat-messages-container > [data-id]"
-    );
-
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-
-      if (checkMessageBottomVisibility(this.element, message)) {
-        firstVisibleMessage = message;
-        break;
-      }
-    }
-
-    const id = firstVisibleMessage?.dataset?.id;
-    return id ? parseInt(id, 10) : null;
+    return firstVisibleMessageId(this.element);
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
+++ b/plugins/chat/assets/javascripts/discourse/modifiers/chat/scrollable-list.js
@@ -54,7 +54,7 @@ export default class ChatScrollableList extends Modifier {
     this.scrollTimer = discourseLater(() => {
       this.options.onScrollEnd?.(
         Object.assign(this.computeState(), {
-          lastVisibleId: this.computeFirstVisibleMessageId(),
+          lastVisibleId: firstVisibleMessageId(this.element),
         })
       );
     }, this.options.delay || 250);
@@ -133,9 +133,5 @@ export default class ChatScrollableList extends Modifier {
     }
 
     return this.element.scrollTop < this.lastScrollTop ? UP : DOWN;
-  }
-
-  computeFirstVisibleMessageId() {
-    return firstVisibleMessageId(this.element);
   }
 }

--- a/plugins/chat/spec/system/update_last_read_spec.rb
+++ b/plugins/chat/spec/system/update_last_read_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Update last read", type: :system do
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:chat_channel) }
-  fab!(:first_unread) { Fabricate(:chat_message, chat_channel: channel_1) }
+  fab!(:messages) { Fabricate.times(15, :chat_message, chat_channel: channel_1) }
 
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
@@ -12,21 +12,27 @@ RSpec.describe "Update last read", type: :system do
   before do
     chat_system_bootstrap
     channel_1.add(current_user)
-    membership.update!(last_read_message_id: first_unread.id)
-    Fabricate.times(25, :chat_message, chat_channel: channel_1)
+
+    membership.update!(last_read_message_id: messages.last.id)
     sign_in(current_user)
   end
 
   context "when the full message is visible" do
-    xit "marks it as read" do
+    it "marks it as read" do
       last_message = Fabricate(:chat_message, chat_channel: channel_1)
       chat_page.visit_channel(channel_1)
 
-      try_until_success do
-        page.execute_script("document.querySelector('.chat-messages-scroller').scrollTo(0, 1)")
-        page.execute_script("document.querySelector('.chat-messages-scroller').scrollTo(0, 0)")
-        expect(membership.reload.last_read_message_id).to eq(last_message.id)
-      end
+      try_until_success { expect(membership.reload.last_read_message_id).to eq(last_message.id) }
+    end
+  end
+
+  context "when receiving a messages" do
+    it "marks it as read" do
+      chat_page.visit_channel(channel_1)
+
+      last_message = Fabricate(:chat_message, chat_channel: channel_1, use_service: true)
+
+      try_until_success { expect(membership.reload.last_read_message_id).to eq(last_message.id) }
     end
   end
 


### PR DESCRIPTION
In a recent commit we moved the computation of last read id into the scroll events, however, we disable scroll events when scroll happens through a new received messages, meaning that we wouldn't update last read in this case even if we should when you are at the bottom of the channel.

This commit now synchronously check the first visible message on `updateLastRead` which should ensure it's always correct.

Few tests have been added to test this behavior, and the visibility check has been extracted to a helper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
