### PR TITLE
FIX: Preveint recurring automations from running before `start_date`

### DIFF
--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -36,6 +36,11 @@ module DiscourseAutomation
         end
 
         start_date = Time.parse(start_date)
+        if start_date > Time.zone.now
+          automation.pending_automations.create!(execute_at: start_date)
+          return
+        end
+
         byday = start_date.strftime("%A").upcase[0, 2]
         interval = interval.to_i
         interval_end = interval + 1


### PR DESCRIPTION
Some combinations of `start_date` and frequency/interval values can cause a recurring automation rule to either trigger before its `start_date` or never trigger. Example repros:

1. Configure a recurring automation with **hourly** recurrence and a `start_date` several days ahead. What this will do is make the automation start running hourly immediately even though the `start_date` is several days ahead.

2. Configure a recurring automation with a **weekly** recurrence and a `start_date` several weeks ahead. This will result in the automation never triggering even after the `start_date`.

These 2 scenarios share the same cause which is that the automation plugin doesn't use the `start_date` as the date for the first run and instead uses the frequency/interval values from the current time to calculate the first run date.

This PR fixes this bug by adding an explicit check for `start_date` and using it as the first run's date if it's ahead of the current time.