### PR TITLE
FIX: `S3Inventory` to ignore files older than last backup restore date

### DIFF
--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -27,6 +27,7 @@ class S3Helper
 
   def initialize(s3_bucket_name, tombstone_prefix = "", options = {})
     @s3_client = options.delete(:client)
+    @s3_bucket = options.delete(:bucket)
     @s3_options = default_s3_options.merge(options)
 
     @s3_bucket_name, @s3_bucket_folder_path =

--- a/spec/jobs/ensure_s3_uploads_existence_spec.rb
+++ b/spec/jobs/ensure_s3_uploads_existence_spec.rb
@@ -13,20 +13,6 @@ RSpec.describe Jobs::EnsureS3UploadsExistence do
       S3Inventory.any_instance.expects(:backfill_etags_and_list_missing).once
       job.execute({})
     end
-
-    it "doesn't execute when the site was restored within the last 48 hours" do
-      S3Inventory.any_instance.expects(:backfill_etags_and_list_missing).never
-      BackupMetadata.update_last_restore_date(47.hours.ago)
-
-      job.execute({})
-    end
-
-    it "executes when the site was restored more than 48 hours ago" do
-      S3Inventory.any_instance.expects(:backfill_etags_and_list_missing).once
-      BackupMetadata.update_last_restore_date(49.hours.ago)
-
-      job.execute({})
-    end
   end
 
   context "with S3 inventory disabled" do


### PR DESCRIPTION
This commit updates `S3Inventory#files` to ignore S3 inventory files
which have a `last_modified` timestamp which are not at least 2 days
older than `BackupMetadata.last_restore_date` timestamp.

This check was previously only in `Jobs::EnsureS3UploadsExistence` but
`S3Inventory` can also be used via Rake tasks so this protection needs
to be in `S3Inventory` and not in the scheduled job.
