### PR TITLE
DEV: Change UserField#field_type to an ActiveRecord enum - Part 2

### DIFF
--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -19,10 +19,7 @@ class UserField < ActiveRecord::Base
   scope :public_fields, -> { where(show_on_profile: true).or(where(show_on_user_card: true)) }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
-
-  # TODO: Drop old field_type and rename this column into field_type and remove alias.
-  enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
-  alias_attribute :field_type, :field_type_enum
+  enum :field_type, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
 
   def self.max_length
     2048
@@ -51,7 +48,6 @@ end
 #
 #  id                :integer          not null, primary key
 #  name              :string           not null
-#  field_type        :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  editable          :boolean          default(FALSE), not null
@@ -64,5 +60,5 @@ end
 #  external_type     :string
 #  searchable        :boolean          default(FALSE), not null
 #  requirement       :integer          default("optional"), not null
-#  field_type_enum   :integer          not null
+#  field_type        :integer          not null
 #

--- a/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
+++ b/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SwapFieldTypeWithFieldTypeEnumOnUserFields < ActiveRecord::Migration[7.0]
+  DROPPED_COLUMNS ||= { user_fields: %i[field_type] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+    rename_column :user_fields, :field_type_enum, :field_type
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### What is this change?

Follow up to: #27444. In that PR we added a new integer column for `UserField#field_type` and populated the data based on the old text field.

In this PR we drop the old text column and swap in the new integer (enum) column.