### PR TITLE
DEV: Fix admin sidebar filter flaky

### DIFF
--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -129,12 +129,12 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     filter.filter("bevelaqua")
     find(".sidebar-additional-filter-users").click
     expect(page).to have_current_path("/admin/users/list/active?username=bevelaqua")
-    within(".users-list-container") { expect(page).to have_content("bevelaqua") }
+    expect(find(".users-list-container")).to have_content("bevelaqua")
 
     filter.filter("moltisanti")
     find(".sidebar-additional-filter-users").click
     expect(page).to have_current_path("/admin/users/list/active?username=moltisanti")
-    within(".users-list-container") { expect(page).to have_content("moltisanti") }
+    expect(find(".users-list-container")).to have_content("moltisanti")
   end
 
   it "allows sections to be expanded" do


### PR DESCRIPTION
`within` is the devil, let's try this fix to
followup 79cccaf61fe5ab23f0305464919d03edeab33023
and prevent `Selenium::WebDriver::Error::StaleElementReferenceError`
