### PR TITLE
DEV: Delete upload references on draft cleanup

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -237,19 +237,18 @@ class Draft < ActiveRecord::Base
   end
 
   def self.cleanup!
-    DB.exec(<<~SQL)
-      DELETE FROM drafts
-       WHERE sequence < (
+    Draft.where(<<~SQL).in_batches(of: 100).destroy_all
+      sequence < (
         SELECT MAX(s.sequence)
           FROM draft_sequences s
-         WHERE s.draft_key = drafts.draft_key
-           AND s.user_id = drafts.user_id
+          WHERE s.draft_key = drafts.draft_key
+          AND s.user_id = drafts.user_id
       )
     SQL
 
     # remove old drafts
     delete_drafts_older_than_n_days = SiteSetting.delete_drafts_older_than_n_days.days.ago
-    Draft.where("updated_at < ?", delete_drafts_older_than_n_days).destroy_all
+    Draft.where("updated_at < ?", delete_drafts_older_than_n_days).in_batches(of: 100).destroy_all
 
     UserStat.update_draft_count
   end

--- a/db/post_migrate/20240506035024_clear_orphaned_draft_upload_references.rb
+++ b/db/post_migrate/20240506035024_clear_orphaned_draft_upload_references.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ClearOrphanedDraftUploadReferences < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      DELETE
+      FROM
+        "upload_references"
+      WHERE
+        "upload_references"."target_type" = 'Draft' AND
+        "upload_references"."target_id" NOT IN (
+          SELECT "drafts"."id" FROM "drafts"
+        )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Draft do
     key = Draft::NEW_TOPIC
 
     Draft.set(user, key, 0, "draft")
+
     Draft.cleanup!
     expect(Draft.count).to eq 1
     expect(user.user_stat.draft_count).to eq(1)
@@ -142,10 +143,16 @@ RSpec.describe Draft do
     Draft.set(user, key, seq, "draft")
     DraftSequence.update_all("sequence = sequence + 1")
 
+    draft = Draft.first
+    draft.upload_references << UploadReference.create!(target: draft, upload: Fabricate(:upload))
+
+    expect(UploadReference.count).to eq(1)
+
     Draft.cleanup!
 
     expect(Draft.count).to eq 0
     expect(user.reload.user_stat.draft_count).to eq(0)
+    expect(UploadReference.count).to eq(0)
 
     Draft.set(Fabricate(:user), Draft::NEW_TOPIC, 0, "draft")
 


### PR DESCRIPTION
### What is this change?

In #22851 we added a dependent strategy for deleting upload references when a draft is destroyed. This, however, didn't catch all cases, because we still have some code that issues `DELETE drafts` queries directly to the database. Specifically in the weekly cleanup job handled by `Draft#cleanup!`.

This PR fixes that by turning the raw query into an ActiveRecord `#destroy_all`, which will invoke the dependent strategy that ultimately deletes the upload references. It also includes a post migration to clear orphaned upload references that are already in the database.

### What about performance?

I don't think we need the optimization here for a couple of reasons:

1. The method is called from a background job, so won't block any requests.
2. When checking for drafts matching the query on meta, I find 1 record.
3. A few lines below, we're already using `#destroy_all` for old drafts, which are greater in number, and this hasn't caused issues.

For good measure, I've added batching to both `#destroy_all` calls, so there's no risk they can starve the worker of memory.