### PR TITLE
FIX: close d-menu before action in topic menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -20,15 +20,15 @@ export default class TopicAdminMenu extends Component {
   }
 
   @action
-  onButtonAction(buttonAction) {
+  async onButtonAction(buttonAction) {
+    await this.dMenu.close();
     this.args[buttonAction]?.();
-    this.dMenu.close();
   }
 
   @action
-  onExtraButtonAction(buttonAction) {
+  async onExtraButtonAction(buttonAction) {
+    await this.dMenu.close();
     buttonAction?.();
-    this.dMenu.close();
   }
 
   get extraButtons() {


### PR DESCRIPTION
Prior to this fix we were making the action and then closing the d-menu which in this case would be a modal and close the modal opened by the action.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
