### PR TITLE
UX: Fix report color duplication

### DIFF
--- a/app/models/concerns/reports/consolidated_page_views_browser_detection.rb
+++ b/app/models/concerns/reports/consolidated_page_views_browser_detection.rb
@@ -60,7 +60,7 @@ module Reports::ConsolidatedPageViewsBrowserDetection
           req: "page_view_crawler",
           label:
             I18n.t("reports.consolidated_page_views_browser_detection.xaxis.page_view_crawler"),
-          color: report.colors[2],
+          color: report.colors[3],
           data: data.map { |row| { x: row.date, y: row.page_view_crawler } },
         },
         {


### PR DESCRIPTION
In the "Consolidated Pageviews with Browser Detection (Experimental)"
report we used the same color for "Known Crawler" and "Other pageviews"
which makes the report confusing to look at, this commit makes them
different.
