### PR TITLE
FIX: correctly compute the window for email summaries

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -224,7 +224,8 @@ class UserNotifications < ActionMailer::Base
     build_summary_for(user)
     @unsubscribe_key = UnsubscribeKey.create_key_for(@user, UnsubscribeKey::DIGEST_TYPE)
 
-    @since = opts[:since] || user.last_seen_at || user.user_stat&.digest_attempted_at || 1.month.ago
+    @since = opts[:since].presence
+    @since ||= [user.last_seen_at, user.user_stat&.digest_attempted_at, 1.month.ago].compact.max
 
     # Fetch some topics and posts to show
     digest_opts = {


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/958437e7ddce6e015725522d25c3f8327ff4064a we ensured that the email summaries are properly sent based on 'digest_attempted_at' for people who barely/never visit the forum.

This fixed the "frequency" of the email summaries but introduced a bug where the digest would be sent even though there wasn't anything new since for some users.

The logic we use to compute the threshold date for the content to be included in the digest was

```ruby
@since = opts[:since] || user.last_seen_at || user.user_stat&.digest_attempted_at || 1.month.ago
```

It was working as expected for users who were never seen but for users who had connected at least once, we would use their "last_seen_at" date as the "threshold date" for the content to be sent in a summary 😬

This fix changes the logic to be the most recent date amongst the `last_seen_at`, `digest_attempted_at` and `1.month.ago` so it's correctly handling cases where

- user has never been seen nor emailed a summary (capped at 1 month)
- user has been seen in a while but has recently been sent a summary
- user has been sent a summary recently but hasn't been seen in a while

Context - https://meta.discourse.org/t/some-user-profiles-now-email-summaries-every-30-minutes-after-update/309485