### PR TITLE
DEV: Don't add 0-width char if there's no icon in d-button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -178,15 +178,13 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
     >
       {{#if @isLoading}}
         {{~icon "spinner" class="loading-icon"~}}
-      {{else}}
-        {{#if @icon}}
-          {{#if @ariaHidden}}
-            <span aria-hidden="true">
-              {{~icon @icon~}}
-            </span>
-          {{else}}
+      {{else if @icon}}
+        {{#if @ariaHidden}}
+          <span aria-hidden="true">
             {{~icon @icon~}}
-          {{/if}}
+          </span>
+        {{else}}
+          {{~icon @icon~}}
         {{/if}}
       {{/if}}
 
@@ -197,7 +195,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             &hellip;
           {{~/if~}}
         </span>
-      {{~else~}}
+      {{~else if (or @icon @isLoading)~}}
         &#8203;
         {{! Zero-width space character, so icon-only button height = regular button height }}
       {{~/if~}}


### PR DESCRIPTION
Previously, if you supplied your own content to DButton it would still add the character:

```hbs
<DButton>my text</DButton>
```

```html
<button>&#8203; my text</button>
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
