### PR TITLE
FIX: topic embed blank tags or passed with nil do not blank out existing topic tags

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -124,7 +124,7 @@ class TopicEmbed < ActiveRecord::Base
         existing_tag_names = post.topic.tags.pluck(:name).sort
         incoming_tag_names = Array(tags).map { |tag| tag.respond_to?(:name) ? tag.name : tag }.sort
 
-        tags_changed = existing_tag_names != incoming_tag_names
+        tags_changed = !tags.nil? && existing_tag_names != incoming_tag_names
 
         if (content_sha1 != embed.content_sha1) || (title && title != post&.topic&.title) ||
              tags_changed

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -371,6 +371,18 @@ RSpec.describe TopicEmbed do
         imported_page = TopicEmbed.import(user, url, title, contents, tags: tags)
         expect(imported_page.topic.tags).to match_array([tag1, tag2])
       end
+
+      it "does not update tags if tags are nil or unspecified" do
+        imported_page = TopicEmbed.import(user, url, title, contents)
+        expect(imported_page.topic.tags).to match_array([tag1])
+        imported_page = TopicEmbed.import(user, url, title, contents, tags: nil)
+        expect(imported_page.topic.tags).to match_array([tag1])
+      end
+
+      it "does update tags if tags are empty" do
+        imported_page = TopicEmbed.import(user, url, title, contents, tags: [])
+        expect(imported_page.topic.tags).to match_array([])
+      end
     end
 
     context "with specified user and tags" do


### PR DESCRIPTION
When a topic embed is run with either no tags argument or a nil tag argument this should not affect any existing tags.

Only update topic tags when tags argument is explicitly empty.

See also:
https://meta.discourse.org/t/rss-polling-plugin-removes-tags-added-manually/311811