### PR TITLE
DEV: manual require scheduled jobs for dev env

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -41,6 +41,13 @@ end
 require_relative "lib/chat/engine"
 
 after_initialize do
+  %w[
+    app/jobs/scheduled/chat/auto_join_users
+    app/jobs/scheduled/chat/delete_old_messages
+    app/jobs/scheduled/chat/email_notifications
+    app/jobs/scheduled/chat/periodical_updates
+  ].each { |path| require_relative path }
+
   register_seedfu_fixtures(Rails.root.join("plugins", "chat", "db", "fixtures"))
 
   UserNotifications.append_view_path(File.expand_path("../app/views", __FILE__))


### PR DESCRIPTION
Scheduled jobs are currently not eager loaded by zeitwerk in development environment. They were correctly loaded in production.

It seems we have a hack for this in core which is not applying to plugins: https://github.com/discourse/discourse/blob/a6624af66e512dcf9e08c0dd0ab8432a7c135298/config/initializers/100-sidekiq.rb#L72-L73


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
