### PR TITLE
FIX: correctly handles near-message-with-thread route in drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -34,6 +34,7 @@ export default class ChatRoute extends DiscourseRoute {
       "chat.channel.thread",
       "chat.channel.thread.index",
       "chat.channel.thread.near-message",
+      "chat.channel.near-message-with-thread",
       "chat.channel.threads",
       "chat.channel.index",
       "chat.channel.near-message",

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -57,6 +57,15 @@ const ROUTES = {
       };
     },
   },
+  "chat.channel.near-message-with-thread": {
+    name: ChatDrawerRoutesChannel,
+    extractParams: (route) => {
+      return {
+        channelId: route.parent.params.channelId,
+        messageId: route.params.messageId,
+      };
+    },
+  },
   "chat.channel-legacy": {
     name: ChatDrawerRoutesChannel,
     extractParams: (route) => {

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -106,6 +106,22 @@ describe "Single thread in side panel", type: :system do
       end
     end
 
+    context "when in drawer" do
+      it "opens the channel and highlights the message when clicking original message link" do
+        visit("/latest")
+        chat_page.open_from_header
+        chat_drawer_page.open_channel(channel)
+        channel_page.message_thread_indicator(thread.original_message).click
+        find(".chat-message-info__original-message").click
+
+        expect(chat_drawer_page).to have_open_channel(channel)
+        expect(channel_page.messages).to have_message(
+          id: thread.original_message.id,
+          highlighted: true,
+        )
+      end
+    end
+
     it "highlights the message in the channel when clicking original message link" do
       chat_page.visit_thread(thread)
 


### PR DESCRIPTION
Prior to this fix we wouldn't intercept it, and we also wouldn't handle it, which in result would cause us to handle as a full page interaction and open the full page chat even if you were in drawer mode.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
