### PR TITLE
UX: Change consolidated pageview experimental report colors

### DIFF
--- a/app/models/concerns/reports/consolidated_api_requests.rb
+++ b/app/models/concerns/reports/consolidated_api_requests.rb
@@ -11,7 +11,7 @@ module Reports::ConsolidatedApiRequests
 
       requests =
         filters.map do |filter|
-          color = filter == "api" ? report.colors[0] : report.colors[1]
+          color = filter == "api" ? report.colors[:turquoise] : report.colors[:lime]
 
           {
             req: filter,

--- a/app/models/concerns/reports/consolidated_page_views.rb
+++ b/app/models/concerns/reports/consolidated_page_views.rb
@@ -11,9 +11,9 @@ module Reports::ConsolidatedPageViews
 
       requests =
         filters.map do |filter|
-          color = report.colors[0]
-          color = report.colors[1] if filter == "page_view_anon"
-          color = report.colors[2] if filter == "page_view_crawler"
+          color = report.colors[:turquoise]
+          color = report.colors[:lime] if filter == "page_view_anon"
+          color = report.colors[:purple] if filter == "page_view_crawler"
 
           {
             req: filter,

--- a/app/models/concerns/reports/consolidated_page_views_browser_detection.rb
+++ b/app/models/concerns/reports/consolidated_page_views_browser_detection.rb
@@ -44,7 +44,7 @@ module Reports::ConsolidatedPageViewsBrowserDetection
             I18n.t(
               "reports.consolidated_page_views_browser_detection.xaxis.page_view_logged_in_browser",
             ),
-          color: report.colors[0],
+          color: report.colors[:turquoise],
           data: data.map { |row| { x: row.date, y: row.page_view_logged_in_browser } },
         },
         {
@@ -53,20 +53,20 @@ module Reports::ConsolidatedPageViewsBrowserDetection
             I18n.t(
               "reports.consolidated_page_views_browser_detection.xaxis.page_view_anon_browser",
             ),
-          color: report.colors[1],
+          color: report.colors[:lime],
           data: data.map { |row| { x: row.date, y: row.page_view_anon_browser } },
         },
         {
           req: "page_view_crawler",
           label:
             I18n.t("reports.consolidated_page_views_browser_detection.xaxis.page_view_crawler"),
-          color: report.colors[3],
+          color: report.colors[:purple],
           data: data.map { |row| { x: row.date, y: row.page_view_crawler } },
         },
         {
           req: "page_view_other",
           label: I18n.t("reports.consolidated_page_views_browser_detection.xaxis.page_view_other"),
-          color: report.colors[2],
+          color: report.colors[:magenta],
           data: data.map { |row| { x: row.date, y: row.page_view_other } },
         },
       ]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -419,7 +419,13 @@ class Report
   end
 
   def colors
-    %w[#1EB8D1 #9BC53D #721D8D #E84A5F #8A6916]
+    {
+      turquoise: "#1EB8D1",
+      lime: "#9BC53D",
+      purple: "#721D8D",
+      magenta: "#E84A5F",
+      brown: "#8A6916",
+    }
   end
 
   private


### PR DESCRIPTION
Followup 94fe31e5b37c6dc9296a191cf2f7013419a3f50e,
change the color of the "Known Crawler" bar on the
new "Consolidated Pageviews with Browser Detection (Experimental)"
report to be purple, like it was on the original
"Consolidated Pageviews" report to allow for easier
visual comparison.

Also removes the report colors to named keys in a hash
for easier reference than having to look up the
index of the array all the time.

**Before**

![image](https://github.com/discourse/discourse/assets/920448/f92899ce-125b-4701-8263-6f91bc7e7fc3)

**After**

![image](https://github.com/discourse/discourse/assets/920448/abe8214b-b8be-4736-913d-9c2be6b7b5aa)
