### PR TITLE
UX: enable_powered_by_discourse site setting default is true

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2854,7 +2854,7 @@ uncategorized:
   share_anonymized_statistics: true
 
   enable_powered_by_discourse:
-    default: false
+    default: true
     client: true
 
   auto_handle_queued_age:


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
