### PR TITLE
FIX: Render a 404 error on a bad redirect in list controller

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -49,6 +49,10 @@ class ListController < ApplicationController
                   :filter,
                 ].flatten
 
+  rescue_from ActionController::Redirecting::UnsafeRedirectError do
+    raise Discourse::NotFound
+  end
+
   # Create our filters
   Discourse.filters.each do |filter|
     define_method(filter) do |options = nil|

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1124,6 +1124,20 @@ RSpec.describe ListController do
         )
       end
     end
+
+    context "when redirect raises an unsafe redirect error" do
+      before do
+        ListController
+          .any_instance
+          .stubs(:redirect_to)
+          .raises(ActionController::Redirecting::UnsafeRedirectError)
+      end
+
+      it "renders a 404" do
+        get "/c/hello/world/bye/#{subsubcategory.id}"
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 
   describe "shared drafts" do


### PR DESCRIPTION
When bad data is provided in the URI for redirecting to a category, Rails raises an `ActionController::Redirecting::UnsafeRedirectError` error, leading to a 500 error.

This PR catches the exception to render a 404 instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
