### PR TITLE
UX: prevent twitter like/retweet counts from wrapping

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -693,6 +693,7 @@ aside.onebox.twitterstatus .onebox-body {
     color: var(--primary-medium);
     display: flex;
     margin-left: 0.75em;
+    white-space: nowrap;
 
     svg {
       fill: currentColor;


### PR DESCRIPTION
most commonly seen in chat threads because the width is adjustable 

before:
![image](https://github.com/discourse/discourse/assets/1681963/c970f02d-f0e3-485c-a417-6ac1c2c98efe)


after:
![image](https://github.com/discourse/discourse/assets/1681963/ac44dda7-cd89-4334-978b-93ab9676068f)
