### PR TITLE
DEV: Use safer SQL function for string queries when searching groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -638,7 +638,10 @@ class GroupsController < ApplicationController
 
     if (term = params[:term]).present?
       groups =
-        groups.where("groups.name ILIKE :term OR groups.full_name ILIKE :term", term: "%#{term}%")
+        groups.where(
+          "position(LOWER(:term) IN LOWER(groups.name)) <> 0 OR position(LOWER(:term) IN LOWER(groups.full_name)) <> 0",
+          term: term,
+        )
     end
 
     groups = groups.where(automatic: false) if params[:ignore_automatic].to_s == "true"


### PR DESCRIPTION
... so that special characters in 'term' aren't interpreted by ILIKE.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
