### PR TITLE
UX: fix only-emoji size in user-stream excerpts

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -140,6 +140,13 @@
     details.disabled {
       color: var(--primary-medium);
     }
+    .emoji.only-emoji {
+      // oversized emoji break excerpt layout
+      // so we match inline emoji size
+      width: 20px;
+      height: 20px;
+      margin: 0;
+    }
   }
 
   .group-member-info {


### PR DESCRIPTION
excerpt content is mostly rendered inline to be shorter, so the large emojis in posts (within tables and other elements) don't really work 

before:
![image](https://github.com/discourse/discourse/assets/1681963/7daa74c9-04f1-496a-b644-b8cf952fd3ef)


after:
![image](https://github.com/discourse/discourse/assets/1681963/c820fafe-6db1-42c0-8403-475dd4f06993)
