### PR TITLE
FIX: correctly pass topic/posts context

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/extract-current-topic-info.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/extract-current-topic-info.js
@@ -7,7 +7,7 @@ export function extractCurrentTopicInfo(context) {
     return;
   }
 
-  const info = { topic_id: topic.id };
+  const info = { context_topic_id: topic.id };
   const currentPostNumber = parseInt(topic.current_post_number, 10);
   const posts = topic.postStream.posts;
 
@@ -23,7 +23,11 @@ export function extractCurrentTopicInfo(context) {
       !post.hidden && !post.deleted_at && post.post_number > currentPostNumber
   );
 
-  info.post_ids = [previousPost?.id, currentPost?.id, nextPost?.id];
+  info.context_post_ids = [
+    previousPost?.id,
+    currentPost?.id,
+    nextPost?.id,
+  ].filter(Boolean);
 
   return info;
 }

--- a/plugins/chat/spec/system/send_message_spec.rb
+++ b/plugins/chat/spec/system/send_message_spec.rb
@@ -104,4 +104,39 @@ RSpec.describe "Send message", type: :system do
       end
     end
   end
+
+  context "sending message from drawer" do
+    let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
+    let(:topic_page) { PageObjects::Pages::Topic.new }
+
+    fab!(:post_1) { Fabricate(:post) }
+    fab!(:post_2) { Fabricate(:post, topic: post_1.topic) }
+    fab!(:channel_1) { Fabricate(:chat_channel) }
+
+    before do
+      sign_in(user_1)
+      channel_1.add(user_1)
+      Jobs.run_immediately!
+    end
+
+    it "has topic context" do
+      tested_context = {}
+      blk = Proc.new { |message, channel, user, context| tested_context = context }
+
+      begin
+        DiscourseEvent.on(:chat_message_created, &blk)
+        topic_page.visit_topic(post_1.topic)
+        chat_page.open_from_header
+        drawer_page.open_channel(channel_1)
+        channel_page.send_message
+
+        try_until_success do
+          expect(tested_context.dig(:context, :post_ids)).to eq([post_1.id, post_2.id])
+          expect(tested_context.dig(:context, :topic_id)).to eq(post_1.topic_id)
+        end
+      ensure
+        DiscourseEvent.off(:chat_message_created, &blk)
+      end
+    end
+  end
 end

--- a/plugins/chat/spec/system/send_message_spec.rb
+++ b/plugins/chat/spec/system/send_message_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Send message", type: :system do
     end
   end
 
-  context "sending message from drawer" do
+  context "when sending message from drawer" do
     let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
     let(:topic_page) { PageObjects::Pages::Topic.new }
 


### PR DESCRIPTION
This case had not been tested end to end as `Discourse.track_events` was not working when wrapping `send_message`. Because of this lack of end to end test, a regression has been created when renaming the expected context properties. This commit fixes the regression and write a slightly convulted, but effective end to end test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
