### PR TITLE
FIX: send activity summaries based on "last seen"

### DIFF
--- a/app/jobs/scheduled/enqueue_digest_emails.rb
+++ b/app/jobs/scheduled/enqueue_digest_emails.rb
@@ -5,13 +5,13 @@ module Jobs
     every 30.minutes
 
     def execute(args)
-      if SiteSetting.disable_digest_emails? || SiteSetting.private_email? ||
-           SiteSetting.disable_emails == "yes"
-        return
-      end
-      users = target_user_ids
+      return if SiteSetting.disable_emails == "yes"
+      return if SiteSetting.disable_digest_emails?
+      return if SiteSetting.private_email?
 
-      users.each { |user_id| ::Jobs.enqueue(:user_email, type: "digest", user_id: user_id) }
+      target_user_ids.each do |user_id|
+        ::Jobs.enqueue(:user_email, type: "digest", user_id: user_id)
+      end
     end
 
     def target_user_ids
@@ -20,20 +20,23 @@ module Jobs
         User
           .real
           .activated
+          .not_staged
           .not_suspended
-          .where(staged: false)
           .joins(:user_option, :user_stat, :user_emails)
           .where("user_options.email_digests")
+          .where(
+            "COALESCE(user_options.digest_after_minutes, ?) > 0",
+            SiteSetting.default_email_digest_frequency,
+          )
           .where("user_stats.bounce_score < ?", SiteSetting.bounce_score_threshold)
           .where("user_emails.primary")
           .where(
-            "COALESCE(last_emailed_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)",
+            "COALESCE(user_stats.digest_attempted_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * COALESCE(user_options.digest_after_minutes, ?))",
+            SiteSetting.default_email_digest_frequency,
           )
           .where(
-            "COALESCE(user_stats.digest_attempted_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)",
-          )
-          .where(
-            "COALESCE(last_seen_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)",
+            "COALESCE(last_seen_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * COALESCE(user_options.digest_after_minutes, ?))",
+            SiteSetting.default_email_digest_frequency,
           )
           .where(
             "COALESCE(last_seen_at, '2010-01-01') >= CURRENT_TIMESTAMP - ('1 DAY'::INTERVAL * ?)",

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -224,18 +224,18 @@ class UserNotifications < ActionMailer::Base
     build_summary_for(user)
     @unsubscribe_key = UnsubscribeKey.create_key_for(@user, UnsubscribeKey::DIGEST_TYPE)
 
-    min_date = opts[:since] || user.last_emailed_at || user.last_seen_at || 1.month.ago
+    @since = opts[:since] || user.last_seen_at || user.user_stat&.digest_attempted_at || 1.month.ago
 
     # Fetch some topics and posts to show
     digest_opts = {
       limit: SiteSetting.digest_topics + SiteSetting.digest_other_topics,
       top_order: true,
     }
-    topics_for_digest = Topic.for_digest(user, min_date, digest_opts)
+    topics_for_digest = Topic.for_digest(user, @since, digest_opts)
     if topics_for_digest.empty? && !user.user_option.try(:include_tl0_in_digests)
       # Find some topics from new users that are at least 24 hours old
       topics_for_digest =
-        Topic.for_digest(user, min_date, digest_opts.merge(include_tl0: true)).where(
+        Topic.for_digest(user, @since, digest_opts.merge(include_tl0: true)).where(
           "topics.created_at < ?",
           24.hours.ago,
         )
@@ -257,7 +257,7 @@ class UserNotifications < ActionMailer::Base
         if SiteSetting.digest_posts > 0
           Post
             .order("posts.score DESC")
-            .for_mailing_list(user, min_date)
+            .for_mailing_list(user, @since)
             .where("posts.post_type = ?", Post.types[:regular])
             .where(
               "posts.deleted_at IS NULL AND posts.hidden = false AND posts.user_deleted = false",
@@ -275,20 +275,16 @@ class UserNotifications < ActionMailer::Base
 
       @excerpts = {}
 
-      @popular_topics.map do |t|
-        @excerpts[t.first_post.id] = email_excerpt(
-          t.first_post.cooked,
-          t.first_post,
-        ) if t.first_post.present?
+      @popular_topics.each do |t|
+        next if t.first_post.blank?
+        @excerpts[t.first_post.id] = email_excerpt(t.first_post.cooked, t.first_post)
       end
 
       # Try to find 3 interesting stats for the top of the digest
-      new_topics_count = Topic.for_digest(user, min_date).count
+      new_topics_count = Topic.for_digest(user, @since).count
+      # We used topics from new users instead, so count should match
+      new_topics_count = topics_for_digest.size if new_topics_count == 0
 
-      if new_topics_count == 0
-        # We used topics from new users instead, so count should match
-        new_topics_count = topics_for_digest.size
-      end
       @counts = [
         {
           id: "new_topics",
@@ -312,7 +308,7 @@ class UserNotifications < ActionMailer::Base
       end
 
       if @counts.size < 3
-        value = user.unread_notifications_of_type(Notification.types[:liked], since: min_date)
+        value = user.unread_notifications_of_type(Notification.types[:liked], since: @since)
         if value > 0
           @counts << {
             id: "likes_received",
@@ -324,7 +320,7 @@ class UserNotifications < ActionMailer::Base
       end
 
       if @counts.size < 3 && user.user_option.digest_after_minutes.to_i >= 1440
-        value = summary_new_users_count(min_date)
+        value = summary_new_users_count(@since)
         if value > 0
           @counts << {
             id: "new_users",
@@ -335,9 +331,7 @@ class UserNotifications < ActionMailer::Base
         end
       end
 
-      @last_seen_at = short_date(user.last_seen_at || user.created_at)
-
-      @preheader_text = I18n.t("user_notifications.digest.preheader", last_seen_at: @last_seen_at)
+      @preheader_text = I18n.t("user_notifications.digest.preheader", since: @since)
 
       opts = {
         from_alias: I18n.t("user_notifications.digest.from", site_name: Email.site_title),
@@ -841,7 +835,7 @@ class UserNotifications < ActionMailer::Base
   end
 
   def build_summary_for(user)
-    @site_name = SiteSetting.email_prefix.presence || SiteSetting.title # used by I18n
+    @site_name = SiteSetting.email_prefix.presence || SiteSetting.title
     @user = user
     @date = short_date(Time.now)
     @base_url = Discourse.base_url
@@ -853,24 +847,17 @@ class UserNotifications < ActionMailer::Base
     @disable_email_custom_styles = !SiteSetting.apply_custom_styles_to_digest
   end
 
-  def self.summary_new_users_count_key(min_date_str)
-    "summary-new-users:#{min_date_str}"
-  end
-
-  def summary_new_users_count(min_date)
-    min_date_str = min_date.is_a?(String) ? min_date : min_date.strftime("%Y-%m-%d")
-    key = self.class.summary_new_users_count_key(min_date_str)
-    ((count = Discourse.redis.get(key)) && count.to_i) ||
-      begin
-        count =
-          User
-            .real
-            .where(active: true, staged: false)
-            .not_suspended
-            .where("created_at > ?", min_date_str)
-            .count
-        Discourse.redis.setex(key, 1.day, count)
-        count
-      end
+  def summary_new_users_count(since)
+    date = since.is_a?(String) ? since : since.strftime("%Y-%m-%d")
+    key = "summary-new-users:#{date}"
+    Discourse.redis.get(key)&.to_i ||
+      User
+        .real
+        .activated
+        .not_staged
+        .not_suspended
+        .where("created_at > ?", date)
+        .count
+        .tap { Discourse.redis.setex(key, 1.day, _1) }
   end
 end

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -85,14 +85,8 @@ class UserOption < ActiveRecord::Base
 
     self.like_notification_frequency = SiteSetting.default_other_like_notification_frequency
 
-    if SiteSetting.default_email_digest_frequency.to_i <= 0
-      self.email_digests = false
-    else
-      self.email_digests = true
-    end
-
-    self.digest_after_minutes ||= SiteSetting.default_email_digest_frequency.to_i
-
+    self.email_digests = SiteSetting.default_email_digest_frequency.to_i > 0
+    self.digest_after_minutes = SiteSetting.default_email_digest_frequency.to_i
     self.include_tl0_in_digests = SiteSetting.default_include_tl0_in_digests
 
     self.text_size = SiteSetting.default_text_size
@@ -107,8 +101,7 @@ class UserOption < ActiveRecord::Base
   end
 
   def mailing_list_mode
-    return false if SiteSetting.disable_mailing_list_mode
-    super
+    SiteSetting.disable_mailing_list_mode ? false : super
   end
 
   def redirected_to_top_yet?

--- a/app/views/user_notifications/digest.text.erb
+++ b/app/views/user_notifications/digest.text.erb
@@ -1,7 +1,5 @@
 <%- site_link = raw(@markdown_linker.create(@site_name, '/')) %>
-<%= raw(t 'user_notifications.digest.why',
-      site_link: site_link,
-      last_seen_at: @last_seen_at) %>
+<%= raw(t 'user_notifications.digest.why', site_link: site_link, since: @since) %>
 
 <%- @counts.each do |count| -%>
 <%= count[:value] -%> <%=t count[:label_key] %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4232,7 +4232,7 @@ en:
         If you have any questions, [contact our friendly staff](%{base_url}/about).
 
     digest:
-      why: "A brief summary of %{site_link} since your last visit on %{last_seen_at}"
+      why: "A brief summary of %{site_link} since %{since}"
       since_last_visit: "Since your last visit"
       new_topics: "New Topics"
       unread_notifications: "Unread Notifications"
@@ -4248,7 +4248,7 @@ en:
       your_email_settings: "your email settings"
       click_here: "click here"
       from: "%{site_name}"
-      preheader: "A brief summary since your last visit on %{last_seen_at}"
+      preheader: "A brief summary since %{since}"
       custom:
         html:
           header: ""

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -48,6 +48,37 @@ RSpec.describe Jobs::UserEmail do
       expect(ActionMailer::Base.deliveries).to eq([])
     end
 
+    it "doesn't call the mailer when the user is suspended" do
+      suspended.update!(last_seen_at: 8.days.ago, last_emailed_at: 8.days.ago)
+      Jobs::UserEmail.new.execute(type: :digest, user_id: suspended.id)
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
+    it "doesn't call the mailer when the user is not active" do
+      user.update!(active: false)
+      Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
+    it "doesn't call the mailer when the user has disabled email digests" do
+      user.user_option.update!(email_digests: false)
+      Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
+    it "doesn't call the mailer when the user has enabled mailing list mode" do
+      SiteSetting.disable_mailing_list_mode = false
+      user.user_option.update!(mailing_list_mode: true)
+      Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
+    it "doesn't call the mailer when the user's digest_after_minute is 0" do
+      user.user_option.update!(digest_after_minutes: 0)
+      Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
     context "when not emailed recently" do
       before do
         freeze_time
@@ -65,6 +96,20 @@ RSpec.describe Jobs::UserEmail do
       before do
         freeze_time
         user.update!(last_emailed_at: 2.hours.ago)
+        user.user_option.update!(digest_after_minutes: 1.day.to_i / 60)
+      end
+
+      it "still sends the digest email" do
+        Jobs::UserEmail.new.execute(type: :digest, user_id: user.id)
+        expect(ActionMailer::Base.deliveries).to_not be_empty
+        expect(user.user_stat.reload.digest_attempted_at).to eq_time(Time.zone.now)
+      end
+    end
+
+    context "when recently seen" do
+      before do
+        freeze_time
+        user.update!(last_seen_at: 2.hours.ago)
         user.user_option.update!(digest_after_minutes: 1.day.to_i / 60)
       end
 
@@ -269,8 +314,8 @@ RSpec.describe Jobs::UserEmail do
     it "creates an email log when the mail is sent (via Email::Sender)" do
       freeze_time
 
-      last_emailed_at = 7.days.ago
-      user.update!(last_emailed_at: last_emailed_at)
+      last_seen_at = 7.days.ago
+      user.update!(last_seen_at: last_seen_at)
       Topic.last.update(created_at: 1.minute.ago)
 
       expect do Jobs::UserEmail.new.execute(type: :digest, user_id: user.id) end.to change {
@@ -282,7 +327,7 @@ RSpec.describe Jobs::UserEmail do
       expect(email_log.user).to eq(user)
       expect(email_log.post).to eq(nil)
       # last_emailed_at should have changed
-      expect(email_log.user.last_emailed_at).to_not eq_time(last_emailed_at)
+      expect(email_log.user.last_emailed_at).to_not eq_time(last_seen_at)
     end
 
     it "creates a skipped email log when the mail is skipped" do


### PR DESCRIPTION
instead of "last emailed" so that people getting email notifications (from a watched topic for example) also get the activity summaries.

Context - https://meta.discourse.org/t/activity-summary-not-sent-if-other-emails-are-sent/293040

Internal Ref - t/125582

Improvement over https://github.com/discourse/discourse/commit/95885645d92cc84e69cb9ecffeaec8f69fe8d286

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
