### PR TITLE
DEV: Allow afterFramePaint to be used in tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/after-frame-paint.js
+++ b/app/assets/javascripts/discourse/app/lib/after-frame-paint.js
@@ -1,8 +1,13 @@
+import { registerWaiter } from "@ember/test";
+
 /**
  * Runs `callback` shortly after the next browser Frame is produced.
  * ref: https://webperf.tips/tip/measuring-paint-time
  */
 export default function runAfterFramePaint(callback) {
+  let done = false;
+  registerWaiter(() => done);
+
   // Queue a "before Render Steps" callback via requestAnimationFrame.
   requestAnimationFrame(() => {
     // MessageChannel is one of the highest priority task queues
@@ -10,7 +15,10 @@ export default function runAfterFramePaint(callback) {
     const messageChannel = new MessageChannel();
 
     // Setup the callback to run in a Task
-    messageChannel.port1.onmessage = callback;
+    messageChannel.port1.onmessage = () => {
+      done = true;
+      callback();
+    };
 
     // Queue the Task on the Task Queue
     messageChannel.port2.postMessage(undefined);


### PR DESCRIPTION
We need to register a waiter so that `settled()` will wait for `runAfterFramePaint()` callbacks to be run before proceeding.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
