### PR TITLE
FEATURE: Smarter list editing in DEditor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -326,6 +326,7 @@ export default Component.extend(TextareaTextManipulation, {
     this._itsatrap.bind(`${PLATFORM_KEY_MODIFIER}+shift+.`, () =>
       this.send("insertCurrentTime")
     );
+    this._itsatrap.bind("enter", () => this.maybeContinueList(), "keyup");
 
     // disable clicking on links in the preview
     this.element


### PR DESCRIPTION
This commit introduces behaviour similar to sites
like GitHub, Notion, and others where, if you
are already typing a list and press enter in the composer,
we continue the list on the next line.

Then, if you press enter again on the next line with
an empty list item, we remove that item on that last line.

This works with the following list types:

```
* star bullet
- dash bullet
* [] star and dash bullet with checkbox
1. numbered
```

This also works if you are in the middle of a list, and
with indented sub-lists.

With the numbered lists, we continue with the next number
in the sequence, and if you start a new line in the middle
of the list, we renumber the rest of the list.


<video src="https://github.com/discourse/discourse/assets/920448/932662d5-b67c-4f32-a193-dcdbb7d89caa" />

