### PR TITLE
FEATURE: align with /filter and allow multiple category search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -575,7 +575,7 @@ class Search
         found.each do |row|
           category_ids << row.id
           @category_filter_matched ||= true
-          category_ids += Category.subcategory_ids(category_ids.first) if !matches[row.term]
+          category_ids += Category.subcategory_ids(row.id) if !matches[row.term]
         end
       end
     end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -566,7 +566,7 @@ class Search
           unnest(ARRAY[:matches]) AS term ON
           c.slug ILIKE term OR
           c.name ILIKE term OR
-          (term ~ '^[0-9]{1,19}$' AND c.id = term::int)
+          (term ~ '^[0-9]{1,10}$' AND c.id = term::int)
       SQL
 
       found = DB.query(sql, matches: matches.keys)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -542,7 +542,7 @@ class Search
 
   advanced_filter(/\Awith:images\z/i) { |posts| posts.where("posts.image_upload_id IS NOT NULL") }
 
-  advanced_filter(/\Acategory:(.+)\z/i) do |posts, terms|
+  advanced_filter(/\Acategor(?:y|ies):(.+)\z/i) do |posts, terms|
     exact = false
 
     matches = terms.split(",")

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -566,7 +566,7 @@ class Search
           unnest(ARRAY[:matches]) AS term ON
           c.slug ILIKE term OR
           c.name ILIKE term OR
-          (term ~ '^[0-9]+$' AND c.id = term::int)
+          (term ~ '^[0-9]{1,19}$' AND c.id = term::int)
       SQL
 
       found = DB.query(sql, matches: matches.keys)

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1275,6 +1275,16 @@ RSpec.describe Search do
 
       search = Search.execute("snow category:abc,#{category.id}")
       expect(search.posts.map(&:id)).to contain_exactly(post.id, post2.id)
+
+      child_category = Fabricate(:category, parent_category: category2)
+      child_topic = Fabricate(:topic, category: child_category)
+      child_post = Fabricate(:post, topic: child_topic, raw: "snow monkey")
+
+      search = Search.execute("monkey category:zzz,nnn,=abc,mmm")
+      expect(search.posts.map(&:id)).to contain_exactly(post2.id)
+
+      search = Search.execute("monkey category:zzz,nnn,abc,mmm")
+      expect(search.posts.map(&:id)).to contain_exactly(post2.id, child_post.id)
     end
 
     it "should return the right categories" do

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1270,6 +1270,9 @@ RSpec.describe Search do
       search = Search.execute("monkey categories:abc,def")
       expect(search.posts.map(&:id)).to contain_exactly(post2.id, post3.id)
 
+      search = Search.execute("monkey categories:xxxxx,=abc,=def")
+      expect(search.posts.map(&:id)).to contain_exactly(post2.id, post3.id)
+
       search = Search.execute("snow category:abc,#{category.id}")
       expect(search.posts.map(&:id)).to contain_exactly(post.id, post2.id)
     end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1267,6 +1267,9 @@ RSpec.describe Search do
       search = Search.execute("monkey category:abc,def")
       expect(search.posts.map(&:id)).to contain_exactly(post2.id, post3.id)
 
+      search = Search.execute("monkey categories:abc,def")
+      expect(search.posts.map(&:id)).to contain_exactly(post2.id, post3.id)
+
       search = Search.execute("snow category:abc,#{category.id}")
       expect(search.posts.map(&:id)).to contain_exactly(post.id, post2.id)
     end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1283,7 +1283,10 @@ RSpec.describe Search do
       search = Search.execute("monkey category:zzz,nnn,=abc,mmm")
       expect(search.posts.map(&:id)).to contain_exactly(post2.id)
 
-      search = Search.execute("monkey category:zzz,nnn,abc,mmm")
+      search =
+        Search.execute(
+          "monkey category:0007847874874874874748749398384398439843984938439843948394834984934839483984983498394834983498349834983,zzz,nnn,abc,mmm",
+        )
       expect(search.posts.map(&:id)).to contain_exactly(post2.id, child_post.id)
     end
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1255,6 +1255,22 @@ RSpec.describe Search do
       )
     end
 
+    it "allow searching for multiple categories" do
+      category2 = Fabricate(:category, name: "abc")
+      topic2 = Fabricate(:topic, category: category2)
+      post2 = Fabricate(:post, topic: topic2, raw: "snow monkey")
+
+      category3 = Fabricate(:category, name: "def")
+      topic3 = Fabricate(:topic, category: category3)
+      post3 = Fabricate(:post, topic: topic3, raw: "snow monkey")
+
+      search = Search.execute("monkey category:abc,def")
+      expect(search.posts.map(&:id)).to contain_exactly(post2.id, post3.id)
+
+      search = Search.execute("snow category:abc,#{category.id}")
+      expect(search.posts.map(&:id)).to contain_exactly(post.id, post2.id)
+    end
+
     it "should return the right categories" do
       search = Search.execute("monkey")
 


### PR DESCRIPTION
This introduces the syntax of

`category:a,b,c` which will search across multiple categories.

Previously there was no way to allow search across a wide selection of
categories.
