### PR TITLE
FIX: Update do-not-disturb icon in real-time on glimmer header

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/reactive-target-date.js
+++ b/app/assets/javascripts/discourse/app/lib/reactive-target-date.js
@@ -1,0 +1,57 @@
+import { cached } from "@glimmer/tracking";
+import { destroy, isDestroyed, registerDestructor } from "@ember/destroyable";
+import { dedupeTracked } from "./tracked-tools";
+
+const MAX_CHECK_INTERVAL_MS = 60_000;
+const DELAY_CHECK_MS = 50;
+
+export default class ReactiveTargetDate {
+  #timer;
+
+  @dedupeTracked _targetHasPassed;
+
+  constructor(targetDateCallback) {
+    registerDestructor(this, () => clearTimeout(this.#timer));
+    this.targetDateCallback = targetDateCallback;
+  }
+
+  @cached
+  get hasPassed() {
+    this.#check();
+    return this._targetHasPassed;
+  }
+
+  #check() {
+    if (isDestroyed(this)) {
+      throw "Cannot use a destroyed ReactiveTargetDate";
+    }
+
+    clearTimeout(this.#timer);
+
+    const now = new Date();
+    const rawTarget = this.targetDateCallback();
+
+    if (rawTarget === undefined || rawTarget === null) {
+      this._targetHasPassed = null;
+      return;
+    }
+
+    const target = new Date(rawTarget);
+
+    if (target < now) {
+      this._targetHasPassed = true;
+    } else {
+      this._targetHasPassed = false;
+      const msToTarget = target - now;
+      const checkAgainMs = Math.min(
+        msToTarget + DELAY_CHECK_MS,
+        MAX_CHECK_INTERVAL_MS
+      );
+      this.#timer = setTimeout(() => this.#check(), checkAgainMs);
+    }
+  }
+
+  destroy() {
+    destroy(this);
+  }
+}

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1226,10 +1226,11 @@ export default class User extends RestModel.extend(Evented) {
   }
 
   isInDoNotDisturb() {
-    return (
-      this.do_not_disturb_until &&
-      new Date(this.do_not_disturb_until) >= new Date()
-    );
+    if (this !== getOwner(this).lookup("service:current-user")) {
+      throw "isInDoNotDisturb is only supported for currentUser";
+    }
+
+    return getOwner(this).lookup("service:notifications").isInDoNotDisturb;
   }
 
   @discourseComputed(

--- a/app/assets/javascripts/discourse/app/services/notifications.js
+++ b/app/assets/javascripts/discourse/app/services/notifications.js
@@ -1,0 +1,35 @@
+import Service, { service } from "@ember/service";
+import { disableImplicitInjections } from "discourse/lib/implicit-injections";
+import ReactiveTargetDate from "discourse/lib/reactive-target-date";
+
+@disableImplicitInjections
+export default class NotificationsService extends Service {
+  @service currentUser;
+
+  #dndReactiveTargetDate;
+
+  /**
+   * Whether the current user is in do not disturb mode.
+   * This getter is autotrackable, and will recompute when the 'do not disturb until'
+   * value changes, or when the threshold is passed.
+   */
+  get isInDoNotDisturb() {
+    if (!this.currentUser) {
+      return false;
+    }
+
+    if (!this.currentUser.do_not_disturb_until) {
+      return false;
+    }
+
+    this.#dndReactiveTargetDate ??= new ReactiveTargetDate(
+      () => this.currentUser.do_not_disturb_until
+    );
+
+    return !this.#dndReactiveTargetDate.hasPassed;
+  }
+
+  willDestroy() {
+    this.#dndReactiveTargetDate?.destroy();
+  }
+}


### PR DESCRIPTION
To achieve this, a new ReactiveTargetDate 'resource' is introduced. This is constructed using a callback, which should return the target date (in this case, when do-not-disturb will end). The utility then provides an autotrackable `.hasPassed` getter which returns a boolean.

This resource needs to be properly torn down at the end of the application lifecycle in tests, so the logic is moved out of the user model and into a new Notifications service.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
