### PR TITLE
DEV: prevent duplication of chat drawer routes

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -15,6 +15,7 @@ export default class ChatRoute extends DiscourseRoute {
   @service chat;
   @service router;
   @service chatStateManager;
+  @service chatDrawerRouter;
   @service currentUser;
 
   titleToken() {
@@ -26,29 +27,10 @@ export default class ChatRoute extends DiscourseRoute {
       return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
 
-    const INTERCEPTABLE_ROUTES = [
-      "chat.channel",
-      "chat.direct-messages",
-      "chat.channels",
-      "chat.threads",
-      "chat.channel.thread",
-      "chat.channel.thread.index",
-      "chat.channel.thread.near-message",
-      "chat.channel.near-message-with-thread",
-      "chat.channel.threads",
-      "chat.channel.index",
-      "chat.channel.near-message",
-      "chat.channel-legacy",
-      "chat.channel.info.settings",
-      "chat.channel.info.members",
-      "chat",
-      "chat.index",
-    ];
-
     if (
       transition.from && // don't intercept when directly loading chat
       this.chatStateManager.isDrawerPreferred &&
-      INTERCEPTABLE_ROUTES.includes(transition.targetName)
+      this.chatDrawerRouter.routeNames.includes(transition.targetName)
     ) {
       transition.abort();
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -9,7 +9,9 @@ import ChatDrawerRoutesSettings from "discourse/plugins/chat/discourse/component
 import ChatDrawerRoutesThreads from "discourse/plugins/chat/discourse/components/chat/drawer-routes/threads";
 
 const ROUTES = {
+  "chat.index": { name: ChatDrawerRoutesChannels },
   "chat.channel": { name: ChatDrawerRoutesChannel },
+  "chat.channel.index": { name: ChatDrawerRoutesChannel },
   "chat.channel.thread": {
     name: ChatDrawerRoutesChannelThread,
     extractParams: (route) => {
@@ -102,6 +104,8 @@ export default class ChatDrawerRouter extends Service {
   @tracked component = null;
   @tracked drawerRoute = null;
   @tracked params = null;
+
+  routeNames = Object.keys(ROUTES);
 
   stateFor(route) {
     this.drawerRoute?.deactivate?.(this.chatHistory.currentRoute);


### PR DESCRIPTION
This change prevents explicitly declaring each route that should be intercepted for chat drawer mode.

In theory all chat drawer routes should be intercepted from the main chat routes file and therefore we would only need to add new drawer routes directly within `chat-drawer-router.js`.