### PR TITLE
FIX: Open Powered-by link in new tab

### DIFF
--- a/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
+++ b/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
@@ -2,6 +2,7 @@ import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
 const PoweredByDiscourse = <template>
+  {{! template-lint-disable link-rel-noopener }}
   <a
     class="powered-by-discourse"
     href="https://discourse.org/powered-by"

--- a/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
+++ b/app/assets/javascripts/discourse/app/components/powered-by-discourse.gjs
@@ -2,7 +2,11 @@ import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 
 const PoweredByDiscourse = <template>
-  <a class="powered-by-discourse" href="https://discourse.org/powered-by">
+  <a
+    class="powered-by-discourse"
+    href="https://discourse.org/powered-by"
+    target="_blank"
+  >
     <span class="powered-by-discourse__content">
       <span class="powered-by-discourse__logo">
         {{icon "fab-discourse"}}


### PR DESCRIPTION
Opening the Discourse Powered-by link in a new tab doesn't take away from focus in the forum, avoids back button issues.
