### PR TITLE
UX: improve alignment of extra PM info in header

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -312,6 +312,9 @@
     }
     .topic-header-extra {
       grid-area: extra;
+      .archetype-private_message & {
+        grid-area: categories;
+      }
     }
   }
   .topic-link {


### PR DESCRIPTION
Personal messages don't have categories, so this information should be moved to the earlier grid column so it aligns properly. 

Before:
![Untitled 2](https://github.com/discourse/discourse/assets/1681963/a29443b9-e73c-4745-b4b1-01c7d4fa9a1b)

After:
![Untitled](https://github.com/discourse/discourse/assets/1681963/18c5d029-67f0-4272-90ad-9e9e95af521d)
