### PR TITLE
FIX: Message for bulk closing topics silently

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -87,7 +87,9 @@ export default class BulkTopicActions extends Component {
     const options = {};
 
     if (this.isSilent) {
-      operation = { type: "silent_close" };
+      const newType =
+        operation.type === "close" ? "silent_close" : operation.type;
+      operation.type = newType;
     }
 
     if (this.isCloseAction && this.closeNote) {

--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -13,7 +13,11 @@ TopicStatusUpdater =
         if updated
           highest_post_number = topic.highest_post_number
           create_moderator_post_for(status, opts)
-          update_read_state_for(status, highest_post_number)
+          update_read_state_for(
+            status,
+            highest_post_number,
+            silent_tracking: opts[:silent_tracking],
+          )
         end
       end
 
@@ -90,8 +94,8 @@ TopicStatusUpdater =
       topic.reload
     end
 
-    def update_read_state_for(status, old_highest_read)
-      if status.autoclosed? && status.enabled?
+    def update_read_state_for(status, old_highest_read, silent_tracking: false)
+      if (status.autoclosed? && status.enabled?) || (status.closed? && silent_tracking)
         # let's pretend all the people that read up to the autoclose message
         # actually read the topic
         PostTiming.pretend_read(topic.id, old_highest_read, topic.highest_post_number)

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -174,7 +174,12 @@ class TopicsBulkAction
   def silent_close
     topics.each do |t|
       if guardian.can_moderate?(t)
-        t.update_status("autoclosed", true, @user, { message: @operation[:message] })
+        t.update_status(
+          "closed",
+          true,
+          @user,
+          { message: @operation[:message], silent_tracking: true },
+        )
         @changed_ids << t.id
       end
     end


### PR DESCRIPTION
We were using `autoclose` as the topic status update
when silently closing topics using the bulk
actions (introduced in https://github.com/discourse/discourse/commit/0464ddcd9b377d8249d8a3c15cfe91d7a8e97bfc).

However, this resulted in a message like this showing in
the topic as a small moderator post:

> This topic was automatically closed after X days.

This is not accurate, the topic was bulk closed by someone.
Instead, we can use `closed` as the status, and a more accurate

> Closed on DATE

message is used. `TopicStatusUpdater` needed an additional
option to keep the same "fake read" behaviour as autoclose
so we can keep the same functionality for silently closing
topics in bulk actions.