### PR TITLE
DEV: Fix the order of operations in themes-frontend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,12 +147,8 @@ jobs:
           key: ${{ runner.os }}-plugin-gems-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-${{ hashFiles('plugins/*/plugin.rb') }}
 
       - name: Checkout official themes
-        if: matrix.target == 'themes' && matrix.build_type == 'system'
-        run: bin/rake themes:clone_all_official
-
-      - name: Pull compatible versions of themes
         if: matrix.target == 'themes'
-        run: bin/rake themes:pull_compatible_all
+        run: bin/rake themes:clone_all_official themes:pull_compatible_all
 
       - name: Add hosts to /etc/hosts, otherwise Chromium cannot reach minio
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -255,7 +255,7 @@ end
 # Note that this should only be used in CI where it is safe to mutate the database without rolling back since running
 # the themes QUnit tests requires the themes to be installed in the database.
 desc "Runs qunit tests for all official themes"
-task "themes:qunit_all_official" => ["themes:clone_all_official", :environment] do |task, args|
+task "themes:qunit_all_official" => :environment do |task, args|
   theme_ids_with_qunit_tests = []
 
   ThemeMetadata::OFFICIAL_THEMES.each do |theme_name|


### PR DESCRIPTION
Previously "themes frontend" CI job would:

1. pull compatible versions of themes that happened to be in the base image
2. clone all official themes (overriding the compatible versions from 1.)
3. run tests