### PR TITLE
DEV: Add `sortOrder` to `full-page-search-below-search-header`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -91,6 +91,7 @@
         type=this.search_type
         model=this.model
         addSearchResults=this.addSearchResults
+        sortOrder=this.sortOrder
       }}
     />
 


### PR DESCRIPTION
This PR adds the `sortOrder` property to the `full-page-search-below-search-header` so that we can use it in a tracking context in Discourse AI for conditionally showing AI search results toggle based on the sort order selected.