### PR TITLE
FIX: Make `getCategoryIdByName` theme migration helper case insensitive

### DIFF
--- a/app/services/theme_settings_migrations_runner.rb
+++ b/app/services/theme_settings_migrations_runner.rb
@@ -13,7 +13,7 @@ class ThemeSettingsMigrationsRunner
     # @return [Integer|nil] The id of the category with the given name or nil if a category does not exist for the given
     #   name.
     def get_category_id_by_name(category_name)
-      Category.where(name_lower: category_name).pick(:id)
+      Category.where("name_lower = LOWER(?)", category_name).pick(:id)
     end
 
     # @param [String] URL string to check if it is a valid absolute URL, path or anchor.

--- a/spec/services/theme_settings_migrations_runner_spec.rb
+++ b/spec/services/theme_settings_migrations_runner_spec.rb
@@ -356,14 +356,14 @@ describe ThemeSettingsMigrationsRunner do
     end
 
     it "attaches the getCategoryIdByName() function to the context of the migrations" do
-      category = Fabricate(:category, name: "some-category")
+      category = Fabricate(:category, name: "Some Category Name")
 
       theme.update_setting(:integer_setting, -10)
       theme.save!
 
       migration_field.update!(value: <<~JS)
         export default function migrate(settings, helpers) {
-          const categoryId = helpers.getCategoryIdByName("some-category");
+          const categoryId = helpers.getCategoryIdByName("some CatEgory Name");
           settings.set("integer_setting", categoryId);
           return settings;
         }


### PR DESCRIPTION
This commit makes the `getCategoryIdByName` theme settings migration helper case insensitive so that the helper is easier to use.