### PR TITLE
REVERT: UX: keep recent search items on same line as icon (#27264)

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -229,6 +229,23 @@
   }
 }
 
+.hamburger-panel {
+  // remove once glimmer search menu in place
+  a.widget-link {
+    width: 100%;
+    box-sizing: border-box;
+    @include ellipsis;
+  }
+  a.search-link {
+    width: 100%;
+    box-sizing: border-box;
+    @include ellipsis;
+  }
+  .panel-body {
+    overflow-y: auto;
+  }
+}
+
 .menu-links.columned {
   li {
     width: 50%;

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -256,9 +256,6 @@ $search-pad-horizontal: 0.5em;
     }
 
     .search-item-slug {
-      overflow-wrap: anywhere;
-      white-space: wrap;
-      min-width: 0;
       .keyword {
         margin-right: 0.33em;
       }
@@ -325,9 +322,6 @@ $search-pad-horizontal: 0.5em;
   .search-menu-recent {
     @include separator;
 
-    .search-menu-assistant-item .search-link {
-      flex-wrap: nowrap;
-    }
     .heading {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
This was making the hamburger menu un-scrollable on mobile.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
