### PR TITLE
DEV: allows to get a menu by its identifier

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -265,4 +265,17 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
 
     assert.dom(".fk-d-menu__content.test-content").doesNotExist();
   });
+
+  test("get a menu by identifier", async function (assert) {
+    await render(hbs`<DMenu @inline={{true}} @identifier="test">test</DMenu>`);
+    await open();
+
+    const activeMenu = getOwner(this)
+      .lookup("service:menu")
+      .getByIdentifier("test");
+
+    await activeMenu.close();
+
+    assert.dom(".fk-d-menu__content.test-content").doesNotExist();
+  });
 });

--- a/app/assets/javascripts/float-kit/addon/services/menu.js
+++ b/app/assets/javascripts/float-kit/addon/services/menu.js
@@ -78,8 +78,22 @@ export default class Menu extends Service {
   }
 
   /**
-   * Closes the active menu
-   * @param {DMenuInstance} [menu] - the menu to close, if not provider will close any active menu
+   * Returns an existing menu by its identifier if found
+   *
+   * @param {String} identifier - the menu identifier to retrieve
+   *
+   * @returns {Promise<DMenuInstance>}
+   */
+  getByIdentifier(identifier) {
+    return this.registeredMenus.find(
+      (registeredMenu) => registeredMenu.options.identifier === identifier
+    );
+  }
+
+  /**
+   * Closes the given menu
+   *
+   * @param {DMenuInstance | String} [menu | identifier] - the menu to close, can accept an instance or an identifier
    */
   @action
   async close(menu) {


### PR DESCRIPTION
Usage:

```javascript
this.menu.getByIdentifier("foo");
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
