### PR TITLE
UX: hide user count in original message link

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-info.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-info.scss
@@ -67,6 +67,7 @@
 }
 
 .chat-message-info__original-message {
+  @include ellipsis;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -97,6 +98,9 @@
       width: 0.35em;
       margin-right: 0.4em;
       padding: 1px 1px 2px 1px;
+    }
+    &:has(.--users-count) {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Avoiding this:
![image](https://github.com/discourse/discourse/assets/101828855/2f16c731-048d-4e22-86e7-afd12c74fdc0)

By hiding the user-count in the link as its not important anyway.

And fixing link overflow:
<img width="590" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c78be338-8098-4169-bce0-f6228ed5d8b2">


