### PR TITLE
FIX: Track `User.status` property

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -177,6 +177,7 @@ export default class User extends RestModel.extend(Evented) {
   @service userTips;
 
   @tracked do_not_disturb_until;
+  @tracked status;
 
   @userOption("mailing_list_mode") mailing_list_mode;
   @userOption("external_links_in_new_tab") external_links_in_new_tab;


### PR DESCRIPTION
Fixes a bug I stumbled upon in dev env:

```
Error: Assertion Failed: You attempted to update <discourse@model:user::ember337>.status to "[object Object]", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
