### PR TITLE
DEV: Monkey patch `Capybara.using_session` to resolve `localhost` in CI

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -519,33 +519,36 @@ RSpec.configure do |config|
       end
     end
 
-    # This is a monkey patch for the `Selenium::WebDriver::Platform.localhost` method in `selenium-webdriver`. For some
+    # This is a monkey patch for the `Capybara.using_session` method in `capybara`. For some
     # unknown reasons on Github Actions, we are seeing system tests failing intermittently with the error
-    # `Socket::ResolutionError: getaddrinfo: Temporary failure in name resolution` when `selenium-webdriver` tries to
-    # resolve `localhost` in a `Capybara#using_session` block.
+    # `Socket::ResolutionError: getaddrinfo: Temporary failure in name resolution` when the app tries to resolve
+    # `localhost` from within a `Capybara#using_session` block. Therefore, we will ensure we can resolve `localhost` first
+    # before starting the new session.
     #
     # Too much time has been spent trying to debug this issue and the root cause is still unknown so we are just dropping
     # this workaround for now.
-    module Selenium
-      module WebDriver
-        module Platform
-          def self.localhost_with_retry
+    module Capybara
+      class << self
+        def using_session_with_localhost_resolution(name, &block)
+          self._using_session(name) do |session|
             attempts = 0
 
             begin
-              localhost_without_retry
+              Socket.getaddrinfo("localhost", 80, Socket::AF_INET, Socket::SOCK_STREAM)
             rescue Socket::ResolutionError
               attempts += 1
               attempts <= 3 ? retry : raise
             end
+
+            block.call(session)
           end
         end
       end
     end
 
-    Selenium::WebDriver::Platform.singleton_class.class_eval do
-      alias_method :localhost_without_retry, :localhost
-      alias_method :localhost, :localhost_with_retry
+    Capybara.singleton_class.class_eval do
+      alias_method :_using_session, :using_session
+      alias_method :using_session, :using_session_with_localhost_resolution
     end
   end
 


### PR DESCRIPTION
This is a follow up to 9ff0805a1de5695982b0dd5464e6786764fd94b3. We
noticed that `localhost` can fail to resolve in other spots of the app
and not just in selenium-webdriver.

From the failing tests we have seen, the `getaddrinfo: Temporary failure in name resolution` error is only
seen from within the `Capybara.using_session` block. This commit aims to
ensure that `localhost` can be resolve after the new session is started.
