### PR TITLE
DEV: Delay rendering sidebar sections after sidebar is shown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/deferred-render.gjs
+++ b/app/assets/javascripts/discourse/app/components/deferred-render.gjs
@@ -1,14 +1,14 @@
-import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import runAfterFramePaint from "discourse/lib/after-frame-paint";
 
 export default class DeferredRender extends Component {
   @tracked shouldRender = false;
 
-  constructor(){
+  constructor() {
     super(...arguments);
-    runAfterFramePaint(() => this.shouldRender = true);
+    runAfterFramePaint(() => (this.shouldRender = true));
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/deferred-render.gjs
+++ b/app/assets/javascripts/discourse/app/components/deferred-render.gjs
@@ -1,0 +1,21 @@
+import { tracked } from "@glimmer/tracking";
+import Component from "@glimmer/component";
+import loadingSpinner from "discourse/helpers/loading-spinner";
+import runAfterFramePaint from "discourse/lib/after-frame-paint";
+
+export default class DeferredRender extends Component {
+  @tracked shouldRender = false;
+
+  constructor(){
+    super(...arguments);
+    runAfterFramePaint(() => this.shouldRender = true);
+  }
+
+  <template>
+    {{#if this.shouldRender}}
+      {{yield}}
+    {{else}}
+      {{loadingSpinner}}
+    {{/if}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/deferred-render.gjs
+++ b/app/assets/javascripts/discourse/app/components/deferred-render.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import loadingSpinner from "discourse/helpers/loading-spinner";
 import runAfterFramePaint from "discourse/lib/after-frame-paint";
 
 export default class DeferredRender extends Component {
@@ -14,8 +13,6 @@ export default class DeferredRender extends Component {
   <template>
     {{#if this.shouldRender}}
       {{yield}}
-    {{else}}
-      {{loadingSpinner}}
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -7,8 +7,7 @@ import ApiPanels from "./api-panels";
 import Footer from "./footer";
 import Sections from "./sections";
 import { tracked } from "@glimmer/tracking";
-import runAfterFramePaint from "discourse/lib/after-frame-paint";
-import loadingSpinner from "discourse/helpers/loading-spinner";
+import DeferredRender from "discourse/components/deferred-render";
 
 export default class SidebarHamburgerDropdown extends Component {
   @service appEvents;
@@ -21,13 +20,6 @@ export default class SidebarHamburgerDropdown extends Component {
   @action
   triggerRenderedAppEvent() {
     this.appEvents.trigger("sidebar-hamburger-dropdown:rendered");
-  }
-
-  @action
-  triggerLoadSections() {
-    runAfterFramePaint(() => {
-      this.initialLoad = false;
-    });
   }
 
   get collapsableSections() {
@@ -50,10 +42,8 @@ export default class SidebarHamburgerDropdown extends Component {
       >
         <div class="panel-body">
           <div class="panel-body-contents">
-            <div class="sidebar-hamburger-dropdown" {{didInsert this.triggerLoadSections}}>
-              {{#if this.initialLoad}}
-                {{loadingSpinner size="small"}}
-              {{else}}
+            <DeferredRender>
+              <div class="sidebar-hamburger-dropdown">
                 {{#if
                   (or this.sidebarState.showMainPanel @forceMainSidebarPanel)
                 }}
@@ -69,9 +59,9 @@ export default class SidebarHamburgerDropdown extends Component {
                     @collapsableSections={{this.collapsableSections}}
                   />
                 {{/if}}
-              {{/if}}
-              <Footer />
-            </div>
+                <Footer />
+              </div>
+            </DeferredRender>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
@@ -15,7 +14,6 @@ export default class SidebarHamburgerDropdown extends Component {
   @service site;
   @service siteSettings;
   @service sidebarState;
-  @tracked initialLoad = true;
 
   @action
   triggerRenderedAppEvent() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -1,13 +1,13 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
+import DeferredRender from "discourse/components/deferred-render";
 import ApiPanels from "./api-panels";
 import Footer from "./footer";
 import Sections from "./sections";
-import { tracked } from "@glimmer/tracking";
-import DeferredRender from "discourse/components/deferred-render";
 
 export default class SidebarHamburgerDropdown extends Component {
   @service appEvents;


### PR DESCRIPTION
Rendering sidebar sections is costly due to 1. the popper and 2. the number of sections that may be displayed.

This PR introduces a `DeferredRender` which allows us to split the time to paint both.

Before:

https://github.com/discourse/discourse/assets/1555215/1eee16c9-8439-426a-8dec-47d6ac229962

After:

https://github.com/discourse/discourse/assets/1555215/c872aee9-9875-4de5-9812-5d8759baa32c


