### PR TITLE
UX: add active highlight for breadcrumb navigation

### DIFF
--- a/app/assets/stylesheets/common/select-kit/category-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/category-drop.scss
@@ -19,6 +19,13 @@
         }
       }
 
+      &.has-selection {
+        .category-drop-header {
+          color: var(--quaternary);
+          border-color: var(--quaternary);
+        }
+      }
+
       .select-kit-row {
         flex-direction: column;
         align-items: flex-start;

--- a/app/assets/stylesheets/common/select-kit/tag-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/tag-drop.scss
@@ -14,6 +14,13 @@
       .tag-drop-header {
         color: var(--primary-high);
       }
+
+      &.has-selection {
+        .tag-drop-header {
+          color: var(--quaternary);
+          border-color: var(--quaternary);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This commits add a border + text colour when a tag or category breadcrumb has been selected to indicate the filter is active.

## Before
![image](https://github.com/discourse/discourse/assets/101828855/8af2a656-295e-4901-9888-7da0658e3bcb)

## After
![image](https://github.com/discourse/discourse/assets/101828855/fba78d4e-aa93-42e6-ac83-2da6c1c2ea0b)
