### PR TITLE
FIX: group activity's mentions infinite loading

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -229,7 +229,10 @@ class GroupsController < ApplicationController
     guardian.ensure_can_see_group_members!(group)
 
     posts =
-      group.mentioned_posts_for(guardian, params.permit(:before_post_id, :category_id)).limit(20)
+      group.mentioned_posts_for(
+        guardian,
+        params.permit(:before_post_id, :before, :category_id),
+      ).limit(20)
 
     response = { posts: serialize_data(posts, GroupPostSerializer) }
 
@@ -249,7 +252,10 @@ class GroupsController < ApplicationController
     guardian.ensure_can_see_group_members!(group)
 
     @posts =
-      group.mentioned_posts_for(guardian, params.permit(:before_post_id, :category_id)).limit(50)
+      group.mentioned_posts_for(
+        guardian,
+        params.permit(:before_post_id, :before, :category_id),
+      ).limit(50)
     @title =
       "#{SiteSetting.title} - #{I18n.t("rss_description.group_mentions", group_name: group.name)}"
     @link = Discourse.base_url

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -433,29 +433,6 @@ class Group < ActiveRecord::Base
     result.order("posts.created_at desc")
   end
 
-  def messages_for(guardian, opts = nil)
-    opts ||= {}
-
-    result =
-      Post
-        .includes(:user, :topic, topic: :category)
-        .references(:posts, :topics, :category)
-        .where("topics.archetype = ?", Archetype.private_message)
-        .where(post_type: Post.types[:regular])
-        .where(
-          "topics.id IN (SELECT topic_id FROM topic_allowed_groups WHERE group_id = ?)",
-          self.id,
-        )
-
-    if opts[:category_id].present?
-      result = result.where("topics.category_id = ?", opts[:category_id].to_i)
-    end
-
-    result = guardian.filter_allowed_categories(result)
-    result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
-    result.order("posts.created_at desc")
-  end
-
   def mentioned_posts_for(guardian, opts = nil)
     opts ||= {}
     result =
@@ -473,6 +450,7 @@ class Group < ActiveRecord::Base
 
     result = guardian.filter_allowed_categories(result)
     result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
+    result = result.where("posts.created_at < ?", opts[:before].to_datetime) if opts[:before]
     result.order("posts.created_at desc")
   end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -564,6 +564,38 @@ RSpec.describe GroupsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
+
+    it "supports pagination using before (date)" do
+      post = Fabricate(:post)
+      GroupMention.create!(post: post, group: group)
+
+      sign_in(user)
+      get "/groups/#{group.name}/mentions.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+
+      get "/groups/#{group.name}/mentions.json", params: { before: post.created_at }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"]).to be_empty
+    end
+
+    it "supports pagination using before_post_id" do
+      post = Fabricate(:post)
+      GroupMention.create!(post: post, group: group)
+
+      sign_in(user)
+      get "/groups/#{group.name}/mentions.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+
+      get "/groups/#{group.name}/mentions.json", params: { before_post_id: post.id }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"]).to be_empty
+    end
   end
 
   describe "#posts" do
@@ -601,6 +633,36 @@ RSpec.describe GroupsController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+    end
+
+    it "supports pagination using before (date)" do
+      post = Fabricate(:post, user: user)
+
+      sign_in(user)
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+
+      get "/groups/#{group.name}/posts.json", params: { before: post.created_at }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"]).to be_empty
+    end
+
+    it "supports pagination using before_post_id" do
+      post = Fabricate(:post, user: user)
+
+      sign_in(user)
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+
+      get "/groups/#{group.name}/posts.json", params: { before_post_id: post.id }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"]).to be_empty
     end
   end
 


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/07ecbb5a3b980115e6b8dfc127b8e336997a2ea8 we ensure the mentions in a group's activity page worked properly but we missed adding proper support for infinite loading.

The client is using the `before` parameter instead of the `before_post_id` to do the pagination.

This adds support for `before` as well as some tests to ensure it doesn't regress.

I also added tests to the group's activity posts as well since those were missing.

Finally I deleted some unused code (`group.messages_for`) which is not used anymore.

Context - https://meta.discourse.org/t/-/308044/9

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
