### PR TITLE
FIX: invalid user locale when accepting group membership

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -484,10 +484,12 @@ class GroupsController < ApplicationController
     request_topic =
       Topic.find_by(
         title:
-          (
-            I18n.t "groups.request_membership_pm.title", group_name: group.name, locale: user.locale
+          I18n.t(
+            "groups.request_membership_pm.title",
+            group_name: group.name,
+            locale: user.effective_locale,
           ),
-        archetype: "private_message",
+        archetype: Archetype.private_message,
         user_id: user.id,
       )
 
@@ -506,7 +508,11 @@ class GroupsController < ApplicationController
         post_type: Post.types[:regular],
         topic_id: request_topic.id,
         raw:
-          (I18n.t "groups.request_accepted_pm.body", group_name: group.name, locale: user.locale),
+          I18n.t(
+            "groups.request_accepted_pm.body",
+            group_name: group.name,
+            locale: user.effective_locale,
+          ),
         reply_to_post_number: 1,
         target_usernames: user.username,
         skip_validations: true,

--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -353,7 +353,7 @@ class DiscourseConnect < DiscourseConnectBase
       user.name = name || User.suggest_name(username.blank? ? email : username)
     end
 
-    if locale_force_update && SiteSetting.allow_user_locale && locale &&
+    if locale_force_update && SiteSetting.allow_user_locale && locale.present? &&
          LocaleSiteSetting.valid_value?(locale)
       user.locale = locale
     end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -102,7 +102,7 @@ class BadgeGranter
         user_id: user.id,
         badge_id: badge.id,
       )
-      notification = send_notification(user.id, user.username, user.locale, badge)
+      notification = send_notification(user.id, user.username, user.effective_locale, badge)
 
       DB.exec(<<~SQL, notification_id: notification.id, user_id: user.id, badge_id: badge.id)
         UPDATE user_badges


### PR DESCRIPTION
If, for whatever reasons, the user's locale is "blank" and an admin is accepting their group membership request, there will be an error because we're generating posts with the locale of recipient.

In order to fix this, we now use the `user.effective_locale` which takes care of multiple things, including returning the default locale when the user's locale is blank.

Internal ref - t/132347