### PR TITLE
FIX: correctly generate pm path on user

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -324,19 +324,21 @@ export default class User extends RestModel.extend(Evented) {
   }
 
   pmPath(topic) {
-    const userId = this.id;
     const username = this.username_lower;
-
-    const details = topic && topic.get("details");
-    const allowedUsers = details && details.get("allowed_users");
-    const groups = details && details.get("allowed_groups");
+    const details = topic.details;
+    const allowedUsers = details?.allowed_users;
+    const groups = details?.allowed_groups;
 
     // directly targeted so go to inbox
-    if (!groups || (allowedUsers && allowedUsers.findBy("id", userId))) {
+    if (!groups || allowedUsers?.findBy("id", this.id)) {
       return userPath(`${username}/messages`);
-    } else {
-      if (groups && groups[0]) {
-        return userPath(`${username}/messages/group/${groups[0].name}`);
+    } else if (groups) {
+      const firstAllowedGroup = groups.find((allowedGroup) =>
+        this.groups.some((userGroup) => userGroup.id === allowedGroup.id)
+      );
+
+      if (firstAllowedGroup) {
+        return userPath(`${username}/messages/group/${firstAllowedGroup.name}`);
       }
     }
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -16,7 +16,7 @@ import I18n from "discourse-i18n";
 import selectKit from "../helpers/select-kit-helper";
 
 acceptance("Personal Message", function (needs) {
-  needs.user();
+  needs.user({ id: 1 });
 
   test("suggested messages", async function (assert) {
     await visit("/t/pm-for-testing/12");

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -194,4 +194,42 @@ module("Unit | Model | user", function (hooks) {
       "_clearStatusTimerId wasn't set"
     );
   });
+
+  test("pmPath", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const user = store.createRecord("user", {
+      id: 1,
+      username: "eviltrout",
+      groups: [],
+    });
+    const topic = store.createRecord("topic", { id: 1, details: {} });
+
+    assert.strictEqual(
+      user.pmPath(topic),
+      `/u/${user.username_lower}/messages`,
+      "user is in no groups and not directly allowed on the topic"
+    );
+
+    const group1 = store.createRecord("group", { id: 1, name: "group1" });
+    const group2 = store.createRecord("group", { id: 2, name: "group2" });
+    topic.details = {
+      allowed_users: [user],
+      allowed_groups: [group1, group2],
+    };
+    user.groups = [group2];
+
+    assert.strictEqual(
+      user.pmPath(topic),
+      `/u/${user.username_lower}/messages`,
+      "user is in one group (not the first one) and allowed on the topic"
+    );
+
+    topic.details.allowed_users = [];
+
+    assert.strictEqual(
+      user.pmPath(topic),
+      `/u/${user.username_lower}/messages/group/${group2.name}`,
+      "user is in one group (not the first one) and not allowed on the topic"
+    );
+  });
 });


### PR DESCRIPTION
Before this fix when generating a pm path leading to a group messages inbox we would blindly take the first group of the pm, however, it's possible our current user doesn't have access to this group.

This commit will now try to find the first group the user has access to, and generate a path to this group’s inbox.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
