### PR TITLE
DEV: clean after replacing flags spec

### DIFF
--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -675,7 +675,10 @@ TEXT
   end
 
   describe "#replace_flags" do
-    after { PostActionType.replace_flag_settings(nil) }
+    after do
+      PostActionType.replace_flag_settings(nil)
+      Flag.reset_flag_settings!
+    end
 
     let(:original_flags) { PostActionType.flag_settings }
 


### PR DESCRIPTION
After flags are replaced, we need to bring the state back to the original. Otherwise, it causes flaky specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
