### PR TITLE
UX: show disclaimer on account creation unconditionally

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.js
@@ -151,12 +151,10 @@ export default class CreateAccount extends Component.extend(
 
   @discourseComputed
   disclaimerHtml() {
-    if (this.site.tos_url && this.site.privacy_policy_url) {
-      return I18n.t("create_account.disclaimer", {
-        tos_link: this.site.tos_url,
-        privacy_link: this.site.privacy_policy_url,
-      });
-    }
+    return I18n.t("create_account.disclaimer", {
+      tos_link: "/tos",
+      privacy_link: "/privacy",
+    });
   }
 
   // Check the email address


### PR DESCRIPTION
At the moment this won't appear if `tos_url` and `privacy_policy_url` are undefined... I don't believe these settings are serialized in the case of `login_required`, so the disclaimer will never appear: 

https://meta.discourse.org/t/terms-of-service-privacy-policy-agreement-notice-missing-when-forum-log-in-is-forced/305744

When these settings *are* set, `/tos` and `/privacy` redirect to the setting URL... so maybe we don't need the check at all here? 

The one case this isn't cover is when the default TOS and Privacy Policy aren't generated, which can happen if a company name isn't added to the site setup wizard. Though I wonder if the broken state is more desirable to bring an admin's attention to this issue 🤔 

Very possible this is more complicated... so feel free to close if this is an oversimplification. 