### PR TITLE
FIX: keep topic.word_count in sync

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -855,14 +855,22 @@ class Topic < ActiveRecord::Base
         FROM posts
         WHERE deleted_at IS NULL AND post_type <> 4
         GROUP BY topic_id
-      )
+      ),
+      Z as (
+        SELECT topic_id,
+               SUM(COALESCE(posts.word_count, 0)) word_count
+        FROM posts
+        WHERE deleted_at IS NULL AND post_type <> 4
+        GROUP BY topic_id
+      )       
       UPDATE topics
       SET
         highest_staff_post_number = X.highest_post_number,
         highest_post_number = Y.highest_post_number,
         last_posted_at = Y.last_posted_at,
-        posts_count = Y.posts_count
-      FROM X, Y
+        posts_count = Y.posts_count,
+        word_count = Z.word_count
+      FROM X, Y, Z
       WHERE
         topics.archetype <> 'private_message' AND
         X.topic_id = topics.id AND
@@ -870,7 +878,8 @@ class Topic < ActiveRecord::Base
           topics.highest_staff_post_number <> X.highest_post_number OR
           topics.highest_post_number <> Y.highest_post_number OR
           topics.last_posted_at <> Y.last_posted_at OR
-          topics.posts_count <> Y.posts_count
+          topics.posts_count <> Y.posts_count OR
+          topics.word_count <> Z.word_count
         )
     SQL
 
@@ -891,14 +900,22 @@ class Topic < ActiveRecord::Base
         FROM posts
         WHERE deleted_at IS NULL AND post_type <> 3 AND post_type <> 4
         GROUP BY topic_id
+      ),
+      Z as (
+        SELECT topic_id,
+                SUM(COALESCE(posts.word_count, 0)) word_count
+        FROM posts
+        WHERE deleted_at IS NULL AND post_type <> 3 AND post_type <> 4
+        GROUP BY topic_id
       )
       UPDATE topics
       SET
         highest_staff_post_number = X.highest_post_number,
         highest_post_number = Y.highest_post_number,
         last_posted_at = Y.last_posted_at,
-        posts_count = Y.posts_count
-      FROM X, Y
+        posts_count = Y.posts_count,
+        word_count = Z.word_count
+      FROM X, Y, Z
       WHERE
         topics.archetype = 'private_message' AND
         X.topic_id = topics.id AND
@@ -906,7 +923,8 @@ class Topic < ActiveRecord::Base
           topics.highest_staff_post_number <> X.highest_post_number OR
           topics.highest_post_number <> Y.highest_post_number OR
           topics.last_posted_at <> Y.last_posted_at OR
-          topics.posts_count <> Y.posts_count
+          topics.posts_count <> Y.posts_count OR
+          topics.word_count <> Z.word_count
         )
     SQL
   end
@@ -938,6 +956,13 @@ class Topic < ActiveRecord::Base
           SELECT count(*) FROM posts
           WHERE deleted_at IS NULL AND
                 topic_id = :topic_id AND
+                post_type <> 4
+                #{post_type}
+        ),
+        word_count = (
+          SELECT SUM(COALESCE(posts.word_count, 0)) FROM posts
+          WHERE topic_id = :topic_id AND
+                deleted_at IS NULL AND
                 post_type <> 4
                 #{post_type}
         ),

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -287,6 +287,9 @@ class PostRevisor
       advance_draft_sequence if !opts[:keep_existing_draft]
     end
 
+    # bail out if the post or topic failed to save
+    return false if !successfully_saved_post_and_topic
+
     # Lock the post by default if the appropriate setting is true
     if (
          SiteSetting.staff_edit_locks_post? && !@post.wiki? && @fields.has_key?("raw") &&
@@ -312,15 +315,14 @@ class PostRevisor
     # it can fire events in sidekiq before the post is done saving
     # leading to corrupt state
     QuotedPost.extract_from(@post)
+    TopicLink.extract_from(@post)
+
+    Topic.reset_highest(@topic.id)
 
     post_process_post
-
-    update_topic_word_counts
     alert_users
     publish_changes
     grant_badge
-
-    TopicLink.extract_from(@post)
 
     ReviewablePost.queue_for_review_if_possible(@post, @editor) if should_create_new_version?
 
@@ -712,19 +714,6 @@ class PostRevisor
     @post.invalidate_oneboxes = true
     @post.trigger_post_process
     DiscourseEvent.trigger(:post_edited, @post, self.topic_changed?, self)
-  end
-
-  def update_topic_word_counts
-    DB.exec(
-      "UPDATE topics
-                    SET word_count = (
-                      SELECT SUM(COALESCE(posts.word_count, 0))
-                      FROM posts
-                      WHERE posts.topic_id = :topic_id
-                    )
-                    WHERE topics.id = :topic_id",
-      topic_id: @topic.id,
-    )
   end
 
   def alert_users

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2874,6 +2874,7 @@ RSpec.describe Topic do
     topic.reload
 
     expect(topic.posts_count).to eq(1)
+    expect(topic.word_count).to eq(post1.word_count)
     expect(topic.highest_post_number).to eq(post1.post_number)
     expect(topic.highest_staff_post_number).to eq(post2.post_number)
     expect(topic.last_posted_at).to eq_time(post1.created_at)


### PR DESCRIPTION
Whenever one creates, updates, or deletes a post, we should keep the `topic.word_count` counter in sync.

Context - https://meta.discourse.org/t/-/308062

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
