### PR TITLE
FIX: bypass fast edit when selected text isn't editable

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -749,3 +749,7 @@ export function cleanNullQueryParams(params) {
   }
   return params;
 }
+
+export function getElement(node) {
+  return node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+}

--- a/spec/system/post_selection_fast_edit_spec.rb
+++ b/spec/system/post_selection_fast_edit_spec.rb
@@ -9,6 +9,13 @@ describe "Post selection | Fast edit", type: :system do
   fab!(:spanish_post) { Fabricate(:post, topic: topic, raw: "Hola Juan, ¿cómo estás?") }
   fab!(:chinese_post) { Fabricate(:post, topic: topic, raw: "这是一个测试") }
   fab!(:post_with_emoji) { Fabricate(:post, topic: topic, raw: "Good morning :wave:!") }
+  fab!(:post_with_quote) do
+    Fabricate(
+      :post,
+      topic: topic,
+      raw: "[quote]\n#{post_2.raw}\n[/quote]\n\nBelle journée, n'est-ce pas ?",
+    )
+  end
   fab!(:current_user) { Fabricate(:admin) }
 
   before { sign_in(current_user) }
@@ -37,6 +44,17 @@ describe "Post selection | Fast edit", type: :system do
         expect(el).not_to eq("Hello world")
         expect(el).to have_content("Howdy")
       end
+    end
+  end
+
+  context "when text selected is inside a quote" do
+    it "opens the composer directly" do
+      topic_page.visit_topic(topic)
+
+      select_text_range("#{topic_page.post_by_number_selector(6)} .cooked p", 5, 10)
+      topic_page.click_fast_edit_button
+
+      expect(topic_page).to have_expanded_composer
     end
   end
 


### PR DESCRIPTION
When selected some text inside a post, we offer the ability to "fast edit" the selected text without opening the composer.

However, there are certain cases where this isn't working quite a expected, due to the fact that we have some text in the "cooked" version of the post that isn't literally in the "raw" version of the post.

This ensures that whenever someone selects the within

- a quote
- a onebox
- an encrypted message
- a "cooked" date

we directly show the composer instead of showing the fast edit modal and then leaving the user with an invisible error.

Internal ref. t/128400