### PR TITLE
FIX: Discrepency between admin page view reports

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -296,13 +296,14 @@ class Report
   def self.req_report(report, filter = nil)
     data =
       if filter == :page_view_total
+        # For this report we intentionally do not want to count mobile pageviews
+        # or "browser" pageviews. See `ConsolidatedPageViewsBrowserDetection` for
+        # browser pageviews.
         ApplicationRequest.where(
           req_type: [
-            ApplicationRequest
-              .req_types
-              .reject { |k, v| k =~ /mobile/ }
-              .map { |k, v| v if k =~ /page_view/ }
-              .compact,
+            ApplicationRequest.req_types[:page_view_crawler],
+            ApplicationRequest.req_types[:page_view_anon],
+            ApplicationRequest.req_types[:page_view_logged_in],
           ].flatten,
         )
       else


### PR DESCRIPTION
Followup 2f2da7274732cba30d03b6c5c3a4194652cb6783

When the "Consolidated Pageviews with Browser Detection (Experimental)"
report was introduced, we started counting the original
"page_view_logged_in" and "page_view_anon" ApplicationRequest
data as "Other Pageviews", subtracting
"page_view_anon_browser" and "page_view_logged_in_browser" from
this number.

However we unknowingly automatically started counting these
browser-based page views, which are a subset of the total
"page_view_logged_in" and "page_view_anon" counts, in the
original "Pageviews" report, leading to double counting
which meant that when you looked at the data for each
report side-by-side the data didn't add up.

This commit fixes the issue by not counting the "browser"
pageviews in the Pageviews report, and making the code where
we were only counting certain types of requests for this
report more plain, explicitly stating which types of requests
we want.