### PR TITLE
FIX: correctly load channels in chat webhooks

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/admin-plugins-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/admin-plugins-chat.js
@@ -9,7 +9,7 @@ export default class AdminPluginsChatRoute extends DiscourseRoute {
       return { model: null };
     }
 
-    return ajax("/admin/plugins/chat.json").then((model) => {
+    return ajax("/admin/plugins/chat/hooks.json").then((model) => {
       model.incoming_chat_webhooks = model.incoming_chat_webhooks.map(
         (webhook) => EmberObject.create(webhook)
       );

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -132,16 +132,6 @@ after_initialize do
     end
   end
 
-  add_to_serializer(
-    :admin_plugin,
-    :incoming_chat_webhooks,
-    include_condition: -> { self.name == "chat" },
-  ) { Chat::IncomingWebhook.includes(:chat_channel).all }
-
-  add_to_serializer(:admin_plugin, :chat_channels, include_condition: -> { self.name == "chat" }) do
-    Chat::Channel.public_channels
-  end
-
   add_to_serializer(:user_card, :can_chat_user) do
     return false if !SiteSetting.chat_enabled
     return false if scope.user.blank? || scope.user.id == object.id
@@ -436,7 +426,7 @@ after_initialize do
   Discourse::Application.routes.append do
     mount ::Chat::Engine, at: "/chat"
 
-    get "/admin/plugins/chat" => "chat/admin/incoming_webhooks#index",
+    get "/admin/plugins/chat/hooks" => "chat/admin/incoming_webhooks#index",
         :constraints => StaffConstraint.new
     post "/admin/plugins/chat/hooks" => "chat/admin/incoming_webhooks#create",
          :constraints => StaffConstraint.new

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -152,24 +152,6 @@ describe Chat do
     end
   end
 
-  describe "admin plugin serializer extension" do
-    let(:admin) { Fabricate(:admin) }
-    let(:chat_plugin) do
-      Plugin::Instance.parse_from_source(File.join(Rails.root, "plugins", "chat", "plugin.rb"))
-    end
-    let(:serializer) { AdminPluginSerializer.new(chat_plugin, scope: admin.guardian) }
-
-    it "includes all incoming webhooks via :incoming_chat_webhooks" do
-      webhook = Fabricate(:incoming_chat_webhook)
-      expect(serializer.incoming_chat_webhooks).to contain_exactly(webhook)
-    end
-
-    it "includes all chat channels via :chat_channels" do
-      channel = Fabricate(:chat_channel)
-      expect(serializer.chat_channels).to contain_exactly(channel)
-    end
-  end
-
   describe "chat oneboxes" do
     fab!(:chat_channel) { Fabricate(:category_channel) }
     fab!(:user)

--- a/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/admin/incoming_webhooks_controller_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Chat::Admin::IncomingWebhooksController do
 
     it "blocks non-admin" do
       sign_in(user)
-      get "/admin/plugins/chat.json"
+      get "/admin/plugins/chat/hooks.json"
       expect(response.status).to eq(404)
     end
 
     it "Returns chat_channels and incoming_chat_webhooks for admin" do
       sign_in(admin)
-      get "/admin/plugins/chat.json"
+      get "/admin/plugins/chat/hooks.json"
       expect(response.status).to eq(200)
       expect(
         response.parsed_body["incoming_chat_webhooks"].map { |webhook| webhook["id"] },


### PR DESCRIPTION
In 4e7a75a7ece3205ce9f3f188b5e016bf75a869c0, we moved to a single admin plugin page and added a few fields to the "plugin serializer" but we already had a proper route with the correct serializers to properly load channels.

This fixes it by removing the "add_to_serializer" calls and changed the calls to "/admin/plugins/chat.json" to the proper "/admin/plugins/chat/hooks.json" route.

Meta - https://meta.discourse.org/t/names-are-missing-from-list-when-creating-new-chat-channel-webhooks/308481

