### PR TITLE
DEV: remove composer.modal_cancel translation key

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/insert-hyperlink.hbs
@@ -67,7 +67,7 @@
 
     <DButton
       @action={{@closeModal}}
-      @label="composer.modal_cancel"
+      @label="composer.cancel"
       class="btn-danger"
     />
   </:footer>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2599,7 +2599,6 @@ en:
       show_toolbar: "show composer toolbar"
       hide_toolbar: "hide composer toolbar"
       modal_ok: "OK"
-      modal_cancel: "Cancel"
       cant_send_pm: "Sorry, you can't send a message to %{username}."
       create_message_error: "Sorry, there was an error creating that message. Please try again."
       yourself_confirm:


### PR DESCRIPTION
Dependent on https://github.com/discourse/discourse/pull/27443 which removes the second last use of this translation key.

This replaces the last usage of the `composer.modal_cancel` key with `composer.cancel`, and removes that translation from our locale files.