### PR TITLE
DEV: Move webhook event header modifier for redelivery-recalucation

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -47,13 +47,6 @@ module Jobs
       uri = URI(@web_hook.payload_url.strip)
 
       web_hook_headers = build_webhook_headers(uri, web_hook_body, web_hook_event)
-      web_hook_headers =
-        DiscoursePluginRegistry.apply_modifier(
-          :web_hook_event_headers,
-          web_hook_headers,
-          web_hook_body,
-          web_hook_event,
-        )
 
       emitter = WebHookEmitter.new(@web_hook, web_hook_event)
       web_hook_response = emitter.emit!(headers: web_hook_headers, body: web_hook_body)

--- a/app/services/web_hook_emitter.rb
+++ b/app/services/web_hook_emitter.rb
@@ -19,6 +19,9 @@ class WebHookEmitter
       },
     }
 
+    headers =
+      DiscoursePluginRegistry.apply_modifier(:web_hook_event_headers, headers, body, @webhook_event)
+
     connection_opts[:ssl] = { verify: false } if !@webhook.verify_certificate
 
     conn = Faraday.new(nil, connection_opts) { |f| f.adapter FinalDestination::FaradayAdapter }


### PR DESCRIPTION
I added this modifier a bit ago in this commits https://github.com/discourse/discourse/commit/9264479c277467f9d82934e68448c39e878d736c

The issue is that when re-driving a failed webhook event, the headers are not modified again. Moving the modifier into the `WebHookEmitter` is nice b/c it allows for modifying headers on re-deliver. This adds to spec to make sure this case does work (redelivery) and ensures that modified headers are saved into the DB.