### PR TITLE
UX: Use regular reset-password flow for expired passwords

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/login.hbs
@@ -5,6 +5,7 @@
   @flash={{this.flash}}
   @flashType={{this.flashType}}
   {{did-insert this.preloadLogin}}
+  {{on "click" this.interceptResetLink}}
 >
   <:body>
     <PluginOutlet @name="login-before-modal-body" @connectorTagName="div" />

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -353,13 +353,7 @@ class SessionController < ApplicationController
 
       # User's password has expired so they need to reset it
       if user.password_expired?(password)
-        begin
-          enqueue_password_reset_for_user(user)
-        rescue RateLimiter::LimitExceeded
-          # Just noop here as user would have already been sent the forgot password email more than once
-        end
-
-        render json: { error: I18n.t("login.password_expired") }
+        render json: { error: "expired", reason: "expired" }
         return
       end
     else

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2291,6 +2291,7 @@ en:
       error: "Unknown error"
       cookies_error: "Your browser seems to have cookies disabled. You might not be able to log in without enabling them first."
       rate_limit: "Please wait before trying to log in again."
+      password_expired: "Password expired. Please <a href='%{reset_url}'>reset your password</a>."
       blank_username: "Please enter your email or username."
       blank_username_or_password: "Please enter your email or username, and password."
       reset_password: "Reset Password"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2899,7 +2899,6 @@ en:
     not_approved: "Your account hasn't been approved yet. You will be notified by email when you are ready to log in."
     incorrect_username_email_or_password: "Incorrect username, email or password"
     incorrect_password: "Incorrect password"
-    password_expired: "Password expired. Reset instructions sent to your email."
     incorrect_password_or_passkey: "Incorrect password or passkey"
     wait_approval: "Thanks for signing up. We will notify you when your account has been approved."
     active: "Your account is activated and ready to use."


### PR DESCRIPTION
This makes it more obvious what's happening, and makes it much less likely that users will send repeated reset emails (and thereby hit the rate limit)

Followup to e97ef7e9af60788f5761f6989ea2b70edaa3b79d

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
