### PR TITLE
FIX: Restore user-cards in composer preview

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -354,15 +354,17 @@ export default Component.extend(TextareaTextManipulation, {
     if (event.target.tagName === "A") {
       if (event.target.classList.contains("mention")) {
         this.appEvents.trigger(
-          "click.discourse-preview-user-card-mention",
-          $(event.target)
+          "d-editor:preview-click-user-card",
+          event.target,
+          event
         );
       }
 
       if (event.target.classList.contains("mention-group")) {
         this.appEvents.trigger(
-          "click.discourse-preview-group-card-mention-group",
-          $(event.target)
+          "d-editor:preview-click-group-card",
+          event.target,
+          event
         );
       }
 

--- a/app/assets/javascripts/discourse/app/components/header/topic/participant.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/participant.gjs
@@ -22,7 +22,8 @@ export default class Participant extends Component {
     this.appEvents.trigger(
       `topic-header:trigger-${this.args.type}-card`,
       this.args.username,
-      e.target
+      e.target,
+      e
     );
     e.preventDefault();
   }

--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -51,7 +51,8 @@ createWidget("topic-header-participant", {
     this.appEvents.trigger(
       `topic-header:trigger-${this.attrs.type}-card`,
       this.attrs.username,
-      e.target
+      e.target,
+      e
     );
     e.preventDefault();
   },

--- a/spec/system/composer_spec.rb
+++ b/spec/system/composer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe "Composer", type: :system do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  before { sign_in(user) }
+
+  it "displays user cards in preview" do
+    page.visit "/new-topic"
+
+    expect(composer).to be_opened
+
+    composer.fill_content("@#{user.username}")
+    # binding.pry
+    composer.preview.find("a.mention").click
+
+    page.has_css?("#user-card")
+  end
+end


### PR DESCRIPTION
The ability to display them was lost in 91456ad2cbbf767f71aedffb6b556617df64342f

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
