### PR TITLE
DEV: Fix missing require in `spec/support/fake_s3`

### DIFF
--- a/spec/support/fake_s3.rb
+++ b/spec/support/fake_s3.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "aws-sdk-s3"
+
 class FakeS3
   attr_reader :s3_client
 


### PR DESCRIPTION
When running ` rspec spec/services/external_upload_manager_spec.rb`
in the development environment, tests were failing with the following
error:

```
NameError:
  uninitialized constant FakeS3::Aws
```
