### PR TITLE
Additional rake tasks to cover expected functionality

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -50,20 +50,6 @@ task "admin:promote", [:username] => [:environment] do |_, args|
   say("User #{username} is now an admin")
 end
 
-desc "Demote a user from adminstrator"
-task "admin:demote", [:username] => [:environment] do |_, args|
-  username = args[:username]
-  user = find_user(username)
-  if !user
-    puts "ERROR: User with username #{username} does not exist"
-    exit 1
-  end
-  puts "Revoking admin!"
-  user.revoke_admin!
-  user.email_tokens.update_all confirmed: true
-  say("User #{username} is no longer an admin")
-end
-
 desc "Creates a forum administrator"
 task "admin:create" => :environment do
   require "highline/import"

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -35,21 +35,6 @@ task "admin:invite", [:email] => [:environment] do |_, args|
   )
 end
 
-desc "Promote a user to adminstrator"
-task "admin:promote", [:username] => [:environment] do |_, args|
-  username = args[:username]
-  user = find_user(username)
-  if !user
-    puts "ERROR: User with username #{username} does not exist"
-    exit 1
-  end
-  puts "Granting admin!"
-  user.grant_admin!
-  user.change_trust_level!(1) if user.trust_level < 1
-  user.email_tokens.update_all confirmed: true
-  say("User #{username} is now an admin")
-end
-
 desc "Creates a forum administrator"
 task "admin:create" => :environment do
   require "highline/import"

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -35,6 +35,35 @@ task "admin:invite", [:email] => [:environment] do |_, args|
   )
 end
 
+desc "Promote a user to adminstrator"
+task "admin:promote", [:username] => [:environment] do |_, args|
+  username = args[:username]
+  user = find_user(username)
+  if !user
+    puts "ERROR: User with username #{username} does not exist"
+    exit 1
+  end
+  puts "Granting admin!"
+  user.grant_admin!
+  user.change_trust_level!(1) if user.trust_level < 1
+  user.email_tokens.update_all confirmed: true
+  say("User #{username} is now an admin")
+end
+
+desc "Demote a user from adminstrator"
+task "admin:demote", [:username] => [:environment] do |_, args|
+  username = args[:username]
+  user = find_user(username)
+  if !user
+    puts "ERROR: User with username #{username} does not exist"
+    exit 1
+  end
+  puts "Revoking admin!"
+  user.revoke_admin!
+  user.email_tokens.update_all confirmed: true
+  say("User #{username} is no longer an admin")
+end
+
 desc "Creates a forum administrator"
 task "admin:create" => :environment do
   require "highline/import"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -210,6 +210,39 @@ task "users:list_recent_staff" => :environment do
   puts "user_ids = [#{all_ids.uniq.join(",")}]"
 end
 
+desc "Check if a user exists for given email address"
+task "users:exists", [:email] => [:environment] do |_, args|
+  email = args[:email]
+  if !email || email !~ /@/
+    puts "ERROR: Expecting rake users:exists[some@email.com]"
+    exit 1
+  end
+  if User.find_by_email(email)
+    puts "ERROR: User with email #{email} not found"
+    exit 1
+  end
+  puts "User with email #{email} exists"
+end
+
+desc "Create a new user with given credentials"
+task "users:create", [:email, :password] => [:environment] do |_, args|
+  email = args[:email]
+  password = args[:password]
+  if !email || email !~ || !password /@/
+    puts "ERROR: Expecting rake users:create[some@email.com,password]"
+    exit 1
+  end
+  existing_user = User.find_by_email(email)
+  if existing_user
+    puts "ERROR: User with email #{email} already exists"
+    exit 1
+  end
+  user = User.new(email: email, password: password)
+  admin.username = UserNameSuggester.suggest(admin.email)
+  user.active = true
+  user.save!
+  puts "User #{email} created with password #{password}"
+
 def find_user(username)
   user = User.find_by_username(username)
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -228,7 +228,7 @@ desc "Create a new user with given credentials"
 task "users:create", [:email, :password] => [:environment] do |_, args|
   email = args[:email]
   password = args[:password]
-  if !email || email !~ || !password /@/
+  if !email || email !~ /@/ || !password
     puts "ERROR: Expecting rake users:create[some@email.com,password]"
     exit 1
   end
@@ -242,6 +242,7 @@ task "users:create", [:email, :password] => [:environment] do |_, args|
   user.active = true
   user.save!
   puts "User #{email} created with password #{password}"
+end
 
 def find_user(username)
   user = User.find_by_username(username)

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -238,7 +238,7 @@ task "users:create", [:email, :password] => [:environment] do |_, args|
     exit 1
   end
   user = User.new(email: email, password: password)
-  admin.username = UserNameSuggester.suggest(admin.email)
+  user.username = UserNameSuggester.suggest(user.email)
   user.active = true
   user.save!
   puts "User #{email} created with password #{password}"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -213,35 +213,12 @@ end
 desc "Check if a user exists for given email address"
 task "users:exists", [:email] => [:environment] do |_, args|
   email = args[:email]
-  if !email || email !~ /@/
-    puts "ERROR: Expecting rake users:exists[some@email.com]"
-    exit 1
-  end
   if User.find_by_email(email)
-    puts "ERROR: User with email #{email} not found"
-    exit 1
+    puts "User with email #{email} exists"
+    exit 0
   end
-  puts "User with email #{email} exists"
-end
-
-desc "Create a new user with given credentials"
-task "users:create", [:email, :password] => [:environment] do |_, args|
-  email = args[:email]
-  password = args[:password]
-  if !email || email !~ /@/ || !password
-    puts "ERROR: Expecting rake users:create[some@email.com,password]"
-    exit 1
-  end
-  existing_user = User.find_by_email(email)
-  if existing_user
-    puts "ERROR: User with email #{email} already exists"
-    exit 1
-  end
-  user = User.new(email: email, password: password)
-  user.username = UserNameSuggester.suggest(user.email)
-  user.active = true
-  user.save!
-  puts "User #{email} created with password #{password}"
+  puts "ERROR: User with email #{email} not found"
+  exit 1
 end
 
 def find_user(username)


### PR DESCRIPTION
While doing some work on the `discourse-k8s-operator` charm, functionality that I would expect to be covered in the rake tasks is not present. Notably, to create a non-admin user, we must interface with the `admin:create` task, and select specific parameters to ensure that a user is created with the correct permission level. This seems unintuitive.

This PR aims to resolve this by creating a small number of rake tasks with clearly confined behaviour, that I believe should exist already. These new rake tasks also depend on arguments being passed to the function rather that relying on `stdin` - which I find to be more deterministic for developers.