### PR TITLE
DEV: Fix flaky sidebar category names matcher

### DIFF
--- a/spec/system/page_objects/modals/sidebar_edit_categories.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_categories.rb
@@ -36,7 +36,7 @@ module PageObjects
             count: category_names.length,
           )
 
-        expect(categories.map(&:text)).to eq(category_names)
+        expect(categories.map(&:text)).to contain_exactly(category_names)
       end
 
       def toggle_category_checkbox(category)


### PR DESCRIPTION
### What is this fix?

I'm having the following flaky test result for sidebar category name matching:

```
2) Editing sidebar categories navigation allows a user to filter the categories in the modal by selection
     Failure/Error: expect(categories.map(&:text)).to eq(category_names)
     
       expected: ["category", "category subcategory 2", "category subcategory", "category 2", "category 2 subcategory"]
            got: ["category 2", "category 2 subcategory", "category", "category subcategory 2", "category subcategory"]
     
       (compared using ==)
```

The elements are the same, but the order is different. I can't find any evidence that this is supposed to assert a strict ordering, so I've changed the matcher from `#eq` go `#contain_exactly`.