### PR TITLE
FIX: Remove references to `Rails.logger.chained`

### DIFF
--- a/config/initializers/002-rails_failover.rb
+++ b/config/initializers/002-rails_failover.rb
@@ -19,7 +19,7 @@ if defined?(RailsFailover::Redis)
     SiteSetting.refresh!
   end
 
-  RailsFailover::Redis.logger = Rails.logger.chained.first if Rails.logger.respond_to? :chained
+  RailsFailover::Redis.logger = Rails.logger.broadcasts.first
 end
 
 if defined?(RailsFailover::ActiveRecord)

--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -2,7 +2,7 @@
 
 if GlobalSetting.skip_redis?
   Rails.application.reloader.to_prepare do
-    Rails.logger = Rails.logger.chained.first if Rails.logger.respond_to? :chained
+    Rails.logger.stop_broadcasting_to(Logster.logger) if defined?(Logster::Logger) && Logster.logger
   end
   return
 end
@@ -118,10 +118,7 @@ RailsMultisite::ConnectionManagement.each_connection do
 end
 
 if Rails.configuration.multisite
-  if Rails.logger.respond_to? :chained
-    chained = Rails.logger.chained
-    chained && chained.first.formatter = RailsMultisite::Formatter.new
-  end
+  Rails.logger.broadcasts.first.formatter = RailsMultisite::Formatter.new
 end
 
 Logster.config.project_directories = [

--- a/config/initializers/100-quiet_logger.rb
+++ b/config/initializers/100-quiet_logger.rb
@@ -11,9 +11,9 @@ module DiscourseRackQuietAssetsLogger
          (env["PATH_INFO"].index("/service-worker") == 0) ||
          (env["PATH_INFO"].index("mini-profiler-resources") == 0) ||
          (env["PATH_INFO"].index("/srv/status") == 0)
-      if ::Logster::Logger === Rails.logger
+      if defined?(::Logster::Logger) && Logster.logger
         override = true
-        Rails.logger.override_level = Logger::ERROR
+        Logster.logger.override_level = Logger::ERROR
       end
     end
 

--- a/config/initializers/100-silence_logger.rb
+++ b/config/initializers/100-silence_logger.rb
@@ -20,9 +20,9 @@ class SilenceLogger < Rails::Rack::Logger
     if env[HTTP_X_SILENCE_LOGGER] || @opts[:silenced].include?(path_info) ||
          path_info.start_with?("/logs") || path_info.start_with?("/user_avatar") ||
          path_info.start_with?("/letter_avatar")
-      if ::Logster::Logger === Rails.logger
+      if defined?(::Logster::Logger) && Logster.logger
         override = true
-        Rails.logger.override_level = Logger::WARN
+        Logster.logger.override_level = Logger::WARN
       end
       @app.call(env)
     else

--- a/config/initializers/101-lograge.rb
+++ b/config/initializers/101-lograge.rb
@@ -111,8 +111,8 @@ Rails.application.config.to_prepare do
 
         # Remove ActiveSupport::Logger from the chain and replace with Lograge's
         # logger
-        Rails.logger.chained.pop
-        Rails.logger.chain(config.lograge.logger)
+        Rails.logger.stop_broadcasting_to(Rails.logger.broadcasts.last)
+        Rails.logger.broadcast_to(config.lograge.logger)
       end
     end
   end

--- a/config/initializers/102-truncate-logs.rb
+++ b/config/initializers/102-truncate-logs.rb
@@ -22,10 +22,6 @@ if Rails.env.production? || ENV["ENABLE_LOGS_TRUNCATION"] == "1"
   end
 
   Rails.application.config.to_prepare do
-    set_or_extend_truncate_logs_formatter(Rails.logger)
-
-    if Rails.logger.respond_to? :chained
-      Rails.logger.chained.each { |logger| set_or_extend_truncate_logs_formatter(logger) }
-    end
+    Rails.logger.broadcasts.each { |logger| set_or_extend_truncate_logs_formatter(logger) }
   end
 end

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -954,14 +954,7 @@ module Discourse
   def self.warn(message, env = nil)
     append = env ? (+" ") << env.map { |k, v| "#{k}: #{v}" }.join(" ") : ""
 
-    if !(Logster::Logger === Rails.logger)
-      Rails.logger.warn("#{message}#{append}")
-      return
-    end
-
-    loggers = [Rails.logger]
-    loggers.concat(Rails.logger.chained) if Rails.logger.chained
-
+    loggers = Rails.logger.broadcasts
     logster_env = env
 
     if old_env = Thread.current[Logster::Logger::LOGSTER_ENV]

--- a/spec/support/fake_logger.rb
+++ b/spec/support/fake_logger.rb
@@ -60,4 +60,8 @@ class FakeLogger
   def add(severity, message = nil, progname = nil)
     public_send(severities[severity]) << message
   end
+
+  def broadcasts
+    [self]
+  end
 end


### PR DESCRIPTION
`Rails.logger.chained` was provided by Logster before Rails 7.1 introduced their broadcast logger. Now all the loggers are added to `Rails.logger.broadcasts`.

Some code in our initializers was still using `chained` instead of `broadcasts`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
