### PR TITLE
DEV: Fix flaky login and activate account system test

### DIFF
--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -45,7 +45,7 @@ shared_examples "login scenarios" do
 
       find("#activate-account-button").click
 
-      visit "/"
+      expect(page).to have_current_path("/")
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
 


### PR DESCRIPTION
After clicking activate, we cannot manually visit "/" and instead need
to wait for the response from the server in order for the user to be
signed in.
