### PR TITLE
DEV: Remove hashtag deprecations

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -2,17 +2,7 @@ import { cancel } from "@ember/runloop";
 import { htmlSafe } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
-import {
-  decorateHashtags as decorateHashtagsNew,
-  fetchUnseenHashtagsInContext as fetchUnseenHashtagsInContextNew,
-  generatePlaceholderHashtagHTML as generatePlaceholderHashtagHTMLNew,
-  linkSeenHashtagsInContext as linkSeenHashtagsInContextNew,
-} from "discourse/lib/hashtag-decorator";
-import {
-  cleanUpHashtagTypeClasses as cleanUpHashtagTypeClassesNew,
-  getHashtagTypeClasses as getHashtagTypeClassesNew,
-  registerHashtagType as registerHashtagTypeNew,
-} from "discourse/lib/hashtag-type-registry";
+import { getHashtagTypeClasses as getHashtagTypeClassesNew } from "discourse/lib/hashtag-type-registry";
 import { emojiUnescape } from "discourse/lib/text";
 import {
   caretPosition,
@@ -21,89 +11,8 @@ import {
 } from "discourse/lib/utilities";
 import { INPUT_DELAY, isTesting } from "discourse-common/config/environment";
 import discourseDebounce from "discourse-common/lib/debounce";
-import deprecated from "discourse-common/lib/deprecated";
 import discourseLater from "discourse-common/lib/later";
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
-
-// TODO (martin) Remove this once plugins have changed to use hashtag-decorator and
-// hashtag-type-registry imports
-export function fetchUnseenHashtagsInContext() {
-  deprecated(
-    `fetchUnseenHashtagsInContext is has been moved to the module 'discourse/lib/hashtag-decorator'`,
-    {
-      id: "discourse.hashtag.fetchUnseenHashtagsInContext",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return fetchUnseenHashtagsInContextNew(...arguments);
-}
-export function linkSeenHashtagsInContext() {
-  deprecated(
-    `linkSeenHashtagsInContext is has been moved to the module 'discourse/lib/hashtag-decorator'`,
-    {
-      id: "discourse.hashtag.linkSeenHashtagsInContext",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return linkSeenHashtagsInContextNew(...arguments);
-}
-export function generatePlaceholderHashtagHTML() {
-  deprecated(
-    `generatePlaceholderHashtagHTML is has been moved to the module 'discourse/lib/hashtag-decorator'`,
-    {
-      id: "discourse.hashtag.generatePlaceholderHashtagHTML",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return generatePlaceholderHashtagHTMLNew(...arguments);
-}
-export function decorateHashtags() {
-  deprecated(
-    `decorateHashtags is has been moved to the module 'discourse/lib/hashtag-decorator'`,
-    {
-      id: "discourse.hashtag.decorateHashtags",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return decorateHashtagsNew(...arguments);
-}
-export function getHashtagTypeClasses() {
-  deprecated(
-    `getHashtagTypeClasses is has been moved to the module 'discourse/lib/hashtag-type-registry'`,
-    {
-      id: "discourse.hashtag.getHashtagTypeClasses",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return getHashtagTypeClassesNew(...arguments);
-}
-export function registerHashtagType() {
-  deprecated(
-    `registerHashtagType is has been moved to the module 'discourse/lib/hashtag-type-registry'`,
-    {
-      id: "discourse.hashtag.registerHashtagType",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return registerHashtagTypeNew(...arguments);
-}
-export function cleanUpHashtagTypeClasses() {
-  deprecated(
-    `cleanUpHashtagTypeClasses is has been moved to the module 'discourse/lib/hashtag-type-registry'`,
-    {
-      id: "discourse.hashtag.cleanUpHashtagTypeClasses",
-      since: "3.2.0.beta5-dev",
-      dropFrom: "3.2.1",
-    }
-  );
-  return cleanUpHashtagTypeClassesNew(...arguments);
-}
 
 /**
  * Sets up a textarea using the jQuery autocomplete plugin, specifically

--- a/spec/system/page_objects/components/topic_list_header.rb
+++ b/spec/system/page_objects/components/topic_list_header.rb
@@ -32,12 +32,6 @@ module PageObjects
         find(bulk_select_dropdown_item(name)).click
       end
 
-      # TODO (martin) Remove all this once discourse-assign is using the new bulk select
-      # modal page object in specs.
-      def has_close_topics_button?
-        page.has_css?(bulk_select_dropdown_item("close-topics"))
-      end
-
       def click_close_topics_button
         find(bulk_select_dropdown_item("close-topics")).click
       end


### PR DESCRIPTION
Introduced in
https://github.com/discourse/discourse/commit/c7860173c1683fcbe33600d29b5294c0bb228253,
they are no longer necessary once https://github.com/discourse/discourse-encrypt/pull/317
is merged
