### PR TITLE
FIX: Inline footnotes doesn’t work in the table at fullscreen

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/post-decorations.js
@@ -156,7 +156,16 @@ export default {
       function generateFullScreenTableModal(event) {
         const table = event.currentTarget.parentElement.nextElementSibling;
         const tempTable = table.cloneNode(true);
-        modal.show(FullscreenTableModal, { model: { tableHtml: tempTable } });
+        const cookedWrapper = document.createElement("div");
+        cookedWrapper.classList.add("cooked");
+        if (siteSettings.display_footnotes_inline) {
+          cookedWrapper.classList.add("inline-footnotes");
+        }
+        cookedWrapper.dataset.refPostId = this.id;
+        cookedWrapper.appendChild(tempTable);
+        modal.show(FullscreenTableModal, {
+          model: { tableHtml: cookedWrapper },
+        });
       }
 
       function generateSpreadsheetModal() {
@@ -228,7 +237,7 @@ export default {
           buttonWrapper.append(expandTableBtn);
           expandTableBtn.addEventListener(
             "click",
-            generateFullScreenTableModal,
+            generateFullScreenTableModal.bind(attrs),
             false
           );
           table.parentNode.insertBefore(buttonWrapper, table);

--- a/plugins/footnote/assets/javascripts/initializers/inline-footnotes.js
+++ b/plugins/footnote/assets/javascripts/initializers/inline-footnotes.js
@@ -65,7 +65,13 @@ function footnoteEventHandler(event) {
 
   // append footnote to tooltip body
   const footnoteContent = tooltip.querySelector(".footnote-tooltip-content");
-  const cooked = expandableFootnote.closest(".cooked");
+  let cooked = expandableFootnote.closest(".cooked");
+  if (cooked.dataset.refPostId != null) {
+    // For full screen tables, redirect
+    cooked = document.querySelector(
+      `article[data-post-id="${cooked.dataset.refPostId}"] .cooked`
+    );
+  }
   const newContent = cooked.querySelector(footnoteId);
   footnoteContent.innerHTML = newContent.innerHTML;
 

--- a/plugins/footnote/assets/javascripts/initializers/inline-footnotes.js
+++ b/plugins/footnote/assets/javascripts/initializers/inline-footnotes.js
@@ -113,7 +113,7 @@ export default {
     }
 
     document.body.append(buildTooltip());
-    window.addEventListener("click", footnoteEventHandler);
+    window.addEventListener("click", footnoteEventHandler, true);
 
     withPluginApi("0.8.9", (api) => {
       api.decorateCookedElement((elem) => applyInlineFootnotes(elem), {

--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -45,7 +45,7 @@
   font-size: var(--font-down-1);
   border-radius: 3px;
   display: none;
-  z-index: z("tooltip");
+  z-index: z("modal", "tooltip");
   max-width: 400px;
   overflow-wrap: break-word;
 


### PR DESCRIPTION
meta topic: https://meta.discourse.org/t/inline-footnotes-doesnt-work-in-the-table-at-fullscreen/313445

after:

![image](https://github.com/discourse/discourse/assets/41134017/6f980e42-79a5-44fa-8f2d-9a35e4af4179)
