### PR TITLE
FEATURE: revert redirect from wizard to guide

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
+++ b/app/assets/javascripts/discourse/app/templates/wizard/step.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import RouteTemplate from "ember-route-template";
-import DiscourseURL from "discourse/lib/url";
 import { defaultHomepage } from "discourse/lib/utilities";
 import WizardCanvas from "discourse/static/wizard/components/wizard-canvas";
 import WizardStep from "discourse/static/wizard/components/wizard-step";
@@ -35,16 +34,6 @@ export default RouteTemplate(
       return this.step.id === "ready";
     }
 
-    #goHomeOrQuickStart() {
-      if (this.siteSettings.bootstrap_mode_enabled) {
-        DiscourseURL.routeTo(
-          `/t/${this.siteSettings.admin_quick_start_topic_id}`
-        );
-      } else {
-        this.router.transitionTo(`discovery.${defaultHomepage()}`);
-      }
-    }
-
     @action
     goNext(response) {
       const next = this.step.next;
@@ -54,7 +43,7 @@ export default RouteTemplate(
       } else if (response?.success && next) {
         this.router.transitionTo("wizard.step", next);
       } else if (response?.success) {
-        this.#goHomeOrQuickStart();
+        this.router.transitionTo(`discovery.${defaultHomepage()}`);
       }
     }
 
@@ -65,7 +54,7 @@ export default RouteTemplate(
 
     @action
     goHome() {
-      this.#goHomeOrQuickStart();
+      this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
   }
 );

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -15,14 +15,4 @@ describe "Wizard", type: :system do
 
     expect(page).to have_current_path("/latest")
   end
-
-  it "redirects to admin guide when wizard is completed and bootstrap mode is enabled" do
-    SiteSetting.bootstrap_mode_enabled = true
-    SiteSetting.admin_quick_start_topic_id = topic.id
-
-    visit("/wizard/steps/ready")
-    wizard_page.click_jump_in
-
-    expect(page).to have_current_path("/t/admin-guide-with-15-chars/#{topic.id}")
-  end
 end


### PR DESCRIPTION
In this PR we started redirecting to the guide page after the wizard - https://github.com/discourse/discourse/pull/26696

The guide will require rebrand and until it is ready, we should redirect to `/latest`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
