### PR TITLE
DEV: Remove `hostname` from `DiscourseLogstashLogger` output

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -3,22 +3,11 @@
 require "logstash-logger"
 
 class DiscourseLogstashLogger
-  def self.hostname
-    @hostname ||=
-      begin
-        require "socket"
-        Socket.gethostname
-      rescue => e
-        `hostname`.chomp
-      end
-  end
-
   def self.logger(uri:, type:)
     LogStashLogger.new(
       uri: uri,
       sync: true,
       customize_event: ->(event) do
-        event["hostname"] = self.hostname
         event["severity_name"] = event["severity"]
         event["severity"] = Object.const_get("Logger::Severity::#{event["severity"]}")
         event["type"] = type


### PR DESCRIPTION
This is a duplicate of the `host` field which means we are bloating the
logs unnecessarily.

Just remove without depreciation for now but we are open to properly
depreciating it if others depend on this field.
