### PR TITLE
DEV: Use `127.0.0.1` instead of `localhost` as Capybara's server host

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -315,7 +315,7 @@ RSpec.configure do |config|
     Capybara.w3c_click_offset = false
 
     Capybara.configure do |capybara_config|
-      capybara_config.server_host = ENV["CAPYBARA_SERVER_HOST"].presence || "localhost"
+      capybara_config.server_host = ENV["CAPYBARA_SERVER_HOST"].presence || "127.0.0.1"
 
       capybara_config.server_port =
         (ENV["CAPYBARA_SERVER_PORT"].presence || "31_337").to_i + ENV["TEST_ENV_NUMBER"].to_i

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -67,6 +67,9 @@ describe "Changing email", type: :system do
   end
 
   it "works when user has webauthn 2fa" do
+    @original_host = Capybara.server_host
+    SiteSetting.force_hostname = Capybara.server_host = "localhost"
+
     # enforced 2FA flow needs a user created > 5 minutes ago
     user.created_at = 6.minutes.ago
     user.save!
@@ -74,6 +77,7 @@ describe "Changing email", type: :system do
     sign_in user
 
     DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+
     options =
       ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
         user_verification: true,
@@ -103,6 +107,7 @@ describe "Changing email", type: :system do
     expect(user_preferences_page).to have_primary_email(new_email)
   ensure
     authenticator.remove!
+    SiteSetting.force_hostname = Capybara.server_host = @original_host
   end
 
   it "does not require login to verify" do

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -8,6 +8,9 @@ describe "User preferences | Security", type: :system do
   let(:user_menu) { PageObjects::Components::UserMenu.new }
 
   before do
+    @original_host = Capybara.server_host
+    SiteSetting.force_hostname = Capybara.server_host = "localhost"
+
     user.activate
     # testing the enforced 2FA flow requires a user that was created > 5 minutes ago
     user.created_at = 6.minutes.ago
@@ -17,6 +20,8 @@ describe "User preferences | Security", type: :system do
     # system specs run on their own host + port
     DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
   end
+
+  after { SiteSetting.force_hostname = Capybara.server_host = @original_host }
 
   shared_examples "security keys" do
     it "adds a 2FA security key and logs in with it" do


### PR DESCRIPTION
We are seeing a weird resolution error on Github actions with the
following backtrace:

```
Failure/Error:
  visit File.join(
          GlobalSetting.relative_url_root || "",
          "/session/#{user.encoded_username}/become.json?redirect=false",
        )

Socket::ResolutionError:
  getaddrinfo: Temporary failure in name resolution
```

Switch to use `127.0.0.1` instead of forcing a name resolution.
