### PR TITLE
UX: create space for new topics banner on /new, /unread

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery/topics.hbs
@@ -34,6 +34,7 @@
   @model={{@model}}
   @incomingCount={{this.topicTrackingState.incomingCount}}
   @bulkSelectHelper={{@bulkSelectHelper}}
+  @class={{if this.footerEducation "--no-topics-education"}}
 >
   {{#if this.top}}
     <div class="top-lists">

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -141,12 +141,15 @@
 }
 
 .topic-list-bottom {
-  margin: 20px 0;
-  .footer-message {
-    padding-top: 4px;
-  }
+  margin: 1.25em 0;
   .dismiss-container-bottom {
     float: right;
+  }
+  .--no-topics-education + & {
+    margin: 0;
+    .footer-message {
+      padding-top: 4em;
+    }
   }
 }
 


### PR DESCRIPTION
Solves this issue by adding a class to `.contents` when the education footer message is present: https://meta.discourse.org/t/new-or-unread-topics-banners-cover-text-at-new-unread/301669

Before:
![image](https://github.com/discourse/discourse/assets/1681963/91742a3f-5081-45e8-8c78-368b0670b02a)

![image](https://github.com/discourse/discourse/assets/1681963/56173232-e697-4a50-b7d9-4c0e72334d27)



After:
![image](https://github.com/discourse/discourse/assets/1681963/8108a18f-5930-46c0-bc0d-102e061060c3)

![image](https://github.com/discourse/discourse/assets/1681963/eba33942-49cb-4a71-9a51-984fc5cc5751)


Mobile's new/unread banner shifts content down to accommodate, so there's no change there. 
