### PR TITLE
FIX: rescue mmdb download failure

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -55,27 +55,32 @@ class DiscourseIpInfo
         end
       end
 
-    gz_file =
-      FileHelper.download(
-        url,
-        max_file_size: 100.megabytes,
-        tmp_file_name: "#{name}.gz",
-        validate_uri: false,
-        follow_redirect: true,
-        extra_headers:,
-      )
+    begin
+      gz_file =
+        FileHelper.download(
+          url,
+          max_file_size: 100.megabytes,
+          tmp_file_name: "#{name}.gz",
+          validate_uri: false,
+          follow_redirect: true,
+          extra_headers:,
+        )
 
-    filename = File.basename(gz_file.path)
+      filename = File.basename(gz_file.path)
 
-    dir = "#{Dir.tmpdir}/#{SecureRandom.hex}"
+      dir = "#{Dir.tmpdir}/#{SecureRandom.hex}"
 
-    Discourse::Utils.execute_command("mkdir", "-p", dir)
+      Discourse::Utils.execute_command("mkdir", "-p", dir)
 
-    Discourse::Utils.execute_command("cp", gz_file.path, "#{dir}/#{filename}")
+      Discourse::Utils.execute_command("cp", gz_file.path, "#{dir}/#{filename}")
 
-    Discourse::Utils.execute_command("tar", "-xzvf", "#{dir}/#{filename}", chdir: dir)
+      Discourse::Utils.execute_command("tar", "-xzvf", "#{dir}/#{filename}", chdir: dir)
 
-    Dir["#{dir}/**/*.mmdb"].each { |f| FileUtils.mv(f, mmdb_path(name)) }
+      Dir["#{dir}/**/*.mmdb"].each { |f| FileUtils.mv(f, mmdb_path(name)) }
+    rescue => e
+      Discourse.warn_exception(e, message: "MaxMind database download failed.")
+    end
+
   ensure
     FileUtils.rm_r(dir, force: true) if dir
     gz_file&.close!
@@ -175,3 +180,4 @@ class DiscourseIpInfo
     instance.get(ip, locale: locale, resolve_hostname: resolve_hostname)
   end
 end
+

--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -80,7 +80,6 @@ class DiscourseIpInfo
     rescue => e
       Discourse.warn_exception(e, message: "MaxMind database download failed.")
     end
-
   ensure
     FileUtils.rm_r(dir, force: true) if dir
     gz_file&.close!
@@ -180,4 +179,3 @@ class DiscourseIpInfo
     instance.get(ip, locale: locale, resolve_hostname: resolve_hostname)
   end
 end
-


### PR DESCRIPTION
If mmdb database fails to download a bootstrap fails. This is a trivial fix for that problem. A more elegant solution might check whether the dataabase was downloaded and provide a helpful error message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
