### PR TITLE
UX: removes blinking indicator while streaming message

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-text.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-text.scss
@@ -1,23 +1,4 @@
 .chat-message-container.-streaming {
-  .chat-message-text {
-    @keyframes cursor-blink {
-      0% {
-        opacity: 0;
-      }
-    }
-
-    p::after {
-      margin-left: 1px;
-      margin-bottom: -4px;
-      content: "";
-      width: 6px;
-      height: 17px;
-      background: var(--primary);
-      display: inline-block;
-      animation: cursor-blink 0.5s steps(2) infinite;
-    }
-  }
-
   .stop-streaming-btn {
     margin-top: 0.5rem;
     margin-bottom: 0.25rem;


### PR DESCRIPTION
Given this is currently buggy and  we have the cancel button Im not sure this is actually necessary. I feel like it's adding a lot of noise of low value.

For now at least, it's better without it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
