### PR TITLE
DEV: remove obsolete needs_review score type

### DIFF
--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -62,8 +62,6 @@ after_initialize do
   register_reviewable_type Chat::ReviewableMessage
 
   reloadable_patch do |plugin|
-    ReviewableScore.add_new_types([:needs_review])
-
     Site.preloaded_category_custom_fields << Chat::HAS_CHAT_ENABLED
 
     Guardian.prepend Chat::GuardianExtensions


### PR DESCRIPTION
Chat messages are following normal post flags. 
This newly registered `:needs_review` score type is not used anymore