### PR TITLE
FIX: prevent duplicate attachments in incoming emails - take 2

### DIFF
--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -766,6 +766,19 @@ RSpec.describe Email::Receiver do
       expect(topic.posts.last.raw).not_to match %r{upload://}
     end
 
+    it "tries not to repeat duplicate secure attachments" do
+      setup_s3
+      stub_s3_store
+      SiteSetting.secure_uploads = true
+      SiteSetting.authorized_extensions = "jpg"
+
+      expect { process(:logo_1) }.to change { UploadReference.count }.by(1)
+      expect(topic.posts.last.raw).to match %r{upload://}
+
+      expect { process(:logo_2) }.not_to change { UploadReference.count }
+      expect(topic.posts.last.raw).not_to match %r{upload://}
+    end
+
     it "works with removed attachments" do
       SiteSetting.authorized_extensions = "jpg"
 


### PR DESCRIPTION
This is a follow up of https://github.com/discourse/discourse/commit/5fcb7c262ddfff0a8f0a08d0a8eb90a942122721

It was missing the case where secure uploads is enabled, which creates a copy of the upload no matter what. Thus creating a new Upload record even if the sha is already present in the table.

So this checks for the original_sha1 of the uploads as well when checking for duplicates.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
