### PR TITLE
PERF: bail out of expensive post validations

### DIFF
--- a/lib/validators/stripped_length_validator.rb
+++ b/lib/validators/stripped_length_validator.rb
@@ -2,7 +2,7 @@
 
 class StrippedLengthValidator < ActiveModel::EachValidator
   def self.validate(record, attribute, value, range)
-    if value.nil?
+    if value.blank?
       record.errors.add attribute, I18n.t("errors.messages.blank")
     elsif value.length > range.end
       record.errors.add attribute,

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -318,6 +318,9 @@ class DiscoursePoll::Poll
     # creation process. `raw` could be nil here.
     return [] if raw.blank?
 
+    # bail-out early if the post does not contain a poll
+    return [] if !raw.include?("[/poll]")
+
     # TODO: we should fix the callback mess so that the cooked version is available
     # in the validators instead of cooking twice
     raw = raw.sub(%r{\[quote.+/quote\]}m, "")


### PR DESCRIPTION
Whenever a post already failed "lightweight" validations, we skip all the expensive validations (that cooks the post or run SQL queries) so that we reply as soon as possible.

Also skip validating polls when there's no "[/poll]" in the raw.

Internal ref - t/115890

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
