### PR TITLE
UX: Add CSS for admin plugin empty list CTA

### DIFF
--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -123,4 +123,9 @@
       margin-bottom: 1em;
     }
   }
+
+  &__empty-list {
+    padding: 1em;
+    border: 1px solid var(--primary-low);
+  }
 }


### PR DESCRIPTION
This adds `admin-plugin-config-area__empty-list`,
allows us to standardize on CTA styling for empty lists.

![2024-05-09_11-59](https://github.com/discourse/discourse/assets/920448/9bf25cb1-28f1-4197-b551-c5ae8f0c1b7b)
