### PR TITLE
FIX: Prevent field type migration from poisoning AR cache

### DIFF
--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -6,6 +6,7 @@ class UserField < ActiveRecord::Base
   include HasSanitizableFields
 
   deprecate_column :required, drop_from: "3.3"
+  self.ignored_columns += %i[field_type]
 
   validates_presence_of :description
   validates_presence_of :name, unless: -> { field_type == "confirm" }
@@ -19,7 +20,8 @@ class UserField < ActiveRecord::Base
   scope :public_fields, -> { where(show_on_profile: true).or(where(show_on_user_card: true)) }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
-  enum :field_type, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
+  enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
+  alias_attribute :field_type, :field_type_enum
 
   def self.max_length
     2048
@@ -60,5 +62,5 @@ end
 #  external_type     :string
 #  searchable        :boolean          default(FALSE), not null
 #  requirement       :integer          default("optional"), not null
-#  field_type        :integer          not null
+#  field_type_enum   :integer          not null
 #

--- a/db/migrate/20240620024938_add_back_field_type_enum_to_user_fields.rb
+++ b/db/migrate/20240620024938_add_back_field_type_enum_to_user_fields.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddBackFieldTypeEnumToUserFields < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: This is here to undo the swap done in SwapFieldTypeWithFieldTypeEnumOnUserFields,
+    #       as that change was breaking the AR cache until the application is rebooted.
+    #       The condition here is to ensure it's only executed if that post-migration has been
+    #       applied.
+    if !ActiveRecord::Base.connection.column_exists?(:user_fields, :field_type_enum)
+      add_column :user_fields, :field_type_enum, :integer
+      change_column_null :user_fields, :field_type, true
+
+      execute(<<~SQL)
+        UPDATE user_fields
+        SET field_type_enum = field_type
+      SQL
+
+      change_column_null :user_fields, :field_type_enum, false
+    end
+  end
+end

--- a/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
+++ b/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class SwapFieldTypeWithFieldTypeEnumOnUserFields < ActiveRecord::Migration[7.0]
-  DROPPED_COLUMNS ||= { user_fields: %i[field_type] }
+  # DROPPED_COLUMNS ||= { user_fields: %i[field_type] }
 
-  def up
-    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
-    rename_column :user_fields, :field_type_enum, :field_type
-  end
+  # def up
+  #   # WARNING: Swapping in a column of a different type in a post-migration will break the AR
+  #   #          cache, since the application is already booted, requiring a restart.
+  #   #
+  #   DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  #   rename_column :user_fields, :field_type_enum, :field_type
+  # end
 
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
+  # def down
+  #   raise ActiveRecord::IrreversibleMigration
+  # end
 end


### PR DESCRIPTION
## What is happening?

We previously migrated `field_type` from a string to an `integer` backed enum. Part of this involved renaming a column in a post migration, swapping out `field_type:string` for `field_type:integer`. This borks the ActiveRecord cache since the application is already running. Rebooting fixes it, but we want to avoid having this happen in the first place.

## Current state

All instances are now in one of two states:

1. Migrations have been run, and there is a `field_type:integer`. (Affected by the cache poisoning.)
2. Migrations have not been run, and there is a `field_type:string`. (Not yet affected.)

The desired state is:

We have a `field_type:any` (ignored) and a `field_type_enum:integer` backing the enum.

## How do we get there?

<img width="1138" alt="Screenshot 2024-06-20 at 11 41 01 AM" src="https://github.com/discourse/discourse/assets/5259935/0a75e747-94a9-4866-96d4-9bf4b2964624">

### For affected instances

For instances where migrations have already been run, we want to:

1. Create `field_type_enum:integer`.
2. Copy over the values from `field_type:integer`.

This is accomplished with a new migration (`AddBackFieldTypeEnumToUserFields`). This is run only if there's no `field_type_enum` column already there.

### For unaffected instances

For instances where migrations have not been run, we want to:

1. Create `field_type_enum:integer`.
2. Map over values from `field_type:string`.

This is accomplished with the old migration (`AddFieldTypeEnumToUserFields`), and by disabling the post migration that was doing the swapping of the columns.

### For all instances

Regardless of starting state, we want to:

- Make `field_type` nullable.
- Ignore `field_type` column.
- Have the enum backed by `field_type_enum`.

## Manual verification

- [x] Admin can create new user fields.
- [x] New user can fill up user fields on sign-up. 