### PR TITLE
UX: Fix user bookmark list keyboard focus state

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.hbs
@@ -80,7 +80,7 @@
                 </label>
               </td>
             {{/if}}
-            <th scope="row" class="main-link topic-list-data">
+            <td class="main-link topic-list-data">
               <span class="link-top-line">
                 <div class="bookmark-metadata">
                   {{#if bookmark.reminder_at}}
@@ -157,7 +157,7 @@
                 class="post-excerpt"
                 {{on "click" this.screenExcerptForExternalLink}}
               >{{html-safe bookmark.excerpt}}</p>
-            </th>
+            </td>
             {{#if this.site.desktopView}}
               <td class="author-avatar topic-list-data">
                 {{#if bookmark.user.avatar_template}}


### PR DESCRIPTION
Should fix this issue: 

![image](https://github.com/discourse/discourse/assets/368961/bcd4d2dc-d155-4ffc-99b0-7679f49e5674)

We don't need to use a `<th>` here, a regular `<td>` element is fine. And we don't need to add `role="rowheader"` to the TD element either, that is only useful when the layout of the table uses flex or grid, but in this case we don't use either. 