### PR TITLE
UX: vertical alignment for lighbox-wrapper

### DIFF
--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -24,6 +24,7 @@ $meta-element-margin: 6px;
 
 .lightbox-wrapper {
   display: inline-block;
+  vertical-align: middle;
   img {
     object-fit: cover;
     object-position: top;


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/lightboxed-images-do-not-have-vertical-align-set-misaligning-them-with-naked-img-s/312553/1

Since images have `vertical-align: middle`, the lightbox wrapper needs it for aligning with sibling images (without lightboxes) in posts. 

Before: 
![image](https://github.com/discourse/discourse/assets/1681963/36802082-065f-45a7-b54c-5cd5d476bdef)

After:
![image](https://github.com/discourse/discourse/assets/1681963/6976a4b4-2123-4816-892d-f63e328336f6)
