### PR TITLE
FIX: quoting a spoiler

### DIFF
--- a/plugins/spoiler-alert/assets/javascripts/initializers/spoiler-alert.js
+++ b/plugins/spoiler-alert/assets/javascripts/initializers/spoiler-alert.js
@@ -28,7 +28,9 @@ export function initializeSpoiler(api) {
   });
 
   addTagDecorateCallback(function () {
-    if (this.element.attributes.class === "spoiled") {
+    const { attributes } = this.element;
+
+    if (/\bspoiled\b/.test(attributes.class)) {
       this.prefix = "[spoiler]";
       this.suffix = "[/spoiler]";
     }
@@ -37,9 +39,9 @@ export function initializeSpoiler(api) {
   addBlockDecorateCallback(function (text) {
     const { name, attributes } = this.element;
 
-    if (name === "div" && attributes.class === "spoiled") {
-      this.prefix = "[spoiler]";
-      this.suffix = "[/spoiler]";
+    if (name === "div" && /\bspoiled\b/.test(attributes.class)) {
+      this.prefix = "[spoiler]\n";
+      this.suffix = "\n[/spoiler]";
       return text.trim();
     }
   });

--- a/plugins/spoiler-alert/test/javascripts/unit/lib/to-markdown-test.js
+++ b/plugins/spoiler-alert/test/javascripts/unit/lib/to-markdown-test.js
@@ -10,8 +10,8 @@ discourseModule("Spoiler Alert | Unit | to-markdown", function (hooks) {
   });
 
   test("handles spoiler tags", function (assert) {
-    let html = `<div>Text with a</div><div class="spoiled">spoiled</div><div>word.</div>`;
-    let markdown = `Text with a\n\n[spoiler]spoiled[/spoiler]\n\nword.`;
+    let html = `<div>Text with a</div><div class="spoiled spoiler-blurred">spoiled</div><div>word.</div>`;
+    let markdown = `Text with a\n\n[spoiler]\nspoiled\n[/spoiler]\n\nword.`;
 
     assert.strictEqual(
       toMarkdown(html),


### PR DESCRIPTION
Was "removing" (rather not re-applying) the `[spoiler]` BBCode because we were testing the **whole** class of the `span`/`div` was `spoiled` but we added another class and thus broke this functionnality.

In order to fix this issue, the test to determine whether a `span`/`div` is a spoiler, now uses a regular expression to check whether the `class` **contains** the word `spoiled`.

Also slightly improved the `toMarkdown` of the block version of a spoiler to add newlines after the opening `[spoiler]` tag and before the closing `[/spoiler]` tag.

Reference - https://meta.discourse.org/t/quoting-spoiler-text-doesnt-include-spoiler-tags-in-the-quote/170145

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
