### PR TITLE
DEV: Don't run `discourse-ai` plugin specs when running against stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,11 @@ jobs:
         if: matrix.target == 'plugins'
         run: bin/rake plugin:install_all_official
 
+      # Remove discourse-ai from stable as it is not compatible with Ruby 3.3 which we are now using for the base image
+      - name: Remove discourse-ai from stable
+        if: matrix.target == 'plugins' && (github.ref_name == 'stable' || github.base_ref == 'stable')
+        run: rm -rf plugins/discourse-ai
+
       - name: Pull compatible versions of plugins
         if: matrix.target == 'plugins'
         run: bin/rake plugin:pull_compatible_all


### PR DESCRIPTION
`discourse-ai` has custom gems which need to be bumped in order to be
compatible with Ruby 3.3. However, its version is pinned so we can't
pull in the commits in which upgrades the gems to be compatible with
Ruby 3.3. Just avoid running the specs on `stable` branch for now until
we release a new stable.
