### PR TITLE
UX: make tag filter color consistent with category filters

### DIFF
--- a/app/assets/stylesheets/common/select-kit/tag-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/tag-drop.scss
@@ -3,16 +3,17 @@
     &.tag-drop {
       min-width: auto;
 
+      .tag-drop-header,
+      .selected-name {
+        color: var(--primary-high);
+      }
+
       .select-kit-row {
         &[data-value="all-tags"],
         &[data-value="no-tags"] {
           color: var(--tertiary);
           font-weight: 700;
         }
-      }
-
-      .tag-drop-header {
-        color: var(--primary-high);
       }
 
       &.has-selection {


### PR DESCRIPTION
this keeps the tag name `--primary-high` to match the category dropdowns (and tag names in general)

Before:
![image](https://github.com/discourse/discourse/assets/1681963/a17f4c04-2d7b-4fb2-9f34-3566b2ad0780)


After:
![image](https://github.com/discourse/discourse/assets/1681963/81ada057-6870-4f0d-8de4-bee8f4cb8103)
