### PR TITLE
DEV: Remove deprecated UsersController#modify_user_params method

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2132,31 +2132,12 @@ class UsersController < ApplicationController
       result.merge!(params.permit(:active, :staged, :approved))
     end
 
-    deprecate_modify_user_params_method
-    result = modify_user_params(result)
     DiscoursePluginRegistry.apply_modifier(
       :users_controller_update_user_params,
       result,
       current_user,
       params,
     )
-  end
-
-  # Plugins can use this to modify user parameters
-  def modify_user_params(attrs)
-    attrs
-  end
-
-  def deprecate_modify_user_params_method
-    # only issue a deprecation warning if the method is overridden somewhere
-    if method(:modify_user_params).source_location[0] !=
-         "#{Rails.root}/app/controllers/users_controller.rb"
-      Discourse.deprecate(
-        "`UsersController#modify_user_params` method is deprecated. Please use the `users_controller_update_user_params` modifier instead.",
-        since: "3.1.0.beta4",
-        drop_from: "3.2.0",
-      )
-    end
   end
 
   def fail_with(key)


### PR DESCRIPTION
### What is this change?

The `UsersController#modify_user_params` method is deprecated and replaced with a plugin modifier (`users_controller_update_user_params`). It is marked for removal in 3.2. This PR removes it.

### Verification

- [x] There are no deprecation warnings in logs across our hosting.
- [x] A search in public- and private repos find only one usage, in a plugin that was archived in 2021.