### PR TITLE
DEV: Avoid loading header twice in topics to prevent CLS (Mobile)

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -49,6 +49,11 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
   },
 
   _highlightPost(postNumber, options = {}) {
+    if (postNumber > 1) {
+      this.header.showTopic = true;
+    } else {
+      this.header.showTopic = false;
+    }
     if (isBlank(options.jump) || options.jump !== false) {
       scheduleOnce("afterRender", null, highlightPost, postNumber);
     }
@@ -56,8 +61,8 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
 
   _hideTopicInHeader() {
     this.appEvents.trigger("header:hide-topic");
-    this.header.topic = null;
     this._lastShowTopic = false;
+    this.header.showTopic = false;
   },
 
   _showTopicInHeader(topic) {
@@ -65,8 +70,8 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
       return;
     }
     this.appEvents.trigger("header:show-topic", topic);
-    this.header.topic = topic;
     this._lastShowTopic = true;
+    this.header.showTopic = true;
   },
 
   _updateTopic(topic, debounceDuration) {
@@ -87,12 +92,10 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
     }
 
     const offset = window.pageYOffset || document.documentElement.scrollTop;
-    this._lastShowTopic = this.shouldShowTopicInHeader(topic, offset);
+    this._lastShowTopic = this.shouldShowTopicInHeader(offset);
 
     if (this._lastShowTopic) {
       this._showTopicInHeader(topic);
-    } else {
-      this._hideTopicInHeader();
     }
   },
 
@@ -113,6 +116,7 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
       ".cooked a, a.track-link",
       (e) => ClickTrack.trackClick(e, getOwner(this))
     );
+    this.header.topic = this.topic;
   },
 
   willDestroy() {
@@ -147,7 +151,7 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
     this.set("dockAt", 0);
   },
 
-  shouldShowTopicInHeader(topic, offset) {
+  shouldShowTopicInHeader(offset) {
     // On mobile, we show the header topic if the user has scrolled past the topic
     // title and the current scroll direction is down
     // On desktop the user only needs to scroll past the topic title.
@@ -174,7 +178,7 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
 
     this.set("hasScrolled", offset > 0);
 
-    const showTopic = this.shouldShowTopicInHeader(this.topic, offset);
+    const showTopic = this.shouldShowTopicInHeader(offset);
 
     if (showTopic !== this._lastShowTopic) {
       if (showTopic) {

--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -69,6 +69,10 @@ export default Component.extend(Scrolling, MobileScrollDirection, {
     if (this.pauseHeaderTopicUpdate) {
       return;
     }
+    if (topic.errorLoading) {
+      this._hideTopicInHeader();
+      return;
+    }
     this.appEvents.trigger("header:show-topic", topic);
     this._lastShowTopic = true;
     this.header.showTopic = true;

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -188,7 +188,9 @@ export default class GlimmerHeader extends Component {
   get canLoadContent() {
     // we want to determine if we need to show the topic info or not
     // *before* we load content to prevent content layout shift
+    // on mobile
     return (
+      this.site.desktopView ||
       (this.router.currentRouteName.startsWith("topic.") &&
         this.header.showTopic !== null) ||
       !this.router.currentRouteName.startsWith("topic.")

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -185,60 +185,74 @@ export default class GlimmerHeader extends Component {
     }
   }
 
+  get canLoadContent() {
+    // we want to determine if we need to show the topic info or not
+    // *before* we load content to prevent content layout shift
+    return (
+      (this.router.currentRouteName.startsWith("topic.") &&
+        this.header.showTopic !== null) ||
+      !this.router.currentRouteName.startsWith("topic.")
+    );
+  }
+
   <template>
     <header class="d-header" {{this.appEventsListeners}}>
       <div class="wrap">
-        <Contents
-          @sidebarEnabled={{@sidebarEnabled}}
-          @toggleNavigationMenu={{this.toggleNavigationMenu}}
-          @showSidebar={{@showSidebar}}
-        >
-          <span class="header-buttons">
-            {{#each (headerButtons.resolve) as |entry|}}
-              {{#if (and (eq entry.key "auth") (not this.currentUser))}}
-                <AuthButtons
-                  @showCreateAccount={{@showCreateAccount}}
-                  @showLogin={{@showLogin}}
-                  @canSignUp={{@canSignUp}}
-                />
-              {{else if entry.value}}
-                <entry.value />
-              {{/if}}
-            {{/each}}
-          </span>
+        {{#if this.canLoadContent}}
+          <Contents
+            @sidebarEnabled={{@sidebarEnabled}}
+            @toggleNavigationMenu={{this.toggleNavigationMenu}}
+            @showSidebar={{@showSidebar}}
+          >
+            <span class="header-buttons">
+              {{#each (headerButtons.resolve) as |entry|}}
+                {{#if (and (eq entry.key "auth") (not this.currentUser))}}
+                  <AuthButtons
+                    @showCreateAccount={{@showCreateAccount}}
+                    @showLogin={{@showLogin}}
+                    @canSignUp={{@canSignUp}}
+                  />
+                {{else if entry.value}}
+                  <entry.value />
+                {{/if}}
+              {{/each}}
+            </span>
 
-          {{#if
-            (not (and this.siteSettings.login_required (not this.currentUser)))
-          }}
-            <Icons
-              @sidebarEnabled={{@sidebarEnabled}}
-              @toggleSearchMenu={{this.toggleSearchMenu}}
-              @toggleNavigationMenu={{this.toggleNavigationMenu}}
-              @toggleUserMenu={{this.toggleUserMenu}}
-              @searchButtonId={{SEARCH_BUTTON_ID}}
-            />
-          {{/if}}
+            {{#if
+              (not
+                (and this.siteSettings.login_required (not this.currentUser))
+              )
+            }}
+              <Icons
+                @sidebarEnabled={{@sidebarEnabled}}
+                @toggleSearchMenu={{this.toggleSearchMenu}}
+                @toggleNavigationMenu={{this.toggleNavigationMenu}}
+                @toggleUserMenu={{this.toggleUserMenu}}
+                @searchButtonId={{SEARCH_BUTTON_ID}}
+              />
+            {{/if}}
 
-          {{#if this.search.visible}}
-            <SearchMenuWrapper @closeSearchMenu={{this.toggleSearchMenu}} />
-          {{else if this.header.hamburgerVisible}}
-            <HamburgerDropdownWrapper
-              @toggleNavigationMenu={{this.toggleNavigationMenu}}
-              @sidebarEnabled={{@sidebarEnabled}}
-            />
-          {{else if this.header.userVisible}}
-            <UserMenuWrapper @toggleUserMenu={{this.toggleUserMenu}} />
-          {{/if}}
+            {{#if this.search.visible}}
+              <SearchMenuWrapper @closeSearchMenu={{this.toggleSearchMenu}} />
+            {{else if this.header.hamburgerVisible}}
+              <HamburgerDropdownWrapper
+                @toggleNavigationMenu={{this.toggleNavigationMenu}}
+                @sidebarEnabled={{@sidebarEnabled}}
+              />
+            {{else if this.header.userVisible}}
+              <UserMenuWrapper @toggleUserMenu={{this.toggleUserMenu}} />
+            {{/if}}
 
-          {{#if
-            (and
-              (or this.site.mobileView this.site.narrowDesktopView)
-              (or this.header.hamburgerVisible this.header.userVisible)
-            )
-          }}
-            <div class="header-cloak"></div>
-          {{/if}}
-        </Contents>
+            {{#if
+              (and
+                (or this.site.mobileView this.site.narrowDesktopView)
+                (or this.header.hamburgerVisible this.header.userVisible)
+              )
+            }}
+              <div class="header-cloak"></div>
+            {{/if}}
+          </Contents>
+        {{/if}}
       </div>
       <PluginOutlet
         @name="after-header"

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -15,10 +15,6 @@ export default class Contents extends Component {
   @service header;
   @service sidebarState;
 
-  get topicPresent() {
-    return !!this.header.topic;
-  }
-
   get sidebarIcon() {
     if (this.sidebarState.adminSidebarAllowedWithLegacyNavigationMenu) {
       return "discourse-sidebar";
@@ -31,7 +27,7 @@ export default class Contents extends Component {
     <div class="contents">
       <PluginOutlet
         @name="header-contents__before"
-        @outletArgs={{hash topic=this.header.topic}}
+        @outletArgs={{hash topic=this.header.showTopic}}
       />
       {{#if this.site.desktopView}}
         {{#if @sidebarEnabled}}
@@ -45,11 +41,11 @@ export default class Contents extends Component {
 
       <div class="home-logo-wrapper-outlet">
         <PluginOutlet @name="home-logo-wrapper">
-          <HomeLogo @minimized={{this.topicPresent}} />
+          <HomeLogo @minimized={{this.header.showTopic}} />
         </PluginOutlet>
       </div>
 
-      {{#if this.header.topic}}
+      {{#if this.header.showTopic}}
         <TopicInfo @topic={{this.header.topic}} />
       {{else if
         (and

--- a/app/assets/javascripts/discourse/app/services/header.js
+++ b/app/assets/javascripts/discourse/app/services/header.js
@@ -9,6 +9,7 @@ export default class Header extends Service {
   @service siteSettings;
 
   @tracked topic = null;
+  @tracked showTopic = null;
   @tracked hamburgerVisible = false;
   @tracked userVisible = false;
   @tracked anyWidgetHeaderOverrides = false;


### PR DESCRIPTION
On certain slower devices, e.g. Pixel 6, the mobile header loads twice as seen in the video below. This causes large Content Layout Shift (>0.25) depending on the difference in width of the `logo-small` and `logo-big`. Two headers are loaded: firstly the "big logo+nav", then the "small logo+topic info", especially on topic pages that are not loading the first post.

https://github.com/discourse/discourse/assets/1555215/696223c7-9a81-4ef9-b661-b764d55e3cec

The way the "small logo+topic info" is currently decided to be displayed is the presence of `this.header.topic` in the `header` service. There are two problems with the current method
1. The `<Header>` has no knowledge of when its `<Content>` is ready to be shown. So when `this.header.topic` is not ready yet, it briefly shows the big logo.
2. When scrolling up in mobile, it clears `this.header.topic` instead of using a flag to say "please show the big logo + nav". Technically, the topic is still there so it shouldn't clear the topic to indicate this.

This PR sets a new flag in the header service to indicate if the header topic should be shown or not.

The following videos are recorded after the change for mobile and desktop.

https://github.com/discourse/discourse/assets/1555215/e0301bbf-61d3-4d68-98a3-e190d733186d

https://github.com/discourse/discourse/assets/1555215/6f989a62-711b-488f-a5c0-87dc59787b4d


