### PR TITLE
FIX: Remove duplicate user menu for old header implementation

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -289,16 +289,6 @@ createWidget("header-icons", {
       }
     });
 
-    if (attrs.user) {
-      icons.push(
-        this.attach("user-dropdown", {
-          active: attrs.userVisible,
-          action: "toggleUserMenu",
-          user: attrs.user,
-        })
-      );
-    }
-
     return icons;
   },
 });


### PR DESCRIPTION
Some of the old (pre-dag) header logic was accidently re-introduced as part of 9bcbfbba43b876ae92cb90d6d619be7b1154c119 (presumably by mistake while resolving a merge conflict). This causes sites on the old header implementation to end up with duplicate user menu icons.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
