### PR TITLE
FEATURE: enable list keyboard shortcuts on filter route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -1,3 +1,4 @@
+import { setTopicList } from "discourse/lib/topic-list-tracker";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "discourse-i18n";
 
@@ -6,11 +7,15 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
     q: { replace: true, refreshModel: true },
   };
 
-  model(data) {
-    return this.store.findFiltered("topicList", {
+  async model(data) {
+    const list = await this.store.findFiltered("topicList", {
       filter: "filter",
       params: { q: data.q },
     });
+
+    setTopicList(list);
+
+    return list;
   }
 
   titleToken() {

--- a/spec/system/filtering_topics_spec.rb
+++ b/spec/system/filtering_topics_spec.rb
@@ -44,8 +44,16 @@ describe "Filtering topics", type: :system do
   end
 
   describe "when filtering by status" do
-    fab!(:topic)
-    fab!(:closed_topic) { Fabricate(:topic, closed: true) }
+    fab!(:topic) do
+      topic = Fabricate(:topic, bumped_at: 1.day.ago)
+      Fabricate(:post, topic: topic)
+      topic
+    end
+    fab!(:closed_topic) do
+      topic = Fabricate(:topic, closed: true)
+      Fabricate(:post, topic: topic)
+      topic
+    end
 
     it "should display the right topics when the status filter is used in the query string" do
       sign_in(user)
@@ -55,6 +63,14 @@ describe "Filtering topics", type: :system do
       expect(topic_list).to have_topic(topic)
       expect(topic_list).to have_topic(closed_topic)
 
+      topic_list.visit_topic(closed_topic)
+      expect(page).to have_current_path(closed_topic.url)
+
+      send_keys("gj")
+
+      expect(page).to have_current_path(topic.url)
+
+      visit("/filter")
       topic_query_filter.fill_in("status:open")
 
       expect(topic_list).to have_topic(topic)


### PR DESCRIPTION
Previously filter route was not setting topic list, this meant that
keyboard navigation using "G" "J" was not functioning.

This amends it by ensuring the list is set after looking up the model.
