### PR TITLE
FIX: post revision serializer when tags is a string

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -279,7 +279,7 @@ class PostRevisionSerializer < ApplicationSerializer
   end
 
   def filter_tags(tags)
-    tags - hidden_tags
+    tags.is_a?(Array) && tags.any? ? tags - hidden_tags : tags
   end
 
   def filter_category_id(category_id)

--- a/spec/serializers/post_revision_serializer_spec.rb
+++ b/spec/serializers/post_revision_serializer_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe PostRevisionSerializer do
     end
   end
 
+  it "handles tags not being an array" do
+    pr = Fabricate(:post_revision, post: post, modifications: { "tags" => ["[]", ""] })
+
+    json =
+      PostRevisionSerializer.new(pr, scope: Guardian.new(Fabricate(:user)), root: false).as_json
+
+    expect(json[:tags_changes][:previous]).to eq("[]")
+    expect(json[:tags_changes][:current]).to eq([])
+  end
+
   context "with hidden tags" do
     fab!(:public_tag) { Fabricate(:tag, name: "public") }
     fab!(:public_tag2) { Fabricate(:tag, name: "visible") }


### PR DESCRIPTION
In some instances, the `modifications` of `tags` hasn't been properly serialized as a Ruby array but rather as a string (I've seen `""`, `"[]"`, and `"[\"\"]"`).

This generates an error when we try to `filter_tags` and remove `hidden_tags` (which is an array) from `tags` which might be a string.

Internal ref - t/131126

I wasn't able to figure out the root cause of this so I reverted the behavior that was introduced ~6 years ago in f2c060bdf2a309fd4ba884b529367df66837a6d7

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
