### PR TITLE
FIX: shows errors when converting to public is impossible

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/convert-to-public-topic.js
+++ b/app/assets/javascripts/discourse/app/components/modal/convert-to-public-topic.js
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import I18n from "discourse-i18n";
+import { extractError } from "discourse/lib/ajax-error";
 
 export default class ConvertToPublicTopic extends Component {
   @service appEvents;
@@ -13,18 +13,18 @@ export default class ConvertToPublicTopic extends Component {
 
   @action
   async makePublic() {
+    const { topic } = this.args.model;
+
     try {
       this.saving = true;
-      await this.args.model.topic.convertTopic("public", {
-        categoryId: this.publicCategoryId,
-      });
-      this.args.model.topic.set("archetype", "regular");
-      this.args.model.topic.set("category_id", this.publicCategoryId);
-      this.appEvents.trigger("header:show-topic", this.args.model.topic);
-      this.saving = false;
+      await topic.convertTopic("public", { categoryId: this.publicCategoryId });
+      topic.set("archetype", "regular");
+      topic.set("category_id", this.publicCategoryId);
+      this.appEvents.trigger("header:show-topic", topic);
       this.args.closeModal();
     } catch (e) {
-      this.flash = I18n.t("generic_error");
+      this.flash = extractError(e);
+    } finally {
       this.saving = false;
     }
   }

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -228,6 +228,18 @@ module PageObjects
         post_by_number(post).has_css?(".read-state.read", visible: :all, wait: 3)
       end
 
+      def move_to_public_category(category)
+        click_admin_menu_button
+        find(".topic-admin-menu-content li.topic-admin-convert").click
+        move_to_public_modal.find(".category-chooser").click
+        find(".category-row[data-value=\"#{category.id}\"]").click
+        move_to_public_modal.find(".btn-primary").click
+      end
+
+      def move_to_public_modal
+        find(".modal.convert-to-public-topic")
+      end
+
       private
 
       def within_post(post)

--- a/spec/system/topic_admin_menu_spec.rb
+++ b/spec/system/topic_admin_menu_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe "Topic Admin Menu", type: :system do
+  fab!(:admin)
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before { sign_in(admin) }
+
+  context "for a PM" do
+    fab!(:pm) { Fabricate(:private_message_topic, title: "Can you help me with this?") }
+    fab!(:op) { Fabricate(:post, topic: pm, user: admin, created_at: 1.day.ago) }
+    fab!(:category)
+
+    it "shows the errors when converting to a public topic is not possible" do
+      # create a topic with the same title to force a "duplicate title" error
+      Fabricate(:topic, title: pm.title, category: category)
+
+      topic_page.visit_topic(pm)
+      topic_page.move_to_public_category(category)
+      expect(topic_page.move_to_public_modal).to have_css("#modal-alert")
+    end
+  end
+end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/commit/e04ac5e2d8fed5badf984ae4aece69b45a05bdcd which missed showing the error messages in the "convert to public" modal 🤦‍♂️

It was instead showing a generic error message, which wasn't helpful.

### BEFORE

<img width="600" alt="image" src="https://github.com/discourse/discourse/assets/362783/24ce049f-e681-4184-bdb2-3524f8d6dfbe">


### AFTER

<img width="601" alt="image" src="https://github.com/discourse/discourse/assets/362783/2f82fb00-0c44-4e10-ad3c-fda60249a82e">
