### PR TITLE
UX: allow cooked local-dates to wrap

### DIFF
--- a/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
+++ b/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
@@ -8,7 +8,6 @@
     color: var(--primary);
     cursor: pointer;
     border-bottom: 1px dashed var(--primary-medium);
-    white-space: nowrap;
 
     .d-icon {
       color: var(--primary);


### PR DESCRIPTION
surprised this hasn't come up sooner 

before:
![image](https://github.com/discourse/discourse/assets/1681963/0dda8048-0b64-4a25-a953-e2c09861eafb)


after:
![image](https://github.com/discourse/discourse/assets/1681963/fe4e1960-664e-4a23-8b89-2c357efaaf13)
