### PR TITLE
DEV: Fix a flaky system test for editing sidebar navigation tags

### DIFF
--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -166,6 +166,7 @@ module PageObjects
           end
 
           expect(page).to have_css(".d-modal:not(.is-animating)")
+          expect(page).to have_css(".d-modal .sidebar-tags-form")
 
           PageObjects::Modals::SidebarEditTags.new
         end


### PR DESCRIPTION
This commits updates
`PageObjects::Components::NavigationMenu::Base#click_edit_tags_button`
to wait for `.sidebar-tags-form` to be present before returning. This is
essential because the client side app has to load the tags from the
server when the modal is open. If we don't wait for all the tags to be
loaded, it makes it hard to reason about the state of the UI when
interacting with the modal. In the case of "allows a user to deselect all tags in the modal which will display the site's top tags" which
was flaky, the system test was interacting with the UI when the tags are
still loading.
