### PR TITLE
FIX: incorrect divider in topic admin menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -281,11 +281,11 @@ export default class TopicAdminMenu extends Component {
                       @icon="hourglass-start"
                     />
                   </dropdown.item>
-
-                  <dropdown.divider />
                 {{/if}}
 
                 {{#if (or this.currentUser.staff this.extraButtons.length)}}
+                  <dropdown.divider />
+
                   {{#if this.currentUser.staff}}
                     <dropdown.item class="topic-admin-moderation-history">
                       <DButton


### PR DESCRIPTION
Adds a divider only if we are staff or have extra buttons.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
