### PR TITLE
DEV: Fix invalid hbs syntax in tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -88,7 +88,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("-expanded class", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-menu__trigger").doesNotHaveClass("-expanded");
 
@@ -98,7 +98,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("trigger id attribute", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-menu__trigger").hasAttribute("id");
   });
@@ -116,7 +116,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("aria-expanded attribute", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-menu__trigger").hasAttribute("aria-expanded", "false");
 
@@ -144,7 +144,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("content role attribute", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
     await open();
 
@@ -168,7 +168,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("content aria-labelledby attribute", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
     await open();
 
@@ -180,7 +180,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
 
   test("@closeOnEscape", async function (assert) {
     await render(
-      hbs`<DMenu @inline={{true}} @label="label" @closeOnEscape={{true}}  />`
+      hbs`<DMenu @inline={{true}} @label="label" @closeOnEscape={{true}} />`
     );
     await open();
     await triggerKeyEvent(document.activeElement, "keydown", "Escape");
@@ -188,7 +188,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu").doesNotExist();
 
     await render(
-      hbs`<DMenu @inline={{true}} @label="label" @closeOnEscape={{false}}  />`
+      hbs`<DMenu @inline={{true}} @label="label" @closeOnEscape={{false}} />`
     );
     await open();
     await triggerKeyEvent(document.activeElement, "keydown", "Escape");
@@ -198,7 +198,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
 
   test("@closeOnClickOutside", async function (assert) {
     await render(
-      hbs`<span class="test">test</span><DMenu @inline={{true}} @label="label" @closeOnClickOutside={{true}}  />`
+      hbs`<span class="test">test</span><DMenu @inline={{true}} @label="label" @closeOnClickOutside={{true}} />`
     );
     await open();
     await triggerEvent(".test", "pointerdown");
@@ -206,7 +206,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu").doesNotExist();
 
     await render(
-      hbs`<span class="test">test</span><DMenu @inline={{true}} @label="label" @closeOnClickOutside={{false}}  />`
+      hbs`<span class="test">test</span><DMenu @inline={{true}} @label="label" @closeOnClickOutside={{false}} />`
     );
     await open();
     await triggerEvent(".test", "pointerdown");
@@ -216,7 +216,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
 
   test("@maxWidth", async function (assert) {
     await render(
-      hbs`<DMenu @inline={{true}} @label="label" @maxWidth={{20}}  />`
+      hbs`<DMenu @inline={{true}} @label="label" @maxWidth={{20}} />`
     );
     await open();
 
@@ -226,7 +226,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("applies position", async function (assert) {
-    await render(hbs`<DMenu @inline={{true}} @label="label"  />`);
+    await render(hbs`<DMenu @inline={{true}} @label="label" />`);
     await open();
 
     assert.dom(".fk-d-menu").hasAttribute("style", /left: /);

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-tooltip-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-tooltip-test.js
@@ -88,13 +88,13 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
   });
 
   test("trigger role attribute", async function (assert) {
-    await render(hbs`<DTooltip @inline={{true}} @label="label"  />`);
+    await render(hbs`<DTooltip @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-tooltip__trigger").hasAttribute("role", "button");
   });
 
   test("trigger id attribute", async function (assert) {
-    await render(hbs`<DTooltip @inline={{true}} @label="label"  />`);
+    await render(hbs`<DTooltip @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-tooltip__trigger").hasAttribute("id");
   });
@@ -112,7 +112,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
   });
 
   test("aria-expanded attribute", async function (assert) {
-    await render(hbs`<DTooltip @inline={{true}} @label="label"  />`);
+    await render(hbs`<DTooltip @inline={{true}} @label="label" />`);
 
     assert.dom(".fk-d-tooltip__trigger").hasAttribute("aria-expanded", "false");
 
@@ -123,7 +123,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
 
   test("<:trigger>", async function (assert) {
     await render(
-      hbs`<DTooltip @inline={{true}}><:trigger>label</:trigger></DTooltip />`
+      hbs`<DTooltip @inline={{true}}><:trigger>label</:trigger></DTooltip>`
     );
 
     assert.dom(".fk-d-tooltip__trigger").hasText("label");
@@ -131,7 +131,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
 
   test("<:content>", async function (assert) {
     await render(
-      hbs`<DTooltip @inline={{true}}><:content>content</:content></DTooltip />`
+      hbs`<DTooltip @inline={{true}}><:content>content</:content></DTooltip>`
     );
 
     await hover();
@@ -140,7 +140,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
   });
 
   test("content role attribute", async function (assert) {
-    await render(hbs`<DTooltip @inline={{true}} @label="label"  />`);
+    await render(hbs`<DTooltip @inline={{true}} @label="label" />`);
 
     await hover();
 
@@ -164,7 +164,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
   });
 
   test("content aria-labelledby attribute", async function (assert) {
-    await render(hbs`<DTooltip @inline={{true}} @label="label"  />`);
+    await render(hbs`<DTooltip @inline={{true}} @label="label" />`);
 
     await hover();
 

--- a/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
@@ -125,7 +125,7 @@ module("Integration | Component | user-info", function (hooks) {
     this.currentUser.status = { emoji: "tooth", description: "off to dentist" };
 
     await render(
-      hbs`<UserInfo @user={{this.currentUser}} @showStatus={{true}}  /><DTooltips />`
+      hbs`<UserInfo @user={{this.currentUser}} @showStatus={{true}} /><DTooltips />`
     );
     await triggerEvent(query(".user-status-message"), "mousemove");
 


### PR DESCRIPTION
Followup to 26198fb32817c6df336ea20e6d234f0f58d663da

also removes superfluous whitespace

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
