### PR TITLE
Improve `HtmlToMarkdown`

### DIFF
--- a/lib/html_to_markdown.rb
+++ b/lib/html_to_markdown.rb
@@ -197,7 +197,9 @@ class HtmlToMarkdown
 
   ALLOWED ||= %w[kbd del ins small big sub sup dl dd dt mark]
   ALLOWED.each do |tag|
-    define_method("visit_#{tag}") { |node| "<#{tag}>#{traverse(node)}</#{tag}>" }
+    define_method("visit_#{tag}") do |node|
+      "<#{tag}>#{traverse(node, within_html_block: true)}</#{tag}>"
+    end
   end
 
   def visit_blockquote(node)
@@ -250,8 +252,8 @@ class HtmlToMarkdown
 
   def visit_abbr(node)
     title = node["title"].presence
-    title_attr = title ? %[ title="#{title}"] : ""
-    "<abbr#{title_attr}>#{traverse(node)}</abbr>"
+    attributes = { title: } if title
+    create_element("abbr", traverse(node, within_html_block: true), attributes).to_html
   end
 
   def visit_acronym(node)

--- a/lib/html_to_markdown.rb
+++ b/lib/html_to_markdown.rb
@@ -220,7 +220,7 @@ class HtmlToMarkdown
     "\n\n#{traverse(node)}\n\n"
   end
 
-  TRAVERSABLES ||= %w[aside font span thead tbody tfoot u]
+  TRAVERSABLES ||= %w[aside font span thead tbody tfoot u center]
   TRAVERSABLES.each { |tag| define_method("visit_#{tag}") { |node| traverse(node) } }
 
   def visit_tt(node)

--- a/lib/html_to_markdown.rb
+++ b/lib/html_to_markdown.rb
@@ -220,7 +220,7 @@ class HtmlToMarkdown
     "\n\n#{traverse(node)}\n\n"
   end
 
-  TRAVERSABLES ||= %w[aside font span thead tbody tfooter u]
+  TRAVERSABLES ||= %w[aside font span thead tbody tfoot u]
   TRAVERSABLES.each { |tag| define_method("visit_#{tag}") { |node| traverse(node) } }
 
   def visit_tt(node)

--- a/lib/html_to_markdown.rb
+++ b/lib/html_to_markdown.rb
@@ -26,7 +26,7 @@ class HtmlToMarkdown
   end
 
   def remove_not_allowed!(doc)
-    allowed = Set.new
+    allowed = Set.new(@opts[:additional_allowed_tags] || [])
 
     HtmlToMarkdown.private_instance_methods.each do |m|
       if tag = m.to_s[/^visit_(.+)/, 1]

--- a/spec/lib/html_to_markdown_spec.rb
+++ b/spec/lib/html_to_markdown_spec.rb
@@ -527,6 +527,14 @@ RSpec.describe HtmlToMarkdown do
             <td>line</td>
           </tr>
         </tbody>
+        <tfoot>
+          <tr>
+            <td>This</td>
+            <td>is</td>
+            <td>the</td>
+            <td>footer</td>
+          </tr>
+        </tfoot>
       </table>
     HTML
 
@@ -535,6 +543,7 @@ RSpec.describe HtmlToMarkdown do
       | - | - | - | - |
       | I am | the | **first** | row |
       | And this | is the | 2<sup>nd</sup> | line |
+      | This | is | the | footer |
     MD
 
     expect(html_to_markdown(html)).to eq(markdown.strip)
@@ -565,24 +574,24 @@ RSpec.describe HtmlToMarkdown do
       <table>
       <tr>
       <th>
-      
+
       1
-      
+
       </th>
       <th>
-      
+
       2
-      
+
       </th>
       <th>
-      
+
       3
-      
+
       </th>
       <th>
-      
+
       4
-      
+
       </th>
       </tr>
       <tr>
@@ -592,12 +601,12 @@ RSpec.describe HtmlToMarkdown do
 
       </td>
       <td>
-      
+
       **Two**
 
       </td>
       <td>
-      
+
       Three
 
       </td>
@@ -625,14 +634,14 @@ RSpec.describe HtmlToMarkdown do
       <table>
       <tr>
       <th>
-      
+
       1
-      
+
       </th>
       <th>
-      
+
       2
-      
+
       </th>
       </tr>
       <tr>
@@ -671,31 +680,31 @@ RSpec.describe HtmlToMarkdown do
       <th>
 
       1
-      
+
       </th>
       <th>
-      
+
       2
-      
+
       </th>
       </tr>
       <tr>
       <td>
 
       A
-      
+
       </td>
       <td rowspan="2">
-      
+
       B
-      
+
       </td>
       </tr>
       <tr>
       <td>
-      
+
       C
-      
+
       </td>
       </tr>
       </table>

--- a/spec/lib/html_to_markdown_spec.rb
+++ b/spec/lib/html_to_markdown_spec.rb
@@ -413,6 +413,10 @@ RSpec.describe HtmlToMarkdown do
     expect(html_to_markdown("<u>Underline</u>")).to eq("Underline")
   end
 
+  it "swallows <center>" do
+    expect(html_to_markdown("<center>Centered</center>")).to eq("Centered")
+  end
+
   it "removes <script>" do
     expect(html_to_markdown("<script>var foo = 'bar'</script>")).to eq("")
   end

--- a/spec/lib/html_to_markdown_spec.rb
+++ b/spec/lib/html_to_markdown_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe HtmlToMarkdown do
     )
   end
 
-  it "doesn't swallow badly formatted <table>" do
+  it "keeps HTML for badly formatted <table>" do
     html = <<~HTML
       <table>
         <tr>
@@ -554,13 +554,153 @@ RSpec.describe HtmlToMarkdown do
           <th>4</th>
         </tr>
         <tr>
-          <td>One</td>
-          <td>Two</td>
-          <td>Three</td>
+          <td>&lt;One&gt;</td>
+          <td><strong>Two</strong></td>
+          <td>Three<script>alert("foo")</script></td>
         </tr>
       </table>
     HTML
 
-    expect(html_to_markdown(html)).to eq("1 2 3 4 \nOne Two Three")
+    markdown = <<~MD
+      <table>
+      <tr>
+      <th>
+      
+      1
+      
+      </th>
+      <th>
+      
+      2
+      
+      </th>
+      <th>
+      
+      3
+      
+      </th>
+      <th>
+      
+      4
+      
+      </th>
+      </tr>
+      <tr>
+      <td>
+
+      &lt;One&gt;
+
+      </td>
+      <td>
+      
+      **Two**
+
+      </td>
+      <td>
+      
+      Three
+
+      </td>
+      </tr>
+      </table>
+    MD
+
+    expect(html_to_markdown(html)).to eq(markdown.strip)
+  end
+
+  it "keeps HTML for <table> with colspan" do
+    html = <<~HTML
+      <table>
+        <tr>
+          <th>1</th>
+          <th>2</th>
+        </tr>
+        <tr>
+          <td colspan="2">One / Two</td>
+        </tr>
+      </table>
+    HTML
+
+    markdown = <<~MD
+      <table>
+      <tr>
+      <th>
+      
+      1
+      
+      </th>
+      <th>
+      
+      2
+      
+      </th>
+      </tr>
+      <tr>
+      <td colspan="2">
+
+      One / Two
+
+      </td>
+      </tr>
+      </table>
+    MD
+
+    expect(html_to_markdown(html)).to eq(markdown.strip)
+  end
+
+  it "keeps HTML for <table> with rowspan" do
+    html = <<~HTML
+      <table>
+        <tr>
+          <th>1</th>
+          <th>2</th>
+        </tr>
+        <tr>
+          <td>A</td>
+          <td rowspan="2">B</td>
+        </tr>
+        <tr>
+          <td>C</td>
+        </tr>
+      </table>
+    HTML
+
+    markdown = <<~MD
+      <table>
+      <tr>
+      <th>
+
+      1
+      
+      </th>
+      <th>
+      
+      2
+      
+      </th>
+      </tr>
+      <tr>
+      <td>
+
+      A
+      
+      </td>
+      <td rowspan="2">
+      
+      B
+      
+      </td>
+      </tr>
+      <tr>
+      <td>
+      
+      C
+      
+      </td>
+      </tr>
+      </table>
+    MD
+
+    expect(html_to_markdown(html)).to eq(markdown.strip)
   end
 end


### PR DESCRIPTION
This PR contains multiple commits to make the changes easier to understand.

* **DEV: Add `additional_allowed_tags` to `HtmlToMarkdown`**
Import script often use subclasses of `HtmlToMarkdown` and might need to allow additional tags that can be used within the custom class.

* **FEATURE: Use basic HTML table if it can't be converted to Markdown**
Previously, `HtmlToMarkdown` always converted HTML tables into Markdown tables. That lead to some badly formatted Markdown tables, e.g. when the table contained `rowspan` or `colspan`. This solves the issue by using very basic HTML tables in those cases.

* **FIX: `HtmlToMarkdown` didn't support `tfoot` in tables**

* **FIX: `HtmlToMarkdown` didn't keep text from within `<center>` tag**
It should ignore the `<center>` tag, but keep the text from within the element.

* **FIX: `HtmlToMarkdown` should keep HTML entities for <, > and & within HTML elements**
Not all HTML elements are converted into Markdown. Some are kept as HTML.
Without this fix XML/HTML entities that are formatted as text instead of code are swallowed by Discourse.
This also fixes quotes in the `title` attribute of the `<abbr>` tag.

