### PR TITLE
UX: add space between revision avatar and username

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -75,6 +75,7 @@
   .revision-details__user {
     display: flex;
     align-items: center;
+    gap: 0.25em;
   }
 
   .revision__title,


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse/assets/1681963/1173442f-42b1-4f30-97bb-4a39cdea31b2)


After:
![image](https://github.com/discourse/discourse/assets/1681963/83bc3b74-2f18-4dfa-861f-4c7d7086b3fb)
