### PR TITLE
Revert "DEV: Use `127.0.0.1` instead of `localhost` as Capybara's server host (#27215)"

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -315,7 +315,7 @@ RSpec.configure do |config|
     Capybara.w3c_click_offset = false
 
     Capybara.configure do |capybara_config|
-      capybara_config.server_host = ENV["CAPYBARA_SERVER_HOST"].presence || "127.0.0.1"
+      capybara_config.server_host = ENV["CAPYBARA_SERVER_HOST"].presence || "localhost"
 
       capybara_config.server_port =
         (ENV["CAPYBARA_SERVER_PORT"].presence || "31_337").to_i + ENV["TEST_ENV_NUMBER"].to_i

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -67,9 +67,6 @@ describe "Changing email", type: :system do
   end
 
   it "works when user has webauthn 2fa" do
-    @original_host = Capybara.server_host
-    SiteSetting.force_hostname = Capybara.server_host = "localhost"
-
     # enforced 2FA flow needs a user created > 5 minutes ago
     user.created_at = 6.minutes.ago
     user.save!
@@ -77,7 +74,6 @@ describe "Changing email", type: :system do
     sign_in user
 
     DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
-
     options =
       ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
         user_verification: true,
@@ -107,7 +103,6 @@ describe "Changing email", type: :system do
     expect(user_preferences_page).to have_primary_email(new_email)
   ensure
     authenticator.remove!
-    SiteSetting.force_hostname = Capybara.server_host = @original_host
   end
 
   it "does not require login to verify" do

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -8,9 +8,6 @@ describe "User preferences | Security", type: :system do
   let(:user_menu) { PageObjects::Components::UserMenu.new }
 
   before do
-    @original_host = Capybara.server_host
-    SiteSetting.force_hostname = Capybara.server_host = "localhost"
-
     user.activate
     # testing the enforced 2FA flow requires a user that was created > 5 minutes ago
     user.created_at = 6.minutes.ago
@@ -20,8 +17,6 @@ describe "User preferences | Security", type: :system do
     # system specs run on their own host + port
     DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
   end
-
-  after { SiteSetting.force_hostname = Capybara.server_host = @original_host }
 
   shared_examples "security keys" do
     it "adds a 2FA security key and logs in with it" do


### PR DESCRIPTION
This reverts commit 998b50fdf4b83383c9b8cbebdf606477f2a799a2.

Ended up making system tests even more unstable
