### PR TITLE
FIX: Crawler requests exceptions for non UTF-8 user agents with invalid bytes

### DIFF
--- a/lib/http_user_agent_encoder.rb
+++ b/lib/http_user_agent_encoder.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module HttpUserAgentEncoder
+  def self.ensure_utf8(user_agent)
+    return "" unless user_agent
+
+    if user_agent.encoding != Encoding::UTF_8
+      user_agent = user_agent.encode("utf-8", invalid: :replace, undef: :replace)
+      user_agent.scrub!
+    end
+
+    user_agent || ""
+  end
+end

--- a/lib/http_user_agent_encoder.rb
+++ b/lib/http_user_agent_encoder.rb
@@ -5,8 +5,7 @@ module HttpUserAgentEncoder
     return "" unless user_agent
 
     if user_agent.encoding != Encoding::UTF_8
-      user_agent = user_agent.encode("utf-8", invalid: :replace, undef: :replace)
-      user_agent.scrub!
+      user_agent = user_agent.encode!("utf-8", invalid: :replace, undef: :replace).scrub!
     end
 
     user_agent || ""

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -2,6 +2,7 @@
 
 require "method_profiler"
 require "middleware/anonymous_cache"
+require "http_user_agent_encoder"
 
 class Middleware::RequestTracker
   @@detailed_request_loggers = nil
@@ -186,10 +187,7 @@ class Middleware::RequestTracker
 
     if h[:is_crawler]
       user_agent = env["HTTP_USER_AGENT"]
-      if user_agent && (user_agent.encoding != Encoding::UTF_8)
-        user_agent = user_agent.encode("utf-8")
-        user_agent.scrub!
-      end
+      user_agent = HttpUserAgentEncoder.ensure_utf8(user_agent) if user_agent
       h[:user_agent] = user_agent
     end
 

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -460,7 +460,7 @@ class Middleware::RequestTracker
     slow_down_agents = SiteSetting.slow_down_crawler_user_agents
     return if slow_down_agents.blank?
 
-    user_agent = env["HTTP_USER_AGENT"]&.downcase
+    user_agent = HttpUserAgentEncoder.ensure_utf8(env["HTTP_USER_AGENT"])&.downcase
     return if user_agent.blank?
 
     return if !CrawlerDetection.crawler?(user_agent)


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/encoding-conversion-error-from-ascii-8bit-to-utf-8-in-logs/308603/2

Crawler requests for non-UTF-8 user agents that contain invalid bytes generate an exception at two places.
See [`get_data()`](https://github.com/discourse/discourse/blob/main/lib/middleware/request_tracker.rb#L158-L193) function:
* On `encode("utf-8")` that results either in the following error depending on the incoming encoding
  * `InvalidByteSequenceError`
  * `UndefinedConversionError`
* On matching user-agent with invalid byte results to `ArgumentError`.
_Called from `helper.is_crawler` and `helper.is_mobile`, part of the `AnonymousCache::Helper` class._

This PR does the following:
* Handles `encode()` exceptions by relying on `undef` and `invalid` params to replace the faulty bytes instead of raising an exception. It moved into its own module.
* Provides a safe user agent in `AnonymousCache::Helper.`

The `anonymous_cache_spec.rb` tests are specifically for the methods: `blocked_crawler?`, `key_is_modern_mobile_device?`, and `key_is_old_browser?`.

Hopefully, the implementation is okay.