### PR TITLE
UX: Chat footer unread indicator

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -47,7 +47,7 @@ export default class ChatFooter extends Component {
           aria-label={{i18n "chat.channel_list.aria_label"}}
           id="c-footer-channels"
           class={{concatClass
-            "btn-flat"
+            "btn-transparent"
             "c-footer__item"
             (if (eq @activeTab "channels") "--active")
           }}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/footer/unread-indicator.gjs
@@ -58,13 +58,13 @@ export default class FooterUnreadIndicator extends Component {
 
   <template>
     {{#if this.showUrgent}}
-      <div class="chat-channel-unread-indicator -urgent">
-        <div class="chat-channel-unread-indicator__number">
+      <div class="c-unread-indicator -urgent">
+        <div class="c-unread-indicator__number">
           {{this.urgentBadgeCount}}
         </div>
       </div>
     {{else if this.showUnread}}
-      <div class="chat-channel-unread-indicator"></div>
+      <div class="c-unread-indicator"></div>
     {{/if}}
   </template>
 }

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -65,8 +65,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   }
 }
 
-.header-dropdown-toggle.chat-header-icon .icon,
-.c-footer .c-footer__item {
+.header-dropdown-toggle.chat-header-icon .icon {
   .chat-channel-unread-indicator {
     @include chat-unread-indicator;
     border: 2px solid var(--header_background);

--- a/plugins/chat/assets/stylesheets/common/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-footer.scss
@@ -38,7 +38,6 @@
     &:focus {
       .discourse-no-touch &,
       .discourse-touch & {
-        background-color: var(--primary-low);
         .d-icon,
         .d-button-label {
           color: var(--quaternary);
@@ -61,17 +60,22 @@
       color: var(--primary-medium);
     }
 
-    .chat-channel-unread-indicator,
-    .chat-channel-unread-indicator.-urgent {
-      top: 0.25rem;
+    .c-unread-indicator {
+      position: absolute;
+      top: 0.35rem;
       right: unset;
       left: 50%;
       margin-left: 0.75rem;
-    }
-
-    .chat-channel-unread-indicator:not(.-urgent) {
-      width: 11px;
-      height: 11px;
+      &.-urgent {
+        height: 1em;
+        width: min-content;
+        min-width: 0.6em;
+        padding: 0.21em 0.42em;
+      }
+      &:not(.-urgent) {
+        width: 11px;
+        height: 11px;
+      }
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
@@ -11,6 +11,15 @@
   }
 }
 
+.c-footer {
+  &__item {
+    .c-unread-indicator,
+    .c-unread-indicator.-urgent {
+      margin-left: 1rem;
+    }
+  }
+}
+
 .has-full-page-chat div#reply-control {
   display: none;
 }

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -116,10 +116,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
           user: user_2,
         )
 
-        expect(page).to have_css(
-          "#c-footer-channels .c-unread-indicator.-urgent",
-          text: "1",
-        )
+        expect(page).to have_css("#c-footer-channels .c-unread-indicator.-urgent", text: "1")
       end
     end
 

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
         )
 
         expect(page).to have_css(
-          "#c-footer-channels .chat-channel-unread-indicator.-urgent",
+          "#c-footer-channels .c-unread-indicator.-urgent",
           text: "1",
         )
       end

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
         visit("/")
         chat_page.open_from_header
 
-        expect(page).to have_css("#c-footer-channels .chat-channel-unread-indicator")
+        expect(page).to have_css("#c-footer-channels .c-unread-indicator")
       end
 
       it "is urgent for mentions" do
@@ -131,7 +131,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
         visit("/")
         chat_page.open_from_header
 
-        expect(page).to have_css("#c-footer-direct-messages .chat-channel-unread-indicator.-urgent")
+        expect(page).to have_css("#c-footer-direct-messages .c-unread-indicator.-urgent")
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
         visit("/")
         chat_page.open_from_header
 
-        expect(page).to have_css("#c-footer-threads .chat-channel-unread-indicator")
+        expect(page).to have_css("#c-footer-threads .c-unread-indicator")
       end
     end
   end


### PR DESCRIPTION
A few follup changes after changing to the chat footer split for drawer:
* Fixing a bug that stretched the unread indicator on mobile
* Minor style changes in hover/focus behaviour for chat drawer
* Repositioning of unread indicator so it has more space at the top of the footer
* Using the `c-unread-indicator` mixin 

### Before
<img width="693" alt="image" src="https://github.com/discourse/discourse/assets/101828855/73cb54ab-005e-4f8b-aced-b78b77af7895">

<img width="364" alt="image" src="https://github.com/discourse/discourse/assets/101828855/8822d005-d884-4219-9139-bfc1f5614466">


### After
<img width="703" alt="image" src="https://github.com/discourse/discourse/assets/101828855/e43868ce-e26e-4884-9d22-6cddc51aa57f">

<img width="367" alt="image" src="https://github.com/discourse/discourse/assets/101828855/cd982112-410f-42d6-b5fd-14d5df20ae0a">
