### PR TITLE
UX: make chat drawer settings page full height

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
@@ -579,6 +579,12 @@ export default class ChatRouteChannelInfoSettings extends Component {
         {{/if}}
 
         <form.section class="--leave-channel" as |section|>
+          {{#if @channel.chatable.group}}
+            <div class="c-channel-settings__leave-info">
+              {{icon "exclamation-triangle"}}
+              {{i18n "chat.channel_settings.leave_groupchat_info"}}
+            </div>
+          {{/if}}
           <section.row>
             <:action>
               <ToggleChannelMembershipButton
@@ -593,12 +599,6 @@ export default class ChatRouteChannelInfoSettings extends Component {
               />
             </:action>
           </section.row>
-          {{#if @channel.chatable.group}}
-            <div class="c-channel-settings__leave-info">
-              {{icon "exclamation-triangle"}}
-              {{i18n "chat.channel_settings.leave_groupchat_info"}}
-            </div>
-          {{/if}}
         </form.section>
       </ChatForm>
     </div>

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -90,10 +90,25 @@ html.rtl {
 
 .chat-drawer-content {
   @include chat-scrollbar();
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   height: 100%;
   min-height: 1px;
   position: relative;
   overflow-y: auto;
   overscroll-behavior: contain;
+
+  .c-channel-settings {
+    flex-grow: 1;
+
+    .chat-form {
+      height: 100%;
+    }
+
+    .chat-form__section.--leave-channel {
+      margin-top: auto;
+      margin-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
Now that we can access the settings page in desktop drawer, there was an adjustment needed to keep the button at the bottom, which looks better for short pages:

<img width="854" alt="image" src="https://github.com/discourse/discourse/assets/101828855/21594ed4-a5d2-4dff-aa9e-a129130064dd">
VS
<img width="850" alt="image" src="https://github.com/discourse/discourse/assets/101828855/ad920d37-b4b8-4b2e-a413-2d3e1fedc260">


