### PR TITLE
DEV: Deprecate the `user-dropdown` header widget

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -165,6 +165,7 @@ const DEPRECATED_HEADER_WIDGETS = [
   "header-topic-info",
   "header-notifications",
   "home-logo",
+  "user-dropdown",
 ];
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
