### PR TITLE
FIX: Small delay when auto-adding list item in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -326,7 +326,12 @@ export default Component.extend(TextareaTextManipulation, {
     this._itsatrap.bind(`${PLATFORM_KEY_MODIFIER}+shift+.`, () =>
       this.send("insertCurrentTime")
     );
-    this._itsatrap.bind("enter", () => this.maybeContinueList(), "keyup");
+    this._itsatrap.bind("enter", () => {
+      // Check the textarea value after a brief delay to ensure the input event has updated the value
+      setTimeout(() => {
+        this.maybeContinueList();
+      }, 0);
+    });
 
     // disable clicking on links in the preview
     this.element

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -989,7 +989,7 @@ third line`
       const initialValue = "* first item in list\n";
       this.set("value", initialValue);
       setCaretPosition(textarea, initialValue.length);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "* ");
     }
   );
@@ -1000,7 +1000,7 @@ third line`
       const initialValue = "- first item in list\n";
       this.set("value", initialValue);
       setCaretPosition(textarea, initialValue.length);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "- ");
     }
   );
@@ -1011,7 +1011,7 @@ third line`
       const initialValue = "1. first item in list\n";
       this.set("value", initialValue);
       setCaretPosition(textarea, initialValue.length);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "2. ");
     }
   );
@@ -1022,7 +1022,7 @@ third line`
       const initialValue = "* first item in list\n\n* second item in list";
       this.set("value", initialValue);
       setCaretPosition(textarea, 21);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(
         this.value,
         "* first item in list\n* \n* second item in list"
@@ -1036,7 +1036,7 @@ third line`
       const initialValue = "1. first item in list\n\n2. second item in list";
       this.set("value", initialValue);
       setCaretPosition(textarea, 22);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(
         this.value,
         "1. first item in list\n2. \n3. second item in list"
@@ -1050,7 +1050,7 @@ third line`
       const initialValue = "* first item in list with empty line\n* \n";
       this.set("value", initialValue);
       setCaretPosition(textarea, initialValue.length);
-      await triggerKeyEvent(textarea, "keyup", "Enter");
+      await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, "* first item in list with empty line\n");
     }
   );


### PR DESCRIPTION
Followup 30fdd7738ec942126bb055c9a6a8d69ddffba2da,

The issue with keyup is that it happens too late. maybeContinueList
itself runs in about 1 or 2 ms. But we show the linebreak in the
textarea on keydown and we handle it in keyup, which causes the “lag”.

The fix here is “hacking” itsatrap and textarea behavior to allow us to handle
it right away after the linebreak is inserted.

Full credit to Joffrey Jaffeux for this fix, I am making him
"co-author" below.

BEFORE

https://github.com/discourse/discourse/assets/920448/7f25750e-81c6-4e00-aa37-44e19a96bb4f

AFTER

https://github.com/discourse/discourse/assets/920448/2ed15f38-e3f3-48ea-b0e4-b7644cf5236a

Co-authored-by: Joffrey JAFFEUX <j.jaffeux@gmail.com>
