### PR TITLE
DEV: Update LinkedIn OIDC client secret validation format

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -512,7 +512,7 @@ login:
     regex: "^[a-z0-9]+$"
   linkedin_oidc_client_secret:
     default: ""
-    regex: "^[a-zA-Z0-9]+$"
+    regex: "^[a-zA-Z0-9_=\\.]+$"
     secret: true
   auth_skip_create_confirm:
     default: false


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/configure-linkedin-openid-connect-login-for-discourse/305366/3)

### What is this change?

The LinkedIn OIDC client secret used to look something like:

```
sHyUiKxnLJKBE1Do
```

but now they are generating secrets that look like:

```
WPL_AP0.UIM1fMSfJMdLtHm0.agwMyzJw1xoAcEJ0==
```

This updates the regular expression used for validation to reflect this.