### PR TITLE
FIX: avoid error from missing twitter meta tags

### DIFF
--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -111,7 +111,7 @@ module Onebox
         if twitter_api_credentials_present?
           raw.dig(:includes, :users)&.first&.dig(:name)
         else
-          meta_tags_data("givenName")[tweet_index]
+          twitter_data[:title]
         end
       end
 
@@ -119,13 +119,15 @@ module Onebox
         if twitter_api_credentials_present?
           raw.dig(:includes, :users)&.first&.dig(:username)
         else
-          meta_tags_data("additionalName")[tweet_index]
+          twitter_data[:title][/\(@([^\)\(]*)\) on X/, 1] if twitter_data[:title].present?
         end
       end
 
       def avatar
         if twitter_api_credentials_present?
           raw.dig(:includes, :users)&.first&.dig(:profile_image_url)
+        else
+          twitter_data[:image] if twitter_data[:image]&.include?("profile_images")
         end
       end
 

--- a/spec/fixtures/onebox/twitterstatus_noclient.response
+++ b/spec/fixtures/onebox/twitterstatus_noclient.response
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover">
+<link rel="preconnect" href="//abs.twimg.com">
+<link rel="dns-prefetch" href="//abs.twimg.com">
+<link rel="preconnect" href="//api.twitter.com">
+<link rel="dns-prefetch" href="//api.twitter.com">
+<link rel="preconnect" href="//api.x.com">
+<link rel="dns-prefetch" href="//api.x.com">
+<link rel="preconnect" href="//pbs.twimg.com">
+<link rel="dns-prefetch" href="//pbs.twimg.com">
+<link rel="preconnect" href="//t.co">
+<link rel="dns-prefetch" href="//t.co">
+<link rel="preconnect" href="//video.twimg.com">
+<link rel="dns-prefetch" href="//video.twimg.com">
+<meta http-equiv="onion-location" content="https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/">
+<meta property="fb:app_id" content="2231777543">
+<meta content="X (formerly Twitter)" property="og:site_name">
+<meta name="google-site-verification" content="600dQ0pZYsH2xOFt4hYmf5f5NpjCbWE_qk5Y04dErYM">
+<meta name="facebook-domain-verification" content="x6sdcc8b5ju3bh8nbm59eswogvg6t1">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Twitter">
+<meta name="apple-mobile-web-app-status-bar-style" content="white">
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
+<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Twitter">
+<link rel="shortcut icon" href="//abs.twimg.com/favicons/twitter.3.ico">
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="#FFFFFF">
+<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","url":"https://twitter.com/","potentialAction":{"@type":"SearchAction","query-input":"required name=search_term_string","target":{"@type":"EntryPoint","urlTemplate":"https://twitter.com/search?q={search_term_string}&ref_src=twcamp%5Eseo_searchbox%7Ctwsrc%5Eseo"}}}</script><meta http-equiv="origin-trial" content="AlpCmb40F5ZjDi9ZYe+wnr/V8MF+XmY41K4qUhoq+2mbepJTNd3q4CRqlACfnythEPZqcjryfAS1+ExS0FFRcA8AAABmeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJMYXVuY2ggSGFuZGxlciIsImV4cGlyeSI6MTY1NTI1MTE5OSwiaXNTdWJkb21haW4iOnRydWV9">
+<style>html,body{height: 100%;}::cue{white-space:normal}</style>
+<meta content="article" property="og:type">
+<meta content="https://twitter.com/MKBHD/status/1625192182859632661" property="og:url">
+<meta content="Marques Brownlee (@MKBHD) on X" property="og:title">
+<meta content="I've never played Minecraft" property="og:description">
+<meta content="https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_200x200.jpg" property="og:image">
+<meta content="I've never played Minecraft" name="description">
+<meta content="Marques Brownlee (@MKBHD) on X" name="title">
+<meta content="twitter://status?id=1625192182859632661" property="al:ios:url">
+<meta content="333903271" property="al:ios:app_store_id">
+<meta content="X" property="al:ios:app_name">
+<meta content="twitter://status?id=1625192182859632661" property="al:android:url">
+<meta content="com.twitter.android" property="al:android:package">
+<meta content="X" property="al:android:app_name">
+</head>
+<body style="background-color: #FFFFFF;"><div id="react-root" style="height:100%;display:flex;"></div></body>
+</html>

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -143,6 +143,25 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
 
       expect(html).to eq("")
     end
+
+    describe "it resorts to html open graph tags" do
+      context "with a standard tweet" do
+        let(:tweet_content) { "I've never played Minecraft" }
+        include_context "with standard tweet info"
+        before { @onebox_fixture = "twitterstatus_noclient" }
+        include_context "with engines"
+
+        let(:avatar) do
+          "https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_200x200.jpg"
+        end
+        let(:timestamp) { "" }
+        let(:favorite_count) { "" }
+        let(:retweets_count) { "" }
+
+        it_behaves_like "an engine"
+        it_behaves_like "#to_html"
+      end
+    end
   end
 
   context "with twitter client" do


### PR DESCRIPTION
There is an error ("no implicit conversion of Array into Integer") if some meta tags are missing. At some point the twitter HTML changed and Murphy's law kicked in. This fixes the error and uses meta tags that exist.