### PR TITLE
DEV: Add Lefthook command to auto-correct staged files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -39,6 +39,20 @@ pre-commit:
       glob: "**/{client,server}.en.yml"
       run: bundle exec ruby script/i18n_lint.rb {staged_files}
 
+fix-staged:
+  parallel: false
+  commands:
+    prettier:
+      glob: "*.js"
+      include: "app/assets/javascripts|plugins/.+?/assets/javascripts"
+      run: yarn pprettier --write {staged_files}
+    rubocop:
+      glob: "*.rb"
+      run: bundle exec rubocop --force-exclusion -A {staged_files}
+    syntax_tree:
+      glob: "*.{rb,rake}"
+      run: bundle exec stree write Gemfile {staged_files}
+
 lints:
   parallel: true
   commands:


### PR DESCRIPTION
### What is this change?

Often when the pre-commit hook is run and reports a problem, I want to follow up by running the auto-correct command of the respective linter, but that means I need to remember what to run. "Let's see. Did prettier need a double-dash before write or not?"

This change adds a `lefthook run fix-staged` command that runs linter auto-corrects on any staged files.