### PR TITLE
DEV: Remove deprecated User#saw_notification_id method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -788,18 +788,6 @@ class User < ActiveRecord::Base
     Reviewable.list_for(self, include_claimed_by_others: false).count
   end
 
-  def saw_notification_id(notification_id)
-    Discourse.deprecate(<<~TEXT, since: "2.9", drop_from: "3.0")
-      User#saw_notification_id is deprecated. Please use User#bump_last_seen_notification! instead.
-    TEXT
-    if seen_notification_id.to_i < notification_id.to_i
-      update_columns(seen_notification_id: notification_id.to_i)
-      true
-    else
-      false
-    end
-  end
-
   def bump_last_seen_notification!
     query = self.notifications.visible
     query = query.where("notifications.id > ?", seen_notification_id) if seen_notification_id

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -114,7 +114,6 @@ after_initialize do
     notification = Notification.where(topic_id: topic.id, post_number: first_post.post_number).first
     if notification.present?
       Notification.read(self, notification.id)
-      self.saw_notification_id(notification.id)
       self.reload
       self.publish_notifications_state
     end


### PR DESCRIPTION
### What is this change?

The `User#saw_notification_id` has been deprecated and replaced with `User#bump_last_seen_notification!`. It was marked for removal in 3.0.

According to both logs and a code search in public- and private GitHub organizations, there is only one remaining call site. This PR updates it one and removes the method.