### PR TITLE
FIX: correctly show validation errors in automation

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -2,7 +2,7 @@
 
 <section class="discourse-automation-form edit">
   <form class="form-horizontal">
-    <FormError @error={{error}} />
+    <FormError @error={{this.error}} />
 
     <section class="form-section edit">
       <div class="control-group">

--- a/plugins/automation/admin/assets/javascripts/admin/templates/components/form-error.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/components/form-error.hbs
@@ -1,5 +1,5 @@
-{{#if error}}
+{{#if @error}}
   <div class="alert alert-error form-errors">
-    {{html-safe error}}
+    {{html-safe @error}}
   </div>
 {{/if}}

--- a/plugins/automation/app/controllers/discourse_automation/admin_scriptables_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_scriptables_controller.rb
@@ -8,11 +8,18 @@ module DiscourseAutomation
       scriptables =
         DiscourseAutomation::Scriptable.all.map do |s|
           id = s.to_s.gsub(/^__scriptable_/, "")
+          description_key = "discourse_automation.scriptables.#{id}.description"
+          doc_key = "discourse_automation.scriptables.#{id}.doc"
+
           {
             id: id,
-            name: I18n.t("discourse_automation.scriptables.#{id}.title"),
-            description: I18n.t("discourse_automation.scriptables.#{id}.description", default: ""),
-            doc: I18n.t("discourse_automation.scriptables.#{id}.doc", default: ""),
+            name:
+              I18n.t(
+                "discourse_automation.scriptables.#{id}.title",
+                default: "Missing translation for discourse_automation.scriptables.#{id}.title",
+              ),
+            description: I18n.exists?(description_key, :en) ? I18n.t(description_key) : nil,
+            doc: I18n.exists?(doc_key, :en) ? I18n.t(doc_key) : nil,
           }
         end
 

--- a/plugins/automation/app/serializers/discourse_automation/automation_serializer.rb
+++ b/plugins/automation/app/serializers/discourse_automation/automation_serializer.rb
@@ -47,8 +47,12 @@ module DiscourseAutomation
       {
         id: object.script,
         version: scriptable.version,
-        name: I18n.t("#{key}.#{object.script}.title"),
-        description: I18n.t("#{key}.#{object.script}.description"),
+        name:
+          I18n.t(
+            "#{key}.#{object.script}.title",
+            default: "Missing translation for #{key}.#{object.script}.title",
+          ),
+        description: I18n.t("#{key}.#{object.script}.description", default: ""),
         doc: I18n.exists?(doc_key, :en) ? I18n.t(doc_key) : nil,
         with_trigger_doc:
           I18n.exists?(script_with_trigger_key, :en) ? I18n.t(script_with_trigger_key) : nil,
@@ -66,8 +70,12 @@ module DiscourseAutomation
 
       {
         id: object.trigger,
-        name: I18n.t("#{key}.#{object.trigger}.title"),
-        description: I18n.t("#{key}.#{object.trigger}.description"),
+        name:
+          I18n.t(
+            "#{key}.#{object.trigger}.title",
+            default: "Missing translation for #{key}.#{object.trigger}.title",
+          ),
+        description: I18n.t("#{key}.#{object.trigger}.description", default: ""),
         doc: I18n.exists?(doc_key, :en) ? I18n.t(doc_key) : nil,
         not_found: triggerable&.not_found,
         templates: process_templates(triggerable&.fields || []),

--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "DiscourseAutomation | error", type: :system, js: true do
+describe "DiscourseAutomation | error", type: :system do
   fab!(:admin)
 
   before do

--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "DiscourseAutomation | error", type: :system, js: true do
+  fab!(:admin)
+
+  before do
+    SiteSetting.discourse_automation_enabled = true
+    sign_in(admin)
+  end
+
+  context "when saving the form with an error" do
+    it "shows the error correctly" do
+      visit("/admin/plugins/discourse-automation")
+
+      find(".new-automation").click
+      fill_in("automation-name", with: "aaaaa")
+      select_kit = PageObjects::Components::SelectKit.new(".scriptables")
+      select_kit.expand
+      select_kit.select_row_by_value("post")
+      find(".create-automation").click
+      select_kit = PageObjects::Components::SelectKit.new(".triggerables")
+      select_kit.expand
+      select_kit.select_row_by_value("recurring")
+      find(".update-automation").click
+
+      expect(page).to have_content(
+        I18n.t(
+          "discourse_automation.models.fields.required_field",
+          { name: "topic", target: "script", target_name: "post" },
+        ),
+      )
+    end
+  end
+end

--- a/plugins/automation/spec/system/smoke_test_spec.rb
+++ b/plugins/automation/spec/system/smoke_test_spec.rb
@@ -6,34 +6,6 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
   fab!(:badge) { Fabricate(:badge, name: "badge") }
 
   before do
-    I18n.backend.store_translations(
-      :en,
-      {
-        discourse_automation: {
-          scriptables: {
-            test: {
-              title: "Test",
-              description: "Test",
-            },
-            something_about_us: {
-              title: "Something about us.",
-              description: "We rock!",
-            },
-            nothing_about_us: {
-              title: "Nothing about us.",
-              description: "We don't rock!",
-            },
-          },
-          triggerables: {
-            title: "Triggerable",
-            description: "Triggerable",
-            user_first_logged_in: {
-              description: "User first logged in.",
-            },
-          },
-        },
-      },
-    )
     SiteSetting.discourse_automation_enabled = true
     sign_in(admin)
   end


### PR DESCRIPTION
A previous refactor has prevented errors to show correctly. The guilt of the issue is that we were not calling the error variable correctly in the templates.

This commit also adds a spec for this case, and removes the need for `I18n.backend.store_translations` in specs so we don't have to write too much boilerplate each time we write a spec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
