### PR TITLE
FIX: "Replace Text" didn't list "Welcome Topic" when "General" category is missing

### DIFF
--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -22,7 +22,10 @@ module SeedData
 
     def update(site_setting_names: nil, skip_changed: false)
       I18n.with_locale(@locale) do
-        topics(site_setting_names: site_setting_names).each do |params|
+        topics(
+          site_setting_names: site_setting_names,
+          require_existing_categories: false,
+        ).each do |params|
           update_topic(**params.except(:category, :after_create), skip_changed: skip_changed)
         end
       end
@@ -38,7 +41,7 @@ module SeedData
 
     def reseed_options
       I18n.with_locale(@locale) do
-        topics
+        topics(require_existing_categories: false)
           .map do |params|
             post = find_post(params[:site_setting_name])
             next unless post
@@ -51,7 +54,13 @@ module SeedData
 
     private
 
-    def topics(site_setting_names: nil, include_welcome_topics: true, include_legal_topics: true)
+    def topics(
+      site_setting_names: nil,
+      include_welcome_topics: true,
+      include_legal_topics: true,
+      require_existing_categories: true
+    )
+      general_category = Category.find_by(id: SiteSetting.general_category_id)
       staff_category = Category.find_by(id: SiteSetting.staff_category_id)
       feedback_category = Category.find_by(id: SiteSetting.meta_category_id)
       feedback_category_hashtag =
@@ -105,7 +114,7 @@ module SeedData
 
       if include_welcome_topics
         # Welcome Topic
-        if general_category = Category.find_by(id: SiteSetting.general_category_id)
+        if general_category || !require_existing_categories
           site_info_quote =
             if SiteSetting.title.present? && SiteSetting.site_description.present?
               <<~RAW

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe SeedData::Topics do
       expect(seeder.reseed_options).to eq(expected_options)
     end
 
-    it "updates 'Welcome Topic' even when `general_category_id` doesn't exist" do
+    it "returns 'Welcome Topic' even when `general_category_id` doesn't exist" do
       create_topic("welcome_topic_id")
       SiteSetting.general_category_id = nil
 

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe SeedData::Topics do
       expect(post.raw).not_to include("> ## My Awesome Community")
     end
 
+    it "doesn't create a welcome topic when the 'General' category is missing" do
+      SiteSetting.general_category_id = nil
+
+      create_topic("welcome_topic_id")
+
+      expect(SiteSetting.welcome_topic_id).to eq(-1)
+    end
+
     it "creates a welcome topic with site title and description" do
       SiteSetting.title = "My Awesome Community"
       SiteSetting.site_description = "The best community"
@@ -180,6 +188,28 @@ RSpec.describe SeedData::Topics do
       expect(topic.title).to eq("New topic title")
       expect(topic.first_post.raw).to eq("New text of first post.")
     end
+
+    it "updates 'Welcome Topic' even when `general_category_id` doesn't exist" do
+      create_topic("welcome_topic_id")
+      SiteSetting.general_category_id = nil
+
+      post = Post.last
+      post.revise(Discourse.system_user, raw: "New text of first post.")
+
+      update_topic
+      post.reload
+
+      expect(post.raw).to eq(
+        I18n.t(
+          "discourse_welcome_topic.body",
+          base_path: Discourse.base_path,
+          site_title: SiteSetting.title,
+          site_description: SiteSetting.site_description,
+          site_info_quote: "",
+          feedback_category: "#site-feedback",
+        ).rstrip,
+      )
+    end
   end
 
   describe "#delete" do
@@ -214,6 +244,21 @@ RSpec.describe SeedData::Topics do
       expected_options = [
         { id: "guidelines_topic_id", name: I18n.t("guidelines_topic.title"), selected: true },
         { id: "welcome_topic_id", name: "Changed Topic Title", selected: false },
+      ]
+
+      expect(seeder.reseed_options).to eq(expected_options)
+    end
+
+    it "updates 'Welcome Topic' even when `general_category_id` doesn't exist" do
+      create_topic("welcome_topic_id")
+      SiteSetting.general_category_id = nil
+
+      expected_options = [
+        {
+          id: "welcome_topic_id",
+          name: I18n.t("discourse_welcome_topic.title", site_title: SiteSetting.title),
+          selected: true,
+        },
       ]
 
       expect(seeder.reseed_options).to eq(expected_options)


### PR DESCRIPTION
Replacing the text of seeded topics doesn't require categories to exist, so this change removes that requirement for updates.