### PR TITLE
Add before and after guardian checks

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -70,6 +70,7 @@ class DiscoursePluginRegistry
   define_register :demon_processes, Set
   define_register :groups_callback_for_users_search_controller_action, Hash
   define_register :mail_pollers, Set
+  define_register :guardian_checks, Hash
 
   define_filtered_register :staff_user_custom_fields
   define_filtered_register :public_user_custom_fields

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -10,6 +10,7 @@ require "guardian/sidebar_guardian"
 require "guardian/tag_guardian"
 require "guardian/topic_guardian"
 require "guardian/user_guardian"
+require "guardian/plugin_checks"
 
 # The guardian is responsible for confirming access to various site resources and operations
 class Guardian
@@ -23,6 +24,7 @@ class Guardian
   include TagGuardian
   include TopicGuardian
   include UserGuardian
+  include PluginChecks
 
   class AnonymousUser
     def blank?

--- a/lib/guardian/plugin_checks.rb
+++ b/lib/guardian/plugin_checks.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PluginChecks
+  def self.included(mod)
+    mod.instance_methods.each do |method_name|
+      if method_name.to_s =~ /\Acan_(.*)/
+        method = mod.instance_method(method_name)
+        check_name = Regexp.last_match[1].chomp("?")
+        mod.define_method(method_name) do |*args, **kwargs|
+          result = true
+          return false unless PluginChecks.pass?(self, :before, check_name, result, *args, **kwargs)
+          result = method.bind(self).call(*args, **kwargs)
+          PluginChecks.pass?(self, :after, check_name, result, *args, **kwargs)
+        end
+      end
+    end
+  end
+
+  def self.pass?(instance, check_type, check_name, result, *args, **kwargs)
+    return result unless DiscoursePluginRegistry.guardian_checks[check_type].present?
+    checks = DiscoursePluginRegistry.guardian_checks[check_type][check_name.to_sym]
+    return result if checks.blank?
+    checks.each { |check| result = check[:proc].call(instance, result, *args, **kwargs) }
+    !!result
+  end
+end


### PR DESCRIPTION
Adds a system to allow plugins to more easily modify guardian `can_` method outcomes.

### Example

Currently the only way to modify guardian `can_` method outcomes is via module pre-pension, for example:

```
module DiscourseActivityPubGuardianExtension
  def can_edit_post?(post)
    return false if post.activity_pub_remote?
    super
  end

  def can_change_post_owner?
    return false if activity_pub_enabled_topic?
    super
  end

  def activity_pub_enabled_topic?
    return false unless DiscourseActivityPub.enabled && request&.params&.[]("topic_id")
    topic = Topic.find_by(id: request.params["topic_id"].to_i)
    topic&.activity_pub_enabled
  end
end
...
Guardian.prepend DiscourseActivityPubGuardianExtension
``` 
[See further](https://github.com/discourse/discourse-activity-pub/blob/main/extensions/discourse_activity_pub_guardian_extension.rb)

This change would mean the above could be done via the plugin api like so:

```
add_guardian_check(:before, :edit_post) do |guardian, result, post|
  !post.activity_pub_remote?
end

add_guardian_check(:before, :change_post_owner) do |guardian|
  return true unless DiscourseActivityPub.enabled && guardian.request&.params&.[]("topic_id")
  topic = Topic.find_by(id: guardian.request.params["topic_id"].to_i)
  !topic&.activity_pub_enabled
end
```