### PR TITLE
FEATURE: add option to delete user associated account on password reset

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -901,6 +901,10 @@ class UsersController < ApplicationController
           secure_session["password-#{token}"] = nil
           secure_session["second-factor-#{token}"] = nil
 
+          if SiteSetting.delete_associated_accounts_on_password_reset
+            @user.user_associated_accounts.destroy_all
+          end
+
           UserHistory.create!(
             target_user: @user,
             acting_user: @user,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2369,6 +2369,8 @@ en:
     allow_users_to_hide_profile: "Allow users to hide their profile and presence"
     hide_user_activity_tab: "Hide the activity tab on user profiles except for Admin and self."
 
+    delete_associated_accounts_on_password_reset: "Delete user associated account when user changes the password."
+
     allow_featured_topic_on_user_profiles: "Allow users to feature a link to a topic on their user card and profile."
 
     show_inactive_accounts: "Allow logged in users to browse profiles of inactive accounts."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -793,6 +793,8 @@ users:
   hide_user_activity_tab:
     default: false
     client: true
+  delete_associated_accounts_on_password_reset:
+    default: false
 
 groups:
   enable_group_directory:


### PR DESCRIPTION
When user changes password, add an option to delete their associated accounts (google, facebook, etc).