### PR TITLE
DEV: Log backtrace along with the error

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -943,7 +943,7 @@ module Discourse
       # Skip warmup in development mode - it makes boot take ~2s longer
       PrettyText.cook("warm up **pretty text**") if !Rails.env.development?
     rescue => e
-      Rails.logger.error("Failed to warm up pretty text: #{e}")
+      Rails.logger.error("Failed to warm up pretty text: #{e}\n#{e.backtrace.join("\n")}")
     end
 
     nil


### PR DESCRIPTION
Just logging the error message is useless if we don't know where the
error message is raised from.

### Screenshot

<img width="1261" alt="Screenshot 2024-05-29 at 2 58 34 PM" src="https://github.com/discourse/discourse/assets/4335742/5bc3e3d9-175f-4c18-bcf3-715865961e27">
