### PR TITLE
DEV: Show parameters on a service contract failure

### DIFF
--- a/app/services/service/base.rb
+++ b/app/services/service/base.rb
@@ -177,7 +177,7 @@ module Service
         context[contract_name] = contract
         context[result_key] = Context.build
         if contract.invalid?
-          context[result_key].fail(errors: contract.errors)
+          context[result_key].fail(errors: contract.errors, parameters: contract.raw_attributes)
           context.fail!
         end
       end
@@ -218,6 +218,10 @@ module Service
           include ActiveModel::Attributes
           include ActiveModel::AttributeMethods
           include ActiveModel::Validations::Callbacks
+
+          def raw_attributes
+            @attributes.values_before_type_cast
+          end
         end
     end
 

--- a/lib/steps_inspector.rb
+++ b/lib/steps_inspector.rb
@@ -73,7 +73,7 @@ class StepsInspector
   # @!visibility private
   class Contract < Step
     def error
-      step_result.errors.inspect
+      "#{step_result.errors.inspect}\n\nProvided parameters: #{step_result.parameters.pretty_inspect}"
     end
   end
 

--- a/spec/lib/steps_inspector_spec.rb
+++ b/spec/lib/steps_inspector_spec.rb
@@ -219,6 +219,10 @@ RSpec.describe StepsInspector do
       it "returns an error related to the contract" do
         expect(error).to match(/ActiveModel::Error attribute=parameter, type=blank, options={}/)
       end
+
+      it "returns the provided paramaters" do
+        expect(error).to match(/{"parameter"=>nil}/)
+      end
     end
 
     context "when the policy step is failing" do


### PR DESCRIPTION
Now, when calling `StepsInspector#error` on a contract failure, the output will contain the parameters provided to the contract.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
