### PR TITLE
Revert "DEV: Allow afterFramePaint to be used in tests (#27226)"

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/after-frame-paint.js
+++ b/app/assets/javascripts/discourse/app/lib/after-frame-paint.js
@@ -1,13 +1,8 @@
-import { registerWaiter } from "@ember/test";
-
 /**
  * Runs `callback` shortly after the next browser Frame is produced.
  * ref: https://webperf.tips/tip/measuring-paint-time
  */
 export default function runAfterFramePaint(callback) {
-  let done = false;
-  registerWaiter(() => done);
-
   // Queue a "before Render Steps" callback via requestAnimationFrame.
   requestAnimationFrame(() => {
     // MessageChannel is one of the highest priority task queues
@@ -15,10 +10,7 @@ export default function runAfterFramePaint(callback) {
     const messageChannel = new MessageChannel();
 
     // Setup the callback to run in a Task
-    messageChannel.port1.onmessage = () => {
-      done = true;
-      callback();
-    };
+    messageChannel.port1.onmessage = callback;
 
     // Queue the Task on the Task Queue
     messageChannel.port2.postMessage(undefined);


### PR DESCRIPTION
This reverts commit 63b7b598cb9cd93e90e447fea24f2f517c2592c5.

Causing issues in production builds

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
