### PR TITLE
FIX: Order categories in SQL for Categories#search

### DIFF
--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1408,6 +1408,18 @@ RSpec.describe CategoriesController do
           [category4.id, category2.id, category3.id, category1.id],
         )
       end
+
+      it "returns categories in the correct order when the limit is lower than the total number of categories" do
+        categories =
+          4.times.flat_map do |i|
+            get "/categories/search.json", params: { term: "ordered", page: i + 1, limit: 1 }
+            response.parsed_body["categories"]
+          end
+
+        expect(categories.map { |c| c["id"] }).to eq(
+          [category4.id, category2.id, category3.id, category1.id],
+        )
+      end
     end
 
     it "returns user fields" do


### PR DESCRIPTION
Otherwise, the results don't make sense if the number of categories is more than the limit provided.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
