### PR TITLE
DEV: Also noindex embedded comments

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -85,13 +85,13 @@ class EmbedController < ApplicationController
       raise Discourse::InvalidAccess.new("invalid embed host")
     end
 
-    topic_id = nil
     if embed_url.present?
       topic_id = TopicEmbed.topic_id_for_embed(embed_url)
     else
       topic_id = params[:topic_id].to_i
     end
 
+    response.headers["X-Robots-Tag"] = "noindex, indexifembedded"
     if topic_id
       @topic_view =
         TopicView.new(


### PR DESCRIPTION
For some reason, despite iframe also indicating a

```
<meta name="robots" content="noindex">
```

.. Google is still indexing the embed/comment URLs. This causes links like http://\<site>/embed/comments\?topic_id\=6366 to be indexed instead of the topic.

This PR adds it explicitly in the header.