### PR TITLE
UX: Show chat and message buttons on your own profile

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -147,7 +147,7 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   def can_send_private_message_to_user
-    scope.can_send_private_message?(object) && scope.current_user != object
+    scope.can_send_private_message?(object) || scope.current_user == object
   end
 
   def include_suspend_reason?

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -133,7 +133,7 @@ after_initialize do
 
   add_to_serializer(:user_card, :can_chat_user) do
     return false if !SiteSetting.chat_enabled
-    return false if scope.user.blank? || scope.user.id == object.id
+    return false if scope.user.blank?
     return false if !scope.user.user_option.chat_enabled || !object.user_option.chat_enabled
 
     scope.can_direct_message? && Guardian.new(object).can_chat?
@@ -141,7 +141,7 @@ after_initialize do
 
   add_to_serializer(:hidden_profile, :can_chat_user) do
     return false if !SiteSetting.chat_enabled
-    return false if scope.user.blank? || scope.user.id == object.id
+    return false if scope.user.blank?
     return false if !scope.user.user_option.chat_enabled || !object.user_option.chat_enabled
 
     scope.can_direct_message? && Guardian.new(object).can_chat?

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe UserCardSerializer do
       it "serializes pending_posts_count" do
         expect(json[:pending_posts_count]).to eq 0
       end
+
+      it "can_send_private_message_to_user is true" do
+        expect(json[:can_send_private_message_to_user]).to eq true
+      end
     end
   end
 


### PR DESCRIPTION
We specifically checked against this before, but it's more consistent to show the buttons since the functionality is already allowed