### PR TITLE
DEV: reset flag state after toggle flag spec

### DIFF
--- a/spec/services/toggle_flag_spec.rb
+++ b/spec/services/toggle_flag_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe(ToggleFlag) do
 
   let(:flag) { Flag.system.last }
 
+  after do
+    Flag.update_all(enabled: true)
+    Flag.reset_flag_settings!
+  end
+
   context "when user is not allowed to perform the action" do
     fab!(:current_user) { Fabricate(:user) }
 
@@ -13,8 +18,6 @@ RSpec.describe(ToggleFlag) do
 
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
-
-    after { flag.update!(enabled: true) }
 
     it "sets the service result as successful" do
       expect(result).to be_a_success


### PR DESCRIPTION
Another flaky spec because the state was not restored after the toggle flag spec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
