### PR TITLE
FIX: paginating posts should allow for deletions and PMs

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -110,8 +110,6 @@ class PostsController < ApplicationController
 
     posts = posts.to_a
 
-    # Remove posts the user doesn't have permission to see
-    # This isn't leaking any information we weren't already through the post ID numbers
     counts = PostAction.counts_for(posts, current_user)
 
     respond_to do |format|


### PR DESCRIPTION
Note this may have performance issues in some cases, will need to be monitored

Previous to this change we were bracketing on 50 id windows. They may end up
having zero posts we are searching for leading to posts.rss and .json returning
no results.
