### PR TITLE
FIX: flaky user_merger_spec.rb

### DIFF
--- a/spec/lib/guardian/flag_guardian_spec.rb
+++ b/spec/lib/guardian/flag_guardian_spec.rb
@@ -3,12 +3,15 @@
 RSpec.describe FlagGuardian do
   fab!(:user)
   fab!(:admin)
-  fab!(:flag)
+
+  after(:each) { Flag.reset_flag_settings! }
 
   describe "#can_edit_flag?" do
     it "returns true for admin and false for regular user" do
+      flag = Fabricate(:flag)
       expect(Guardian.new(admin).can_edit_flag?(flag)).to eq(true)
       expect(Guardian.new(user).can_edit_flag?(flag)).to eq(false)
+      flag.destroy!
     end
 
     it "returns false when flag is system" do
@@ -16,13 +19,17 @@ RSpec.describe FlagGuardian do
     end
 
     it "returns false when flag was already used with post action" do
+      flag = Fabricate(:flag)
       Fabricate(:post_action, post_action_type_id: flag.id)
       expect(Guardian.new(admin).can_edit_flag?(flag)).to eq(false)
+      flag.destroy!
     end
 
     it "returns false when flag was already used with reviewable" do
+      flag = Fabricate(:flag)
       Fabricate(:reviewable_score, reviewable_score_type: flag.id)
       expect(Guardian.new(admin).can_edit_flag?(flag)).to eq(false)
+      flag.destroy!
     end
   end
 end


### PR DESCRIPTION
Flag guardian spec needs to clean state after evaluation. Each created flag is adding PostActionType.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
