### PR TITLE
FIX: deep linking to a message in a thread

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -223,11 +223,12 @@ export default class ChatThread extends Component {
 
     this.messagesManager.clear();
 
-    findArgs.targetMessageId ??=
+    findArgs.target_message_id ??=
+      findArgs.targetMessageId ||
       this.args.targetMessageId ||
       this.args.thread.currentUserMembership?.lastReadMessageId;
 
-    if (!findArgs.targetMessageId) {
+    if (!findArgs.target_message_id) {
       findArgs.direction = FUTURE;
     }
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -140,6 +140,10 @@ module PageObjects
         messages.edit(message)
         send_message(message.message + " " + text) if text
       end
+
+      def has_bookmarked_message?(message)
+        find(message_by_id_selector(message.id) + ".-bookmarked")
+      end
     end
   end
 end


### PR DESCRIPTION
Whenever you get a bookmark notification, a mention notification, or click on a bookmark on a message in a long thread, we should ensure we always highlight and show the proper message.

Before this fix, we would correctly load the thread, but would always start at the bottom.

Internal ref. t/128103

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
