### PR TITLE
FIX: properly escape user status's title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/user-status-bubble.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/user-status-bubble.gjs
@@ -1,15 +1,19 @@
 import { concat } from "@ember/helper";
 import emoji from "discourse/helpers/emoji";
+import escape from "discourse-common/lib/escape";
 import I18n from "discourse-i18n";
 
 const title = (description, endsAt, timezone) => {
-  let content = description;
+  let content = escape(description);
+
   if (endsAt) {
     const until = moment
       .tz(endsAt, timezone)
       .format(I18n.t("dates.long_date_without_year"));
+
     content += `\n${I18n.t("until")} ${until}`;
   }
+
   return content;
 };
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -217,10 +217,17 @@ acceptance("User Status", function (needs) {
     await visit("/");
     await openUserStatusModal();
 
-    await fillIn(".user-status-description", userStatus);
+    await fillIn(".user-status-description", "off to <img src=''> dentist");
     await pickEmoji(userStatusEmoji);
     await click("#tap_tile_one_hour");
     await click(".btn-primary"); // save
+
+    assert.ok(
+      query(".user-status-background img").title.startsWith(
+        "off to <img src=''> dentist",
+        "title is properly escaped"
+      )
+    );
 
     await click(".header-dropdown-toggle.current-user button");
     await click("#user-menu-button-profile");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -222,12 +222,13 @@ acceptance("User Status", function (needs) {
     await click("#tap_tile_one_hour");
     await click(".btn-primary"); // save
 
-    assert.ok(
-      query(".user-status-background img").title.startsWith(
-        "off to <img src=''> dentist",
+    assert
+      .dom(".user-status-background img")
+      .hasAttribute(
+        "title",
+        /^off to <img src=''> dentist/,
         "title is properly escaped"
-      )
-    );
+      );
 
     await click(".header-dropdown-toggle.current-user button");
     await click("#user-menu-button-profile");


### PR DESCRIPTION
We didn't escape the "user status" before inserting in in the title of the "user status badge" next to the current user avatar.

This only affects the current user.

Internal ref - t/130332
