### PR TITLE
UX: move users link to the top of the admin sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -83,13 +83,6 @@ export const ADMIN_NAV_MAP = [
         icon: "user-shield",
       },
       {
-        name: "admin_users",
-        route: "adminUsers",
-        label: "admin.community.sidebar_link.users",
-        icon: "users",
-        moderator: true,
-      },
-      {
         name: "admin_user_fields",
         route: "adminUserFields",
         label: "admin.community.sidebar_link.user_fields",

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -159,6 +159,13 @@ export function useAdminNavConfig(navMap) {
           moderator: true,
         },
         {
+          name: "admin_users",
+          route: "adminUsers",
+          label: "admin.community.sidebar_link.users",
+          icon: "users",
+          moderator: true,
+        },
+        {
           name: "admin_all_site_settings",
           route: "adminSiteSettings",
           label: "admin.advanced.sidebar_link.all_site_settings",

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -34,8 +34,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "collapses sections by default" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(2)
-    expect(links.map(&:text)).to eq(["Dashboard", "All Site Settings"])
+    expect(links.count).to eq(3)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
   end
 
   it "respects the user homepage preference for the Back to Forum link" do
@@ -116,8 +116,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "temporarily expands section when filter" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(2)
-    expect(links.map(&:text)).to eq(["Dashboard", "All Site Settings"])
+    expect(links.count).to eq(3)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
 
     filter.filter("ie")
     links = page.all(".sidebar-section-link-content-text")
@@ -126,8 +126,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
 
     filter.filter("")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(2)
-    expect(links.map(&:text)).to eq(["Dashboard", "All Site Settings"])
+    expect(links.count).to eq(3)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
   end
 
   it "allows further filtering of site settings or users if links do not show results" do
@@ -167,8 +167,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     sidebar.toggle_all_sections
 
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(2)
-    expect(links.map(&:text)).to eq(["Dashboard", "All Site Settings"])
+    expect(links.count).to eq(3)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
 
     sidebar.toggle_all_sections
     links = page.all(".sidebar-section-link-content-text")
@@ -224,9 +224,9 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(links.map(&:text)).to eq(
       [
         "Dashboard",
+        "Users",
         "What's New",
         "All",
-        "Users",
         "Watched Words",
         "Screened Emails",
         "Screened IPs",


### PR DESCRIPTION
Before, users link was in the community section.

<img width="463" alt="Screenshot 2024-06-05 at 10 55 20 AM" src="https://github.com/discourse/discourse/assets/72780/ddfa5d2b-20a2-4f18-b82a-1a2bf0ec17dd">

