### PR TITLE
FIX: My Thread's last reply excerpt on mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/user-threads/preview.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-threads/preview.gjs
@@ -1,5 +1,7 @@
 import Component from "@glimmer/component";
+import { htmlSafe } from "@ember/template";
 import formatDate from "discourse/helpers/format-date";
+import replaceEmoji from "discourse/helpers/replace-emoji";
 
 export default class ThreadPreview extends Component {
   get lastReplyDate() {
@@ -16,7 +18,7 @@ export default class ThreadPreview extends Component {
       </span>
       <span>:</span>
       <span class="c-user-thread__excerpt-text">
-        {{@preview.lastReplyExcerpt}}
+        {{replaceEmoji (htmlSafe @preview.lastReplyExcerpt)}}
       </span>
     </span>
   </template>

--- a/plugins/chat/spec/system/page_objects/chat/user_threads.rb
+++ b/plugins/chat/spec/system/page_objects/chat/user_threads.rb
@@ -11,6 +11,10 @@ module PageObjects
       def open_thread(thread)
         find(".c-user-thread[data-id='#{thread.id}'] .chat__thread-title__name").click
       end
+
+      def excerpt_text
+        find(".c-user-thread__excerpt-text").text
+      end
     end
   end
 end

--- a/plugins/chat/spec/system/user_threads_spec.rb
+++ b/plugins/chat/spec/system/user_threads_spec.rb
@@ -245,7 +245,13 @@ RSpec.describe "User threads", type: :system do
 
   context "when in mobile", mobile: true do
     before do
-      chat_thread_chain_bootstrap(channel: channel_1, users: [current_user, Fabricate(:user)])
+      last_message =
+        chat_thread_chain_bootstrap(
+          channel: channel_1,
+          users: [current_user, Fabricate(:user)],
+        ).last_message
+
+      update_message!(last_message, text: "How's everyone doing?")
     end
 
     it "has the expected UI elements" do
@@ -258,6 +264,8 @@ RSpec.describe "User threads", type: :system do
       expect(user_threads_page).to have_css(".c-user-thread__excerpt")
       expect(user_threads_page).to have_css(".c-user-thread__excerpt-poster")
       expect(user_threads_page).to have_css(".c-user-thread .relative-date")
+
+      expect(user_threads_page.excerpt_text).to eq("How's everyone doing?")
     end
   end
 end


### PR DESCRIPTION
... wasn't properly escaped so it would show html entities (like `&#39;` instead of the apostrophe `'`).

I checked all the other places we show an excerpt and this was the only one that was missing the call to `htmlSafe` -> `replaceEmoji`.

Internal ref - t/128877

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
