### PR TITLE
FIX: send activity summaries based on "last seen"

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -120,21 +120,21 @@ module Jobs
 
       if type == "digest"
         return if user.staged
-        if user.last_emailed_at &&
-             user.last_emailed_at >
+
+        if user.last_seen_at
+          if user.last_seen_at >
                (
                  user.user_option&.digest_after_minutes ||
                    SiteSetting.default_email_digest_frequency.to_i
                ).minutes.ago
-          return
+            return
+          end
         end
       end
 
       seen_recently =
-        (
-          user.last_seen_at.present? &&
-            user.last_seen_at > SiteSetting.email_time_window_mins.minutes.ago
-        )
+        user.last_seen_at && user.last_seen_at > SiteSetting.email_time_window_mins.minutes.ago
+
       if !args[:force_respect_seen_recently] &&
            (
              always_email_regular?(user, type) || always_email_private_message?(user, type) ||

--- a/app/jobs/scheduled/enqueue_digest_emails.rb
+++ b/app/jobs/scheduled/enqueue_digest_emails.rb
@@ -5,13 +5,13 @@ module Jobs
     every 30.minutes
 
     def execute(args)
-      if SiteSetting.disable_digest_emails? || SiteSetting.private_email? ||
-           SiteSetting.disable_emails == "yes"
-        return
-      end
-      users = target_user_ids
+      return if SiteSetting.disable_emails == "yes"
+      return if SiteSetting.disable_digest_emails?
+      return if SiteSetting.private_email?
 
-      users.each { |user_id| ::Jobs.enqueue(:user_email, type: "digest", user_id: user_id) }
+      target_user_ids.each do |user_id|
+        ::Jobs.enqueue(:user_email, type: "digest", user_id: user_id)
+      end
     end
 
     def target_user_ids
@@ -21,14 +21,11 @@ module Jobs
           .real
           .activated
           .not_suspended
-          .where(staged: false)
+          .not_staged
           .joins(:user_option, :user_stat, :user_emails)
           .where("user_options.email_digests")
           .where("user_stats.bounce_score < ?", SiteSetting.bounce_score_threshold)
           .where("user_emails.primary")
-          .where(
-            "COALESCE(last_emailed_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)",
-          )
           .where(
             "COALESCE(user_stats.digest_attempted_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)",
           )

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -224,7 +224,7 @@ class UserNotifications < ActionMailer::Base
     build_summary_for(user)
     @unsubscribe_key = UnsubscribeKey.create_key_for(@user, UnsubscribeKey::DIGEST_TYPE)
 
-    min_date = opts[:since] || user.last_emailed_at || user.last_seen_at || 1.month.ago
+    min_date = opts[:since] || user.last_seen_at || 1.month.ago
 
     # Fetch some topics and posts to show
     digest_opts = {


### PR DESCRIPTION
instead of "last emailed" so that people getting email notifications (from a watched topic for example) also get the activity summaries.

Context - https://meta.discourse.org/t/activity-summary-not-sent-if-other-emails-are-sent/293040

Internal Ref - t//125582

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
