### PR TITLE
FIX: flaky specs related to flags

### DIFF
--- a/spec/services/toggle_flag_spec.rb
+++ b/spec/services/toggle_flag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe(ToggleFlag) do
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
 
-    after { flag.update!(enabled: true) }
+    after { flag.reload.update!(enabled: true) }
 
     it "sets the service result as successful" do
       expect(result).to be_a_success


### PR DESCRIPTION
Because the flag was not reloaded and contained old values, `update! `was not triggered and didn't clean flags to the original state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
