### PR TITLE
DEV: depend less on pngquant version

### DIFF
--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe UploadCreator do
           UploadCreator.new(file, filename, pasted: true, force_optimize: true).create_for(user.id)
 
         # no optimisation possible without losing details
-        expect(upload.filesize).to eq(9202)
+        expect(upload.filesize).to be < 9210
 
         thumbnail_size = upload.get_optimized_image(upload.width, upload.height, {}).filesize
 


### PR DESCRIPTION
This spec has been failing forever on my machine. I guess I have a "better" version of pngquant?

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
