### PR TITLE
FIX: ensures bulk-select is correctly working on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -167,7 +167,9 @@ export default class BulkSelectTopicsDropdown extends Component {
   }
 
   @action
-  onSelect(id) {
+  async onSelect(id) {
+    await this.dMenu.close();
+
     switch (id) {
       case "update-category":
         this.showBulkTopicActionsModal(id, "change_category", {
@@ -225,8 +227,6 @@ export default class BulkSelectTopicsDropdown extends Component {
           });
         }
     }
-
-    this.dMenu.close();
   }
 
   @action

--- a/spec/system/page_objects/components/topic_list_header.rb
+++ b/spec/system/page_objects/components/topic_list_header.rb
@@ -11,11 +11,11 @@ module PageObjects
       end
 
       def has_bulk_select_button?
-        page.has_css?("#{TOPIC_LIST_HEADER_SELECTOR} button.bulk-select")
+        page.has_css?(".bulk-select")
       end
 
       def click_bulk_select_button
-        find("#{TOPIC_LIST_HEADER_SELECTOR} button.bulk-select").click
+        find(".bulk-select").click
       end
 
       def has_bulk_select_topics_dropdown?

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -35,6 +35,14 @@ describe "Topic bulk select", type: :system do
       expect(topic_bulk_actions_modal).to be_open
     end
 
+    context "when in mobile", mobile: true do
+      it "is working" do
+        # behavior is already tested on desktop, we simply ensure
+        # the general workflow is working on mobile
+        open_append_modal
+      end
+    end
+
     it "appends tags to selected topics" do
       open_append_modal
 


### PR DESCRIPTION
Prior to this fix we were opening a modal before closing the `DMenu` modal, given `DModal` expects only one modal at a time it was closing the latest modal and instantly closing the one we just opened.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
