### PR TITLE
FIX: Set `override_level` on Logster loggers

### DIFF
--- a/config/initializers/100-quiet_logger.rb
+++ b/config/initializers/100-quiet_logger.rb
@@ -17,7 +17,7 @@ module DiscourseRackQuietAssetsLogger
       end
     end
 
-    super(env).tap { Rails.logger.override_level = nil if override }
+    super(env).tap { Logster.logger.override_level = nil if override }
   end
 end
 

--- a/config/initializers/100-silence_logger.rb
+++ b/config/initializers/100-silence_logger.rb
@@ -29,7 +29,7 @@ class SilenceLogger < Rails::Rack::Logger
       super(env)
     end
   ensure
-    Rails.logger.override_level = nil if override
+    Logster.logger.override_level = nil if override
   end
 end
 


### PR DESCRIPTION
A followup to f595d599dd361b7fb39fb3c82cbc11d19d518c19

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
