### PR TITLE
UX: Hide the error tooltip when focusing the topic title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -195,22 +195,24 @@
                   {{/if}}
 
                   {{#if this.composer.canEditTags}}
-                    <MiniTagChooser
-                      @value={{this.composer.model.tags}}
-                      @onChange={{fn (mut this.composer.model.tags)}}
-                      @options={{hash
-                        disabled=this.composer.disableTagsChooser
-                        categoryId=this.composer.model.categoryId
-                        minimum=this.composer.model.minimumRequiredTags
-                      }}
-                    />
-                    <PluginOutlet
-                      @name="after-composer-tag-input"
-                      @outletArgs={{hash composer=this.composer.model}}
-                    />
-                    <PopupInputTip
-                      @validation={{this.composer.tagValidation}}
-                    />
+                    <div class="tags-input">
+                      <MiniTagChooser
+                        @value={{this.composer.model.tags}}
+                        @onChange={{fn (mut this.composer.model.tags)}}
+                        @options={{hash
+                          disabled=this.composer.disableTagsChooser
+                          categoryId=this.composer.model.categoryId
+                          minimum=this.composer.model.minimumRequiredTags
+                        }}
+                      />
+                      <PluginOutlet
+                        @name="after-composer-tag-input"
+                        @outletArgs={{hash composer=this.composer.model}}
+                      />
+                      <PopupInputTip
+                        @validation={{this.composer.tagValidation}}
+                      />
+                    </div>
                   {{/if}}
 
                   <PluginOutlet

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -235,14 +235,16 @@ html.composer-open {
     }
 
     .archetype-private_message & {
-      // PMs don's have categories, so we need a wider tag input
+      // PMs don't have categories, so we need a wider tag input
       .mini-tag-chooser {
         width: 100%;
+        max-width: 100%;
       }
     }
   }
 
   .category-input {
+    position: relative;
     display: flex;
     flex: 1 0 40%;
     max-width: 40%;
@@ -324,18 +326,22 @@ html.composer-open {
     }
   }
 
-  .category-input + .mini-tag-chooser {
+  .category-input + .tags-input {
     margin-left: 8px;
     width: auto;
     max-width: calc(50% - 4px);
   }
 
-  .mini-tag-chooser {
-    flex-grow: 1;
+  .tags-input {
+    position: relative;
     margin: 0 0 8px 0px;
-    z-index: z("composer", "dropdown");
-    .select-kit-header {
-      color: var(--primary-high);
+    flex-grow: 1;
+    .mini-tag-chooser {
+      z-index: z("composer", "dropdown");
+      width: 100%;
+      .select-kit-header {
+        color: var(--primary-high);
+      }
     }
   }
 

--- a/app/assets/stylesheets/common/input_tip.scss
+++ b/app/assets/stylesheets/common/input_tip.scss
@@ -13,6 +13,7 @@
 .popup-tip {
   @include form-item-sizing;
   position: absolute;
+  left: 0;
   z-index: z("composer", "dropdown") + 1;
   cursor: pointer;
   @media (prefers-reduced-motion: no-preference) {

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -24,9 +24,8 @@
       .title-and-category {
         flex-wrap: nowrap;
         gap: 0.5em;
-        .mini-tag-chooser {
+        .tags-input {
           max-width: 50%;
-          margin-bottom: 8px; // match title input margin
           flex: 1 1 auto;
         }
       }

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -205,9 +205,10 @@
       z-index: z("base");
     }
 
-    .mini-tag-chooser {
+    .tags-input {
       margin: 0 0 6px 6px;
       max-width: calc(50% - 3px);
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
It hides the popup error for the title when you focus on the input. I also fixed the alignment for the tags popup.

<div align=center>

![demo](https://github.com/discourse/discourse/assets/66427541/fc462596-20a5-4256-9a75-10032011b619)


**Before**
![2024-06-18_23-39](https://github.com/discourse/discourse/assets/66427541/bf193586-49f9-47cd-b8ea-a0ec5db70bb8)

**After**
![2024-06-18_23-40](https://github.com/discourse/discourse/assets/66427541/ef0b0347-2762-4547-bafc-b641ecae8588)

</div>