### PR TITLE
UX: adjust category badge size for new default font-size

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -35,8 +35,8 @@
       content: "";
       background: var(--category-badge-color);
       flex: 0 0 auto;
-      width: 0.67rem; // fixed dimensions because otherwise they may not be square
-      height: 0.67rem;
+      width: 0.625rem; // fixed dimensions (10px square)
+      height: 0.625rem;
     }
 
     &__name {


### PR DESCRIPTION
Follow-up to 5c09792

This needs a slight adjustment, otherwise badge splits are slightly off for subcategories 


Get your 🔎 out 😜 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/e94e9b27-a5b8-4276-b2ed-ee9a2b3bd356)


After:
![image](https://github.com/discourse/discourse/assets/1681963/764944a5-70bc-4b26-b9b2-8787c9c507a1)
