### PR TITLE
FIX: correctly check for disabled notifications, tab and is idle

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -136,29 +136,46 @@ function setupNotifications(appEvents) {
   appEvents.on("page:changed", resetIdle);
 }
 
-export function resetIdle() {
+function resetIdle() {
   lastAction = Date.now();
 }
+
 function isIdle() {
   return lastAction + idleThresholdTime < Date.now();
 }
 
+function setLastAction(time) {
+  lastAction = time;
+}
+
+function canUserReceiveNotifications(user) {
+  if (!primaryTab) {
+    return false;
+  }
+
+  if (!isIdle()) {
+    return false;
+  }
+
+  if (user.isInDoNotDisturb()) {
+    return false;
+  }
+
+  if (keyValueStore.getItem("notifications-disabled")) {
+    return false;
+  }
+
+  return true;
+}
+
 // Call-in point from message bus
 async function onNotification(data, siteSettings, user, appEvents) {
+  if (!canUserReceiveNotifications(user)) {
+    return;
+  }
+
   if (!liveEnabled) {
-    return;
-  }
-  if (!primaryTab) {
-    return;
-  }
-  if (!isIdle()) {
-    return;
-  }
-  if (user.isInDoNotDisturb()) {
-    return;
-  }
-  if (keyValueStore.getItem("notifications-disabled")) {
-    return;
+    return false;
   }
 
   const notificationTitle =
@@ -244,4 +261,7 @@ export {
   alertChannel,
   confirmNotification,
   disable,
+  canUserReceiveNotifications,
+  resetIdle,
+  setLastAction,
 };

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
@@ -1,4 +1,5 @@
 import Service, { service } from "@ember/service";
+import { canUserReceiveNotifications } from "discourse/lib/desktop-notifications";
 
 export default class ChatChannelNotificationSound extends Service {
   @service chat;
@@ -7,15 +8,15 @@ export default class ChatChannelNotificationSound extends Service {
   @service site;
 
   async play(channel) {
+    if (!canUserReceiveNotifications(this.currentUser)) {
+      return false;
+    }
+
     if (channel.isCategoryChannel) {
       return false;
     }
 
     if (channel.chatable.group) {
-      return false;
-    }
-
-    if (this.currentUser.isInDoNotDisturb()) {
       return false;
     }
 


### PR DESCRIPTION
This commit reuses the existing codepath in desktop-notifications and make it available to use to chat.

primaryTab was too hard to test if not impossible in this service test, however isIdle and disabled notifications are correctly tested.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
