### PR TITLE
FIX: Bump reject_reason limit for reviewables to 2000 characters

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -173,6 +173,7 @@ export default Component.extend({
         `/review/${reviewable.id}/perform/${performableAction.server_action}?version=${version}`,
         {
           type: "PUT",
+          dataType: "json",
           data,
         }
       )

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -36,7 +36,7 @@ class Reviewable < ActiveRecord::Base
   enum :priority, { low: 0, medium: 5, high: 10 }, scopes: false, suffix: true
   enum :sensitivity, { disabled: 0, low: 9, medium: 6, high: 3 }, scopes: false, suffix: true
 
-  validates :reject_reason, length: { maximum: 500 }
+  validates :reject_reason, length: { maximum: 2000 }
 
   after_create { log_history(:created, created_by) }
 

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Reviewable, type: :model do
   describe "Validations" do
-    it { is_expected.to validate_length_of(:reject_reason).is_at_most(500) }
+    it { is_expected.to validate_length_of(:reject_reason).is_at_most(2000) }
   end
 
   describe ".create" do

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -187,6 +187,25 @@ RSpec.describe ReviewablesController do
         expect(json["errors"][0]).to eq(I18n.t("reviewables.already_handled_and_user_not_exist"))
       end
 
+      it "returns a readable error message if reject_reason is too long" do
+        sign_in(admin)
+        Jobs.run_immediately!
+        SiteSetting.must_approve_users = true
+        user = Fabricate(:user)
+        user.activate
+        reviewable = ReviewableUser.find_by(target: user)
+
+        put "/review/#{reviewable.id}/perform/delete_user.json?version=0",
+            params: {
+              send_email: true,
+              reject_reason: "a" * 3000,
+            }
+        expect(response.code).to eq("422")
+        expect(response.parsed_body["errors"]).to eq(
+          ["Reject reason " + I18n.t("errors.messages.too_long", count: 2000)],
+        )
+      end
+
       context "when filtering by range" do
         let(:from) { 3.days.ago.strftime("%F") }
         let(:to) { 1.day.ago.strftime("%F") }


### PR DESCRIPTION
Followup 783c935dcb7f114c206da4fe9c46c91ca5c687f3

Some admins were finding that the limit introduced above was
too short especially when sending an email to rejected users.
This commit bumps the limit from 500 to 2000 and also fixes
an issue where the friendly error message was not shown in
the browser.

c.f. https://meta.discourse.org/t/500-character-reject-reason-is-too-small-a-limit/291884