### PR TITLE
UX: truncate too-long names in usercard

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -88,6 +88,7 @@
       .name-username-wrapper {
         margin-right: 0;
         flex: 0 1 auto;
+        @include ellipsis;
       }
       span {
         display: block;


### PR DESCRIPTION
Before:
![image](https://github.com/discourse/discourse/assets/1681963/4f2db2f7-cdb3-4a07-9f94-2caf66313e92)

After:
![image](https://github.com/discourse/discourse/assets/1681963/1f85096a-f785-40bf-8f56-aafbc98477cd)

also works when name is prioritized 

![image](https://github.com/discourse/discourse/assets/1681963/f85bcfb1-12ba-4be8-8f13-868a426ca86d)
