### PR TITLE
FIX: Do not show bookmark button label in PM topic footer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -29,7 +29,7 @@
     {{#if (eq actionable.type "inline-button")}}
       {{#if (eq actionable.id "bookmark")}}
         <BookmarkMenu
-          @showLabel={{true}}
+          @showLabel={{this.showBookmarkLabel}}
           @bookmarkManager={{this.topicBookmarkManager}}
           @buttonClasses="btn-default"
         />

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -74,4 +74,7 @@ export default Component.extend({
   @discourseComputed("topic.message_archived")
   archiveLabel: (archived) =>
     archived ? "topic.move_to_inbox.title" : "topic.archive_message.title",
+
+  @discourseComputed("topic.isPrivateMessage")
+  showBookmarkLabel: (isPM) => !isPM,
 });

--- a/app/assets/javascripts/discourse/app/instance-initializers/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/topic-footer-buttons.js
@@ -1,10 +1,5 @@
 import ShareTopicModal from "discourse/components/modal/share-topic";
 import { registerTopicFooterButton } from "discourse/lib/register-topic-footer-button";
-import {
-  NO_REMINDER_ICON,
-  WITH_REMINDER_ICON,
-} from "discourse/models/bookmark";
-import I18n from "discourse-i18n";
 
 const SHARE_PRIORITY = 1000;
 const BOOKMARK_PRIORITY = 900;
@@ -73,53 +68,16 @@ export default {
     registerTopicFooterButton({
       dependentKeys: ["topic.bookmarked", "topic.bookmarksWereChanged"],
       id: "bookmark",
-      icon() {
-        if (this.topic.bookmarks.some((bookmark) => bookmark.reminder_at)) {
-          return WITH_REMINDER_ICON;
-        }
-        return NO_REMINDER_ICON;
-      },
       priority: BOOKMARK_PRIORITY,
-      classNames() {
-        return this.topic.bookmarked
-          ? ["bookmark", "bookmarked"]
-          : ["bookmark"];
-      },
-      label() {
-        if (!this.topic.isPrivateMessage || this.site.mobileView) {
-          if (this.topic.bookmarkCount === 0) {
-            return "bookmarked.title";
-          } else if (this.topic.bookmarkCount === 1) {
-            return "bookmarked.edit_bookmark";
-          } else {
-            return "bookmarked.clear_bookmarks";
-          }
-        }
+      action: "toggleBookmark",
+
+      // NOTE: These are null because the BookmarkMenu component is used
+      // for this button instead in the template.
+      icon() {
+        return null;
       },
       translatedTitle() {
-        if (this.topic.bookmarkCount === 0) {
-          return I18n.t("bookmarked.help.bookmark");
-        } else if (this.topic.bookmarkCount === 1) {
-          const anyTopicBookmarks = this.topic.bookmarks.some(
-            (bookmark) => bookmark.bookmarkable_type === "Topic"
-          );
-
-          if (anyTopicBookmarks) {
-            return I18n.t("bookmarked.help.edit_bookmark_for_topic");
-          } else {
-            return I18n.t("bookmarked.help.edit_bookmark");
-          }
-        } else if (
-          this.topic.bookmarks.some((bookmark) => bookmark.reminder_at)
-        ) {
-          return I18n.t("bookmarked.help.unbookmark_with_reminder");
-        } else {
-          return I18n.t("bookmarked.help.unbookmark");
-        }
-      },
-      action: "toggleBookmark",
-      dropdown() {
-        return this.site.mobileView;
+        return null;
       },
     });
 


### PR DESCRIPTION
Followup 2d2329095c38dd754f2d4ecfea1774509d25ee04

Previous to the above commit, in PMs the bookmark button
was icon-only and did not show a label. This restores the
same functionality.
