### PR TITLE
DEV: Silence whitespace-eating-comment warnings

### DIFF
--- a/app/assets/javascripts/deprecation-silencer/index.js
+++ b/app/assets/javascripts/deprecation-silencer/index.js
@@ -1,6 +1,6 @@
 const SILENCED_WARN_PREFIXES = [
   "Setting the `jquery-integration` optional feature flag",
-  'unexpectedly found "!',
+  'unexpectedly found "!', // https://github.com/emberjs/ember.js/issues/19392
 ];
 
 class DeprecationSilencer {

--- a/app/assets/javascripts/deprecation-silencer/index.js
+++ b/app/assets/javascripts/deprecation-silencer/index.js
@@ -1,5 +1,6 @@
 const SILENCED_WARN_PREFIXES = [
   "Setting the `jquery-integration` optional feature flag",
+  'unexpectedly found "!',
 ];
 
 class DeprecationSilencer {


### PR DESCRIPTION
e.g. `unexpectedly found "! no whitespace ~" when slicing source, but expected " no whitespace "`

See: https://github.com/emberjs/ember.js/issues/19392

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
