### PR TITLE
FIX: Admin setting search debounce losing characters

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugin-filtered-site-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-filtered-site-settings.gjs
@@ -23,18 +23,6 @@ export default class AdminPluginFilteredSiteSettings extends Component {
     this.filterChanged({ filter: "", onlyOverridden: false });
   }
 
-  filterSettings(filterData) {
-    this.args.onFilterChanged(filterData);
-    this.visibleSettings = this.siteSettingFilter.filterSettings(
-      filterData.filter,
-      {
-        includeAllCategory: false,
-        onlyOverridden: filterData.onlyOverridden,
-      }
-    )[0]?.siteSettings;
-    this.loading = false;
-  }
-
   @action
   filterChanged(filterData) {
     this._debouncedOnChangeFilter(filterData);
@@ -52,6 +40,18 @@ export default class AdminPluginFilteredSiteSettings extends Component {
       filterData,
       100
     );
+  }
+
+  filterSettings(filterData) {
+    this.args.onFilterChanged(filterData);
+    this.visibleSettings = this.siteSettingFilter.filterSettings(
+      filterData.filter,
+      {
+        includeAllCategory: false,
+        onlyOverridden: filterData.onlyOverridden,
+      }
+    )[0]?.siteSettings;
+    this.loading = false;
   }
 
   <template>

--- a/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
@@ -6,7 +6,6 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import DButton from "discourse/components/d-button";
-import TextField from "discourse/components/text-field";
 import i18n from "discourse-common/helpers/i18n";
 
 export default class AdminSiteSettingsFilterControls extends Component {
@@ -26,6 +25,12 @@ export default class AdminSiteSettingsFilterControls extends Component {
       filter: this.filter,
       onlyOverridden: this.onlyOverridden,
     });
+  }
+
+  @action
+  onChangeFilterInput(event) {
+    this.filter = event.target.value;
+    this.onChangeFilter();
   }
 
   @action
@@ -57,14 +62,14 @@ export default class AdminSiteSettingsFilterControls extends Component {
               class="menu-toggle"
             />
           {{/if}}
-          <TextField
-            @type="text"
-            @value={{this.filter}}
-            placeholder={{i18n "type_to_filter"}}
-            @onChange={{this.onChangeFilter}}
-            class="no-blur"
+          <input
+            {{on "input" this.onChangeFilterInput}}
             id="setting-filter"
+            class="no-blur admin-site-settings-filter-controls__input"
+            placeholder={{i18n "type_to_filter"}}
             autocomplete="off"
+            type="text"
+            value={{this.filter}}
           />
           <DButton
             @action={{this.clearFilter}}

--- a/app/assets/javascripts/admin/addon/controllers/admin-plugins-show-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-plugins-show-settings.js
@@ -1,7 +1,7 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 
-export default class AdminSiteSettingsController extends Controller {
+export default class AdminPluginsShowSettingsController extends Controller {
   filter = "";
 
   @action


### PR DESCRIPTION
When typing slowly in the admin setting filter input,
we were losing characters after the debounce. This commit
changes to use native <input /> instead of the ember
<Input /> component similar to the change in
bfd6a7b86c094ea41617bcb3477353baf08b50a9

c.f https://meta.discourse.org/t/settings-filter-loses-some-of-the-letters-you-entered/305201
