### PR TITLE
UX: fix featured link alignment, hide participants wrapper outside of PMs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
@@ -157,8 +157,8 @@ export default class Info extends Component {
 
             <div class="topic-header-extra">
               {{htmlSafe this.tags}}
-              <div class="topic-header-participants">
-                {{#if this.showPM}}
+              {{#if this.showPM}}
+                <div class="topic-header-participants">
                   {{#each this.participants as |participant|}}
                     <Participant
                       @user={{participant}}
@@ -178,8 +178,8 @@ export default class Info extends Component {
                       +{{this.remainingParticipantCount}}
                     </a>
                   {{/if}}
-                {{/if}}
-              </div>
+                </div>
+              {{/if}}
               {{#if this.siteSettings.topic_featured_link_enabled}}
                 <FeaturedLink />
               {{/if}}

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -363,6 +363,12 @@
         vertical-align: unset;
       }
     }
+    .topic-featured-link {
+      align-self: baseline;
+      .d-icon {
+        font-size: var(--font-down-2);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This fixes this featured link header misalignment...


before:
![image](https://github.com/discourse/discourse/assets/1681963/e07cd20f-c00a-46ab-ac10-567af7d9898d)

after:
![image](https://github.com/discourse/discourse/assets/1681963/0d693378-bcab-4842-aa83-348c1de78f5d)

and also eliminates some extra space created by an empty `topic-header-participants` div