### PR TITLE
UX: update "all tags" to "remove filter" for tag breadcrumb dropdown

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -58,8 +58,8 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
     );
     assert.strictEqual(
       content[1].name,
-      I18n.t("tagging.selector_all_tags"),
-      "it has the correct label for all-tags"
+      I18n.t("tagging.selector_remove_filter"),
+      "it has the correct label for removing the tag filter"
     );
 
     await this.subject.fillInFilter("dav");

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -106,7 +106,7 @@ export default ComboBoxComponent.extend(TagsMixin, {
     if (this.tagId) {
       shortcuts.push({
         id: ALL_TAGS_ID,
-        name: I18n.t("tagging.selector_all_tags"),
+        name: I18n.t("tagging.selector_remove_filter"),
       });
     }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4454,7 +4454,7 @@ en:
       all_tags: "All tags"
       other_tags: "Other Tags"
       selector_tags: "tags"
-      selector_all_tags: "all tags"
+      selector_all_tags: "remove filter"
       selector_no_tags: "no tags"
       selector_remove_filter: "remove filter"
       tags: "Tags"
@@ -5381,7 +5381,6 @@ en:
           watched_words: "Watched Words"
           legal: "Legal"
           moderation_flags: "Moderation Flags"
-
 
       appearance:
         title: "Appearance"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4454,7 +4454,6 @@ en:
       all_tags: "All tags"
       other_tags: "Other Tags"
       selector_tags: "tags"
-      selector_all_tags: "remove filter"
       selector_no_tags: "no tags"
       selector_remove_filter: "remove filter"
       tags: "Tags"


### PR DESCRIPTION
This matches the category dropdown updates done as part of category scaling work 

before:
![image](https://github.com/discourse/discourse/assets/1681963/d864ce44-3a5c-4854-8708-0a7bc10ccfa4)


after:
![image](https://github.com/discourse/discourse/assets/1681963/0a1abf6d-f06a-4fd0-b799-dc5d42d58997)


for consistency with category dropdown, 

![image](https://github.com/discourse/discourse/assets/1681963/0aa9d852-a250-4f87-930f-a77b73793e4c)
