### PR TITLE
DEV: Use @bagaar/ember-breadcrumbs for admin breadcrumb navigation

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
@@ -1,9 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
-import BreadcrumbsContainer from "@bagaar/ember-breadcrumbs/components/breadcrumbs-container";
 import AdminPluginConfigArea from "./admin-plugin-config-area";
 import AdminPluginConfigMetadata from "./admin-plugin-config-metadata";
-import AdminPluginConfigTopNav from "./admin-plugin-config-top-nav";
 
 export default class AdminPluginConfigPage extends Component {
   @service currentUser;
@@ -23,15 +21,7 @@ export default class AdminPluginConfigPage extends Component {
 
   <template>
     <div class="admin-plugin-config-page">
-      {{#if this.adminPluginNavManager.isTopMode}}
-        <AdminPluginConfigTopNav />
-      {{/if}}
 
-      <BreadcrumbsContainer
-        @itemClass="breadcrumbs__item"
-        @linkClass="breadcrumbs__link"
-        class="breadcrumbs"
-      />
       <AdminPluginConfigMetadata @plugin={{@plugin}} />
 
       <div class="admin-plugin-config-page__content">

--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+import BreadcrumbsContainer from "@bagaar/ember-breadcrumbs/components/breadcrumbs-container";
 import AdminPluginConfigArea from "./admin-plugin-config-area";
 import AdminPluginConfigMetadata from "./admin-plugin-config-metadata";
 import AdminPluginConfigTopNav from "./admin-plugin-config-top-nav";
@@ -26,6 +27,11 @@ export default class AdminPluginConfigPage extends Component {
         <AdminPluginConfigTopNav />
       {{/if}}
 
+      <BreadcrumbsContainer
+        @itemClass="breadcrumbs__item"
+        @linkClass="breadcrumbs__link"
+        class="breadcrumbs"
+      />
       <AdminPluginConfigMetadata @plugin={{@plugin}} />
 
       <div class="admin-plugin-config-page__content">

--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-top-nav.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-top-nav.gjs
@@ -16,21 +16,26 @@ export default class AdminPluginConfigTopNav extends Component {
   }
 
   <template>
-    <div class="admin-controls">
-      <HorizontalOverflowNav
-        class="nav-pills action-list main-nav nav plugin-nav"
-      >
-        {{#each this.adminPluginNavManager.currentConfigNav.links as |navLink|}}
-          <NavItem
-            @route={{navLink.route}}
-            @i18nLabel={{this.linkText navLink}}
-            title={{this.linkText navLink}}
-            class="admin-plugin-config-page__top-nav-item"
-          >
-            {{this.linkText navLink}}
-          </NavItem>
-        {{/each}}
-      </HorizontalOverflowNav>
-    </div>
+    {{#if this.adminPluginNavManager.isTopMode}}
+      <div class="admin-controls">
+        <HorizontalOverflowNav
+          class="nav-pills action-list main-nav nav plugin-nav"
+        >
+          {{#each
+            this.adminPluginNavManager.currentConfigNav.links
+            as |navLink|
+          }}
+            <NavItem
+              @route={{navLink.route}}
+              @i18nLabel={{this.linkText navLink}}
+              title={{this.linkText navLink}}
+              class="admin-plugin-config-page__top-nav-item"
+            >
+              {{this.linkText navLink}}
+            </NavItem>
+          {{/each}}
+        </HorizontalOverflowNav>
+      </div>
+    {{/if}}
   </template>
 }

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
@@ -1,5 +1,16 @@
 <div class="admin-plugins-list-container">
   {{#if this.model.length}}
+    <DBreadcrumbsContainer />
+    <DBreadcrumbsItem as |linkClass|>
+      <LinkTo @route="admin" class={{linkClass}}>
+        {{i18n "admin_title"}}
+      </LinkTo>
+    </DBreadcrumbsItem>
+    <DBreadcrumbsItem as |linkClass|>
+      <LinkTo @route="adminPlugins" class={{linkClass}}>
+        {{i18n "admin.plugins.title"}}
+      </LinkTo>
+    </DBreadcrumbsItem>
     <h2>{{i18n "admin.plugins.installed"}}</h2>
     <AdminPluginsList @plugins={{this.model}} />
   {{else}}

--- a/app/assets/javascripts/admin/addon/templates/plugins-show-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-show-settings.hbs
@@ -1,3 +1,14 @@
+<DBreadcrumbsItem as |linkClass|>
+  <LinkTo
+    @route="adminPlugins.show.settings"
+    @model={{@model.plugin}}
+    class={{linkClass}}
+  >
+    {{@model.plugin.nameTitleized}}
+    {{i18n "admin.plugins.change_settings_short"}}
+  </LinkTo>
+</DBreadcrumbsItem>
+
 <div
   class="content-body admin-plugin-config-area__settings admin-detail pull-left"
 >

--- a/app/assets/javascripts/admin/addon/templates/plugins-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-show.hbs
@@ -1,3 +1,18 @@
+<AdminPluginConfigTopNav />
+
+<DBreadcrumbsContainer />
+
+<DBreadcrumbsItem as |linkClass|>
+  <LinkTo @route="admin" class={{linkClass}}>
+    {{i18n "admin_title"}}
+  </LinkTo>
+</DBreadcrumbsItem>
+<DBreadcrumbsItem as |linkClass|>
+  <LinkTo @route="adminPlugins" class={{linkClass}}>
+    {{i18n "admin.plugins.title"}}
+  </LinkTo>
+</DBreadcrumbsItem>
+
 <AdminPluginConfigPage @plugin={{this.model}}>
   {{outlet}}
 </AdminPluginConfigPage>

--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -21,6 +21,7 @@
     "ember-template-imports": "^4.1.0"
   },
   "devDependencies": {
+    "@bagaar/ember-breadcrumbs": "^5.0.0",
     "@ember/optional-features": "^2.1.0",
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
@@ -37,6 +38,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.5.0",
     "ember-source-channel-url": "^3.0.0",
+    "ember-auto-import": "^2.7.2",
     "loader.js": "^4.7.0",
     "webpack": "^5.91.0"
   },

--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -21,7 +21,6 @@
     "ember-template-imports": "^4.1.0"
   },
   "devDependencies": {
-    "@bagaar/ember-breadcrumbs": "^5.0.0",
     "@ember/optional-features": "^2.1.0",
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
@@ -38,7 +37,6 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.5.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-auto-import": "^2.7.2",
     "loader.js": "^4.7.0",
     "webpack": "^5.91.0"
   },

--- a/app/assets/javascripts/discourse/app/components/d-breadcrumbs-container.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-breadcrumbs-container.gjs
@@ -1,0 +1,12 @@
+import BreadcrumbsContainer from "discourse/components/breadcrumbs-container";
+import concatClass from "discourse/helpers/concat-class";
+
+const DBreadcrumbsContainer = <template>
+  <BreadcrumbsContainer
+    @itemClass={{concatClass "d-breadcrumbs__item" @itemClass}}
+    @linkClass={{concatClass "d-breadcrumbs__link" @linkClass}}
+    class="d-breadcrumbs"
+  />
+</template>;
+
+export default DBreadcrumbsContainer;

--- a/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
@@ -1,0 +1,9 @@
+import BreadcrumbsItem from "discourse/components/breadcrumbs-item";
+
+const DBreadcrumbsItem = <template>
+  <BreadcrumbsItem as |linkClass|>
+    {{yield linkClass}}
+  </BreadcrumbsItem>
+</template>;
+
+export default DBreadcrumbsItem;

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -20,6 +20,7 @@
     "@faker-js/faker": "^8.4.1",
     "@glimmer/syntax": "^0.92.0",
     "@highlightjs/cdn-assets": "^11.9.0",
+    "decorator-transforms": "^1.2.1",
     "discourse-hbr": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
     "ember-route-template": "^1.0.3",
@@ -32,6 +33,7 @@
     "decorator-transforms": "^2.0.0"
   },
   "devDependencies": {
+    "@bagaar/ember-breadcrumbs": "^5.0.0",
     "@babel/core": "^7.24.5",
     "@babel/standalone": "^7.24.5",
     "@colors/colors": "^1.6.0",

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -20,7 +20,6 @@
     "@faker-js/faker": "^8.4.1",
     "@glimmer/syntax": "^0.92.0",
     "@highlightjs/cdn-assets": "^11.9.0",
-    "decorator-transforms": "^1.2.1",
     "discourse-hbr": "1.0.0",
     "discourse-widget-hbs": "1.0.0",
     "ember-route-template": "^1.0.3",

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -123,4 +123,9 @@
       margin-bottom: 1em;
     }
   }
+
+  &__empty-list {
+    padding: 1em;
+    border: 1px solid var(--primary-low);
+  }
 }

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -37,6 +37,7 @@
 @import "sidebar/edit-navigation-menu/modal";
 @import "sidebar/edit-navigation-menu/tags-modal";
 @import "svg";
+@import "d-breadcrumbs";
 @import "tap-tile";
 @import "time-input";
 @import "time-shortcut-picker";

--- a/app/assets/stylesheets/common/components/d-breadcrumbs.scss
+++ b/app/assets/stylesheets/common/components/d-breadcrumbs.scss
@@ -1,0 +1,19 @@
+.d-breadcrumbs {
+  display: flex;
+  margin: 0;
+
+  li {
+    list-style-type: none;
+  }
+
+  &__link,
+  &__link:visited {
+    color: var(--primary-medium);
+  }
+
+  li:not(:last-child) a::after {
+    display: inline;
+    padding: 0 0.25em;
+    content: ">";
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,14 @@
     "@babel/helper-validator-identifier" "^7.24.5"
     to-fast-properties "^2.0.0"
 
+"@bagaar/ember-breadcrumbs@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@bagaar/ember-breadcrumbs/-/ember-breadcrumbs-5.0.0.tgz#da1e26171c37d6816ba1c6e69d0fe599d3d2fa02"
+  integrity sha512-LwlVOcUZ3bB/etwuze9e5r43adHah9z/MMHfZQ5tTY6avYn3yYhaxidBwcabh//6jYQfb8YI75xT1jWKHNRtjw==
+  dependencies:
+    "@embroider/addon-shim" "^1.8.7"
+    decorator-transforms "^1.0.1"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -4957,7 +4965,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
-decorator-transforms@^1.2.1:
+decorator-transforms@^1.0.1, decorator-transforms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/decorator-transforms/-/decorator-transforms-1.2.1.tgz#d72e39b95c9e3d63465f82b148d021919e9d198f"
   integrity sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==
@@ -11587,16 +11595,7 @@ string-template@~0.2.0, string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11683,7 +11682,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11703,13 +11702,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12828,7 +12820,7 @@ workerpool@^6.0.0, workerpool@^6.0.2, workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.4.1.tgz#1398eb5f8f44fb2d21ed9225cf34bb0131504c1d"
   integrity sha512-zIK7qRgM1Mk+ySxOJl7ZpjX6SlKt5gugxzl8eXHPdbpXX8iDAaVIxYJz4Apn6JdDxP2buY/Ekqg0bOLNSf0u0g==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12841,15 +12833,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This commit adds a third party component lib, https://github.com/Bagaar/ember-breadcrumbs,
for use in the admin section to generate breadcrumbs. We went with a third party solution because
it's quite small and self-contained and does exactly what we need; an equivalent version in core
would essentially be a 1-1 copy.

We do wrap the third party component in `DBreadcrumbsContainer` and `DBreadcrumbsItem`
so we can replace it easier if needed.

![2024-05-07_17-02](https://github.com/discourse/discourse/assets/920448/33b2843c-6d7b-4019-a2f2-c980c1a7a207)
