### PR TITLE
DEV: Run flake check only on discourse/discourse (stable)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Check for flaky tests report
         id: check-flaky-spec-report
-        if: always()
+        if: always() && github.repository == 'discourse/discourse'
         run: |
           if [ -f tmp/turbo_rspec_flaky_tests.json ]; then
             echo "exists=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
script/get_github_workflow_run_job_id.rb would fail on forks anyway

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
