### PR TITLE
FIX: Topic embedding importer should accept string tags

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -122,7 +122,7 @@ class TopicEmbed < ActiveRecord::Base
         end
 
         existing_tag_names = post.topic.tags.pluck(:name).sort
-        incoming_tag_names = Array(tags).map(&:name).sort
+        incoming_tag_names = Array(tags).map { |tag| tag.respond_to?(:name) ? tag.name : tag }.sort
 
         tags_changed = existing_tag_names != incoming_tag_names
 

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe TopicEmbed do
       end
     end
 
-    context "when creating with string tags" do
+    context "when importing a topic embed with string tags" do
       fab!(:tag1) { Fabricate(:tag, name: "interesting") }
       fab!(:tag2) { Fabricate(:tag, name: "article") }
       let(:tags) { [tag1.name, tag2.name] }
@@ -310,7 +310,7 @@ RSpec.describe TopicEmbed do
       end
     end
 
-    context "when updating an existing topic with string tags" do
+    context "when updating an existing topic embed with string tags" do
       fab!(:tag1) { Fabricate(:tag, name: "interesting") }
       fab!(:tag2) { Fabricate(:tag, name: "article") }
       let(:tags) { [tag1, tag2] }

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -299,6 +299,30 @@ RSpec.describe TopicEmbed do
       end
     end
 
+    context "when creating with string tags" do
+      fab!(:tag1) { Fabricate(:tag, name: "interesting") }
+      fab!(:tag2) { Fabricate(:tag, name: "article") }
+      let(:tags) { [tag1.name, tag2.name] }
+
+      it "associates the specified tags with the existing topic" do
+        imported_page = TopicEmbed.import(user, url, title, contents, tags: tags)
+        expect(imported_page.topic.tags).to match_array([tag1, tag2])
+      end
+    end
+
+    context "when updating an existing topic with string tags" do
+      fab!(:tag1) { Fabricate(:tag, name: "interesting") }
+      fab!(:tag2) { Fabricate(:tag, name: "article") }
+      let(:tags) { [tag1, tag2] }
+
+      before { TopicEmbed.import(user, url, title, contents, tags: [tag1.name]) }
+
+      it "associates the specified tags with the existing topic" do
+        imported_page = TopicEmbed.import(user, url, title, contents, tags: tags)
+        expect(imported_page.topic.tags).to match_array([tag1, tag2])
+      end
+    end
+
     context "with specified user and tags" do
       fab!(:tag1) { Fabricate(:tag, name: "interesting") }
       fab!(:tag2) { Fabricate(:tag, name: "article") }


### PR DESCRIPTION
This PR addresses an issue in the topic embedding importer where the import method fails when tags are passed as strings. The change ensures that the tags are correctly processed whether they are passed as strings or objects.

