### PR TITLE
UX: topic admin button should match height of siblings

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -91,6 +91,7 @@ export default class TopicAdminMenu extends Component {
             @triggerClass="toggle-admin-menu"
             @modalForMobile={{true}}
             @autofocus={{true}}
+            @class="btn-default btn-icon"
           >
             <:trigger>
               {{icon "wrench"}}

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -171,6 +171,10 @@
     touch-action: none;
     min-width: 6em;
 
+    .topic-admin-menu-button .btn {
+      height: 100%;
+    }
+
     .timeline-controls {
       margin-bottom: 1em;
     }


### PR DESCRIPTION
Fixes this theme component mismatch issue and also adds some missing button classes

Before: 
![image](https://github.com/discourse/discourse/assets/1681963/001596b8-781e-43c7-8974-9c22dfcef63f)


After:
![image](https://github.com/discourse/discourse/assets/1681963/86aa0819-5766-45ed-ba28-dd19fae67f86)
