### PR TITLE
FIX: missing flag serializer

### DIFF
--- a/app/serializers/flag_serializer.rb
+++ b/app/serializers/flag_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class FlagSerializer < ApplicationSerializer
+  attributes :id, :name, :name_key, :description, :applies_to, :position, :enabled
+end

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -75,6 +75,18 @@ describe "Admin Flags Page", type: :system do
     admin_flag_form_page.fill_in_applies_to("Post")
     admin_flag_form_page.click_save
 
+    expect(all(".admin-flag-item__name").map(&:text)).to eq(
+      [
+        "Send @%{username} a message",
+        "Off-Topic",
+        "Inappropriate",
+        "Spam",
+        "Illegal",
+        "Something Else",
+        "Vulgar",
+      ],
+    )
+
     topic_page.visit_topic(post.topic)
     topic_page.open_flag_topic_modal
     expect(all(".flag-action-type-details strong").map(&:text)).to eq(


### PR DESCRIPTION
FlagSerializer is used in this PR
https://github.com/discourse/discourse/pull/27484 but was not staged.

The original system spec didn't catch it because the record was created and before the error was displayed we redirected to a topic page to check available flags. 


