### PR TITLE
Revert "FIX: Properly close user-card after page transition (#27423)"

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -1,5 +1,5 @@
 import { getOwner } from "@ember/owner";
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import {
@@ -9,23 +9,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
 import I18n from "discourse-i18n";
-
-acceptance("User Card", function (needs) {
-  needs.user();
-
-  test("opens and closes properly", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    await click('a[data-user-card="charlie"]');
-
-    assert.dom(".user-card .card-content").exists();
-
-    await click(".card-huge-avatar");
-
-    assert.strictEqual(currentURL(), "/u/charlie/summary");
-    assert.dom(".user-card").doesNotExist();
-    assert.dom(".card-content").doesNotExist();
-  });
-});
 
 acceptance("User Card - Show Local Time", function (needs) {
   needs.user();

--- a/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
@@ -112,7 +112,6 @@ export default class DMenuInstance extends FloatKitInstance {
 
   @action
   destroy() {
-    this.close();
     this.tearDownListeners();
   }
 }

--- a/app/assets/javascripts/float-kit/addon/lib/d-tooltip-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-tooltip-instance.js
@@ -102,7 +102,6 @@ export default class DTooltipInstance extends FloatKitInstance {
 
   @action
   destroy() {
-    this.close();
     this.tearDownListeners();
   }
 }


### PR DESCRIPTION
This reverts commit 1ecfc397d36536795824d5b46d7687a5f76778f4.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
