### PR TITLE
Backport fixes required for `discourse-reactions` plugin

### DIFF
--- a/app/controllers/post_action_users_controller.rb
+++ b/app/controllers/post_action_users_controller.rb
@@ -12,18 +12,8 @@ class PostActionUsersController < ApplicationController
     page_size = fetch_limit_from_params(default: INDEX_LIMIT, max: INDEX_LIMIT)
 
     # Find the post, and then determine if they can see the post (if deleted)
-    post = Post.with_deleted.where(id: params[:id].to_i).first
+    post = Post.with_deleted.find_by(id: params[:id].to_i)
     guardian.ensure_can_see!(post)
-
-    unknown_user_ids = Set.new
-    if current_user.present?
-      result = DB.query_single(<<~SQL, user_id: current_user.id)
-        SELECT mu.muted_user_id AS id FROM muted_users AS mu WHERE mu.user_id = :user_id
-        UNION
-        SELECT iu.ignored_user_id AS id FROM ignored_users AS iu WHERE iu.user_id = :user_id
-      SQL
-      unknown_user_ids.merge(result)
-    end
 
     post_actions =
       post
@@ -34,25 +24,38 @@ class PostActionUsersController < ApplicationController
         .order("post_actions.created_at ASC")
         .limit(page_size)
 
+    post_actions =
+      DiscoursePluginRegistry.apply_modifier(:post_action_users_list, post_actions, post)
+
     if !guardian.can_see_post_actors?(post.topic, post_action_type_id)
-      raise Discourse::InvalidAccess unless current_user
+      raise Discourse::InvalidAccess if current_user.blank?
       post_actions = post_actions.where(user_id: current_user.id)
     end
 
     action_type = PostActionType.types.key(post_action_type_id)
     total_count = post["#{action_type}_count"].to_i
-
+    post_actions = post_actions.to_a
     data = {
       post_action_users:
         serialize_data(
-          post_actions.to_a,
+          post_actions,
           PostActionUserSerializer,
-          unknown_user_ids: unknown_user_ids,
+          unknown_user_ids: current_user_muting_or_ignoring_users(post_actions.map(&:user_id)),
         ),
     }
 
     data[:total_rows_post_action_users] = total_count if total_count > page_size
 
     render_json_dump(data)
+  end
+
+  private
+
+  def current_user_muting_or_ignoring_users(user_ids)
+    return [] if current_user.blank?
+    UserCommScreener.new(
+      acting_user: current_user,
+      target_user_ids: user_ids,
+    ).actor_preventing_communication
   end
 end

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -227,6 +227,7 @@ class UserAction < ActiveRecord::Base
       LEFT JOIN categories c on c.id = t.category_id
       LEFT JOIN post_custom_fields pc ON pc.post_id = a.target_post_id AND pc.name = 'action_code_who'
       LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc2.name = 'action_code_path'
+      /*left_join*/
       /*where*/
       /*order_by*/
       /*offset*/
@@ -256,6 +257,8 @@ class UserAction < ActiveRecord::Base
 
       builder.order_by("a.created_at desc").offset(offset.to_i).limit(limit.to_i)
     end
+
+    DiscoursePluginRegistry.apply_modifier(:user_action_stream_builder, builder)
 
     builder.query
   end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -97,7 +97,7 @@ class Guardian
   attr_reader :request
 
   def initialize(user = nil, request = nil)
-    @user = user.presence || AnonymousUser.new
+    @user = user.presence || Guardian::AnonymousUser.new
     @request = request
   end
 
@@ -640,12 +640,17 @@ class Guardian
   private
 
   def is_my_own?(obj)
-    if anonymous?
+    # NOTE: This looks strange...but we are checking if someone is posting anonymously
+    # as a AnonymousUser model, _not_ as Guardian::AnonymousUser which is a different thing
+    # used when !authenticated?
+    if authenticated? && is_anonymous?
       return(
         SiteSetting.allow_anonymous_likes? && obj.class == PostAction && obj.is_like? &&
           obj.user_id == @user.id
       )
     end
+
+    return false if anonymous?
     return obj.user_id == @user.id if obj.respond_to?(:user_id) && obj.user_id && @user.id
     return obj.user == @user if obj.respond_to?(:user)
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Guardian do
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:post)
 
-    describe "an anonymous user" do
+    describe "an authenticated user posting anonymously" do
       before { SiteSetting.allow_anonymous_posting = true }
 
       context "when allow_anonymous_likes is enabled" do
@@ -2491,7 +2491,7 @@ RSpec.describe Guardian do
     end
   end
 
-  describe "#can_delete_post_action" do
+  describe "#can_delete_post_action?" do
     before do
       SiteSetting.allow_anonymous_posting = true
       Guardian.any_instance.stubs(:anonymous?).returns(true)
@@ -2499,7 +2499,8 @@ RSpec.describe Guardian do
 
     context "with allow_anonymous_likes enabled" do
       before { SiteSetting.allow_anonymous_likes = true }
-      describe "an anonymous user" do
+
+      describe "an authenticated anonymous user" do
         let(:post_action) do
           user.id = anonymous_user.id
           post.id = 1
@@ -2539,6 +2540,10 @@ RSpec.describe Guardian do
 
         it "returns true if the post belongs to the anonymous user" do
           expect(Guardian.new(anonymous_user).can_delete_post_action?(post_action)).to be_truthy
+        end
+
+        it "returns false if the user is an unauthenticated anonymous user" do
+          expect(Guardian.new.can_delete_post_action?(post_action)).to be_falsey
         end
 
         it "return false if the post belongs to another user" do

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe UserAction do
     end
 
     describe "assignments" do
-      let(:stream) { UserAction.stream(user_id: user.id, guardian: Guardian.new(user)) }
+      let(:stream) { UserAction.stream(user_id: user.id, guardian: user.guardian) }
 
       before do
         log_test_action(action_type: UserAction::ASSIGNED)
@@ -146,7 +146,7 @@ RSpec.describe UserAction do
     describe "mentions" do
       before { log_test_action(action_type: UserAction::MENTION) }
 
-      let(:stream) { UserAction.stream(user_id: user.id, guardian: Guardian.new(user)) }
+      let(:stream) { UserAction.stream(user_id: user.id, guardian: user.guardian) }
 
       it "is returned by the stream" do
         expect(stream.count).to eq(1)
@@ -156,6 +156,33 @@ RSpec.describe UserAction do
       it "isn't returned when mentions aren't enabled" do
         SiteSetting.enable_mentions = false
         expect(stream).to be_blank
+      end
+    end
+
+    describe "when a plugin registers the :user_action_stream_builder modifier" do
+      before do
+        log_test_action(action_type: UserAction::LIKE)
+        log_test_action(action_type: UserAction::WAS_LIKED)
+      end
+
+      after { DiscoursePluginRegistry.clear_modifiers! }
+
+      it "allows the plugin to modify the builder query" do
+        Plugin::Instance
+          .new
+          .register_modifier(:user_action_stream_builder) do |builder|
+            expect(builder).to be_a(MiniSqlMultisiteConnection::CustomBuilder)
+            builder.limit(1)
+          end
+
+        stream = UserAction.stream(user_id: user.id, guardian: user.guardian)
+
+        expect(stream.count).to eq(1)
+
+        DiscoursePluginRegistry.clear_modifiers!
+
+        stream = UserAction.stream(user_id: user.id, guardian: user.guardian)
+        expect(stream.count).to eq(2)
       end
     end
   end

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -138,4 +138,41 @@ RSpec.describe PostActionUsersController do
     expect(users.length).to eq(0)
     expect(total).to be_nil
   end
+
+  describe "when a plugin registers the :post_action_users_list modifier" do
+    before do
+      @post_action_1 = PostActionCreator.like(Fabricate(:user), post).post_action
+      @post_action_2 = PostActionCreator.like(Fabricate(:user), post).post_action
+    end
+
+    after { DiscoursePluginRegistry.clear_modifiers! }
+
+    it "allows the plugin to modify the post action query" do
+      excluded_post_action_ids = [@post_action_1.id]
+      Plugin::Instance
+        .new
+        .register_modifier(:post_action_users_list) do |query, modifier_post|
+          expect(modifier_post.id).to eq(post.id)
+          query.where("post_actions.id NOT IN (?)", excluded_post_action_ids)
+        end
+
+      get "/post_action_users.json",
+          params: {
+            id: post.id,
+            post_action_type_id: PostActionType.types[:like],
+          }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["post_action_users"].count).to eq(1)
+
+      DiscoursePluginRegistry.clear_modifiers!
+
+      get "/post_action_users.json",
+          params: {
+            id: post.id,
+            post_action_type_id: PostActionType.types[:like],
+          }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["post_action_users"].count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/discourse/discourse-reactions/commit/04c4742f938825f86694bf53627c8cb32d10fe17, we mark the plugin as compatible with `stable` to pull in a security fix with the plugin. However, the plugin was never really compatible with stable because the tests for the plugins were broken.

This PR backports the changes made to core which the `discourse-reaction` plugins needs in order for the latest commit of the plugin to be compatible with stable.