### PR TITLE
FIX: restore behaviour of adding docked classname to document.body in glimmer header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { DEBUG } from "@glimmer/env";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { cancel, schedule } from "@ember/runloop";
@@ -28,10 +29,11 @@ export default class GlimmerSiteHeader extends Component {
   @service site;
   @service header;
 
+  docking;
   pxClosed;
   headerElement;
-  docking;
-  _dockedHeader = false;
+
+  @tracked _dockedHeader = false;
   _animate = false;
   _headerWrap;
   _swipeMenuOrigin;


### PR DESCRIPTION
Some themes have styling applied for body.docked, but in the current glimmer header, this classname never gets applied. This fix restores that behaviour.