### PR TITLE
DEV: Add modifier for webhook event header generation

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -45,7 +45,15 @@ module Jobs
       web_hook_body = build_webhook_body
       web_hook_event = create_webhook_event(web_hook_body)
       uri = URI(@web_hook.payload_url.strip)
+
       web_hook_headers = build_webhook_headers(uri, web_hook_body, web_hook_event)
+      web_hook_headers =
+        DiscoursePluginRegistry.apply_modifier(
+          :web_hook_event_headers,
+          web_hook_headers,
+          web_hook_body,
+          web_hook_event,
+        )
 
       emitter = WebHookEmitter.new(@web_hook, web_hook_event)
       web_hook_response = emitter.emit!(headers: web_hook_headers, body: web_hook_body)


### PR DESCRIPTION
This allows for webhook event headers to be modified. The payload and webhook event instance are passed to the modifier so that the new/modified headers can be based off data in the payload/event type.