### PR TITLE
UX: Chat mobile menu styling update

### DIFF
--- a/app/assets/stylesheets/mobile/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu.scss
@@ -1,5 +1,5 @@
 .fk-d-menu-modal {
   .d-modal__body {
-    padding: 0;
+    padding: 0.5rem 0;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -80,7 +80,7 @@ export default class ChatMessageActionsMobile extends Component {
       <DModal
         @closeModal={{@closeModal}}
         @headerClass="hidden"
-        class="chat-message-actions"
+        class="fk-d-menu-modal chat-message-actions"
         {{didInsert this.vibrate}}
       >
         <:body>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -80,7 +80,7 @@ export default class ChatMessageActionsMobile extends Component {
       <DModal
         @closeModal={{@closeModal}}
         @headerClass="hidden"
-        class="fk-d-menu-modal chat-message-actions"
+        class="chat-message-actions"
         {{didInsert this.vibrate}}
       >
         <:body>

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
@@ -1,6 +1,6 @@
 .chat-message-actions {
   .selected-message-container {
-    padding: 1rem 0.5em;
+    padding: 0.75rem 1rem;
   }
 
   .selected-message {
@@ -118,9 +118,9 @@
         gap: 0.25em;
         background: none;
         width: 100%;
-        height: 2.25em;
         border: 0;
         color: var(--primary);
+        padding: 0.75rem 1em;
 
         &:focus,
         .d-icon {

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
@@ -1,6 +1,6 @@
 .chat-message-actions {
   .selected-message-container {
-    padding: 0.5em 0 1em 0;
+    padding: 1rem 0.5em;
   }
 
   .selected-message {
@@ -101,10 +101,8 @@
     margin: 0;
 
     .chat-message-action-item {
-      border-bottom: 1px solid var(--primary-low);
       width: 100%;
       list-style: none;
-      padding: 0.25em 0;
       display: flex;
 
       &:active {
@@ -117,8 +115,10 @@
 
       .chat-message-action {
         justify-content: flex-start;
+        gap: 0.25em;
         background: none;
         width: 100%;
+        height: 2.25em;
         border: 0;
         color: var(--primary);
 

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
@@ -129,4 +129,11 @@
       }
     }
   }
+
+  //temporary until this uses a proper component instead of the modal
+  .d-modal {
+    &__body {
+      padding: 0;
+    }
+  }
 }


### PR DESCRIPTION
Bringing the message popup menu more in line with other menus by:

* increasing vertical spacing
* decreasing horizontal space
* removing the lines inbetween items

(screenshots not 1-1 with reality due to devtools)

### Before
<img width="382" alt="image" src="https://github.com/discourse/discourse/assets/101828855/a10e1ada-7e23-4749-ad34-dbeae3773a0a">

### After
<img width="387" alt="image" src="https://github.com/discourse/discourse/assets/101828855/2e8fbad5-638c-40ad-ba96-33eaca880275">


