### PR TITLE
FEATURE: Extend PM recipient bulk imports

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -636,6 +636,8 @@ class BulkImport::Base
 
   TOPIC_ALLOWED_USER_COLUMNS ||= %i[topic_id user_id created_at updated_at]
 
+  TOPIC_ALLOWED_GROUP_COLUMNS ||= %i[topic_id group_id created_at updated_at]
+
   TOPIC_TAG_COLUMNS ||= %i[topic_id tag_id created_at updated_at]
 
   TOPIC_USER_COLUMNS ||= %i[
@@ -877,6 +879,10 @@ class BulkImport::Base
 
   def create_topic_allowed_users(rows, &block)
     create_records(rows, "topic_allowed_user", TOPIC_ALLOWED_USER_COLUMNS, &block)
+  end
+
+  def create_topic_allowed_groups(rows, &block)
+    create_records(rows, "topic_allowed_group", TOPIC_ALLOWED_GROUP_COLUMNS, &block)
   end
 
   def create_topic_tags(rows, &block)
@@ -1305,6 +1311,12 @@ class BulkImport::Base
     topic_allowed_user[:created_at] = NOW
     topic_allowed_user[:updated_at] = NOW
     topic_allowed_user
+  end
+
+  def process_topic_allowed_group(topic_allowed_group)
+    topic_allowed_group[:created_at] = NOW
+    topic_allowed_group[:updated_at] = NOW
+    topic_allowed_group
   end
 
   def process_topic_tag(topic_tag)

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -676,30 +676,30 @@ class BulkImport::Generic < BulkImport::Base
   end
 
   def import_topic_allowed_users
-    # FIXME: This is not working correctly because it imports only the first user from the list!
-    # Groups are ignored completely. And there is no check for existing records.
-
     puts "", "Importing topic_allowed_users..."
 
     topics = query(<<~SQL)
-      SELECT *
-      FROM topics
-      WHERE private_message IS NOT NULL
-      ORDER BY id
+      SELECT
+        t.id,
+        user_ids.value AS user_id
+      FROM topics t, JSON_EACH(t.private_message, '$.user_ids') AS user_ids
+      WHERE t.private_message IS NOT NULL
+      ORDER BY t.id
     SQL
 
     added = 0
+    existing_topic_allowed_users = TopicAllowedUser.pluck(:topic_id, :user_id).to_set
 
     create_topic_allowed_users(topics) do |row|
-      next unless (topic_id = topic_id_from_imported_id(row["id"]))
-      imported_user_id = JSON.parse(row["private_message"])["user_ids"].first
-      user_id = user_id_from_imported_id(imported_user_id)
+      topic_id = topic_id_from_imported_id(row["id"])
+      user_id = user_id_from_imported_id(row["user_id"])
+
+      next unless topic_id && user_id
+      next unless existing_topic_allowed_users.add?([topic_id, user_id])
+
       added += 1
-      {
-        # FIXME: missing imported_id
-        topic_id: topic_id,
-        user_id: user_id,
-      }
+
+      { topic_id: topic_id, user_id: user_id }
     end
 
     topics.close


### PR DESCRIPTION
Currently, only one topic allowed user can be imported. This change introduces support for importing multiple topic-allowed users.

It also introduces a new step to support imports of  topic allowed groups.