### PR TITLE
FIX: missing route for edit components

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Discourse::Application.routes.draw do
         get "themes/:id/:target/:field_name/edit" => "themes#index"
         get "themes/:id" => "themes#index"
         get "components/:id" => "themes#index"
+        get "components/:id/:target/:field_name/edit" => "themes#index"
         get "themes/:id/export" => "themes#export"
         get "themes/:id/schema/:setting_name" => "themes#schema"
         get "components/:id/schema/:setting_name" => "themes#schema"

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -478,6 +478,18 @@ RSpec.describe Admin::ThemesController do
       end
     end
 
+    it "allows themes and components to be edited" do
+      sign_in(admin)
+      theme = Fabricate(:theme, name: "Awesome Theme")
+      component = Fabricate(:theme, name: "Awesome component", component: true)
+
+      get "/admin/customize/themes/#{theme.id}/common/scss/edit"
+      expect(response.status).to eq(200)
+
+      get "/admin/customize/components/#{component.id}/common/scss/edit"
+      expect(response.status).to eq(200)
+    end
+
     shared_examples "themes inaccessible" do
       it "denies access with a 404 response" do
         get "/admin/themes.json"


### PR DESCRIPTION
In this PR separate route for components was introduced https://github.com/discourse/discourse/pull/26644

However, the route to edit components was missed and it was 404 when reloaded.

Meta: https://meta.discourse.org/t/missing-admin-theme-component-edit-route/306560