### PR TITLE
FIX: chat replies are not always in a thread

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -266,7 +266,7 @@ module Chat
     end
 
     def in_thread?
-      self.thread_id.present?
+      self.thread_id.present? && self.chat_channel&.threading_enabled
     end
 
     def thread_reply?

--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -266,7 +266,7 @@ module Chat
     end
 
     def in_thread?
-      self.thread_id.present? && self.chat_channel&.threading_enabled
+      self.thread_id.present? && self.chat_channel.threading_enabled
     end
 
     def thread_reply?

--- a/plugins/chat/spec/requests/chat/api/messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/messages_controller_spec.rb
@@ -205,7 +205,9 @@ RSpec.describe Chat::Api::ChannelMessagesController do
     let(:message) { "This is a message" }
 
     describe "for category" do
-      fab!(:chat_channel) { Fabricate(:category_channel, chatable: category) }
+      fab!(:chat_channel) do
+        Fabricate(:category_channel, chatable: category, threading_enabled: true)
+      end
 
       before do
         chat_channel.add(user)

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system do
     end
 
     context "when category channel" do
-      fab!(:channel_1) { Fabricate(:chat_channel) }
+      fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
 
       before do
         Jobs.run_immediately!


### PR DESCRIPTION
When you reply to a chat message, we [always create a thread][1]. But when the channel we're in doesn't have threading enabled, the reply is _technically_ not a thread.

This changes the `in_thread?` method to check for both the presence of a `thread_id` and to ensure that the channel has `threading_enabled`.

Internal ref - t/128103/3

[1]: https://github.com/discourse/discourse/blob/e6e3eaf472a0112aca882811267a260c4cc73a89/plugins/chat/app/services/chat/create_message.rb#L110-L115

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
