### PR TITLE
FIX: Avoid duplicating e-mail body in summary e-mail

### DIFF
--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -642,8 +642,11 @@ RSpec.describe Email::Sender do
 
         it "attaches allowed images from multiple posts in the activity summary" do
           digest_post = Fabricate(:post)
+          other_digest_post = Fabricate(:post)
 
-          Topic.stubs(:for_digest).returns(Topic.where(id: [digest_post.topic_id]))
+          Topic.stubs(:for_digest).returns(
+            Topic.where(id: [digest_post.topic_id, other_digest_post.topic_id]),
+          )
 
           summary = UserNotifications.digest(post.user, since: 24.hours.ago)
 
@@ -655,6 +658,14 @@ RSpec.describe Email::Sender do
           @secure_image_2.update_secure_status(override: true)
           @secure_image_2.update(access_control_post_id: digest_post.id)
 
+          @secure_image_3 =
+            UploadCreator.new(
+              file_from_fixtures("logo.png", "images"),
+              "something-cooler.png",
+            ).create_for(Discourse.system_user.id)
+          @secure_image_3.update_secure_status(override: true)
+          @secure_image_3.update(access_control_post_id: other_digest_post.id)
+
           Jobs::PullHotlinkedImages.any_instance.expects(:execute)
           digest_post.update(
             raw:
@@ -662,16 +673,21 @@ RSpec.describe Email::Sender do
           )
           digest_post.rebake!
 
+          other_digest_post.update(raw: "#{UploadMarkdown.new(@secure_image_3).image_markdown}")
+          other_digest_post.rebake!
+
           summary.header["X-Discourse-Post-Id"] = nil
-          summary.header["X-Discourse-Post-Ids"] = "#{digest_post.id}"
+          summary.header["X-Discourse-Post-Ids"] = "#{digest_post.id},#{other_digest_post.id}"
 
           Email::Sender.new(summary, "digest").send
 
           expect(summary.attachments.map(&:filename)).to include(
-            *[@secure_image, @secure_image_2].map(&:original_filename),
+            *[@secure_image, @secure_image_2, @secure_image_3].map(&:original_filename),
           )
-          expect(summary.to_s.scan(/cid:[\w\-@.]+/).length).to eq(2)
-          expect(summary.to_s.scan(/cid:[\w\-@.]+/).uniq.length).to eq(2)
+          expect(summary.to_s.scan("Content-Type: text/html;").length).to eq(1)
+          expect(summary.to_s.scan("Content-Type: text/plain;").length).to eq(1)
+          expect(summary.to_s.scan(/cid:[\w\-@.]+/).length).to eq(3)
+          expect(summary.to_s.scan(/cid:[\w\-@.]+/).uniq.length).to eq(3)
         end
 
         it "does not attach images that are not marked as secure, in the case of a non-secure upload copied to a PM" do


### PR DESCRIPTION
## What is this fix?

We recently fixed a problem where secure upload images weren't re-attached when sending the activity summary e-mail.

This fix contained a bug that would lead to n copies of the e-mail body being included, n being the number of duplicates. This is because `#fix_parts_after_attachments!` was called once per attachment, and adding more parts to the multipart e-mail.

This PR fixes that by:

1. Adding a failing test case for the above.
2. Moving the looping over multiple posts into `#fix_parts_after_attachments!` itself.