### PR TITLE
DEV: Remove deprecated AuthProvider#enabled_setting=

### DIFF
--- a/lib/auth/auth_provider.rb
+++ b/lib/auth/auth_provider.rb
@@ -17,7 +17,6 @@ class Auth::AuthProvider
       frame_height
       pretty_name_setting
       title_setting
-      enabled_setting
       full_screen_login
       full_screen_login_setting
       custom_url
@@ -27,14 +26,6 @@ class Auth::AuthProvider
   end
 
   attr_accessor(*auth_attributes)
-
-  def enabled_setting=(val)
-    Discourse.deprecate(
-      "(#{authenticator.name}) enabled_setting is deprecated. Please define authenticator.enabled? instead",
-      drop_from: "2.9.0",
-    )
-    @enabled_setting = val
-  end
 
   def background_color=(val)
     Discourse.deprecate(

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -791,25 +791,6 @@ class Plugin::Instance
         provider.public_send("#{sym}=", opts.delete(sym)) if opts.has_key?(sym)
       end
 
-      begin
-        provider.authenticator.enabled?
-      rescue NotImplementedError
-        provider
-          .authenticator
-          .define_singleton_method(:enabled?) do
-            Discourse.deprecate(
-              "#{provider.authenticator.class.name} should define an `enabled?` function. Patching for now.",
-              drop_from: "2.9.0",
-            )
-            return SiteSetting.get(provider.enabled_setting) if provider.enabled_setting
-            Discourse.deprecate(
-              "#{provider.authenticator.class.name} has not defined an enabled_setting. Defaulting to true.",
-              drop_from: "2.9.0",
-            )
-            true
-          end
-      end
-
       DiscoursePluginRegistry.register_auth_provider(provider)
     end
   end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -324,49 +324,6 @@ TEXT
     end
   end
 
-  it "patches the enabled? function for auth_providers if not defined" do
-    SimpleAuthenticator =
-      Class.new(Auth::Authenticator) do
-        def name
-          "my_authenticator"
-        end
-      end
-
-    plugin = Plugin::Instance.new
-
-    # lets piggy back on another boolean setting, so we don't dirty our SiteSetting object
-    SiteSetting.enable_badges = false
-
-    # No enabled_site_setting
-    authenticator = SimpleAuthenticator.new
-    plugin.auth_provider(authenticator: authenticator)
-    plugin.notify_after_initialize
-    expect(authenticator.enabled?).to eq(true)
-
-    # With enabled site setting
-    plugin = Plugin::Instance.new
-    authenticator = SimpleAuthenticator.new
-    plugin.auth_provider(enabled_setting: "enable_badges", authenticator: authenticator)
-    plugin.notify_after_initialize
-    expect(authenticator.enabled?).to eq(false)
-
-    # Defines own method
-    plugin = Plugin::Instance.new
-
-    SiteSetting.enable_badges = true
-    authenticator =
-      Class
-        .new(SimpleAuthenticator) do
-          def enabled?
-            false
-          end
-        end
-        .new
-    plugin.auth_provider(enabled_setting: "enable_badges", authenticator: authenticator)
-    plugin.notify_after_initialize
-    expect(authenticator.enabled?).to eq(false)
-  end
-
   describe "#activate!" do
     before do
       # lets piggy back on another boolean setting, so we don't dirty our SiteSetting object

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Users::OmniauthCallbacksController do
             end
             .new
 
-        provider.enabled_setting = "ubuntu_login_enabled"
         provider
       end
 


### PR DESCRIPTION
### What is this change?

`AuthProvider#enabled_setting=`, used primarily by plugins, has been deprecated since version 2.9, in favour of `Authenticator#enabled?`. This PR confirms we are seeing no more usage and removes the method.

### Verification

- [x] A search through the logs shows no warnings regarding this.
- [x] A search through our plugins shows no plugins are registering any auth provider with an `enabled_setting` keyword. 