### PR TITLE
FEATURE: show my threads from muted chat channels

### DIFF
--- a/plugins/chat/app/services/chat/lookup_user_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_user_threads.rb
@@ -84,7 +84,6 @@ module Chat
             ::Chat::Channel
               .joins(:user_chat_channel_memberships)
               .where(user_chat_channel_memberships: { user_id: guardian.user.id, following: true })
-              .where.not("user_chat_channel_memberships.muted")
               .where(
                 {
                   chatable_type: "Category",

--- a/plugins/chat/spec/services/chat/lookup_user_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_user_threads_spec.rb
@@ -168,4 +168,13 @@ RSpec.describe ::Chat::LookupUserThreads do
 
     expect(result.threads).to eq([])
   end
+
+  it "returns threads from muted channels" do
+    thread_1 = Fabricate(:chat_thread, channel: channel_1, with_replies: 1)
+    thread_1.add(current_user)
+
+    channel_1.membership_for(current_user).update!(muted: true)
+
+    expect(result.threads).to eq([thread_1])
+  end
 end

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
-  fab!(:user)
-  fab!(:user_2) { Fabricate(:user) }
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:other_user) { Fabricate(:user) }
   fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
-  fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: user) }
+  fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: current_user) }
   let(:chat_page) { PageObjects::Pages::Chat.new }
 
   before do
     chat_system_bootstrap
-    sign_in(user)
-    channel.add(user)
-    channel.add(user_2)
+    sign_in(current_user)
+    channel.add(current_user)
+    channel.add(other_user)
   end
 
   context "with multiple tabs" do
@@ -55,11 +55,11 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
     context "when user is not a member of any channel with threads" do
       before do
         other_channel = Fabricate(:chat_channel, threading_enabled: false)
-        other_channel.add(user)
-        channel.remove(user)
+        other_channel.add(current_user)
+        channel.remove(current_user)
       end
 
-      it "shows threads tab when user has threads" do
+      it "does not show my threads" do
         SiteSetting.chat_threads_enabled = true
 
         visit("/")
@@ -112,8 +112,8 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
         Fabricate(
           :chat_message_with_service,
           chat_channel: channel,
-          message: "hello @#{user.username}",
-          user: user_2,
+          message: "hello @#{current_user.username}",
+          user: other_user,
         )
 
         expect(page).to have_css("#c-footer-channels .c-unread-indicator.-urgent", text: "1")
@@ -121,7 +121,7 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
     end
 
     context "for direct messages" do
-      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user]) }
+      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user]) }
       fab!(:dm_message) { Fabricate(:chat_message, chat_channel: dm_channel) }
 
       it "is urgent" do
@@ -132,17 +132,26 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
       end
     end
 
-    context "for threads" do
+    context "for my threads" do
       fab!(:thread) { Fabricate(:chat_thread, channel: channel, original_message: message) }
       fab!(:thread_message) { Fabricate(:chat_message, chat_channel: channel, thread: thread) }
 
-      it "is unread" do
-        SiteSetting.chat_threads_enabled = true
+      before { SiteSetting.chat_threads_enabled = true }
 
+      it "is unread" do
         visit("/")
         chat_page.open_from_header
 
         expect(page).to have_css("#c-footer-threads .c-unread-indicator")
+      end
+
+      it "is not unread when thread is from a muted channel" do
+        channel.membership_for(current_user).update!(muted: true)
+
+        visit("/")
+        chat_page.open_from_header
+
+        expect(page).to have_no_css("#c-footer-threads .c-unread-indicator")
       end
     end
   end


### PR DESCRIPTION
We should show threads from muted channels in the My Threads area so that users can easily access their followed threads.

#### Objectives

- When a user is following a thread in a muted channel, it should still be visible in My Threads.
- Activity in followed threads for muted channels should not generate an activity indicator (e.g. blue notification dot) on My Threads.