### PR TITLE
Revert "DEV: Update how we determine the presence of a topic in the header (#27138)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -56,7 +56,7 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
 
   _hideTopicInHeader() {
     this.appEvents.trigger("header:hide-topic");
-    this.header.inTopic = false;
+    this.header.topic = null;
     this._lastShowTopic = false;
   },
 
@@ -65,7 +65,7 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
       return;
     }
     this.appEvents.trigger("header:show-topic", topic);
-    this.header.inTopic = true;
+    this.header.topic = topic;
     this._lastShowTopic = true;
   },
 

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -242,7 +242,7 @@ export default class GlimmerHeader extends Component {
       </div>
       <PluginOutlet
         @name="after-header"
-        @outletArgs={{hash minimized=this.header.inTopic}}
+        @outletArgs={{hash minimized=(globalThis.Boolean this.header.topic)}}
       />
     </header>
   </template>

--- a/app/assets/javascripts/discourse/app/components/header/auth-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/auth-buttons.gjs
@@ -8,7 +8,7 @@ export default class AuthButtons extends Component {
 
   <template>
     <span class="auth-buttons">
-      {{#if (and @canSignUp (not this.header.inTopic))}}
+      {{#if (and @canSignUp (not this.header.topic))}}
         <DButton
           class="btn-primary btn-small sign-up-button"
           @action={{@showCreateAccount}}

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -16,7 +16,7 @@ export default class Contents extends Component {
   @service sidebarState;
 
   get topicPresent() {
-    return this.header.inTopic;
+    return !!this.header.topic;
   }
 
   get sidebarIcon() {
@@ -45,7 +45,7 @@ export default class Contents extends Component {
         </PluginOutlet>
       </div>
 
-      {{#if this.header.inTopic}}
+      {{#if this.header.topic}}
         <TopicInfo @topic={{this.header.topic}} />
       {{else if
         (and

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -10,7 +10,6 @@ import { isTesting } from "discourse-common/config/environment";
 // This route is used for retrieving a topic based on params
 export default DiscourseRoute.extend({
   composer: service(),
-  header: service(),
 
   // Avoid default model hook
   model(params) {
@@ -45,8 +44,6 @@ export default DiscourseRoute.extend({
     if (topic.isPrivateMessage && topic.suggested_topics) {
       this.pmTopicTrackingState.startTracking();
     }
-
-    this.header.topic = topic;
   },
 
   deactivate() {

--- a/app/assets/javascripts/discourse/app/services/header.js
+++ b/app/assets/javascripts/discourse/app/services/header.js
@@ -7,7 +7,6 @@ export default class Header extends Service {
   @service siteSettings;
 
   @tracked topic = null;
-  @tracked inTopic = false;
   @tracked hamburgerVisible = false;
   @tracked userVisible = false;
   @tracked anyWidgetHeaderOverrides = false;


### PR DESCRIPTION
This reverts commit caa29ec97351f1443f7be9560187116f045b820b. (#27138)

The reverted commit introduced an issue where`header.topic` is not being cleared when leaving the topic to another route.

Unfortunately, just setting it to `null` on the route's `deactivate` method causes the `Header::Info` component to crash.

Reverting it for now until we can review the commit and tests to avoid introducing more bugs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
