### PR TITLE
DEV: Add `csv` to Gemfile to resolve Ruby 3.3 deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -267,6 +267,7 @@ gem "net-http"
 gem "cgi", ">= 0.3.6", require: false
 
 gem "tzinfo-data"
+gem "csv", require: false
 
 # dependencies for the automation plugin
 gem "iso8601"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
+    csv (3.3.0)
     date (3.3.4)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
@@ -568,6 +569,7 @@ DEPENDENCIES
   cose
   cppjieba_rb
   css_parser
+  csv
   diffy
   digest
   discourse-fonts


### PR DESCRIPTION
The following warning is being printed when running Discourse with Ruby
3.3

`warning: /usr/local/lib/ruby/3.3.0/csv.rb was loaded from the standard
library, but will no longer be part of the default gems since Ruby
3.4.0. Add csv to your Gemfile or gemspec.`
