### PR TITLE
A11Y: fix topic admin menu button colors for WCAG colors

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -88,10 +88,9 @@ export default class TopicAdminMenu extends Component {
           <DMenu
             @identifier="topic-admin-menu"
             @onRegisterApi={{this.onRegisterApi}}
-            @triggerClass="toggle-admin-menu"
             @modalForMobile={{true}}
             @autofocus={{true}}
-            @triggerClass="btn-default btn-icon"
+            @triggerClass="btn-default btn-icon toggle-admin-menu"
           >
             <:trigger>
               {{icon "wrench"}}

--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -91,7 +91,7 @@ export default class TopicAdminMenu extends Component {
             @triggerClass="toggle-admin-menu"
             @modalForMobile={{true}}
             @autofocus={{true}}
-            @class="btn-default btn-icon"
+            @triggerClass="btn-default btn-icon"
           >
             <:trigger>
               {{icon "wrench"}}

--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -12,12 +12,9 @@
 }
 
 html.discourse-no-touch {
-  .btn-default:not(.btn-flat, .btn-danger, .btn-primary),
-  .btn-icon:not(.btn-flat, .btn-danger, .btn-primary) {
-    &.btn-default {
-      .d-icon {
-        color: var(--primary-medium);
-      }
+  .btn-default {
+    .d-icon {
+      color: var(--primary-medium);
     }
     &:hover,
     &.btn-hover,
@@ -32,7 +29,7 @@ html.discourse-no-touch {
   }
   .btn-icon.ok,
   .btn-icon.cancel,
-  .btn-danger:not(.btn-flat) {
+  .btn-danger:not(.btn-flat, .btn-transparent) {
     .d-icon {
       color: var(--secondary);
     }


### PR DESCRIPTION
A few things:

* The change in 47cabdc caused the `btn-default` class to be applied to the dropdown, switching this to `@triggerClass` fixes it 

* It seems the btn-default styles can be simplified a little bit because we're applying the button classes better than we used to 4 years ago

* Add the new `.btn-transparent` class to the btn-danger rule exception 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/c2933728-c8ec-42e1-885e-a732e5f74e9e)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/0b49c046-afbf-4647-b9a9-bf12d2cb2a67)
