### PR TITLE
DEV: Remove `modKeysPressed`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -4,8 +4,8 @@ import { alias, gt } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { Promise } from "rsvp";
 import { setting } from "discourse/lib/computed";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { groupPath } from "discourse/lib/url";
-import { modKeysPressed } from "discourse/lib/utilities";
 import CardContentsBase from "discourse/mixins/card-contents-base";
 import CleansUp from "discourse/mixins/cleans-up";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -14,6 +14,7 @@ const maxMembersToDisplay = 10;
 
 export default Component.extend(CardContentsBase, CleansUp, {
   composer: service(),
+
   elementId: "group-card",
   mentionSelector: "a.mention-group",
   classNames: ["no-bg", "group-card"],
@@ -88,10 +89,11 @@ export default Component.extend(CardContentsBase, CleansUp, {
 
   @action
   handleShowGroup(group, event) {
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
-    event?.preventDefault();
+
+    event.preventDefault();
     // Invokes `showGroup` argument. Convert to `this.args.showGroup` when
     // refactoring this to a glimmer component.
     this.showGroup(group);

--- a/app/assets/javascripts/discourse/app/components/search-result-entry.js
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.js
@@ -1,7 +1,7 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { logSearchLinkClick } from "discourse/lib/search";
-import { modKeysPressed } from "discourse/lib/utilities";
 
 export default Component.extend({
   tagName: "div",
@@ -13,9 +13,10 @@ export default Component.extend({
   @action
   logClick(topicId, event) {
     // Avoid click logging when any modifier keys are pressed.
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
+
     if (this.searchLogId && topicId) {
       logSearchLinkClick({
         searchLogId: this.searchLogId,

--- a/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
@@ -4,10 +4,10 @@ import TopicEntrance from "discourse/components/topic-list/topic-entrance";
 import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
 import formatAge from "discourse/helpers/format-age";
-import { modKeysPressed } from "discourse/lib/utilities";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 
 const onTimestampClick = function (event) {
-  if (modKeysPressed(event).length) {
+  if (wantsNewWindow(event)) {
     // Allow opening the link in a new tab/window
     event.stopPropagation();
   } else {

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -5,9 +5,10 @@ import { dasherize } from "@ember/string";
 import { isEmpty } from "@ember/utils";
 import { propertyNotEqual, setting } from "discourse/lib/computed";
 import { durationTiny } from "discourse/lib/formatter";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { emojiUnescape } from "discourse/lib/text";
-import { escapeExpression, modKeysPressed } from "discourse/lib/utilities";
+import { escapeExpression } from "discourse/lib/utilities";
 import CanCheckEmails from "discourse/mixins/can-check-emails";
 import CardContentsBase from "discourse/mixins/card-contents-base";
 import CleansUp from "discourse/mixins/cleans-up";
@@ -233,10 +234,11 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
 
   @action
   handleShowUser(user, event) {
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
-    event?.preventDefault();
+
+    event.preventDefault();
     // Invokes `showUser` argument. Convert to `this.args.showUser` when
     // refactoring this to a glimmer component.
     this.showUser(user);

--- a/app/assets/javascripts/discourse/app/controllers/password-reset.js
+++ b/app/assets/javascripts/discourse/app/controllers/password-reset.js
@@ -2,8 +2,8 @@ import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { alias, or, readOnly } from "@ember/object/computed";
 import { ajax } from "discourse/lib/ajax";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import DiscourseURL, { userPath } from "discourse/lib/url";
-import { modKeysPressed } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
 import PasswordValidation from "discourse/mixins/password-validation";
 import { SECOND_FACTOR_METHODS } from "discourse/models/user";
@@ -66,10 +66,11 @@ export default Controller.extend(PasswordValidation, {
 
   @action
   done(event) {
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
-    event?.preventDefault();
+
+    event.preventDefault();
     this.set("redirected", true);
     DiscourseURL.redirectTo(this.redirectTo || "/");
   },

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -19,11 +19,12 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { BookmarkFormData } from "discourse/lib/bookmark-form-data";
 import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { buildQuote } from "discourse/lib/quote";
 import QuoteState from "discourse/lib/quote-state";
 import { extractLinkMeta } from "discourse/lib/render-topic-featured-link";
 import DiscourseURL, { userPath } from "discourse/lib/url";
-import { escapeExpression, modKeysPressed } from "discourse/lib/utilities";
+import { escapeExpression } from "discourse/lib/utilities";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import Bookmark, { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import Category from "discourse/models/category";
@@ -339,10 +340,11 @@ export default Controller.extend(bufferedProperty("model"), {
 
   @action
   jumpTop(event) {
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
-    event?.preventDefault();
+
+    event.preventDefault();
     DiscourseURL.routeTo(this.get("model.firstPostUrl"), {
       skipIfOnScreen: false,
       keepFilter: true,

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -463,12 +463,6 @@ export async function inCodeBlock(text, pos) {
   return CODE_TOKEN_TYPES.includes(type);
 }
 
-// Return an array of modifier keys that are pressed during a given `MouseEvent`
-// or `KeyboardEvent`.
-export function modKeysPressed(event) {
-  return ["alt", "shift", "meta", "ctrl"].filter((key) => event[`${key}Key`]);
-}
-
 export function translateModKey(string) {
   const { isApple } = capabilities;
   // Apple device users are used to glyphs for shortcut keys

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -21,6 +21,7 @@ import prepareFormTemplateData, {
 } from "discourse/lib/form-template-validation";
 import { shortDate } from "discourse/lib/formatter";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { buildQuote } from "discourse/lib/quote";
 import renderTags from "discourse/lib/render-tags";
 import { emojiUnescape } from "discourse/lib/text";
@@ -29,7 +30,7 @@ import {
   uploadIcon,
 } from "discourse/lib/uploads";
 import DiscourseURL from "discourse/lib/url";
-import { escapeExpression, modKeysPressed } from "discourse/lib/utilities";
+import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Composer, {
   CREATE_TOPIC,
@@ -645,10 +646,11 @@ export default class ComposerService extends Service {
 
   @action
   viewNewReply(event) {
-    if (event && modKeysPressed(event).length > 0) {
-      return false;
+    if (wantsNewWindow(event)) {
+      return;
     }
-    event?.preventDefault();
+
+    event.preventDefault();
     DiscourseURL.routeTo(this.get("model.createdPost.url"));
     this.close();
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -1,6 +1,4 @@
 import { getOwner } from "@ember/application";
-import { click, render } from "@ember/test-helpers";
-import { hbs } from "ember-cli-htmlbars";
 import { setupTest } from "ember-qunit";
 import Handlebars from "handlebars";
 import { module, test } from "qunit";
@@ -18,7 +16,6 @@ import {
   inCodeBlock,
   initializeDefaultHomepage,
   mergeSortedLists,
-  modKeysPressed,
   setCaretPosition,
   setDefaultHomepage,
   slugify,
@@ -29,7 +26,6 @@ import {
   mdTableNonUniqueHeadings,
   mdTableSpecialChars,
 } from "discourse/tests/fixtures/md-table";
-import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { chromeTest } from "discourse/tests/helpers/qunit-helpers";
 
 module("Unit | Utilities", function (hooks) {
@@ -268,54 +264,6 @@ module("Unit | Utilities", function (hooks) {
       [6, 5, 4, 3, 2, 2, 1, 1],
       "it correctly merges lists that share common items"
     );
-  });
-});
-
-module("Unit | Utilities | modKeysPressed", function (hooks) {
-  setupRenderingTest(hooks);
-
-  test("returns an array of modifier keys pressed during keyboard or mouse event", async function (assert) {
-    let i = 0;
-
-    this.handleClick = (event) => {
-      if (i === 0) {
-        assert.deepEqual(modKeysPressed(event), []);
-      } else if (i === 1) {
-        assert.deepEqual(modKeysPressed(event), ["alt"]);
-      } else if (i === 2) {
-        assert.deepEqual(modKeysPressed(event), ["shift"]);
-      } else if (i === 3) {
-        assert.deepEqual(modKeysPressed(event), ["meta"]);
-      } else if (i === 4) {
-        assert.deepEqual(modKeysPressed(event), ["ctrl"]);
-      } else if (i === 5) {
-        assert.deepEqual(modKeysPressed(event), [
-          "alt",
-          "shift",
-          "meta",
-          "ctrl",
-        ]);
-      }
-    };
-
-    await render(hbs`<button id="btn" {{on "click" this.handleClick}} />`);
-
-    await click("#btn");
-    i++;
-    await click("#btn", { altKey: true });
-    i++;
-    await click("#btn", { shiftKey: true });
-    i++;
-    await click("#btn", { metaKey: true });
-    i++;
-    await click("#btn", { ctrlKey: true });
-    i++;
-    await click("#btn", {
-      altKey: true,
-      shiftKey: true,
-      metaKey: true,
-      ctrlKey: true,
-    });
   });
 });
 


### PR DESCRIPTION
It was added when removing `{{action}}` modifiers from the app, but we already had `wantsNewWindow` so use that instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
