### PR TITLE
DEV: Remove discourse-moderator-attention

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -48,7 +48,6 @@ class Plugin::Metadata
         discourse-lti
         discourse-math
         discourse-microsoft-auth
-        discourse-moderator-attention
         discourse-narrative-bot
         discourse-newsletter-integration
         discourse-no-bump


### PR DESCRIPTION
…from the official plugins list. It's archived now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
