### PR TITLE
FIX: Apply crawler rate limits to cached requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  before_action :rate_limit_crawlers
   before_action :check_readonly_mode
   before_action :handle_theme
   before_action :set_current_user_for_logs
@@ -1051,28 +1050,6 @@ class ApplicationController < ActionController::Base
     return "{}" if id.blank?
     ids = Theme.transform_ids(id)
     Theme.where(id: ids).pluck(:id, :name).to_h.to_json
-  end
-
-  def rate_limit_crawlers
-    return if current_user.present?
-    return if SiteSetting.slow_down_crawler_user_agents.blank?
-
-    user_agent = request.user_agent&.downcase
-    return if user_agent.blank?
-
-    SiteSetting
-      .slow_down_crawler_user_agents
-      .downcase
-      .split("|")
-      .each do |crawler|
-        if user_agent.include?(crawler)
-          key = "#{crawler}_crawler_rate_limit"
-          limiter =
-            RateLimiter.new(nil, key, 1, SiteSetting.slow_down_crawler_rate, error_code: key)
-          limiter.performed!
-          break
-        end
-      end
   end
 
   def run_second_factor!(action_class, action_data: nil, target_user: current_user)

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -267,6 +267,24 @@ class Middleware::RequestTracker
       end
       return 429, headers, [message]
     end
+
+    if !cookie
+      if error_details = check_crawler_limits(env)
+        available_in, error_code = error_details
+        message = <<~TEXT
+          Slow down, too many crawling requests.
+          Please retry again in #{available_in} seconds.
+          Error code: #{error_code}.
+        TEXT
+        headers = {
+          "Content-Type" => "text/plain",
+          "Retry-After" => available_in.to_s,
+          "Discourse-Rate-Limit-Error-Code" => error_code,
+        }
+        return 429, headers, [message]
+      end
+    end
+
     env["discourse.request_tracker"] = self
 
     MethodProfiler.start
@@ -442,5 +460,31 @@ class Middleware::RequestTracker
         nil
       end
     end
+  end
+
+  def check_crawler_limits(env)
+    slow_down_agents = SiteSetting.slow_down_crawler_user_agents
+    return if slow_down_agents.blank?
+
+    user_agent = env["HTTP_USER_AGENT"]&.downcase
+    return if user_agent.blank?
+
+    return if !CrawlerDetection.crawler?(user_agent)
+
+    slow_down_agents
+      .downcase
+      .split("|")
+      .each do |crawler|
+        if user_agent.include?(crawler)
+          key = "#{crawler}_crawler_rate_limit"
+          limiter =
+            RateLimiter.new(nil, key, 1, SiteSetting.slow_down_crawler_rate, error_code: key)
+          limiter.performed!
+          break
+        end
+      end
+    nil
+  rescue RateLimiter::LimitExceeded => e
+    [e.available_in, e.error_code]
   end
 end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -271,11 +271,7 @@ class Middleware::RequestTracker
     if !cookie
       if error_details = check_crawler_limits(env)
         available_in, error_code = error_details
-        message = <<~TEXT
-          Slow down, too many crawling requests.
-          Please retry again in #{available_in} seconds.
-          Error code: #{error_code}.
-        TEXT
+        message = "Too many crawling requests. Error code: #{error_code}."
         headers = {
           "Content-Type" => "text/plain",
           "Retry-After" => available_in.to_s,


### PR DESCRIPTION
This PR moves the logic for crawler rate limits out of the application controller and into the request tracker middleware. The reason for this move is to apply rate limits to all crawler requests instead of just the requests that make it to the application controller. Some requests are served early from the middleware stack without reaching the Rails app for performance reasons (e.g. `AnonymousCache`) which results in crawlers getting 200 responses even though they've reached their limits and should be getting 429 responses.

Internal topic: t/128810.