### PR TITLE
FIX: UserField#field_type column change to enum migration

### DIFF
--- a/db/migrate/20240612063735_add_field_type_enum_to_user_fields.rb
+++ b/db/migrate/20240612063735_add_field_type_enum_to_user_fields.rb
@@ -19,5 +19,8 @@ class AddFieldTypeEnumToUserFields < ActiveRecord::Migration[7.0]
       change_column_null :user_fields, :field_type, true
       change_column_null :user_fields, :field_type_enum, false
     end
+
+    rename_column :user_fields, :field_type, :field_type_old
+    rename_column :user_fields, :field_type_enum, :field_type
   end
 end

--- a/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
+++ b/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class SwapFieldTypeWithFieldTypeEnumOnUserFields < ActiveRecord::Migration[7.0]
-  DROPPED_COLUMNS ||= { user_fields: %i[field_type] }
+  DROPPED_COLUMNS ||= { user_fields: %i[field_type_old] }
 
   def up
     DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
-    rename_column :user_fields, :field_type_enum, :field_type
   end
 
   def down


### PR DESCRIPTION
Followup 5963c03643851db4434972cd338d0843fabc5748 and
6be4ef59fac332977d98f7369e1a8c2e7e423be7

This migration was causing issues on deploy for some sites that
had user fields required to be filled in on signup. The Site#user_fields
cache was getting poisoned, and the `field_type` for all fields
was ending up as `null`, making it impossible to fill
them out in a form.

This commit rectifies the issue by doing the column rename/swap
in the initial migration and _only_ dropping columns in the
post migration, since this messes with the AR cache.
