### PR TITLE
UX: move composer image controls below image

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -163,10 +163,10 @@
 }
 
 .d-editor-preview .image-wrapper {
-  --resizer-height: 2.5em;
+  --resizer-height: 2.25em;
   position: relative;
   display: inline-block;
-  min-height: calc(var(--resizer-height) * 2);
+  padding-bottom: var(--resizer-height);
 
   .button-wrapper {
     box-sizing: border-box;
@@ -179,7 +179,7 @@
     gap: 0 0.5em;
     position: absolute;
     height: var(--resizer-height);
-    bottom: 0.4em;
+    bottom: 0;
     left: 0;
     opacity: 0.9;
     z-index: 1; // needs to be higher than image


### PR DESCRIPTION
This is a follow-up to https://github.com/discourse/discourse/commit/0a99407bfb363a28ae1a419cc5e4c16346b784f8

Overlaying the image proved to be annoying in cases where you want to see text in an image, so let's move back to controls below the image. 

Before:
![image](https://github.com/discourse/discourse/assets/1681963/a662766b-5d39-498c-9cd5-f9f865493d92)

After:
![image](https://github.com/discourse/discourse/assets/1681963/c67b4ddd-99e7-4a6a-9f92-367f0862dfee)
