### PR TITLE
FEATURE: Add tag_group option in `/filter`

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -74,6 +74,8 @@ class TopicsFilter
         filter_by_number_of_posters(max: filter_values)
       when "status"
         filter_values.each { |status| @scope = filter_status(status: status) }
+      when "tag_group"
+        filter_tags(values: tag_groups_to_tags(key_prefixes.zip(filter_values)))
       when "tag"
         filter_tags(values: key_prefixes.zip(filter_values))
       when "views-min"
@@ -366,6 +368,19 @@ class TopicsFilter
     all_tag_ids.compact!
     all_tag_ids.uniq!
     all_tag_ids
+  end
+
+  def tag_groups_to_tags(values)
+    values.map do |key_prefix, value|
+      tag_groups_names =
+        if value.include?(",")
+          value.split(",")
+        else
+          [value]
+        end
+      tags = TagGroup.where(name: tag_groups_names).map(&:tags).flatten.map(&:name).join(",")
+      [key_prefix, tags]
+    end
   end
 
   def filter_tags(values:)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -373,7 +373,7 @@ class TopicsFilter
   def filter_tag_groups(values:)
     values.each do |key_prefix, tag_groups|
       should_exclude = "NOT" if key_prefix == "-"
-      tag_group_ids = TagGroup.where(name: tag_groups).pluck(:id)
+      tag_group_ids = TagGroup.visible(@guardian).where(name: tag_groups).pluck(:id)
       @scope =
         @scope
           .joins(:tags)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -385,11 +385,6 @@ class TopicsFilter
     end
   end
 
-  def include_topics_with_tags_from_tag_groups
-  end
-
-  def exclude_topics_with_tags_from_tag_groups
-  end
   def filter_tags(values:)
     return if !SiteSetting.tagging_enabled?
 

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -942,6 +942,21 @@ RSpec.describe TopicsFilter do
       fab!(:tag_group) { Fabricate(:tag_group, tag_names: [tag.name, tag2.name]) }
       fab!(:topic_with_tag3) { Fabricate(:topic, tags: [tag3]) }
 
+      fab!(:staff_only_tag) { Fabricate(:tag, name: "group-only-tag") }
+      fab!(:group)
+      let!(:staff_tag_group) do
+        Fabricate(
+          :tag_group,
+          permissions: {
+            group.name => TagGroupPermission.permission_types[:full],
+          },
+          name: "staff-only-tag-group",
+          tag_names: [staff_only_tag.name],
+        )
+      end
+
+      fab!(:topic_with_staff_only_tag) { Fabricate(:topic, tags: [staff_only_tag]) }
+
       it "should only return topics that are tagged with any of the specified tag_group when query string is tag_group:tag_group_name" do
         expect(
           TopicsFilter
@@ -957,7 +972,27 @@ RSpec.describe TopicsFilter do
             .new(guardian: Guardian.new)
             .filter_from_query_string("-tag_group:#{tag_group.name}")
             .pluck(:id),
-        ).to contain_exactly(topic_with_tag3.id, topic_without_tag.id)
+        ).to contain_exactly(topic_with_tag3.id, topic_without_tag.id, topic_with_staff_only_tag.id)
+      end
+
+      it "should return the right topics when query string is `tag_group:staff_tag_group` and user has access to specified tag" do
+        group.add(admin)
+
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new(admin))
+            .filter_from_query_string("tag_group:#{staff_tag_group.name}")
+            .pluck(:id),
+        ).to contain_exactly(topic_with_staff_only_tag.id)
+      end
+
+      it "should not return any topics when query string is `tag_group:staff_tag_group` because specified tag is hidden to user" do
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("tag_group:#{staff_tag_group.name}")
+            .pluck(:id),
+        ).to eq([])
       end
     end
     describe "when filtering by topic author" do

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -929,6 +929,37 @@ RSpec.describe TopicsFilter do
       end
     end
 
+    describe "when filtering by tag_groups" do
+      fab!(:tag) { Fabricate(:tag, name: "tag1") }
+      fab!(:tag2) { Fabricate(:tag, name: "tag2") }
+      fab!(:tag3) { Fabricate(:tag, name: "tag3") }
+
+      fab!(:topic_without_tag) { Fabricate(:topic) }
+      fab!(:topic_with_tag) { Fabricate(:topic, tags: [tag]) }
+      fab!(:topic_with_tag_and_tag2) { Fabricate(:topic, tags: [tag, tag2]) }
+      fab!(:topic_with_tag2) { Fabricate(:topic, tags: [tag2]) }
+
+      fab!(:tag_group) { Fabricate(:tag_group, tag_names: [tag.name, tag2.name]) }
+      fab!(:topic_with_tag3) { Fabricate(:topic, tags: [tag3]) }
+
+      it "should only return topics that are tagged with any of the specified tag_group when query string is tag_group:tag_group_name" do
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("tag_group:#{tag_group.name}")
+            .pluck(:id),
+        ).to contain_exactly(topic_with_tag.id, topic_with_tag_and_tag2.id, topic_with_tag2.id)
+      end
+
+      it "should only return topics that are not excluded by the specified tag_group when query string is -tag_group:tag_group_name" do
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-tag_group:#{tag_group.name}")
+            .pluck(:id),
+        ).to contain_exactly(topic_with_tag3.id, topic_without_tag.id)
+      end
+    end
     describe "when filtering by topic author" do
       fab!(:user2) { Fabricate(:user, username: "username2") }
       fab!(:topic_by_user) { Fabricate(:topic, user: user) }

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1283,6 +1283,35 @@ RSpec.describe ListController do
       end
     end
 
+    it "should filter with tag_group option" do
+      topic_with_tag = Fabricate(:topic, tags: [tag])
+      topic2_with_tag = Fabricate(:topic, tags: [tag])
+      Fabricate(:tag_group, tags: [tag], name: "tag_group")
+
+      sign_in(user)
+
+      get "/filter.json", params: { q: "tags:tag1" }
+
+      expect(response.status).to eq(200)
+
+      parsed = response.parsed_body
+
+      expect(parsed["topic_list"]["topics"].length).to eq(2)
+      expect(parsed["topic_list"]["topics"].map { |topic| topic["id"] }).to contain_exactly(
+        topic_with_tag.id,
+        topic2_with_tag.id,
+      )
+
+      get "/filter.json", params: { q: "tag_group:tag_group" }
+
+      expect(response.status).to eq(200)
+      expect(parsed["topic_list"]["topics"].length).to eq(2)
+      expect(parsed["topic_list"]["topics"].map { |topic| topic["id"] }).to contain_exactly(
+        topic_with_tag.id,
+        topic2_with_tag.id,
+      )
+    end
+
     describe "when filtering with the `created-by:<username>` filter" do
       fab!(:topic2) { Fabricate(:topic, user: admin) }
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1286,24 +1286,13 @@ RSpec.describe ListController do
     it "should filter with tag_group option" do
       topic_with_tag = Fabricate(:topic, tags: [tag])
       topic2_with_tag = Fabricate(:topic, tags: [tag])
-      Fabricate(:tag_group, tags: [tag], name: "tag_group")
+      tag_group = Fabricate(:tag_group, tags: [tag])
 
       sign_in(user)
 
-      get "/filter.json", params: { q: "tags:tag1" }
-
-      expect(response.status).to eq(200)
+      get "/filter.json", params: { q: "tag_group:#{tag_group.name}" }
 
       parsed = response.parsed_body
-
-      expect(parsed["topic_list"]["topics"].length).to eq(2)
-      expect(parsed["topic_list"]["topics"].map { |topic| topic["id"] }).to contain_exactly(
-        topic_with_tag.id,
-        topic2_with_tag.id,
-      )
-
-      get "/filter.json", params: { q: "tag_group:tag_group" }
-
       expect(response.status).to eq(200)
       expect(parsed["topic_list"]["topics"].length).to eq(2)
       expect(parsed["topic_list"]["topics"].map { |topic| topic["id"] }).to contain_exactly(


### PR DESCRIPTION

As mentioned in [this](https://meta.discourse.org/t/discourse-custom-topic-lists/311186/9?u=grubba) meta topic

It would be nice to have `tag_group` in the `/filter` feature. This PR addresses that.

From what I understand, `tag_group` is an alias for a specific list of `tags`:
 `tag_group` -> `tag1,tag2,tag3`
 
