### PR TITLE
Suggest "reply by email address" is incorrect, if emails are failing

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -198,6 +198,7 @@ task "emails:test", [:email] => [:environment] do |_, args|
   rescue => error
     puts "Sending mail failed."
     puts error.message
+    puts "Maybe \"reply by email address\" is incorrect"
   end
 
   puts <<~TEXT if SiteSetting.disable_emails != "no"


### PR DESCRIPTION
I spent 4 hours digging through code this morning, because of a typo when setting up reply by email.

The Mail gem only reports the last error in the SMTP interaction, which is always "Too many errors" so I dug into `vendor/bundle/ruby/3.2.0/gems/net-smtp-0.5.0/lib/net/smtp.rb` and added `puts reqline` in `get_ok()`, and `puts res.string` in `check_response()` so I can see the exchange, where I found that it was trying to send from the address with the typo.

It would be really good if there was a way to see that kind of detail (or at least the previous error not just "too many errors"), but at least here is a tiny suggestion that might help anyone else who messes up like I did

Shouldn't need any testing, it's just a puts statment in the doctor