### PR TITLE
UX: add text-overflow for channel members list

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -12,7 +12,6 @@
     flex-direction: column;
 
     &-item {
-      @include ellipsis;
       display: flex;
       list-style: none;
       border-bottom: 1px solid var(--primary-low);
@@ -34,11 +33,14 @@
           margin-right: 0.5rem;
         }
 
-        .chat-user-display-name span:not(.-first) {
-          color: var(--primary-high);
-          font-size: var(--font-down-1);
-          margin-left: 0.5rem;
-          overflow-wrap: anywhere;
+        .chat-user-display-name {
+          @include ellipsis;
+
+          span:not(.-first) {
+            color: var(--primary-high);
+            font-size: var(--font-down-1);
+            margin-left: 0.5rem;
+          }
         }
 
         .user-status-message {

--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -12,6 +12,7 @@
     flex-direction: column;
 
     &-item {
+      @include ellipsis;
       display: flex;
       list-style: none;
       border-bottom: 1px solid var(--primary-low);
@@ -37,6 +38,7 @@
           color: var(--primary-high);
           font-size: var(--font-down-1);
           margin-left: 0.5rem;
+          overflow-wrap: anywhere;
         }
 
         .user-status-message {


### PR DESCRIPTION
Fix for 
https://meta.discourse.org/t/very-long-real-names-overflow-the-member-list-for-chat-and-the-usercard/300264

Now:
<img width="576" alt="image" src="https://github.com/discourse/discourse/assets/101828855/ec13987f-d92d-4e9c-80e0-b3034400149b">



