### PR TITLE
FIX: "in posts by" user search

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.js
@@ -135,6 +135,7 @@ export default class InitialOptions extends Component {
   }
 
   userContextType() {
+    this.contextTypeKeyword = "@";
     this.slug = `@${this.search.searchContext.user.username}`;
     this.suffix = I18n.t("search.in_posts_by", {
       username: this.search.searchContext.user.username,

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -38,6 +38,10 @@ module PageObjects
         find(".d-header #search-button").click
       end
 
+      def click_in_posts_by_user
+        find(".search-menu-container .search-menu-assistant-item").click
+      end
+
       def click_first_topic
         find(".topic-list-body tr:first-of-type").click
       end
@@ -66,6 +70,14 @@ module PageObjects
 
       def has_warning_message?
         page.has_selector?(".search-results .warning")
+      end
+
+      def has_found_no_results?
+        page.has_css?(".search-menu-container .results .no-results")
+      end
+
+      def search_term
+        page.find("#search-term").value
       end
 
       SEARCH_PAGE_SELECTOR = "body.search-page"

--- a/spec/system/user_page/user_page_search_spec.rb
+++ b/spec/system/user_page/user_page_search_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe "User page search", type: :system do
+  fab!(:user)
+  let(:search_page) { PageObjects::Pages::Search.new }
+
+  it "filters down to the user" do
+    sign_in(user)
+
+    visit("/u/#{user.username}")
+    search_page.click_search_icon
+    search_page.click_in_posts_by_user
+
+    expect(search_page).to have_found_no_results
+    expect(search_page.search_term).to eq("@#{user.username}")
+  end
+end


### PR DESCRIPTION
When visiting a user profile, and then opening the search, there's an option to filter down by posts made by that user.

When clicking that option, it used to pre-fill the "search bar" with "@<username>" to filter down the search.

This restore this behaviour and add a system spec to ensure it doesn't regress.

Context - https://meta.discourse.org/t/in-posts-by-search-option-does-not-work-when-clicked/312916