### PR TITLE
FIX: fix Webhook events filter 'loadMore' not taking params

### DIFF
--- a/app/controllers/admin/web_hooks_controller.rb
+++ b/app/controllers/admin/web_hooks_controller.rb
@@ -88,9 +88,10 @@ class Admin::WebHooksController < Admin::AdminController
     limit = 50
     offset = params[:offset].to_i
     events = @web_hook.web_hook_events
-    if params[:status] == "successful"
+    status = params[:status]
+    if status == "successful"
       events = events.successful
-    elsif params[:status] == "failed"
+    elsif status == "failed"
       events = events.failed
     end
 
@@ -101,7 +102,12 @@ class Admin::WebHooksController < Admin::AdminController
       web_hook_events: serialize_data(events, AdminWebHookEventSerializer),
       total_rows_web_hook_events: total,
       load_more_web_hook_events:
-        web_hook_events_admin_api_index_path(limit: limit, offset: offset + limit, format: :json),
+        web_hook_events_admin_api_index_path(
+          limit: limit,
+          offset: offset + limit,
+          status: status,
+          format: :json,
+        ),
       extras: {
         web_hook_id: @web_hook.id,
       },

--- a/spec/requests/admin/web_hooks_controller_spec.rb
+++ b/spec/requests/admin/web_hooks_controller_spec.rb
@@ -203,6 +203,13 @@ RSpec.describe Admin::WebHooksController do
 
     before { sign_in(admin) }
 
+    context "when status param is provided" do
+      it "load_more_web_hook_events URL is correct" do
+        get "/admin/api/web_hook_events/#{web_hook.id}.json", params: { status: "successful" }
+        expect(response.parsed_body["load_more_web_hook_events"]).to include("status=successful")
+      end
+    end
+
     context "when status is 'successful'" do
       it "lists the successfully delivered webhook events" do
         get "/admin/api/web_hook_events/#{web_hook.id}.json", params: { status: "successful" }


### PR DESCRIPTION
After working on the [Webhook events filter by Status](https://github.com/discourse/discourse/pull/27332), I noticed that the 'Delivered' and 'Failed' options do not take the status param when loading more than fifty Webhook events. It causes to load all Webhook events regardless of its status after the first load.  

This PR is adding webhook events status for the filter to the param when loading more than fifty Webhook events.