### PR TITLE
DEV: Backport `after-header-panel` plugin outlet to widget header

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/after-header-panel-outlet.js
+++ b/app/assets/javascripts/discourse/app/widgets/after-header-panel-outlet.js
@@ -1,0 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
+import { registerWidgetShim } from "discourse/widgets/render-glimmer";
+
+registerWidgetShim(
+  "after-header-panel-outlet",
+  "div.after-header-panel-outlet",
+  hbs`<PluginOutlet @name="after-header-panel" @outletArgs={{hash topic=@data.topic}} /> `
+);

--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -30,5 +30,7 @@ createWidget("header-contents", {
     {{before-header-panel-outlet attrs=attrs}}
 
     <div class="panel" role="navigation">{{yield}}</div>
+
+    {{after-header-panel-outlet attrs=attrs}}
   `,
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
