### PR TITLE
DEV: Update chat scheduled job loading to match skeleton

### DIFF
--- a/plugins/chat/lib/chat/engine.rb
+++ b/plugins/chat/lib/chat/engine.rb
@@ -8,8 +8,9 @@ module ::Chat
     engine_name PLUGIN_NAME
     isolate_namespace Chat
     config.autoload_paths << File.join(config.root, "lib")
+    scheduled_job_dir = "#{config.root}/app/jobs/scheduled"
     config.to_prepare do
-      Rails.autoloaders.main.eager_load_dir("#{Chat::Engine.config.root}/app/jobs/scheduled")
+      Rails.autoloaders.main.eager_load_dir(scheduled_job_dir) if Dir.exist?(scheduled_job_dir)
     end
   end
 


### PR DESCRIPTION
Followup to e949684fc54e629035b8883dabd9ef2916251da1, ref https://github.com/discourse/discourse-plugin-skeleton/pull/47

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
