### PR TITLE
FIX: restore docked body document from glimmer site header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -243,7 +243,7 @@ export default class GlimmerSiteHeader extends Component {
 
   @bind
   dockCheck() {
-    if (this._docAt === null) {
+    if (this._docAt === undefined || this._docAt === null) {
       if (!this.headerElement) {
         return;
       }

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe "Glimmer Header", type: :system do
     expect(header.get_computed_style_value(".d-header", "--header-offset")).to eq("60px")
   end
 
+  it "body document is permanently docked regardless of scroll positioning" do
+    Fabricate.times(20, :topic)
+    sign_in(current_user)
+    visit "/"
+
+    expect(page).to have_selector("body.docked")
+    page.execute_script("window.scrollBy(0, 1000)")
+    expect(page).to have_selector("body.docked")
+    page.execute_script("window.scrollTo(0, 0)")
+    expect(page).to have_selector("body.docked")
+  end
+
   it "moves focus between tabs using arrow keys" do
     sign_in(current_user)
     visit "/"


### PR DESCRIPTION
Follow up on https://github.com/discourse/discourse/pull/26967 - that earlier fix didn't actually fix the issue. Added a simple test to ensure this fix actually works this time 😅 .

Main bug:

In the dockCheck function for both glimmer and widget site-headers, we only set the `_docAt` property if it's strictly equivalent to null i.e. `if this._docAt === null` .

However, that property is initialized to different values in both versions of the site-header:

```javascript
// in widget header
    docAt: null,

// in glimmer header - glimmer-site-header.gjs
  _docAt; // this is undefined
```
So we never set `_docAt` to an integer in the glimmer header... and comparing any integer to `undefined` always returns `false` in Javascript. (funnily enough, comparing any positive integer to `null` returns true... yes Wat). 


#### More on the dockCheck function to determine if we should set the `docked` class name:

Besides the above bug, it appears that in our widget site header, we've always had the site header perma-docked (see any sites still using the widget header and look at the `body` element). The current offset checking logic in `dockCheck`:

```
 const main = (this._applicationElement ??=
      document.querySelector(".ember-application"));
    const offsetTop = main?.offsetTop ?? 0;
    const offset = window.pageYOffset - offsetTop;
    if (offset >= this._docAt) {
      // set docked
    } else {
      // unset docked
    }

```
Since the `main` element's offsetTop will always be `0` (you can try this out in console regardless of current scroll position), that `offset` variable is always `window.pageYOffset` which cannot be less than `this._docAt` (`this.headerElement.offsetTop`), and therefore we never reach the scenario where we will set docked to `false`.

That said, I'm unsure if this was intentionally left as-is in the glimmer site-header, so will leave it for now. 