### PR TITLE
FIX: Admin sidebar disappeared on some routes for header dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -99,7 +99,7 @@ export default Controller.extend({
 
     // Always show sidebar for admin if user can see the admin sidbar
     if (
-      this.router.currentRouteName.startsWith("admin.") &&
+      this.router.currentRouteName.startsWith("admin") &&
       this.currentUser?.use_admin_sidebar
     ) {
       return true;

--- a/spec/system/navigation_menu_state_integration_spec.rb
+++ b/spec/system/navigation_menu_state_integration_spec.rb
@@ -50,6 +50,15 @@ describe "Navigation menu states", type: :system, js: true do
         expect(header_dropdown).to have_no_dropdown_visible
       end
 
+      it "shows the sidebar on other admin pages" do
+        visit "/admin"
+        expect(sidebar_navigation).to be_visible
+        visit "/admin/site_settings/category/all_results"
+        expect(sidebar_navigation).to be_visible
+        visit "/admin/reports"
+        expect(sidebar_navigation).to be_visible
+      end
+
       context "when the user is not in admin_sidebar_enabled_groups" do
         before { SiteSetting.admin_sidebar_enabled_groups = "" }
 


### PR DESCRIPTION
When navigation_menu is set to header dropdown, we are
still forcing admin sidebar by checking if the user is an
admin route (c.f. 9bcbfbba43b876ae92cb90d6d619be7b1154c119).

However in the initial commit the route check had the
false premise that all admin routes started with `admin.`;
there are others that don't. We need to force admin sidebar
on all routes starting with `admin` (no `.`).

c.f. https://meta.discourse.org/t/feedback-on-admin-sidebar-when-header-dropdown-navigation-selected/309490/3?u=martin
