### PR TITLE
UX: improve topic timeline date titles

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -74,7 +74,7 @@
       <a
         class="start-date"
         onClick={{this.updatePercentage}}
-        title={{this.startDate}}
+        title={{i18n "topic_entrance.sr_jump_top_button"}}
       >
         <span>
           {{this.startDate}}

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -193,6 +193,7 @@ export default class TopicTimelineScrollArea extends Component {
 
   get nowDateOptions() {
     return {
+      customTitle: I18n.t("topic_entrance.sr_jump_bottom_button"),
       addAgo: true,
       defaultFormat: timelineDate,
     };

--- a/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
+++ b/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
@@ -7,6 +7,7 @@ registerRawHelper("age-with-tooltip", ageWithTooltip);
 export default function ageWithTooltip(dt, params = {}) {
   return htmlSafe(
     autoUpdatingRelativeAge(new Date(dt), {
+      customTitle: params.customTitle,
       title: true,
       addAgo: params.addAgo || false,
       ...(params.defaultFormat && { defaultFormat: params.defaultFormat }),

--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -98,7 +98,9 @@ export function autoUpdatingRelativeAge(date, options) {
     append += " with-year";
   }
 
-  if (options.title) {
+  if (options.customTitle) {
+    append += "' title='" + options.customTitle;
+  } else if (options.title) {
     append += "' title='" + longDate(date);
   }
 


### PR DESCRIPTION
The redundant dates in title are not useful, we should describe the button functionality instead.

Before:
![image](https://github.com/discourse/discourse/assets/1681963/72eb4386-79c8-4f8a-80fb-657017727bc3)

![image](https://github.com/discourse/discourse/assets/1681963/1d86a0cc-60e9-4393-a95b-4c157fe9d6e6)


After:
![image](https://github.com/discourse/discourse/assets/1681963/41b7a8d7-7e66-44b9-b3b5-79ed8acd2109)

![image](https://github.com/discourse/discourse/assets/1681963/f1c72533-73a7-4bff-9fbe-ac88339a4157)
