### PR TITLE
FIX: allows listing messages of any thread

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
@@ -13,7 +13,6 @@ class Chat::Api::ChannelThreadMessagesController < Chat::ApiController
         )
       end
       on_failure { render(json: failed_json, status: 422) }
-      on_failed_policy(:ensure_thread_enabled) { raise Discourse::NotFound }
       on_failed_policy(:target_message_exists) { raise Discourse::NotFound }
       on_failed_policy(:can_view_thread) { raise Discourse::InvalidAccess }
       on_model_not_found(:thread) { raise Discourse::NotFound }

--- a/plugins/chat/app/services/chat/list_channel_thread_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_thread_messages.rb
@@ -18,7 +18,6 @@ module Chat
     contract
 
     model :thread
-    policy :ensure_thread_enabled
     policy :can_view_thread
     step :fetch_optional_membership
     step :determine_target_message_id
@@ -60,10 +59,6 @@ module Chat
 
     def fetch_thread(contract:)
       ::Chat::Thread.strict_loading.includes(channel: :chatable).find_by(id: contract.thread_id)
-    end
-
-    def ensure_thread_enabled(thread:)
-      thread.channel.threading_enabled || thread.force
     end
 
     def can_view_thread(guardian:, thread:)

--- a/plugins/chat/lib/chat_sdk/thread.rb
+++ b/plugins/chat/lib/chat_sdk/thread.rb
@@ -86,9 +86,6 @@ module ChatSDK
         on_success { result.messages }
         on_failed_policy(:can_view_thread) { raise "Guardian can't view thread" }
         on_failed_policy(:target_message_exists) { raise "Target message doesn't exist" }
-        on_failed_policy(:ensure_thread_enabled) do
-          raise "Threading is not enabled for this channel"
-        end
         on_failure { raise "Unexpected error" }
       end
     end

--- a/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
@@ -60,18 +60,6 @@ RSpec.describe Chat::Api::ChannelThreadMessagesController do
       end
     end
 
-    context "when channel disabled threading" do
-      fab!(:thread) do
-        Fabricate(:chat_thread, channel: Fabricate(:chat_channel, threading_enabled: false))
-      end
-
-      it "returns a 404" do
-        get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages"
-
-        expect(response.status).to eq(404)
-      end
-    end
-
     context "when params are invalid" do
       it "returns a 400" do
         get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages?page_size=9999"

--- a/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Chat::ListChannelThreadMessages do
   subject(:result) { described_class.call(params) }
 
   fab!(:user)
-  fab!(:thread) do
-    Fabricate(:chat_thread, channel: Fabricate(:chat_channel, threading_enabled: true))
-  end
+  fab!(:thread) { Fabricate(:chat_thread, channel: Fabricate(:chat_channel)) }
 
   let(:guardian) { Guardian.new(user) }
   let(:thread_id) { thread.id }
@@ -37,34 +35,9 @@ RSpec.describe Chat::ListChannelThreadMessages do
     end
   end
 
-  context "when ensure_thread_enabled?" do
-    context "when channel threading is disabled" do
-      before { thread.channel.update!(threading_enabled: false) }
-
-      it { is_expected.to fail_a_policy(:ensure_thread_enabled) }
-
-      context "when the thread is forced" do
-        before { thread.update!(force: true) }
-
-        it { is_expected.to be_a_success }
-      end
-    end
-
-    context "when channel and site setting are enabling threading" do
-      before { thread.channel.update!(threading_enabled: true) }
-
-      it { is_expected.to be_a_success }
-    end
-  end
-
   context "when can_view_thread" do
     context "when channel is private" do
-      fab!(:thread) do
-        Fabricate(
-          :chat_thread,
-          channel: Fabricate(:private_category_channel, threading_enabled: true),
-        )
-      end
+      fab!(:thread) { Fabricate(:chat_thread, channel: Fabricate(:private_category_channel)) }
 
       it { is_expected.to fail_a_policy(:can_view_thread) }
 


### PR DESCRIPTION
Before this fix we could only list messages of a thread if it was part of a `threading_enabled` channel or if the thread was set to `force`.

Due to our design of also using a thread id when this is just a chain of replies so we can switch from threading enabled to disabled at any time, we will allow `Chat:: ListChannelThreadMessages` to list the messages of any thread, the only important requirements are:
- having a thread id
- being able to access this thread

To allow this, this commit simply removes the check on `threading_enabled` or `force.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
