### PR TITLE
FIX: Update dependencies for Ruby 3.3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem "message_bus"
 
 gem "rails_multisite"
 
-gem "fast_xs", platform: :ruby
 
 gem "fastimage"
 
@@ -199,7 +198,6 @@ gem "puma", require: false
 
 gem "rbtrace", require: false, platform: :mri
 
-gem "gc_tracer", require: false, platform: :mri
 
 # required for feed importing and embedding
 gem "ruby-readability", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,17 +146,15 @@ GEM
     faraday-retry (2.2.0)
       faraday (~> 2.0)
     fast_blank (1.0.1)
-    fast_xs (0.8.0)
     fastimage (2.3.0)
     ffi (1.16.3)
     fspath (3.1.2)
-    gc_tracer (1.5.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.2-aarch64-linux)
-    google-protobuf (3.25.2-arm64-darwin)
-    google-protobuf (3.25.2-x86_64-darwin)
-    google-protobuf (3.25.2-x86_64-linux)
+    google-protobuf (3.25.3-aarch64-linux)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     guess_html_encoding (0.0.11)
     hana (1.3.7)
     hashdiff (1.1.0)
@@ -568,9 +566,7 @@ DEPENDENCIES
   faraday
   faraday-retry
   fast_blank
-  fast_xs
   fastimage
-  gc_tracer
   highline
   htmlentities
   http_accept_language


### PR DESCRIPTION
- Drop fast_cs (backport 6cfeb62)
- Drop gc_tracer (backport 5c6b561)
- Upgrade google-protobuf patch version for Ruby 3.3 support (backport 8ce9842)