### PR TITLE
DEV: Prevent possible Ember rendering error on Chat::DeleteChannel modal

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/delete-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/delete-channel.gjs
@@ -1,12 +1,14 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
-import TextField from "discourse/components/text-field";
+import withEventValue from "discourse/helpers/with-event-value";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import i18n from "discourse-common/helpers/i18n";
 import discourseLater from "discourse-common/lib/later";
@@ -83,13 +85,16 @@ export default class ChatModalDeleteChannel extends Component {
         <p class="chat-modal-delete-channel__instructions">
           {{this.instructionsText}}
         </p>
-
-        <TextField
-          @value={{this.channelNameConfirmation}}
-          @id="channel-delete-confirm-name"
-          @placeholderKey="chat.channel_delete.confirm_channel_name"
-          @autocorrect="off"
-          @autocapitalize="off"
+        <input
+          {{on
+            "input"
+            (withEventValue (fn (mut this.channelNameConfirmation)))
+          }}
+          id="channel-delete-confirm-name"
+          placeholder={{i18n "chat.channel_delete.confirm_channel_name"}}
+          autocorrect="off"
+          autocapitalize="off"
+          type="text"
         />
       </:body>
       <:footer>


### PR DESCRIPTION
Under some circumstances, the TextField component could trigger a `Assertion Failed: You attempted to update attrs on ..., but it had already been used previously in the same computation...` error, causing the Ember app to crash.
