### PR TITLE
UX: Add <span> within discourse-tag

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -55,9 +55,9 @@ export function defaultRenderTag(tag, params) {
     (params.description ? ' title="' + escape(hoverDescription) + '" ' : "") +
     " class='" +
     classes.join(" ") +
-    "'>" +
+    "'><span>" +
     (params.displayName ? escape(params.displayName) : visibleName) +
-    "</" +
+    "</span></" +
     tagName +
     ">";
 


### PR DESCRIPTION
The content of `.discourse-tag` should be wrapped with a `<span>`, similar to how `.badge-category > span.badge-category__name` is structured. This ensures more robust syntax when using pseudo-elements or when siblings are present, as seen in [Discourse Tag Icons](https://github.com/discourse/discourse-tag-icons).

Before

```
<a href="/tag/example" data-tag-name="example" class="discourse-tag simple">
  <span style="color: #ff0000" class="tag-icon">
    <svg class="fa d-icon d-icon-anchor svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#anchor"</use></svg>
  </span>
  example
</a>
```

After

```
<a href="/tag/example" data-tag-name="example" class="discourse-tag simple">
  <span style="color: #ff0000" class="tag-icon">
    <svg class="fa d-icon d-icon-anchor svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#anchor"</use></svg>
  </span>
  <span>
    example
  </span>
</a>
```