### PR TITLE
FIX: add excerpt fallback for chat message replies

### DIFF
--- a/plugins/chat/app/serializers/chat/in_reply_to_serializer.rb
+++ b/plugins/chat/app/serializers/chat/in_reply_to_serializer.rb
@@ -10,5 +10,9 @@ module Chat
     def user
       object.user || Chat::NullUser.new
     end
+
+    def excerpt
+      object.excerpt || object.build_excerpt
+    end
   end
 end

--- a/plugins/chat/spec/serializer/chat/in_reply_to_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/in_reply_to_serializer_spec.rb
@@ -30,5 +30,10 @@ RSpec.describe Chat::InReplyToSerializer do
     it "censors words" do
       expect(serializer.as_json[:excerpt]).to eq("ok ■■■■■")
     end
+
+    it "builds an excerpt for replied to message if it doesn’t have one" do
+      message.update!(excerpt: nil)
+      expect(serializer.as_json[:excerpt]).to eq(message.build_excerpt)
+    end
   end
 end


### PR DESCRIPTION
This was missed from #26765, this fixes an issue of missing excerpts for older messages when threads are disabled for a chat channel and a user has already replied to an older message. We previously addressed this for new message replies but this is a separate case when the reply has been sent.