### PR TITLE
FIX: ensures invalid OTP blocks submit

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/password-reset.js
+++ b/app/assets/javascripts/discourse/app/controllers/password-reset.js
@@ -93,7 +93,7 @@ export default Controller.extend(PasswordValidation, {
               DiscourseURL.redirectTo(result.redirect_to || "/");
             }
           } else {
-            if (result.errors && !result.errors.password) {
+            if (result.errors.security_keys) {
               this.setProperties({
                 secondFactorRequired: this.secondFactorRequired,
                 securityKeyRequired: this.securityKeyRequired,

--- a/app/assets/javascripts/discourse/app/controllers/password-reset.js
+++ b/app/assets/javascripts/discourse/app/controllers/password-reset.js
@@ -93,7 +93,10 @@ export default Controller.extend(PasswordValidation, {
               DiscourseURL.redirectTo(result.redirect_to || "/");
             }
           } else {
-            if (result.errors.security_keys) {
+            if (
+              result.errors.security_keys ||
+              result.errors.user_second_factors
+            ) {
               this.setProperties({
                 secondFactorRequired: this.secondFactorRequired,
                 securityKeyRequired: this.securityKeyRequired,

--- a/app/assets/javascripts/discourse/app/templates/password-reset.hbs
+++ b/app/assets/javascripts/discourse/app/templates/password-reset.hbs
@@ -70,6 +70,10 @@
           {{/unless}}
         {{else}}
           <h2>{{i18n "user.change_password.choose"}}</h2>
+          {{#if this.errorMessage}}
+            <div class="alert alert-error">{{this.errorMessage}}</div>
+            <br />
+          {{/if}}
 
           <div class="input">
             <PasswordField

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -187,6 +187,26 @@ shared_examples "login scenarios" do
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
 
+    it "shows error correctly when TOTP code is invalid" do
+      login_modal.open
+      login_modal.fill_username("john")
+      login_modal.forgot_password
+      find("button.forgot-password-reset").click
+
+      reset_password_link = wait_for_email_link(user, :reset_password)
+      visit reset_password_link
+
+      find(".second-factor-token-input").fill_in(with: "123456")
+      find(".password-reset .btn-primary").click
+
+      expect(page).to have_css(
+        ".alert-error",
+        text: "Invalid authentication code. Each code can only be used once.",
+      )
+
+      expect(page).to have_css(".second-factor-token-input")
+    end
+
     it "can reset password with a backup code" do
       login_modal.open
       login_modal.fill_username("john")


### PR DESCRIPTION
The current password reset on 2FA accounts is not showing when the OTP is invalid before you actually submit your password.

Repro:

- add TOTP to a user account
- log out
- start password reset process
- enter wrong TOTP code when asked
- :boom: you see the password input when you should have seen an error and stay on the OTP input step
