### PR TITLE
FIX: missing appEvents param for onNotification

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -11,6 +11,8 @@ export default class ChatNotificationManager extends Service {
   @service presence;
   @service chat;
   @service chatStateManager;
+  @service currentUser;
+  @service appEvents;
 
   _subscribedToCore = true;
   _subscribedToChat = false;
@@ -143,7 +145,12 @@ export default class ChatNotificationManager extends Service {
 
   @bind
   onMessage(data) {
-    return onNotification(data, this.siteSettings, this.currentUser);
+    return onNotification(
+      data,
+      this.siteSettings,
+      this.currentUser,
+      this.appEvents
+    );
   }
 
   _shouldRun() {


### PR DESCRIPTION
The `onNotification` signature is:

```
onNotification(data, siteSettings, user, appEvents)
```

And we were not passing `appEvents`.

Also explicitly inject `currentUser` in `chat-notification-manager` service.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
