### PR TITLE
DEV: Add more _map extensions for list site settings

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -584,9 +584,9 @@ module SiteSettingExtension
       end
     end
 
-    # Same logic as above for group_list settings, with the caveat that normal
+    # Same logic as above for other list type settings, with the caveat that normal
     # list settings are not necessarily integers, so we just want to handle the splitting.
-    if type_supervisor.get_type(name) == :list
+    if %i[list emoji_list tag_list].include?(type_supervisor.get_type(name))
       list_type = type_supervisor.get_list_type(name)
 
       if %w[simple compact].include?(list_type) || list_type.nil?

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -906,6 +906,16 @@ RSpec.describe SiteSettingExtension do
       expect(SiteSetting.respond_to?(:discourse_connect_provider_secrets_map)).to eq(false)
     end
 
+    it "handles splitting emoji_list settings" do
+      SiteSetting.emoji_deny_list = "smile|frown"
+      expect(SiteSetting.emoji_deny_list_map).to eq(%w[smile frown])
+    end
+
+    it "handles splitting tag_list settings" do
+      SiteSetting.digest_suppress_tags = "blah|blah2"
+      expect(SiteSetting.digest_suppress_tags_map).to eq(%w[blah blah2])
+    end
+
     it "handles null values for settings" do
       SiteSetting.ga_universal_auto_link_domains = nil
       SiteSetting.pm_tags_allowed_for_groups = nil


### PR DESCRIPTION
Following on from eea74e0e32f704f0756202c3f3ae801bcc8ac8bb,
this commit adds the automatic _map splitting shorthand
for emoji_list, tag_list site settings.
