### PR TITLE
FIX: ensures bot can always chat

### DIFF
--- a/plugins/chat/app/policies/chat/channel/message_creation_policy.rb
+++ b/plugins/chat/app/policies/chat/channel/message_creation_policy.rb
@@ -4,7 +4,8 @@ class Chat::Channel::MessageCreationPolicy < PolicyBase
   class DirectMessageStrategy
     class << self
       def call(guardian, channel)
-        guardian.can_create_channel_message?(channel) || guardian.can_create_direct_message?
+        guardian.can_create_channel_message?(channel) && guardian.can_create_direct_message? &&
+          guardian.can_chat?
       end
 
       def reason(*)
@@ -16,7 +17,7 @@ class Chat::Channel::MessageCreationPolicy < PolicyBase
   class CategoryStrategy
     class << self
       def call(guardian, channel)
-        guardian.can_create_channel_message?(channel)
+        guardian.can_create_channel_message?(channel) && guardian.can_chat?
       end
 
       def reason(_, channel)

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -82,7 +82,9 @@ module Chat
     end
 
     def can_modify_channel_message(guardian:, message:)
-      guardian.can_modify_channel_message?(message.chat_channel)
+      result = guardian.can_modify_channel_message?(message.chat_channel) && guardian.can_chat?
+      result &&= guardian.can_direct_message? if message.chat_channel.direct_message_channel?
+      result
     end
 
     def can_modify_message(guardian:, message:)

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -17,7 +17,8 @@ module Chat
     end
 
     def can_direct_message?
-      @user.in_any_groups?(SiteSetting.direct_message_enabled_groups_map)
+      return false if anonymous?
+      is_staff? || @user.bot? || @user.in_any_groups?(SiteSetting.direct_message_enabled_groups_map)
     end
 
     def can_create_chat_message?
@@ -25,7 +26,7 @@ module Chat
     end
 
     def can_create_direct_message?
-      is_staff? || can_direct_message?
+      can_direct_message?
     end
 
     def hidden_tag_names

--- a/plugins/chat/spec/system/bot_spec.rb
+++ b/plugins/chat/spec/system/bot_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "Bot", type: :system do
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+  let(:current_user) { Discourse.system_user }
+
+  before do
+    chat_system_bootstrap
+    sign_in(current_user)
+  end
+
+  context "when not allowed to chat" do
+    before { SiteSetting.chat_allowed_groups = "" }
+
+    it "can send a message in a public channel" do
+      channel_1 = Fabricate(:category_channel)
+      message_1 =
+        Fabricate(:chat_message, chat_channel: channel_1, user: current_user, use_service: true)
+      chat_page.visit_channel(channel_1)
+
+      expect(channel_page.messages).to have_message(id: message_1.id)
+    end
+  end
+
+  context "when not allowed to use direct message" do
+    before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:staff] }
+
+    it "can send a message in a direct message channel" do
+      channel_1 = Fabricate(:direct_message_channel)
+      message_1 =
+        Fabricate(:chat_message, chat_channel: channel_1, user: current_user, use_service: true)
+      chat_page.visit_channel(channel_1)
+
+      expect(channel_page.messages).to have_message(id: message_1.id)
+    end
+  end
+end


### PR DESCRIPTION
Part of this change we also ensure a user can always chat before creating/updating messages

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
