### PR TITLE
FIX: Make edit categories sidebar modal work more intuitively

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -173,51 +173,51 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
     this.performSearch();
   }
 
-  setFetchedCategories(categories) {
-    this.fetchedCategories = categories;
-    this.partialCategoryInfos = findPartialCategories(categories);
-
-    this.fetchedCategoriesGroupings = splitWhere(
-      categories,
-      (category) => category.parent_category_id === undefined
-    ).map((categories) => addShowMore(categories, this.partialCategoryInfos));
-  }
-
-  concatFetchedCategories(categories) {
-    this.fetchedCategories = this.fetchedCategories.concat(categories);
-    this.partialCategoryInfos = new Map([
-      ...this.partialCategoryInfos,
-      ...findPartialCategories(categories),
-    ]);
-
+  recomputeGroupings() {
     this.fetchedCategoriesGroupings = splitWhere(
       this.fetchedCategories,
       (category) => category.parent_category_id === undefined
     ).map((categories) => addShowMore(categories, this.partialCategoryInfos));
   }
 
+  setFetchedCategories(categories) {
+    this.fetchedCategories = categories;
+    this.partialCategoryInfos = findPartialCategories(categories);
+    this.recomputeGroupings();
+  }
+
+  concatFetchedCategories(categories) {
+    this.fetchedCategories = this.fetchedCategories.concat(categories);
+
+    this.partialCategoryInfos = new Map([
+      ...this.partialCategoryInfos,
+      ...findPartialCategories(categories),
+    ]);
+
+    this.recomputeGroupings();
+  }
+
   substituteInFetchedCategories(id, subcategories, offset) {
     this.partialCategoryInfos.delete(id);
-    const index = this.fetchedCategories.findLastIndex((c) => c.parent_category_id === id) + 1;
+    this.recomputeGroupings();
 
     if (subcategories.length !== 0) {
       this.partialCategoryInfos.set(id, {offset: offset + subcategories.length});
+      const index = this.fetchedCategories.findLastIndex((c) => c.parent_category_id === id) + 1;
 
       this.fetchedCategories = [
         ...this.fetchedCategories.slice(0, index),
         ...subcategories,
         ...this.fetchedCategories.slice(index),
       ];
+
       this.partialCategoryInfos = new Map([
         ...this.partialCategoryInfos,
         ...findPartialCategories(subcategories),
       ]);
-    }
 
-    this.fetchedCategoriesGroupings = splitWhere(
-      this.fetchedCategories,
-      (category) => category.parent_category_id === undefined
-    ).map((categories) => addShowMore(categories, this.partialCategoryInfos));
+      this.recomputeGroupings();
+    }
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -184,14 +184,14 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
   }
 
   concatFetchedCategories(categories) {
-    this.fetchedCategories.concat(categories);
+    this.fetchedCategories = this.fetchedCategories.concat(categories);
     this.partialCategoryInfos = new Map([
       ...this.partialCategoryInfos,
       ...findPartialCategories(categories),
     ]);
 
     this.fetchedCategoriesGroupings = splitWhere(
-      categories,
+      this.fetchedCategories,
       (category) => category.parent_category_id === undefined
     ).map((categories) => addShowMore(categories, this.partialCategoryInfos));
   }

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -72,8 +72,13 @@ function splitWhere(elements, f) {
 }
 
 function addShowMore(categories) {
+  const categoriesPerParent = new Map();
+
   return categories.reduce((acc, el, i) => {
     acc.push({type: "category", category: el});
+
+    const count = (categoriesPerParent.get(el.parent_category_id) || 0) + 1;
+    categoriesPerParent.set(el.parent_category_id, count)
 
     const elID = categories[i].id;
     const elParentID = categories[i].parent_category_id;
@@ -82,7 +87,7 @@ function addShowMore(categories) {
     const nextIsSibling = nextParentID === elParentID;
     const nextIsChild = nextParentID === elID;
 
-    if (!nextIsSibling && !nextIsChild) {
+    if (!nextIsSibling && !nextIsChild && count == 5) {
       acc.push({type: "show-more", level: el.level});
     }
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -440,51 +440,49 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
             >
               {{#each categories as |c|}}
                 {{#if (eq c.type "category")}}
-                  {{#with c.category as |category|}}
-                    <div
-                      {{didInsert this.didInsert}}
-                      data-category-id={{category.id}}
-                      data-category-level={{category.level}}
-                      class="sidebar-categories-form__category-row"
+                  <div
+                    {{didInsert this.didInsert}}
+                    data-category-id={{c.category.id}}
+                    data-category-level={{c.category.level}}
+                    class="sidebar-categories-form__category-row"
+                  >
+                    <label
+                      for={{concat
+                        "sidebar-categories-form__input--"
+                        c.category.id
+                      }}
+                      class="sidebar-categories-form__category-label"
                     >
-                      <label
-                        for={{concat
-                          "sidebar-categories-form__input--"
-                          category.id
-                        }}
-                        class="sidebar-categories-form__category-label"
-                      >
-                        <div class="sidebar-categories-form__category-wrapper">
-                          <div class="sidebar-categories-form__category-badge">
-                            {{categoryBadge category}}
+                      <div class="sidebar-categories-form__category-wrapper">
+                        <div class="sidebar-categories-form__category-badge">
+                          {{categoryBadge c.category}}
 
-                          </div>
-
-                          {{#unless category.parentCategory}}
-                            <div
-                              class="sidebar-categories-form__category-description"
-                            >
-                              {{dirSpan
-                                category.description_excerpt
-                                htmlSafe="true"
-                              }}
-                            </div>
-                          {{/unless}}
                         </div>
 
-                        <input
-                          {{on "click" (fn this.toggleCategory category.id)}}
-                          type="checkbox"
-                          checked={{has this.selectedCategoryIds category.id}}
-                          id={{concat
-                            "sidebar-categories-form__input--"
-                            category.id
-                          }}
-                          class="sidebar-categories-form__input"
-                        />
-                      </label>
-                    </div>
-                  {{/with}}
+                        {{#unless c.category.parentCategory}}
+                          <div
+                            class="sidebar-categories-form__category-description"
+                          >
+                            {{dirSpan
+                              c.category.description_excerpt
+                              htmlSafe="true"
+                            }}
+                          </div>
+                        {{/unless}}
+                      </div>
+
+                      <input
+                        {{on "click" (fn this.toggleCategory c.category.id)}}
+                        type="checkbox"
+                        checked={{has this.selectedCategoryIds c.category.id}}
+                        id={{concat
+                          "sidebar-categories-form__input--"
+                          c.category.id
+                        }}
+                        class="sidebar-categories-form__input"
+                      />
+                    </label>
+                  </div>
                 {{else}}
                   <div
                     {{didInsert this.didInsert}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -456,7 +456,6 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
                       <div class="sidebar-categories-form__category-wrapper">
                         <div class="sidebar-categories-form__category-badge">
                           {{categoryBadge c.category}}
-
                         </div>
 
                         {{#unless c.category.parentCategory}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -136,10 +136,7 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
       this.loadedPage = null;
       this.hasMorePages = false;
     } else {
-      const { categories } = await Category.asyncSearch(filter, {
-        includeAncestors: true,
-        includeUncategorized: false,
-      });
+      const categories = await Category.asyncHierarchicalSearch(filter, {});
 
       this.setFetchedCategories(mode, categories);
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -189,6 +189,19 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
   concatFetchedCategories(categories) {
     this.fetchedCategories = this.fetchedCategories.concat(categories);
 
+    // In order to find partially loaded categories correctly, we need to
+    // ensure that we account for categories that may have been partially
+    // loaded, because the total number of categories in the response clipped
+    // them off.
+    if (categories[0].parent_category_id !== undefined) {
+      const index = this.fetchedCategories.findLastIndex(element => element.parent_category_id === undefined);
+
+      categories = [
+        ...this.fetchedCategories.slice(index),
+        ...categories,
+      ];
+    }
+
     this.partialCategoryInfos = new Map([
       ...this.partialCategoryInfos,
       ...findPartialCategories(categories),

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -14,6 +14,7 @@ import { MultiCache } from "discourse-common/utils/multi-cache";
 
 const STAFF_GROUP_NAME = "staff";
 const CATEGORY_ASYNC_SEARCH_CACHE = {};
+const CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE = {};
 
 export default class Category extends RestModel {
   // Sort subcategories directly under parents
@@ -383,6 +384,28 @@ export default class Category extends RestModel {
     }
 
     return data.sortBy("read_restricted");
+  }
+
+  static async asyncHierarchicalSearch(term, opts) {
+    opts ||= {};
+
+    const data = {
+      term,
+      parent_category_id: opts.parentCategoryId,
+      limit: opts.limit,
+      page: opts.page,
+    };
+
+    const result = (CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE[
+      JSON.stringify(data)
+    ] ||= await ajax("/categories/hierarchical_search", {
+      method: "GET",
+      data,
+    }));
+
+    return result["categories"].map((category) =>
+      Site.current().updateCategory(category)
+    );
   }
 
   static async asyncSearch(term, opts) {

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -396,6 +396,7 @@ export default class Category extends RestModel {
       only: opts.only,
       except: opts.except,
       page: opts.page,
+      offset: opts.offset,
     };
 
     const result = (CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE[

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -397,6 +397,7 @@ export default class Category extends RestModel {
       except: opts.except,
       page: opts.page,
       offset: opts.offset,
+      include_uncategorized: opts.includeUncategorized,
     };
 
     const result = (CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE[

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -393,6 +393,8 @@ export default class Category extends RestModel {
       term,
       parent_category_id: opts.parentCategoryId,
       limit: opts.limit,
+      only: opts.only,
+      except: opts.except,
       page: opts.page,
     };
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -91,8 +91,8 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       return helper.response(cloneJSON(categoryFixture["/c/1/show.json"]));
     });
 
-    server.post("/categories/search", () => {
-      return helper.response({ categories: [], ancestors: [] });
+    server.get("/categories/hierarchical_search", () => {
+      return helper.response({ categories: [] });
     });
   });
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -366,7 +366,7 @@ class CategoriesController < ApplicationController
     categories =
       Category
         .limited_categories_matching(only, except, parent_category_id, term)
-        .includes(
+        .preload(
           :uploaded_logo,
           :uploaded_logo_dark,
           :uploaded_background,
@@ -380,6 +380,7 @@ class CategoriesController < ApplicationController
         .select("categories.*, t.slug topic_slug")
         .limit(limit)
         .offset((page - 1) * limit + offset)
+        .to_a
 
     if Site.preloaded_category_custom_fields.present?
       Category.preload_custom_fields(categories, Site.preloaded_category_custom_fields)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -340,7 +340,19 @@ class CategoriesController < ApplicationController
     offset = params[:offset].to_i
     parent_category_id = params[:parent_category_id].to_i if params[:parent_category_id].present?
     only = Category.where(id: params[:only].to_a.map(&:to_i)) if params[:only].present?
-    except = Category.where(id: params[:except].to_a.map(&:to_i)) if params[:except].present?
+    except_ids = params[:except].to_a.map(&:to_i)
+    include_uncategorized =
+      (
+        if params[:include_uncategorized].present?
+          ActiveModel::Type::Boolean.new.cast(params[:include_uncategorized])
+        else
+          true
+        end
+      )
+
+    except_ids << SiteSetting.uncategorized_category_id unless include_uncategorized
+
+    except = Category.where(id: except_ids) if except_ids.present?
 
     limit =
       (

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -365,6 +365,7 @@ class CategoriesController < ApplicationController
 
     categories =
       Category
+        .secured(guardian)
         .limited_categories_matching(only, except, parent_category_id, term)
         .preload(
           :uploaded_logo,

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -338,6 +338,8 @@ class CategoriesController < ApplicationController
     term = params[:term].to_s.strip
     page = [1, params[:page].to_i].max
     parent_category_id = params[:parent_category_id].to_i if params[:parent_category_id].present?
+    only = Category.where(id: params[:only].to_a.map(&:to_i)) if params[:only].present?
+    except = Category.where(id: params[:except].to_a.map(&:to_i)) if params[:except].present?
 
     limit =
       (
@@ -350,7 +352,7 @@ class CategoriesController < ApplicationController
 
     categories =
       Category
-        .limited_categories_matching(parent_category_id, term)
+        .limited_categories_matching(only, except, parent_category_id, term)
         .includes(
           :uploaded_logo,
           :uploaded_logo_dark,

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -337,6 +337,7 @@ class CategoriesController < ApplicationController
   def hierarchical_search
     term = params[:term].to_s.strip
     page = [1, params[:page].to_i].max
+    offset = params[:offset].to_i
     parent_category_id = params[:parent_category_id].to_i if params[:parent_category_id].present?
     only = Category.where(id: params[:only].to_a.map(&:to_i)) if params[:only].present?
     except = Category.where(id: params[:except].to_a.map(&:to_i)) if params[:except].present?
@@ -366,7 +367,7 @@ class CategoriesController < ApplicationController
         .joins("LEFT JOIN topics t on t.id = categories.topic_id")
         .select("categories.*, t.slug topic_slug")
         .limit(limit)
-        .offset((page - 1) * limit)
+        .offset((page - 1) * limit + offset)
 
     if Site.preloaded_category_custom_fields.present?
       Category.preload_custom_fields(categories, Site.preloaded_category_custom_fields)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -394,7 +394,7 @@ class Category < ActiveRecord::Base
 
   scope :limited_categories_matching,
         ->(only, except, parent_id, term) do
-          Category.joins(<<~SQL).order("c.ancestors || ARRAY[ROW(NOT c.matches, c.name)]")
+          joins(<<~SQL).order("c.ancestors || ARRAY[ROW(NOT c.matches, c.name)]")
             INNER JOIN (
               WITH matches AS (#{Category.tree_search(only, except, term).to_sql})
               #{Category.where(parent_category_id: parent_id).select_descendants(Category.from("matches").select(:matches, :id), 5).to_sql}

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -291,11 +291,10 @@ class Category < ActiveRecord::Base
           word_match = <<~SQL
             COALESCE(
               (
-                SELECT DISTINCT true
+                SELECT BOOL_AND(position(pattern IN LOWER(categories.name)) <> 0)
                 FROM unnest(regexp_split_to_array(#{escaped_term}, '\s+')) AS pattern
-                WHERE position(pattern IN LOWER(categories.name)) <> 0
               ),
-              false
+              true
             )
           SQL
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -279,6 +279,119 @@ class Category < ActiveRecord::Base
     where(id: ancestor_ids)
   end
 
+  # Perform a search. If a category exists in the result, its ancestors do too.
+  # Also check for prefix matches. If a category has a prefix match, its
+  # ancestors report a match too.
+  scope :tree_search,
+        ->(term) do
+          term = term.strip
+          escaped_term = ActiveRecord::Base.connection.quote(term.downcase)
+          prefix_match = "starts_with(LOWER(categories.name), #{escaped_term})"
+
+          word_match = <<~SQL
+            COALESCE(
+              (
+                SELECT DISTINCT true
+                FROM unnest(regexp_split_to_array(#{escaped_term}, '\s+')) AS pattern
+                WHERE position(pattern IN LOWER(categories.name)) <> 0
+              ),
+              false
+            )
+          SQL
+
+          categories =
+            Category.select(
+              "categories.*",
+              "#{prefix_match} AS has_prefix_match",
+              "#{word_match} AS has_word_match",
+            )
+
+          (1...SiteSetting.max_category_nesting).each do
+            categories = Category.from("(#{categories.to_sql}) AS categories")
+
+            subcategory_matches =
+              categories
+                .where.not(parent_category_id: nil)
+                .group("categories.parent_category_id")
+                .select(
+                  "categories.parent_category_id AS id",
+                  "BOOL_OR(categories.has_prefix_match) AS has_prefix_match",
+                  "BOOL_OR(categories.has_word_match) AS has_word_match",
+                )
+
+            categories =
+              Category.joins(
+                "LEFT JOIN (#{subcategory_matches.to_sql}) AS subcategory_matches ON categories.id = subcategory_matches.id",
+              ).select(
+                "categories.*",
+                "#{prefix_match} OR COALESCE(subcategory_matches.has_prefix_match, false) AS has_prefix_match",
+                "#{word_match} OR COALESCE(subcategory_matches.has_word_match, false) AS has_word_match",
+              )
+          end
+
+          Category
+            .from("(#{categories.to_sql}) AS categories")
+            .where(has_word_match: true)
+            .select("has_prefix_match AS matches", :id)
+        end
+
+  # Given a relation, 'matches', which contains category ids and a 'matches'
+  # boolean, and a limit (the maximum number of subcategories per category),
+  # produce a subset of the matches categories annotated with information about
+  # their ancestors.
+  scope :select_descendants,
+        ->(matches, limit) do
+          max_nesting = SiteSetting.max_category_nesting
+
+          categories =
+            joins("INNER JOIN (#{matches.to_sql}) AS matches ON matches.id = categories.id").select(
+              "categories.id",
+              "categories.name",
+              "ARRAY[]::record[] AS ancestors",
+              "0 AS depth",
+              "matches.matches",
+            )
+
+          categories = Category.unscoped.from("(#{categories.to_sql}) AS c1")
+
+          (1...max_nesting).each { |i| categories = categories.joins(<<~SQL) }
+            INNER JOIN LATERAL (
+              SELECT c#{i}.id, c#{i}.name, c#{i}.ancestors, c#{i}.depth, c#{i}.matches
+              UNION ALL
+              SELECT
+                categories.id,
+                categories.name,
+                c#{i}.ancestors || ARRAY[ROW(NOT c#{i}.matches, c#{i}.name)] AS ancestors,
+                c#{i}.depth + 1 as depth,
+                matches.matches
+              FROM categories
+              INNER JOIN matches
+              ON matches.id = categories.id
+              WHERE categories.parent_category_id = c#{i}.id
+              AND c#{i}.depth = #{i - 1}
+              LIMIT #{limit}
+            ) c#{i + 1} ON true
+          SQL
+
+          categories.select(
+            "c#{max_nesting}.id",
+            "c#{max_nesting}.ancestors",
+            "c#{max_nesting}.name",
+            "c#{max_nesting}.matches",
+          )
+        end
+
+  scope :limited_categories_matching,
+        ->(parent_id, term) do
+          Category.joins(<<~SQL).order("c.ancestors || ARRAY[ROW(NOT c.matches, c.name)]")
+            INNER JOIN (
+              WITH matches AS (#{Category.tree_search(term).where.not(id: SiteSetting.uncategorized_category_id).to_sql})
+              #{Category.where(parent_category_id: parent_id).select_descendants(Category.from("matches").select(:matches, :id), 5).to_sql}
+            ) AS c
+            ON categories.id = c.id
+          SQL
+        end
+
   def self.topic_id_cache
     @topic_id_cache ||= DistributedCache.new("category_topic_ids")
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -352,7 +352,7 @@ class Category < ActiveRecord::Base
               "matches.matches",
             )
 
-          categories = Category.unscoped.from("(#{categories.to_sql}) AS c1")
+          categories = Category.from("(#{categories.to_sql}) AS c1")
 
           (1...max_nesting).each { |i| categories = categories.joins(<<~SQL) }
             INNER JOIN LATERAL (

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4668,6 +4668,7 @@ en:
           text: "and we'll automatically show this site's most popular categories"
         filter_placeholder: "Filter categories"
         no_categories: "There are no categories matching the given term."
+        show_more: "Show more"
       tags_form_modal:
         title: "Edit tags navigation"
         filter_placeholder: "Filter tags"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1174,6 +1174,7 @@ Discourse::Application.routes.draw do
     post "categories/reorder" => "categories#reorder"
     get "categories/find" => "categories#find"
     post "categories/search" => "categories#search"
+    get "categories/hierarchical_search" => "categories#hierarchical_search"
     get "categories/:parent_category_id" => "categories#index"
 
     scope path: "category/:category_id" do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1550,4 +1550,17 @@ RSpec.describe Category do
       )
     end
   end
+
+  describe ".limited_categories_matching" do
+    before_all { SiteSetting.max_category_nesting = 3 }
+
+    fab!(:foo) { Fabricate(:category, name: "foo") }
+    fab!(:bar) { Fabricate(:category, name: "bar", parent_category: foo) }
+    fab!(:baz) { Fabricate(:category, name: "baz", parent_category: bar) }
+
+    it "produces results in depth-first pre-order" do
+      SiteSetting.max_category_nesting = 3
+      expect(Category.limited_categories_matching(nil, "baz").pluck(:name)).to eq(%w[foo bar baz])
+    end
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1560,7 +1560,9 @@ RSpec.describe Category do
 
     it "produces results in depth-first pre-order" do
       SiteSetting.max_category_nesting = 3
-      expect(Category.limited_categories_matching(nil, "baz").pluck(:name)).to eq(%w[foo bar baz])
+      expect(Category.limited_categories_matching(nil, nil, nil, "baz").pluck(:name)).to eq(
+        %w[foo bar baz],
+      )
     end
   end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1451,5 +1451,14 @@ RSpec.describe CategoriesController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["categories"].length).to eq(0)
     end
+
+    it "doesn't expose secret categories" do
+      category.update!(read_restricted: true)
+
+      get "/categories/hierarchical_search.json", params: { term: "" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["categories"].map { |c| c["id"] }).not_to include(category.id)
+    end
   end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1434,4 +1434,22 @@ RSpec.describe CategoriesController do
       expect(category["subcategory_count"]).to eq(1)
     end
   end
+
+  describe "#hierachical_search" do
+    before { sign_in(user) }
+
+    it "produces categories with an empty term" do
+      get "/categories/hierarchical_search.json", params: { term: "" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["categories"].length).not_to eq(0)
+    end
+
+    it "doesn't produce categories with a very specific term" do
+      get "/categories/hierarchical_search.json", params: { term: "acategorythatdoesnotexist" }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["categories"].length).to eq(0)
+    end
+  end
 end

--- a/spec/system/editing_sidebar_categories_navigation_spec.rb
+++ b/spec/system/editing_sidebar_categories_navigation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       expect(modal).to have_no_reset_to_defaults_button
 
       expect(modal).to have_categories(
-        [category2, category2_subcategory, category, category_subcategory2, category_subcategory],
+        [category, category_subcategory, category_subcategory2, category2, category2_subcategory],
       )
 
       modal
@@ -100,18 +100,6 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
 
   describe "when on mobile" do
     include_examples "a user can edit the sidebar categories navigation", true
-  end
-
-  it "displays the categories in the modal based on the fixed position of the category when `fixed_category_positions` site setting is enabled" do
-    SiteSetting.fixed_category_positions = true
-
-    visit "/latest"
-
-    modal = sidebar.click_edit_categories_button
-
-    expect(modal).to have_categories(
-      [category2, category2_subcategory, category, category_subcategory2, category_subcategory],
-    )
   end
 
   it "allows a user to deselect all categories in the modal" do
@@ -165,13 +153,13 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
     modal.filter("subcategory")
 
     expect(modal).to have_categories(
-      [category2, category2_subcategory, category, category_subcategory2, category_subcategory],
+      [category, category_subcategory, category_subcategory2, category2, category2_subcategory],
     )
 
     modal.filter("2")
 
     expect(modal).to have_categories(
-      [category2, category2_subcategory, category, category_subcategory2],
+      [category, category_subcategory2, category2, category2_subcategory],
     )
 
     modal.filter("someinvalidterm")
@@ -190,16 +178,11 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
     modal = sidebar.click_edit_categories_button
     modal.filter_by_selected
 
-    expect(modal).to have_categories([category2, category, category_subcategory])
-    expect(modal).to have_checkbox(category, disabled: true)
-    expect(modal).to have_checkbox(category_subcategory)
-    expect(modal).to have_checkbox(category2)
+    expect(modal).to have_categories([category, category_subcategory, category2])
 
     modal.filter("category subcategory")
 
     expect(modal).to have_categories([category, category_subcategory])
-    expect(modal).to have_checkbox(category, disabled: true)
-    expect(modal).to have_checkbox(category_subcategory)
 
     modal.filter("").filter_by_unselected
 
@@ -207,22 +190,11 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       [category, category_subcategory2, category2, category2_subcategory],
     )
 
-    expect(modal).to have_checkbox(category)
-    expect(modal).to have_checkbox(category_subcategory2)
-    expect(modal).to have_checkbox(category2, disabled: true)
-    expect(modal).to have_checkbox(category2_subcategory)
-
     modal.filter_by_all
 
     expect(modal).to have_categories(
-      [category, category_subcategory2, category_subcategory, category2, category2_subcategory],
+      [category, category_subcategory, category_subcategory2, category2, category2_subcategory],
     )
-
-    expect(modal).to have_checkbox(category)
-    expect(modal).to have_checkbox(category_subcategory)
-    expect(modal).to have_checkbox(category_subcategory2)
-    expect(modal).to have_checkbox(category2)
-    expect(modal).to have_checkbox(category2_subcategory)
   end
 
   context "when there are more categories than the page limit" do
@@ -264,6 +236,8 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
 
   describe "when max_category_nesting has been set to 3" do
     before_all { SiteSetting.max_category_nesting = 3 }
+
+    before { SiteSetting.max_category_nesting = 3 }
 
     fab!(:category_subcategory_subcategory) do
       Fabricate(
@@ -335,9 +309,9 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
           category2_subcategory,
           category2_subcategory_subcategory,
           category,
-          category_subcategory2,
           category_subcategory,
           category_subcategory_subcategory2,
+          category_subcategory2,
         ],
       )
     end


### PR DESCRIPTION
 * Load search results in displayed order so that when more categories are loaded, they appear at the end,

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
