### PR TITLE
UX: Remove tertiary color from non-link elements

### DIFF
--- a/app/assets/stylesheets/common/admin/flags.scss
+++ b/app/assets/stylesheets/common/admin/flags.scss
@@ -1,7 +1,6 @@
 .admin-flag-item {
   &__name {
     font-weight: bold;
-    color: var(--tertiary);
     padding-bottom: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

**What changed?**
Removed tertiary color styling from names that are not clickable

### Before
<img width="533" alt="image" src="https://github.com/discourse/discourse/assets/2790986/de0866cd-375e-4844-aa50-a85bef8f9936">

### After
<img width="495" alt="image" src="https://github.com/discourse/discourse/assets/2790986/b7aaf7ac-29d9-4bd0-af62-8cf47bff45f7">
