### PR TITLE
DEV: Use safer SQL functions for string queries in CategoryHashTagDataSource

### DIFF
--- a/app/services/category_hashtag_data_source.rb
+++ b/app/services/category_hashtag_data_source.rb
@@ -60,10 +60,13 @@ class CategoryHashtagDataSource
         .includes(:parent_category)
 
     if condition == HashtagAutocompleteService.search_conditions[:starts_with]
-      base_search = base_search.where("LOWER(slug) LIKE :term", term: "#{term}%")
+      base_search = base_search.where("starts_with(LOWER(slug), LOWER(:term))", term: term)
     elsif condition == HashtagAutocompleteService.search_conditions[:contains]
       base_search =
-        base_search.where("LOWER(name) LIKE :term OR LOWER(slug) LIKE :term", term: "%#{term}%")
+        base_search.where(
+          "position(LOWER(:term) IN LOWER(name)) <> 0 OR position(LOWER(:term) IN LOWER(slug)) <> 0",
+          term: term,
+        )
     else
       raise Discourse::InvalidParameters.new("Unknown search condition: #{condition}")
     end


### PR DESCRIPTION
Instead of `LIKE`, use either `starts_with` or `position`. This way the term isn't interpreted as a pattern.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
