### PR TITLE
FIX: flaky post action counts specs

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -331,7 +331,7 @@ class PostSerializer < BasicPostSerializer
         summary[:count] = summary[:acted] ? 1 : 0
       end
 
-      summary.delete(:count) if summary[:count] == 0 || summary[:count].nil?
+      summary.delete(:count) if summary[:count].to_i.zero?
 
       # Only include it if the user can do it or it has a count
       result << summary if summary[:can_act] || summary[:count]

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -331,7 +331,7 @@ class PostSerializer < BasicPostSerializer
         summary[:count] = summary[:acted] ? 1 : 0
       end
 
-      summary.delete(:count) if summary[:count] == 0
+      summary.delete(:count) if summary[:count] == 0 || summary[:count].nil?
 
       # Only include it if the user can do it or it has a count
       result << summary if summary[:can_act] || summary[:count]

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Flag, type: :model do
-  before { Flag.reset_flag_settings! }
+  around do |test|
+    Flag.reset_flag_settings!
+    test.call
+    Flag.reset_flag_settings!
+  end
 
   it "has id lower than 1000 for system flags" do
     flag = Fabricate(:flag, id: 1)


### PR DESCRIPTION
After flags were moved to the database, with each save they are changing available PostActionTypes. Therefore, flag specs should clear the state before and after each example not just before.

In addition, we need to clear `nil` counts for dynamically created flags from serializer.
