### PR TITLE
DEV: Redo `DiscourseLogstashLogger` to not rely on `logstash-logger`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -212,7 +212,6 @@ gem "cppjieba_rb", require: false
 
 gem "lograge", require: false
 gem "logstash-event", require: false
-gem "logstash-logger", require: false
 gem "logster"
 
 # A fork of sassc with dart-sass support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,9 +218,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    logstash-logger (0.26.1)
-      logstash-event (~> 1.2)
-    logster (2.19.1)
+    logster (2.20.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -640,7 +638,6 @@ DEPENDENCIES
   listen
   lograge
   logstash-event
-  logstash-logger
   logster
   loofah
   lru_redux

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,7 @@ Discourse::Application.configure do
 
   config.log_level = ENV["DISCOURSE_DEV_LOG_LEVEL"] if ENV["DISCOURSE_DEV_LOG_LEVEL"]
 
+  config.active_record.logger = nil if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1"
   config.active_record.verbose_query_logs = true if ENV["RAILS_VERBOSE_QUERY_LOGS"] == "1"
 
   if defined?(BetterErrors)
@@ -89,8 +90,6 @@ Discourse::Application.configure do
         line =~ %r{lib/freedom_patches}
       end
     end
-
-    ActiveRecord::Base.logger = nil if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1"
 
     if ENV["BULLET"]
       Bullet.enable = true

--- a/config/initializers/101-lograge.rb
+++ b/config/initializers/101-lograge.rb
@@ -102,18 +102,29 @@ Rails.application.config.to_prepare do
           end
         end
 
-      if ENV["LOGSTASH_URI"]
+      if ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
         config.lograge.formatter = Lograge::Formatters::Logstash.new
 
         require "discourse_logstash_logger"
 
         config.lograge.logger =
-          DiscourseLogstashLogger.logger(uri: ENV["LOGSTASH_URI"], type: :rails)
+          DiscourseLogstashLogger.logger(
+            logdev: Rails.root.join("log", "#{Rails.env}.log"),
+            type: :rails,
+            customize_event:
+              lambda do |event|
+                event["database"] = RailsMultisite::ConnectionManagement.current_db
+              end,
+          )
 
-        # Remove ActiveSupport::Logger from the chain and replace with Lograge's
-        # logger
-        Rails.logger.stop_broadcasting_to(Rails.logger.broadcasts.first)
-        Rails.logger.broadcast_to(config.lograge.logger)
+        # Stop broadcasting to Rails' default logger
+        Rails.logger.stop_broadcasting_to(
+          Rails.logger.broadcasts.find { |logger| logger.is_a?(ActiveSupport::Logger) },
+        )
+
+        Logster.logger.subscribe do |severity, message, progname, opts, &block|
+          config.lograge.logger.add_with_opts(severity, message, progname, opts, &block)
+        end
       end
     end
   end

--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html
-
-if (ENV["LOGSTASH_UNICORN_URI"] || "").length > 0
-  require_relative "../lib/discourse_logstash_logger"
-  require_relative "../lib/unicorn_logstash_patch"
-  logger DiscourseLogstashLogger.logger(uri: ENV["LOGSTASH_UNICORN_URI"], type: :unicorn)
-end
-
 discourse_path = File.expand_path(File.expand_path(File.dirname(__FILE__)) + "/../")
 
 # tune down if not enough ram
@@ -25,18 +18,31 @@ FileUtils.mkdir_p("#{discourse_path}/tmp/pids") if !File.exist?("#{discourse_pat
 # feel free to point this anywhere accessible on the filesystem
 pid(ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
 
-if ENV["RAILS_ENV"] != "production"
-  logger Logger.new(STDOUT)
-  # we want a longer timeout in dev cause first request can be really slow
-  timeout(ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
-else
+if ENV["RAILS_ENV"] == "production"
   # By default, the Unicorn logger will write to stderr.
   # Additionally, some applications/frameworks log to stderr or stdout,
   # so prevent them from going to /dev/null when daemonized here:
   stderr_path "#{discourse_path}/log/unicorn.stderr.log"
   stdout_path "#{discourse_path}/log/unicorn.stdout.log"
+
   # nuke workers after 30 seconds instead of 60 seconds (the default)
   timeout 30
+else
+  # we want a longer timeout in dev cause first request can be really slow
+  timeout(ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)
+end
+
+enable_logstash_logger = ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
+
+if enable_logstash_logger
+  require_relative "../lib/discourse_logstash_logger"
+  require_relative "../lib/unicorn_logstash_patch"
+  logger DiscourseLogstashLogger.logger(
+           logdev: "#{discourse_path}/log/unicorn.stderr.log",
+           type: :unicorn,
+         )
+else
+  logger Logger.new(STDOUT)
 end
 
 # important for Ruby 2.0

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -4,6 +4,7 @@ require "cache"
 require "open3"
 require "plugin/instance"
 require "version"
+require "git_utils"
 
 module Discourse
   DB_POST_MIGRATE_PATH ||= "db/post_migrate"
@@ -829,42 +830,23 @@ module Discourse
   end
 
   def self.git_version
-    @git_version ||=
-      begin
-        git_cmd = "git rev-parse HEAD"
-        self.try_git(git_cmd, Discourse::VERSION::STRING)
-      end
+    @git_version ||= GitUtils.git_version
   end
 
   def self.git_branch
-    @git_branch ||=
-      self.try_git("git branch --show-current", nil) ||
-        self.try_git("git config user.discourse-version", "unknown")
+    @git_branch ||= GitUtils.git_branch
   end
 
   def self.full_version
-    @full_version ||=
-      begin
-        git_cmd = 'git describe --dirty --match "v[0-9]*" 2> /dev/null'
-        self.try_git(git_cmd, "unknown")
-      end
+    @full_version ||= GitUtils.full_version
   end
 
   def self.last_commit_date
-    @last_commit_date ||=
-      begin
-        git_cmd = 'git log -1 --format="%ct"'
-        seconds = self.try_git(git_cmd, nil)
-        seconds.nil? ? nil : DateTime.strptime(seconds, "%s")
-      end
+    @last_commit_date ||= GitUtils.last_commit_date
   end
 
   def self.try_git(git_cmd, default_value)
-    begin
-      `#{git_cmd}`.strip
-    rescue StandardError
-      default_value
-    end.presence || default_value
+    GitUtils.try_git(git_cmd, default_value)
   end
 
   # Either returns the site_contact_username user or the first admin.

--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -1,18 +1,104 @@
 # frozen_string_literal: true
 
-require "logstash-logger"
+require "json"
+require "socket"
+require_relative "git_utils"
 
-class DiscourseLogstashLogger
-  def self.logger(uri:, type:)
-    LogStashLogger.new(
-      uri: uri,
-      sync: true,
-      customize_event: ->(event) do
-        event["severity_name"] = event["severity"]
-        event["severity"] = Object.const_get("Logger::Severity::#{event["severity"]}")
-        event["type"] = type
-        event["pid"] = Process.pid
-      end,
-    )
+class DiscourseLogstashLogger < Logger
+  PROCESS_PID = Process.pid
+  HOST = Socket.gethostname
+  GIT_VERSION = GitUtils.git_version
+
+  attr_accessor :customize_event, :type
+
+  # Creates a new logger instance.
+  #
+  # @param logdev [String, IO, nil] The log device. This can be one of:
+  #   - A string filepath: entries are written to the file at that path. If the file exists, new entries are appended.
+  #   - An IO stream (typically +$stdout+, +$stderr+, or an open file): entries are written to the given stream.
+  #   - nil or File::NULL: no entries are written.
+  # @param type [String] The type of log messages. This will add a `type` field to all log messages.
+  # @param customize_event [Proc, nil] A proc that customizes the log event before it is written to the log device.
+  #   The proc is called with a hash of log event data and can be modified in place.
+  #
+  # @return [Logger] A new logger instance with the specified log device and type.
+  def self.logger(logdev:, type:, customize_event: nil)
+    logger = self.new(logdev)
+    logger.type = type
+    logger.customize_event = customize_event if customize_event
+    logger
+  end
+
+  # :nodoc:
+  def add(*args, &block)
+    add_with_opts(*args, &block)
+  end
+
+  ALLOWED_HEADERS_FROM_ENV = %w[
+    REQUEST_URI
+    REQUEST_METHOD
+    HTTP_HOST
+    HTTP_USER_AGENT
+    HTTP_ACCEPT
+    HTTP_REFERER
+    HTTP_X_FORWARDED_FOR
+    HTTP_X_REAL_IP
+  ]
+
+  # :nodoc:
+  def add_with_opts(severity, message = nil, progname = nil, opts = {}, &block)
+    return true if @logdev.nil? || severity < @level
+
+    progname = @progname if progname.nil?
+
+    if message.nil?
+      if block_given?
+        message = yield
+      else
+        message = progname
+        progname = @progname
+      end
+    end
+
+    event = {
+      "message" => message,
+      "severity" => severity,
+      "severity_name" => Logger::SEV_LABEL[severity],
+      "pid" => PROCESS_PID,
+      "type" => @type.to_s,
+      "host" => HOST,
+      "git_version" => GitUtils.git_version,
+    }
+
+    # Only log backtrace and env for Logger::WARN and above.
+    # Backtrace is just noise for anything below that.
+    if severity >= Logger::WARN
+      if (backtrace = opts&.dig(:backtrace)).present?
+        event["backtrace"] = backtrace
+      end
+
+      if (env = opts&.dig(:env)).present?
+        ALLOWED_HEADERS_FROM_ENV.each do |header|
+          event["request.headers.#{header.downcase}"] = opts[:env][header]
+        end
+      end
+    end
+
+    if message.start_with?("{") && message.end_with?("}")
+      begin
+        parsed = JSON.parse(message)
+        event["message"] = parsed.delete("message") if parsed["message"]
+        event.merge!(parsed)
+        event
+      rescue JSON::ParserError
+        # Do nothing
+      end
+    end
+
+    @customize_event.call(event) if @customize_event
+
+    @logdev.write("#{event.to_json}\n")
+  rescue Exception => e
+    STDERR.puts "Error logging message in DiscourseLogstashLogger: #{message} (#{e.message})\n#{e.backtrace.join("\n")}"
   end
 end

--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class GitUtils
+  def self.git_version
+    self.try_git("git rev-parse HEAD", "unknown")
+  end
+
+  def self.git_branch
+    self.try_git("git branch --show-current", nil) ||
+      self.try_git("git config user.discourse-version", "unknown")
+  end
+
+  def self.full_version
+    self.try_git('git describe --dirty --match "v[0-9]*" 2> /dev/null', "unknown")
+  end
+
+  def self.last_commit_date
+    git_cmd = 'git log -1 --format="%ct"'
+    seconds = self.try_git(git_cmd, nil)
+    seconds.nil? ? nil : DateTime.strptime(seconds, "%s")
+  end
+
+  def self.try_git(git_cmd, default_value)
+    value =
+      begin
+        `#{git_cmd}`.strip
+      rescue StandardError
+        default_value
+      end
+
+    (value.present? ? value : nil) || default_value
+  end
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,7 +3,6 @@
 module Discourse
   VERSION_REGEXP ||= /\A\d+\.\d+\.\d+(\.beta\d+)?\z/
   VERSION_COMPATIBILITY_FILENAME ||= ".discourse-compatibility"
-
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
@@ -16,8 +15,8 @@ module Discourse
       MAJOR = PARTS[0].to_i
       MINOR = PARTS[1].to_i
       TINY = PARTS[2].to_i
-      PRE = PARTS[3]&.split("-", 2)&.first
-      DEV = PARTS[3]&.split("-", 2)&.second
+      PRE = PARTS[3]&.split("-", 2)&.[](0)
+      DEV = PARTS[3]&.split("-", 2)&.[](1)
     end
   end
 

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseLogstashLogger do
+  let(:lograge_logstash_formatter_formatted_message) do
+    "{\"method\":\"GET\",\"path\":\"/\",\"format\":\"html\",\"controller\":\"ListController\",\"action\":\"latest\",\"status\":200,\"allocations\":242307,\"duration\":178.2,\"view\":78.36,\"db\":0.0,\"params\":\"\",\"ip\":\"127.0.0.1\",\"username\":null,\"@timestamp\":\"2024-07-01T07:51:11.283Z\",\"@version\":\"1\",\"message\":\"[200] GET / (ListController#latest)\"}"
+  end
+
+  let(:output) { StringIO.new }
+  let(:logger) { described_class.logger(logdev: output, type: "test") }
+
+  describe "#add" do
+    it "logs a JSON string with the right fields" do
+      logger.add(Logger::INFO, lograge_logstash_formatter_formatted_message)
+      output.rewind
+
+      expect(output.read.chomp).to eq(
+        {
+          "message" => "[200] GET / (ListController#latest)",
+          "severity" => 1,
+          "severity_name" => "INFO",
+          "pid" => described_class::PROCESS_PID,
+          "type" => "test",
+          "host" => described_class::HOST,
+          "git_version" => described_class::GIT_VERSION,
+          "method" => "GET",
+          "path" => "/",
+          "format" => "html",
+          "controller" => "ListController",
+          "action" => "latest",
+          "status" => 200,
+          "allocations" => 242_307,
+          "duration" => 178.2,
+          "view" => 78.36,
+          "db" => 0.0,
+          "params" => "",
+          "ip" => "127.0.0.1",
+          "username" => nil,
+          "@timestamp" => "2024-07-01T07:51:11.283Z",
+          "@version" => "1",
+        }.to_json,
+      )
+    end
+
+    it "logs a JSON string with the right fields when `customize_event` attribute is set" do
+      logger =
+        described_class.logger(
+          logdev: output,
+          type: "test",
+          customize_event: ->(event) { event["custom"] = "custom" },
+        )
+
+      logger.add(Logger::INFO, lograge_logstash_formatter_formatted_message)
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed["custom"]).to eq("custom")
+    end
+
+    it "does not log a JSON string with the `backtrace` field when severity is less than `Logger::WARN`" do
+      logger.add(
+        Logger::INFO,
+        lograge_logstash_formatter_formatted_message,
+        nil,
+        backtrace: "backtrace",
+      )
+
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed).not_to have_key("backtrace")
+    end
+
+    it "logs a JSON string with the `backtrace` field when severity is at least `Logger::WARN`" do
+      logger.add(
+        Logger::ERROR,
+        lograge_logstash_formatter_formatted_message,
+        nil,
+        backtrace: "backtrace",
+      )
+
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed["backtrace"]).to eq("backtrace")
+    end
+
+    described_class::ALLOWED_HEADERS_FROM_ENV.each do |header|
+      it "does not include `#{header}` from `env` keyword argument in the logged JSON string when severity is less than `Logger::WARN`" do
+        logger.add(
+          Logger::INFO,
+          lograge_logstash_formatter_formatted_message,
+          nil,
+          env: {
+            header => "header",
+          },
+        )
+
+        output.rewind
+        parsed = JSON.parse(output.read.chomp)
+
+        expect(parsed).not_to have_key("request.headers.#{header.downcase}")
+      end
+
+      it "includes `#{header}` from `env` keyword argument in the logged JSON string when severity is at least `Logger::WARN`" do
+        logger.add(
+          Logger::ERROR,
+          lograge_logstash_formatter_formatted_message,
+          nil,
+          env: {
+            header => "header",
+          },
+        )
+
+        output.rewind
+        parsed = JSON.parse(output.read.chomp)
+
+        expect(parsed["request.headers.#{header.downcase}"]).to eq("header")
+      end
+    end
+
+    it "does not include keys from `env` keyword argument in the logged JSOn string which are not in the allow list" do
+      logger.add(
+        Logger::ERROR,
+        lograge_logstash_formatter_formatted_message,
+        nil,
+        env: {
+          "SOME_RANDOM_HEADER" => "header",
+        },
+      )
+
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed).not_to have_key("request.headers.some_random_header")
+    end
+  end
+end


### PR DESCRIPTION
This commit rewrites `DiscourseLogstashLogger` to not be an instance
of `LogstashLogger`. The reason we don't want it to be an instance of
`LogstashLogger` is because we want the new logger to be chained to
Logster's logger which can then pass down useful information like the
request's env and error backtraces which Logster has already gathered.

Note that this commit does not bother to maintain backwards
compatibility and drops the `LOGSTASH_URI` and `UNICORN_LOGSTASH_URI`
ENV variables which were previously used to configure the destination in
which `logstash-logger` would send the logs to. Instead, we introduce
the `ENABLE_LOGSTASH_LOGGER` ENV variable to replace both ENV and remove
the need for the log paths to be specified. Note that the previous
feature was considered experimental as stated in d888d3c54c4744d52b9d21d3728f5d6dbc132cde
and the new feature should be considered experimental as well. The code
may be moved into a plugin in the future.

### Reviewer notes

Unit tests have been written for `DiscourseLogstashLogger` but it is hard to test the actual content of logs being written. As such, the following manual testing instruction has been provided:

1. `cd` into your Discourse git directory
1. Run `tail -f log/development.log`
1. Run `tail -f log/unicorn.stderr.log`
1. Run `RAILS_DISABLE_ACTIVERECORD_LOGS=1 RAILS_LOGS_STDOUT=0 ENABLE_LOGSTASH_LOGGER=1 ENABLE_LOGRAGE=1 RAILS_VERBOSE_QUERY_LOGS=0  RAILS_DISABLE_ACTIVERECORD_LOGS=1 bin/rails s`
1. Look at the tail of logs to ensure they are in the JSON formatted and fields look like what they should be. 

#### Sample Rails application INFO logs

```
{"message":"[200] GET /service-worker.js (StaticController#service_worker_asset)","severity":1,"severity_name":"INFO","pid":82024,"type":"rails","host":"Guos-MBP","git_version":"7eb190425772542500a17618374570e3e0cc8837","method":"GET","path":"/service-worker.js","format":"*/*","controller":"StaticController","action":"service_worker_asset","status":200,"allocations":5569,"duration":9.5,"view":1.03,"db":0.0,"params":"","database":"default","ip":"127.0.0.1","username":null,"@timestamp":"2024-07-01T10:06:54.957Z","@version":"1"}
```

#### Sample Rails application ERROR logs

```
{"message":"NameError (Could not render layout: uninitialized constant ApplicationController::SiteSettin)\napp/controllers/application_controller.rb:65:in `has_escaped_fragment?'\napp/controllers/application_controller.rb:78:in `use_crawler_layout?'\napp/controllers/application_controller.rb:122:in `set_layout'\nlib/topic_list_responder.rb:15:in `block (2 levels) in respond_with_list'\nlib/topic_list_responder.rb:8:in `respond_with_list'\napp/controllers/list_controller.rb:111:in `block (2 levels) in \u003cclass:ListController\u003e'\napp/controllers/application_controller.rb:424:in `block in with_resolved_locale'\napp/controllers/application_controller.rb:424:in `with_resolved_locale'\nlib/middleware/omniauth_bypass_middleware.rb:64:in `call'\nlib/content_security_policy/middleware.rb:12:in `call'\nlib/middleware/csp_script_nonce_injector.rb:12:in `call'\nconfig/initializers/008-rack-cors.rb:14:in `call'\nconfig/initializers/100-quiet_logger.rb:20:in `call'\nconfig/initializers/100-silence_logger.rb:29:in `call'\nlib/middleware/missing_avatars.rb:22:in `call'\nlib/middleware/turbo_dev.rb:31:in `call'","severity":4,"severity_name":"FATAL","pid":91921,"type":"rails","host":"Guos-MBP","git_version":"8cf786fc706240860818cd755323daac46f9b0c5","backtrace":"app/controllers/application_controller.rb:65:in `has_escaped_fragment?'\napp/controllers/application_controller.rb:78:in `use_crawler_layout?'\napp/controllers/application_controller.rb:122:in `set_layout'\nactionview (7.0.8.4) lib/action_view/layouts.rb:330:in `_layout'\nactionview (7.0.8.4) lib/action_view/layouts.rb:417:in `_default_layout'\nactionview (7.0.8.4) lib/action_view/layouts.rb:393:in `block in _layout_for_option'\nactionview (7.0.8.4) lib/action_view/renderer/template_renderer.rb:108:in `resolve_layout'\nactionview (7.0.8.4) lib/action_view/renderer/template_renderer.rb:88:in `find_layout'\nactionview (7.0.8.4) lib/action_view/renderer/template_renderer.rb:71:in `render_with_layout'\nactionview (7.0.8.4) lib/action_view/renderer/template_renderer.rb:59:in `render_template'\nactionview (7.0.8.4) lib/action_view/renderer/template_renderer.rb:11:in `render'\nactionview (7.0.8.4) lib/action_view/renderer/renderer.rb:61:in `render_template_to_object'\nactionview (7.0.8.4) lib/action_view/renderer/renderer.rb:29:in `render_to_object'\nactionview (7.0.8.4) lib/action_view/rendering.rb:117:in `block in _render_template'\nactionview (7.0.8.4) lib/action_view/base.rb:270:in `in_rendering_context'\nactionview (7.0.8.4) lib/action_view/rendering.rb:116:in `_render_template'\nactionpack (7.0.8.4) lib/action_controller/metal/streaming.rb:216:in `_render_template'\nactionview (7.0.8.4) lib/action_view/rendering.rb:103:in `render_to_body'\nactionpack (7.0.8.4) lib/action_controller/metal/rendering.rb:158:in `render_to_body'\nactionpack (7.0.8.4) lib/action_controller/metal/renderers.rb:141:in `render_to_body'\nactionpack (7.0.8.4) lib/abstract_controller/rendering.rb:27:in `render'\nactionpack (7.0.8.4) lib/action_controller/metal/rendering.rb:139:in `render'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:22:in `block (2 levels) in render'\n/Users/tgxworld/.asdf/installs/ruby/3.3.2/lib/ruby/3.3.0/benchmark.rb:313:in `realtime'\nactivesupport (7.0.8.4) lib/active_support/core_ext/benchmark.rb:14:in `ms'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:22:in `block in render'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:91:in `cleanup_view_runtime'\nactiverecord (7.0.8.4) lib/active_record/railties/controller_runtime.rb:34:in `cleanup_view_runtime'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:21:in `render'\nlib/topic_list_responder.rb:15:in `block (2 levels) in respond_with_list'\nactionpack (7.0.8.4) lib/action_controller/metal/mime_responds.rb:214:in `respond_to'\nlib/topic_list_responder.rb:8:in `respond_with_list'\napp/controllers/list_controller.rb:111:in `block (2 levels) in \u003cclass:ListController\u003e'\nactionpack (7.0.8.4) lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'\nactionpack (7.0.8.4) lib/abstract_controller/base.rb:215:in `process_action'\nactionpack (7.0.8.4) lib/action_controller/metal/rendering.rb:165:in `process_action'\nactionpack (7.0.8.4) lib/abstract_controller/callbacks.rb:234:in `block in process_action'\nactivesupport (7.0.8.4) lib/active_support/callbacks.rb:118:in `block in run_callbacks'\napp/controllers/application_controller.rb:424:in `block in with_resolved_locale'\ni18n (1.14.5) lib/i18n.rb:351:in `with_locale'\napp/controllers/application_controller.rb:424:in `with_resolved_locale'\nactivesupport (7.0.8.4) lib/active_support/callbacks.rb:127:in `block in run_callbacks'\nactivesupport (7.0.8.4) lib/active_support/callbacks.rb:138:in `run_callbacks'\nactionpack (7.0.8.4) lib/abstract_controller/callbacks.rb:233:in `process_action'\nactionpack (7.0.8.4) lib/action_controller/metal/rescue.rb:23:in `process_action'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:67:in `block in process_action'\nactivesupport (7.0.8.4) lib/active_support/notifications.rb:206:in `block in instrument'\nactivesupport (7.0.8.4) lib/active_support/notifications/instrumenter.rb:24:in `instrument'\nactivesupport (7.0.8.4) lib/active_support/notifications.rb:206:in `instrument'\nactionpack (7.0.8.4) lib/action_controller/metal/instrumentation.rb:66:in `process_action'\nactionpack (7.0.8.4) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'\nactiverecord (7.0.8.4) lib/active_record/railties/controller_runtime.rb:27:in `process_action'\nactionpack (7.0.8.4) lib/abstract_controller/base.rb:151:in `process'\nactionview (7.0.8.4) lib/action_view/rendering.rb:39:in `process'\nrack-mini-profiler (3.3.1) lib/mini_profiler/profiling_methods.rb:115:in `block in profile_method'\nactionpack (7.0.8.4) lib/action_controller/metal.rb:188:in `dispatch'\nactionpack (7.0.8.4) lib/action_controller/metal.rb:251:in `dispatch'\nactionpack (7.0.8.4) lib/action_dispatch/routing/route_set.rb:49:in `dispatch'\nactionpack (7.0.8.4) lib/action_dispatch/routing/route_set.rb:32:in `serve'\nactionpack (7.0.8.4) lib/action_dispatch/routing/mapper.rb:18:in `block in \u003cclass:Constraints\u003e'\nactionpack (7.0.8.4) lib/action_dispatch/routing/mapper.rb:48:in `serve'\nactionpack (7.0.8.4) lib/action_dispatch/journey/router.rb:50:in `block in serve'\nactionpack (7.0.8.4) lib/action_dispatch/journey/router.rb:32:in `each'\nactionpack (7.0.8.4) lib/action_dispatch/journey/router.rb:32:in `serve'\nactionpack (7.0.8.4) lib/action_dispatch/routing/route_set.rb:852:in `call'\nlib/middleware/omniauth_bypass_middleware.rb:64:in `call'\nrack (2.2.9) lib/rack/tempfile_reaper.rb:15:in `call'\nrack (2.2.9) lib/rack/conditional_get.rb:27:in `call'\nrack (2.2.9) lib/rack/head.rb:12:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/http/permissions_policy.rb:38:in `call'\nlib/content_security_policy/middleware.rb:12:in `call'\nlib/middleware/csp_script_nonce_injector.rb:12:in `call'\nconfig/initializers/008-rack-cors.rb:14:in `call'\nrack (2.2.9) lib/rack/session/abstract/id.rb:266:in `context'\nrack (2.2.9) lib/rack/session/abstract/id.rb:260:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/cookies.rb:704:in `call'\nactiverecord (7.0.8.4) lib/active_record/migration.rb:638:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'\nactivesupport (7.0.8.4) lib/active_support/callbacks.rb:99:in `run_callbacks'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/callbacks.rb:26:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/executor.rb:14:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/debug_exceptions.rb:28:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/show_exceptions.rb:29:in `call'\n/Users/tgxworld/work/logster/lib/logster/middleware/reporter.rb:40:in `call'\nlograge (0.14.0) lib/lograge/rails_ext/rack/logger.rb:18:in `call_app'\nrailties (7.0.8.4) lib/rails/rack/logger.rb:27:in `call'\nconfig/initializers/100-quiet_logger.rb:20:in `call'\nconfig/initializers/100-silence_logger.rb:29:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/remote_ip.rb:93:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/request_id.rb:26:in `call'\nrack (2.2.9) lib/rack/method_override.rb:24:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/executor.rb:14:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/static.rb:23:in `call'\nrack (2.2.9) lib/rack/sendfile.rb:110:in `call'\nactionpack (7.0.8.4) lib/action_dispatch/middleware/host_authorization.rb:138:in `call'\nlib/middleware/missing_avatars.rb:22:in `call'\nlib/middleware/turbo_dev.rb:31:in `call'\nrack-mini-profiler (3.3.1) lib/mini_profiler.rb:334:in `call'\nmessage_bus (4.3.8) lib/message_bus/rack/middleware.rb:60:in `call'\nrailties (7.0.8.4) lib/rails/engine.rb:530:in `call'\nrailties (7.0.8.4) lib/rails/railtie.rb:226:in `public_send'\nrailties (7.0.8.4) lib/rails/railtie.rb:226:in `method_missing'\nrack (2.2.9) lib/rack/urlmap.rb:74:in `block in call'\nrack (2.2.9) lib/rack/urlmap.rb:58:in `each'\nrack (2.2.9) lib/rack/urlmap.rb:58:in `call'\nunicorn (6.1.0) lib/unicorn/http_server.rb:634:in `process_client'\nunicorn (6.1.0) lib/unicorn/http_server.rb:739:in `worker_loop'\nunicorn (6.1.0) lib/unicorn/http_server.rb:547:in `spawn_missing_workers'\nunicorn (6.1.0) lib/unicorn/http_server.rb:143:in `start'\nunicorn (6.1.0) bin/unicorn:128:in `\u003ctop (required)\u003e'\nbin/unicorn:93:in `load'\nbin/unicorn:93:in `block in \u003cmain\u003e'\nbin/unicorn:92:in `fork'\nbin/unicorn:92:in `\u003cmain\u003e'","request.headers.request_uri":"/","request.headers.request_method":"GET","request.headers.http_host":"127.0.0.1:3000","request.headers.http_user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36","request.headers.http_accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7","request.headers.http_referer":null,"request.headers.http_x_forwarded_for":null,"request.headers.http_x_real_ip":null,"database":"default"}
``` 

#### Sample Unicorn logs output

```
{"message":"master complete","severity":1,"severity_name":"INFO","pid":82024,"type":"unicorn","host":"Guos-MBP","git_version":"7eb190425772542500a17618374570e3e0cc8837"}
```