### PR TITLE
FIX: correctly rename scroller everywhere

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -747,6 +747,7 @@ export default class ChatChannel extends Component {
             @channel={{@channel}}
             @uploadDropZone={{this.uploadDropZone}}
             @onSendMessage={{this.onSendMessage}}
+            @scroller={{this.scroller}}
           />
         {{/if}}
       {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -145,7 +145,7 @@ export default class ChatComposer extends Component {
 
   @action
   setup() {
-    this.composer.scrollable = this.args.scrollable;
+    this.composer.scroller = this.args.scroller;
     this.appEvents.on("chat:modify-selection", this, "modifySelection");
     this.appEvents.on(
       "chat:open-insert-link-modal",

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -578,6 +578,7 @@ export default class ChatThread extends Component {
           @thread={{@thread}}
           @onSendMessage={{this.onSendMessage}}
           @uploadDropZone={{this.uploadDropZone}}
+          @scroller={{this.scroller}}
         />
       {{/if}}
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-composer.js
@@ -16,7 +16,7 @@ export default class ChatChannelComposer extends Service {
   @service site;
 
   @tracked textarea;
-  @tracked scrollable;
+  @tracked scroller;
 
   init() {
     super.init(...arguments);
@@ -34,7 +34,7 @@ export default class ChatChannelComposer extends Service {
 
     schedule("afterRender", () => {
       if (this.capabilities.isIOS && !this.capabilities.isIpadOS) {
-        disableBodyScroll(this.scrollable, { reverse: true });
+        disableBodyScroll(this.scroller, { reverse: true });
       }
     });
   }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-thread-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-thread-composer.js
@@ -11,7 +11,7 @@ export default class ChatThreadComposer extends Service {
   @service site;
 
   @tracked textarea;
-  @tracked scrollable;
+  @tracked scroller;
 
   init() {
     super.init(...arguments);
@@ -29,7 +29,7 @@ export default class ChatThreadComposer extends Service {
 
     schedule("afterRender", () => {
       if (this.capabilities.isIOS && !this.capabilities.isIpadOS) {
-        disableBodyScroll(this.scrollable, { reverse: true });
+        disableBodyScroll(this.scroller, { reverse: true });
       }
     });
   }


### PR DESCRIPTION
Scrollable has been renamed to scroller in https://github.com/discourse/discourse/commit/52e8d57293edaa7914a644677ca54e4993e85895 but some places were forget.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
