### PR TITLE
UX: admin sidebar headings are bold

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_revamp.scss
+++ b/app/assets/stylesheets/common/admin/admin_revamp.scss
@@ -28,4 +28,7 @@
 
 .admin-area .sidebar-wrapper {
   background-color: var(--d-sidebar-admin-background);
+  .sidebar-section-header-text {
+    font-weight: bold;
+  }
 }


### PR DESCRIPTION
Make admin sidebar headings bold.

Admin screenshot
<img width="1456" alt="Screenshot 2024-04-29 at 4 17 20 PM" src="https://github.com/discourse/discourse/assets/72780/63920b63-a498-4614-b6b9-ece7a24e6bda">


Original sidebar headers are untouched
<img width="1449" alt="Screenshot 2024-04-29 at 4 17 38 PM" src="https://github.com/discourse/discourse/assets/72780/354f3527-e04f-4b04-87f5-27d5676a6b3b">
