### PR TITLE
UX: highlight "no subcategories" as active dropdown option

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -22,6 +22,7 @@ const MORE_COLLECTION = "MORE_COLLECTION";
 export default ComboBoxComponent.extend({
   pluginApiIdentifiers: ["category-drop"],
   classNames: ["category-drop"],
+  classNameBindings: ["noSubcategories:has-selection"],
   value: readOnly("category.id"),
   content: readOnly("categoriesWithShortcuts.[]"),
   noCategoriesLabel: I18n.t("categories.no_subcategories"),
@@ -64,6 +65,10 @@ export default ComboBoxComponent.extend({
     return CategoryRow;
   },
 
+  noSubcategories: computed("selectKit.options.noSubcategories", function () {
+    return this.selectKit.options.noSubcategories;
+  }),
+
   displayCategoryDescription: computed(function () {
     return !(
       this.get("currentUser.staff") || this.get("currentUser.trust_level") > 0
@@ -101,8 +106,7 @@ export default ComboBoxComponent.extend({
         });
       }
 
-      // If there is a single shortcut, we can have a single "remove filter"
-      // option
+      // If there is a single shortcut, we can have a single "remove filter" option
       if (shortcuts.length === 1 && shortcuts[0].id === ALL_CATEGORIES_ID) {
         shortcuts[0].name = I18n.t("categories.remove_filter");
       }

--- a/app/assets/stylesheets/common/select-kit/category-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/category-drop.scss
@@ -21,8 +21,10 @@
 
       &.has-selection {
         .category-drop-header {
-          color: var(--quaternary);
           border-color: var(--quaternary);
+          .caret-icon {
+            color: var(--quaternary);
+          }
         }
       }
 


### PR DESCRIPTION
"No subcategories" is technically a user-changed filter, so we should highlight it as well. 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/4c97fa63-112b-4ee9-ab6e-afa8fa1db94f)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/61318bab-a9dc-45c0-86e7-4d91d3146a53)

This gets us consistent with "no tags" too:

![image](https://github.com/discourse/discourse/assets/1681963/86a8d1bf-10b7-45ca-b9a6-d4c0eb1dac16)

