### PR TITLE
FIX: ensures bulk-select on messages page is working

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -40,7 +40,7 @@ export default class extends Controller {
   @readOnly("site.can_tag_pms") pmTaggingEnabled;
 
   get bulkSelectHelper() {
-    this.userTopicsList.bulkSelectHelper;
+    return this.userTopicsList.bulkSelectHelper;
   }
 
   get messagesDropdownValue() {


### PR DESCRIPTION
The issue was simple, we were just not returning the helper in the `user-private-messages` controller which was preventing any action to happen.

Follow up: we should write specs for this toggle.

Internal: t/-/128853

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
