### PR TITLE
DEV: bots are always allowed to chat

### DIFF
--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -13,7 +13,7 @@ module Chat
 
     def can_chat?
       return false if anonymous?
-      @user.staff? || @user.in_any_groups?(Chat.allowed_group_ids)
+      is_staff? || @user.bot? || @user.in_any_groups?(Chat.allowed_group_ids)
     end
 
     def can_direct_message?
@@ -140,7 +140,7 @@ module Chat
 
     def can_flag_chat_messages?
       return false if @user.silenced?
-      return true if @user.staff?
+      return true if is_staff?
 
       @user.in_any_groups?(SiteSetting.chat_message_flag_allowed_groups_map)
     end

--- a/plugins/chat/spec/serializer/chat/direct_message_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/direct_message_serializer_spec.rb
@@ -3,9 +3,9 @@
 describe Chat::DirectMessageSerializer do
   describe "#user" do
     it "returns you when there are two of us" do
-      me = Fabricate.build(:user)
-      you = Fabricate.build(:user)
-      direct_message = Fabricate.build(:direct_message, users: [me, you])
+      me = Fabricate(:user)
+      you = Fabricate(:user)
+      direct_message = Fabricate(:direct_message, users: [me, you])
 
       serializer = described_class.new(direct_message, scope: Guardian.new(me), root: false)
       json = serializer.as_json
@@ -14,10 +14,10 @@ describe Chat::DirectMessageSerializer do
     end
 
     it "returns you both if there are three of us" do
-      me = Fabricate.build(:user)
-      you = Fabricate.build(:user)
-      other_you = Fabricate.build(:user)
-      direct_message = Fabricate.build(:direct_message, users: [me, you, other_you])
+      me = Fabricate(:user)
+      you = Fabricate(:user)
+      other_you = Fabricate(:user)
+      direct_message = Fabricate(:direct_message, users: [me, you, other_you])
 
       serializer = described_class.new(direct_message, scope: Guardian.new(me), root: false)
       json = serializer.as_json
@@ -28,8 +28,8 @@ describe Chat::DirectMessageSerializer do
     end
 
     it "returns me if there is only me" do
-      me = Fabricate.build(:user)
-      direct_message = Fabricate.build(:direct_message, users: [me])
+      me = Fabricate(:user)
+      direct_message = Fabricate(:direct_message, users: [me])
 
       serializer = described_class.new(direct_message, scope: Guardian.new(me), root: false)
       json = serializer.as_json


### PR DESCRIPTION
Bots should be allowed to chat regardless of their groups, just like staff. It makes configuring bots to work in chat much easier.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
