### PR TITLE
DEV: Add `mutex_m` and `drb` to Gemfile to remove deprecation warning

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -64,3 +64,4 @@ reviewed:
     - tilt # MIT
     - unf # BSD-2-Clause
     - unicorn # Ruby or GPLv2/GPLv3
+    - drb # BSD-2-Clause

--- a/Gemfile
+++ b/Gemfile
@@ -269,6 +269,10 @@ gem "cgi", ">= 0.3.6", require: false
 gem "tzinfo-data"
 gem "csv", require: false
 
+# TODO: Can be removed once we upgrade to Rails 7.1
+gem "mutex_m"
+gem "drb"
+
 # dependencies for the automation plugin
 gem "iso8601"
 gem "rrule"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       faker (~> 2.16)
       literate_randomizer
     docile (1.4.0)
+    drb (2.2.1)
     email_reply_trimmer (0.1.13)
     erubi (1.12.0)
     excon (0.110.0)
@@ -233,6 +234,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mustache (1.1.1)
+    mutex_m (0.2.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.11)
@@ -575,6 +577,7 @@ DEPENDENCIES
   discourse-fonts
   discourse-seed-fu
   discourse_dev_assets
+  drb
   email_reply_trimmer
   excon
   execjs
@@ -613,6 +616,7 @@ DEPENDENCIES
   mocha
   multi_json
   mustache
+  mutex_m
   net-http
   net-imap
   net-pop


### PR DESCRIPTION
Resolves the following deprecation warnings when running Discourse on
Ruby 3.3

```
warning: /Users/tgxworld/.asdf/installs/ruby/3.3.1/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.1 to add mutex_m into its gemspec.

warning: /Users/tgxworld/.asdf/installs/ruby/3.3.1/lib/ruby/3.3.0/drb.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add drb to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.1 to add drb into its gemspec.
```
