### PR TITLE
FIX: Rejection email sent even if reject reason too long

### DIFF
--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -46,6 +46,9 @@ class ReviewableUser < Reviewable
       begin
         self.reject_reason = args[:reject_reason]
 
+        # Without this, we end up sending the email even if this reject_reason is too long.
+        self.validate!
+
         if args[:send_email] && SiteSetting.must_approve_users?
           # Execute job instead of enqueue because user has to exists to send email
           Jobs::CriticalUserEmail.new.execute(


### PR DESCRIPTION
Followup 6b872c4c5382e5e58c14d55bc92b8da5ba158ce1

Even though we were showing a validation error for a reject
reason that was too long, we were still sending an email and
doing other operations on the user which we are rejecting.

This commit fixes this by validating the reviewable model
before attempting to do anything else after the reason is set.
