### PR TITLE
FIX: increase secure session for OAuth expiration time

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -370,6 +370,7 @@ class SessionController < ApplicationController
     return render(json: @second_factor_failure_payload) if !second_factor_auth_result.ok
 
     if user.active && user.email_confirmed?
+      secure_session["oauth"] = false if !SiteSetting.persistent_sessions
       login(user, second_factor_auth_result)
     else
       not_activated(user)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -86,7 +86,7 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     cookies["_bypass_cache"] = true
     cookies[:authentication_data] = { value: client_hash.to_json, path: Discourse.base_path("/") }
-    secure_session["oauth"] = true
+    secure_session.set("oauth", true, expires: SiteSetting.maximum_session_age.hours)
     redirect_to @origin
   end
 

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -237,6 +237,10 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["can_edit_username"]).to eq(true)
         expect(data["destination_url"]).to eq(destination_url)
         expect(read_secure_session["oauth"]).to eq("true")
+        expect(Discourse.redis.ttl("#{session[:secure_session_id]}oauth")).to be_between(
+          SiteSetting.maximum_session_age.hours.seconds - 10,
+          SiteSetting.maximum_session_age.hours.seconds,
+        )
       end
 
       it "should return the right response for staged users" do


### PR DESCRIPTION
By default, secure sessions expire after 1 hour.
For OAuth authentication it should expire at the same time when the authentication cookie expires - `SiteSetting.maximum_session_age.hours`.

It is possible that the forum will not have persistent sessions, based on `persistent_sessions` site setting. In that case, with next username and password authentication we need to reset information about OAuth.

Bug introduced in this PR - https://github.com/discourse/discourse/pull/27547
