### PR TITLE
FIX: Do not reset sidebar defaults in wizard

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -94,7 +94,6 @@ class Wizard
           updater.update_setting(:invite_only, updater.fields[:invite_only])
           updater.update_setting(:must_approve_users, updater.fields[:must_approve_users])
           updater.update_setting(:chat_enabled, updater.fields[:chat_enabled]) if defined?(::Chat)
-          updater.update_setting(:navigation_menu, updater.fields[:enable_sidebar])
         end
       end
 

--- a/lib/wizard/step_updater.rb
+++ b/lib/wizard/step_updater.rb
@@ -37,17 +37,6 @@ class Wizard
         value = Upload.get_from_url(value) || ""
       end
 
-      if id == :navigation_menu
-        value =
-          (
-            if value.to_s == "true"
-              NavigationMenuSiteSetting::SIDEBAR
-            else
-              NavigationMenuSiteSetting::HEADER_DROPDOWN
-            end
-          )
-      end
-
       SiteSetting.set_and_log(id, value, @current_user) if SiteSetting.get(id) != value
     end
 


### PR DESCRIPTION
We removed the option to enable/disable the sidebar in the wizard in https://github.com/discourse/discourse/pull/26926, but these lines of code were resetting it quietly to `header_dropdown`.
