### PR TITLE
FIX: Don't error out when loading a badge with a deleted image

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -27,6 +27,7 @@ class Upload < ActiveRecord::Base
   has_many :upload_references, dependent: :destroy
   has_many :posts, through: :upload_references, source: :target, source_type: "Post"
   has_many :topic_thumbnails
+  has_many :badges, foreign_key: :image_upload_id, dependent: :nullify
 
   attr_accessor :for_group_message
   attr_accessor :for_theme

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Upload do
   let(:attachment_path) { __FILE__ }
   let(:attachment) { File.new(attachment_path) }
 
+  it { is_expected.to have_many(:badges).dependent(:nullify) }
+
   describe ".with_no_non_post_relations" do
     it "does not find non-post related uploads" do
       post_upload = Fabricate(:upload)


### PR DESCRIPTION
### What was happening?

Badges can have their associated image uploads deleted. When this happens, any user who has that badge will have their profile page error out.

### How does this fix it?

When deleting an upload that's associated with a badge, nullify the foreign key ID on the badge. This makes the existing safeguard work correctly.