### PR TITLE
FIX: Do not schedule avatar download if image is ""

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -148,7 +148,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   end
 
   def retrieve_avatar(user, url)
-    return unless user && url
+    return unless user && url.present?
     return if user.user_avatar.try(:custom_upload_id).present?
     Jobs.enqueue(:download_avatar_from_url, url: url, user_id: user.id, override_gravatar: false)
   end

--- a/spec/lib/auth/managed_authenticator_spec.rb
+++ b/spec/lib/auth/managed_authenticator_spec.rb
@@ -293,6 +293,14 @@ RSpec.describe Auth::ManagedAuthenticator do
         }.not_to change { Jobs::DownloadAvatarFromUrl.jobs.count }
       end
 
+      it "does not schedule if image is empty" do
+        association.info["image"] = ""
+        association.save!
+        expect {
+          authenticator.after_create_account(user, create_auth_result(extra_data: create_hash))
+        }.not_to change { Jobs::DownloadAvatarFromUrl.jobs.count }
+      end
+
       it "schedules with image" do
         association.info["image"] = "https://some.domain/image.jpg"
         association.save!


### PR DESCRIPTION
Currently seeing an influx of `Job exception: url` due to `Jobs::DownloadAvatarFromUrl`

`return unless user && url` doesn't return if `url = ""`, so this fix ensures that a `""` won't pass through.