### PR TITLE
FIX: prevents flakey due to usernames with quotes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/fabricators.js
+++ b/app/assets/javascripts/discourse/app/lib/fabricators.js
@@ -58,7 +58,7 @@ export default class CoreFabricators {
   user(args = {}) {
     return this.store.createRecord("user", {
       id: args.id || incrementSequence(),
-      username: args.username || getLoadedFaker().faker.person.firstName(),
+      username: args.username || getLoadedFaker().faker.internet.domainWord(),
       name: args.name,
       avatar_template: "/letter_avatar_proxy/v3/letter/t/41988e/{size}.png",
       suspended_till: args.suspended_till,


### PR DESCRIPTION
Faker could generate usernames like `D'angelo` and that doesn’t work out nicely for our tests. Using domain names seems safer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
