### PR TITLE
DEV: Remove unused `ignored_columns` from ActiveRecord models

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,12 +3,6 @@
 class Category < ActiveRecord::Base
   RESERVED_SLUGS = ["none"]
 
-  self.ignored_columns = [
-    :suppress_from_latest, # TODO(2020-11-18): remove
-    :required_tag_group_id, # TODO(2023-04-01): remove
-    :min_tags_from_required_group, # TODO(2023-04-01): remove
-  ]
-
   include Searchable
   include Positionable
   include HasCustomFields

--- a/app/models/directory_column.rb
+++ b/app/models/directory_column.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DirectoryColumn < ActiveRecord::Base
-  # TODO(2021-06-18): Remove automatic column
-  self.ignored_columns = ["automatic"]
   self.inheritance_column = nil
 
   enum type: { automatic: 0, user_field: 1, plugin: 2 }, _scopes: false

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -40,9 +40,6 @@ class EmailToken < ActiveRecord::Base
     end
   end
 
-  # TODO(2022-01-01): Remove
-  self.ignored_columns = %w[token]
-
   def self.scopes
     @scopes ||= Enum.new(signup: 1, password_reset: 2, email_login: 3, email_update: 4)
   end

--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -10,9 +10,6 @@ class EmbeddableHost < ActiveRecord::Base
     self.host.sub!(%r{/.*\z}, "")
   end
 
-  # TODO(2021-07-23): Remove
-  self.ignored_columns = ["path_whitelist"]
-
   def self.record_for_url(uri)
     if uri.is_a?(String)
       uri =

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,9 +3,6 @@
 require "net/imap"
 
 class Group < ActiveRecord::Base
-  # TODO(2021-05-26): remove
-  self.ignored_columns = %w[flair_url]
-
   include HasCustomFields
   include AnonCacheInvalidator
   include HasDestroyedWebHook

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -13,9 +13,6 @@ class Invite < ActiveRecord::Base
   include RateLimiter::OnCreateRecord
   include Trashable
 
-  # TODO(2021-05-22): remove
-  self.ignored_columns = %w[user_id redeemed_at]
-
   BULK_INVITE_EMAIL_LIMIT = 200
   DOMAIN_REGEX =
     /\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,11 +10,6 @@ class Post < ActiveRecord::Base
   include HasCustomFields
   include LimitedEdit
 
-  self.ignored_columns = [
-    "avg_time", # TODO(2021-01-04): remove
-    "image_url", # TODO(2021-06-01): remove
-  ]
-
   cattr_accessor :plugin_permitted_create_params, :plugin_permitted_update_params
   self.plugin_permitted_create_params = {}
   self.plugin_permitted_update_params = {}

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,10 +5,6 @@ class Tag < ActiveRecord::Base
   include HasDestroyedWebHook
   include HasSanitizableFields
 
-  self.ignored_columns = [
-    "topic_count", # TODO(tgxworld): Remove on 1 July 2023
-  ]
-
   RESERVED_TAGS = [
     "none",
     "constructor", # prevents issues with javascript's constructor of objects

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -15,11 +15,6 @@ class Topic < ActiveRecord::Base
 
   EXTERNAL_ID_MAX_LENGTH = 50
 
-  self.ignored_columns = [
-    "avg_time", # TODO(2021-01-04): remove
-    "image_url", # TODO(2021-06-01): remove
-  ]
-
   def_delegator :featured_users, :user_ids, :featured_user_ids
   def_delegator :featured_users, :choose, :feature_topic_users
 

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class TopicUser < ActiveRecord::Base
-  self.ignored_columns = [
-    :highest_seen_post_number, # Remove after 01 Jan 2022
-  ]
-
   belongs_to :user
   belongs_to :topic
 

--- a/app/models/user_api_key.rb
+++ b/app/models/user_api_key.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class UserApiKey < ActiveRecord::Base
-  self.ignored_columns = [
-    "scopes", # TODO(2020-12-18): remove
-  ]
-
   REVOKE_MATCHER = RouteMatcher.new(actions: "user_api_keys#revoke", methods: :post, params: [:id])
 
   belongs_to :user

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -13,11 +13,6 @@ class UserOption < ActiveRecord::Base
     # 8 => reserved for "hot"
   }
 
-  self.ignored_columns = [
-    "disable_jump_reply", # Remove once 20210706091905 is promoted from post_deploy to regular migration
-    "sidebar_list_destination", # TODO(osama): Remove in January 2024
-  ]
-
   self.primary_key = :user_id
   belongs_to :user
   before_create :set_defaults

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class UserProfile < ActiveRecord::Base
-  # TODO Remove `badge_granted_title` after 2023-09-01
-  self.ignored_columns = ["badge_granted_title"]
-
   BAKED_VERSION = 1
 
   belongs_to :user, inverse_of: :user_profile

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -3,9 +3,6 @@ class UserStat < ActiveRecord::Base
   belongs_to :user
   after_save :trigger_badges
 
-  # TODO(2021-05-13): Remove
-  self.ignored_columns = ["topic_reply_count"]
-
   def self.ensure_consistency!(last_seen = 1.hour.ago)
     reset_bounce_scores
     update_distinct_badge_count


### PR DESCRIPTION
The columns have already been dropped in
beea8215d71a71f0bcd54c0a7376342bea9bcc38.
