### PR TITLE
FIX: chat activity indicator wasn't working for threads

### DIFF
--- a/plugins/chat/app/models/chat/user_chat_channel_membership.rb
+++ b/plugins/chat/app/models/chat/user_chat_channel_membership.rb
@@ -13,6 +13,10 @@ module Chat
     enum :desktop_notification_level, NOTIFICATION_LEVELS, prefix: :desktop_notifications
     enum :mobile_notification_level, NOTIFICATION_LEVELS, prefix: :mobile_notifications
     enum :join_mode, { manual: 0, automatic: 1 }
+
+    def mark_read!(new_last_read_id = nil)
+      update!(last_read_message_id: new_last_read_id || chat_channel.last_message_id)
+    end
   end
 end
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/header/icon/unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/header/icon/unread-indicator.gjs
@@ -34,6 +34,12 @@ export default class ChatHeaderIconUnreadIndicator extends Component {
     );
   }
 
+  get hasUnreads() {
+    return (
+      this.unreadCount > 0 || this.chatTrackingStateManager.hasUnreadThreads
+    );
+  }
+
   get indicatorPreference() {
     return (
       this.args.indicatorPreference ||
@@ -57,7 +63,7 @@ export default class ChatHeaderIconUnreadIndicator extends Component {
 
   get showUnreadIndicator() {
     return (
-      this.unreadCount > 0 &&
+      this.hasUnreads &&
       this.#hasAnyIndicatorPreference([HEADER_INDICATOR_PREFERENCE_ALL_NEW])
     );
   }

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -6,10 +6,8 @@ describe "Thread indicator for chat messages", type: :system do
 
   let(:chat_page) { PageObjects::Pages::Chat.new }
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
-  let(:thread_page) { PageObjects::Pages::ChatThread.new }
   let(:side_panel) { PageObjects::Pages::ChatSidePanel.new }
   let(:open_thread) { PageObjects::Pages::ChatThread.new }
-  let(:chat_drawer_page) { PageObjects::Pages::ChatDrawer.new }
 
   before do
     chat_system_bootstrap(current_user, [channel])


### PR DESCRIPTION
When a user had the chat option "Show activity indicator in header" set to "all new messages", and they would get a reply to a thread they're part of, the chat icon in the header would not show the unread bubble indicator.

In order to fix this, the `ChatHeaderIconUnreadIndicator` component will now `showUnreadIndicator` whenever there is either one unread public channel or there are unread threads.

I only added a system spec for this very specific path because I don't want to slow down the whole suite to test for all the various combination of the `chat_header_indicator_preference` values.

Internal ref - t/128874
