### PR TITLE
FIX: Watched Words (+ Groups) with missing action

### DIFF
--- a/db/migrate/20240430185434_fix_watched_words_without_action.rb
+++ b/db/migrate/20240430185434_fix_watched_words_without_action.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FixWatchedWordsWithoutAction < ActiveRecord::Migration[7.0]
+  def up
+    # Set "censor" action to watched words without replacement
+    execute <<~SQL
+      UPDATE watched_words
+      SET action = 2
+      WHERE action = 0
+      AND LENGTH(COALESCE(replacement, '')) = 0
+    SQL
+
+    # Set "replace" action to watched words with replacement
+    execute <<~SQL
+      UPDATE watched_words
+      SET action = 5
+      WHERE action = 0
+    SQL
+
+    # Update watched word groups with matching action
+    execute <<~SQL
+      UPDATE watched_word_groups
+      SET action = ww.action
+      FROM watched_words ww
+      WHERE ww.watched_word_group_id = watched_word_groups.id
+      AND ww.action != 0
+      AND watched_word_groups.action = 0
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This defaults the action to

- Censor if there are no "replacement"
- Replace if there's a "replacement"

It also fixes the `WatchedWordGroups` action to the action of one of their `WatchedWords`

We unfortunately don't have enough data to restore to correct action, so use the one that is the least disruptive.

Follow up to https://github.com/discourse/discourse/commit/e7d0083dbe4ffe84a8d6645cde248d6a2beac155 which fixes an issue introduced in https://github.com/discourse/discourse/commit/143f06f2c600bc9aa94c4d64ca84cd9a06b75b9e.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
