### PR TITLE
FIX: various revision history modal quirks

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history.hbs
@@ -7,7 +7,6 @@
     <ConditionalLoadingSpinner @condition={{this.initialLoad}}>
       <Modal::History::Revision
         @model={{this.postRevision}}
-        @wikiDisabled={{this.wikiDisabled}}
         @previousCategory={{this.previousCategory}}
         @currentCategory={{this.currentCategory}}
         @displayInline={{this.displayInline}}
@@ -20,8 +19,6 @@
         @hiddenClasses={{this.hiddenClasses}}
         @mobileView={{this.site.mobileView}}
         @userChanges={{this.user_changes}}
-        @wikiDisabled={{this.wikiDisabled}}
-        @postTypeDisabled={{this.postTypeDisabled}}
         @previousCategory={{this.previousCategory}}
         @currentCategory={{this.currentCategory}}
         @previousTagChanges={{this.previousTagChanges}}

--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -238,32 +238,27 @@ export default class History extends Component {
   }
 
   get previousCategory() {
-    if (this.postRevision?.category_id_changes) {
+    if (this.postRevision?.category_id_changes?.previous) {
       let category = Category.findById(
         this.postRevision.category_id_changes.previous
       );
-      return categoryBadgeHTML(category, { allowUncategorized: true });
+      return categoryBadgeHTML(category, {
+        allowUncategorized: true,
+        extraClasses: "diff-del",
+      });
     }
   }
 
   get currentCategory() {
-    if (this.postRevision?.category_id_changes) {
+    if (this.postRevision?.category_id_changes?.current) {
       let category = Category.findById(
         this.postRevision.category_id_changes.current
       );
-      return categoryBadgeHTML(category, { allowUncategorized: true });
+      return categoryBadgeHTML(category, {
+        allowUncategorized: true,
+        extraClasses: "diff-ins",
+      });
     }
-  }
-
-  get wikiDisabled() {
-    return !this.postRevision.wiki_changes?.current;
-  }
-
-  get postTypeDisabled() {
-    return (
-      this.postRevision?.post_type_changes?.current !==
-      this.site.post_types.moderator_action
-    );
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.hbs
@@ -35,15 +35,34 @@
         {{/if}}
 
         {{#if @model.wiki_changes}}
-          {{d-icon "far-edit" class=(if @model.wiki_changes.current "diff-ins" "diff-del")}}
+          {{d-icon
+            "far-edit"
+            class=(if @model.wiki_changes.current "diff-ins" "diff-del")
+          }}
         {{/if}}
 
         {{#if @model.post_type_changes}}
-          {{d-icon "shield-alt" class=(if (eq @model.post_type_changes.current @site.post_types.moderator_action) "diff-del" "diff-ins")}}
+          {{d-icon
+            "shield-alt"
+            class=(if
+              (eq
+                @model.post_type_changes.current
+                @site.post_types.moderator_action
+              )
+              "diff-del"
+              "diff-ins"
+            )
+          }}
         {{/if}}
 
         {{#if @model.archetype_changes}}
-          {{d-icon (if (eq @model.archetype_changes.current "private_message") "envelope" "comment")}}
+          {{d-icon
+            (if
+              (eq @model.archetype_changes.current "private_message")
+              "envelope"
+              "comment"
+            )
+          }}
         {{/if}}
 
         {{#if (and @model.category_id_changes (not @model.archetype_changes))}}

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.hbs
@@ -35,17 +35,29 @@
         {{/if}}
 
         {{#if @model.wiki_changes}}
-          <DisabledIcon @icon="far-edit" @disabled={{@wikiDisabled}} />
+          {{d-icon "far-edit" class=(if @model.wiki_changes.current "diff-ins" "diff-del")}}
         {{/if}}
 
         {{#if @model.post_type_changes}}
-          <DisabledIcon @icon="shield-alt" @disabled={{@postTypeDisabled}} />
+          {{d-icon "shield-alt" class=(if (eq @model.post_type_changes.current @site.post_types.moderator_action) "diff-del" "diff-ins")}}
         {{/if}}
 
-        {{#if @model.category_id_changes}}
-          {{html-safe @previousCategory}}
+        {{#if @model.archetype_changes}}
+          {{d-icon (if (eq @model.archetype_changes.current "private_message") "envelope" "comment")}}
+        {{/if}}
+
+        {{#if (and @model.category_id_changes (not @model.archetype_changes))}}
+          {{#if @previousCategory}}
+            {{html-safe @previousCategory}}
+          {{else}}
+            {{d-icon "far-eye-slash" class="diff-del"}}
+          {{/if}}
           &rarr;
-          {{html-safe @currentCategory}}
+          {{#if @currentCategory}}
+            {{html-safe @currentCategory}}
+          {{else}}
+            {{d-icon "far-eye-slash" class="diff-ins"}}
+          {{/if}}
         {{/if}}
       </span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
@@ -22,19 +22,27 @@
     {{/if}}
     {{#if @model.wiki_changes}}
       <div class="row">
-        <DisabledIcon @icon="far-edit" @disabled={{@wikiDisabled}} />
+        {{d-icon "far-edit" class=(if @model.wiki_changes.current "diff-ins" "diff-del")}}
       </div>
     {{/if}}
-    {{#if @model.post_type_changes}}
+    {{#if @model.archetype_changes}}
       <div class="row">
-        <DisabledIcon @icon="shield-alt" @disabled={{@postTypeDisabled}} />
+        {{d-icon (if (eq @model.archetype_changes.current "private_message") "envelope" "comment")}}
       </div>
     {{/if}}
-    {{#if @model.category_id_changes}}
+    {{#if (and @model.category_id_changes (not @model.archetype_changes))}}
       <div class="row">
-        {{html-safe @previousCategory}}
+        {{#if @previousCategory}}
+          {{html-safe @previousCategory}}
+        {{else}}
+          {{d-icon "far-eye-slash" class="diff-del"}}
+        {{/if}}
         &rarr;
-        {{html-safe @currentCategory}}
+        {{#if @currentCategory}}
+          {{html-safe @currentCategory}}
+        {{else}}
+          {{d-icon "far-eye-slash" class="diff-ins"}}
+        {{/if}}
       </div>
     {{/if}}
   {{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.hbs
@@ -22,12 +22,21 @@
     {{/if}}
     {{#if @model.wiki_changes}}
       <div class="row">
-        {{d-icon "far-edit" class=(if @model.wiki_changes.current "diff-ins" "diff-del")}}
+        {{d-icon
+          "far-edit"
+          class=(if @model.wiki_changes.current "diff-ins" "diff-del")
+        }}
       </div>
     {{/if}}
     {{#if @model.archetype_changes}}
       <div class="row">
-        {{d-icon (if (eq @model.archetype_changes.current "private_message") "envelope" "comment")}}
+        {{d-icon
+          (if
+            (eq @model.archetype_changes.current "private_message")
+            "envelope"
+            "comment"
+          )
+        }}
       </div>
     {{/if}}
     {{#if (and @model.category_id_changes (not @model.archetype_changes))}}


### PR DESCRIPTION
- FIX: properly scope category changes to what the current user can see
- UX: previous category is now highlighted in "red", new category is highlighted in "green"
- PERF: no need to serialize the categories
- FIX: properly track wiki
- FIX: properly track post_type (aka. Staff Color)
- FIX: properly track making a topic a PM
- FIX: never show the category changes when a topic is made a PM
- PERF: post_revision serializer is now more leaner (never includes title changes when post_number > 1, never includes user changes if there aren't any)
- UX: always sort the tags by name

Context - https://meta.discourse.org/t/-/304696

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
