### PR TITLE
Remove non-official plugins

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -18,7 +18,6 @@ class Plugin::Metadata
         discourse-auto-deactivate
         discourse-bbcode
         discourse-bbcode-color
-        discourse-bcc
         discourse-cakeday
         discourse-calendar
         discourse-categories-suppressed
@@ -48,6 +47,7 @@ class Plugin::Metadata
         discourse-logster-transporter
         discourse-lti
         discourse-math
+        discourse-microsoft-auth
         discourse-moderator-attention
         discourse-narrative-bot
         discourse-newsletter-integration
@@ -56,8 +56,6 @@ class Plugin::Metadata
         discourse-openid-connect
         discourse-patreon
         discourse-perspective-api
-        discourse-linkedin-auth
-        discourse-microsoft-auth
         discourse-policy
         discourse-post-voting
         discourse-presence
@@ -70,9 +68,7 @@ class Plugin::Metadata
         discourse-salesforce
         discourse-saml
         discourse-saved-searches
-        discourse-shared-edits
         discourse-signatures
-        discourse-sitemap
         discourse-solved
         discourse-staff-alias
         discourse-steam-login
@@ -91,13 +87,13 @@ class Plugin::Metadata
         discourse-zendesk-plugin
         discourse-zoom
         automation
-        docker_manager
         chat
-        poll
-        styleguide
         checklist
+        docker_manager
         footnote
+        poll
         spoiler-alert
+        styleguide
       ],
     )
 


### PR DESCRIPTION
Removes BCC, Shared Edits, and Linkedin-auth from the official plugin list. 

Also corrects some alphabetising

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
