### PR TITLE
FIX: Don't unnecessarily scrub query params from homepage (stable)

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/homepage-router-overrides.js
+++ b/app/assets/javascripts/discourse/app/lib/homepage-router-overrides.js
@@ -21,12 +21,14 @@ export default function applyRouterHomepageOverrides(router) {
   }
 }
 
+const homepageRewriteParam = "_discourse_homepage_rewrite";
+
 /**
  * Returns a magic URL which `discovery-index` will redirect to.
  * We watch for this, and then perform the rewrite in the router.
  */
 export function homepageDestination() {
-  return `/${defaultHomepage()}?_discourse_homepage_rewrite=1`;
+  return `/${defaultHomepage()}?${homepageRewriteParam}=1`;
 }
 
 function rewriteIfNeeded(url, transition) {
@@ -34,12 +36,16 @@ function rewriteIfNeeded(url, transition) {
   if (
     intentUrl?.startsWith(homepageDestination()) ||
     (transition?.intent.name === `discovery.${defaultHomepage()}` &&
-      transition?.intent.queryParams["_discourse_homepage_rewrite"])
+      transition?.intent.queryParams[homepageRewriteParam])
   ) {
-    const params = url.split("?", 2)[1];
+    const params = (intentUrl || url).split("?", 2)[1];
     url = "/";
     if (params) {
-      url += `?${params}`;
+      const searchParams = new URLSearchParams(params);
+      searchParams.delete(homepageRewriteParam);
+      if (searchParams.size) {
+        url += `?${searchParams.toString()}`;
+      }
     }
   }
   return url;

--- a/app/assets/javascripts/discourse/tests/acceptance/homepage-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/homepage-test.js
@@ -74,4 +74,18 @@ acceptance("Dynamic homepage handling", function () {
     await click(".nav-item_categories a");
     assertOnCategories("/categories");
   });
+
+  test("it passes query params through", async function (assert) {
+    await visit("/?test-one=true");
+
+    const router = getOwner(this).lookup("service:router");
+    assert.strictEqual(router.currentURL, "/?test-one=true");
+  });
+
+  test("it removes the _discourse_homepage_rewrite param from the URL", async function (assert) {
+    await visit("/?_discourse_homepage_rewrite=1&test-one=true");
+
+    const router = getOwner(this).lookup("service:router");
+    assert.strictEqual(router.currentURL, "/?test-one=true");
+  });
 });


### PR DESCRIPTION
Seems like an accident that the homepage route will always strip all query params from the URL.. This fixes that :)

Backport of 4f75cee6d2e1184159c0c13983e26fe357d0d2f4

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
