### PR TITLE
UX: add missing class for oneboxing youtube video

### DIFF
--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
@@ -30,7 +30,7 @@ class Onebox::Engine::YoutubeOnebox
           data-video-title="#{escaped_title}"
           data-video-start-time="#{escaped_start_time}"
           data-provider-name="youtube">
-          <a href="https://www.youtube.com/watch?v=#{video_id}#{t_param}" target="_blank">
+          <a href="https://www.youtube.com/watch?v=#{video_id}#{t_param}" target="_blank" class="video-thumbnail">
             <img class="youtube-thumbnail"
               src="#{thumbnail_url}"
               title="#{escaped_title}">


### PR DESCRIPTION
Fix overflowing youtube video thumbnail in chat

<img width="873" alt="image" src="https://github.com/discourse/discourse/assets/101828855/9f353df9-ee72-4ed7-aad6-f37ed3fc381d">

