### PR TITLE
DEV: Use unicorn's logger when logging in `Demon::Base`

### DIFF
--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -3,45 +3,12 @@
 require "demon/base"
 
 class Demon::Sidekiq < ::Demon::Base
-  cattr_accessor :logger
-
   def self.prefix
     "sidekiq"
   end
 
   def self.after_fork(&blk)
     blk ? (@blk = blk) : @blk
-  end
-
-  def self.format(message)
-    "[#{Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%6N")} ##{Process.pid}] #{message}"
-  end
-
-  def self.log(message, level: :info)
-    # We use an IO pipe and log messages using the logger in a seperate thread to avoid the `log writing failed. can't be called from trap context`
-    # error message that is raised when trying to log from within a `Signal.trap` block.
-    if logger
-      if !defined?(@logger_read_pipe)
-        @logger_read_pipe, @logger_write_pipe = IO.pipe
-
-        @logger_thread =
-          Thread.new do
-            begin
-              while readable_io = IO.select([@logger_read_pipe])
-                logger.public_send(level, readable_io.first[0].gets.strip)
-              end
-            rescue => e
-              STDOUT.puts self.format(
-                            "Error in Sidekiq demon logger thread: #{e.message}\n#{e.backtrace.join("\n")}",
-                          )
-            end
-          end
-      end
-
-      @logger_write_pipe.puts(message)
-    else
-      STDOUT.puts self.format(message)
-    end
   end
 
   private
@@ -54,10 +21,6 @@ class Demon::Sidekiq < ::Demon::Base
     false
   end
 
-  def log(message, level: :info)
-    self.class.log(message, level:)
-  end
-
   def after_fork
     Demon::Sidekiq.after_fork&.call
 
@@ -67,9 +30,9 @@ class Demon::Sidekiq < ::Demon::Base
 
     # Unicorn uses USR1 to indicate that log files have been rotated
     Signal.trap("USR1") do
-      log("Sidekiq reopening logs...")
+      log_in_trap("Sidekiq reopening logs...")
       Unicorn::Util.reopen_logs
-      log("Sidekiq done reopening logs...")
+      log_in_trap("Sidekiq done reopening logs...")
     end
 
     options = ["-c", GlobalSetting.sidekiq_workers.to_s]
@@ -91,8 +54,7 @@ class Demon::Sidekiq < ::Demon::Base
     load Rails.root + "config/initializers/100-sidekiq.rb"
     cli.run
   rescue => e
-    STDERR.puts e.message
-    STDERR.puts e.backtrace.join("\n")
+    log("Error encountered while starting Sidekiq: #{e.message}\n#{e.backtrace.join("\n")}")
     exit 1
   end
 end


### PR DESCRIPTION
This is a continuation of e9c8e182d338af470244d05db944b378439fac9f.

Going through a proper logger
means the log messages are logged in the format which the logger has configured.
This means we get proper timestamp for the log messages.
