### PR TITLE
FIX: Do not enforce 2FA for users who are using social logins

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1155,11 +1155,12 @@ export default class User extends RestModel.extend(Evented) {
     }
   }
 
-  @discourseComputed("second_factor_enabled", "staff")
-  enforcedSecondFactor(secondFactorEnabled, staff) {
+  @discourseComputed("second_factor_enabled", "staff", "local_login_only")
+  enforcedSecondFactor(secondFactorEnabled, staff, localLoginOnly) {
     const enforce = this.siteSettings.enforce_second_factor;
     return (
       !secondFactorEnabled &&
+      localLoginOnly &&
       (enforce === "all" || (enforce === "staff" && staff))
     );
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -919,14 +919,14 @@ class ApplicationController < ActionController::Base
   end
 
   def should_enforce_second_factor?
-    disqualified_from_2fa_enforcement =
+    exempted_from_2fa_enforcement =
       request.format.json? || is_api? || current_user.anonymous? || !current_user.local_login_only?
     enforcing_2fa =
       (
         (SiteSetting.enforce_second_factor == "staff" && current_user.staff?) ||
           SiteSetting.enforce_second_factor == "all"
       )
-    !disqualified_from_2fa_enforcement && enforcing_2fa &&
+    !exempted_from_2fa_enforcement && enforcing_2fa &&
       !current_user.has_any_second_factor_methods_enabled?
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -909,7 +909,7 @@ class ApplicationController < ActionController::Base
     end
 
     return if !current_user
-    return if !should_enforce_2fa?
+    return if !should_enforce_second_factor?
 
     redirect_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
     if !request.fullpath.start_with?(redirect_path)
@@ -918,8 +918,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def should_enforce_2fa?
-    disqualified_from_2fa_enforcement = request.format.json? || is_api? || current_user.anonymous?
+  def should_enforce_second_factor?
+    disqualified_from_2fa_enforcement =
+      request.format.json? || is_api? || current_user.anonymous? || !current_user.local_login_only?
     enforcing_2fa =
       (
         (SiteSetting.enforce_second_factor == "staff" && current_user.staff?) ||

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1515,6 +1515,10 @@ class User < ActiveRecord::Base
     result
   end
 
+  def local_login_only?
+    (associated_accounts.empty? && !single_sign_on_record) || has_any_second_factor_methods_enabled?
+  end
+
   USER_FIELD_PREFIX ||= "user_field_"
 
   def user_fields(field_ids = nil)

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -75,7 +75,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_experimental_topic_bulk_actions?,
              :use_admin_sidebar,
              :can_view_raw_email,
-             :use_glimmer_topic_list?
+             :use_glimmer_topic_list?,
+             :local_login_only?
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -289,7 +290,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled? || object.security_keys_enabled?
+    object.has_any_second_factor_methods_enabled?
   end
 
   def featured_topic

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1760,7 +1760,7 @@ en:
     email_custom_headers: "A pipe-delimited list of custom email headers"
     email_subject: "Customizable subject format for standard emails. See <a href='https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801' target='_blank'>https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801</a>"
     detailed_404: "Provides more details to users about why they can’t access a particular topic. Note: This is less secure because users will know if a URL links to a valid topic."
-    enforce_second_factor: "Require users to enable two-factor authentication before they can access the Discourse UI. Select 'all' to enforce it to all users. Select 'staff' to enforce it to staff users only. This setting does not affect API or 'DiscourseConnect provider' authentication."
+    enforce_second_factor: "Require users to enable two-factor authentication before they can access the Discourse UI. Select 'all' to enforce it to all users. Select 'staff' to enforce it to staff users only. This setting does not affect API, 'DiscourseConnect provider' authentication, or social logins (e.g. Twitter, Facebook, GitHub)."
     force_https: "Force your site to use HTTPS only. WARNING: do NOT enable this until you verify HTTPS is fully set up and working absolutely everywhere! Did you check your CDN, all social logins, and any external logos / dependencies to make sure they are all HTTPS compatible, too?"
 
     summary_score_threshold: "The minimum score required for a post to be included in 'Summarize This Topic'"

--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -8,7 +8,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   end
 
   def description_for_user(user)
-    associated_account = UserAssociatedAccount.find_by(provider_name: name, user_id: user.id)
+    associated_account = user.user_associated_accounts.find { |acc| acc.provider_name == name }
     return "" if associated_account.nil?
     description_for_auth_hash(associated_account) || I18n.t("associated_accounts.connected")
   end

--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -8,7 +8,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   end
 
   def description_for_user(user)
-    associated_account = user.user_associated_accounts.find { |acc| acc.provider_name == name }
+    associated_account = user.user_associated_accounts.find_by(provider_name: name)
     return "" if associated_account.nil?
     description_for_auth_hash(associated_account) || I18n.t("associated_accounts.connected")
   end

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -219,15 +219,6 @@ module SiteSettings::Validations
     if new_val != "no" && SiteSetting.enable_discourse_connect?
       return validate_error :second_factor_cannot_be_enforced_with_discourse_connect_enabled
     end
-    if new_val == "all" && Discourse.enabled_auth_providers.count > 0
-      auth_provider_names = Discourse.enabled_auth_providers.map(&:name).join(", ")
-      return(
-        validate_error(
-          :second_factor_cannot_enforce_with_socials,
-          auth_provider_names: auth_provider_names,
-        )
-      )
-    end
     return if SiteSetting.enable_local_logins
     return if new_val == "no"
     validate_error :second_factor_cannot_be_enforced_with_disabled_local_login

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -152,3 +152,14 @@ Fabricator(:east_coast_user, from: :user) do
     user.save
   end
 end
+
+Fabricator(:social_login_user, from: :user) do
+  transient :provider_name
+  password SecureRandom.hex
+  name "Test Social User"
+  email { sequence(:email) { |i| "testsocial#{i}@test.com" } }
+
+  after_create do |user, transients|
+    Fabricate(:user_associated_account, user: user, provider_name: transients[:provider_name])
+  end
+end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -160,6 +160,10 @@ Fabricator(:social_login_user, from: :user) do
   email { sequence(:email) { |i| "testsocial#{i}@test.com" } }
 
   after_create do |user, transients|
-    Fabricate(:user_associated_account, user: user, provider_name: transients[:provider_name])
+    Fabricate(
+      :user_associated_account,
+      user: user,
+      provider_name: transients[:provider_name] || "facebook",
+    )
   end
 end

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe SiteSettings::Validations do
         before { SiteSetting.enable_local_logins = false }
 
         it "should raise an error" do
-          expect { validations.validate_enforce_second_factor("t") }.to raise_error(
+          expect { validations.validate_enforce_second_factor("all") }.to raise_error(
             Discourse::InvalidParameters,
             error_message,
           )
@@ -155,7 +155,7 @@ RSpec.describe SiteSettings::Validations do
         before { SiteSetting.enable_local_logins = true }
 
         it "should be ok" do
-          expect { validations.validate_enforce_second_factor("t") }.not_to raise_error
+          expect { validations.validate_enforce_second_factor("all") }.not_to raise_error
         end
       end
 
@@ -171,11 +171,8 @@ RSpec.describe SiteSettings::Validations do
           SiteSetting.enable_github_logins = true
         end
 
-        it "raises and error, and specifies the auth providers" do
-          expect { validations.validate_enforce_second_factor("all") }.to raise_error(
-            Discourse::InvalidParameters,
-            error_message,
-          )
+        it "should be ok" do
+          expect { validations.validate_enforce_second_factor("all") }.not_to raise_error
         end
       end
 
@@ -191,7 +188,7 @@ RSpec.describe SiteSettings::Validations do
         end
 
         it "should raise an error" do
-          expect { validations.validate_enforce_second_factor("t") }.to raise_error(
+          expect { validations.validate_enforce_second_factor("all") }.to raise_error(
             Discourse::InvalidParameters,
             error_message,
           )

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -204,6 +204,20 @@ RSpec.describe ApplicationController do
       expect(response).to redirect_to("/u/#{user.encoded_username}/preferences/second-factor")
     end
 
+    it "should not enforce second factor for users who are using social logins instead of local logins" do
+      SiteSetting.enforce_second_factor = "all"
+      SiteSetting.enable_facebook_logins = true
+      social_login_user = Fabricate(:social_login_user)
+
+      sign_in(social_login_user)
+
+      get "/"
+      expect(response).not_to redirect_to(
+        "/u/#{social_login_user.username}/preferences/second-factor",
+      )
+      expect(response.status).to eq(200)
+    end
+
     context "when enforcing second factor for staff" do
       before do
         SiteSetting.enforce_second_factor = "staff"


### PR DESCRIPTION
Previously, we did not allow setting `enforce_second_factor` to
`all` if any social/external auth providers were enabled for the
site. This was inconsistent, as you could still set it to `staff`,
and lead to a bad experience where since the users were forced to
enable 2FA, they were no longer able to use their social login.

This commit changes things so that:

* If a user only has social/external auth, they will not have 2FA
  enforced even if it is set to all/staff
* We no longer disallow turning on `enforce_second_factor` if
  social/external auth is configured for the site
* We update the site setting description for `enforce_second_factor`
  to reflect this

This way, site admins can enforce 2FA for people who are using
only local logins, and people using social logins can use
2FA on the external site and not need double-2FA on Discourse.
