### PR TITLE
FIX: `CalendarDateTimeInput` renders the wrong day

### DIFF
--- a/app/assets/javascripts/discourse/app/components/calendar-date-time-input.js
+++ b/app/assets/javascripts/discourse/app/components/calendar-date-time-input.js
@@ -40,7 +40,8 @@ export default class CalendarDateTimeInput extends Component {
     if (moment(this.args.date, this._dateFormat).isValid()) {
       this._date = this.args.date;
       this._picker.setDate(
-        moment.utc(this._date).format(this._dateFormat),
+        // using the format YYYY-MM-DD returns the previous day for some timezones
+        moment.utc(this._date).format("YYYY/MM/DD"),
         true
       );
     } else {


### PR DESCRIPTION
When choosing a date range in some timezones, the displayed date in the calendar will render one day off when switching between the "from date" and the "to date".

<div align=center>

![demo of the issue](https://github.com/discourse/discourse/assets/66427541/5bdc5ab2-0bfc-43da-ad99-fdbb4791511b)

</div>

This is due to some inconsistencies with the default `Date` object in Javascript. For instance:

```javascript
new Date("2015-10-21")
// => Tue Oct 20 2015 21:00:00 GMT-0300 (Argentina Standard Time) // Wrong date

new Date("2015/10/21")
// => Wed Oct 21 2015 00:00:00 GMT-0300 (Argentina Standard Time) // Correct date
```

[Pikaday](https://github.com/Pikaday/Pikaday) uses a `Date` object to parse the string, so using the format `YYYY/MM/DD` solves the issue.
Note that this is strictly visual, the actual selected dates are correct.