### PR TITLE
FEATURE: add agree and edit

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -228,33 +228,31 @@ export default Component.extend({
     this._penalize("showSilenceModal", reviewable, performAction);
   },
 
-  clientEdit(reviewable, performAction) {
-    this.store.find("post", reviewable.post_id).then((p) => {
-      Topic.find(p.topic_id, {}).then((t_json) => {
-        const t = Topic.create(t_json);
-        p.set("topic", t);
+  async clientEdit(reviewable, performAction) {
+    const post = await this.store.find("post", reviewable.post_id);
+    const topic_json = await Topic.find(post.topic_id, {});
 
-        if (!this.currentUser) {
-          return this.dialog.alert(I18n.t("post.controls.edit_anonymous"));
-        } else if (!p.can_edit) {
-          return false;
-        }
+    const topic = Topic.create(topic_json);
+    post.set("topic", topic);
 
-        const opts = {
-          post: p,
-          action: Composer.EDIT,
-          draftKey: p.get("topic.draft_key"),
-          draftSequence: p.get("topic.draft_sequence"),
-          skipDraftCheck: true,
-          skipJumpOnSave: true,
-        };
+    if (!this.currentUser) {
+      return this.dialog.alert(I18n.t("post.controls.edit_anonymous"));
+    } else if (!post.can_edit) {
+      return false;
+    }
 
-        this.composer.open(opts);
+    const opts = {
+      post,
+      action: Composer.EDIT,
+      draftKey: post.get("topic.draft_key"),
+      draftSequence: post.get("topic.draft_sequence"),
+      skipDraftCheck: true,
+      skipJumpOnSave: true,
+    };
 
-        return performAction();
-      });
-    });
-    return;
+    this.composer.open(opts);
+
+    return performAction();
   },
 
   _penalize(adminToolMethod, reviewable, performAction) {

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -229,15 +229,16 @@ export default Component.extend({
   },
 
   async clientEdit(reviewable, performAction) {
+    if (!this.currentUser) {
+      return this.dialog.alert(I18n.t("post.controls.edit_anonymous"));
+    }
     const post = await this.store.find("post", reviewable.post_id);
     const topic_json = await Topic.find(post.topic_id, {});
 
     const topic = Topic.create(topic_json);
     post.set("topic", topic);
 
-    if (!this.currentUser) {
-      return this.dialog.alert(I18n.t("post.controls.edit_anonymous"));
-    } else if (!post.can_edit) {
+    if (!post.can_edit) {
       return false;
     }
 

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -9,6 +9,7 @@ class ReviewableFlaggedPost < Reviewable
       agree_and_keep_hidden: :agree_and_keep,
       agree_and_silence: :agree_and_keep,
       agree_and_suspend: :agree_and_keep,
+      agree_and_edit: :agree_and_keep,
       disagree_and_restore: :disagree,
       ignore_and_do_nothing: :ignore,
     }
@@ -59,6 +60,13 @@ class ReviewableFlaggedPost < Reviewable
       build_action(actions, :agree_and_keep_hidden, icon: "thumbs-up", bundle: agree_bundle)
     else
       build_action(actions, :agree_and_keep, icon: "thumbs-up", bundle: agree_bundle)
+      build_action(
+        actions,
+        :agree_and_edit,
+        icon: "pencil-alt",
+        bundle: agree_bundle,
+        client_action: "edit",
+      )
     end
 
     if guardian.can_delete_post_or_topic?(post)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3474,7 +3474,7 @@ en:
       text_body_template: |
         Your bulk user invite file was processed, %{sent} invites mailed, %{skipped} skipped and %{warnings} warning(s).
 
-        Skipped Invites for Emails: 
+        Skipped Invites for Emails:
 
         ``` text
         %{skipped_emails}
@@ -3490,13 +3490,13 @@ en:
       text_body_template: |
         Your bulk user invite file was processed, %{sent} invites mailed, %{skipped} skipped, %{warnings} warning(s) and %{failed} error(s).
 
-        Skipped Invites for Emails: 
+        Skipped Invites for Emails:
 
         ``` text
         %{skipped_emails}
         ```
 
-        Failed Invites for Emails: 
+        Failed Invites for Emails:
 
         ``` text
         %{failed_emails}
@@ -5523,6 +5523,9 @@ en:
       agree_and_hide:
         title: "Hide post"
         description: "Agree with flag and hide this post + automatically send the user a message urging them to edit it."
+      agree_and_edit:
+        title: "Agree and Edit Post"
+        description: "Agree with flag and open a composer window to edit the post."
       delete_single:
         title: "Delete"
       delete:

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         actions = reviewable.actions_for(guardian)
         expect(actions.has?(:agree_and_hide)).to eq(true)
         expect(actions.has?(:agree_and_keep)).to eq(true)
+        expect(actions.has?(:agree_and_edit)).to eq(true)
         expect(actions.has?(:agree_and_keep_hidden)).to eq(false)
         expect(actions.has?(:agree_and_silence)).to eq(true)
         expect(actions.has?(:agree_and_suspend)).to eq(true)
@@ -56,6 +57,7 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         post.hidden = true
         actions = reviewable.actions_for(guardian)
         expect(actions.has?(:agree_and_keep)).to eq(false)
+        expect(actions.has?(:agree_and_edit)).to eq(false)
         expect(actions.has?(:agree_and_keep_hidden)).to eq(true)
       end
 
@@ -117,6 +119,13 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     end
 
     it "agree_and_keep agrees with the flags and keeps the post" do
+      reviewable.perform(moderator, :agree_and_keep)
+      expect(reviewable).to be_approved
+      expect(score.reload).to be_agreed
+      expect(post).not_to be_hidden
+    end
+
+    it "agree_and_keep agrees with the flags and edits the post" do
       reviewable.perform(moderator, :agree_and_keep)
       expect(reviewable).to be_approved
       expect(score.reload).to be_agreed

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -5,6 +5,8 @@ describe "Reviewables", type: :system do
   fab!(:admin)
   fab!(:theme)
   fab!(:long_post) { Fabricate(:post_with_very_long_raw_content) }
+  fab!(:post)
+  let(:composer) { PageObjects::Components::Composer.new }
 
   before { sign_in(admin) }
 
@@ -23,12 +25,35 @@ describe "Reviewables", type: :system do
   end
 
   describe "when there is a flagged post reviewable with a short post" do
-    fab!(:short_reviewable) { Fabricate(:reviewable_flagged_post) }
+    fab!(:short_reviewable) { Fabricate(:reviewable_flagged_post, target: post) }
 
     it "should not show a button to expand/collapse the post content" do
       visit("/review")
       expect(review_page).to have_no_post_body_collapsed
       expect(review_page).to have_no_post_body_toggle
+    end
+
+    describe "reviewable actions" do
+      it "should have agree_and_edit action" do
+        visit("/review")
+        select_kit =
+          PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide")
+        select_kit.expand
+
+        expect(page).to have_selector("[data-value='post-agree_and_edit']")
+      end
+
+      it "agree_and_edit should open the composer" do
+        visit("/review")
+        select_kit =
+          PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide")
+        select_kit.expand
+
+        find("[data-value='post-agree_and_edit']").click
+
+        expect(composer).to be_opened
+        expect(composer.composer_input.value).to eq(post.raw)
+      end
     end
   end
 


### PR DESCRIPTION
adds agree and edit - an alias for agree and keep -- but with a client action to edit the post in the composer before the flag is agreed with.