### PR TITLE
FIX: Division by zero error on WebHookEventsDailyAggregate

### DIFF
--- a/app/models/web_hook_events_daily_aggregate.rb
+++ b/app/models/web_hook_events_daily_aggregate.rb
@@ -25,7 +25,7 @@ class WebHookEventsDailyAggregate < ActiveRecord::Base
         self.web_hook_id,
       )
 
-    self.mean_duration = events.sum(:duration) / events.count
+    self.mean_duration = events.sum(:duration) / events.count if events.count > 0
 
     self.successful_event_count = events.where("status >= 200 AND status <= 299").count
     self.failed_event_count = events.where("status < 200 OR status > 299").count

--- a/spec/models/web_hook_events_daily_aggregate_spec.rb
+++ b/spec/models/web_hook_events_daily_aggregate_spec.rb
@@ -110,5 +110,11 @@ RSpec.describe WebHookEventsDailyAggregate do
         WebHookEventsDailyAggregate.count
       }
     end
+
+    it "should not fail if there are no events" do
+      expect { Jobs::AggregateWebHooksEvents.new.execute(date: 99.days.ago) }.not_to raise_error
+
+      expect(WebHookEventsDailyAggregate.count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
If, for some reason, there was no data for the day and the aggregate was run, it could result in `ZeroDivisionError`
