### PR TITLE
UX: replace "all subcategories" with "remove filter", reorder tag dropdown

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -53,13 +53,13 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
 
     assert.strictEqual(
       content[0].name,
-      I18n.t("tagging.selector_no_tags"),
-      "it has the translated label for no-tags"
+      I18n.t("tagging.selector_remove_filter"),
+      "it has the correct label for removing the tag filter"
     );
     assert.strictEqual(
       content[1].name,
-      I18n.t("tagging.selector_remove_filter"),
-      "it has the correct label for removing the tag filter"
+      I18n.t("tagging.selector_no_tags"),
+      "it has the translated label for no-tags"
     );
 
     await this.subject.fillInFilter("dav");

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -159,7 +159,7 @@ export default ComboBoxComponent.extend({
       }
 
       if (this.selectKit.options.subCategory) {
-        return I18n.t("categories.all_subcategories", {
+        return I18n.t("categories.remove_filter", {
           categoryName: this.parentCategoryName,
         });
       }

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -96,17 +96,17 @@ export default ComboBoxComponent.extend(TagsMixin, {
   shortcuts: computed("tagId", function () {
     const shortcuts = [];
 
-    if (this.tagId !== NONE_TAG) {
-      shortcuts.push({
-        id: NO_TAG_ID,
-        name: I18n.t("tagging.selector_no_tags"),
-      });
-    }
-
     if (this.tagId) {
       shortcuts.push({
         id: ALL_TAGS_ID,
         name: I18n.t("tagging.selector_remove_filter"),
+      });
+    }
+
+    if (this.tagId !== NONE_TAG) {
+      shortcuts.push({
+        id: NO_TAG_ID,
+        name: I18n.t("tagging.selector_no_tags"),
       });
     }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1076,7 +1076,6 @@ en:
     categories:
       categories_label: "categories"
       subcategories_label: "subcategories"
-      all_subcategories: "all subcategories"
       no_subcategories: "no subcategories"
       remove_filter: "remove filter"
       plus_more_count:


### PR DESCRIPTION
This updates "all subcategories" to "remove filter" to match the categories and tags dropdowns.


Before:
![image](https://github.com/discourse/discourse/assets/1681963/cc07066a-7cd0-493e-8019-b0caa334bea3)

After:
![image](https://github.com/discourse/discourse/assets/1681963/1643fdf1-2510-4c64-9421-04df38cdd13f)

This also reorders the "remove fiter" option from the tag dropdown so it appears first for consistency with other filters:

Before:
![image](https://github.com/discourse/discourse/assets/1681963/62139f3f-0491-4398-ae0f-6e5ab4f9c030)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/736455a7-1b30-471d-99ca-d1462f5a7584)
