### PR TITLE
UX: constrain width of chat transcripts in posts

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -77,6 +77,7 @@
         }
 
         .chat-transcript-thread {
+          min-width: 0;
           &-header {
             margin-bottom: 0.5rem;
           }


### PR DESCRIPTION
Code can cause the transcripts to be too wide, this allows the container to shrink to fit. 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/244b1bfd-c297-49af-b1d0-537cd65dfb39)


After:
![image](https://github.com/discourse/discourse/assets/1681963/ba429e62-7e88-4451-b982-ff71503c5f65)
