### PR TITLE
UX: fix height of lazy youtube embeds

### DIFF
--- a/plugins/discourse-lazy-videos/assets/stylesheets/lazy-videos.scss
+++ b/plugins/discourse-lazy-videos/assets/stylesheets/lazy-videos.scss
@@ -143,3 +143,8 @@
     border-radius: 9px;
   }
 }
+
+// Overrides core onebox height: auto; that can cause a conflict
+.lazy-video-wrapper .lazy-video-container.youtube-onebox {
+  height: 0;
+}


### PR DESCRIPTION
This is a dupe of https://github.com/discourse/discourse-lazy-videos/pull/15, I didn't realize this plugin was added to core. 

The height set here: https://github.com/discourse/discourse/blob/94044591881cd11b71b2b98652e771ab0027fa71/app/assets/stylesheets/common/base/onebox.scss#L920 can sometimes override the height set by the plugin, so this more specific class selector ensures that can't happen. 

![image](https://github.com/discourse/discourse-lazy-videos/assets/1681963/91a1583d-9233-4f79-8d54-c6417a92a078)

