### PR TITLE
FIX: Don’t raise an error on permalinks with external URL

### DIFF
--- a/app/controllers/permalinks_controller.rb
+++ b/app/controllers/permalinks_controller.rb
@@ -11,7 +11,7 @@ class PermalinksController < ApplicationController
     raise Discourse::NotFound unless permalink
 
     if permalink.target_url
-      redirect_to permalink.target_url, status: :moved_permanently
+      redirect_to permalink.target_url, status: :moved_permanently, allow_other_host: true
     else
       raise Discourse::NotFound
     end

--- a/spec/requests/permalinks_controller_spec.rb
+++ b/spec/requests/permalinks_controller_spec.rb
@@ -44,5 +44,14 @@ RSpec.describe PermalinksController do
       get "/not/a/valid/url"
       expect(response.status).to eq(404)
     end
+
+    context "when permalink's target_url is an external URL" do
+      before { permalink.update!(external_url: "https://github.com/discourse/discourse") }
+
+      it "redirects to it properly" do
+        get "/#{permalink.url}"
+        expect(response).to redirect_to(permalink.external_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, redirecting to an external URL through a permalink doesn’t work because Rails raises a
`ActionController::Redirecting::UnsafeRedirectError` error.

This wasn’t the case before we upgraded to Rails 7.0.

This PR fixes the issue by using `allow_other_host: true` on the redirect.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
