### PR TITLE
FIX: Pluralisation for short password count

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/password-validation.js
+++ b/app/assets/javascripts/discourse/app/mixins/password-validation.js
@@ -82,7 +82,7 @@ export default Mixin.create({
       return EmberObject.create(
         Object.assign(failedAttrs, {
           reason: I18n.t("user.password.too_short", {
-            password_min_length: passwordMinLength,
+            count: passwordMinLength,
           }),
         })
       );

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -79,7 +79,7 @@ acceptance("Password Reset", function (needs) {
     assert.ok(
       query(".password-reset .tip.bad").innerHTML.includes(
         I18n.t("user.password.too_short", {
-          password_min_length: this.siteSettings.min_password_length,
+          count: this.siteSettings.min_password_length,
         })
       ),
       "password too short"

--- a/app/assets/javascripts/discourse/tests/unit/components/create-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/components/create-account-test.js
@@ -81,7 +81,7 @@ module("Unit | Component | create-account", function (hooks) {
     testInvalidPassword(
       "x",
       I18n.t("user.password.too_short", {
-        password_min_length: siteSettings.min_password_length,
+        count: siteSettings.min_password_length,
       })
     );
     testInvalidPassword(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1936,8 +1936,8 @@ en:
       password:
         title: "Password"
         too_short:
-          one: "Your password is too short (minimum is %{password_min_length} character)."
-          other: "Your password is too short (minimum is %{password_min_length} characters)."
+          one: "Your password is too short (minimum is %{count} character)."
+          other: "Your password is too short (minimum is %{count} characters)."
         common: "That password is too common."
         same_as_username: "Your password is the same as your username."
         same_as_email: "Your password is the same as your email."


### PR DESCRIPTION
Followup 0434112aa71fc091583d8356a84fbf958f7228fb,
when I introduced the pluralisation for the
password.too_short message I didn't change the
key name to `count`, which is necessary.
