### PR TITLE
DEV: Enable 'cheap source maps' in GitHub CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/main/head' }}
+      CHEAP_SOURCE_MAPS: "1"
 
     strategy:
       fail-fast: false
@@ -362,6 +363,7 @@ jobs:
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
+      CHEAP_SOURCE_MAPS: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/main/head' }}
-      CHEAP_SOURCE_MAPS: "1"
+      DISABLE_SOURCE_MAPS: "1"
 
     strategy:
       fail-fast: false
@@ -363,7 +363,7 @@ jobs:
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
-      CHEAP_SOURCE_MAPS: "1"
+      DISABLE_SOURCE_MAPS: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/main/head' }}
-      DISABLE_SOURCE_MAPS: "1"
+      CHEAP_SOURCE_MAPS: "1"
 
     strategy:
       fail-fast: false
@@ -363,7 +363,7 @@ jobs:
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
-      DISABLE_SOURCE_MAPS: "1"
+      CHEAP_SOURCE_MAPS: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -29,16 +29,16 @@ module.exports = function (defaults) {
 
   const isProduction = EmberApp.env().includes("production");
 
+  const disableSourceMaps = process.env.DISABLE_SOURCE_MAPS === "1";
+  const cheapSourceMaps = process.env.CHEAP_SOURCE_MAPS === "1";
+
   const app = new EmberApp(defaults, {
     autoRun: false,
     "ember-qunit": {
       insertContentForTestBody: false,
     },
     sourcemaps: {
-      // There seems to be a bug with broccoli-concat when sourcemaps are disabled
-      // that causes the `app.import` statements below to fail in production mode.
-      // This forces the use of `fast-sourcemap-concat` which works in production.
-      enabled: true,
+      enabled: !disableSourceMaps,
     },
     fingerprint: {
       // Handled by Rails asset pipeline
@@ -131,15 +131,19 @@ module.exports = function (defaults) {
     .digest("hex")
     .slice(0, 8);
 
+  let webpackDevToolMode = "source-map";
+  if (disableSourceMaps) {
+    webpackDevToolMode = false;
+  } else if (cheapSourceMaps) {
+    webpackDevToolMode = "cheap-source-map";
+  }
+
   const appTree = compatBuild(app, Webpack, {
     splitAtRoutes: ["wizard"],
     staticAppPaths: ["static"],
     packagerOptions: {
       webpackConfig: {
-        devtool:
-          process.env.CHEAP_SOURCE_MAPS === "1"
-            ? "cheap-source-map"
-            : "source-map",
+        devtool: webpackDevToolMode,
         output: {
           publicPath: "auto",
           filename: `assets/chunk.[chunkhash].${cachebusterHash}.js`,


### PR DESCRIPTION
This seems to save ~7s in core build time. I also tried disabling sourcemaps completely, but it didn't bring any additional benefit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
