### PR TITLE
PERF: Cache `hostname` in `DiscourseLogstashLogger`

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -3,21 +3,22 @@
 require "logstash-logger"
 
 class DiscourseLogstashLogger
-  def self.logger(uri:, type:)
-    # See Discourse.os_hostname
-    hostname =
+  def self.hostname
+    @hostname ||=
       begin
         require "socket"
         Socket.gethostname
       rescue => e
         `hostname`.chomp
       end
+  end
 
+  def self.logger(uri:, type:)
     LogStashLogger.new(
       uri: uri,
       sync: true,
       customize_event: ->(event) do
-        event["hostname"] = hostname
+        event["hostname"] = self.hostname
         event["severity_name"] = event["severity"]
         event["severity"] = Object.const_get("Logger::Severity::#{event["severity"]}")
         event["type"] = type


### PR DESCRIPTION
Logging events happen all the time. No need for us to keep running code
to fetch the hostname when it doesn't change between deploys.
