### PR TITLE
FIX: Do not capture OAuth user on 2FA page

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -652,7 +652,7 @@ class SessionController < ApplicationController
 
   def current
     if current_user.present?
-      render_serialized(current_user, CurrentUserSerializer)
+      render_serialized(current_user, CurrentUserSerializer, { login_method: login_method })
     else
       render body: nil, status: 404
     end

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -76,7 +76,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_experimental_topic_bulk_actions?,
              :use_admin_sidebar,
              :can_view_raw_email,
-             :use_glimmer_topic_list?
+             :use_glimmer_topic_list?,
+             :login_method
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -90,6 +91,10 @@ class CurrentUserSerializer < BasicUserSerializer
   def initialize(object, options = {})
     super
     options[:include_status] = true
+  end
+
+  def login_method
+    @options[:login_method]
   end
 
   def groups

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Auth
+  LOGIN_METHOD_OAUTH = "oauth"
+  LOGIN_METHOD_LOCAL = "local"
 end
 
 require "auth/auth_provider"


### PR DESCRIPTION
If the `enforce_second_factor_on_external_auth` setting
is disabled and a user logs in with an OAuth method,
they don't automatically get redirected to /preferences/second-factor
on login. However, they can get there manually, and once there
they cannot leave.

This commit fixes the issue and allows them to leave
and also does some refactors to indicate to the client
what login method is used as a followup to
0e1102b3326ace878c357301e108154051d37c31
