### PR TITLE
FIX: update id types in API docs to integers

### DIFF
--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "posts" do
                          type: %i[string null],
                        },
                        flair_group_id: {
-                         type: %i[string null],
+                         type: %i[integer null],
                        },
                        version: {
                          type: :integer,
@@ -191,7 +191,7 @@ RSpec.describe "posts" do
                          type: :boolean,
                        },
                        reviewable_id: {
-                         type: %i[string null],
+                         type: %i[integer null],
                        },
                        reviewable_score_count: {
                          type: :integer,
@@ -254,6 +254,29 @@ RSpec.describe "posts" do
         schema expected_response_schema
 
         let(:id) { Fabricate(:post).id }
+        run_test!
+
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
+        end
+      end
+
+      response "200", "single reviewable post" do
+        expected_response_schema = load_spec_schema("post_show_response")
+        schema expected_response_schema
+
+        let(:id) do
+          topic = Fabricate(:topic)
+          post = Fabricate(:post, topic: topic)
+          Fabricate(:reviewable_flagged_post, topic: topic, target: post)
+
+          post.id
+        end
+
+        let(:moderator) { Fabricate(:moderator) }
+        before { sign_in(moderator) }
+
         run_test!
 
         it_behaves_like "a JSON endpoint", 200 do
@@ -570,7 +593,7 @@ RSpec.describe "posts" do
                    type: :object,
                  },
                  reviewable_id: {
-                   type: %i[string null],
+                   type: %i[integer null],
                  },
                  reviewable_score_count: {
                    type: :integer,

--- a/spec/requests/api/private_messages_spec.rb
+++ b/spec/requests/api/private_messages_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "private messages" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },
@@ -198,7 +198,7 @@ RSpec.describe "private messages" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },
@@ -385,7 +385,7 @@ RSpec.describe "private messages" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },

--- a/spec/requests/api/schemas/json/admin_user_response.json
+++ b/spec/requests/api/schemas/json/admin_user_response.json
@@ -144,7 +144,7 @@
       ]
     },
     "primary_group_id": {
-      "type": ["string", "null"]
+      "type": ["integer", "null"]
     },
     "badge_count": {
       "type": "integer"
@@ -411,7 +411,7 @@
               "type": ["string", "null"]
             },
             "flair_group_id": {
-              "type": ["string", "null"]
+              "type": ["integer", "null"]
             },
             "bio_raw": {
               "type": ["string", "null"]

--- a/spec/requests/api/schemas/json/category_topics_response.json
+++ b/spec/requests/api/schemas/json/category_topics_response.json
@@ -176,7 +176,7 @@
                         },
                         "primary_group_id": {
                           "type": [
-                            "string",
+                            "integer",
                             "null"
                           ]
                         }

--- a/spec/requests/api/schemas/json/post_replies_response.json
+++ b/spec/requests/api/schemas/json/post_replies_response.json
@@ -103,7 +103,7 @@
       },
       "flair_group_id": {
         "type": [
-          "string",
+          "integer",
           "null"
         ]
       },
@@ -155,7 +155,7 @@
       },
       "actions_summary": {
         "type": "array",
-        "items": 
+        "items":
           {
             "type": "object",
             "additionalProperties": false,
@@ -214,7 +214,7 @@
       },
       "reviewable_id": {
         "type": [
-          "string",
+          "integer",
           "null"
         ]
       },

--- a/spec/requests/api/schemas/json/post_show_response.json
+++ b/spec/requests/api/schemas/json/post_show_response.json
@@ -90,7 +90,7 @@
     },
     "flair_group_id": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },
@@ -193,7 +193,7 @@
     },
     "reviewable_id": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/spec/requests/api/schemas/json/post_update_response.json
+++ b/spec/requests/api/schemas/json/post_update_response.json
@@ -94,7 +94,7 @@
         },
         "flair_group_id": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },
@@ -191,7 +191,7 @@
         },
         "reviewable_id": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },

--- a/spec/requests/api/schemas/json/topic_create_response.json
+++ b/spec/requests/api/schemas/json/topic_create_response.json
@@ -105,7 +105,7 @@
     },
     "flair_group_id": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },
@@ -200,7 +200,7 @@
     },
     "reviewable_id": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/spec/requests/api/schemas/json/topic_show_response.json
+++ b/spec/requests/api/schemas/json/topic_show_response.json
@@ -836,7 +836,7 @@
                 },
                 "flair_group_id": {
                   "type": [
-                    "string",
+                    "integer",
                     "null"
                   ]
                 },

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -119,7 +119,7 @@
         },
         "primary_group_id": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },
@@ -131,7 +131,7 @@
         },
         "flair_group_id": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },
@@ -182,7 +182,7 @@
         },
         "uploaded_avatar_id": {
           "type": [
-            "string",
+            "integer",
             "null"
           ]
         },

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe "tags" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },

--- a/spec/requests/api/topics_spec.rb
+++ b/spec/requests/api/topics_spec.rb
@@ -627,7 +627,7 @@ RSpec.describe "topics" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },
@@ -827,7 +827,7 @@ RSpec.describe "topics" do
                                    type: :integer,
                                  },
                                  primary_group_id: {
-                                   type: %i[string null],
+                                   type: %i[integer null],
                                  },
                                },
                              },
@@ -966,7 +966,7 @@ RSpec.describe "topics" do
                    type: :boolean,
                  },
                  category_id: {
-                   type: %i[string null],
+                   type: %i[integer null],
                  },
                }
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe "users" do
           let(:expected_request_schema) { expected_request_schema }
         end
       end
+
+      response "200", "user with primary group response" do
+        expected_response_schema = load_spec_schema("user_get_response")
+        schema expected_response_schema
+
+        let(:username) { Fabricate(:user, primary_group_id: Fabricate(:group).id).username }
+
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
+        end
+      end
     end
 
     put "Update a user" do


### PR DESCRIPTION
The API docs currently report the types of several ID values as (possibly null) strings when in reality they are (possibly null) values. I found this to be the case for the `primary_group_id`, `flair_group_id`, and `uploaded_avatar_id` attributes of the `User` model; the `reviewable_id` attribute of the `ReviewableScore` model, and the `category_id` attribute of the `TopicTimer` model. 

Pry output for reference:
```rb
[1] pry(main)> User.type_for_attribute("primary_group_id").type
=> :integer
[2] pry(main)> User.type_for_attribute("flair_group_id").type
=> :integer
[3] pry(main)> User.type_for_attribute("uploaded_avatar_id").type
=> :integer
[4] pry(main)> ReviewableScore.type_for_attribute("reviewable_id").type
=> :integer
[5] pry(main)> TopicTimer.type_for_attribute("category_id").type
=> :integer
```