### PR TITLE
FIX: Lazy TikTok embeds height in chat

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -78,5 +78,8 @@ $max_image_height: 150px;
     object-fit: contain;
     max-height: $max_image_height;
     max-width: calc(#{$max_image_height} / 9 * 16);
+    &:has(div[data-provider-name="tiktok"]) {
+      max-height: unset;
+    }
   }
 }


### PR DESCRIPTION
TikTok embeds are vertical and not resizable. We need to allow them to have a greater height than other embeds. This is still under the experimental site setting `lazy_tiktok_enabled`, which is disabled by default.