### PR TITLE
UX: shorten duration of bookmark toasties

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -133,7 +133,7 @@ export default class BookmarkMenu extends Component {
         // a bookmark, it switches to the other Edit/Delete menu.
         this.quicksaved = true;
         this.toasts.success({
-          duration: 3000,
+          duration: 1500,
           views: ["mobile"],
           data: { message: I18n.t("bookmarks.bookmarked_success") },
         });
@@ -172,7 +172,7 @@ export default class BookmarkMenu extends Component {
       const response = await this.bookmarkManager.delete();
       this.bookmarkManager.afterDelete(response, this.existingBookmark.id);
       this.toasts.success({
-        duration: 3000,
+        duration: 1500,
         data: {
           icon: "trash-alt",
           message: I18n.t("bookmarks.deleted_bookmark_success"),
@@ -201,7 +201,7 @@ export default class BookmarkMenu extends Component {
       try {
         await this.bookmarkManager.save();
         this.toasts.success({
-          duration: 3000,
+          duration: 1500,
           views: ["mobile"],
           data: { message: I18n.t("bookmarks.reminder_set_success") },
         });


### PR DESCRIPTION
The bookmarks toasty last a bit too long (3s), taking up space and attention on screen.
This commit halves the time to 1.5s, which is sufficient to read a 1-word toasty.