### PR TITLE
DEV: Pull compatible themes in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,10 @@ jobs:
         if: matrix.target == 'themes' && matrix.build_type == 'system'
         run: bin/rake themes:clone_all_official
 
+      - name: Pull compatible versions of themes
+        if: matrix.target == 'themes'
+        run: bin/rake themes:pull_compatible_all
+
       - name: Add hosts to /etc/hosts, otherwise Chromium cannot reach minio
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: |

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -225,6 +225,33 @@ task "themes:clone_all_official" do |task, args|
     end
 end
 
+desc "pull compatible theme versions for all themes"
+task "themes:pull_compatible_all" do |t|
+  Dir
+    .glob(File.expand_path("#{Rails.root}/tmp/themes/*"))
+    .select { |f| File.directory? f }
+    .each do |theme_path|
+      next unless File.directory?(theme_path + "/.git")
+
+      theme_name = File.basename(theme_path)
+      checkout_version = Discourse.find_compatible_git_resource(theme_path)
+
+      # Checkout value of the version compat
+      if checkout_version
+        puts "checking out compatible #{theme_name} version: #{checkout_version}"
+
+        update_status =
+          system(
+            "git -C '#{theme_path}' cat-file -e #{checkout_version} || git -C '#{theme_path}' fetch --depth 1 $(git -C '#{theme_path}' rev-parse --symbolic-full-name @{upstream} | awk -F '/' '{print $3}') #{checkout_version}; git -C '#{theme_path}' reset --hard #{checkout_version}",
+          )
+
+        abort("Unable to checkout a compatible theme version") unless update_status
+      else
+        puts "#{theme_name} is already at latest compatible version"
+      end
+    end
+end
+
 # Note that this should only be used in CI where it is safe to mutate the database without rolling back since running
 # the themes QUnit tests requires the themes to be installed in the database.
 desc "Runs qunit tests for all official themes"


### PR DESCRIPTION
This commit adds a step in our tests workflow on Github actions to update the themes to
use the compatible version when not running aginast the `main` branch.
This is to ensure that we are not running
the tests for themes against an incompatible version of Discourse.
