### PR TITLE
FIX: ensures topic info is dynamic with scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/extract-current-topic-info.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/extract-current-topic-info.js
@@ -1,14 +1,14 @@
 import { getOwner } from "@ember/application";
 
 export function extractCurrentTopicInfo(context) {
-  const topic = getOwner(context).lookup("controller:topic")?.get("model");
+  const topic = getOwner(context).lookup("controller:topic")?.model;
 
   if (!topic) {
     return;
   }
 
   const info = { context_topic_id: topic.id };
-  const currentPostNumber = parseInt(topic.current_post_number, 10);
+  const currentPostNumber = topic.currentPost;
   const posts = topic.postStream.posts;
 
   const currentPost = posts.find(


### PR DESCRIPTION
Prior to this fix we were using `topic.current_post_number` which is coming from the server side and represents the initial topic scroll position when initial rendered to the end user. However this value is not dynamic and is not updated when the user scroll, `topic.currentPost` is the dynamic equivalent.

No test as there are very low chances a test like this one based on scroll position, will be reliable over time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
