### PR TITLE
FIX: Hide message button for current user if can't message

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -147,7 +147,7 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   def can_send_private_message_to_user
-    scope.can_send_private_message?(object) || scope.current_user == object
+    scope.can_send_private_message?(object)
   end
 
   def include_suspend_reason?

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -66,8 +66,20 @@ RSpec.describe UserCardSerializer do
         expect(json[:pending_posts_count]).to eq 0
       end
 
-      it "can_send_private_message_to_user is true" do
-        expect(json[:can_send_private_message_to_user]).to eq true
+      context "when the user is in a group with PMs enabled" do
+        before { SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:everyone] }
+
+        it "can_send_private_message_to_user is true" do
+          expect(json[:can_send_private_message_to_user]).to eq true
+        end
+      end
+
+      context "when the user is not in a group with PMs enabled" do
+        before { SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:moderators] }
+
+        it "can_send_private_message_to_user is false" do
+          expect(json[:can_send_private_message_to_user]).to eq false
+        end
       end
     end
   end


### PR DESCRIPTION
I thought this was necessary, but it is not, and it overwrites the setting `personal_message_enabled_groups`