### PR TITLE
UX: search context box too dark

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -46,7 +46,7 @@ $search-pad-horizontal: 0.5em;
       margin: 2px;
       margin-right: 0;
       white-space: nowrap;
-      background-color: var(--primary-300);
+      background-color: var(--primary-200);
       &:hover {
         background-color: var(--primary-medium);
       }


### PR DESCRIPTION
The search context uses similar styles to our buttons, but has a slightly too dark background:


Before:
![image](https://github.com/discourse/discourse/assets/1681963/d5566625-567b-4659-aac9-d15032f2c275)


After:
![image](https://github.com/discourse/discourse/assets/1681963/5d58cee5-49dc-4b3f-aff1-90f33da93aaa)
