### PR TITLE
DEV: Add `autofocus` option to d-menu

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -242,4 +242,17 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
 
     assert.dom(".fk-d-menu").doesNotExist();
   });
+
+  test("@autofocus", async function (assert) {
+    await render(hbs`
+      <DMenu @inline={{true}} @autofocus={{true}}>
+        <:content>
+          <DButton class="my-button" />
+        </:content>
+      </DMenu>
+    `);
+    await open();
+
+    assert.dom(document.activeElement).hasClass("my-button");
+  });
 });

--- a/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
@@ -63,7 +63,7 @@ export default class DFloatBody extends Component {
         aria-expanded={{if @instance.expanded "true" "false"}}
         role={{@role}}
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
-        {{(if @trapTab (modifier TrapTab autofocus=false))}}
+        {{(if @trapTab (modifier TrapTab autofocus=this.options.autofocus))}}
         {{(if
           this.supportsCloseOnClickOutside
           (modifier FloatKitCloseOnClickOutside this.trigger @instance.close)

--- a/app/assets/javascripts/float-kit/addon/lib/constants.js
+++ b/app/assets/javascripts/float-kit/addon/lib/constants.js
@@ -46,6 +46,7 @@ export const MENU = {
   options: {
     animated: true,
     arrow: false,
+    autofocus: false,
     beforeTrigger: null,
     closeOnEscape: true,
     closeOnClickOutside: true,


### PR DESCRIPTION
(to be used by the glimmer replacement of topic-entrance component)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
