### PR TITLE
DEV: Clean up state to prevent flaky tests

### DIFF
--- a/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
+++ b/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
@@ -5,6 +5,7 @@ describe DiscourseAutomation::AdminAutomationsController do
 
   before do
     SiteSetting.discourse_automation_enabled = true
+
     I18n.backend.store_translations(
       :en,
       {
@@ -23,6 +24,8 @@ describe DiscourseAutomation::AdminAutomationsController do
       },
     )
   end
+
+  after { I18n.backend.reload! }
 
   describe "#show" do
     context "when logged in as an admin" do

--- a/plugins/automation/spec/serializers/automation_serializer_spec.rb
+++ b/plugins/automation/spec/serializers/automation_serializer_spec.rb
@@ -41,6 +41,7 @@ describe DiscourseAutomation::AutomationSerializer do
       DiscourseAutomation::Scriptable.add("foo") do
         field :bar, component: :text, triggerable: DiscourseAutomation::Triggers::TOPIC
       end
+
       I18n.backend.store_translations(
         :en,
         {
@@ -55,6 +56,8 @@ describe DiscourseAutomation::AutomationSerializer do
         },
       )
     end
+
+    after { I18n.backend.reload! }
 
     context "when automation is not using the specific trigger" do
       fab!(:automation) do
@@ -72,6 +75,7 @@ describe DiscourseAutomation::AutomationSerializer do
             scope: Guardian.new(user),
             root: false,
           )
+
         expect(serializer.script[:templates]).to eq([])
       end
     end


### PR DESCRIPTION
When adding custom translations for tests using `I18n.backend.store_translations`,
we need to remove the custom translations at the end of each test to
prevent the custom translations from leaking to other tests.
