### PR TITLE
UX: link to /latest in welcome topic template

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -827,7 +827,7 @@ en:
 
       :speaking_head: **Introduce yourself** by adding your picture and information about yourself and your interests to [your profile](%{base_path}/my/preferences/account). What is one thing you’d like to be asked about?
 
-      :open_book: **Get to know the community** by [browsing discussions](%{base_path}/top) that are already happening here. When you find a post interesting, informative, or entertaining, use the :heart: to show your appreciation or support!
+      :open_book: **Get to know the community** by [browsing discussions](%{base_path}/latest) that are already happening here. When you find a post interesting, informative, or entertaining, use the :heart: to show your appreciation or support!
 
       :handshake: **Contribute** by commenting, sharing your own perspective, asking questions, or offering feedback in the discussion. Before replying or starting new topics, please review the [Community Guidelines](%{base_path}/faq).
 


### PR DESCRIPTION
On new sites, /top has no topics, which is a poor experience for new users.
