### PR TITLE
FIX: ensures posts and topics always have a user record

### DIFF
--- a/app/services/post_owner_changer.rb
+++ b/app/services/post_owner_changer.rb
@@ -19,7 +19,7 @@ class PostOwnerChanger
 
       if post.is_first_post?
         @topic.user = @new_owner
-        @topic.recover! if post.user.nil?
+        @topic.recover! if post.user.nil? || post.user_id == Discourse::SYSTEM_USER_ID
       end
 
       post.topic = @topic

--- a/app/services/spam_rule/flag_sockpuppets.rb
+++ b/app/services/spam_rule/flag_sockpuppets.rb
@@ -18,7 +18,7 @@ class SpamRule::FlagSockpuppets
 
   def reply_is_from_sockpuppet?
     return false if @post.try(:post_number) == 1
-    return false if first_post.user.nil?
+    return false if first_post.user.nil? || first_post.user_id == Discourse::SYSTEM_USER_ID
 
     !first_post.user.staff? && !@post.user.staff? && !first_post.user.staged? &&
       !@post.user.staged? && @post.user != first_post.user &&

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -70,7 +70,7 @@ class UserDestroyer
           end
         end
 
-        Post.unscoped.where(user_id: result.id).update_all(user_id: nil)
+        Post.unscoped.where(user_id: result.id).update_all(user_id: Discourse::SYSTEM_USER_ID)
 
         # If this user created categories, fix those up:
         Category
@@ -150,13 +150,13 @@ class UserDestroyer
   def delete_posts(user, category_topic_ids, opts)
     user.posts.find_each do |post|
       if post.is_first_post? && category_topic_ids.include?(post.topic_id)
-        post.update!(user: Discourse.system_user)
+        post.update!(user_id: Discourse::SYSTEM_USER_ID)
       else
         PostDestroyer.new(@actor.staff? ? @actor : Discourse.system_user, post).destroy
       end
 
       if post.topic && post.is_first_post?
-        Topic.unscoped.where(id: post.topic_id).update_all(user_id: nil)
+        Topic.unscoped.where(id: post.topic_id).update_all(user_id: Discourse::SYSTEM_USER_ID)
       end
     end
   end

--- a/db/migrate/20240701083035_fix_posts_and_topics_with_invalid_user_id.rb
+++ b/db/migrate/20240701083035_fix_posts_and_topics_with_invalid_user_id.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class FixPostsAndTopicsWithInvalidUserId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  BATCH_SIZE = 5000
+
+  def up
+    # Posts
+    begin
+      updated_count =
+        DB.exec(<<~SQL, batch_size: BATCH_SIZE, system_user_id: Discourse::SYSTEM_USER_ID)
+          UPDATE posts
+          SET user_id = :system_user_id
+          WHERE id IN (
+            SELECT posts.id
+            FROM posts
+            LEFT JOIN users ON posts.user_id = users.id
+            WHERE posts.user_id IS NULL OR users.id IS NULL
+            LIMIT :batch_size
+          )
+        SQL
+    end while updated_count > 0
+
+    # Topics
+    begin
+      updated_count =
+        DB.exec(<<~SQL, batch_size: BATCH_SIZE, system_user_id: Discourse::SYSTEM_USER_ID)
+          WITH batch AS (
+            SELECT topics.id AS topic_id, posts.user_id AS first_post_user_id
+            FROM topics
+            LEFT JOIN users ON topics.user_id = users.id
+            LEFT JOIN posts ON topics.id = posts.topic_id AND posts.post_number = 1
+            WHERE topics.user_id IS NULL OR users.id IS NULL
+            LIMIT :batch_size
+          )
+          UPDATE topics
+          SET user_id = COALESCE(batch.first_post_user_id, :system_user_id)
+          FROM batch
+          WHERE id = batch.topic_id
+      SQL
+    end while updated_count > 0
+  end
+
+  def down
+  end
+end

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -176,9 +176,14 @@ RSpec.describe PostDestroyer do
       post = Fabricate(:post)
       UserDestroyer.new(Discourse.system_user).destroy(post.user, delete_posts: true)
 
-      expect { PostDestroyer.new(admin, post.reload).recover }.to change { post.reload.user_id }.to(
-        Discourse.system_user.id,
-      ).and change { post.topic.user_id }.to(Discourse.system_user.id)
+      post.reload
+      PostDestroyer.new(admin, post).recover
+
+      post.reload
+      expect(post.deleted_at).to eq(nil)
+      expect(post.user_id).to eq(Discourse::SYSTEM_USER_ID)
+      expect(post.topic.deleted_at).to eq(nil)
+      expect(post.topic.user_id).to eq(Discourse::SYSTEM_USER_ID)
     end
 
     it "bypassed validation when updating users" do

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe UserDestroyer do
           it "deletes the posts" do
             destroy
             expect(post.reload.deleted_at).not_to eq(nil)
-            expect(post.user_id).to eq(nil)
+            expect(post.user_id).to eq(Discourse::SYSTEM_USER_ID)
           end
 
           it "does not delete topics started by others in which the user has replies" do
@@ -187,7 +187,7 @@ RSpec.describe UserDestroyer do
             Fabricate(:post, user: user, topic: spammer_topic)
             destroy
             expect(spammer_topic.reload.deleted_at).not_to eq(nil)
-            expect(spammer_topic.user_id).to eq(nil)
+            expect(spammer_topic.user_id).to eq(Discourse::SYSTEM_USER_ID)
           end
 
           context "when delete_as_spammer is true" do
@@ -235,7 +235,7 @@ RSpec.describe UserDestroyer do
           it "deletes the posts" do
             destroy
             expect(post.reload.deleted_at).not_to eq(nil)
-            expect(post.user_id).to eq(nil)
+            expect(post.user_id).to eq(Discourse::SYSTEM_USER_ID)
           end
         end
       end
@@ -267,10 +267,10 @@ RSpec.describe UserDestroyer do
         UserDestroyer.new(admin).destroy(user, delete_posts: true)
 
         expect(first_post.reload.deleted_at).to eq(nil)
-        expect(first_post.user_id).to eq(Discourse.system_user.id)
+        expect(first_post.user_id).to eq(Discourse::SYSTEM_USER_ID)
 
         expect(second_post.reload.deleted_at).not_to eq(nil)
-        expect(second_post.user_id).to eq(nil)
+        expect(second_post.user_id).to eq(Discourse::SYSTEM_USER_ID)
       end
     end
 
@@ -292,7 +292,7 @@ RSpec.describe UserDestroyer do
 
       it "should mark the user's deleted posts as belonging to a nuked user" do
         expect { UserDestroyer.new(admin).destroy(user) }.to change { User.count }.by(-1)
-        expect(deleted_post.reload.user_id).to eq(nil)
+        expect(deleted_post.reload.user_id).to eq(Discourse::SYSTEM_USER_ID)
       end
     end
 


### PR DESCRIPTION
Whenever we delete a user, we'd set the `user_id` of the `topic` to `nil` if the user created the first post of that topic.

This was added back in d76486a48bc9cd50f719fc66d019218a55ea5890 and doesn't hold true anymore. We now use the `@system` user for that.

This fixes the `UserDestroyer` to always set the user of a deleted post and topic to the `@system` user.

There's also a migration to fix the wrong record.

Another step after that is to make these `user_id` column non nullable, but that's for another time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
