### PR TITLE
FIX: should not raise error when minimum_required_tags value not defined for category.

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -57,6 +57,7 @@ export default class NewCategory extends DiscourseRoute {
       search_priority: SEARCH_PRIORITIES.normal,
       required_tag_groups: [],
       form_template_ids: [],
+      minimum_required_tags: 0,
     });
   }
 

--- a/spec/system/new_category_spec.rb
+++ b/spec/system/new_category_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "New Category", type: :system do
+  fab!(:admin)
+  let(:category_page) { PageObjects::Pages::Category.new }
+
+  before { sign_in(admin) }
+
+  it "should create category with 0 in minimum_required_tags column when not defined" do
+    category_page.visit_new_category
+
+    category_page.find(".edit-category-tab-general input.category-name").fill_in(
+      with: "New Category",
+    )
+    category_page.find(".edit-category-nav .edit-category-tags a").click
+    category_page.focus_input(".edit-category-tab-tags #category-minimum-tags")
+    category_page.save_settings
+
+    expect(page).to have_current_path("/c/new-category/edit/general")
+    # it was returning "PG::NotNullViolation: null value in column 'minimum_required_tags'" error
+  end
+end

--- a/spec/system/new_category_spec.rb
+++ b/spec/system/new_category_spec.rb
@@ -13,10 +13,12 @@ describe "New Category", type: :system do
       with: "New Category",
     )
     category_page.find(".edit-category-nav .edit-category-tags a").click
-    category_page.focus_input(".edit-category-tab-tags #category-minimum-tags")
+    category_page.find(".edit-category-tab-tags #category-minimum-tags").click
     category_page.save_settings
 
     expect(page).to have_current_path("/c/new-category/edit/general")
-    # it was returning "PG::NotNullViolation: null value in column 'minimum_required_tags'" error
+
+    category_page.find(".edit-category-nav .edit-category-tags a").click
+    expect(category_page.find(".edit-category-tab-tags #category-minimum-tags").value).to eq("0")
   end
 end

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -20,6 +20,23 @@ module PageObjects
         self
       end
 
+      def visit_categories
+        page.visit("/categories")
+        self
+      end
+
+      def visit_new_category
+        page.visit("/new-category")
+        self
+      end
+
+      def focus_input(selector)
+        execute_script(<<~JS, text)
+          document.querySelector("#{selector}").focus();
+        JS
+        self
+      end
+
       def back_to_category
         find(".edit-category-title-bar span", text: "Back to category").click
         self

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -30,13 +30,6 @@ module PageObjects
         self
       end
 
-      def focus_input(selector)
-        execute_script(<<~JS, text)
-          document.querySelector("#{selector}").focus();
-        JS
-        self
-      end
-
       def back_to_category
         find(".edit-category-title-bar span", text: "Back to category").click
         self


### PR DESCRIPTION
While creating a new category if the user didn't specify a value for `minimum_required_tags` input but clicked it then it returned the "PG::NotNullViolation: null value in column 'minimum_required_tags'" error.