### PR TITLE
FIX: restrict a href protocols on form template description

### DIFF
--- a/lib/validators/form_template_yaml_validator.rb
+++ b/lib/validators/form_template_yaml_validator.rb
@@ -3,7 +3,17 @@
 class FormTemplateYamlValidator < ActiveModel::Validator
   RESERVED_KEYWORDS = %w[title body category category_id tags]
   ALLOWED_TYPES = %w[checkbox dropdown input multi-select textarea upload]
-  HTML_SANITIZATION_OPTIONS = { elements: ["a"], attributes: { "a" => %w[href target] } }
+  HTML_SANITIZATION_OPTIONS = {
+    elements: ["a"],
+    attributes: {
+      "a" => %w[href target],
+    },
+    protocols: {
+      "a" => {
+        "href" => %w[http https mailto],
+      },
+    },
+  }
 
   def validate(record)
     begin

--- a/spec/lib/validators/form_template_yaml_validator_spec.rb
+++ b/spec/lib/validators/form_template_yaml_validator_spec.rb
@@ -136,6 +136,23 @@ RSpec.describe FormTemplateYamlValidator, type: :validator do
         )
       end
     end
+
+    context "when description field has unsafe anchor href" do
+      let(:yaml_content) { <<~YAML }
+          - type: input
+            id: name
+            attributes:
+              label: "Full name"
+              description: "What is your full name? Details <a href='javascript:alert()'>here</a>."
+        YAML
+
+      it "adds a validation error" do
+        validator.validate(form_template)
+        expect(form_template.errors[:template]).to include(
+          I18n.t("form_templates.errors.unsafe_description"),
+        )
+      end
+    end
   end
 
   describe "#check_ids" do


### PR DESCRIPTION
We weren't restricting the `a` `href` protocols on the form template field description, this PR fixes it.