### PR TITLE
FIX: Poll: do not attempt to show voter list on private polls

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
@@ -82,16 +82,18 @@ export default class PollResultsStandardComponent extends Component {
                 style={{htmlSafe (concat "width:" option.percentage "%")}}
               />
             </div>
-            <PollVoters
-              @postId={{@postId}}
-              @pollType={{@pollType}}
-              @optionId={{option.id}}
-              @pollName={{@pollName}}
-              @totalVotes={{option.votes}}
-              @voters={{option.voters}}
-              @fetchVoters={{@fetchVoters}}
-              @loading={{option.loading}}
-            />
+            {{#if @isPublic}}
+              <PollVoters
+                @postId={{@postId}}
+                @pollType={{@pollType}}
+                @optionId={{option.id}}
+                @pollName={{@pollName}}
+                @totalVotes={{option.votes}}
+                @voters={{option.voters}}
+                @fetchVoters={{@fetchVoters}}
+                @loading={{option.loading}}
+              />
+            {{/if}}
           </div>
         </li>
       {{/each}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
@@ -40,7 +40,7 @@ export default class PollResultsStandardComponent extends Component {
       const chosen = (this.args.vote || []).includes(option.id);
       option.percentage = per;
       option.chosen = chosen;
-      let voters = this.args.voters[option.id] || [];
+      let voters = this.args.isPublic ? this.args.voters[option.id] || [] : [];
       option.voters = [...voters];
     });
 

--- a/plugins/poll/test/javascripts/component/poll-results-standard-test.js
+++ b/plugins/poll/test/javascripts/component/poll-results-standard-test.js
@@ -2,7 +2,7 @@ import { render } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { exists, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 const TWO_OPTIONS = [
   { id: "1ddc47be0d2315b9711ee8526ca9d83f", html: "This", votes: 5, rank: 0 },
@@ -41,6 +41,7 @@ module("Poll | Component | poll-results-standard", function (hooks) {
       options: TWO_OPTIONS,
       pollName: "Two Choice Poll",
       pollType: "single",
+      isPublic: true,
       postId: 123,
       vote: ["1ddc47be0d2315b9711ee8526ca9d83f"],
       voters: PRELOADEDVOTERS,
@@ -52,6 +53,7 @@ module("Poll | Component | poll-results-standard", function (hooks) {
       @options={{this.options}}
       @pollName={{this.pollName}}
       @pollType={{this.pollType}}
+      @isPublic={{this.isPublic}}
       @postId={{this.postId}}
       @vote={{this.vote}}
       @voters={{this.voters}}
@@ -61,6 +63,35 @@ module("Poll | Component | poll-results-standard", function (hooks) {
 
     assert.strictEqual(queryAll(".option .percentage")[0].innerText, "56%");
     assert.strictEqual(queryAll(".option .percentage")[1].innerText, "44%");
+    assert.ok(exists("ul.poll-voters-list"));
+  });
+
+  test("Omits voters for private polls", async function (assert) {
+    this.setProperties({
+      options: TWO_OPTIONS,
+      pollName: "Two Choice Poll",
+      pollType: "single",
+      isPublic: false,
+      postId: 123,
+      vote: ["1ddc47be0d2315b9711ee8526ca9d83f"],
+      voters: PRELOADEDVOTERS,
+      votersCount: 9,
+      fetchVoters: () => {},
+    });
+
+    await render(hbs`<PollResultsStandard
+      @options={{this.options}}
+      @pollName={{this.pollName}}
+      @pollType={{this.pollType}}
+      @isPublic={{this.isPublic}}
+      @postId={{this.postId}}
+      @vote={{this.vote}}
+      @voters={{this.voters}}
+      @votersCount={{this.votersCount}}
+      @fetchVoters={{this.fetchVoters}}
+    />`);
+
+    assert.ok(!exists("ul.poll-voters-list"));
   });
 
   test("options in ascending order", async function (assert) {


### PR DESCRIPTION
In transferring widget code to Glimmer, some logic was missed.

* FIX: do not attempt to show voter list on private poll results
* FIX: avoid attempting to enrich results with undefined voters

relates to recent merge #27204

@ZogStriP
