### PR TITLE
DEV: add home-logo-contents plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
@@ -81,36 +81,46 @@ export default class HomeLogo extends Component {
     <PluginOutlet @name="home-logo" @outletArgs={{hash minimized=@minimized}}>
       <div class={{concatClass (if @minimized "title--minimized") "title"}}>
         <a href={{this.href}} {{on "click" this.click}}>
-          {{#if @minimized}}
-            {{#if this.logoSmallUrl}}
+          <PluginOutlet
+            @name="home-logo-contents"
+            @outletArgs={{hash
+              minimized=@minimized
+              logoUrl=this.logoUrl
+              logoSmallUrl=this.logoSmallUrl
+              showMobileLogo=this.showMobileLogo
+            }}
+          >
+            {{#if @minimized}}
+              {{#if this.logoSmallUrl}}
+                <Logo
+                  @key="logo-small"
+                  @url={{this.logoSmallUrl}}
+                  @title={{this.siteSettings.title}}
+                  @darkUrl={{this.logoSmallUrlDark}}
+                />
+              {{else}}
+                {{icon "home"}}
+              {{/if}}
+            {{else if this.showMobileLogo}}
               <Logo
-                @key="logo-small"
-                @url={{this.logoSmallUrl}}
+                @key="logo-mobile"
+                @url={{this.mobileLogoUrl}}
                 @title={{this.siteSettings.title}}
-                @darkUrl={{this.logoSmallUrlDark}}
+                @darkUrl={{this.mobileLogoUrlDark}}
+              />
+            {{else if this.logoUrl}}
+              <Logo
+                @key="logo-big"
+                @url={{this.logoUrl}}
+                @title={{this.siteSettings.title}}
+                @darkUrl={{this.logoUrlDark}}
               />
             {{else}}
-              {{icon "home"}}
+              <h1 id="site-text-logo" class="text-logo">
+                {{this.siteSettings.title}}
+              </h1>
             {{/if}}
-          {{else if this.showMobileLogo}}
-            <Logo
-              @key="logo-mobile"
-              @url={{this.mobileLogoUrl}}
-              @title={{this.siteSettings.title}}
-              @darkUrl={{this.mobileLogoUrlDark}}
-            />
-          {{else if this.logoUrl}}
-            <Logo
-              @key="logo-big"
-              @url={{this.logoUrl}}
-              @title={{this.siteSettings.title}}
-              @darkUrl={{this.logoUrlDark}}
-            />
-          {{else}}
-            <h1 id="site-text-logo" class="text-logo">
-              {{this.siteSettings.title}}
-            </h1>
-          {{/if}}
+          </PluginOutlet>
         </a>
       </div>
     </PluginOutlet>


### PR DESCRIPTION
Adding a new plugin outlet to facilitate upgrading to the glimmer header - this is useful for any widget customizations in themes that use `reopenWidget` to override getters within the home-logo widget that would result in changes of content within the interactive anchor element that makes the entire home-logo section navigate to a specified URL on click.