### PR TITLE
UX: switch post action buttons to inline-flex to avoid extra whitespace

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -316,7 +316,7 @@ nav.post-controls {
       .d-icon {
         opacity: 1;
       }
-      display: inline-block;
+      display: inline-flex;
     }
 
     button {


### PR DESCRIPTION
Most of our `DButton` buttons use `display: flex;` by default... so whitespace is collapsed. 

In `DButton` we have an intentional space character added to increase the icon-only button height to match button heights with text (the text adds a couple px of height).

So the use of `DButton` in the post controls, which are not currently flex buttons, means that we end up with an extra whitespace: 

![image](https://github.com/discourse/discourse/assets/1681963/a3505ce9-d185-470d-8c9c-1e7de604e21c)

This switches the post actions to `inline-flex` instead of `inline-block` to hide this space without requiring additional edits to the way the button is populated:

![image](https://github.com/discourse/discourse/assets/1681963/eb634ce3-776c-4bda-bd37-4e064e666e37)

