### PR TITLE
FIX: Create directory items for new users when in bootstrap mode

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,7 @@ class User < ActiveRecord::Base
   after_create :set_default_categories_preferences
   after_create :set_default_tags_preferences
   after_create :set_default_sidebar_section_links
+  after_create :refresh_user_directory, if: Proc.new { SiteSetting.bootstrap_mode_enabled }
   after_update :set_default_sidebar_section_links, if: Proc.new { self.saved_change_to_staged? }
 
   after_update :trigger_user_updated_event,
@@ -2168,6 +2169,10 @@ class User < ActiveRecord::Base
 
   def validate_status!(status)
     UserStatus.new(status).validate!
+  end
+
+  def refresh_user_directory
+    DirectoryItem.refresh!
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -129,6 +129,27 @@ RSpec.describe User do
         ) { user.update(name: "Batman") }
       end
     end
+
+    describe "#refresh_user_directory" do
+      context "when bootstrap mode is enabled" do
+        before { SiteSetting.bootstrap_mode_enabled = true }
+
+        it "creates directory items for a new user for all periods" do
+          expect do user = Fabricate(:user) end.to change { DirectoryItem.count }.by(
+            DirectoryItem.period_types.count,
+          )
+          expect(DirectoryItem.where(user_id: user.id)).to exist
+        end
+      end
+
+      context "when bootstrap mode is disabled" do
+        before { SiteSetting.bootstrap_mode_enabled = false }
+
+        it "doesn't create directory items for a new user" do
+          expect do Fabricate(:user) end.not_to change { DirectoryItem.count }
+        end
+      end
+    end
   end
 
   describe "Validations" do


### PR DESCRIPTION
The users directory is updated on a daily cadence. However, when a site is new and doesn't have many users, it can be confusing that a user who has just joined doesn't show up in the users until a day after they join. To eliminate this confusion, this PR triggers a refresh for the users directory as soon as as a user joins, if the site is in bootstrap mode. The reason for the conditional trigger is that refreshing the users directory is an expensive operation and doing it often on a large site with many users could lead to performance problems.

Internal topic: t/126076. 