### PR TITLE
FIX: disables the modal on mobile bookmark-menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -246,7 +246,6 @@ export default class BookmarkMenu extends Component {
       @onClose={{this.onCloseMenu}}
       @onShow={{this.onShowMenu}}
       @onRegisterApi={{this.onRegisterApi}}
-      @modalForMobile={{true}}
       @arrow={{false}}
     >
       <:content>


### PR DESCRIPTION
It's a temporary solution while I work a better solution. The problem here is quite tricky. We are showing a modal from a modal. But if we close the previous modal, before the second one is show it means we destroy the menu holding the first modal which prevents showing the second modal.

One possible solution would be to refactor d-modal’s show function. At the moment if you await on show it will await until closed and not when the modal has been inserted to the DOM. It means we don't have a clean moment to close the d-menu.

The second issue it that even though it's possible to have multiple modals on screen, the close modal assumes only one active modal at a time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
