### PR TITLE
DEV: Ensure digest e-mail secure image test uses actual digest e-mail

### DIFF
--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -641,28 +641,37 @@ RSpec.describe Email::Sender do
         end
 
         it "attaches allowed images from multiple posts in the activity summary" do
-          other_post = Fabricate(:post)
+          digest_post = Fabricate(:post)
+
+          Topic.stubs(:for_digest).returns(Topic.where(id: [digest_post.topic_id]))
+
+          summary = UserNotifications.digest(post.user, since: 24.hours.ago)
+
           @secure_image_2 =
             UploadCreator.new(
               file_from_fixtures("logo-dev.png", "images"),
               "something-cool.png",
             ).create_for(Discourse.system_user.id)
           @secure_image_2.update_secure_status(override: true)
-          @secure_image_2.update(access_control_post_id: other_post.id)
+          @secure_image_2.update(access_control_post_id: digest_post.id)
 
           Jobs::PullHotlinkedImages.any_instance.expects(:execute)
-          other_post.update(
+          digest_post.update(
             raw:
               "#{UploadMarkdown.new(@secure_image).image_markdown}\n#{UploadMarkdown.new(@secure_image_2).image_markdown}",
           )
-          other_post.rebake!
+          digest_post.rebake!
 
-          message.header["X-Discourse-Post-Id"] = nil
-          message.header["X-Discourse-Post-Ids"] = "#{reply.id},#{other_post.id}"
-          Email::Sender.new(message, "digest").send
-          expect(message.attachments.map(&:filename)).to include(
-            *[image, @secure_image, @secure_image_2].map(&:original_filename),
+          summary.header["X-Discourse-Post-Id"] = nil
+          summary.header["X-Discourse-Post-Ids"] = "#{digest_post.id}"
+
+          Email::Sender.new(summary, "digest").send
+
+          expect(summary.attachments.map(&:filename)).to include(
+            *[@secure_image, @secure_image_2].map(&:original_filename),
           )
+          expect(summary.to_s.scan(/cid:[\w\-@.]+/).length).to eq(2)
+          expect(summary.to_s.scan(/cid:[\w\-@.]+/).uniq.length).to eq(2)
         end
 
         it "does not attach images that are not marked as secure, in the case of a non-secure upload copied to a PM" do


### PR DESCRIPTION
### What is this change?

The test that checks that securely uploaded images are re-attached to the digest e-mail wasn't rendering the actual digest e-mail template. This change fixes that.