### PR TITLE
UX: add min-height to preview image wrapper to give controls space

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -163,11 +163,12 @@
 }
 
 .d-editor-preview .image-wrapper {
+  --resizer-height: 2.5em;
   position: relative;
   display: inline-block;
+  min-height: calc(var(--resizer-height) * 2);
 
   .button-wrapper {
-    --resizer-height: 2.5em;
     box-sizing: border-box;
     padding: 0.25em 0.5em;
     min-width: 19em; // wide enough to contain all controls


### PR DESCRIPTION
This follow-up to https://github.com/discourse/discourse/commit/0a99407bfb363a28ae1a419cc5e4c16346b784f8, ensures that very short images always have space for the image controls by applying a min-height to the image wrapper. 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/072fb81b-cf8c-4e16-bc8d-015b33252778)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/cc62b0e9-7152-44fd-bdb6-157bf6bd5600)
