### PR TITLE
FIX: only show discourse-ai CTA to admins

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/thread-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/thread-settings.gjs
@@ -12,6 +12,7 @@ import i18n from "discourse-common/helpers/i18n";
 
 export default class ChatModalThreadSettings extends Component {
   @service chatApi;
+  @service currentUser;
 
   @tracked editedTitle = this.thread.title || "";
   @tracked saving = false;
@@ -74,17 +75,19 @@ export default class ChatModalThreadSettings extends Component {
           <span>{{this.threadTitleLength}}</span>/50
         </div>
 
-        <div class="discourse-ai-cta">
-          <p class="discourse-ai-cta__title">{{icon "info-circle"}}
-            {{i18n "chat.thread_title_modal.discourse_ai.title"}}</p>
-          <p class="discourse-ai-cta__description">{{htmlSafe
-              (i18n
-                "chat.thread_title_modal.discourse_ai.description"
-                url="<a href='https://www.discourse.org/ai' rel='noopener noreferrer' target='_blank'>Discourse AI</a>"
-              )
-            }}
-          </p>
-        </div>
+        {{#if this.currentUser.admin}}
+          <div class="discourse-ai-cta">
+            <p class="discourse-ai-cta__title">{{icon "info-circle"}}
+              {{i18n "chat.thread_title_modal.discourse_ai.title"}}</p>
+            <p class="discourse-ai-cta__description">{{htmlSafe
+                (i18n
+                  "chat.thread_title_modal.discourse_ai.description"
+                  url="<a href='https://www.discourse.org/ai' rel='noopener noreferrer' target='_blank'>Discourse AI</a>"
+                )
+              }}
+            </p>
+          </div>
+        {{/if}}
       </:body>
       <:footer>
         <DButton

--- a/plugins/chat/test/javascripts/components/thread-settings-test.gjs
+++ b/plugins/chat/test/javascripts/components/thread-settings-test.gjs
@@ -1,0 +1,32 @@
+import { getOwner } from "@ember/application";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ChatModalThreadSettings from "discourse/plugins/chat/discourse/components/chat/modal/thread-settings";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Discourse Chat | Component | <ThreadSettings />", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("discourse-ai - admin", async function (assert) {
+    this.currentUser.admin = true;
+    const thread = new ChatFabricators(getOwner(this)).thread();
+
+    await render(<template>
+      <ChatModalThreadSettings @inline={{true}} @model={{thread}} />
+    </template>);
+
+    assert.dom(".discourse-ai-cta").exists();
+  });
+
+  test("discourse-ai - not admin", async function (assert) {
+    this.currentUser.admin = false;
+    const thread = new ChatFabricators(getOwner(this)).thread();
+
+    await render(<template>
+      <ChatModalThreadSettings @inline={{true}} @model={{thread}} />
+    </template>);
+
+    assert.dom(".discourse-ai-cta").doesNotExist();
+  });
+});


### PR DESCRIPTION
There's no point in showing a CTA to users who can't act on it.