### PR TITLE
FIX: Use the proper i18n argument name

### DIFF
--- a/app/models/theme_setting.rb
+++ b/app/models/theme_setting.rb
@@ -54,7 +54,7 @@ class ThemeSetting < ActiveRecord::Base
         :json_value,
         I18n.t(
           "theme_settings.errors.json_value.too_large",
-          max_size_megabytes: MAXIMUM_JSON_VALUE_SIZE_BYTES / 1024 / 1024,
+          max_size: MAXIMUM_JSON_VALUE_SIZE_BYTES / 1024 / 1024,
         ),
       )
     end

--- a/spec/models/theme_setting_spec.rb
+++ b/spec/models/theme_setting_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ThemeSetting do
         expect(theme_setting.errors[:json_value]).to contain_exactly(
           I18n.t(
             "theme_settings.errors.json_value.too_large",
-            max_size_megabytes: (bytesize - 1) / 1024 / 1024,
+            max_size: (bytesize - 1) / 1024 / 1024,
           ),
         )
       end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
