### PR TITLE
DEV: More robust referrer host parsing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1008,10 +1008,13 @@ class ApplicationController < ActionController::Base
   end
 
   def set_cross_origin_opener_policy_header
-    response.headers["Cross-Origin-Opener-Policy"] = if SiteSetting
-         .cross_origin_opener_unsafe_none_referrers
-         .split("|")
-         .include?(request.referrer&.split("://")&.last)
+    response.headers[
+      "Cross-Origin-Opener-Policy"
+    ] = if SiteSetting.cross_origin_opener_unsafe_none_referrers.present? &&
+         SiteSetting
+           .cross_origin_opener_unsafe_none_referrers
+           .split("|")
+           .include?(UrlHelper.relaxed_parse(request.referrer.to_s)&.host)
       "unsafe-none"
     else
       SiteSetting.cross_origin_opener_policy_header

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -556,14 +556,19 @@ RSpec.describe ApplicationController do
       end
 
       it "sets `Cross-Origin-Opener-Policy` to `unsafe-none` for a listed referrer" do
-        get "/latest", headers: { "HTTP_REFERER" => "meta.discourse.org" }
+        get "/latest", headers: { "HTTP_REFERER" => "https://meta.discourse.org/" }
+
+        expect(response.status).to eq(200)
+        expect(response.headers["Cross-Origin-Opener-Policy"]).to eq("unsafe-none")
+
+        get "/latest", headers: { "HTTP_REFERER" => "https://meta.discourse.org/hot" }
 
         expect(response.status).to eq(200)
         expect(response.headers["Cross-Origin-Opener-Policy"]).to eq("unsafe-none")
       end
 
       it "sets `Cross-Origin-Opener-Policy` to configured value for a non-listed referrer" do
-        get "/latest", headers: { "HTTP_REFERER" => "www.discourse.org" }
+        get "/latest", headers: { "HTTP_REFERER" => "https://www.discourse.org/" }
 
         expect(response.status).to eq(200)
         expect(response.headers["Cross-Origin-Opener-Policy"]).to eq("same-origin")


### PR DESCRIPTION
### What is this change?

Follow-up to #27510. I hadn't had coffee yet, and my "host extraction" was incredibly primitive. This fixes that.

Update test cases based on [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer):

<img width="551" alt="Screenshot 2024-06-19 at 3 52 22 PM" src="https://github.com/discourse/discourse/assets/5259935/a8808ca4-22e4-4f77-8a78-022ba025a239">
