### PR TITLE
UX: reduces idle time to 0 on chat

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -142,20 +142,20 @@ function resetIdle() {
   lastAction = Date.now();
 }
 
-function isIdle() {
-  return lastAction + idleThresholdTime < Date.now();
+function isIdle(idleThreshold = idleThresholdTime) {
+  return lastAction + idleThreshold < Date.now();
 }
 
 function setLastAction(time) {
   lastAction = time;
 }
 
-function canUserReceiveNotifications(user) {
+function canUserReceiveNotifications(user, options = { idleThresholdTime }) {
   if (!primaryTab) {
     return false;
   }
 
-  if (!isIdle()) {
+  if (!isIdle(options.idleThresholdTime)) {
     return false;
   }
 

--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -139,11 +139,11 @@ function setupNotifications(appEvents) {
 }
 
 function resetIdle() {
-  lastAction = Date.now();
+  lastAction = Date.now() - 10;
 }
 
 function isIdle(idleThreshold = idleThresholdTime) {
-  return lastAction + idleThreshold < Date.now();
+  return lastAction + idleThreshold <= Date.now();
 }
 
 function setLastAction(time) {

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-audio.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-audio.js
@@ -8,14 +8,11 @@ export default {
   name: "chat-audio",
 
   initialize(container) {
-    const chatService = container.lookup("service:chat");
+    const chat = container.lookup("service:chat");
 
-    if (!chatService.userCanChat) {
+    if (!chat.userCanChat) {
       return;
     }
-
-    const chatAudioManager = container.lookup("service:chat-audio-manager");
-    chatAudioManager.setup();
 
     withPluginApi("0.12.1", (api) => {
       api.registerDesktopNotificationHandler((data, siteSettings, user) => {
@@ -28,6 +25,9 @@ export default {
         }
 
         if (CHAT_NOTIFICATION_TYPES.includes(data.notification_type)) {
+          const chatAudioManager = container.lookup(
+            "service:chat-audio-manager"
+          );
           chatAudioManager.play(user.chat_sound);
         }
       });

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notification-sound.js
@@ -8,7 +8,11 @@ export default class ChatChannelNotificationSound extends Service {
   @service site;
 
   async play(channel) {
-    if (!canUserReceiveNotifications(this.currentUser)) {
+    if (
+      !canUserReceiveNotifications(this.currentUser, {
+        idleThresholdTime: 0,
+      })
+    ) {
       return false;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -206,7 +206,13 @@ export default class ChatSubscriptionsManager extends Service {
             channel.tracking.unreadCount++;
           }
 
-          this.chatChannelNotificationSound.play(channel);
+          const secondsPassed = moment().diff(
+            moment(busData.message.created_at),
+            "seconds"
+          );
+          if (secondsPassed < 10) {
+            this.chatChannelNotificationSound.play(channel);
+          }
 
           // Thread should be considered unread if not already.
           if (busData.thread_id && channel.threadingEnabled) {

--- a/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-channel-notification-sound-test.js
@@ -133,7 +133,7 @@ acceptance(
       const channel = buildDirectMessageChannel(getOwner(this));
       resetIdle();
 
-      assert.deepEqual(await this.subject.play(channel), false);
+      assert.deepEqual(await this.subject.play(channel), true);
     });
 
     test("notifications disabled", async function (assert) {


### PR DESCRIPTION
We consider that you should always receive a notification sound when someone speaks directly with you in chat.

This commit also refactors the way we play audio in chat to make it simpler and throttle it to 3 seconds.

We also added a safeguard to ensure we won't play sounds for old messages, this case can happen when message bus is catching up the backlog (eg: in an inactive tab for example).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
