### PR TITLE
FIX: invalid path

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/flags-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/flags-index.hbs
@@ -1,1 +1,0 @@
-<AdminFlags />

--- a/app/assets/javascripts/admin/addon/templates/flags-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/flags-index.hbs
@@ -1,0 +1,1 @@
+<AdminFlags />

--- a/app/assets/javascripts/admin/addon/templates/flags-index.hbs ./config
+++ b/app/assets/javascripts/admin/addon/templates/flags-index.hbs ./config
@@ -1,1 +1,0 @@
-<AdminFlags />


### PR DESCRIPTION
When I attempt to clone this repository on Windows, I encounter the following error: 

![image](https://github.com/discourse/discourse/assets/51732678/d87e1bd4-081b-4de9-b876-58ac143f748d)

The error message indicates an invalid path: `flags-index.hbs ./config`.

I found this file: 

https://github.com/discourse/discourse/blob/0d6bd5207d21de97c864d181b51b8ac41f20beb0/app/assets/javascripts/admin/addon/templates/flags-index.hbs%20./config

The filename contains a space and a dot, which does not seem to be a valid filename.

I suspect the correct filename should be `flags-index.hbs`.