### PR TITLE
UX: contain background for deleted small actions

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1180,7 +1180,10 @@ blockquote > *:last-child {
   }
 
   &.deleted {
-    background-color: var(--danger-low-mid);
+    .topic-avatar,
+    .small-action-desc {
+      background-color: var(--danger-low-mid);
+    }
   }
 
   .topic-avatar,
@@ -1196,6 +1199,7 @@ blockquote > *:last-child {
     padding-top: 1em;
     width: var(--topic-avatar-width);
     justify-content: center;
+    height: auto;
     .d-icon {
       font-size: var(--font-up-3);
       width: var(--topic-avatar-width);


### PR DESCRIPTION
before:
![image](https://github.com/discourse/discourse/assets/1681963/ac1ede01-1364-4038-aedf-9ce2227725c6)


after:
![image](https://github.com/discourse/discourse/assets/1681963/6752e021-f2b5-4855-b2e8-1d3af26a3821)
