### PR TITLE
DEV: Change UserField#field_type to an ActiveRecord enum - Part 1

### DIFF
--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -7,7 +7,7 @@ class UserField < ActiveRecord::Base
 
   deprecate_column :required, drop_from: "3.3"
 
-  validates_presence_of :description, :field_type
+  validates_presence_of :description
   validates_presence_of :name, unless: -> { field_type == "confirm" }
   has_many :user_field_options, dependent: :destroy
   has_one :directory_column, dependent: :destroy
@@ -19,6 +19,10 @@ class UserField < ActiveRecord::Base
   scope :public_fields, -> { where(show_on_profile: true).or(where(show_on_user_card: true)) }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
+
+  # TODO: Drop old field_type and rename this column into field_type and remove alias.
+  enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
+  alias_attribute :field_type, :field_type_enum
 
   def self.max_length
     2048
@@ -47,7 +51,7 @@ end
 #
 #  id                :integer          not null, primary key
 #  name              :string           not null
-#  field_type        :string           not null
+#  field_type        :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  editable          :boolean          default(FALSE), not null
@@ -60,4 +64,5 @@ end
 #  external_type     :string
 #  searchable        :boolean          default(FALSE), not null
 #  requirement       :integer          default("optional"), not null
+#  field_type_enum   :integer          not null
 #

--- a/db/migrate/20240612063735_add_field_type_enum_to_user_fields.rb
+++ b/db/migrate/20240612063735_add_field_type_enum_to_user_fields.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddFieldTypeEnumToUserFields < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_fields, :field_type_enum, :integer
+
+    up_only do
+      execute(<<~SQL)
+        UPDATE user_fields
+        SET field_type_enum =
+          CASE
+            WHEN field_type = 'text' THEN 0
+            WHEN field_type = 'confirm' THEN 1
+            WHEN field_type = 'dropdown' THEN 2
+            WHEN field_type = 'multiselect' THEN 3
+          END
+      SQL
+
+      change_column_null :user_fields, :field_type, true
+      change_column_null :user_fields, :field_type_enum, false
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

Currently this column is a text column, but by right should only take on one of the values text, confirm, dropdown, multiselect. We can convert this to an ActiveRecord enum instead.

This PR adds a new integer column (`field_type_enum`) and populates it based on the existing text column (`field_type`) and adds an alias to replace the latter with the former.

In the next PR we can drop the text column and rename the integer column to replace it.

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGFiZWp2dGoyYXI4dXljbGM3NmEwM2I0cDRjdTk0YmNiZjV4cjAwYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JOxC7fApXUki4/200.webp)

### Manual verifications

- [x] Admins can still create new fields
- [x] New users can still sign up and fill up fields
- [x] Existing users can still fill up fields
- [x] Custom values still showing on user cards if configured