### PR TITLE
FIX: sorting user topics lists

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-views/topic-list-header-column.js
+++ b/app/assets/javascripts/discourse/app/raw-views/topic-list-header-column.js
@@ -18,9 +18,14 @@ export default EmberObject.extend({
 
   @discourseComputed
   sortIcon() {
-    const isAscending = this.parent.ascending || this.parent.context?.ascending;
-    const asc = isAscending ? "up" : "down";
-    return `chevron-${asc}`;
+    const isAscending =
+      (
+        this.parent.ascending ||
+        this.parent.context?.ascending ||
+        ""
+      ).toString() === "true";
+
+    return `chevron-${isAscending ? "up" : "down"}`;
   },
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
@@ -1,6 +1,5 @@
 import { capitalize } from "@ember/string";
 import { findOrResetCachedTopicList } from "discourse/lib/cached-topic-list";
-import { cleanNullQueryParams } from "discourse/lib/utilities";
 import createPMRoute from "discourse/routes/build-private-messages-route";
 import I18n from "discourse-i18n";
 
@@ -40,8 +39,6 @@ export default (inboxType, filter) => {
       if (lastTopicList) {
         return lastTopicList;
       }
-
-      params = cleanNullQueryParams(params);
 
       return this.store
         .findFiltered("topicList", {

--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
@@ -1,7 +1,6 @@
 import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import { findOrResetCachedTopicList } from "discourse/lib/cached-topic-list";
-import { cleanNullQueryParams } from "discourse/lib/utilities";
 import UserAction from "discourse/models/user-action";
 import UserTopicListRoute from "discourse/routes/user-topic-list";
 import getURL from "discourse-common/lib/get-url";
@@ -37,8 +36,6 @@ export default (inboxType, path, filter) => {
       if (lastTopicList) {
         return lastTopicList;
       }
-
-      params = cleanNullQueryParams(params);
 
       return this.store
         .findFiltered("topicList", {

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -4,7 +4,7 @@ import { isEmpty } from "@ember/utils";
 import { queryParams, resetParams } from "discourse/controllers/discovery/list";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
-import { cleanNullQueryParams, defaultHomepage } from "discourse/lib/utilities";
+import { defaultHomepage } from "discourse/lib/utilities";
 import Session from "discourse/models/session";
 import Site from "discourse/models/site";
 import DiscourseRoute from "discourse/routes/discourse";
@@ -29,7 +29,7 @@ export async function findTopicList(
   store,
   tracking,
   filter,
-  filterParams,
+  filterParams = {},
   extras = {}
 ) {
   let list;
@@ -57,16 +57,10 @@ export async function findTopicList(
     session.setProperties({ topicList: null });
   }
 
-  if (!list) {
-    // Clean up any string parameters that might slip through
-    filterParams ||= {};
-    filterParams = cleanNullQueryParams(filterParams);
-
-    list = await store.findFiltered("topicList", {
-      filter,
-      params: filterParams,
-    });
-  }
+  list ||= await store.findFiltered("topicList", {
+    filter,
+    params: filterParams,
+  });
 
   list.set("listParams", filterParams);
 

--- a/app/assets/javascripts/discourse/app/routes/group-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/group-activity-topics.js
@@ -6,9 +6,10 @@ export default DiscourseRoute.extend({
     return I18n.t(`groups.topics`);
   },
 
-  model() {
+  model(params = {}) {
     return this.store.findFiltered("topicList", {
       filter: `topics/groups/${this.modelFor("group").get("name")}`,
+      params,
     });
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -9,10 +9,11 @@ import I18n from "discourse-i18n";
 export default UserTopicListRoute.extend({
   userActionType: UserAction.TYPES.topics,
 
-  model() {
+  model(params = {}) {
     return this.store
       .findFiltered("topicList", {
         filter: "read",
+        params,
       })
       .then((model) => {
         // andrei: we agreed that this is an anti pattern,

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -8,11 +8,12 @@ import I18n from "discourse-i18n";
 export default UserTopicListRoute.extend({
   userActionType: UserAction.TYPES.topics,
 
-  model() {
+  model(params = {}) {
     return this.store
       .findFiltered("topicList", {
         filter:
           "topics/created-by/" + this.modelFor("user").get("username_lower"),
+        params,
       })
       .then((model) => {
         // andrei: we agreed that this is an anti pattern,

--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -4,6 +4,7 @@ import Service from "@ember/service";
 import { underscore } from "@ember/string";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
+import { cleanNullQueryParams } from "discourse/lib/utilities";
 import RestModel from "discourse/models/rest";
 import ResultSet from "discourse/models/result-set";
 import { getRegister } from "discourse-common/lib/get-owner";
@@ -91,6 +92,7 @@ export default class StoreService extends Service {
   // Mostly for legacy, things like TopicList without ResultSets
   findFiltered(type, findArgs) {
     const adapter = this.adapterFor(type);
+    findArgs = cleanNullQueryParams(findArgs);
     return adapter
       .find(this, type, findArgs)
       .then((result) => this._build(type, result))


### PR DESCRIPTION
Sorting a topics list in user activities wasn't working because the query parameters weren't passed to `findFiltered()` that does the request to the server.

Made the `sortIcon` more resilient to "input" by always converting the value to a string and checking against `"true"`.

Moved `cleanNullQueryParams()` inside `findFiltered` so we're always removing `null` query parameters.

Internal ref - t/127068

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
