### PR TITLE
FIX: group's mentions was broken

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -218,26 +218,43 @@ class GroupsController < ApplicationController
       "#{SiteSetting.title} - #{I18n.t("rss_description.group_posts", group_name: group.name)}"
     @link = Discourse.base_url
     @description = I18n.t("rss_description.group_posts", group_name: group.name)
+
     render "posts/latest", formats: [:rss]
   end
 
   def mentions
     raise Discourse::NotFound unless SiteSetting.enable_mentions?
+
     group = find_group(:group_id)
+    guardian.ensure_can_see_group_members!(group)
+
     posts =
       group.mentioned_posts_for(guardian, params.permit(:before_post_id, :category_id)).limit(20)
-    render_serialized posts.to_a, GroupPostSerializer
+
+    response = { posts: serialize_data(posts, GroupPostSerializer) }
+
+    if guardian.can_lazy_load_categories?
+      category_ids = posts.map { |p| p.topic.category_id }.compact.uniq
+      categories = Category.secured(guardian).with_parents(category_ids)
+      response[:categories] = serialize_data(categories, CategoryBadgeSerializer)
+    end
+
+    render json: response
   end
 
   def mentions_feed
     raise Discourse::NotFound unless SiteSetting.enable_mentions?
+
     group = find_group(:group_id)
+    guardian.ensure_can_see_group_members!(group)
+
     @posts =
       group.mentioned_posts_for(guardian, params.permit(:before_post_id, :category_id)).limit(50)
     @title =
       "#{SiteSetting.title} - #{I18n.t("rss_description.group_mentions", group_name: group.name)}"
     @link = Discourse.base_url
     @description = I18n.t("rss_description.group_mentions", group_name: group.name)
+
     render "posts/latest", formats: [:rss]
   end
 


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/1deeff2336a3d9180ec6276a8fd5b399ec6165c8 we changed the format of the results given by the API but we forgot to update the `#mentions` endpoint as well.

Context - https://meta.discourse.org/t/-/308044

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
