### PR TITLE
FIX: play audio sound on message in non group DMs

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-audio-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-audio-manager.js
@@ -37,10 +37,12 @@ export default class ChatAudioManager extends Service {
   }
 
   async play(soundName) {
+    if (isTesting()) {
+      return;
+    }
+
     const audio =
       this._audioCache[soundName] || this._audioCache[DEFAULT_SOUND_NAME];
-
-    audio.muted = isTesting();
 
     if (!audio.paused) {
       audio.pause();

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
@@ -1,0 +1,44 @@
+import Service, { service } from "@ember/service";
+
+export default class ChatChannelNotificationSound extends Service {
+  @service chat;
+  @service chatAudioManager;
+  @service currentUser;
+  @service site;
+
+  async play(channel) {
+    if (channel.isCategoryChannel) {
+      return false;
+    }
+
+    if (channel.chatable.group) {
+      return false;
+    }
+
+    if (this.currentUser.isInDoNotDisturb()) {
+      return false;
+    }
+
+    if (!this.currentUser.chat_sound) {
+      return false;
+    }
+
+    if (this.site.mobileView) {
+      return false;
+    }
+
+    const membership = channel.currentUserMembership;
+    if (
+      !membership.following ||
+      membership.desktopNotificationLevel !== "always" ||
+      membership.muted ||
+      this.chat.activeChannel === channel
+    ) {
+      return false;
+    }
+
+    await this.chatAudioManager.play(this.currentUser.chat_sound);
+
+    return true;
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
@@ -31,15 +31,15 @@ export default class ChatChannelNotificationSound extends Service {
     if (!membership.following) {
       return false;
     }
-    
+
     if (membership.desktopNotificationLevel !== "always") {
       return false;
     }
-    
+
     if (membership.muted) {
       return false;
     }
-    
+
     if (this.chat.activeChannel === channel) {
       return false;
     }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
@@ -28,12 +28,19 @@ export default class ChatChannelNotificationSound extends Service {
     }
 
     const membership = channel.currentUserMembership;
-    if (
-      !membership.following ||
-      membership.desktopNotificationLevel !== "always" ||
-      membership.muted ||
-      this.chat.activeChannel === channel
-    ) {
+    if (!membership.following) {
+      return false;
+    }
+    
+    if (membership.desktopNotificationLevel !== "always") {
+      return false;
+    }
+    
+    if (membership.muted) {
+      return false;
+    }
+    
+    if (this.chat.activeChannel === channel) {
       return false;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -7,6 +7,7 @@ import ChatChannelArchive from "../models/chat-channel-archive";
 export default class ChatSubscriptionsManager extends Service {
   @service store;
   @service chatChannelsManager;
+  @service chatChannelNotificationSound;
   @service chatTrackingStateManager;
   @service currentUser;
   @service appEvents;
@@ -204,6 +205,8 @@ export default class ChatSubscriptionsManager extends Service {
           ) {
             channel.tracking.unreadCount++;
           }
+
+          this.chatChannelNotificationSound.play(channel);
 
           // Thread should be considered unread if not already.
           if (busData.thread_id && channel.threadingEnabled) {

--- a/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
@@ -1,0 +1,119 @@
+import { getOwner } from "@ember/application";
+import { test } from "qunit";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+function buildDirectMessageChannel(owner) {
+  const channel = new ChatFabricators(owner).directMessageChannel();
+  buildMembership(channel);
+  return channel;
+}
+function buildCategoryMessageChannel(owner) {
+  const channel = new ChatFabricators(owner).channel();
+  buildMembership(channel);
+  return channel;
+}
+
+function buildMembership(channel) {
+  channel.currentUserMembership = {
+    following: true,
+    desktop_notification_level: "always",
+    muted: false,
+  };
+  return channel;
+}
+
+acceptance(
+  "Discourse Chat | Unit | Service | chat-channel-notification-sound",
+  function (needs) {
+    needs.hooks.beforeEach(function () {
+      Object.defineProperty(this, "subject", {
+        get: () =>
+          this.container.lookup("service:chat-channel-notification-sound"),
+      });
+
+      Object.defineProperty(this, "site", {
+        get: () => this.container.lookup("service:site"),
+      });
+
+      Object.defineProperty(this, "chat", {
+        get: () => this.container.lookup("service:chat"),
+      });
+
+      updateCurrentUser({ chat_sound: "ding" });
+    });
+
+    needs.user();
+
+    test("in do not disturb", async function (assert) {
+      updateCurrentUser({ do_not_disturb_until: moment().add(1, "hour") });
+      const channel = buildDirectMessageChannel(getOwner(this));
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("not chat sound", async function (assert) {
+      updateCurrentUser({ chat_sound: null });
+      const channel = buildDirectMessageChannel(getOwner(this));
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("mobile", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      this.site.mobileView = true;
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("default", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+
+      assert.deepEqual(await this.subject.play(channel), true);
+    });
+
+    test("muted", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      channel.currentUserMembership.muted = true;
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("not following", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      channel.currentUserMembership.following = false;
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("no notification", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      channel.currentUserMembership.desktopNotificationLevel = "never";
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("currently active channel", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      this.chat.activeChannel = channel;
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("category channel", async function (assert) {
+      const channel = buildCategoryMessageChannel(getOwner(this));
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+
+    test("group", async function (assert) {
+      const channel = buildDirectMessageChannel(getOwner(this));
+      channel.chatable.group = true;
+
+      assert.deepEqual(await this.subject.play(channel), false);
+    });
+  }
+);

--- a/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
@@ -69,7 +69,7 @@ acceptance(
       assert.deepEqual(await this.subject.play(channel), false);
     });
 
-    test("default", async function (assert) {
+    test("plays sound", async function (assert) {
       const channel = buildDirectMessageChannel(getOwner(this));
 
       assert.deepEqual(await this.subject.play(channel), true);

--- a/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
@@ -55,7 +55,7 @@ acceptance(
       assert.deepEqual(await this.subject.play(channel), false);
     });
 
-    test("not chat sound", async function (assert) {
+    test("no chat sound", async function (assert) {
       updateCurrentUser({ chat_sound: null });
       const channel = buildDirectMessageChannel(getOwner(this));
 


### PR DESCRIPTION
Prior to this change, only mentions would get a notification and a sound. This change will not create a notification for this case, but will play a sound. This is still respecting notification settings, not playing the sound when you are viewing the channel or not following it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
