### PR TITLE
FIX: Async load category for composer

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -248,7 +248,14 @@ export default class Composer extends RestModel {
     this._categoryId = categoryId;
 
     if (oldCategoryId !== categoryId) {
-      this.applyTopicTemplate(oldCategoryId, categoryId);
+      let promise = Promise.resolve();
+      if (this.site.lazy_load_categories && categoryId) {
+        promise = Category.asyncFindById(categoryId);
+      }
+
+      promise.then(() => {
+        this.applyTopicTemplate(oldCategoryId, categoryId);
+      });
     }
   }
 


### PR DESCRIPTION
Categories are loaded in the composer via the category chooser, but that only loads a subset of the fields. With these changes, the category will be loaded async to make sure that the template is updated.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
