### PR TITLE
FIX: do not force configure 2FA when OAuth and not enforced

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -919,17 +919,18 @@ class ApplicationController < ActionController::Base
   end
 
   def should_enforce_2fa?
-    disqualified_from_2fa_enforcement = request.format.json? || is_api? || current_user.anonymous?
     enforcing_2fa =
       (
         (SiteSetting.enforce_second_factor == "staff" && current_user.staff?) ||
           SiteSetting.enforce_second_factor == "all"
       )
-    oauth_authenticated_and_not_enforced =
-      !SiteSetting.enforce_second_factor_on_external_auth && secure_session[:oauth]
-
     !disqualified_from_2fa_enforcement && enforcing_2fa &&
-      !current_user.has_any_second_factor_methods_enabled? && !oauth_authenticated_and_not_enforced
+      !current_user.has_any_second_factor_methods_enabled?
+  end
+
+  def disqualified_from_2fa_enforcement
+    request.format.json? || is_api? || current_user.anonymous? ||
+      (!SiteSetting.enforce_second_factor_on_external_auth && secure_session["oauth"])
   end
 
   def build_not_found_page(opts = {})

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -925,8 +925,11 @@ class ApplicationController < ActionController::Base
         (SiteSetting.enforce_second_factor == "staff" && current_user.staff?) ||
           SiteSetting.enforce_second_factor == "all"
       )
+    oauth_authenticated_and_not_enforced =
+      !SiteSetting.enforce_second_factor_on_external_auth && secure_session[:oauth]
+
     !disqualified_from_2fa_enforcement && enforcing_2fa &&
-      !current_user.has_any_second_factor_methods_enabled?
+      !current_user.has_any_second_factor_methods_enabled? && !oauth_authenticated_and_not_enforced
   end
 
   def build_not_found_page(opts = {})

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -86,6 +86,7 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     cookies["_bypass_cache"] = true
     cookies[:authentication_data] = { value: client_hash.to_json, path: Discourse.base_path("/") }
+    secure_session[:oauth] = true
     redirect_to @origin
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -86,7 +86,7 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     cookies["_bypass_cache"] = true
     cookies[:authentication_data] = { value: client_hash.to_json, path: Discourse.base_path("/") }
-    secure_session[:oauth] = true
+    secure_session["oauth"] = true
     redirect_to @origin
   end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -150,6 +150,25 @@ RSpec.describe ApplicationController do
       expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
     end
 
+    it "should redirect users when enforce_second_factor is 'all' and authenticated via oauth" do
+      SiteSetting.enforce_second_factor = "all"
+      write_secure_session("oauth", true)
+      sign_in(user)
+
+      get "/"
+      expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
+    end
+
+    it "should not redirect users when enforce_second_factor is 'all', authenticated via oauth but enforce_second_factor_on_external_auth is false" do
+      SiteSetting.enforce_second_factor = "all"
+      SiteSetting.enforce_second_factor_on_external_auth = false
+      write_secure_session("oauth", true)
+      sign_in(user)
+
+      get "/"
+      expect(response.status).to eq(200)
+    end
+
     it "should not redirect anonymous users when enforce_second_factor is 'all'" do
       SiteSetting.enforce_second_factor = "all"
       SiteSetting.allow_anonymous_posting = true

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["email_valid"]).to eq(true)
         expect(data["can_edit_username"]).to eq(true)
         expect(data["destination_url"]).to eq(destination_url)
+        expect(!!read_secure_session[:oauth]).to be true
       end
 
       it "should return the right response for staged users" do

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["email_valid"]).to eq(true)
         expect(data["can_edit_username"]).to eq(true)
         expect(data["destination_url"]).to eq(destination_url)
-        expect(!!read_secure_session[:oauth]).to be true
+        expect(!!read_secure_session["oauth"]).to be true
       end
 
       it "should return the right response for staged users" do


### PR DESCRIPTION
In this PR we introduced `enforce_second_factor_on_external_auth` setting https://github.com/discourse/discourse/pull/27506

When it is set to false and the user is authenticated via OAuth, then we should not enforce the 2fa configuration.
