### PR TITLE
FIX: User controls buttons order for admins

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -11,7 +11,8 @@
   }
 }
 
-.user-summary-page .details .controls ul {
+.user-summary-page .details .controls ul,
+.user-main .details .controls ul {
   display: flex;
   flex-direction: column;
 
@@ -22,6 +23,10 @@
   li.user-profile-controls-outlet.chat-button {
     order: -1;
   }
+}
+
+.user-main .collapsed-info .details .controls ul {
+  flex-direction: row;
 }
 
 // TODO (davidb): remove once consolidated chat notifications is complete


### PR DESCRIPTION
Small follow-up on #27600: when you are an admin, the buttons are not in the correct order.

<div align=center>

<h4>Before</h4>

![2024-06-28_13-26](https://github.com/discourse/discourse/assets/66427541/8b09fbe4-2018-4821-ba9a-fbce1c22b793)
![2024-06-28_13-32](https://github.com/discourse/discourse/assets/66427541/0cb8badd-10e2-4e24-80cc-1763276939c2)

<h4>After</h4>

![2024-06-28_13-17](https://github.com/discourse/discourse/assets/66427541/fc04f9dc-b21a-4be1-90ac-6c6ce50753a5)
![2024-06-28_13-15](https://github.com/discourse/discourse/assets/66427541/b49c0332-3b5c-4b6c-a5b3-824bb337354f)

</div>


