### PR TITLE
DEV: Fix flaky spec for the /about admin config area

### DIFF
--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -38,7 +38,7 @@ describe "Admin About Config Area Page", type: :system do
       expect(config_area.general_settings_section.community_description_editor.value).to eq(
         "this is an extended description for my forums",
       )
-      expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_picture
+      expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
       expect(config_area.contact_information_section.community_owner_input.value).to eq("kitty")
       expect(config_area.contact_information_section.contact_email_input.value).to eq(
@@ -79,6 +79,7 @@ describe "Admin About Config Area Page", type: :system do
         with: "here's an extended description for the **community**",
       )
       config_area.general_settings_section.banner_image_uploader.select_image(image_file.path)
+      expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
       config_area.general_settings_section.save_button.click
       expect(config_area.general_settings_section).to have_saved_successfully

--- a/spec/system/page_objects/components/uppy_image_uploader.rb
+++ b/spec/system/page_objects/components/uppy_image_uploader.rb
@@ -11,8 +11,12 @@ module PageObjects
         attach_file(path) { @element.find("label.btn-default").click }
       end
 
-      def has_uploaded_picture?
-        @element.has_css?(".uploaded-image-preview")
+      def has_uploaded_image?
+        # if there's a delete button (.btn-danger), then there must be an
+        # uploaded image.
+        # allow up to 10 seconds for the upload to finish in case this is
+        # called immediately after selecting an image.
+        @element.has_css?(".btn-danger", wait: 10)
       end
     end
   end


### PR DESCRIPTION
There's currently a race condition in the following spec:

https://github.com/discourse/discourse/blob/65be7a7880ba0dc1a5cb403956fabd83aaa738d6/spec/system/admin_about_config_area_spec.rb#L70-L95

where the form can be saved before the image uploader field has finished uploading the selected image and causing the assertion at line 94 to fail with the following error:

```
Failure/Error: expect(SiteSetting.about_banner_image.sha1).to eq(Upload.generate_digest(image_file))

NoMethodError:
  undefined method `sha1' for nil

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_admin_about_config_area_page_the_general_settings_card_can_saves_its_fields_to_their_corresponding_site_settings_312.png

~~~~~~~ JS LOGS ~~~~~~~
http://localhost:31338/assets/vendor.js 15902:14 "WARNING: uppy needs a unique id, pass one in to the component implementing this mixin"
~~~~~ END JS LOGS ~~~~~

./spec/system/admin_about_config_area_spec.rb:94:in `block (3 levels) in <main>'
./spec/rails_helper.rb:552:in `block (3 levels) in <top (required)>'
./spec/rails_helper.rb:552:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:513:in `block (3 levels) in <top (required)>'
./spec/rails_helper.rb:503:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'
./vendor/bundle/ruby/3.3.0/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

This PR fixes the problem by making the system test wait for the image to finish uploading (with 10 seconds timeout) before carrying out the rest of the system test.