### PR TITLE
PERF: `PostTiming.pretend_read` to not update `TopicUser` cache columns

### DIFF
--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -35,7 +35,7 @@ class PostTiming < ActiveRecord::Base
 
     DB.exec(sql_query, params)
 
-    TopicUser.ensure_consistency!(topic_id)
+    TopicUser.update_last_read_post_number(topic_id:)
   end
 
   def self.record_new_timing(args)

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -531,8 +531,11 @@ SQL
   end
 
   def self.ensure_consistency!(topic_id = nil)
-    update_post_action_cache(topic_id: topic_id)
+    update_post_action_cache(topic_id:)
+    update_last_read_post_number(topic_id:)
+  end
 
+  def self.update_last_read_post_number(topic_id: nil)
     # TODO this needs some reworking, when we mark stuff skipped
     # we up these numbers so they are not in-sync
     # the simple fix is to add a column here, but table is already quite big


### PR DESCRIPTION
This commit splits out the updating of `TopicUser#last_read_post_number` in `TopicUser.ensure_consistency!` to a new
`TopicUser.update_last_read_post_number` method which `PostTiming.pretend_read` will now call instead. Previously, `PostTiming.pretend_read` calls `TopicUser.ensure_consistency!` which in turn calls `TopicUser.update_post_action_cache` but that is unnecessary for `PostTiming.pretend_read` since `PostTiming.pretend_read` does not affect the `TopicUser#liked` or `TopicUser.bookmarked` columns which `TopicUser.update_post_action_cache` updates. As the query in `TopicUser.update_post_action_cache` can be expensive, we should avoid calling it when it isn't necessary.

One such scenario where it is unnecessary is when we are closing a topic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
