### PR TITLE
Handle maxminddb download errors gracefully

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -65,6 +65,10 @@ class DiscourseIpInfo
         extra_headers:,
       )
 
+    if gz_file.nil?
+      Rails.logger.warn("MaxMindDB could not be downloaded")
+      return
+    end
     filename = File.basename(gz_file.path)
 
     dir = "#{Dir.tmpdir}/#{SecureRandom.hex}"


### PR DESCRIPTION
Handle maxminddb download errors gracefully

Without this patch, we got

    /srv/www/vhosts/discourse/lib/discourse_ip_info.rb:48:in `mmdb_download': undefined method `path' for nil (NoMethodError)
     filename = File.basename(gz_file.path)
                                     ^^^^^
         from /srv/www/vhosts/discourse/lib/tasks/maxminddb.rake:67:in `block (3 levels) in <main>'


note: I don't know how to add tests here. If you deem tests necessary, I'd appreciate some help.
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->