### PR TITLE
FIX: topic search order

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1191,9 +1191,9 @@ class Search
 
           posts.where("topics.category_id in (?)", category_ids)
         elsif is_topic_search
-          posts.where("topics.id = ?", @search_context.id).order(
-            "posts.post_number #{@order == :latest ? "DESC" : ""}",
-          )
+          posts = posts.where("topics.id = ?", @search_context.id)
+          posts = posts.order("posts.post_number ASC") unless @order
+          posts
         elsif @search_context.is_a?(Tag)
           posts =
             posts.joins("LEFT JOIN topic_tags ON topic_tags.topic_id = topics.id").joins(

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2176,6 +2176,18 @@ RSpec.describe Search do
       expect(Search.execute("Topic max_views:150").posts.map(&:id)).to eq([post.id])
     end
 
+    it "can order by likes" do
+      raw = "Foo bar lorem ipsum"
+      topic = Fabricate(:topic)
+      post1 = Fabricate(:post, topic:, raw:, like_count: 1)
+      post2 = Fabricate(:post, topic:, raw:, like_count: 2)
+      post3 = Fabricate(:post, topic:, raw:, like_count: 3)
+
+      expect(Search.execute("topic:#{topic.id} bar order:likes").posts.map(&:id)).to eq(
+        [post3, post2, post1].map(&:id),
+      )
+    end
+
     it "can search for terms with dots" do
       post = Fabricate(:post, raw: "Will.2000 Will.Bob.Bill...")
       expect(Search.execute("bill").posts.map(&:id)).to eq([post.id])


### PR DESCRIPTION
When using the full page search and filtering down to a specific topic, the sort order was overwritten to by by "post_number".

This was confusing because we allow different type of sort order in the full search page.

This fixes it by only sorting by post_number when there's no "global" sort order defined.

Since the "new topic map" uses the search endpoint behind the scene, this also fixes the "most likes" popup.

Context - https://meta.discourse.org/t/searching-order-seems-to-be-broken-when-searching-in-topic/312303

