### PR TITLE
UX: reset idle on tab focus

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -112,6 +112,8 @@ function setupNotifications(appEvents) {
   });
 
   window.addEventListener("focus", function () {
+    resetIdle();
+
     if (!primaryTab) {
       primaryTab = true;
       keyValueStore.setItem(focusTrackerKey, mbClientId);


### PR DESCRIPTION
When users come back to a tab we should consider they are not idle anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
