### PR TITLE
FIX: ensures chat notifications links work with subfolder

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
@@ -1,5 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { formatUsername } from "discourse/lib/utilities";
+import getURL from "discourse-common/lib/get-url";
 import I18n from "discourse-i18n";
 import slugifyChannel from "discourse/plugins/chat/discourse/lib/slugify-channel";
 
@@ -35,7 +36,7 @@ export default {
                   url += `/${data.chat_message_id}`;
                 }
 
-                return url;
+                return getURL(url);
               }
 
               get label() {
@@ -65,7 +66,7 @@ export default {
                 } else {
                   notificationRoute += `/${this.notification.data.chat_message_id}`;
                 }
-                return notificationRoute;
+                return getURL(notificationRoute);
               }
 
               get linkTitle() {

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
     SiteSetting.navigation_menu = "sidebar"
     chat_system_bootstrap
     sign_in(current_user)
+    set_subfolder "/discuss"
   end
 
   shared_examples "chat not available" do
     it "doesn’t show the chat tab" do
-      visit("/")
+      visit("/discuss")
       find(".header-dropdown-toggle.current-user").click
 
       expect(page).to have_no_css("#user-menu-button-chat-notifications")
@@ -53,7 +54,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
         end
 
         it "shows a mention notification" do
-          visit("/")
+          visit("/discuss")
 
           find(".header-dropdown-toggle.current-user").click
           within("#user-menu-button-chat-notifications") do |panel|
@@ -62,7 +63,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
           end
           expect(find("#quick-access-chat-notifications")).to have_link(
             I18n.t("js.notifications.popup.direct_message_chat_mention.direct"),
-            href: "/chat/c/#{other_user.username}/#{dm_channel_1.id}/#{message.id}",
+            href: "/discuss/chat/c/#{other_user.username}/#{dm_channel_1.id}/#{message.id}",
           )
         end
       end
@@ -96,7 +97,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
         end
 
         it "shows a group mention notification" do
-          visit("/")
+          visit("/discuss")
 
           find(".header-dropdown-toggle.current-user").click
           within("#user-menu-button-chat-notifications") do |panel|
@@ -109,7 +110,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
               identifier: "@#{group.name}",
               channel: channel_1.name,
             ),
-            href: "/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
+            href: "/discuss/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
           )
         end
       end
@@ -126,7 +127,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
         end
 
         it "shows a mention notification" do
-          visit("/")
+          visit("/discuss")
 
           find(".header-dropdown-toggle.current-user").click
           within("#user-menu-button-chat-notifications") do |panel|
@@ -136,7 +137,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
 
           expect(find("#quick-access-chat-notifications")).to have_link(
             I18n.t("js.notifications.popup.chat_mention.direct", channel: channel_1.name),
-            href: "/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
+            href: "/discuss/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
           )
         end
 
@@ -152,7 +153,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
           end
 
           it "shows a mention notification when the message is in a thread" do
-            visit("/")
+            visit("/discuss")
 
             find(".header-dropdown-toggle.current-user").click
             within("#user-menu-button-chat-notifications") do |panel|
@@ -162,7 +163,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
 
             expect(find("#quick-access-chat-notifications")).to have_link(
               I18n.t("js.notifications.popup.chat_mention.direct", channel: channel_1.name),
-              href: "/chat/c/#{channel_1.slug}/#{channel_1.id}/t/#{message.thread_id}",
+              href: "/discuss/chat/c/#{channel_1.slug}/#{channel_1.id}/t/#{message.thread_id}",
             )
           end
         end
@@ -180,20 +181,21 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
         end
 
         it "shows a mention notification" do
-          visit("/")
+          visit("/discuss")
 
           find(".header-dropdown-toggle.current-user").click
           within("#user-menu-button-chat-notifications") do |panel|
             expect(panel).to have_content(1)
             panel.click
           end
+
           expect(find("#quick-access-chat-notifications")).to have_link(
             I18n.t(
               "js.notifications.popup.chat_mention.other_plain",
               identifier: "@all",
               channel: channel_1.name,
             ),
-            href: "/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
+            href: "/discuss/chat/c/#{channel_1.slug}/#{channel_1.id}/#{message.id}",
           )
         end
       end
@@ -215,7 +217,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
 
       using_session(:user_1) do
         sign_in(other_user)
-        visit("/")
+        visit("/discuss")
         find(".header-dropdown-toggle.current-user").click
 
         expect(find("#user-menu-button-chat-notifications")).to have_content(1)


### PR DESCRIPTION
We were missing two `getURL` calls.

The test is now written for subfolder but it's good enough. If it's working for subfolder, it's working for non subfolders, the opposite being false.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
