### PR TITLE
FIX: Take into account language fallbacks for admin sidebar plugin links

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -210,7 +210,10 @@ export function addAdminSidebarSectionLink(sectionName, link) {
   }
 
   // label must be valid, don't want broken [XYZ translation missing]
-  if (link.label && typeof I18n.lookup(link.label) !== "string") {
+  if (
+    link.label &&
+    I18n.t(link.label) === I18n.missingTranslation(link.label, null, {})
+  ) {
     // eslint-disable-next-line no-console
     console.debug(
       "[AdminSidebar]",


### PR DESCRIPTION
This commit fixes an issue where `I18n.lookup` was being used to
check if a link had a valid I18n key when the `addAdminSidebarSectionLink`
plugin API was used. However this was imperfect -- usually when we do
`I18n.t`, we fall back to the default locale (`en`), but if
`I18n.lookup` is used we do not do this, so we were removing the link
needlessly.

This issue was identified via the plugin API's use in https://github.com/discourse/docker_manager

c.f. https://meta.discourse.org/t/new-admin-sidebar-wheres-the-update-discourse-button/308213/15?u=martin
