### PR TITLE
DEV: git ignored directories should not have trailing slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,20 +35,20 @@
 
 # Plugins except for the bundled ones
 /plugins/*
-!/plugins/discourse-details/
+!/plugins/discourse-details
 !/plugins/discourse-local-dates
 !/plugins/discourse-narrative-bot
 !/plugins/discourse-presence
-!/plugins/discourse-lazy-videos/
-!/plugins/automation/
+!/plugins/discourse-lazy-videos
+!/plugins/automation
 /plugins/automation/gems
-!/plugins/chat/
-!/plugins/poll/
+!/plugins/chat
+!/plugins/poll
 !/plugins/styleguide
-!/plugins/spoiler-alert/
-!/plugins/checklist/
-!/plugins/footnote/
-/plugins/*/auto_generated/
+!/plugins/spoiler-alert
+!/plugins/checklist
+!/plugins/footnote
+/plugins/*/auto_generated
 
 /spec/fixtures/plugins/my_plugin/auto_generated
 
@@ -71,7 +71,7 @@ yarn-error.log
 
 # Linting artifacts
 .eslintcache
-/lint-progress/
+/lint-progress
 
 # Auto-generated plugin JS assets
 /app/assets/javascripts/plugins/*


### PR DESCRIPTION
VS Code is configured to automatically excludes files and directories from the `.gitignore` but the trailing slash was not working as expected.

The plugins that had a trailing slash in the .gitignore weren't allow-listed properly in VS Code.

There are no tests since it's only affecting how VS Code shows/hides directories.


### BEFORE

![image](https://github.com/discourse/discourse/assets/362783/c02da0fe-fc15-4644-a656-1e66ed7a363a)


### AFTER

![image](https://github.com/discourse/discourse/assets/362783/cdf05c0a-b200-4f7c-b8bc-c829406a64ce)
