### PR TITLE
UX: keep recent search items on same line as icon

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -230,17 +230,6 @@
 }
 
 .hamburger-panel {
-  // remove once glimmer search menu in place
-  a.widget-link {
-    width: 100%;
-    box-sizing: border-box;
-    @include ellipsis;
-  }
-  a.search-link {
-    width: 100%;
-    box-sizing: border-box;
-    @include ellipsis;
-  }
   .panel-body {
     overflow-y: auto;
   }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -256,6 +256,9 @@ $search-pad-horizontal: 0.5em;
     }
 
     .search-item-slug {
+      overflow-wrap: anywhere;
+      white-space: wrap;
+      min-width: 0;
       .keyword {
         margin-right: 0.33em;
       }
@@ -322,6 +325,9 @@ $search-pad-horizontal: 0.5em;
   .search-menu-recent {
     @include separator;
 
+    .search-menu-assistant-item .search-link {
+      flex-wrap: nowrap;
+    }
     .heading {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
Originally attempted in 5eae8ced9eed161d45f73f013e2d6a12f92464d3, then reverted in a9cccf07c649f937a271d7ae4baa37be3f843811 due to preventing sidebar scroll because of the removal of 

```css
 .panel-body {
    overflow-y: auto;
  }
```

This does the same thing as 5eae8ced9eed161d45f73f013e2d6a12f92464d3 but leaves the overflow CSS in place.  


Before:
![image](https://github.com/discourse/discourse/assets/1681963/96104c7c-9928-4ba7-b56a-c4c2288ff791)

After: 
![image](https://github.com/discourse/discourse/assets/1681963/2fbd4aa2-2480-44f5-905a-b804ab32ed9f)
