### PR TITLE
UX: use quaternary colour for keyboard navigation

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -7,12 +7,12 @@
 .topic-list-item.selected td:first-child,
 .latest-topic-list-item.selected,
 .search-results .fps-result.selected {
-  box-shadow: inset 3px 0 0 var(--danger);
+  box-shadow: inset 3px 0 0 var(--quaternary);
 }
 
 .featured-topic.selected,
 .topic-post.selected {
-  box-shadow: -3px 0 0 var(--danger);
+  box-shadow: -3px 0 0 var(--quaternary);
 }
 
 .topic-list tr.selected,


### PR DESCRIPTION
The keyboard navigation should not use the `--danger` colour variable to highlight. Instead, it should use the navigational `--quaternary` variable.

[https://meta.discourse.org/t/error-color-on-focus/306915/6](https://meta.discourse.org/t/error-color-on-focus/306915/6)