### PR TITLE
FEATURE: Add `s3_inventory_bucket` site setting

### DIFF
--- a/app/jobs/regular/update_s3_inventory.rb
+++ b/app/jobs/regular/update_s3_inventory.rb
@@ -12,7 +12,7 @@ module Jobs
       end
 
       %i[upload optimized].each do |type|
-        s3_inventory = S3Inventory.new(Discourse.store.s3_helper, type)
+        s3_inventory = S3Inventory.new(type:)
         s3_inventory.update_bucket_policy if type == :upload
         s3_inventory.update_bucket_inventory_configuration
       end

--- a/app/jobs/scheduled/ensure_s3_uploads_existence.rb
+++ b/app/jobs/scheduled/ensure_s3_uploads_existence.rb
@@ -17,12 +17,8 @@ module Jobs
       end
     end
 
-    def s3_helper
-      Discourse.store.s3_helper
-    end
-
     def prepare_for_all_sites
-      inventory = S3Inventory.new(s3_helper, :upload)
+      inventory = S3Inventory.new(type: :upload)
       @db_inventories = inventory.prepare_for_all_sites
       @inventory_date = inventory.inventory_date
     end
@@ -39,13 +35,12 @@ module Jobs
            preloaded_inventory_file =
              @db_inventories[RailsMultisite::ConnectionManagement.current_db]
         S3Inventory.new(
-          s3_helper,
-          :upload,
+          type: :upload,
           preloaded_inventory_file: preloaded_inventory_file,
           preloaded_inventory_date: @inventory_date,
         ).backfill_etags_and_list_missing
       else
-        S3Inventory.new(s3_helper, :upload).backfill_etags_and_list_missing
+        S3Inventory.new(type: :upload).backfill_etags_and_list_missing
       end
     end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1962,6 +1962,7 @@ en:
     automatic_backups_enabled: "Run automatic backups as defined in backup frequency"
     backup_frequency: "Specifies the interval, in days, at which automatic backups of the site are created. If set to 7, for example, a new backup will be generated every week. The activation of this setting is contingent upon `automatic_backups_enabled`."
     s3_backup_bucket: "The remote bucket to hold backups. WARNING: Make sure it is a private bucket."
+    s3_inventory_bucket: "The remote bucket to hold S3 inventory files. If this is not set and `enable_s3_inventory` is enabled, the bucket defaults to `s3_upload_bucket`. WARNING: Make sure it is a private bucket."
     s3_endpoint: "The endpoint can be modified to backup to an S3 compatible service like DigitalOcean Spaces or Minio. WARNING: Leave blank if using AWS S3."
     s3_configure_tombstone_policy: "Enable automatic deletion policy for tombstone uploads. IMPORTANT: If disabled, no space will be reclaimed after uploads are deleted."
     s3_disable_cleanup: "Prevent removal of old backups from S3 when there are more backups than the maximum allowed."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1586,6 +1586,9 @@ files:
   s3_configure_inventory_policy:
     default: true
     hidden: true
+  s3_inventory_bucket:
+    default: ""
+    regex: '^[a-z0-9\-\/_]+$'
   s3_presigned_get_url_expires_after_seconds:
     default: 300
     hidden: true

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -14,6 +14,7 @@ module FileStore
              :presign_multipart_part,
              :list_multipart_parts,
              :complete_multipart,
+             :s3_client,
              to: :s3_helper
 
     def initialize(s3_helper = nil)
@@ -299,8 +300,8 @@ module FileStore
     def list_missing_uploads(skip_optimized: false)
       if SiteSetting.enable_s3_inventory
         require "s3_inventory"
-        S3Inventory.new(s3_helper, :upload).backfill_etags_and_list_missing
-        S3Inventory.new(s3_helper, :optimized).backfill_etags_and_list_missing unless skip_optimized
+        S3Inventory.new(type: :upload).backfill_etags_and_list_missing
+        S3Inventory.new(type: :optimized).backfill_etags_and_list_missing unless skip_optimized
       else
         list_missing(Upload.by_users, "original/")
         list_missing(OptimizedImage, "optimized/") unless skip_optimized

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -281,7 +281,12 @@ class S3Helper
   end
 
   def s3_client
-    @s3_client ||= Aws::S3::Client.new(@s3_options)
+    @s3_client ||= init_aws_s3_client
+  end
+
+  def stub_client_responses!
+    raise "This method is only allowed to be used in the testing environment" if !Rails.env.test?
+    @s3_client = init_aws_s3_client(stub_responses: true)
   end
 
   def s3_inventory_path(path = "inventory")
@@ -379,6 +384,12 @@ class S3Helper
   end
 
   private
+
+  def init_aws_s3_client(stub_responses: false)
+    options = @s3_options
+    options = options.merge(stub_responses: true) if stub_responses
+    Aws::S3::Client.new(options)
+  end
 
   def fetch_bucket_cors_rules
     begin

--- a/spec/jobs/update_s3_inventory_spec.rb
+++ b/spec/jobs/update_s3_inventory_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Jobs::UpdateS3Inventory do
     SiteSetting.enable_s3_inventory = true
 
     store = FileStore::S3Store.new
-    @client = Aws::S3::Client.new(stub_responses: true)
-    store.s3_helper.stubs(:s3_client).returns(@client)
+    @client = store.s3_client
     Discourse.stubs(:store).returns(store)
   end
 

--- a/spec/lib/s3_inventory_multisite_spec.rb
+++ b/spec/lib/s3_inventory_multisite_spec.rb
@@ -5,9 +5,7 @@ require "s3_inventory"
 require "file_store/s3_store"
 
 RSpec.describe "S3Inventory", type: :multisite do
-  let(:client) { Aws::S3::Client.new(stub_responses: true) }
-  let(:helper) { S3Helper.new(SiteSetting.Upload.s3_upload_bucket.downcase, "", client: client) }
-  let(:inventory) { S3Inventory.new(helper, :upload) }
+  let(:inventory) { S3Inventory.new(type: :upload) }
   let(:csv_filename) { "#{Rails.root}/spec/fixtures/csv/s3_inventory.csv" }
 
   it "can create per-site files" do


### PR DESCRIPTION
This commit adds a new `s3_inventory_bucket` site setting which allows
admins to configure the S3 bucket in which S3 Inventory files should be stored at.
The default for `s3_inventory_bucket` is blank and when it is blank, the
S3 Inventory files will be stored in the S3 bucket given by
`s3_upload_bucket`.
