### PR TITLE
UX: restrict mobile tooltip width to prevent horizontal overflow

### DIFF
--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -49,6 +49,12 @@
   max-width: 400px;
   overflow-wrap: break-word;
 
+  .mobile-view & {
+    // tooltips are positioned 5px from the left
+    // - 10px accounts for this and gives 5px space on the right
+    max-width: calc(100dvw - 10px);
+  }
+
   .footnote-tooltip-content {
     overflow: hidden;
 
@@ -58,7 +64,7 @@
 
     img {
       object-fit: cover;
-      max-width: 385px;
+      max-width: 100%;
     }
 
     p {


### PR DESCRIPTION
This prevents footnotes from being too wide on mobile devices with <400px width

This also adjusts images to fit the container width

before:
![image](https://github.com/discourse/discourse/assets/1681963/d4d534da-c5c8-496c-8f6a-c5899c363a5c)


after:
![image](https://github.com/discourse/discourse/assets/1681963/aacdfe2c-93e0-49a4-903b-ac96a3ff800c)
