### PR TITLE
UX: prevent the tag bullet from shrinking

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -101,6 +101,7 @@
     display: inline-flex;
     align-items: center;
     &:before {
+      flex-shrink: 0;
       background: var(--primary-low-mid);
       margin-right: 5px;
       position: relative;


### PR DESCRIPTION
In cases of long tags and narrow screens, the tag bullet can be hidden by flex-shrink... this prevents that from happening.


Before:
![image](https://github.com/discourse/discourse/assets/1681963/4880fa88-a358-4104-a999-837490d16d8e)


After:
![image](https://github.com/discourse/discourse/assets/1681963/5188b588-93f2-4ea3-9754-346f4bfe5d78)
