### PR TITLE
DEV: Try another workaround for `getaddrinfo: Temporary failure in name resolution`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -522,26 +522,20 @@ RSpec.configure do |config|
     # This is a monkey patch for the `Capybara.using_session` method in `capybara`. For some
     # unknown reasons on Github Actions, we are seeing system tests failing intermittently with the error
     # `Socket::ResolutionError: getaddrinfo: Temporary failure in name resolution` when the app tries to resolve
-    # `localhost` from within a `Capybara#using_session` block. Therefore, we will ensure we can resolve `localhost` first
-    # before starting the new session.
+    # `localhost` from within a `Capybara#using_session` block.
     #
     # Too much time has been spent trying to debug this issue and the root cause is still unknown so we are just dropping
-    # this workaround for now.
+    # this workaround for now where we will retry the block once before raising the error.
+    #
+    # Potentially related: https://bugs.ruby-lang.org/issues/20172
     module Capybara
       class << self
         def using_session_with_localhost_resolution(name, &block)
-          self._using_session(name) do |session|
-            attempts = 0
-
-            begin
-              Socket.getaddrinfo("localhost", 80, Socket::AF_INET, Socket::SOCK_STREAM)
-            rescue Socket::ResolutionError
-              attempts += 1
-              attempts <= 3 ? retry : raise
-            end
-
-            block.call(session)
-          end
+          attempts = 0
+          self._using_session(name, &block)
+        rescue Socket::ResolutionError
+          puts "Socket::ResolutionError error encountered... Current thread count: #{Thread.list.size}"
+          attempts <= 1 ? retry : raise
         end
       end
     end


### PR DESCRIPTION
This commit tries another work around for the `Socket::ResolutionError: getaddrinfo: Temporary failure in name resolution`
error we are seeing on CI.

The problem with the previous workaround is that `Capybara.using_session` will attempt to resolve `localhost`
before yielding the block which means our retry code is not hit.

This problem may be related to https://bugs.ruby-lang.org/issues/20172
which hints at us potentially not being able to spin up threads on CI so
I'm adding a debugging statement when stuff fails.
