### PR TITLE
FIX: do not auto close on empty identifiers

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -311,6 +311,38 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu__content.second").exists();
   });
 
+  test("empty @groupIdentifier", async function (assert) {
+    await render(
+      hbs`<DMenu @inline={{true}} @class="first">1</DMenu><DMenu @inline={{true}} @class="second">2</DMenu>`
+    );
+
+    await click(".first.fk-d-menu__trigger");
+
+    assert.dom(".fk-d-menu__content.first").exists();
+    assert.dom(".fk-d-menu__content.second").doesNotExist();
+
+    await click(".second.fk-d-menu__trigger");
+
+    assert.dom(".fk-d-menu__content.first").exists("it doesn’t autoclose");
+    assert.dom(".fk-d-menu__content.second").exists();
+  });
+
+  test("empty @identifier", async function (assert) {
+    await render(
+      hbs`<DMenu @inline={{true}} @class="first">1</DMenu><DMenu @inline={{true}} @class="second">2</DMenu>`
+    );
+
+    await click(".first.fk-d-menu__trigger");
+
+    assert.dom(".fk-d-menu__content.first").exists();
+    assert.dom(".fk-d-menu__content.second").doesNotExist();
+
+    await click(".second.fk-d-menu__trigger");
+
+    assert.dom(".fk-d-menu__content.first").exists("it doesn’t autoclose");
+    assert.dom(".fk-d-menu__content.second").exists();
+  });
+
   test("@class", async function (assert) {
     await render(hbs`<DMenu @inline={{true}} @class="first">1</DMenu>`);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -311,23 +311,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu__content.second").exists();
   });
 
-  test("empty @groupIdentifier", async function (assert) {
-    await render(
-      hbs`<DMenu @inline={{true}} @class="first">1</DMenu><DMenu @inline={{true}} @class="second">2</DMenu>`
-    );
-
-    await click(".first.fk-d-menu__trigger");
-
-    assert.dom(".fk-d-menu__content.first").exists();
-    assert.dom(".fk-d-menu__content.second").doesNotExist();
-
-    await click(".second.fk-d-menu__trigger");
-
-    assert.dom(".fk-d-menu__content.first").exists("it doesn’t autoclose");
-    assert.dom(".fk-d-menu__content.second").exists();
-  });
-
-  test("empty @identifier", async function (assert) {
+  test("empty @identifier/@groupIdentifier", async function (assert) {
     await render(
       hbs`<DMenu @inline={{true}} @class="first">1</DMenu><DMenu @inline={{true}} @class="second">2</DMenu>`
     );

--- a/app/assets/javascripts/float-kit/addon/services/menu.js
+++ b/app/assets/javascripts/float-kit/addon/services/menu.js
@@ -52,9 +52,12 @@ export default class Menu extends Service {
     if (instance.options.identifier || instance.options.groupIdentifier) {
       for (const registeredMenu of this.registeredMenus) {
         if (
-          (registeredMenu.options.identifier === instance.options.identifier ||
-            registeredMenu.options.groupIdentifier ===
-              instance.options.groupIdentifier) &&
+          ((instance.options.identifier &&
+            registeredMenu.options.identifier ===
+              instance.options.identifier) ||
+            (instance.options.groupIdentifier &&
+              registeredMenu.options.groupIdentifier ===
+                instance.options.groupIdentifier)) &&
           registeredMenu !== instance
         ) {
           await this.close(registeredMenu);


### PR DESCRIPTION
Prior to this fix all menus with empty identifier or groupIdentifier would be considered to be part of the same identifiers/groupIdentifiers and would auto close any existing d-menu with no identifier/groupIdentifier when opened.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
