### PR TITLE
FIX: only show relevent chat channel mentions in summary email

### DIFF
--- a/plugins/chat/lib/chat/user_notifications_extension.rb
+++ b/plugins/chat/lib/chat/user_notifications_extension.rb
@@ -33,6 +33,7 @@ module Chat
           AND chat_messages.created_at > now() - interval '1 week'
           AND (uccm.last_read_message_id IS NULL OR uccm.last_read_message_id < chat_messages.id)
           AND (uccm.last_unread_mention_when_emailed_id IS NULL OR uccm.last_unread_mention_when_emailed_id < chat_messages.id)
+          AND (chat_mentions.target_id = #{user.id} OR chat_mentions.type = 'Chat::AllMention')
           AND NOT notifications.read
           GROUP BY uccm.id
         )

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -464,5 +464,45 @@ describe UserNotifications do
         )
       end
     end
+
+    describe "when another user is mentioned in the channel and user receives a 1:1" do
+      before do
+        create_message(direct_message, "Hello, how are you?")
+        create_message(followed_channel, "Hey @#{another.username}", Chat::UserMention)
+      end
+
+      it "does not show the channel mention in the subject" do
+        chat_summary_with_subject(:chat_dm_1, name: direct_message.title(user), count: 1)
+      end
+
+      it "does not show the channel mention in the body" do
+        html = chat_summary_email.html_part.body.to_s
+
+        expect(html).to include(direct_message.title(user))
+        expect(html).not_to include(followed_channel.title(user))
+      end
+    end
+
+    describe "when mentioning @all in the channel and user receives a 1:1" do
+      before do
+        create_message(direct_message, "Hello, how are you?")
+        create_message(followed_channel, "Hey @all", Chat::AllMention)
+      end
+
+      it "shows the channel mention in the subject" do
+        chat_summary_with_subject(
+          :chat_channel_and_dm,
+          channel: followed_channel.name,
+          name: direct_message.title(user),
+        )
+      end
+
+      it "shows the channel mention in the body" do
+        html = chat_summary_email.html_part.body.to_s
+
+        expect(html).to include(direct_message.title(user))
+        expect(html).to include(followed_channel.title(user))
+      end
+    end
   end
 end

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -489,7 +489,7 @@ describe UserNotifications do
         create_message(followed_channel, "Hey @all", Chat::AllMention)
       end
 
-      it "shows the channel mention in the subject" do
+      it "shows both the channel mention and 1:1 in the subject" do
         chat_summary_with_subject(
           :chat_channel_and_dm,
           channel: followed_channel.name,
@@ -497,7 +497,7 @@ describe UserNotifications do
         )
       end
 
-      it "shows the channel mention in the body" do
+      it "shows both the channel mention and 1:1 in the body" do
         html = chat_summary_email.html_part.body.to_s
 
         expect(html).to include(direct_message.title(user))


### PR DESCRIPTION
The chat summary email currently contains mentions that are not relevant to the current user, by limiting by the target user id or when using `@all` we can restrict to showing only the relevant channel mentions.

/t/132240