### PR TITLE
FIX: Broken link to theme in customize colors page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -33,7 +33,7 @@
           {{i18n "admin.customize.theme_owner"}}
           <LinkTo
             @route="adminCustomizeThemes.show"
-            @model={{this.model.theme_id}}
+            @models={{array "themes" this.model.theme_id}}
           >{{this.model.theme_name}}</LinkTo>
         </span>
       {{else}}


### PR DESCRIPTION
This regressed in https://github.com/discourse/discourse/pull/26644
