### PR TITLE
DEV: Also fetch user when granting admin (stable)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,6 +8,7 @@ class Admin::UsersController < Admin::StaffController
                   suspend
                   unsuspend
                   log_out
+                  grant_admin
                   revoke_admin
                   revoke_moderation
                   grant_moderation


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/27382

> In some admin user controller extensions, @user is used to derive certain values.
>
> The grant_admin method requires @user as well, so we are adding it here. This is tested in the plugin that it is used in. (see below)