### PR TITLE
FIX: add missing translations for staff action logs.

### DIFF
--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -37,13 +37,15 @@ class Admin::WatchedWordsController < Admin::StaffController
     raise Discourse::InvalidParameters.new(:id) unless watched_word
 
     watched_word_group = watched_word.watched_word_group
+
     if watched_word_group&.watched_words&.count == 1
       watched_word_group.destroy!
+      StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word_group)
     else
       watched_word.destroy!
+      StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word)
     end
 
-    StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word)
     render json: success_json
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -934,8 +934,11 @@ class StaffActionLogger
   def log_watched_words_creation(watched_word)
     raise Discourse::InvalidParameters.new(:watched_word) unless watched_word
 
+    action_key = :watched_word_create
+    action_key = :create_watched_word_group if watched_word.is_a?(WatchedWordGroup)
+
     UserHistory.create!(
-      action: UserHistory.actions[:watched_word_create],
+      action: UserHistory.actions[action_key],
       acting_user_id: @admin.id,
       details: watched_word.action_log_details,
       context: WatchedWord.actions[watched_word.action],
@@ -945,8 +948,11 @@ class StaffActionLogger
   def log_watched_words_deletion(watched_word)
     raise Discourse::InvalidParameters.new(:watched_word) unless watched_word
 
+    action_key = :watched_word_destroy
+    action_key = :delete_watched_word_group if watched_word.is_a?(WatchedWordGroup)
+
     UserHistory.create!(
-      action: UserHistory.actions[:watched_word_destroy],
+      action: UserHistory.actions[action_key],
       acting_user_id: @admin.id,
       details: watched_word.action_log_details,
       context: WatchedWord.actions[watched_word.action],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6050,6 +6050,9 @@ en:
             update_public_sidebar_section: "update public sidebar section"
             destroy_public_sidebar_section: "destroy public sidebar section"
             reset_bounce_score: "reset bounce score"
+            create_watched_word_group: "create watched word group"
+            update_watched_word_group: "update watched word group"
+            delete_watched_word_group: "delete watched word group"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -96,6 +96,9 @@ RSpec.describe Admin::WatchedWordsController do
         expect(response.status).to eq(200)
         expect(WatchedWordGroup.exists?(id: watched_word_group.id)).to be_falsey
         expect(WatchedWord.exists?(id: watched_word.id)).to be_falsey
+        expect(
+          UserHistory.where(action: UserHistory.actions[:delete_watched_word_group]).count,
+        ).to eq(1)
       end
     end
   end
@@ -126,6 +129,9 @@ RSpec.describe Admin::WatchedWordsController do
         expect(response.status).to eq(200)
         expect(WatchedWord.take.word).to eq("Deals")
         expect(WatchedWord.last.word).to eq("Offer")
+        expect(
+          UserHistory.where(action: UserHistory.actions[:create_watched_word_group]).count,
+        ).to eq(1)
       end
 
       it "creates a word with the given case sensitivity" do


### PR DESCRIPTION
The watched word group's create, update and delete action logs were missing the translations. This PR will add those strings and will use the group key instead of watched word key where needed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
