### PR TITLE
DEV: Remove uses of `@on` from native classes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/secret-value-list.js
+++ b/app/assets/javascripts/admin/addon/components/secret-value-list.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import { action, set } from "@ember/object";
 import { isEmpty } from "@ember/utils";
 import { classNameBindings } from "@ember-decorators/component";
-import { on } from "@ember-decorators/object";
 import I18n from "discourse-i18n";
 
 @classNameBindings(":value-list", ":secret-value-list")
@@ -12,13 +11,12 @@ export default class SecretValueList extends Component {
   values = null;
   validationMessage = null;
 
-  @on("didReceiveAttrs")
-  _setupCollection() {
-    const values = this.values;
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
 
     this.set(
       "collection",
-      this._splitValues(values, this.inputDelimiter || "\n")
+      this._splitValues(this.values, this.inputDelimiter || "\n")
     );
   }
 

--- a/app/assets/javascripts/admin/addon/components/simple-list.js
+++ b/app/assets/javascripts/admin/addon/components/simple-list.js
@@ -4,7 +4,6 @@ import { action } from "@ember/object";
 import { empty } from "@ember/object/computed";
 import { isEmpty } from "@ember/utils";
 import { classNameBindings } from "@ember-decorators/component";
-import { on } from "@ember-decorators/object";
 import discourseComputed from "discourse-common/utils/decorators";
 
 @classNameBindings(":simple-list", ":value-list")
@@ -18,8 +17,8 @@ export default class SimpleList extends Component {
   choices = null;
   allowAny = false;
 
-  @on("didReceiveAttrs")
-  _setupCollection() {
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
     this.set("collection", this._splitValues(this.values, this.inputDelimiter));
     this.set("isPredefinedList", !this.allowAny && !isEmpty(this.choices));
   }

--- a/app/assets/javascripts/admin/addon/components/site-text-summary.js
+++ b/app/assets/javascripts/admin/addon/components/site-text-summary.js
@@ -1,13 +1,13 @@
 import Component from "@ember/component";
 import { classNameBindings, classNames } from "@ember-decorators/component";
-import { on } from "@ember-decorators/object";
 import highlightHTML from "discourse/lib/highlight-html";
 
 @classNames("site-text")
 @classNameBindings("siteText.overridden")
 export default class SiteTextSummary extends Component {
-  @on("didInsertElement")
-  highlightTerm() {
+  didInsertElement() {
+    super.didInsertElement(...arguments);
+
     const term = this._searchTerm();
 
     if (term) {

--- a/app/assets/javascripts/admin/addon/components/value-list.js
+++ b/app/assets/javascripts/admin/addon/components/value-list.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { empty, reads } from "@ember/object/computed";
 import { classNames } from "@ember-decorators/component";
-import { on } from "@ember-decorators/object";
 import { makeArray } from "discourse-common/lib/helpers";
 import discourseComputed from "discourse-common/utils/decorators";
 
@@ -18,17 +17,17 @@ export default class ValueList extends Component {
 
   @reads("addKey") noneKey;
 
-  @on("didReceiveAttrs")
-  _setupCollection() {
-    const values = this.values;
+  didReceiveAttrs() {
+    super.didReceiveAttrs(...arguments);
+
     if (this.inputType === "array") {
-      this.set("collection", values || []);
+      this.set("collection", this.values || []);
       return;
     }
 
     this.set(
       "collection",
-      this._splitValues(values, this.inputDelimiter || "\n")
+      this._splitValues(this.values, this.inputDelimiter || "\n")
     );
   }
 

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -1,7 +1,6 @@
 import { warn } from "@ember/debug";
 import { computed, get } from "@ember/object";
 import { service } from "@ember/service";
-import { on } from "@ember-decorators/object";
 import { ajax } from "discourse/lib/ajax";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import PermissionType from "discourse/models/permission-type";
@@ -426,13 +425,13 @@ export default class Category extends RestModel {
 
   permissions = null;
 
-  @on("init")
-  setupGroupsAndPermissions() {
-    const availableGroups = this.available_groups;
-    if (!availableGroups) {
+  init() {
+    super.init(...arguments);
+
+    if (!this.available_groups) {
       return;
     }
-    this.set("availableGroups", availableGroups);
+    this.set("availableGroups", this.available_groups);
 
     const groupPermissions = this.group_permissions;
 
@@ -440,7 +439,7 @@ export default class Category extends RestModel {
       this.set(
         "permissions",
         groupPermissions.map((elem) => {
-          availableGroups.removeObject(elem.group_name);
+          this.available_groups.removeObject(elem.group_name);
           return elem;
         })
       );

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -427,18 +427,20 @@ export default class Category extends RestModel {
 
   init() {
     super.init(...arguments);
+    this.setupGroupsAndPermissions();
+  }
 
+  setupGroupsAndPermissions() {
     if (!this.available_groups) {
       return;
     }
+
     this.set("availableGroups", this.available_groups);
 
-    const groupPermissions = this.group_permissions;
-
-    if (groupPermissions) {
+    if (this.group_permissions) {
       this.set(
         "permissions",
-        groupPermissions.map((elem) => {
+        this.group_permissions.map((elem) => {
           this.available_groups.removeObject(elem.group_name);
           return elem;
         })

--- a/app/assets/javascripts/discourse/app/models/user-posts-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-posts-stream.js
@@ -3,22 +3,15 @@ import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { url } from "discourse/lib/computed";
 import UserAction from "discourse/models/user-action";
-import { on } from "discourse-common/utils/decorators";
 
 export default class UserPostsStream extends EmberObject {
   loaded = false;
+  itemsLoaded = 0;
+  canLoadMore = true;
+  content = [];
 
   @url("user.username_lower", "filter", "itemsLoaded", "/posts/%@/%@?offset=%@")
   url;
-
-  @on("init")
-  _initialize() {
-    this.setProperties({
-      itemsLoaded: 0,
-      canLoadMore: true,
-      content: [],
-    });
-  }
 
   filterBy(opts) {
     if (this.loaded && this.filter === opts.filter) {


### PR DESCRIPTION
Fixes a deprecation warning introduced in a64f021f4984a7120a4a3fd95932df150c2dcfd1 and removes all uses of `@on` in native classes. (those are unnecessary)