### PR TITLE
DEV: fix flaky admin_customize_themes spec

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -53,7 +53,7 @@ describe "Admin Customize Themes", type: :system do
     end
 
     it "switching between themes and components tabs keeps the search visible only if both tabs have at least 10 items" do
-      6.times { Fabricate(:theme) }
+      (1..6).each { |number| Fabricate(:theme, component: false, name: "Cool theme #{number}") }
       (1..5).each { |number| Fabricate(:theme, component: true, name: "Cool component #{number}") }
 
       visit("/admin/customize/themes")


### PR DESCRIPTION
Because spec is searching for "5", we need to be sure that "Cool theme 5" is created.

