### PR TITLE
DEV: Use existing loggers for stuff we log in `config/unicorn.conf.rb`

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -71,7 +71,7 @@ before_fork do |server, worker|
       Thread.new do
         while true
           unless File.exist?("/proc/#{supervisor}")
-            puts "Kill self supervisor is gone"
+            server.logger.error "Kill self supervisor is gone"
             Process.kill "TERM", Process.pid
           end
           sleep 2
@@ -165,11 +165,11 @@ before_fork do |server, worker|
               "Sidekiq is consuming too much memory (using: %0.2fM) for '%s', restarting" %
                 [(sidekiq_rss.to_f / 1.megabyte), ENV["DISCOURSE_HOSTNAME"]],
             )
+
             restart = true
           end
 
           if last_heartbeat < Time.now.to_i - @sidekiq_heartbeat_interval
-            STDERR.puts "Sidekiq heartbeat test failed, restarting"
             Rails.logger.warn "Sidekiq heartbeat test failed, restarting"
 
             restart = true
@@ -218,19 +218,21 @@ before_fork do |server, worker|
         last_heartbeat_ago =
           Time.now.to_i - Discourse.redis.get(Demon::EmailSync::HEARTBEAT_KEY).to_i
         if last_heartbeat_ago > Demon::EmailSync::HEARTBEAT_INTERVAL.to_i
-          STDERR.puts(
+          Rails.logger.warn(
             "EmailSync heartbeat test failed (last heartbeat was #{last_heartbeat_ago}s ago), restarting",
           )
+
           restart = true
         end
 
         # Restart process if memory usage is too high
         email_sync_rss = max_email_sync_rss
         if email_sync_rss > max_allowed_email_sync_rss
-          STDERR.puts(
+          Rails.logger.warn(
             "EmailSync is consuming too much memory (using: %0.2fM) for '%s', restarting" %
               [(email_sync_rss.to_f / 1.megabyte), ENV["DISCOURSE_HOSTNAME"]],
           )
+
           restart = true
         end
 


### PR DESCRIPTION
This commit updates various spots in `config/unicorn.conf.rb` which were
doing `STDERR.puts` to either use `server.logger` which is unicorn's
logger or `Rails.logger` which is Rails' logger. The reason we want to
do so is because `STDERR.puts` doesn't format the logs properly and is a
problem especially when custom loggers with structured formatting is
enabled.

Also we are missing critical logging information like timestamp when we simply use `STDERR.puts`. A logger usually attaches the timestamp when it logs the message.