### PR TITLE
UX: Use a different JIT message when there are no search results in the users directory

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -80,13 +80,17 @@
             <div class="empty-state">
               <div class="empty-state-body">
                 <p>
-                  {{i18n "directory.no_results.body"}}
-                  {{#if this.currentUser.staff}}
-                    {{html-safe
-                      (i18n
-                        "directory.no_results.extra_body" basePath=(base-path)
-                      )
-                    }}
+                  {{#if this.name}}
+                    {{i18n "directory.no_results_with_search"}}
+                  {{else}}
+                    {{i18n "directory.no_results.body"}}
+                    {{#if this.currentUser.staff}}
+                      {{html-safe
+                        (i18n
+                          "directory.no_results.extra_body" basePath=(base-path)
+                        )
+                      }}
+                    {{/if}}
                   {{/if}}
                 </p>
               </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -9,6 +9,7 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
+import I18n from "discourse-i18n";
 
 acceptance("User Directory", function () {
   test("Visit Page", async function (assert) {
@@ -92,6 +93,46 @@ acceptance("User Directory", function () {
       query(`${secondHeading} .d-icon-chevron-up`),
       "list has been sorted"
     );
+  });
+
+  test("Visit with no users", async function (assert) {
+    pretender.get("/directory_items", () => {
+      return response({
+        directory_items: [],
+        meta: {
+          last_updated_at: "2024-05-13T18:42:32.000Z",
+          total_rows_directory_items: 0,
+        },
+      });
+    });
+    await visit("/u");
+
+    assert
+      .dom(".empty-state-body")
+      .hasText(
+        I18n.t("directory.no_results.body"),
+        "a JIT message is shown when there are no users"
+      );
+  });
+
+  test("Visit with no search results", async function (assert) {
+    pretender.get("/directory_items", () => {
+      return response({
+        directory_items: [],
+        meta: {
+          last_updated_at: "2024-05-13T18:42:32.000Z",
+          total_rows_directory_items: 0,
+        },
+      });
+    });
+    await visit("/u?name=somenamethatdoesnotexist");
+
+    assert
+      .dom(".empty-state-body")
+      .hasText(
+        I18n.t("directory.no_results_with_search"),
+        "a different JIT message is used when there are no results for the search term"
+      );
   });
 });
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -768,6 +768,7 @@ en:
       no_results:
         body: "A list of community members showing their activity will be shown here. For now the list is empty because your community is still brand new!"
         extra_body: "Admins and moderators can see and manage users in <a href='%{basePath}/admin/users/'>User Admin</a>."
+      no_results_with_search: "No results were found."
       days_visited: "Visits"
       days_visited_long: "Days Visited"
       posts_read: "Read"


### PR DESCRIPTION
This PR adds a different message to the users directory (`/u`) that's shown when there are no results for the search term instead of showing the one for when there are no users on the site yet.

When there's a search term:

![image](https://github.com/discourse/discourse/assets/17474474/4fa9d194-5666-42a7-b015-cb36e35a0663)

When there isn't a search term:

![image](https://github.com/discourse/discourse/assets/17474474/69bf3f08-67dc-4665-8aeb-f04bfdfa4110)

Internal topic: t/126076.