### PR TITLE
fix: confusing comment

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -9,7 +9,7 @@
 # 1. You can do nothing and get these defaults (not recommended, you should at least set hostname)
 # 2. You can copy this file to config/discourse.conf and amend with your settings
 # 3. You can pass in config from your environment, all the settings below are available.
-#    Append DISCOURSE_ and upper case the setting in ENV. For example:
+#    Prepend DISCOURSE_ and upper case the setting in ENV. For example:
 #    to pass in db_pool of 200 you would use DISCOURSE_DB_POOL=200
 
 # All settings apply to production only


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Test coverage is omitted because I only changed a comment. The correct procedure is clearly to _prepend_ `DISCOURSE_` to the setting name, as shown in the example. Appending would result in nonsensical environment variable names like `DB_HOSTDISCOURSE_`.