### PR TITLE
DEV: Convert almost all routes to native class syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/about.js
+++ b/app/assets/javascripts/discourse/app/routes/about.js
@@ -4,8 +4,8 @@ import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  site: service(),
+export default class About extends DiscourseRoute {
+  @service site;
 
   async model() {
     const result = await ajax("/about.json");
@@ -29,9 +29,9 @@ export default DiscourseRoute.extend({
     });
 
     return result.about;
-  },
+  }
 
   titleToken() {
     return I18n.t("about.simple_title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/account-created-edit-email.js
+++ b/app/assets/javascripts/discourse/app/routes/account-created-edit-email.js
@@ -1,9 +1,10 @@
 import Route from "@ember/routing/route";
-export default Route.extend({
+
+export default class AccountCreatedEditEmail extends Route {
   setupController(controller) {
     const accountCreated =
       this.controllerFor("account-created").get("accountCreated");
     controller.set("accountCreated", accountCreated);
     controller.set("newEmail", accountCreated.email);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/account-created-index.js
+++ b/app/assets/javascripts/discourse/app/routes/account-created-index.js
@@ -1,9 +1,10 @@
 import Route from "@ember/routing/route";
-export default Route.extend({
+
+export default class AccountCreatedIndex extends Route {
   setupController(controller) {
     controller.set(
       "accountCreated",
       this.controllerFor("account-created").get("accountCreated")
     );
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/account-created-resent.js
+++ b/app/assets/javascripts/discourse/app/routes/account-created-resent.js
@@ -1,9 +1,10 @@
 import Route from "@ember/routing/route";
-export default Route.extend({
+
+export default class AccountCreatedResent extends Route {
   setupController(controller) {
     controller.set(
       "email",
       this.controllerFor("account-created").get("accountCreated.email")
     );
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/account-created.js
+++ b/app/assets/javascripts/discourse/app/routes/account-created.js
@@ -2,12 +2,12 @@ import PreloadStore from "discourse/lib/preload-store";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class AccountCreated extends DiscourseRoute {
   titleToken() {
     return I18n.t("create_account.activation_title");
-  },
+  }
 
   setupController(controller) {
     controller.set("accountCreated", PreloadStore.get("accountCreated"));
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/associate-account.js
+++ b/app/assets/javascripts/discourse/app/routes/associate-account.js
@@ -7,10 +7,10 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import cookie from "discourse/lib/cookie";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
-  currentUser: service(),
-  modal: service(),
+export default class AssociateAccount extends DiscourseRoute {
+  @service router;
+  @service currentUser;
+  @service modal;
 
   beforeModel(transition) {
     if (!this.currentUser) {
@@ -19,7 +19,7 @@ export default DiscourseRoute.extend({
     }
     const params = this.paramsFor("associate-account");
     this.redirectToAccount(params);
-  },
+  }
 
   @action
   async redirectToAccount(params) {
@@ -27,7 +27,7 @@ export default DiscourseRoute.extend({
       .replaceWith(`preferences.account`, this.currentUser)
       .followRedirects();
     next(() => this.showAssociateAccount(params));
-  },
+  }
 
   @action
   async showAssociateAccount(params) {
@@ -39,5 +39,5 @@ export default DiscourseRoute.extend({
     } catch (e) {
       popupAjaxError(e);
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/badges-index.js
+++ b/app/assets/javascripts/discourse/app/routes/badges-index.js
@@ -3,7 +3,7 @@ import Badge from "discourse/models/badge";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class BadgesIndex extends DiscourseRoute {
   model() {
     if (PreloadStore.get("badges")) {
       return PreloadStore.getAndRemove("badges").then((json) =>
@@ -12,9 +12,9 @@ export default DiscourseRoute.extend({
     } else {
       return Badge.findAll({ onlyListable: true });
     }
-  },
+  }
 
   titleToken() {
     return I18n.t("badges.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/badges-show.js
+++ b/app/assets/javascripts/discourse/app/routes/badges-show.js
@@ -4,16 +4,16 @@ import Badge from "discourse/models/badge";
 import UserBadge from "discourse/models/user-badge";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  queryParams: {
+export default class BadgesShow extends DiscourseRoute {
+  queryParams = {
     username: {
       refreshModel: true,
     },
-  },
+  };
 
   serialize(model) {
     return model.getProperties("id", "slug");
-  },
+  }
 
   model(params) {
     if (PreloadStore.get("badge")) {
@@ -23,7 +23,7 @@ export default DiscourseRoute.extend({
     } else {
       return Badge.findById(params.id);
     }
-  },
+  }
 
   afterModel(model, transition) {
     const usernameFromParams =
@@ -48,18 +48,18 @@ export default DiscourseRoute.extend({
     };
 
     return hash(promises);
-  },
+  }
 
   titleToken() {
     const model = this.modelFor("badges.show");
     if (model) {
       return model.get("name");
     }
-  },
+  }
 
   setupController(controller, model) {
     controller.set("model", model);
     controller.set("userBadges", this.userBadgesGrant);
     controller.set("userBadgesAll", this.userBadgesAll);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/build-group-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-group-messages-route.js
@@ -2,10 +2,10 @@ import UserTopicListRoute from "discourse/routes/user-topic-list";
 import I18n from "discourse-i18n";
 
 export default (type) => {
-  return UserTopicListRoute.extend({
+  return class BuildGroupMessagesRoute extends UserTopicListRoute {
     titleToken() {
       return I18n.t(`user.messages.${type}`);
-    },
+    }
 
     model() {
       const groupName = this.modelFor("group").get("name");
@@ -22,10 +22,10 @@ export default (type) => {
         model.set("emptyState", this.emptyState());
         return model;
       });
-    },
+    }
 
     setupController() {
-      this._super.apply(this, arguments);
+      super.setupController(...arguments);
 
       const groupName = this.modelFor("group").get("name");
       let channel = `/private-messages/group/${groupName}`;
@@ -44,21 +44,21 @@ export default (type) => {
         id: this.currentUser.get("username_lower"),
         user: this.currentUser,
       };
-    },
+    }
 
     emptyState() {
       return {
         title: I18n.t("no_group_messages_title"),
         body: "",
       };
-    },
+    }
 
     _isArchive() {
       return type === "archive";
-    },
+    }
 
     deactivate() {
       this.searchService.searchContext = null;
-    },
-  });
+    }
+  };
 };

--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
@@ -4,8 +4,12 @@ import createPMRoute from "discourse/routes/build-private-messages-route";
 import I18n from "discourse-i18n";
 
 export default (inboxType, filter) => {
-  return createPMRoute(inboxType, "private-messages-groups", filter).extend({
-    groupName: null,
+  return class extends createPMRoute(
+    inboxType,
+    "private-messages-groups",
+    filter
+  ) {
+    groupName = null;
 
     titleToken() {
       const groupName = this.groupName;
@@ -19,7 +23,7 @@ export default (inboxType, filter) => {
 
         return [title, I18n.t(`user.private_messages`)];
       }
-    },
+    }
 
     model(params = {}) {
       const username = this.modelFor("user").get("username_lower");
@@ -53,7 +57,7 @@ export default (inboxType, filter) => {
           topicList.set("emptyState", this.emptyState());
           return topicList;
         });
-    },
+    }
 
     afterModel(model) {
       const filters = model.get("filter").split("/");
@@ -68,10 +72,10 @@ export default (inboxType, filter) => {
       const group = this.modelFor("userPrivateMessages.group");
 
       this.setProperties({ groupName, group });
-    },
+    }
 
     setupController() {
-      this._super.apply(this, arguments);
+      super.setupController(...arguments);
 
       const userTopicsListController = this.controllerFor("user-topics-list");
       userTopicsListController.set("group", this.group);
@@ -82,19 +86,19 @@ export default (inboxType, filter) => {
       );
 
       this.controllerFor("user-private-messages").set("group", this.group);
-    },
+    }
 
     emptyState() {
       return {
         title: I18n.t("user.no_messages_title"),
         body: "",
       };
-    },
+    }
 
     dismissReadOptions() {
       return {
         group_name: this.get("groupName"),
       };
-    },
-  });
+    }
+  };
 };

--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
@@ -14,15 +14,15 @@ export const ARCHIVE_FILTER = "archive";
 
 // A helper to build a user topic list route
 export default (inboxType, path, filter) => {
-  return UserTopicListRoute.extend({
-    userActionType: UserAction.TYPES.messages_received,
+  return class BuildPrivateMessagesRoute extends UserTopicListRoute {
+    userActionType = UserAction.TYPES.messages_received;
 
     titleToken() {
       return [
         I18n.t(`user.messages.${filter}`),
         I18n.t("user.private_messages"),
       ];
-    },
+    }
 
     model(params = {}) {
       const topicListFilter =
@@ -50,10 +50,10 @@ export default (inboxType, path, filter) => {
           model.set("emptyState", this.emptyState());
           return model;
         });
-    },
+    }
 
     setupController() {
-      this._super.apply(this, arguments);
+      super.setupController(...arguments);
 
       const userPrivateMessagesController = this.controllerFor(
         "user-private-messages"
@@ -100,7 +100,7 @@ export default (inboxType, path, filter) => {
         type: "private_messages",
       };
       this.searchService.searchContext = pmSearchContext;
-    },
+    }
 
     emptyState() {
       const title = I18n.t("user.no_messages_title");
@@ -113,7 +113,7 @@ export default (inboxType, path, filter) => {
           )
         : "";
       return { title, body };
-    },
+    }
 
     deactivate() {
       this.controllerFor("user-topics-list").unsubscribe();
@@ -121,11 +121,11 @@ export default (inboxType, path, filter) => {
       this.searchService.searchContext = this.controllerFor("user").get(
         "model.searchContext"
       );
-    },
+    }
 
     dismissReadOptions() {
       return {};
-    },
+    }
 
     @action
     dismissReadTopics(dismissTopics) {
@@ -136,6 +136,6 @@ export default (inboxType, path, filter) => {
         private_message_inbox: inboxType,
         ...this.dismissReadOptions(),
       });
-    },
-  });
+    }
+  };
 };

--- a/app/assets/javascripts/discourse/app/routes/edit-category-index.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category-index.js
@@ -1,11 +1,11 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class EditCategoryIndex extends DiscourseRoute {
+  @service router;
 
   afterModel() {
     const params = this.paramsFor("editCategory");
     this.router.replaceWith(`/c/${params.slug}/edit/general`);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category-tabs.js
@@ -1,12 +1,12 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class EditCategoryTabs extends DiscourseRoute {
   model() {
     return this.modelFor("editCategory");
-  },
+  }
 
   setupController(controller, model, transition) {
-    this._super(...arguments);
+    super.setupController(...arguments);
 
     const parentParams = this.paramsFor("editCategory");
 
@@ -15,5 +15,5 @@ export default DiscourseRoute.extend({
       selectedTab: transition.to.params.tab,
       showTooltip: false,
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/edit-category.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category.js
@@ -3,25 +3,25 @@ import Category from "discourse/models/category";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class EditCategory extends DiscourseRoute {
+  @service router;
 
   model(params) {
     return this.site.lazy_load_categories
       ? Category.asyncFindBySlugPath(params.slug, { includePermissions: true })
       : Category.reloadCategoryWithPermissions(params, this.store, this.site);
-  },
+  }
 
   afterModel(model) {
     if (!model.can_edit) {
       this.router.replaceWith("/404");
       return;
     }
-  },
+  }
 
   titleToken() {
     return I18n.t("category.edit_dialog_title", {
       categoryName: this.currentModel.name,
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/email-login.js
+++ b/app/assets/javascripts/discourse/app/routes/email-login.js
@@ -3,17 +3,17 @@ import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class EmailLogin extends DiscourseRoute {
   titleToken() {
     return I18n.t("login.title");
-  },
+  }
 
   model(params) {
     return ajax(`/session/email-login/${params.token}.json`);
-  },
+  }
 
   setupController(controller, model) {
-    this._super.apply(this, arguments);
+    super.setupController(...arguments);
 
     controller.set(
       "secondFactorMethod",
@@ -21,5 +21,5 @@ export default DiscourseRoute.extend({
         ? SECOND_FACTOR_METHODS.SECURITY_KEY
         : SECOND_FACTOR_METHODS.TOTP
     );
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/exception-unknown.js
+++ b/app/assets/javascripts/discourse/app/routes/exception-unknown.js
@@ -1,5 +1,5 @@
 import UnknownRoute from "discourse/routes/unknown";
 
-export default UnknownRoute.extend({
-  templateName: "unknown",
-});
+export default class ExceptionUnknown extends UnknownRoute {
+  templateName = "unknown";
+}

--- a/app/assets/javascripts/discourse/app/routes/exception.js
+++ b/app/assets/javascripts/discourse/app/routes/exception.js
@@ -1,7 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class Exception extends DiscourseRoute {
   serialize() {
     return "";
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/routes/full-page-search.js
@@ -11,15 +11,16 @@ import { escapeExpression } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  queryParams: {
+export default class FullPageSearch extends DiscourseRoute {
+  queryParams = {
     q: {},
     expanded: false,
     context_id: {},
     context: {},
     skip_context: {},
-  },
-  category: null,
+  };
+
+  category = null;
 
   titleToken() {
     return I18n.t("search.results_page", {
@@ -27,7 +28,7 @@ export default DiscourseRoute.extend({
         this.controllerFor("full-page-search").get("searchTerm")
       ),
     });
-  },
+  }
 
   model(params) {
     const cached = getTransient("lastSearch");
@@ -57,11 +58,11 @@ export default DiscourseRoute.extend({
       setTransient("lastSearch", { searchKey, model }, 5);
       return model;
     });
-  },
+  }
 
   @action
   didTransition() {
     this.controllerFor("full-page-search")._afterTransition();
     return true;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-activity-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-activity-index.js
@@ -1,8 +1,8 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-export default Route.extend({
-  router: service(),
+export default class GroupActivityIndex extends Route {
+  @service router;
 
   beforeModel() {
     const group = this.modelFor("group");
@@ -11,5 +11,5 @@ export default Route.extend({
     } else {
       this.router.transitionTo("group.activity.mentions");
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-activity-posts.js
+++ b/app/assets/javascripts/discourse/app/routes/group-activity-posts.js
@@ -3,19 +3,19 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
 export function buildGroupPage(type) {
-  return DiscourseRoute.extend({
-    type,
-    templateName: "group-activity-posts",
-    controllerName: "group-activity-posts",
+  return class GroupActivityPosts extends DiscourseRoute {
+    type = type;
+    templateName = "group-activity-posts";
+    controllerName = "group-activity-posts";
 
     titleToken() {
       return I18n.t(`groups.${type}`);
-    },
+    }
 
     model(params, transition) {
       let categoryId = get(transition.to, "queryParams.category_id");
       return this.modelFor("group").findPosts({ type, categoryId });
-    },
+    }
 
     setupController(controller, model) {
       let loadedAll = model.length < 20;
@@ -24,13 +24,13 @@ export function buildGroupPage(type) {
         type,
         canLoadMore: !loadedAll,
       });
-    },
+    }
 
     @action
     didTransition() {
       return true;
-    },
-  });
+    }
+  };
 }
 
 export default buildGroupPage("posts");

--- a/app/assets/javascripts/discourse/app/routes/group-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/group-activity-topics.js
@@ -1,15 +1,15 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupActivityTopics extends DiscourseRoute {
   titleToken() {
     return I18n.t(`groups.topics`);
-  },
+  }
 
   model(params = {}) {
     return this.store.findFiltered("topicList", {
       filter: `topics/groups/${this.modelFor("group").get("name")}`,
       params,
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-index.js
@@ -5,17 +5,17 @@ import GroupAddMembersModal from "discourse/components/modal/group-add-members";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  modal: service(),
+export default class GroupIndex extends DiscourseRoute {
+  @service modal;
 
   titleToken() {
     return I18n.t("groups.members.title");
-  },
+  }
 
   model(params) {
     this._params = params;
     return this.modelFor("group");
-  },
+  }
 
   setupController(controller, model) {
     controller.setProperties({
@@ -25,12 +25,12 @@ export default DiscourseRoute.extend({
     });
 
     controller.reloadMembers(true);
-  },
+  }
 
   @action
   showAddMembersModal() {
     this.modal.show(GroupAddMembersModal, { model: this.modelFor("group") });
-  },
+  }
 
   @action
   showInviteModal() {
@@ -38,11 +38,11 @@ export default DiscourseRoute.extend({
     this.modal.show(CreateInvite, {
       model: { groupIds: [group.id] },
     });
-  },
+  }
 
   @action
   didTransition() {
     this.controllerFor("group-index").set("filterInput", this._params.filter);
     return true;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-categories.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupManageCategories extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.manage.categories.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-email.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-email.js
@@ -2,17 +2,17 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupManageEmail extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     // cannot configure IMAP without SMTP being enabled
     if (!this.siteSettings.enable_smtp) {
       return this.router.transitionTo("group.manage.profile");
     }
-  },
+  }
 
   titleToken() {
     return I18n.t("groups.manage.email.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-index.js
@@ -1,10 +1,10 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupManageIndex extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     this.router.transitionTo("group.manage.profile");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-interaction.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-interaction.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupManageInteraction extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.manage.interaction.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-logs.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-logs.js
@@ -2,21 +2,21 @@ import { action } from "@ember/object";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupManageLogs extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.manage.logs.title");
-  },
+  }
 
   model() {
     return this.modelFor("group").findLogs();
-  },
+  }
 
   setupController(controller, model) {
     this.controllerFor("group-manage-logs").setProperties({ model });
-  },
+  }
 
   @action
   willTransition() {
     this.controllerFor("group-manage-logs").reset();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-membership.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-membership.js
@@ -2,16 +2,16 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupManageMembership extends DiscourseRoute {
+  @service router;
 
   titleToken() {
     return I18n.t("groups.manage.membership.title");
-  },
+  }
 
   afterModel(group) {
     if (group.get("automatic")) {
       this.router.replaceWith("group.manage.interaction", group);
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-profile.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-profile.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupManageProfile extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.manage.profile.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage-tags.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-tags.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupManageTags extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.manage.tags.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-manage.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage.js
@@ -2,16 +2,16 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupManage extends DiscourseRoute {
+  @service router;
 
   titleToken() {
     return I18n.t("groups.manage.title");
-  },
+  }
 
   model() {
     return this.modelFor("group");
-  },
+  }
 
   afterModel(group) {
     if (
@@ -21,10 +21,10 @@ export default DiscourseRoute.extend({
     ) {
       this.router.transitionTo("group.members", group);
     }
-  },
+  }
 
   setupController(controller, model) {
     this.controllerFor("group-manage").setProperties({ model });
     this.controllerFor("group").set("showing", "manage");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-members.js
+++ b/app/assets/javascripts/discourse/app/routes/group-members.js
@@ -1,10 +1,10 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupMembers extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     this.router.transitionTo("group.index");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-messages-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-messages-index.js
@@ -1,10 +1,10 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-export default Route.extend({
-  router: service(),
+export default class GroupMessagesIndex extends Route {
+  @service router;
 
   beforeModel() {
     this.router.transitionTo("group.messages.inbox");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/group-messages.js
@@ -3,16 +3,16 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupMessages extends DiscourseRoute {
+  @service router;
 
   titleToken() {
     return I18n.t("groups.messages");
-  },
+  }
 
   model() {
     return this.modelFor("group");
-  },
+  }
 
   afterModel(group) {
     if (
@@ -21,10 +21,10 @@ export default DiscourseRoute.extend({
     ) {
       this.router.transitionTo("group.members", group);
     }
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-permissions.js
+++ b/app/assets/javascripts/discourse/app/routes/group-permissions.js
@@ -4,12 +4,12 @@ import { buildPermissionDescription } from "discourse/models/permission-type";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupPermissions extends DiscourseRoute {
+  @service router;
 
   titleToken() {
     return I18n.t("groups.permissions.title");
-  },
+  }
 
   model() {
     let group = this.modelFor("group");
@@ -26,10 +26,10 @@ export default DiscourseRoute.extend({
       .catch(() => {
         this.router.transitionTo("group.members", group);
       });
-  },
+  }
 
   setupController(controller, model) {
     this.controllerFor("group-permissions").setProperties({ model });
     this.controllerFor("group").set("showing", "permissions");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group-requests.js
+++ b/app/assets/javascripts/discourse/app/routes/group-requests.js
@@ -1,15 +1,15 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class GroupRequests extends DiscourseRoute {
   titleToken() {
     return I18n.t("groups.requests.title");
-  },
+  }
 
   model(params) {
     this._params = params;
     return this.modelFor("group");
-  },
+  }
 
   setupController(controller, model) {
     this.controllerFor("group").set("showing", "requests");
@@ -20,5 +20,5 @@ export default DiscourseRoute.extend({
     });
 
     controller.findRequesters(true);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/group.js
+++ b/app/assets/javascripts/discourse/app/routes/group.js
@@ -1,19 +1,19 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class Group extends DiscourseRoute {
   titleToken() {
     return [this.modelFor("group").get("name")];
-  },
+  }
 
   model(params) {
     return this.store.find("group", params.name);
-  },
+  }
 
   serialize(model) {
     return { name: model.get("name").toLowerCase() };
-  },
+  }
 
   setupController(controller, model) {
     controller.set("model", model);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/groups-new.js
+++ b/app/assets/javascripts/discourse/app/routes/groups-new.js
@@ -3,12 +3,12 @@ import Group from "discourse/models/group";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class GroupsNew extends DiscourseRoute {
+  @service router;
 
   titleToken() {
     return I18n.t("admin.groups.new.title");
-  },
+  }
 
   model() {
     return Group.create({
@@ -16,15 +16,15 @@ export default DiscourseRoute.extend({
       visibility_level: 0,
       can_admin_group: true,
     });
-  },
+  }
 
   setupController(controller, model) {
     controller.set("model", model);
-  },
+  }
 
   afterModel() {
     if (!this.get("currentUser.can_create_group")) {
       this.router.transitionTo("groups");
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/invites-show.js
+++ b/app/assets/javascripts/discourse/app/routes/invites-show.js
@@ -3,10 +3,10 @@ import DiscourseRoute from "discourse/routes/discourse";
 import { deepMerge } from "discourse-common/lib/object";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class InvitesShow extends DiscourseRoute {
   titleToken() {
     return I18n.t("invites.accept_title");
-  },
+  }
 
   model(params) {
     if (PreloadStore.get("invite_info")) {
@@ -16,26 +16,26 @@ export default DiscourseRoute.extend({
     } else {
       return {};
     }
-  },
+  }
 
   activate() {
-    this._super(...arguments);
+    super.activate(...arguments);
 
     this.controllerFor("application").setProperties({
       showSiteHeader: false,
     });
-  },
+  }
 
   deactivate() {
-    this._super(...arguments);
+    super.deactivate(...arguments);
 
     this.controllerFor("application").setProperties({
       showSiteHeader: true,
     });
-  },
+  }
 
   setupController(controller, model) {
-    this._super(...arguments);
+    super.setupController(...arguments);
 
     if (model.user_fields) {
       controller.userFields.forEach((userField) => {
@@ -44,5 +44,5 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -12,11 +12,12 @@ export function setNewCategoryDefaultColors(backgroundColor, textColor) {
   _newCategoryTextColor = textColor;
 }
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class NewCategory extends DiscourseRoute {
+  @service router;
 
-  controllerName: "edit-category-tabs",
-  templateName: "edit-category-tabs",
+  controllerName = "edit-category-tabs";
+
+  templateName = "edit-category-tabs";
 
   beforeModel() {
     if (!this.currentUser) {
@@ -31,7 +32,7 @@ export default DiscourseRoute.extend({
         this.router.replaceWith("/404");
       }
     }
-  },
+  }
 
   model() {
     return Promise.resolve(this.groupPermissions())
@@ -41,7 +42,7 @@ export default DiscourseRoute.extend({
       .catch(() => {
         return this.newCategoryWithPermissions(this.defaultGroupPermissions());
       });
-  },
+  }
 
   newCategoryWithPermissions(group_permissions) {
     return this.store.createRecord("category", {
@@ -57,17 +58,17 @@ export default DiscourseRoute.extend({
       required_tag_groups: [],
       form_template_ids: [],
     });
-  },
+  }
 
   titleToken() {
     return I18n.t("category.create");
-  },
+  }
 
   groupPermissions() {
     // Override this function if you want different groupPermissions from a plugin.
     // If your plugin override fails, permissions will fallback to defaultGroupPermissions
     return this.defaultGroupPermissions();
-  },
+  }
 
   defaultGroupPermissions() {
     return [
@@ -76,5 +77,5 @@ export default DiscourseRoute.extend({
         permission_type: 1,
       },
     ];
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/new-message.js
+++ b/app/assets/javascripts/discourse/app/routes/new-message.js
@@ -5,10 +5,10 @@ import Group from "discourse/models/group";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  dialog: service(),
-  composer: service(),
-  router: service(),
+export default class NewMessage extends DiscourseRoute {
+  @service dialog;
+  @service composer;
+  @service router;
 
   beforeModel(transition) {
     const params = transition.to.queryParams;
@@ -75,7 +75,7 @@ export default DiscourseRoute.extend({
           return this.openComposer(transition);
         });
     }
-  },
+  }
 
   openComposer(transition, recipients) {
     next(() => {
@@ -85,5 +85,5 @@ export default DiscourseRoute.extend({
         body: transition.to.queryParams.body,
       });
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/password-reset.js
+++ b/app/assets/javascripts/discourse/app/routes/password-reset.js
@@ -5,10 +5,10 @@ import DiscourseRoute from "discourse/routes/discourse";
 import { deepMerge } from "discourse-common/lib/object";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class PasswordReset extends DiscourseRoute {
   titleToken() {
     return I18n.t("login.reset_password");
-  },
+  }
 
   model(params) {
     if (PreloadStore.get("password_reset")) {
@@ -16,7 +16,7 @@ export default DiscourseRoute.extend({
         deepMerge(params, json)
       );
     }
-  },
+  }
 
   afterModel(model) {
     // confirm token here so email clients who crawl URLs don't invalidate the link
@@ -26,5 +26,5 @@ export default DiscourseRoute.extend({
         dataType: "json",
       });
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/post.js
+++ b/app/assets/javascripts/discourse/app/routes/post.js
@@ -1,14 +1,14 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class Post extends DiscourseRoute {
+  @service router;
 
   model(params) {
     return this.store.find("post", params.id);
-  },
+  }
 
   afterModel(post) {
     this.router.transitionTo(post.url);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-account.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-account.js
@@ -5,8 +5,9 @@ import UserBadge from "discourse/models/user-badge";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 import I18n from "discourse-i18n";
 
-export default RestrictedUserRoute.extend({
-  modal: service(),
+export default class PreferencesAccount extends RestrictedUserRoute {
+  @service modal;
+
   model() {
     const user = this.modelFor("user");
     if (this.siteSettings.enable_badges) {
@@ -22,7 +23,7 @@ export default RestrictedUserRoute.extend({
     } else {
       return user;
     }
-  },
+  }
 
   setupController(controller, user) {
     controller.reset();
@@ -35,12 +36,12 @@ export default RestrictedUserRoute.extend({
       newStatus: user.status,
       subpageTitle: I18n.t("user.preferences_nav.account"),
     });
-  },
+  }
 
   @action
   showAvatarSelector(user) {
     this.modal.show(AvatarSelectorModal, {
       model: { user },
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-apps.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-apps.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesApps extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-email.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-email.js
@@ -1,9 +1,9 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
+export default class PreferencesEmail extends RestrictedUserRoute {
   model() {
     return this.modelFor("user");
-  },
+  }
 
   setupController(controller, model) {
     controller.reset();
@@ -12,11 +12,11 @@ export default RestrictedUserRoute.extend({
       oldEmail: controller.new ? "" : model.email,
       newEmail: controller.new ? "" : model.email,
     });
-  },
+  }
 
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set("new", undefined);
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-emails.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-emails.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesEmails extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-index.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-index.js
@@ -1,10 +1,10 @@
 import { service } from "@ember/service";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
-  router: service(),
+export default class PreferencesIndex extends RestrictedUserRoute {
+  @service router;
 
   redirect() {
     this.router.transitionTo("preferences.account");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-interface.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-interface.js
@@ -1,7 +1,7 @@
 import { currentThemeId } from "discourse/lib/theme-selector";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
+export default class PreferencesInterface extends RestrictedUserRoute {
   setupController(controller, user) {
     controller.setProperties({
       model: user,
@@ -13,5 +13,5 @@ export default RestrictedUserRoute.extend({
       makeTextSizeDefault:
         user.get("currentTextSize") === user.get("user_option.text_size"),
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-navigation-menu.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-navigation-menu.js
@@ -1,7 +1,7 @@
 import Category from "discourse/models/category";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
+export default class PreferencesNavigationMenu extends RestrictedUserRoute {
   setupController(controller, user) {
     const props = {
       model: user,
@@ -15,5 +15,5 @@ export default RestrictedUserRoute.extend({
     }
 
     controller.setProperties(props);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-notifications.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesNotifications extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-profile.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-profile.js
@@ -1,7 +1,7 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
+export default class PreferencesProfile extends RestrictedUserRoute {
   setupController(controller, model) {
     controller.set("model", model);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-second-factor.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-second-factor.js
@@ -2,14 +2,14 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({
-  currentUser: service(),
-  siteSettings: service(),
-  router: service(),
+export default class PreferencesSecondFactor extends RestrictedUserRoute {
+  @service currentUser;
+  @service siteSettings;
+  @service router;
 
   model() {
     return this.modelFor("user");
-  },
+  }
 
   setupController(controller, model) {
     controller.setProperties({ model, newUsername: model.username });
@@ -32,11 +32,11 @@ export default RestrictedUserRoute.extend({
       })
       .catch(controller.popupAjaxError)
       .finally(() => controller.set("loading", false));
-  },
+  }
 
   @action
   willTransition(transition) {
-    this._super(...arguments);
+    super.willTransition(...arguments);
 
     if (
       transition.targetName === "preferences.second-factor" ||
@@ -52,5 +52,5 @@ export default RestrictedUserRoute.extend({
 
     transition.abort();
     return false;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/preferences-security.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-security.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesSecurity extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-tags.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-tags.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesTags extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-tracking.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-tracking.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesTracking extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences-users.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-users.js
@@ -1,3 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default RestrictedUserRoute.extend({});
+export default class PreferencesUsers extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences.js
@@ -2,12 +2,12 @@ import { service } from "@ember/service";
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 import I18n from "discourse-i18n";
 
-export default RestrictedUserRoute.extend({
-  router: service(),
+export default class Preferences extends RestrictedUserRoute {
+  @service router;
 
   model() {
     return this.modelFor("user");
-  },
+  }
 
   titleToken() {
     let controller = this.controllerFor(this.router.currentRouteName);
@@ -15,5 +15,5 @@ export default RestrictedUserRoute.extend({
     return subpageTitle
       ? `${subpageTitle} - ${I18n.t("user.preferences")}`
       : I18n.t("user.preferences");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/restricted-user.js
+++ b/app/assets/javascripts/discourse/app/routes/restricted-user.js
@@ -2,12 +2,12 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
 // A base route that allows us to redirect when access is restricted
-export default DiscourseRoute.extend({
-  router: service(),
+export default class RestrictedUser extends DiscourseRoute {
+  @service router;
 
   afterModel() {
     if (!this.modelFor("user").get("can_edit")) {
       this.router.replaceWith("userActivity");
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -3,7 +3,7 @@ import { isPresent } from "@ember/utils";
 import DiscourseRoute from "discourse/routes/discourse";
 import { bind } from "discourse-common/utils/decorators";
 
-export default DiscourseRoute.extend({
+export default class ReviewIndex extends DiscourseRoute {
   model(params) {
     if (params.sort_order === null) {
       if (params.status === "reviewed" || params.status === "all") {
@@ -14,7 +14,7 @@ export default DiscourseRoute.extend({
     }
 
     return this.store.findAll("reviewable", params);
-  },
+  }
 
   setupController(controller, model) {
     let meta = model.resultSetMeta;
@@ -49,7 +49,7 @@ export default DiscourseRoute.extend({
     });
 
     controller.reviewables.setEach("last_performing_username", null);
-  },
+  }
 
   activate() {
     this.messageBus.subscribe("/reviewable_claimed", this._updateClaimedBy);
@@ -57,7 +57,7 @@ export default DiscourseRoute.extend({
       this._reviewableCountsChannel,
       this._updateReviewables
     );
-  },
+  }
 
   deactivate() {
     this.messageBus.unsubscribe("/reviewable_claimed", this._updateClaimedBy);
@@ -65,7 +65,7 @@ export default DiscourseRoute.extend({
       this._reviewableCountsChannel,
       this._updateReviewables
     );
-  },
+  }
 
   @bind
   _updateClaimedBy(data) {
@@ -80,7 +80,7 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
+  }
 
   @bind
   _updateReviewables(data) {
@@ -92,14 +92,14 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
+  }
 
   get _reviewableCountsChannel() {
     return `/reviewable_counts/${this.currentUser.id}`;
-  },
+  }
 
   @action
   refreshRoute() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/review-settings.js
+++ b/app/assets/javascripts/discourse/app/routes/review-settings.js
@@ -1,11 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class ReviewSettings extends DiscourseRoute {
   model() {
     return this.store.find("reviewable-settings");
-  },
+  }
 
   setupController(controller, model) {
     controller.set("settings", model);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/review-show.js
+++ b/app/assets/javascripts/discourse/app/routes/review-show.js
@@ -1,7 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class ReviewShow extends DiscourseRoute {
   setupController(controller, model) {
     controller.set("reviewable", model);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/review-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/review-topics.js
@@ -1,11 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class ReviewTopics extends DiscourseRoute {
   model() {
     return this.store.findAll("reviewable-topic");
-  },
+  }
 
   setupController(controller, model) {
     controller.set("reviewableTopics", model);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/review.js
+++ b/app/assets/javascripts/discourse/app/routes/review.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class Review extends DiscourseRoute {
   titleToken() {
     return I18n.t("review.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/second-factor-auth.js
+++ b/app/assets/javascripts/discourse/app/routes/second-factor-auth.js
@@ -3,10 +3,10 @@ import { extractError } from "discourse/lib/ajax-error";
 import PreloadStore from "discourse/lib/preload-store";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  queryParams: {
+export default class SecondFactorAuth extends DiscourseRoute {
+  queryParams = {
     nonce: { refreshModel: true },
-  },
+  };
 
   model(params) {
     if (PreloadStore.data.has("2fa_challenge_data")) {
@@ -24,15 +24,15 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
+  }
 
   setupController(controller, model) {
-    this._super(...arguments);
+    super.setupController(...arguments);
     controller.resetState();
 
     if (model.error) {
       controller.displayError(model.error);
       controller.set("loadError", true);
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/tag-groups-edit.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-groups-edit.js
@@ -1,11 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
+export default class TagGroupsEdit extends DiscourseRoute {
   model(params) {
     return this.store.find("tagGroup", params.id);
-  },
+  }
 
   afterModel(tagGroup) {
     tagGroup.set("savingStatus", null);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/tag-groups-new.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-groups-new.js
@@ -2,18 +2,18 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class TagGroupsNew extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     if (!this.siteSettings.tagging_enabled) {
       this.router.transitionTo("tagGroups");
     }
-  },
+  }
 
   model() {
     return this.store.createRecord("tagGroup", {
       name: I18n.t("tagging.groups.new_name"),
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/tag-groups.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-groups.js
@@ -1,12 +1,12 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class TagGroups extends DiscourseRoute {
   model() {
     return this.store.findAll("tagGroup");
-  },
+  }
 
   titleToken() {
     return I18n.t("tagging.groups.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/tags-index.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-index.js
@@ -4,8 +4,8 @@ import Tag from "discourse/models/tag";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class TagsIndex extends DiscourseRoute {
+  @service router;
 
   model() {
     return this.store.findAll("tag").then((result) => {
@@ -23,11 +23,11 @@ export default DiscourseRoute.extend({
       }
       return result;
     });
-  },
+  }
 
   titleToken() {
     return I18n.t("tagging.tags");
-  },
+  }
 
   setupController(controller, model) {
     this.controllerFor("tags.index").setProperties({
@@ -36,16 +36,16 @@ export default DiscourseRoute.extend({
         ? ["id"]
         : ["totalCount:desc", "id"],
     });
-  },
+  }
 
   @action
   showTagGroups() {
     this.router.transitionTo("tagGroups");
     return true;
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
@@ -1,13 +1,13 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 
-export default Route.extend({
-  router: service(),
+export default class TagsLegacyRedirect extends Route {
+  @service router;
 
   beforeModel() {
     this.router.transitionTo(
       "tag.show",
       this.paramsFor("tags.legacyRedirect").tag_id
     );
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
@@ -2,8 +2,8 @@ import { service } from "@ember/service";
 import Topic, { ID_CONSTRAINT } from "discourse/models/topic";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class TopicBySlugOrId extends DiscourseRoute {
+  @service router;
 
   model(params) {
     if (params.slug_or_id.match(ID_CONSTRAINT)) {
@@ -13,9 +13,9 @@ export default DiscourseRoute.extend({
         return { url: `/t/${data.slug}/${data.topic_id}` };
       });
     }
-  },
+  }
 
   afterModel(result) {
     this.router.transitionTo(result.url);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -8,8 +8,8 @@ import DiscourseRoute from "discourse/routes/discourse";
 import { isTesting } from "discourse-common/config/environment";
 
 // This route is used for retrieving a topic based on params
-export default DiscourseRoute.extend({
-  composer: service(),
+export default class TopicFromParams extends DiscourseRoute {
+  @service composer;
 
   // Avoid default model hook
   model(params) {
@@ -36,7 +36,7 @@ export default DiscourseRoute.extend({
         params._loading_error = true;
         return params;
       });
-  },
+  }
 
   afterModel() {
     const topic = this.modelFor("topic");
@@ -44,12 +44,12 @@ export default DiscourseRoute.extend({
     if (topic.isPrivateMessage && topic.suggested_topics) {
       this.pmTopicTrackingState.startTracking();
     }
-  },
+  }
 
   deactivate() {
-    this._super(...arguments);
+    super.deactivate(...arguments);
     this.controllerFor("topic").unsubscribe();
-  },
+  }
 
   setupController(controller, params, { _discourse_anchor }) {
     // Don't do anything else if we couldn't load
@@ -115,7 +115,7 @@ export default DiscourseRoute.extend({
         topic,
       });
     }
-  },
+  }
 
   @action
   willTransition() {
@@ -124,5 +124,5 @@ export default DiscourseRoute.extend({
     // NOTE: omitting this return can break the back button when transitioning quickly between
     // topics and the latest page.
     return true;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -24,30 +24,31 @@ import discourseLater from "discourse-common/lib/later";
 
 const SCROLL_DELAY = 500;
 
-const TopicRoute = DiscourseRoute.extend({
-  composer: service(),
-  screenTrack: service(),
-  modal: service(),
-  router: service(),
+export default class TopicRoute extends DiscourseRoute {
+  @service composer;
+  @service screenTrack;
+  @service modal;
+  @service router;
 
-  scheduledReplace: null,
-  lastScrollPos: null,
-  isTransitioning: false,
+  scheduledReplace = null;
+
+  lastScrollPos = null;
+  isTransitioning = false;
+
+  queryParams = {
+    filter: { replace: true },
+    username_filters: { replace: true },
+  };
 
   buildRouteInfoMetadata() {
     return {
       scrollOnTransition: false,
     };
-  },
+  }
 
   redirect() {
     return this.redirectIfLoginRequired();
-  },
-
-  queryParams: {
-    filter: { replace: true },
-    username_filters: { replace: true },
-  },
+  }
 
   titleToken() {
     const model = this.modelFor("topic");
@@ -79,7 +80,7 @@ const TopicRoute = DiscourseRoute.extend({
       }
       return result;
     }
-  },
+  }
 
   @action
   showInvite() {
@@ -99,7 +100,7 @@ const TopicRoute = DiscourseRoute.extend({
         inviteModel: this.modelFor("topic"),
       },
     });
-  },
+  }
 
   @action
   showFlags(model) {
@@ -110,7 +111,7 @@ const TopicRoute = DiscourseRoute.extend({
         setHidden: () => model.set("hidden", true),
       },
     });
-  },
+  }
 
   @action
   showFlagTopic() {
@@ -122,7 +123,7 @@ const TopicRoute = DiscourseRoute.extend({
         setHidden: () => model.set("hidden", true),
       },
     });
-  },
+  }
 
   @action
   showPagePublish() {
@@ -130,7 +131,7 @@ const TopicRoute = DiscourseRoute.extend({
     this.modal.show(PublishPageModal, {
       model,
     });
-  },
+  }
 
   @action
   showTopicTimerModal() {
@@ -142,26 +143,26 @@ const TopicRoute = DiscourseRoute.extend({
         updateTopicTimerProperty: this.updateTopicTimerProperty,
       },
     });
-  },
+  }
 
   @action
   updateTopicTimerProperty(property, value) {
     this.modelFor("topic").set(`topic_timer.${property}`, value);
-  },
+  }
 
   @action
   showTopicSlowModeUpdate() {
     this.modal.show(EditSlowModeModal, {
       model: { topic: this.modelFor("topic") },
     });
-  },
+  }
 
   @action
   showChangeTimestamp() {
     this.modal.show(ChangeTimestampModal, {
       model: { topic: this.modelFor("topic") },
     });
-  },
+  }
 
   @action
   showFeatureTopic() {
@@ -181,7 +182,7 @@ const TopicRoute = DiscourseRoute.extend({
         removeBanner: () => topicController.send("removeBanner"),
       },
     });
-  },
+  }
 
   @action
   showHistory(model, revision) {
@@ -193,7 +194,7 @@ const TopicRoute = DiscourseRoute.extend({
         editPost: (post) => this.controllerFor("topic").send("editPost", post),
       },
     });
-  },
+  }
 
   @action
   showGrantBadgeModal() {
@@ -203,12 +204,12 @@ const TopicRoute = DiscourseRoute.extend({
         selectedPost: topicController.selectedPosts[0],
       },
     });
-  },
+  }
 
   @action
   showRawEmail(model) {
     this.modal.show(RawEmailModal, { model });
-  },
+  }
 
   @action
   moveToTopic() {
@@ -223,7 +224,7 @@ const TopicRoute = DiscourseRoute.extend({
         toggleMultiSelect: topicController.toggleMultiSelect,
       },
     });
-  },
+  }
 
   @action
   changeOwner() {
@@ -239,7 +240,7 @@ const TopicRoute = DiscourseRoute.extend({
         topic: this.modelFor("topic"),
       },
     });
-  },
+  }
 
   // Use replaceState to update the URL once it changes
   @action
@@ -288,7 +289,7 @@ const TopicRoute = DiscourseRoute.extend({
         ),
       });
     }
-  },
+  }
 
   @action
   didTransition() {
@@ -296,14 +297,14 @@ const TopicRoute = DiscourseRoute.extend({
     const topicId = controller.get("model.id");
     setTopicId(topicId);
     return true;
-  },
+  }
 
   @action
   willTransition() {
-    this._super(...arguments);
+    super.willTransition(...arguments);
     cancel(this.scheduledReplace);
     return true;
-  },
+  }
 
   // replaceState can be very slow on Android Chrome. This function debounces replaceState
   // within a topic until scrolling stops
@@ -336,7 +337,7 @@ const TopicRoute = DiscourseRoute.extend({
         SCROLL_DELAY
       ),
     });
-  },
+  }
 
   setupParams(topic, params) {
     const postStream = topic.get("postStream");
@@ -351,7 +352,7 @@ const TopicRoute = DiscourseRoute.extend({
     }
 
     return topic;
-  },
+  }
 
   model(params, transition) {
     if (params.slug.match(ID_CONSTRAINT)) {
@@ -373,10 +374,10 @@ const TopicRoute = DiscourseRoute.extend({
       topic = this.store.createRecord("topic", props);
       return this.setupParams(topic, queryParams);
     }
-  },
+  }
 
   deactivate() {
-    this._super(...arguments);
+    super.deactivate(...arguments);
 
     this.searchService.searchContext = null;
 
@@ -392,7 +393,7 @@ const TopicRoute = DiscourseRoute.extend({
     this.appEvents.trigger("header:hide-topic");
 
     this.controllerFor("topic").set("model", null);
-  },
+  }
 
   setupController(controller, model) {
     controller.setProperties({
@@ -416,7 +417,5 @@ const TopicRoute = DiscourseRoute.extend({
     schedule("afterRender", () =>
       this.appEvents.trigger("header:update-topic", model)
     );
-  },
-});
-
-export default TopicRoute;
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks-with-reminders.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks-with-reminders.js
@@ -1,14 +1,14 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserActivityBookmarksWithReminders extends DiscourseRoute {
+  @service router;
 
-  queryParams: {
+  queryParams = {
     q: { replace: true },
-  },
+  };
 
   redirect() {
     this.router.transitionTo("userActivity.bookmarks");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -8,14 +8,15 @@ import Site from "discourse/models/site";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  historyStore: service(),
-  templateName: "user/bookmarks",
+export default class UserActivityBookmarks extends DiscourseRoute {
+  @service historyStore;
 
-  queryParams: {
+  templateName = "user/bookmarks";
+
+  queryParams = {
     acting_username: { refreshModel: true },
     q: { refreshModel: true },
-  },
+  };
 
   model(params) {
     const controller = this.controllerFor("user-activity-bookmarks");
@@ -56,16 +57,16 @@ export default DiscourseRoute.extend({
       })
       .catch(() => controller.set("permissionDenied", true))
       .finally(() => controller.set("loading", false));
-  },
+  }
 
   titleToken() {
     return I18n.t("user_action_groups.3");
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
+  }
 
   _loadBookmarks(params) {
     let url = `/u/${this.modelFor("user").username}/bookmarks.json`;
@@ -75,5 +76,5 @@ export default DiscourseRoute.extend({
     }
 
     return ajax(url);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
@@ -1,8 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  templateName: "user/stream",
+export default class UserActivityDrafts extends DiscourseRoute {
+  templateName = "user/stream";
 
   model() {
     const user = this.modelFor("user");
@@ -15,23 +15,23 @@ export default DiscourseRoute.extend({
         emptyState: this.emptyState(),
       };
     });
-  },
+  }
 
   emptyState() {
     const title = I18n.t("user_activity.no_drafts_title");
     const body = I18n.t("user_activity.no_drafts_body");
     return { title, body };
-  },
+  }
 
   activate() {
     this.appEvents.on("draft:destroyed", this, this.refresh);
-  },
+  }
 
   deactivate() {
     this.appEvents.off("draft:destroyed", this, this.refresh);
-  },
+  }
 
   titleToken() {
     return I18n.t("user_action_groups.15");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-index.js
@@ -4,8 +4,8 @@ import getURL from "discourse-common/lib/get-url";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: null,
+export default class UserActivityIndex extends UserActivityStreamRoute {
+  userActionType = null;
 
   emptyState() {
     const user = this.modelFor("user");
@@ -24,9 +24,9 @@ export default UserActivityStreamRoute.extend({
     }
 
     return { title, body };
-  },
+  }
 
   titleToken() {
     return I18n.t("user.filters.all");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
@@ -4,8 +4,8 @@ import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["likes_given"],
+export default class UserActivityLikesGiven extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["likes_given"];
 
   emptyState() {
     const user = this.modelFor("user");
@@ -22,9 +22,9 @@ export default UserActivityStreamRoute.extend({
     );
 
     return { title, body };
-  },
+  }
 
   titleToken() {
     return I18n.t("user_action_groups.1");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-pending.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-pending.js
@@ -3,12 +3,12 @@ import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserActivityPending extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     this.username = this.modelFor("user").username_lower;
-  },
+  }
 
   model() {
     return this.store
@@ -24,7 +24,7 @@ export default DiscourseRoute.extend({
 
         return pendingPosts;
       });
-  },
+  }
 
   activate() {
     this.appEvents.on(
@@ -32,7 +32,7 @@ export default DiscourseRoute.extend({
       this,
       "_handleCountChange"
     );
-  },
+  }
 
   deactivate() {
     this.appEvents.off(
@@ -40,12 +40,12 @@ export default DiscourseRoute.extend({
       this,
       "_handleCountChange"
     );
-  },
+  }
 
   _handleCountChange(count) {
     this.refresh();
     if (count <= 0) {
       this.router.transitionTo("userActivity");
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -6,8 +6,8 @@ import getURL from "discourse-common/lib/get-url";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "discourse-i18n";
 
-export default UserTopicListRoute.extend({
-  userActionType: UserAction.TYPES.topics,
+export default class UserActivityRead extends UserTopicListRoute {
+  userActionType = UserAction.TYPES.topics;
 
   model(params = {}) {
     return this.store
@@ -23,7 +23,7 @@ export default UserTopicListRoute.extend({
         model.set("emptyState", this.emptyState());
         return model;
       });
-  },
+  }
 
   emptyState() {
     const title = I18n.t("user_activity.no_read_topics_title");
@@ -35,14 +35,14 @@ export default UserTopicListRoute.extend({
       })
     );
     return { title, body };
-  },
+  }
 
   titleToken() {
     return `${I18n.t("user.read")}`;
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
@@ -4,8 +4,8 @@ import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["posts"],
+export default class UserActivityReplies extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["posts"];
 
   emptyState() {
     const user = this.modelFor("user");
@@ -26,9 +26,9 @@ export default UserActivityStreamRoute.extend({
     }
 
     return { title, body };
-  },
+  }
 
   titleToken() {
     return I18n.t("user_action_groups.5");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
@@ -2,12 +2,14 @@ import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend(ViewingActionType, {
-  templateName: "user/stream",
+export default class UserActivityStream extends DiscourseRoute.extend(
+  ViewingActionType
+) {
+  templateName = "user/stream";
 
-  queryParams: {
+  queryParams = {
     acting_username: { refreshModel: true },
-  },
+  };
 
   model() {
     const user = this.modelFor("user");
@@ -17,23 +19,23 @@ export default DiscourseRoute.extend(ViewingActionType, {
       stream,
       emptyState: this.emptyState(),
     };
-  },
+  }
 
   afterModel(model, transition) {
     return model.stream.filterBy({
       filter: this.userActionType,
       actingUsername: transition.to.queryParams.acting_username,
     });
-  },
+  }
 
   setupController() {
-    this._super(...arguments);
+    super.setupController(...arguments);
     this.viewingActionType(this.userActionType);
-  },
+  }
 
   emptyState() {
     const title = I18n.t("user_activity.no_activity_title");
     const body = "";
     return { title, body };
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -5,8 +5,8 @@ import UserTopicListRoute from "discourse/routes/user-topic-list";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "discourse-i18n";
 
-export default UserTopicListRoute.extend({
-  userActionType: UserAction.TYPES.topics,
+export default class UserActivityTopics extends UserTopicListRoute {
+  userActionType = UserAction.TYPES.topics;
 
   model(params = {}) {
     return this.store
@@ -23,7 +23,7 @@ export default UserTopicListRoute.extend({
         model.set("emptyState", this.emptyState());
         return model;
       });
-  },
+  }
 
   emptyState() {
     const user = this.modelFor("user");
@@ -43,14 +43,14 @@ export default UserTopicListRoute.extend({
     }
 
     return { title, body };
-  },
+  }
 
   titleToken() {
     return I18n.t("user_action_groups.4");
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-activity.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity.js
@@ -2,8 +2,8 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserActivity extends DiscourseRoute {
+  @service router;
 
   model() {
     let user = this.modelFor("user");
@@ -12,13 +12,13 @@ export default DiscourseRoute.extend({
     }
 
     return user;
-  },
+  }
 
   setupController(controller, user) {
     this.controllerFor("user-activity").set("model", user);
-  },
+  }
 
   titleToken() {
     return I18n.t("user.activity_stream");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-badges.js
+++ b/app/assets/javascripts/discourse/app/routes/user-badges.js
@@ -3,22 +3,24 @@ import UserBadge from "discourse/models/user-badge";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend(ViewingActionType, {
-  templateName: "user/badges",
+export default class UserBadges extends DiscourseRoute.extend(
+  ViewingActionType
+) {
+  templateName = "user/badges";
 
   model() {
     return UserBadge.findByUsername(
       this.modelFor("user").get("username_lower"),
       { grouped: true }
     );
-  },
+  }
 
   setupController() {
-    this._super(...arguments);
+    super.setupController(...arguments);
     this.viewingActionType(-1);
-  },
+  }
 
   titleToken() {
     return I18n.t("badges.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-invited-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-index.js
@@ -1,10 +1,10 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserInvitedIndex extends DiscourseRoute {
+  @service router;
 
   beforeModel() {
     this.router.replaceWith("userInvited.show", "pending");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-show.js
@@ -4,13 +4,13 @@ import Invite from "discourse/models/invite";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserInvitedShow extends DiscourseRoute {
+  @service router;
 
   model(params) {
     this.inviteFilter = params.filter;
     return Invite.findInvitedBy(this.modelFor("user"), params.filter);
-  },
+  }
 
   afterModel(model) {
     if (!model.can_see_invite_details) {
@@ -19,7 +19,7 @@ export default DiscourseRoute.extend({
     this.controllerFor("user.invited").setProperties({
       invitesCount: model.counts,
     });
-  },
+  }
 
   setupController(controller, model) {
     controller.setProperties({
@@ -29,14 +29,14 @@ export default DiscourseRoute.extend({
       filter: this.inviteFilter,
       searchTerm: "",
     });
-  },
+  }
 
   titleToken() {
     return I18n.t("user.invited." + this.inviteFilter + "_tab");
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-invited.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited.js
@@ -1,7 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class UserInvited extends DiscourseRoute {
   setupController(controller) {
     const can_see_invite_details =
       this.currentUser.staff ||
@@ -10,9 +10,9 @@ export default DiscourseRoute.extend({
     controller.setProperties({
       can_see_invite_details,
     });
-  },
+  }
 
   titleToken() {
     return I18n.t("user.invited.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-edits.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-edits.js
@@ -2,10 +2,10 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["edits"],
+export default class UserNotificationsEdits extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["edits"];
 
   titleToken() {
     return I18n.t("user_action_groups.11");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
@@ -2,18 +2,19 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
-  controllerName: "user-notifications",
-  templateName: "user/notifications-index",
+export default class UserNotificationsIndex extends DiscourseRoute {
+  @service router;
+
+  controllerName = "user-notifications";
+  templateName = "user/notifications-index";
 
   titleToken() {
     return I18n.t("user.filters.all");
-  },
+  }
 
   afterModel(model) {
     if (!model) {
       this.router.transitionTo("userNotifications.responses");
     }
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-likes-received.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-likes-received.js
@@ -2,10 +2,10 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["likes_received"],
+export default class UserNotificationsLikesReceived extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["likes_received"];
 
   titleToken() {
     return I18n.t("user_action_groups.1");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-links.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-links.js
@@ -2,10 +2,10 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["links"],
+export default class UserNotificationsLinks extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["links"];
 
   titleToken() {
     return I18n.t("user_action_groups.17");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-mentions.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-mentions.js
@@ -2,10 +2,10 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["mentions"],
+export default class UserNotificationsMentions extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["mentions"];
 
   titleToken() {
     return I18n.t("user_action_groups.7");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-responses.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-responses.js
@@ -2,10 +2,10 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "discourse-i18n";
 
-export default UserActivityStreamRoute.extend({
-  userActionType: UserAction.TYPES["replies"],
+export default class UserNotificationsResponses extends UserActivityStreamRoute {
+  userActionType = UserAction.TYPES["replies"];
 
   titleToken() {
     return I18n.t("user_action_groups.6");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications.js
@@ -9,9 +9,11 @@ export function setNotificationsLimit(newLimit) {
   limit = newLimit;
 }
 
-export default DiscourseRoute.extend(ViewingActionType, {
-  controllerName: "user-notifications",
-  queryParams: { filter: { refreshModel: true } },
+export default class UserNotifications extends DiscourseRoute.extend(
+  ViewingActionType
+) {
+  controllerName = "user-notifications";
+  queryParams = { filter: { refreshModel: true } };
 
   model(params) {
     const username = this.modelFor("user").get("username");
@@ -26,15 +28,15 @@ export default DiscourseRoute.extend(ViewingActionType, {
         limit,
       });
     }
-  },
+  }
 
   setupController(controller) {
-    this._super(...arguments);
+    super.setupController(...arguments);
     controller.set("user", this.modelFor("user"));
     this.viewingActionType(-1);
-  },
+  }
 
   titleToken() {
     return I18n.t("user.notifications");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-index.js
@@ -4,7 +4,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
+export default class UserPrivateMessagesTagsIndex extends DiscourseRoute {
   model() {
     const username = this.modelFor("user").get("username_lower");
 
@@ -13,11 +13,11 @@ export default DiscourseRoute.extend({
         return result.tags.map((tag) => EmberObject.create(tag));
       })
       .catch(popupAjaxError);
-  },
+  }
 
   titleToken() {
     return [I18n.t("tagging.tags"), I18n.t("user.private_messages")];
-  },
+  }
 
   setupController(controller, model) {
     controller.setProperties({
@@ -32,5 +32,5 @@ export default DiscourseRoute.extend({
       showToggleBulkSelect: false,
     });
     this.controllerFor("user-topics-list").bulkSelectHelper.clear();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-show.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-show.js
@@ -1,14 +1,14 @@
 import createPMRoute from "discourse/routes/build-private-messages-route";
 import I18n from "discourse-i18n";
 
-export default createPMRoute("tags", "private-messages-tags").extend({
+export default class extends createPMRoute("tags", "private-messages-tags") {
   titleToken() {
     return [
       this.get("tagId"),
       I18n.t("tagging.tags"),
       I18n.t("user.private_messages"),
     ];
-  },
+  }
 
   model(params) {
     this.controllerFor("user-private-messages").set("tagId", params.id);
@@ -20,5 +20,5 @@ export default createPMRoute("tags", "private-messages-tags").extend({
     return this.store.findFiltered("topicList", {
       filter: `topics/private-messages-tags/${username}/${params.id}`,
     });
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages-tags.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages-tags.js
@@ -1,3 +1,3 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({});
+export default class UserPrivateMessagesTags extends DiscourseRoute {}

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages.js
@@ -4,16 +4,17 @@ import Composer from "discourse/models/composer";
 import Draft from "discourse/models/draft";
 import DiscourseRoute from "discourse/routes/discourse";
 
-export default DiscourseRoute.extend({
-  templateName: "user/messages",
-  composer: service(),
+export default class UserPrivateMessages extends DiscourseRoute {
+  @service composer;
+
+  templateName = "user/messages";
 
   afterModel() {
     this.pmTopicTrackingState.startTracking();
-  },
+  }
 
   setupController() {
-    this._super(...arguments);
+    super.setupController(...arguments);
 
     if (this.currentUser) {
       Draft.get("new_private_message").then((data) => {
@@ -27,16 +28,16 @@ export default DiscourseRoute.extend({
         }
       });
     }
-  },
+  }
 
   @action
   triggerRefresh() {
     this.refresh();
-  },
+  }
 
   @action
   willTransition() {
-    this._super(...arguments);
+    super.willTransition(...arguments);
     return true;
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user-summary.js
+++ b/app/assets/javascripts/discourse/app/routes/user-summary.js
@@ -2,8 +2,8 @@ import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
+export default class UserSummary extends DiscourseRoute {
+  @service router;
 
   model() {
     const user = this.modelFor("user");
@@ -12,9 +12,9 @@ export default DiscourseRoute.extend({
     }
 
     return user.summary();
-  },
+  }
 
   titleToken() {
     return I18n.t("user.summary.title");
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/user.js
+++ b/app/assets/javascripts/discourse/app/routes/user.js
@@ -6,11 +6,11 @@ import DiscourseRoute from "discourse/routes/discourse";
 import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
-  searchService: service("search"),
-  appEvents: service("app-events"),
-  messageBus: service("message-bus"),
+export default class UserRoute extends DiscourseRoute {
+  @service router;
+  @service("search") searchService;
+  @service appEvents;
+  @service messageBus;
 
   beforeModel() {
     if (this.siteSettings.hide_user_profiles_from_public && !this.currentUser) {
@@ -19,7 +19,7 @@ export default DiscourseRoute.extend({
         desc: I18n.t("user.login_to_view_profile"),
       });
     }
-  },
+  }
 
   model(params) {
     // If we're viewing the currently logged in user, return that object instead
@@ -33,7 +33,7 @@ export default DiscourseRoute.extend({
     return User.create({
       username: encodeURIComponent(params.username),
     });
-  },
+  }
 
   afterModel() {
     const user = this.modelFor("user");
@@ -43,7 +43,7 @@ export default DiscourseRoute.extend({
       .then(() => user.findStaffInfo())
       .then(() => user.statusManager.trackStatus())
       .catch(() => this.router.replaceWith("/404"));
-  },
+  }
 
   serialize(model) {
     if (!model) {
@@ -51,15 +51,15 @@ export default DiscourseRoute.extend({
     }
 
     return { username: (model.username || "").toLowerCase() };
-  },
+  }
 
   setupController(controller, user) {
     controller.set("model", user);
     this.searchService.searchContext = user.searchContext;
-  },
+  }
 
   activate() {
-    this._super(...arguments);
+    super.activate(...arguments);
 
     const user = this.modelFor("user");
     this.messageBus.subscribe(`/u/${user.username_lower}`, this.onUserMessage);
@@ -67,10 +67,10 @@ export default DiscourseRoute.extend({
       `/u/${user.username_lower}/counters`,
       this.onUserCountersMessage
     );
-  },
+  }
 
   deactivate() {
-    this._super(...arguments);
+    super.deactivate(...arguments);
 
     const user = this.modelFor("user");
     this.messageBus.unsubscribe(
@@ -85,13 +85,13 @@ export default DiscourseRoute.extend({
 
     // Remove the search context
     this.searchService.searchContext = null;
-  },
+  }
 
   @bind
   onUserMessage(data) {
     const user = this.modelFor("user");
     return user.loadUserAction(data);
-  },
+  }
 
   @bind
   onUserCountersMessage(data) {
@@ -104,20 +104,20 @@ export default DiscourseRoute.extend({
         value
       )
     );
-  },
+  }
 
   titleToken() {
     const username = this.modelFor("user").username;
     return username ? username : null;
-  },
+  }
 
   @action
   undoRevokeApiKey(key) {
     key.undoRevoke();
-  },
+  }
 
   @action
   revokeApiKey(key) {
     key.revoke();
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/routes/users.js
+++ b/app/assets/javascripts/discourse/app/routes/users.js
@@ -5,12 +5,12 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
-export default DiscourseRoute.extend({
-  router: service(),
-  siteSettings: service(),
-  currentUser: service(),
+export default class Users extends DiscourseRoute {
+  @service router;
+  @service siteSettings;
+  @service currentUser;
 
-  queryParams: {
+  queryParams = {
     period: { refreshModel: true },
     order: { refreshModel: true },
     asc: { refreshModel: true },
@@ -18,11 +18,11 @@ export default DiscourseRoute.extend({
     group: { refreshModel: true },
     exclude_groups: { refreshModel: true },
     exclude_usernames: { refreshModel: true },
-  },
+  };
 
   titleToken() {
     return I18n.t("directory.title");
-  },
+  }
 
   resetController(controller, isExiting) {
     if (isExiting) {
@@ -37,13 +37,13 @@ export default DiscourseRoute.extend({
         lastUpdatedAt: null,
       });
     }
-  },
+  }
 
   beforeModel() {
     if (this.siteSettings.hide_user_profiles_from_public && !this.currentUser) {
       this.router.replaceWith("discovery");
     }
-  },
+  }
 
   model(params) {
     return ajax("/directory-columns.json")
@@ -55,7 +55,7 @@ export default DiscourseRoute.extend({
         return { params, columns: response.directory_columns };
       })
       .catch(popupAjaxError);
-  },
+  }
 
   setupController(controller, model) {
     controller.set("columns", model.columns);
@@ -63,5 +63,5 @@ export default DiscourseRoute.extend({
       controller.loadGroups(),
       controller.loadUsers(model.params),
     ]);
-  },
-});
+  }
+}


### PR DESCRIPTION
Only remaining ones are `routes/discourse.js` and `routes/application.js`. Those two both contain legacy `actions: {}` hashes which need to be updated before being converted to native class syntax.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
