### PR TITLE
DEV: Adjust flaky bulk select spec

### DIFF
--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -161,11 +161,10 @@ describe "Topic bulk select", type: :system do
     it "closes topics silently" do
       # Watch the topic as a user
       sign_in(user)
-      visit("/latest")
       topic = topics.first
       visit("/t/#{topic.slug}/#{topic.id}")
-      topic_page.watch_topic
       expect(topic_page).to have_read_post(1)
+      topic_page.watch_topic
 
       # Bulk close the topic as an admin
       sign_in(admin)


### PR DESCRIPTION
For some reason this test is showing up as flaky. It has something to do
with `have_read_post`:

https://github.com/discourse/discourse/blob/main/spec/system/page_objects/components/topic_view.rb#L10

In an effort to not just increase the wait time for `page.has_css?`
let's make these little tweaks and see if it makes any sort of
difference.
