### PR TITLE
FIX: customize chat dropdown labels

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -18,48 +18,10 @@ const CHAT_ATTRS = [
   "chat_separate_sidebar_mode",
 ];
 
-const EMAIL_FREQUENCY_OPTIONS = [
-  { name: I18n.t("chat.email_frequency.never"), value: "never" },
-  { name: I18n.t("chat.email_frequency.when_away"), value: "when_away" },
-];
-
 export const HEADER_INDICATOR_PREFERENCE_NEVER = "never";
 export const HEADER_INDICATOR_PREFERENCE_DM_AND_MENTIONS = "dm_and_mentions";
 export const HEADER_INDICATOR_PREFERENCE_ALL_NEW = "all_new";
 export const HEADER_INDICATOR_PREFERENCE_ONLY_MENTIONS = "only_mentions";
-const HEADER_INDICATOR_OPTIONS = [
-  {
-    name: I18n.t("chat.header_indicator_preference.all_new"),
-    value: HEADER_INDICATOR_PREFERENCE_ALL_NEW,
-  },
-  {
-    name: I18n.t("chat.header_indicator_preference.dm_and_mentions"),
-    value: HEADER_INDICATOR_PREFERENCE_DM_AND_MENTIONS,
-  },
-  {
-    name: I18n.t("chat.header_indicator_preference.only_mentions"),
-    value: HEADER_INDICATOR_PREFERENCE_ONLY_MENTIONS,
-  },
-  {
-    name: I18n.t("chat.header_indicator_preference.never"),
-    value: HEADER_INDICATOR_PREFERENCE_NEVER,
-  },
-];
-
-const CHAT_SEPARATE_SIDEBAR_MODE_OPTIONS = [
-  {
-    name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.always"),
-    value: "always",
-  },
-  {
-    name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.fullscreen"),
-    value: "fullscreen",
-  },
-  {
-    name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.never"),
-    value: "never",
-  },
-];
 
 export default class PreferencesChatController extends Controller {
   @service chatAudioManager;
@@ -67,9 +29,44 @@ export default class PreferencesChatController extends Controller {
 
   subpageTitle = I18n.t("chat.admin.title");
 
-  emailFrequencyOptions = EMAIL_FREQUENCY_OPTIONS;
-  headerIndicatorOptions = HEADER_INDICATOR_OPTIONS;
-  chatSeparateSidebarModeOptions = CHAT_SEPARATE_SIDEBAR_MODE_OPTIONS;
+  emailFrequencyOptions = [
+    { name: I18n.t("chat.email_frequency.never"), value: "never" },
+    { name: I18n.t("chat.email_frequency.when_away"), value: "when_away" },
+  ];
+
+  headerIndicatorOptions = [
+    {
+      name: I18n.t("chat.header_indicator_preference.all_new"),
+      value: HEADER_INDICATOR_PREFERENCE_ALL_NEW,
+    },
+    {
+      name: I18n.t("chat.header_indicator_preference.dm_and_mentions"),
+      value: HEADER_INDICATOR_PREFERENCE_DM_AND_MENTIONS,
+    },
+    {
+      name: I18n.t("chat.header_indicator_preference.only_mentions"),
+      value: HEADER_INDICATOR_PREFERENCE_ONLY_MENTIONS,
+    },
+    {
+      name: I18n.t("chat.header_indicator_preference.never"),
+      value: HEADER_INDICATOR_PREFERENCE_NEVER,
+    },
+  ];
+
+  chatSeparateSidebarModeOptions = [
+    {
+      name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.always"),
+      value: "always",
+    },
+    {
+      name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.fullscreen"),
+      value: "fullscreen",
+    },
+    {
+      name: I18n.t("admin.site_settings.chat_separate_sidebar_mode.never"),
+      value: "never",
+    },
+  ];
 
   get chatSeparateSidebarMode() {
     const mode = this.model.get("user_option.chat_separate_sidebar_mode");


### PR DESCRIPTION
The translations of the labels of some of the chat preferences dropdowns were not customizable via the "site texts" feature.

This was because they were declared outside of a Controller class and were thus not taking into account the customization through "site texts".

Internal ref - t/128859

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
