### PR TITLE
DEV: allows to disable strip_whitespaces in messages

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -96,9 +96,6 @@ module Chat
     def self.polymorphic_class_mapping = { "ChatMessage" => Chat::Message }
 
     def validate_message
-      self.message =
-        TextCleaner.clean(self.message, strip_whitespaces: true, strip_zero_width_spaces: true)
-
       WatchedWordsValidator.new(attributes: [:message]).validate(self)
 
       if self.new_record? || self.changed.include?("message")

--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -37,7 +37,7 @@ module ChatSDK
     #
     # @see #create
     def self.create_with_stream(**params, &block)
-      self.create(**params, streaming: true, &block)
+      self.create(**params, streaming: true, strip_whitespaces: false, &block)
     end
 
     # Streams to a specific chat message.
@@ -114,6 +114,7 @@ module ChatSDK
       streaming: false,
       enforce_membership: false,
       force_thread: false,
+      strip_whitespaces: false,
       &block
     )
       message =
@@ -179,6 +180,7 @@ module ChatSDK
         message: self.message.message + raw,
         guardian: self.guardian,
         streaming: true,
+        strip_whitespaces: false,
       ) { on_failure { raise "Unexpected error" } }
 
       self.message

--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -114,7 +114,7 @@ module ChatSDK
       streaming: false,
       enforce_membership: false,
       force_thread: false,
-      strip_whitespaces: false,
+      strip_whitespaces: true,
       &block
     )
       message =
@@ -129,6 +129,7 @@ module ChatSDK
           streaming: streaming,
           enforce_membership: enforce_membership,
           force_thread: force_thread,
+          strip_whitespaces: strip_whitespaces,
         ) do
           on_model_not_found(:channel) { raise "Couldn't find channel with id: `#{channel_id}`" }
           on_model_not_found(:channel_membership) do

--- a/plugins/chat/spec/lib/chat_sdk/message_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/message_spec.rb
@@ -150,8 +150,6 @@ describe ChatSDK::Message do
     fab!(:message_1) { Fabricate(:chat_message, message: "first") }
 
     it "enables streaming" do
-      initial_message = message_1.message
-
       edit =
         MessageBus
           .track_publish("/chat/#{message_1.chat_channel.id}") do
@@ -168,24 +166,22 @@ describe ChatSDK::Message do
   end
 
   describe ".stream" do
-    fab!(:message_1) { Fabricate(:chat_message, message: "first") }
+    fab!(:message_1) { Fabricate(:chat_message, message: "first\n") }
     before { message_1.update!(streaming: true) }
 
     it "streams" do
-      initial_message = message_1.message
-
       edit =
         MessageBus
           .track_publish("/chat/#{message_1.chat_channel.id}") do
             described_class.stream(
-              raw: " test",
+              raw: " test\n",
               message_id: message_1.id,
               guardian: message_1.user.guardian,
             )
           end
           .find { |m| m.data["type"] == "edit" }
 
-      expect(edit.data["chat_message"]["message"]).to eq("first test")
+      expect(edit.data["chat_message"]["message"]).to eq("first\n test\n")
       expect(message_1.reload.streaming).to eq(true)
     end
   end

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe Chat::CreateMessage do
         expect { result }.to change { Chat::Mention.count }.by(1)
       end
 
+      it "cleans the message" do
+        params[:message] = "aaaaaaa\n"
+        expect(message.message).to eq("aaaaaaa")
+      end
+
+      context "when strip_whitespace is disabled" do
+        it "doesn't strip newlines" do
+          params[:strip_whitespaces] = false
+          params[:message] = "aaaaaaa\n"
+          expect(message.message).to eq("aaaaaaa\n")
+        end
+      end
+
       context "when coming from a webhook" do
         let(:incoming_webhook) { Fabricate(:incoming_chat_webhook, chat_channel: channel) }
 


### PR DESCRIPTION
The TextCleaner step has been moved from chat message’s validation to create_message/update_message services. It allows us to easily tweak part of its behavior depending on the needs.

For example we will now disable strip_whitespaces by default when streaming messages as we want to keep newlines and spaces at the end of the message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
