### PR TITLE
UX: Make sticky avatars behavior consistent

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/sticky-avatars.js
+++ b/app/assets/javascripts/discourse/app/modifiers/sticky-avatars.js
@@ -122,14 +122,7 @@ export default class StickyAvatars extends Modifier {
               return;
             }
 
-            const postContentHeight =
-              entry.target.querySelector(".contents")?.clientHeight;
-            if (
-              this.direction === "⬆️" ||
-              postContentHeight > window.innerHeight - offset
-            ) {
-              entry.target.classList.add(STICKY_CLASS);
-            }
+            entry.target.classList.add(STICKY_CLASS);
           });
         },
         {


### PR DESCRIPTION
Previously, avatars would be 'sticky' when:

1. The post was longer than the viewport

OR

2. You were scrolling up

The difference in behavior based on scroll direction doesn't 'feel' quite right. This commit makes the behavior consistent, so sticky avatar logic is applied to all posts regardless of scroll direction.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
