### PR TITLE
FEATURE: new 'should_add_email_attachments' plugin modifier

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -360,6 +360,8 @@ module Email
 
       email_size = 0
       posts.each do |post|
+        next unless DiscoursePluginRegistry.apply_modifier(:should_add_email_attachments, post)
+
         post.uploads.each do |original_upload|
           optimized_1X = original_upload.optimized_images.first
 

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -561,6 +561,20 @@ RSpec.describe Email::Sender do
       )
     end
 
+    context "with a plugin" do
+      before { DiscoursePluginRegistry.clear_modifiers! }
+      after { DiscoursePluginRegistry.clear_modifiers! }
+
+      it "allows plugins to control whether attachments are included" do
+        SiteSetting.email_total_attachment_size_limit_kb = 10_000
+
+        Plugin::Instance.new.register_modifier(:should_add_email_attachments) { false }
+
+        Email::Sender.new(message, :valid_type).send
+        expect(message.attachments.size).to eq(0)
+      end
+    end
+
     it "adds only non-image uploads as attachments to the email" do
       SiteSetting.email_total_attachment_size_limit_kb = 10_000
       Email::Sender.new(message, :valid_type).send


### PR DESCRIPTION
That can be used by plugins to control whether attachments should be sent.

Internal ref - t/132149

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
