### PR TITLE
FIX: Do not extract links for hotlinked images

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -404,7 +404,7 @@ module PrettyText
     doc.css("aside.quote a, aside.onebox a, .elided a").remove
 
     # remove hotlinked images
-    doc.css("a.onebox > img").each { |img| img.parent.remove }
+    doc.css("a.lightbox > img, a.onebox > img").each { |img| img.parent.remove }
 
     # extract all links
     doc

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1062,11 +1062,27 @@ RSpec.describe PrettyText do
     it "does not extract links from hotlinked images" do
       html = <<~HTML
         <p>
-        <a href="https://example.com">example</a>
+          <a href="https://example.com">example</a>
+        </p>
 
-        <a href="https://images.pexels.com/photos/1525041/pexels-photo-1525041.jpeg?auto=compress&amp;cs=tinysrgb&amp;w=1260&amp;h=750&amp;dpr=2" target="_blank" rel="noopener" class="onebox">
-        <img src="https://images.pexels.com/photos/1525041/pexels-photo-1525041.jpeg?auto=compress&amp;cs=tinysrgb&amp;w=1260&amp;h=750&amp;dpr=2" width="690" height="459">
-        </a>
+        <p>
+          <a href="https://images.pexels.com/photos/1525041/pexels-photo-1525041.jpeg?auto=compress&amp;cs=tinysrgb&amp;w=1260&amp;h=750&amp;dpr=2" target="_blank" rel="noopener" class="onebox">
+            <img src="https://images.pexels.com/photos/1525041/pexels-photo-1525041.jpeg?auto=compress&amp;cs=tinysrgb&amp;w=1260&amp;h=750&amp;dpr=2" width="690" height="459">
+          </a>
+        </p>
+
+        <p>
+          <div class="lightbox-wrapper">
+            <a class="lightbox" href="//localhost:3000/uploads/default/original/1X/fb7ecffe57b3bc54321635c4f810c5a9396c802c.png" data-download-href="//localhost:3000/uploads/default/fb7ecffe57b3bc54321635c4f810c5a9396c802c" title="image">
+              <img src="//localhost:3000/uploads/default/optimized/1X/fb7ecffe57b3bc54321635c4f810c5a9396c802c_2_545x500.png" alt="image" data-base62-sha1="zSPxs3tDdPBuq4dK3uJ1K3Sv8kI" width="545" height="500" data-dominant-color="F9F9F9" />
+              <div class="meta">
+                <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use href="#far-image"></use></svg>
+                <span class="filename">image</span>
+                <span class="informations">808×740 24.8 KB</span>
+                <svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use href="#discourse-expand"></use></svg>
+              </div>
+            </a>
+          </div>
         </p>
       HTML
 


### PR DESCRIPTION
When a post is cooked the links are extracted and `TopicLink` instances are created for each of them. These links are used in various places, including the topic view, user summary page, etc.

In previous commit 48e5d1a, hotlinked images from Oneboxes have been ignored from the texts, but hotlinked images turned into Lightboxes were still extracted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
