### PR TITLE
FIX: set active thread on correct channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-thread.js
@@ -32,7 +32,7 @@ export default class ChatChannelThread extends DiscourseRoute {
       return;
     }
 
-    this.chat.activeChannel.activeThread = thread;
+    channel.activeThread = thread;
   }
 
   @action


### PR DESCRIPTION
activeChannel is something we should use less and less as it could not exist, in this case we have the channel right here in the function so there's no reason to reach for `this.chat.activeChannel`.

The origin of this commit is a bug which seems to happen with subfolders where `activeChannel` was null at this point, don't have yet the reason for this, but I'm confident that should fix the error.