### PR TITLE
DEV: Disable smart lists for now on Firefox

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -515,6 +515,15 @@ export default Mixin.create({
 
   @bind
   maybeContinueList() {
+    // TODO (martin) Very inconsistent on Firefox at the moment, we end up with
+    // things like this. Something about newlines maybe?
+    //
+    // 1. a
+    // 2. test? 2. 2. 2. 2. 2.
+    if (this.capabilities.isFirefox) {
+      return false;
+    }
+
     const offset = caretPosition(this._textarea);
     const text = this._textarea.value;
     const lines = text.substring(0, offset).split("\n");

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -14,6 +14,7 @@ import { setCaretPosition } from "discourse/lib/utilities";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";
 import {
+  chromeTest,
   exists,
   paste,
   query,
@@ -77,8 +78,13 @@ module("Integration | Component | d-editor", function (hooks) {
     return textarea;
   }
 
-  function testCase(title, testFunc) {
-    test(title, async function (assert) {
+  function testCase(title, testFunc, opts = {}) {
+    let testFn = test;
+    if (opts.chrome) {
+      testFn = chromeTest;
+    }
+
+    testFn(title, async function (assert) {
       this.set("value", "hello world.");
 
       await render(hbs`<DEditor @value={{this.value}} />`);
@@ -991,7 +997,8 @@ third line`
       setCaretPosition(textarea, initialValue.length);
       await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "* ");
-    }
+    },
+    { chrome: true }
   );
 
   testCase(
@@ -1002,7 +1009,8 @@ third line`
       setCaretPosition(textarea, initialValue.length);
       await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "- ");
-    }
+    },
+    { chrome: true }
   );
 
   testCase(
@@ -1013,7 +1021,8 @@ third line`
       setCaretPosition(textarea, initialValue.length);
       await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, initialValue + "2. ");
-    }
+    },
+    { chrome: true }
   );
 
   testCase(
@@ -1027,7 +1036,8 @@ third line`
         this.value,
         "* first item in list\n* \n* second item in list"
       );
-    }
+    },
+    { chrome: true }
   );
 
   testCase(
@@ -1041,7 +1051,8 @@ third line`
         this.value,
         "1. first item in list\n2. \n3. second item in list"
       );
-    }
+    },
+    { chrome: true }
   );
 
   testCase(
@@ -1052,7 +1063,8 @@ third line`
       setCaretPosition(textarea, initialValue.length);
       await triggerKeyEvent(textarea, "keydown", "Enter");
       assert.strictEqual(this.value, "* first item in list with empty line\n");
-    }
+    },
+    { chrome: true }
   );
 
   (() => {


### PR DESCRIPTION
Firefox is having a lot of inconsistent issues with this
feature introduced in 30fdd7738ec942126bb055c9a6a8d69ddffba2da,
disabling it there for now until further investigation can
be done.
