### PR TITLE
DEV: Extract theme resolution to a helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -560,7 +560,7 @@ module ApplicationHelper
   end
 
   def current_homepage
-    current_user&.user_option&.homepage || HomepageHelper.resolve(request, current_user)
+    current_user&.user_option&.homepage || HomepageHelper.resolve(theme_id, current_user)
   end
 
   def build_plugin_html(name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1597,7 +1597,9 @@ Discourse::Application.routes.draw do
          constraints: HomePageConstraint.new("finish_installation"),
          as: "installation_redirect"
 
-    root to: "custom#index", constraints: HomePageConstraint.new("custom"), as: "custom_index"
+    root to: "custom_homepage#index",
+         constraints: HomePageConstraint.new("custom"),
+         as: "custom_index"
 
     get "/user-api-key/new" => "user_api_keys#new"
     post "/user-api-key" => "user_api_keys#create"

--- a/lib/homepage_constraint.rb
+++ b/lib/homepage_constraint.rb
@@ -9,7 +9,11 @@ class HomePageConstraint
     return @filter == "finish_installation" if SiteSetting.has_login_hint?
 
     current_user = CurrentUser.lookup_from_env(request.env)
-    homepage = current_user&.user_option&.homepage || HomepageHelper.resolve(request, current_user)
+
+    # ensures we resolve the theme id as early as possible
+    theme_id = ThemeResolver.resolve_theme_id(request, Guardian.new(current_user), current_user)
+
+    homepage = current_user&.user_option&.homepage || HomepageHelper.resolve(theme_id, current_user)
     homepage == @filter
   rescue Discourse::InvalidAccess, Discourse::ReadOnly
     false

--- a/lib/homepage_helper.rb
+++ b/lib/homepage_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class HomepageHelper
-  def self.resolve(request = nil, current_user = nil)
-    return "custom" if ThemeModifierHelper.new(request: request).custom_homepage
+  def self.resolve(theme_id = nil, current_user = nil)
+    return "custom" if ThemeModifierHelper.new(theme_ids: theme_id).custom_homepage
 
     current_user ? SiteSetting.homepage : SiteSetting.anonymous_homepage
   end

--- a/lib/theme_resolver.rb
+++ b/lib/theme_resolver.rb
@@ -2,6 +2,8 @@
 
 module ThemeResolver
   def self.resolve_theme_id(request, guardian, current_user)
+    return request.env[:resolved_theme_id] if request.env[:resolved_theme_id] != nil
+
     theme_id = nil
 
     if (preview_theme_id = request[:preview_theme_id]&.to_i) &&
@@ -28,7 +30,7 @@ module ThemeResolver
          guardian.allow_themes?([SiteSetting.default_theme_id])
       theme_id = SiteSetting.default_theme_id
     end
-    pp theme_id
+
     request.env[:resolved_theme_id] = theme_id
   end
 end

--- a/lib/theme_resolver.rb
+++ b/lib/theme_resolver.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ThemeResolver
+  def self.resolve_theme_id(request, guardian, current_user)
+    theme_id = nil
+
+    if (preview_theme_id = request[:preview_theme_id]&.to_i) &&
+         guardian.allow_themes?([preview_theme_id], include_preview: true)
+      theme_id = preview_theme_id
+    end
+
+    user_option = current_user&.user_option
+
+    if theme_id.blank? && request.cookies[:theme_ids].present?
+      ids, seq = request.cookies[:theme_ids]&.split("|")
+      id = ids&.split(",")&.map(&:to_i)&.first
+      if id.present? && seq && seq.to_i == user_option&.theme_key_seq.to_i
+        theme_id = id if guardian.allow_themes?([id])
+      end
+    end
+
+    if theme_id.blank?
+      ids = user_option&.theme_ids || []
+      theme_id = ids.first if guardian.allow_themes?(ids)
+    end
+
+    if theme_id.blank? && SiteSetting.default_theme_id != -1 &&
+         guardian.allow_themes?([SiteSetting.default_theme_id])
+      theme_id = SiteSetting.default_theme_id
+    end
+    pp theme_id
+    request.env[:resolved_theme_id] = theme_id
+  end
+end

--- a/lib/theme_resolver.rb
+++ b/lib/theme_resolver.rb
@@ -13,8 +13,8 @@ module ThemeResolver
 
     user_option = current_user&.user_option
 
-    if theme_id.blank? && request.cookies[:theme_ids].present?
-      ids, seq = request.cookies[:theme_ids]&.split("|")
+    if theme_id.blank? && request.cookie_jar[:theme_ids].present?
+      ids, seq = request.cookie_jar[:theme_ids]&.split("|")
       id = ids&.split(",")&.map(&:to_i)&.first
       if id.present? && seq && seq.to_i == user_option&.theme_key_seq.to_i
         theme_id = id if guardian.allow_themes?([id])

--- a/spec/lib/homepage_helper_spec.rb
+++ b/spec/lib/homepage_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe HomepageHelper do
       expect(HomepageHelper.resolve).to eq("custom")
     end
 
-    context "when first item in top menu is no valid for anons" do
+    context "when first item in top menu is not valid for anons" do
       it "distinguishes between auth homepage and anon homepage" do
         SiteSetting.top_menu = "new|top|latest|unread"
 


### PR DESCRIPTION
This ensures that the theme id is resolved as early as possible in the request cycle. This is necessary for the custom homepage to skip preloading the wrong data.
