### PR TITLE
UX: remove redundant nav-pill active border

### DIFF
--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -144,17 +144,11 @@
         &:hover {
           color: var(--tertiary);
           background-color: transparent;
-          border-color: transparent;
         }
 
         &.active {
           color: var(--tertiary);
           background-color: transparent;
-          border-bottom-left-radius: 0;
-          border-bottom-right-radius: 0;
-          border-width: 0;
-          border-bottom: var(--active-border-width) solid var(--tertiary);
-          padding-bottom: var(--space-2);
         }
       }
 

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -131,15 +131,12 @@
     }
 
     .admin-plugin-config-page__top-nav {
-      --active-border-width: var(--space-1);
-
-      width: auto !important;
+      width: auto;
       margin: 0;
 
       a {
         font-size: var(--font-down-0);
-        padding: var(--space-2) var(--space-3)
-          calc(0.5rem + var(--active-border-width));
+        padding: var(--space-2) var(--space-3) var(--space-3);
 
         &:hover {
           color: var(--tertiary);


### PR DESCRIPTION
The change in https://github.com/discourse/discourse/commit/e5c0cfcd27d6844669fcdbcb88d6c4e289d537aa, gets these underline styles for free on `nav-pills`: 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/4dac9a19-f269-4445-960e-09d2db8d4fd4)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/9d1c25bb-7ecf-496c-9c8d-bc95f93eaf13)
