### PR TITLE
FIX: Cache breadcrumb-item template

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
 
 export default class DBreadcrumbsItem extends Component {
@@ -23,6 +24,7 @@ export default class DBreadcrumbsItem extends Component {
     }
   }
 
+  @cached
   get templateForContainer() {
     // Those are evaluated in a different context than the `@linkClass`
     const { label } = this.args;


### PR DESCRIPTION
…to avoid re-evaulation right before destroying.

With `DeferredTrackedSet` we delay both adding and removing elements from the set. That means when you're transitioning between routes, and breadcrumbs change, both old and new breadcrumbs are rendered (briefly, in a first render pass)

And since the arguments for the old breadcrumbs can be (and often are) destroyed - it would blow up the renderer. By caching the template it will reuse it in that first pass.

---

No test because I couldn't figure out a synthetic test setup where you have breadcrumbs in a deeply nested route and where you navigate from that route to one of the parent routes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
