### PR TITLE
FIX: should not raise error when both group & site tag preferences are same

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2035,7 +2035,7 @@ class User < ActiveRecord::Base
         end
     end
 
-    TagUser.insert_all!(values) if values.present?
+    TagUser.insert_all(values) if values.present?
   end
 
   def self.purge_unactivated

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -326,13 +326,24 @@ RSpec.describe Invite do
     end
 
     context "when inviting to groups" do
-      it "add the user to the correct groups" do
-        group = Fabricate(:group)
+      fab!(:group)
+
+      before do
         group.add_owner(invite.invited_by)
         invite.invited_groups.create!(group_id: group.id)
+      end
 
+      it "add the user to the correct groups" do
         user = invite.redeem
         expect(user.groups).to contain_exactly(group)
+      end
+      it "should not raise error when both group & site tag preferences same" do
+        tag = Fabricate(:tag)
+        group.tracking_tags = [tag.name]
+        group.save!
+        SiteSetting.default_tags_tracking = tag.name
+
+        expect { invite.redeem }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
When tag preference in group and site settings are both used with the same default notification level it will break new users' signups because it tries to create duplicate records in the tag_users table which can’t happen because we have a unique index set.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
