### PR TITLE
PERF: Improve production JS build in low-memory environments

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -136,11 +136,18 @@ module.exports = function (defaults) {
     staticAppPaths: ["static"],
     packagerOptions: {
       webpackConfig: {
-        devtool: "source-map",
+        devtool:
+          process.env.CHEAP_SOURCE_MAPS === "1"
+            ? "cheap-source-map"
+            : "source-map",
         output: {
           publicPath: "auto",
           filename: `assets/chunk.[chunkhash].${cachebusterHash}.js`,
           chunkFilename: `assets/chunk.[chunkhash].${cachebusterHash}.js`,
+        },
+        optimization: {
+          // Disable webpack minimization. Embroider automatically applies terser after webpack.
+          minimize: false,
         },
         cache: isProduction
           ? false

--- a/app/assets/javascripts/ember-cli-progress-ci/index.js
+++ b/app/assets/javascripts/ember-cli-progress-ci/index.js
@@ -42,7 +42,7 @@ module.exports = {
     ) {
       this._sameOutputCount++;
     } else {
-      this.project.ui.writeInfoLine("..." + (text ? `[${text}]` : "."));
+      process.stderr.write("..." + (text ? `[${text}]` : ".") + "\n");
       this._sameOutputCount = 0;
     }
     this._lastText = text;

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -17,8 +17,9 @@ task "assets:precompile:build" do
     heap_size_limit = check_node_heap_size_limit
 
     if heap_size_limit < 2048
-      STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 2048MB. Setting --max-old-space-size=2048."
-      compile_command = "NODE_OPTIONS='--max-old-space-size=2048' #{compile_command}"
+      STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 2048MB. Setting --max-old-space-size=2048 and CHEAP_SOURCE_MAPS=1"
+      compile_command =
+        "JOBS=0 CI=1 NODE_OPTIONS='--max-old-space-size=2048' CHEAP_SOURCE_MAPS=1 #{compile_command}"
     end
 
     ember_env = ENV["EMBER_ENV"] || "production"


### PR DESCRIPTION
- Use 'cheap-source-map' webpack config on low-memory machines

  This results in worse quality sourcemaps in browser dev tools, but it significantly reduces memory use in our webpack build. In approximate local testing it drops from 1100mb to 590mb. This should make the rebuild process on low-memory machines much faster and less likely to trigger OOM errors.

  In development, and on higher-memory machines, the higher-quality 'source-map' option is maintained.

- Disable Webpack's built-in `minimize` feature. Embroider already applies Terser after the webpack build is complete. There is no need to double-minimize the output.

- Update ember-cli-progress-ci to print to stderr instead of stdout. For some reason, pups (used by discourse_docker) buffers the stdout of commands and only prints when they are finished. stderr does not have this same limitation, so switching will mean sysadmins can see the progress of the ember build in real-time.

Given the number of variables it's hard to promise exact numbers. But, in my tests on a DO droplet with 1GB RAM (+2GB swap), this reduced the `ember build` portion of a `./launcher rebuild app` from ~50 minutes to ~15 minutes.