### PR TITLE
DEV: Prevent removed keys from being resolved in the DAG

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/dag.js
+++ b/app/assets/javascripts/discourse/app/lib/dag.js
@@ -91,7 +91,14 @@ export default class DAG {
   @bind
   resolve() {
     const result = [];
-    this.#dag.each((key, value) => result.push({ key, value }));
+    this.#dag.each((key, value) => {
+      // We need to filter keys that do not exist in the rawData because the DAGMap will insert a vertex for
+      // dependencies, for example if an item has a "before: search" dependency, the "search" vertex will be included
+      // even if it was explicitly excluded from the raw data.
+      if (this.has(key)) {
+        result.push({ key, value });
+      }
+    });
     return result;
   }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/dag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/dag-test.js
@@ -70,6 +70,20 @@ module("Unit | Lib | DAG", function (hooks) {
     assert.deepEqual(keys, ["key1", "key2", "key4", "key3"]);
   });
 
+  test("should resolve only existing keys", function (assert) {
+    dag = new DAG();
+    dag.add("key1", "value1");
+    dag.add("key2", "value2", { before: "key1" });
+    dag.add("key3", "value3");
+
+    dag.delete("key1");
+
+    const resolved = dag.resolve();
+    const keys = resolved.map((pair) => pair.key);
+
+    assert.deepEqual(keys, ["key2", "key3"]);
+  });
+
   test("throws on bad positioning", function (assert) {
     dag = new DAG();
 


### PR DESCRIPTION
The `dag-map` library inserts vertexes for keys that are used as reference points in the graph.

We need to compare that with the items on the raw data to ensure that keys that were deliberately
deleted are not included again among the returned results from `dag.resolve`.