### PR TITLE
FIX: show selected topic with above-topic-list-item

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -1,10 +1,10 @@
-.topic-list-item td:first-child,
+.topic-list-item td:first-of-type,
 .topic-post {
   border-left: 1px solid transparent;
 }
 
-.topic-list tr.selected td:first-child,
-.topic-list-item.selected td:first-child,
+.topic-list tr.selected td:first-of-type,
+.topic-list-item.selected td:first-of-type,
 .latest-topic-list-item.selected,
 .search-results .fps-result.selected {
   box-shadow: inset 3px 0 0 var(--quaternary);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
In a topic item list, the row currently selected by the <kbd>j</kbd>/<kbd>k</kbd> keyboard shortcuts is indicated by a style applied to the [`td:first-child` of selected rows](https://github.com/discourse/discourse/blob/ce2388e40b44a10a7b1577b689c9d5042c0c6dbe/app/assets/stylesheets/common/components/keyboard_shortcuts.scss#L6), but the "above-topic-list-item" plugin outlet allows for inserting elements as the first child of those rows. If the inserted element is not a `<tr>` element, then there's no element matching the CSS selector and thus no way to tell what row is currently selected to navigate from.

For example, the Clickable Topic plugin inserts a [hidden `<div>`](https://github.com/discourse/discourse-clickable-topic/blob/611e3462f7d742c22b833f48c25a4130ddddd558/javascripts/discourse/connectors/above-topic-list-item/clickable-topic-row.hbs) in the "above-topic-list-item" plugin outlet which means there's no visual indication of what item is selected.