### PR TITLE
UX: always show image preview controls, improve spacing

### DIFF
--- a/app/assets/stylesheets/common/base/d-image-grid.scss
+++ b/app/assets/stylesheets/common/base/d-image-grid.scss
@@ -24,6 +24,10 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
+    .button-wrapper {
+      bottom: 0;
+      min-width: unset;
+    }
 
     > div,
     > span {
@@ -85,17 +89,6 @@
         &[editing] .wrap-image-grid-button {
           display: none;
         }
-      }
-    }
-  }
-
-  .mobile-view .d-editor-preview & {
-    .image-wrapper {
-      .button-wrapper {
-        opacity: 0;
-      }
-      &:hover .button-wrapper {
-        opacity: 1;
       }
     }
   }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -186,10 +186,6 @@
     background: var(--secondary);
     color: var(--primary);
 
-    &[editing] {
-      opacity: 1;
-    }
-
     .scale-btn-container,
     .alt-text-readonly-container,
     .alt-text-edit-container,

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -149,12 +149,12 @@
 }
 
 .d-editor-preview img {
-  padding-bottom: 1.4em;
+  vertical-align: baseline; // consistent with cooked
   &.emoji,
   &.avatar,
   &.onebox-avatar,
   &.site-icon {
-    padding-bottom: 0;
+    vertical-align: text-bottom;
   }
   &.resizable {
     object-fit: cover;
@@ -163,40 +163,28 @@
 }
 
 .d-editor-preview .image-wrapper {
-  --resizer-height: 1.75em;
   position: relative;
   display: inline-block;
-  .discourse-no-touch & {
-    // on hover-capable devices we position the controls within the padding
-    padding-bottom: var(--resizer-height);
-    margin-bottom: calc(var(--resizer-height) * -1);
-  }
-
-  img {
-    padding-bottom: 0;
-  }
-
-  &:hover {
-    .button-wrapper {
-      opacity: 1;
-    }
-  }
 
   .button-wrapper {
-    min-width: 10em;
+    --resizer-height: 2.5em;
+    box-sizing: border-box;
+    padding: 0.25em 0.5em;
+    min-width: 19em; // wide enough to contain all controls
     width: 100%;
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
     gap: 0 0.5em;
     position: absolute;
-    height: calc(var(--resizer-height) + 0.5em);
-    bottom: 0;
+    height: var(--resizer-height);
+    bottom: 0.4em;
     left: 0;
-    opacity: 0;
+    opacity: 0.9;
     transition: all 0.25s;
     z-index: 1; // needs to be higher than image
-    background: var(--secondary); // for when images are wider than controls
+    background: var(--secondary);
+    color: var(--primary);
 
     &[editing] {
       opacity: 1;
@@ -206,7 +194,6 @@
     .alt-text-readonly-container,
     .alt-text-edit-container,
     .delete-image-button {
-      background: var(--secondary);
       display: flex;
       height: var(--resizer-height);
       align-items: center;
@@ -262,11 +249,11 @@
       gap: 0 0.25em;
       flex: 1;
       max-width: 100%;
-
+      height: 95%; // gives input some padding
       .alt-text-input,
       .alt-text-edit-ok,
       .alt-text-edit-cancel {
-        height: var(--resizer-height);
+        height: 100%;
       }
 
       .alt-text-input {
@@ -308,10 +295,6 @@
       pointer-events: none;
     }
   }
-}
-
-.discourse-touch .d-editor-preview .image-wrapper .button-wrapper {
-  opacity: 1;
 }
 
 // d-editor bar button sizing


### PR DESCRIPTION
This makes it so the image resize/alt-text controls in the composer editor are always visible on desktop, instead of relying on hover (they're already always visible in the mobile preview).

This makes the controls more discoverable, and if we position them over the image, it means we end up with a preview that has spacing much closer to the cooked result. 

We planned on doing this long ago, but lost sight of it: https://meta.discourse.org/t/make-it-more-obvious-an-image-is-resizable-when-uploading-an-image/132030


Before:
![image](https://github.com/discourse/discourse/assets/1681963/55d2f806-0319-48f2-8133-62ae37524c76)

After:
![image](https://github.com/discourse/discourse/assets/1681963/2c6c1668-8aaf-406d-a20d-58fbd7bcf3e5)

and cooked spacing...

Preview before:
![image](https://github.com/discourse/discourse/assets/1681963/19e45680-5909-4e93-a902-aaf9f4436378)

Preview after:
![image](https://github.com/discourse/discourse/assets/1681963/926bf2dd-9419-4134-a580-86bcdb4bc436)


Actual spacing in cooked post: 
![image](https://github.com/discourse/discourse/assets/1681963/18c2e275-7c3d-4e92-860c-f7d67c0c8f9a)


For tiny images... more of the image is obscured this way, but there's a slight transparency so it's still somewhat visible: 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/97d4723f-26ec-4736-8dbd-f348e056bcd0)


After:
![image](https://github.com/discourse/discourse/assets/1681963/f5622c13-cee9-49f3-b7f3-f5aa582e30a6)


Other states like grid and editing:

![image](https://github.com/discourse/discourse/assets/1681963/3d81156c-72ad-4944-bfd9-cf41d987b8aa)

![image](https://github.com/discourse/discourse/assets/1681963/f1ecc606-eee8-42af-a192-0e1cd19040ad)


