### PR TITLE
DEV: Make uppy markdown resolvers async/await

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -319,13 +319,13 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
     });
 
     this._uppyInstance.on("upload-success", (file, response) => {
-      run(() => {
+      run(async () => {
         if (!this._uppyInstance) {
           return;
         }
         this._removeInProgressUpload(file.id);
         let upload = response.body;
-        const markdown = this.uploadMarkdownResolvers.reduce(
+        const markdown = await this.uploadMarkdownResolvers.reduce(
           (md, resolver) => resolver(upload) || md,
           getUploadMarkdown(upload)
         );


### PR DESCRIPTION
Discourse AI will be using the pluginAPI method: `addComposerUploadMarkdownResolver()` to add an optional feature of automatic image captions. However, since the existing API doesn't declare `async`/`await` keywords, the API cannot be used in an asynchronous manner, which will be necessary so we can fetch image captions and update the markdown after generating a caption.

**This PR adds async/await support to the markdown resolvers used in composer uploads.**

This allows those consuming the api `api.addComposerUploadMarkdownResolver` to return a promise and update the markdown asynchronously.