### PR TITLE
UX: remove padding to fix mobile date pinning in chat threads

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
@@ -2,10 +2,6 @@
   &__body {
     margin: 0 1px 0 0;
   }
-
-  .chat-messages-scroller {
-    padding: 10px 10px 0 10px;
-  }
 }
 
 .thread-toast {


### PR DESCRIPTION
This fixes an issue where sticky dates within threads on mobile weren't getting the `is-pinned` class from this intersection observer: https://github.com/discourse/discourse/blob/2014f1a0b7139ad4d488e1a15316877c861a1747/plugins/chat/assets/javascripts/discourse/components/chat-message-separator.gjs#L13

The issue seems to be this additional padding pushing the date down and preventing the intersection from happening. 

I can't really find a reason for the padding, removing it makes the thread layout spacing more consistent with the main chat channel anyway. 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/1d229270-b3c0-4582-8732-8da8397da736)


After:
![image](https://github.com/discourse/discourse/assets/1681963/e2c92819-9cd1-4ff6-a544-b122587f2677)

