### PR TITLE
DEV: Search for `-gnu` gem variants

### DIFF
--- a/lib/plugin_gem.rb
+++ b/lib/plugin_gem.rb
@@ -34,12 +34,13 @@ module PluginGem
 
   def self.platform_variants(spec_file)
     platform_less = "#{spec_file}.gemspec"
-
     platform_full = "#{spec_file}-#{RUBY_PLATFORM}.gemspec"
-
     platform_version_less =
       "#{spec_file}-#{Gem::Platform.local.cpu}-#{Gem::Platform.local.os}.gemspec"
 
-    [platform_less, platform_full, platform_version_less]
+    variants = [platform_less, platform_full, platform_version_less]
+    variants << "#{spec_file}-#{RUBY_PLATFORM}-gnu.gemspec" if RUBY_PLATFORM.end_with?("-linux")
+
+    variants.uniq
   end
 end


### PR DESCRIPTION
> Platform names with a *-linux suffix are aliases for *-linux-gnu

Should fix the ffi upgrade issue

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
