### PR TITLE
UX: Show message and chat buttons on hidden profiles

### DIFF
--- a/app/serializers/hidden_profile_serializer.rb
+++ b/app/serializers/hidden_profile_serializer.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class HiddenProfileSerializer < BasicUserSerializer
-  attributes(:profile_hidden?, :title, :primary_group_name)
+  attributes(:profile_hidden?, :title, :primary_group_name, :can_send_private_message_to_user)
 
   def profile_hidden?
     true
+  end
+
+  def can_send_private_message_to_user
+    scope.can_send_private_message?(object)
   end
 
   def primary_group_name

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -150,6 +150,14 @@ after_initialize do
     scope.can_direct_message? && Guardian.new(object).can_chat?
   end
 
+  add_to_serializer(:hidden_profile, :can_chat_user) do
+    return false if !SiteSetting.chat_enabled
+    return false if scope.user.blank? || scope.user.id == object.id
+    return false if !scope.user.user_option.chat_enabled || !object.user_option.chat_enabled
+
+    scope.can_direct_message? && Guardian.new(object).can_chat?
+  end
+
   add_to_serializer(
     :current_user,
     :can_chat,

--- a/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
@@ -53,4 +53,34 @@ describe UsersController do
       expect(notifications.size).to eq(0)
     end
   end
+
+  describe "#show_card" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:another_user) { Fabricate(:user) }
+    context "when hidden users" do
+      before do
+        sign_in(another_user)
+        SiteSetting.chat_enabled = true
+        SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+        SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
+        user.user_option.update!(hide_profile_and_presence: true)
+      end
+
+      it "returns the correct partial response when the user has chat enabled" do
+        user.user_option.update!(chat_enabled: true)
+        get "/u/#{user.username}/card.json"
+        expect(response).to be_successful
+        expect(response.parsed_body["user"]["profile_hidden"]).to eq(true)
+        expect(response.parsed_body["user"]["can_chat_user"]).to eq(true)
+      end
+
+      it "returns the correct partial response when the user has chat disabled" do
+        user.user_option.update!(chat_enabled: false)
+        get "/u/#{user.username}/card.json"
+        expect(response).to be_successful
+        expect(response.parsed_body["user"]["profile_hidden"]).to eq(true)
+        expect(response.parsed_body["user"]["can_chat_user"]).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows displaying the Chat/Message buttons on the user's profile even when the user has their public profile hidden

<div align=center>

![2024-06-07_04-21](https://github.com/discourse/discourse/assets/66427541/6ca4f8c9-ecbf-4a3d-bf22-cd2374b0def3)
![2024-06-07_04-21_1](https://github.com/discourse/discourse/assets/66427541/7cee0e74-675c-4145-b090-42b16dbe1fff)

![2024-06-07_04-20_1](https://github.com/discourse/discourse/assets/66427541/28528aff-2918-4a4b-a64c-ba58eac5e50e)
![2024-06-07_04-20](https://github.com/discourse/discourse/assets/66427541/eb8b0d64-5254-4677-a2c7-4fed3c6d174a)

</div>
