### PR TITLE
UX: Group membership PMs thread

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -460,7 +460,10 @@ class GroupsController < ApplicationController
     # find original membership request PM
     request_topic =
       Topic.find_by(
-        title: I18n.t("groups.request_membership_pm.title", group_name: group.name),
+        title:
+          (
+            I18n.t "groups.request_membership_pm.title", group_name: group.name, locale: user.locale
+          ),
         archetype: "private_message",
         user_id: user.id,
       )
@@ -479,7 +482,8 @@ class GroupsController < ApplicationController
         current_user,
         post_type: Post.types[:regular],
         topic_id: request_topic.id,
-        raw: I18n.t("groups.request_accepted_pm.body", group_name: group.name),
+        raw:
+          (I18n.t "groups.request_accepted_pm.body", group_name: group.name, locale: user.locale),
         reply_to_post_number: 1,
         target_usernames: user.username,
         skip_validations: true,

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -457,6 +457,14 @@ class GroupsController < ApplicationController
     user = User.find_by(id: params[:user_id])
     raise Discourse::InvalidParameters.new(:user_id) if user.blank?
 
+    # find original membership request PM
+    request_topic =
+      Topic.find_by(
+        title: I18n.t("groups.request_membership_pm.title", group_name: group.name),
+        archetype: "private_message",
+        user_id: user.id,
+      )
+
     ActiveRecord::Base.transaction do
       if params[:accept]
         group.add(user)
@@ -469,9 +477,10 @@ class GroupsController < ApplicationController
     if params[:accept]
       PostCreator.new(
         current_user,
-        title: I18n.t("groups.request_accepted_pm.title", group_name: group.name),
+        post_type: Post.types[:regular],
+        topic_id: request_topic.id,
         raw: I18n.t("groups.request_accepted_pm.body", group_name: group.name),
-        archetype: Archetype.private_message,
+        reply_to_post_number: 1,
         target_usernames: user.username,
         skip_validations: true,
       ).create!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -638,7 +638,6 @@ en:
     request_membership_pm:
       title: "Membership Request for @%{group_name}"
     request_accepted_pm:
-      title: "You've been accepted into @%{group_name}"
       body: |
         Your request to enter @%{group_name} has been accepted and you are now a member.
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2200,6 +2200,50 @@ RSpec.describe GroupsController do
         I18n.t("groups.request_accepted_pm.body", group_name: group.name).strip,
       )
     end
+
+    it "sends accepted membership request reply even if request is in another language" do
+      SiteSetting.allow_user_locale = true
+      other_user.update!(locale: "fr")
+
+      GroupRequest.create!(group: group, user: other_user)
+
+      # send the initial request PM
+      PostCreator.new(
+        other_user,
+        title:
+          (
+            I18n.t "groups.request_membership_pm.title",
+                   group_name: group.name,
+                   locale: other_user.locale
+          ),
+        raw: "*French accent* Please let me in!",
+        archetype: Archetype.private_message,
+        target_usernames: "#{user.username}",
+        skip_validations: true,
+      ).create!
+
+      topic = Topic.last
+
+      expect {
+        put "/groups/#{group.id}/handle_membership_request.json",
+            params: {
+              user_id: other_user.id,
+              accept: true,
+            }
+      }.to_not change { Topic.count }
+
+      expect(topic.archetype).to eq(Archetype.private_message)
+      expect(Topic.first.title).to eq(
+        I18n.t("groups.request_membership_pm.title", group_name: group.name, locale: "fr"),
+      )
+
+      post = Post.last
+      expect(post.topic_id).to eq(Topic.last.id)
+      expect(topic.posts.count).to eq(2)
+      expect(post.raw).to eq(
+        I18n.t("groups.request_accepted_pm.body", group_name: group.name, locale: "fr").strip,
+      )
+    end
   end
 
   describe "#histories" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2165,20 +2165,38 @@ RSpec.describe GroupsController do
       sign_in(user)
     end
 
-    it "sends a private message when accepted" do
+    it "sends a reply to the request membership topic when accepted" do
       GroupRequest.create!(group: group, user: other_user)
+
+      # send the initial request PM
+      PostCreator.new(
+        other_user,
+        title: I18n.t("groups.request_membership_pm.title", group_name: group.name),
+        raw: "*British accent* Please, sir, may I have some group?",
+        archetype: Archetype.private_message,
+        target_usernames: "#{user.username}",
+        skip_validations: true,
+      ).create!
+
+      topic = Topic.last
+
       expect {
         put "/groups/#{group.id}/handle_membership_request.json",
             params: {
               user_id: other_user.id,
               accept: true,
             }
-      }.to change { Topic.count }.by(1).and change { Post.count }.by(1)
+      }.to_not change { Topic.count }
 
-      topic = Topic.last
       expect(topic.archetype).to eq(Archetype.private_message)
-      expect(topic.title).to eq(I18n.t("groups.request_accepted_pm.title", group_name: group.name))
-      expect(topic.first_post.raw).to eq(
+      expect(Topic.first.title).to eq(
+        I18n.t("groups.request_membership_pm.title", group_name: group.name),
+      )
+
+      post = Post.last
+      expect(post.topic_id).to eq(Topic.last.id)
+      expect(topic.posts.count).to eq(2)
+      expect(post.raw).to eq(
         I18n.t("groups.request_accepted_pm.body", group_name: group.name).strip,
       )
     end


### PR DESCRIPTION
Slight alteration on group request messaging per [this meta post](https://meta.discourse.org/t/better-flow-for-group-membership-requests/64412/23?).

Instead of creating two separate Topics when a user (1) requests to join a group and (2) gets accepted in, this makes the acceptance message into a Post under the origin group request Topic.

<img width="816" alt="Screenshot 2024-05-10 at 5 43 17 PM" src="https://github.com/discourse/discourse/assets/25828824/e22ea219-8ead-40b2-989e-5602f0b8ef5e">

