### PR TITLE
DEV: Add `after-header-panel` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -56,6 +56,12 @@ export default class Contents extends Component {
         />
       </div>
       <div class="panel" role="navigation">{{yield}}</div>
+      <div class="after-header-panel-outlet">
+        <PluginOutlet
+          @name="after-header-panel"
+          @outletArgs={{hash topic=this.header.topic}}
+        />
+      </div>
     </div>
   </template>
 }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
