### PR TITLE
DEV: Clean up sidebar modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/modal.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
-import { hash } from "@ember/helper";
+import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
@@ -15,7 +14,6 @@ import DropdownSelectBox from "select-kit/components/dropdown-select-box";
 export default class SidebarEditNavigationMenuModal extends Component {
   @tracked filter = "";
   @tracked filterDropdownValue = "all";
-
   filterDropdownContent = [
     {
       id: "all",
@@ -80,10 +78,11 @@ export default class SidebarEditNavigationMenuModal extends Component {
               class="sidebar__edit-navigation-menu__filter-input-icon"
             }}
 
-            <Input
+            <input
+              {{on "input" (withEventValue (fn (mut this.filter)))}}
               {{on "input" (withEventValue @onFilterInput)}}
-              @type="text"
-              @value={{this.filter}}
+              type="text"
+              value={{this.filter}}
               placeholder={{@inputFilterPlaceholder}}
               autofocus="true"
               class="sidebar__edit-navigation-menu__filter-input-field"

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
@@ -21,7 +21,6 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
   @service store;
 
   @tracked disableFiltering = false;
-  @tracked filter = "";
   @tracked saving = false;
   @tracked selectedTags = new TrackedSet([...this.currentUser.sidebarTagNames]);
   @tracked tags = [];
@@ -142,9 +141,9 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
   @action
   toggleTag(tag) {
     if (this.selectedTags.has(tag)) {
-      this.selectedTags.add(tag);
-    } else {
       this.selectedTags.delete(tag);
+    } else {
+      this.selectedTags.add(tag);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/tags-modal.gjs
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
 import { concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
-import { gt, includes, or } from "truth-helpers";
+import { TrackedSet } from "@ember-compat/tracked-built-ins";
+import { gt, has, or } from "truth-helpers";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -20,13 +20,15 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
   @service siteSettings;
   @service store;
 
+  @tracked disableFiltering = false;
   @tracked filter = "";
-  @tracked onlySelected = false;
-  @tracked onlyUnSelected = false;
+  @tracked saving = false;
+  @tracked selectedTags = new TrackedSet([...this.currentUser.sidebarTagNames]);
   @tracked tags = [];
-  @tracked tagsLoading;
-  @tracked disableFiltering;
-  @tracked selectedTags = [...this.currentUser.sidebarTagNames];
+  @tracked tagsLoading = false;
+  observer;
+  onlySelected = false;
+  onlyUnselected = false;
 
   constructor() {
     super(...arguments);
@@ -38,30 +40,25 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
 
     const findArgs = {};
 
-    if (this.filter !== "") {
+    if (this.filter) {
       findArgs.filter = this.filter;
     }
 
     if (this.onlySelected) {
-      findArgs.only_tags = this.selectedTags.join(",");
+      findArgs.only_tags = [...this.selectedTags].join(",");
+    } else if (this.onlyUnselected) {
+      findArgs.exclude_tags = [...this.selectedTags].join(",");
     }
 
-    if (this.onlyUnselected) {
-      findArgs.exclude_tags = this.selectedTags.join(",");
+    try {
+      const tags = await this.store.findAll("listTag", findArgs);
+      this.tags = tags;
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.tagsLoading = false;
+      this.disableFiltering = false;
     }
-
-    await this.store
-      .findAll("listTag", findArgs)
-      .then((tags) => {
-        this.tags = tags;
-      })
-      .catch((error) => {
-        popupAjaxError(error);
-      })
-      .finally(() => {
-        this.tagsLoading = false;
-        this.disableFiltering = false;
-      });
   }
 
   @action
@@ -137,38 +134,36 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
 
   @action
   resetToDefaults() {
-    this.selectedTags =
-      this.siteSettings.default_navigation_menu_tags.split("|");
+    this.selectedTags = new TrackedSet(
+      this.siteSettings.default_navigation_menu_tags.split("|")
+    );
   }
 
   @action
   toggleTag(tag) {
-    if (this.selectedTags.includes(tag)) {
-      this.selectedTags.removeObject(tag);
+    if (this.selectedTags.has(tag)) {
+      this.selectedTags.add(tag);
     } else {
-      this.selectedTags.addObject(tag);
+      this.selectedTags.delete(tag);
     }
   }
 
   @action
-  save() {
+  async save() {
     this.saving = true;
     const initialSidebarTags = this.currentUser.sidebar_tags;
-    this.currentUser.set("sidebar_tag_names", this.selectedTags);
+    this.currentUser.set("sidebar_tag_names", [...this.selectedTags]);
 
-    this.currentUser
-      .save(["sidebar_tag_names"])
-      .then((result) => {
-        this.currentUser.set("sidebar_tags", result.user.sidebar_tags);
-        this.args.closeModal();
-      })
-      .catch((error) => {
-        this.currentUser.set("sidebar_tags", initialSidebarTags);
-        popupAjaxError(error);
-      })
-      .finally(() => {
-        this.saving = false;
-      });
+    try {
+      const result = await this.currentUser.save(["sidebar_tag_names"]);
+      this.currentUser.set("sidebar_tags", result.user.sidebar_tags);
+      this.args.closeModal();
+    } catch (error) {
+      this.currentUser.set("sidebar_tags", initialSidebarTags);
+      popupAjaxError(error);
+    } finally {
+      this.saving = false;
+    }
   }
 
   <template>
@@ -204,10 +199,10 @@ export default class SidebarEditNavigationMenuTagsModal extends Component {
               data-tag-name={{tag.name}}
               class="sidebar-tags-form__tag"
             >
-              <Input
+              <input
                 {{on "click" (fn this.toggleTag tag.name)}}
-                @type="checkbox"
-                @checked={{includes this.selectedTags tag.name}}
+                type="checkbox"
+                checked={{has this.selectedTags tag.name}}
                 id={{concat "sidebar-tags-form__input--" tag.name}}
                 class="sidebar-tags-form__input"
               />


### PR DESCRIPTION
1. async/await
2. TrackedSet
3. don't rely on ember array methods
4. list used props
5. move stuff out of constructors
6. don't use ember's Input component
7. convert a function to a class method (to avoid passing in a class prop)
8. add missing `@tracked`
9. remove tracking from props that don't need it (not used in templates)