### PR TITLE
UX: Increase spacing mobile menus

### DIFF
--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -4,6 +4,10 @@
 
   .user-menu.revamped & {
     height: 100%;
+
+    .quick-access-panel li {
+      padding-block: 0.15em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mobile/sidebar.scss
+++ b/app/assets/stylesheets/mobile/sidebar.scss
@@ -1,3 +1,7 @@
+:root {
+  --d-sidebar-row-height: 2.4em;
+}
+
 .sidebar-section-form-modal {
   .row-wrapper {
     grid-template-columns: 4.5em repeat(2, 1fr) 2em;


### PR DESCRIPTION
## Before
<img width="390" alt="image" src="https://github.com/discourse/discourse/assets/101828855/9e488e32-1ac2-4762-8d09-39ca18fb758f">
<img width="380" alt="image" src="https://github.com/discourse/discourse/assets/101828855/c634464d-a611-4249-a3c7-5f348396b771">
***

## After
<img width="391" alt="image" src="https://github.com/discourse/discourse/assets/101828855/73caa1f9-589c-4a7f-9996-ea5cdf8b5545">
<img width="385" alt="image" src="https://github.com/discourse/discourse/assets/101828855/36595fbc-fb52-403f-8e00-8af5bb2a9b91">


