### PR TITLE
FIX: correct in_thread? message logic

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -266,7 +266,7 @@ module Chat
     end
 
     def in_thread?
-      self.thread_id.present? && self.chat_channel.threading_enabled
+      self.thread_id.present? && (self.chat_channel.threading_enabled || self.thread&.force)
     end
 
     def thread_reply?

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -11,6 +11,40 @@ describe Chat::Message do
     it { is_expected.to validate_length_of(:cooked).is_at_most(20_000) }
   end
 
+  describe ".in_thread?" do
+    context "when in a thread enabled channel" do
+      fab!(:message) do
+        Fabricate(
+          :chat_message,
+          thread_id: 1,
+          chat_channel: Fabricate(:chat_channel, threading_enabled: true),
+        )
+      end
+
+      it "returns true for messages in a thread" do
+        expect(message.in_thread?).to eq(true)
+      end
+
+      it "returns false for messages not in a thread" do
+        message.update!(thread_id: nil)
+        expect(message.in_thread?).to eq(false)
+      end
+    end
+
+    context "when the thread is forced" do
+      fab!(:message) { Fabricate(:chat_message, thread: Fabricate(:chat_thread, force: true)) }
+
+      it "returns true for messages in a thread" do
+        expect(message.in_thread?).to eq(true)
+      end
+
+      it "returns false for messages not in a thread" do
+        message.update!(thread_id: nil)
+        expect(message.in_thread?).to eq(false)
+      end
+    end
+  end
+
   describe ".cook" do
     it "does not support HTML tags" do
       cooked = described_class.cook("<h1>test</h1>")


### PR DESCRIPTION
A message is in a thread if:
- it has a `thread_id`
- it is in `threading_enabled` channel OR the associated thread is marked as `force`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
