### PR TITLE
FIX: Uses `\n` for line breaks in table builder

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -645,7 +645,7 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
   // Generate table headers
   table += "|";
   table += cols.join(" | ");
-  table += "|\r\n|";
+  table += "|\n|";
 
   const alignMap = {
     left: ":--",
@@ -657,7 +657,7 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
   table += cols
     .map((_, index) => alignMap[String(alignments?.[index])] || "---")
     .join(" | ");
-  table += "|\r\n";
+  table += "|\n";
 
   // Generate table body
   array.forEach(function (item) {
@@ -671,7 +671,7 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
             " "
           );
         })
-        .join(" | ") + "|\r\n";
+        .join(" | ") + "|\n";
   });
 
   return table;

--- a/app/assets/javascripts/discourse/tests/fixtures/md-table.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/md-table.js
@@ -1,3 +1,3 @@
-export const mdTable = `|Make | Model | Year|\r\n|--- | --- | ---|\r\n|Toyota | Supra | 1998|\r\n|Nissan | Skyline | 1999|\r\n|Honda | S2000 | 2001|\r\n`;
-export const mdTableSpecialChars = `|Make | Model | Price|\r\n|--- | --- | ---|\r\n|Toyota | Supra | $50,000|\r\n| | Celica | $20,000|\r\n|Nissan | GTR | $80,000|\r\n`;
-export const mdTableNonUniqueHeadings = `|col1 | col2 | col1|\r\n|--- | --- | ---|\r\n|Col A | Col B | Col C|\r\n`;
+export const mdTable = `|Make | Model | Year|\n|--- | --- | ---|\n|Toyota | Supra | 1998|\n|Nissan | Skyline | 1999|\n|Honda | S2000 | 2001|\n`;
+export const mdTableSpecialChars = `|Make | Model | Price|\n|--- | --- | ---|\n|Toyota | Supra | $50,000|\n| | Celica | $20,000|\n|Nissan | GTR | $80,000|\n`;
+export const mdTableNonUniqueHeadings = `|col1 | col2 | col1|\n|--- | --- | ---|\n|Col A | Col B | Col C|\n`;

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -388,7 +388,7 @@ module("Unit | Utilities | table-builder", function (hooks) {
 
     assert.strictEqual(
       arrayToTable(tableData, ["Col 1", "Col 2"], "A"),
-      `|Col 1 | Col 2|\r\n|--- | ---|\r\n|hey | you|\r\n|over | there|\r\n`,
+      `|Col 1 | Col 2|\n|--- | ---|\n|hey | you|\n|over | there|\n`,
       "it works"
     );
   });
@@ -407,7 +407,7 @@ module("Unit | Utilities | table-builder", function (hooks) {
 
     assert.strictEqual(
       arrayToTable(tableData, ["Col 1", "Col 2"]),
-      `|Col 1 | Col 2|\r\n|--- | ---|\r\n|Jane Doe | Teri|\r\n|Finch | Sami|\r\n`,
+      `|Col 1 | Col 2|\n|--- | ---|\n|Jane Doe | Teri|\n|Finch | Sami|\n`,
       "it creates a valid table"
     );
   });
@@ -425,13 +425,13 @@ module("Unit | Utilities | table-builder", function (hooks) {
         "col",
         alignment
       ),
-      "|Col 1 | Col 2 | Col 3 | Col 4|\r\n|:-- | :-: | --: | ---|\r\n|left | center | right | unspecificated|\r\n|111 | 222 | 333 | 444|\r\n",
+      "|Col 1 | Col 2 | Col 3 | Col 4|\n|:-- | :-: | --: | ---|\n|left | center | right | unspecificated|\n|111 | 222 | 333 | 444|\n",
       "it creates a valid table"
     );
   });
 
   test("findTableRegex", function (assert) {
-    const oneTable = `|Make|Model|Year|\r\n|--- | --- | ---|\r\n|Toyota|Supra|1998|`;
+    const oneTable = `|Make|Model|Year|\n|--- | --- | ---|\n|Toyota|Supra|1998|`;
 
     assert.strictEqual(
       oneTable.match(findTableRegex()).length,


### PR DESCRIPTION
The old implementation used unnecessary `\r\n` and caused the table generator to incorrectly add extra empty lines. This commit replaces it with `\n`, fixing the bug.

before:

![image](https://github.com/discourse/discourse/assets/41134017/53318e8a-d0e7-4ed5-a4b2-95a7231a9ac8)
![image](https://github.com/discourse/discourse/assets/41134017/2e9004ed-217f-4143-a94d-799f9f7b025b)

after:
![image](https://github.com/discourse/discourse/assets/41134017/b0a4cde4-d7e1-4348-be14-7e879cb78e2f)

Note: This PR was tested on Windows. I am not sure if it will work on other platforms (Linux, Mac), but it is likely to work.

Related meta topic: https://meta.discourse.org/t/creating-a-table-sometimes-insert-empty-lines-between-rows-breaking-the-table/270658

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
