### PR TITLE
FIX: subfolder absolute links in summaries

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -506,17 +506,23 @@ module PrettyText
   end
 
   def self.make_all_links_absolute(doc)
-    site_uri = nil
     doc
-      .css("a")
-      .each do |link|
-        href = link["href"].to_s
+      .css("a[href]")
+      .each do |a|
         begin
-          uri = URI(href)
-          site_uri ||= URI(Discourse.base_url)
-          unless uri.host.present? || href.start_with?("mailto")
-            link["href"] = "#{site_uri}#{link["href"]}"
-          end
+          href = a["href"].to_s
+          next if href.blank?
+          next if href.start_with?("mailto:")
+          next if href.start_with?(Discourse.base_url)
+          next if URI(href).host.present?
+
+          a["href"] = (
+            if href.start_with?(Discourse.base_path)
+              "#{Discourse.base_url_no_prefix}#{href}"
+            else
+              "#{Discourse.base_url}#{href}"
+            end
+          )
         rescue URI::Error
           # leave it
         end

--- a/plugins/discourse-details/plugin.rb
+++ b/plugins/discourse-details/plugin.rb
@@ -37,7 +37,7 @@ after_initialize do
       .each do |el|
         text = el.css("summary").text
         link = fragment.document.create_element("a")
-        link["href"] = post.url if post
+        link["href"] = post&.url.presence || Discourse.base_url
         link.content = I18n.t("details.excerpt_details")
         el.replace CGI.escapeHTML(text) + " " + link.to_html
       end


### PR DESCRIPTION
This fixes the `PrettyText.make_all_links_absolute` to better handle subfolder.

In subfolder, when given the cooked version of a post, links to mentions includes the `Discourse.base_path` prefix. Adding the `Discourse.base_url` was doubling the `Discourse.base_path`.

The issue was hidden behind the specs which was stubbing `Discourse.base_url` instead of relying on `Discourse.base_path`.

This fixes both the "algorithm" used in `PrettyText.make_all_links_absolute` to better handle this case and correct the specs to properly handle subfolder cases.

There are lots of changes in the specs due to a refactoring to use squiggly heredoc strings for easier reading and less escaping.

