### PR TITLE
FIX: thread safety for active automation tracking

### DIFF
--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -30,11 +30,11 @@ module ::DiscourseAutomation
   USER_GROUP_MEMBERSHIP_THROUGH_BADGE_BULK_MODIFY_START_COUNT = 1000
 
   def self.set_active_automation(id)
-    @active_automation_id = id
+    Thread.current[:active_automation_id] = id
   end
 
   def self.get_active_automation
-    @active_automation_id
+    Thread.current[:active_automation_id]
   end
 end
 

--- a/plugins/automation/spec/lib/triggerable_spec.rb
+++ b/plugins/automation/spec/lib/triggerable_spec.rb
@@ -16,6 +16,20 @@ describe DiscourseAutomation::Triggerable do
 
   fab!(:automation) { Fabricate(:automation, trigger: "foo") }
 
+  describe "active automation thread safety" do
+    after { DiscourseAutomation.set_active_automation(nil) }
+
+    it "ensurese thread safety when setting automation id" do
+      DiscourseAutomation.set_active_automation(10)
+
+      thread = Thread.new { DiscourseAutomation.get_active_automation }
+      thread.join
+      expect(thread.value).to eq(nil)
+
+      expect(DiscourseAutomation.get_active_automation).to eq(10)
+    end
+  end
+
   describe "#setting" do
     before { DiscourseAutomation::Triggerable.add("foo") { setting :bar, :baz } }
 


### PR DESCRIPTION
Previously active automation id was set globally, even though multiple threads could be running an automation leading to tracking falling apart in sidekiq. 