### PR TITLE
UX: keep recent search items on same line as icon

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -229,23 +229,6 @@
   }
 }
 
-.hamburger-panel {
-  // remove once glimmer search menu in place
-  a.widget-link {
-    width: 100%;
-    box-sizing: border-box;
-    @include ellipsis;
-  }
-  a.search-link {
-    width: 100%;
-    box-sizing: border-box;
-    @include ellipsis;
-  }
-  .panel-body {
-    overflow-y: auto;
-  }
-}
-
 .menu-links.columned {
   li {
     width: 50%;

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -256,6 +256,9 @@ $search-pad-horizontal: 0.5em;
     }
 
     .search-item-slug {
+      overflow-wrap: anywhere;
+      white-space: wrap;
+      min-width: 0;
       .keyword {
         margin-right: 0.33em;
       }
@@ -322,6 +325,9 @@ $search-pad-horizontal: 0.5em;
   .search-menu-recent {
     @include separator;
 
+    .search-menu-assistant-item .search-link {
+      flex-wrap: nowrap;
+    }
     .heading {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
Also removing a little bit of dead `.hamburger-panel` css

Before:
![image](https://github.com/discourse/discourse/assets/1681963/8a2d6d39-ce0f-4404-922a-a861bf8eef7a)


After:
![image](https://github.com/discourse/discourse/assets/1681963/4463f25d-83b0-4019-89d6-adca43bb5cdb)
