### PR TITLE
UX: fix chat drawer z-index

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -103,6 +103,7 @@ $z-layers: (
     "content": 400,
   ),
   "dropdown": 300,
+  "chat-drawer": 200,
   "timeline": 100,
   "base": 1,
 );

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -25,8 +25,8 @@ html.rtl {
 }
 
 .chat-drawer-outlet-container {
-  // higher than timeline, lower than composer, lower than user card (bump up below)
-  z-index: z("composer", "content") - 1;
+  // higher than timeline, lower than composer, dropdown, and user card
+  z-index: z("chat-drawer");
   position: fixed;
   right: var(--composer-right, 20px);
   left: 0;


### PR DESCRIPTION
Adds a new z-index value for the drawer 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/e376a604-9e0e-4f46-9802-5e8ef115543f)

After:
![image](https://github.com/discourse/discourse/assets/1681963/101062b0-83c9-4082-a064-3e45d3ee2830)
