### PR TITLE
DEV: Introduce `@dedupeTracked`

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/tracked-tools-test.gjs
+++ b/app/assets/javascripts/discourse/tests/unit/lib/tracked-tools-test.gjs
@@ -1,0 +1,56 @@
+import { render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { dedupeTracked } from "discourse/lib/tracked-tools";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Unit | tracked-tools", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("@dedupeTracked", async function (assert) {
+    class Pet {
+      initialsEvaluatedCount = 0;
+
+      @dedupeTracked name;
+
+      get initials() {
+        this.initialsEvaluatedCount++;
+        return this.name
+          ?.split(" ")
+          .map((n) => n[0])
+          .join("");
+      }
+    }
+
+    const pet = new Pet();
+    pet.name = "Scooby Doo";
+
+    await render(<template>
+      <span id="initials">{{pet.initials}}</span>
+    </template>);
+
+    assert.dom("#initials").hasText("SD", "Initials are correct");
+    assert.strictEqual(
+      pet.initialsEvaluatedCount,
+      1,
+      "Initials getter evaluated once"
+    );
+
+    pet.name = "Scooby Doo";
+    await settled();
+    assert.dom("#initials").hasText("SD", "Initials are correct");
+    assert.strictEqual(
+      pet.initialsEvaluatedCount,
+      1,
+      "Initials getter not re-evaluated"
+    );
+
+    pet.name = "Fluffy";
+    await settled();
+    assert.dom("#initials").hasText("F", "Initials are correct");
+    assert.strictEqual(
+      pet.initialsEvaluatedCount,
+      2,
+      "Initials getter re-evaluated"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/tracked-tools-test.gjs
+++ b/app/assets/javascripts/discourse/tests/unit/lib/tracked-tools-test.gjs
@@ -1,17 +1,15 @@
-import { render, settled } from "@ember/test-helpers";
+import { cached } from "@glimmer/tracking";
 import { module, test } from "qunit";
 import { dedupeTracked } from "discourse/lib/tracked-tools";
-import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Unit | tracked-tools", function (hooks) {
-  setupRenderingTest(hooks);
-
+module("Unit | tracked-tools", function () {
   test("@dedupeTracked", async function (assert) {
     class Pet {
       initialsEvaluatedCount = 0;
 
       @dedupeTracked name;
 
+      @cached
       get initials() {
         this.initialsEvaluatedCount++;
         return this.name
@@ -24,11 +22,7 @@ module("Unit | tracked-tools", function (hooks) {
     const pet = new Pet();
     pet.name = "Scooby Doo";
 
-    await render(<template>
-      <span id="initials">{{pet.initials}}</span>
-    </template>);
-
-    assert.dom("#initials").hasText("SD", "Initials are correct");
+    assert.strictEqual(pet.initials, "SD", "Initials are correct");
     assert.strictEqual(
       pet.initialsEvaluatedCount,
       1,
@@ -36,8 +30,7 @@ module("Unit | tracked-tools", function (hooks) {
     );
 
     pet.name = "Scooby Doo";
-    await settled();
-    assert.dom("#initials").hasText("SD", "Initials are correct");
+    assert.strictEqual(pet.initials, "SD", "Initials are correct");
     assert.strictEqual(
       pet.initialsEvaluatedCount,
       1,
@@ -45,8 +38,7 @@ module("Unit | tracked-tools", function (hooks) {
     );
 
     pet.name = "Fluffy";
-    await settled();
-    assert.dom("#initials").hasText("F", "Initials are correct");
+    assert.strictEqual(pet.initials, "F", "Initials are correct");
     assert.strictEqual(
       pet.initialsEvaluatedCount,
       2,


### PR DESCRIPTION
Same as `@tracked`, but skips notifying consumers if the value is unchanged. This introduces some performance overhead, so should only be used where excessive downstream re-evaluations are a problem.

This is loosely based on `@dedupeTracked` in the `tracked-toolbox` package, but without the added complexity of a customizable 'comparator'. Implementing ourselves also avoids the need for pulling in the entire package, which contains some tools which we don't want, or which are now implemented in Ember/Glimmer (e.g. `@cached`).