### PR TITLE
A11Y: topic list links should not be headings

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
@@ -13,8 +13,6 @@ export default class TopicLink extends Component {
     <a
       href={{this.url}}
       data-topic-id={{@topic.id}}
-      role="heading"
-      aria-level="2"
       class="title"
       ...attributes
     >{{htmlSafe @topic.fancyTitle}}</a>

--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -17,8 +17,6 @@ export default function topicLink(topic, args = {}) {
 
   return htmlSafe(
     `<a href='${url}'
-        role='heading'
-        aria-level='2'
         class='${classes.join(" ")}'
         data-topic-id='${topic.id}'>${title}</a>`
   );


### PR DESCRIPTION
Both internal and customer accessibility audits have flagged this as an issue. 