### PR TITLE
DEV: Check for "true" in oauth check for 2FA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -904,7 +904,7 @@ class ApplicationController < ActionController::Base
 
   def disqualified_from_2fa_enforcement
     request.format.json? || is_api? || current_user.anonymous? ||
-      (!SiteSetting.enforce_second_factor_on_external_auth && secure_session["oauth"])
+      (!SiteSetting.enforce_second_factor_on_external_auth && secure_session["oauth"] == "true")
   end
 
   def build_not_found_page(opts = {})

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["email_valid"]).to eq(true)
         expect(data["can_edit_username"]).to eq(true)
         expect(data["destination_url"]).to eq(destination_url)
-        expect(!!read_secure_session["oauth"]).to be true
+        expect(read_secure_session["oauth"]).to eq("true")
       end
 
       it "should return the right response for staged users" do


### PR DESCRIPTION
Followup to 0e1102b3326ace878c357301e108154051d37c31

Minor followup, makes the condition check against the
boolean val, see the difference here:

```ruby
!SiteSetting.enforce_second_factor_on_external_auth && "true"
=> "true"
```

vs:

```ruby
!SiteSetting.enforce_second_factor_on_external_auth && "true" == "true"
=> true
```
