### PR TITLE
UX: add ellipsis to usernames in topic post map (PMs)

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -813,6 +813,7 @@ aside.quote {
     }
 
     .user {
+      @include ellipsis;
       border: 1px solid var(--primary-low);
       border-radius: 0.25em;
       padding: 0;
@@ -823,6 +824,7 @@ aside.quote {
 
       .user-link,
       .group-link {
+        @include ellipsis;
         color: var(--primary-high);
 
         &:hover {


### PR DESCRIPTION
Preventing:

![image](https://github.com/discourse/discourse/assets/101828855/71db2877-50e7-4971-afbb-a7d9caebc2cb)

