### PR TITLE
DEV: Add support for various fields in generic bulk importer

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -589,6 +589,8 @@ class BulkImport::Base
     visible
     closed
     pinned_at
+    pinned_until
+    pinned_globally
     views
     subtype
     created_at


### PR DESCRIPTION
* user_profiles - `location`
* users - `date_of_birth`
* topics - `pinned_at`, `pinned_until`, `pinned_globally`

This also includes changes to correctly import PMs. Currently PM topics are skipped because of a check in `import_users` step which requires `category_id` to be present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
