### PR TITLE
FEATURE: Remove "Enable Sidebar" step from setup wizard

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5306,9 +5306,6 @@ en:
           chat_enabled:
             placeholder: "Enable chat"
             extra_description: "Engage with your members in real time"
-          enable_sidebar:
-            placeholder: "Enable sidebar"
-            extra_description: "Access your favorite spaces with ease"
 
       ready:
         title: "Your site is ready!"

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -89,13 +89,6 @@ class Wizard
           )
         end
 
-        step.add_field(
-          id: "enable_sidebar",
-          type: "checkbox",
-          icon: "bars",
-          value: SiteSetting.navigation_menu == NavigationMenuSiteSetting::SIDEBAR,
-        )
-
         step.on_update do |updater|
           updater.update_setting(:login_required, updater.fields[:login_required])
           updater.update_setting(:invite_only, updater.fields[:invite_only])

--- a/spec/lib/wizard/wizard_builder_spec.rb
+++ b/spec/lib/wizard/wizard_builder_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Wizard::Builder do
       chat_enabled_field = fields.second_to_last if defined?(::Chat)
       navigation_menu_field = fields.last
 
-      count = defined?(::Chat) ? 5 : 4
+      count = defined?(::Chat) ? 4 : 3
       expect(fields.length).to eq(count)
       expect(login_required_field.id).to eq("login_required")
       expect(login_required_field.value).to eq(true)
@@ -91,8 +91,6 @@ RSpec.describe Wizard::Builder do
         expect(chat_enabled_field.id).to eq("chat_enabled")
         expect(chat_enabled_field.value).to eq(true)
       end
-      expect(navigation_menu_field.id).to eq("enable_sidebar")
-      expect(navigation_menu_field.value).to eq(true)
     end
   end
 


### PR DESCRIPTION
This keeps coming up in user testing as something
we want to get rid of. The `navigation_menu` setting
has been set to sidebar by default for some time now,
and we are rolling out admin sidebar widely. It just
doesn't make sense to let people turn this off in
the first step of the wizard -- we _want_ people to
use the sidebar.
