### PR TITLE
DEV: Increase external avatar url limit

### DIFF
--- a/app/models/single_sign_on_record.rb
+++ b/app/models/single_sign_on_record.rb
@@ -19,7 +19,7 @@ end
 #  external_username               :string
 #  external_email                  :string
 #  external_name                   :string
-#  external_avatar_url             :string(1000)
+#  external_avatar_url             :string(1500)
 #  external_profile_background_url :string
 #  external_card_background_url    :string
 #

--- a/db/migrate/20240510073417_increase_external_avatar_url_limit.rb
+++ b/db/migrate/20240510073417_increase_external_avatar_url_limit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class IncreaseExternalAvatarUrlLimit < ActiveRecord::Migration[7.0]
+  def change
+    change_column :single_sign_on_records, :external_avatar_url, :string, limit: 1500
+  end
+end


### PR DESCRIPTION
😮‍💨 

In some cases, e.g. /307494, a google avatar URL can exceed 1000 characters. 

This PR allows users with such lengthy avatar URLs to log in.