### PR TITLE
DEV: Use Unicorn logger to log Sidekiq signal handling events

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -84,12 +84,12 @@ before_fork do |server, worker|
       server.logger.info "starting #{sidekiqs} supervised sidekiqs"
 
       require "demon/sidekiq"
+      Demon::Sidekiq.logger = server.logger
       Demon::Sidekiq.after_fork { DiscourseEvent.trigger(:sidekiq_fork_started) }
-
       Demon::Sidekiq.start(sidekiqs)
 
       Signal.trap("SIGTSTP") do
-        STDERR.puts "#{Time.now}: Issuing stop to sidekiq"
+        Demon::Sidekiq.log("Issuing stop to Sidekiq")
         Demon::Sidekiq.stop
       end
 


### PR DESCRIPTION
This commit updates all Sidekiq signal handling event logs to go through
Unicorn's logger instead of logging to STDOUT. Going through a proper logger
means the log messages are logged in the format which the logger has configured.
This means we get proper timestamp for the log messages.

### Screenshots 

#### Before

<img width="700" alt="Screenshot 2024-05-29 at 10 57 29 AM" src="https://github.com/discourse/discourse/assets/4335742/171c82f1-6d1c-4694-8a7c-a6e03618aa12">

#### After
<img width="821" alt="Screenshot 2024-05-29 at 10 43 59 AM" src="https://github.com/discourse/discourse/assets/4335742/29ea7cfc-9be3-4eab-adab-cd5cc03ec577">
