### PR TITLE
FIX: show group based notifications in chat summary email

### DIFF
--- a/plugins/chat/lib/chat/user_notifications_extension.rb
+++ b/plugins/chat/lib/chat/user_notifications_extension.rb
@@ -43,7 +43,7 @@ module Chat
           AND chat_messages.created_at > now() - interval '1 week'
           AND (uccm.last_read_message_id IS NULL OR uccm.last_read_message_id < chat_messages.id)
           AND (uccm.last_unread_mention_when_emailed_id IS NULL OR uccm.last_unread_mention_when_emailed_id < chat_messages.id)
-          AND ((chat_mentions.type = 'Chat::UserMention' AND chat_mentions.target_id = #{user.id}) OR chat_mentions.type = 'Chat::AllMention' #{group_sql})
+          AND ((chat_mentions.type = 'Chat::UserMention' AND chat_mentions.target_id = #{user.id}) OR (chat_mentions.type = 'Chat::AllMention' AND chat_channels.allow_channel_wide_mentions = true) #{group_sql})
           AND NOT notifications.read
           GROUP BY uccm.id
         )

--- a/plugins/chat/lib/chat/user_notifications_extension.rb
+++ b/plugins/chat/lib/chat/user_notifications_extension.rb
@@ -13,6 +13,16 @@ module Chat
       return if user.user_option.send_chat_email_never?
       return if user.user_option.email_level == UserOption.email_level_types[:never]
 
+      group_ids = user.groups.where.not(mentionable_level: Group::ALIAS_LEVELS[:nobody]).pluck(:id)
+      group_sql =
+        (
+          if group_ids.any?
+            " OR (chat_mentions.type = 'Chat::GroupMention' AND chat_mentions.target_id IN (#{group_ids.join(",")}))"
+          else
+            ""
+          end
+        )
+
       unread_mentions = DB.query_array <<~SQL
         WITH unread_mentions AS (
           SELECT uccm.id membership_id, uccm.chat_channel_id, MIN(chat_messages.id) first_chat_message_id, MAX(chat_messages.id) last_chat_message_id
@@ -33,7 +43,7 @@ module Chat
           AND chat_messages.created_at > now() - interval '1 week'
           AND (uccm.last_read_message_id IS NULL OR uccm.last_read_message_id < chat_messages.id)
           AND (uccm.last_unread_mention_when_emailed_id IS NULL OR uccm.last_unread_mention_when_emailed_id < chat_messages.id)
-          AND (chat_mentions.target_id = #{user.id} OR chat_mentions.type = 'Chat::AllMention')
+          AND ((chat_mentions.type = 'Chat::UserMention' AND chat_mentions.target_id = #{user.id}) OR chat_mentions.type = 'Chat::AllMention' #{group_sql})
           AND NOT notifications.read
           GROUP BY uccm.id
         )

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -245,6 +245,15 @@ describe UserNotifications do
         end
       end
     end
+
+    describe "channel does not allow channel wide mentions" do
+      before { followed_channel.update!(allow_channel_wide_mentions: false) }
+
+      it "does not send a chat summary email" do
+        create_message(followed_channel, "hello @all", Chat::AllMention)
+        no_chat_summary_email
+      end
+    end
   end
 
   describe "in two followed channels" do

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -560,6 +560,14 @@ describe UserNotifications do
           expect(html).not_to include(group.name)
         end
       end
+
+      describe "when user is removed from group" do
+        before { group.remove(user) }
+
+        it "does not show the group mention in the email subject" do
+          chat_summary_with_subject(:chat_dm_1, name: direct_message.title(user), count: 1)
+        end
+      end
     end
   end
 end

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -226,6 +226,25 @@ describe UserNotifications do
         no_chat_summary_email
       end
     end
+
+    describe "group is mentioned" do
+      before do
+        group.update!(mentionable_level: Group::ALIAS_LEVELS[:everyone])
+        create_message(followed_channel, "hello @#{group.name}", Chat::GroupMention)
+      end
+
+      it "sends a chat summary email" do
+        chat_summary_with_subject(:chat_channel_1, channel: followed_channel.name, count: 1)
+      end
+
+      describe "when the group is not mentionable" do
+        before { group.update!(mentionable_level: Group::ALIAS_LEVELS[:nobody]) }
+
+        it "does not send a chat summary email" do
+          no_chat_summary_email
+        end
+      end
+    end
   end
 
   describe "in two followed channels" do
@@ -502,6 +521,44 @@ describe UserNotifications do
 
         expect(html).to include(direct_message.title(user))
         expect(html).to include(followed_channel.title(user))
+      end
+    end
+
+    describe "when mentioning a group in the channel and user receives a 1:1" do
+      before do
+        group.update!(mentionable_level: Group::ALIAS_LEVELS[:everyone])
+        create_message(direct_message, "Hello, how are you?")
+        create_message(followed_channel, "Hey @#{group.name}", Chat::GroupMention)
+      end
+
+      it "shows the group mention in the email subject" do
+        chat_summary_with_subject(
+          :chat_channel_and_dm,
+          channel: followed_channel.name,
+          name: direct_message.title(user),
+        )
+      end
+
+      it "shows the group mention in the email body" do
+        html = chat_summary_email.html_part.body.to_s
+
+        expect(html).to include(direct_message.title(user))
+        expect(html).to include(group.name)
+      end
+
+      describe "when the group is not mentionable" do
+        before { group.update!(mentionable_level: Group::ALIAS_LEVELS[:nobody]) }
+
+        it "does not show the group mention in the email subject" do
+          chat_summary_with_subject(:chat_dm_1, name: direct_message.title(user), count: 1)
+        end
+
+        it "does not show the group mention in the email body" do
+          html = chat_summary_email.html_part.body.to_s
+
+          expect(html).to include(direct_message.title(user))
+          expect(html).not_to include(group.name)
+        end
       end
     end
   end


### PR DESCRIPTION
Follow up to #27631 to account for group mentions in channels.

We only want to show mentions for groups that are currently mentionable and those that the current user belongs to.