### PR TITLE
FIX: Email::Sender expects type to be a string

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -253,7 +253,7 @@ module Email
       if post.present?
         @stripped_secure_upload_shas = style.stripped_upload_sha_map.values
         add_attachments(post)
-      elsif @email_type == :digest
+      elsif @email_type.to_s == "digest"
         @stripped_secure_upload_shas = style.stripped_upload_sha_map.values
         digest_posts.each { |p| add_attachments(p) }
       end

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe Email::Sender do
 
           message.header["X-Discourse-Post-Id"] = nil
           message.header["X-Discourse-Post-Ids"] = "#{reply.id},#{other_post.id}"
-          Email::Sender.new(message, :digest).send
+          Email::Sender.new(message, "digest").send
           expect(message.attachments.map(&:filename)).to include(
             *[image, @secure_image, @secure_image_2].map(&:original_filename),
           )


### PR DESCRIPTION
### What was happening?

In #26642 we introduced a change that re-attaches securely uploaded images in the digest e-mail. However, this change assumed that the `type` argument to the `Email::Sender` constructor would be a symbol, but when it is coming from the `UserEmail` job it is a string. This PR fixes that.