### PR TITLE
FIX: Show featured topics for categories on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
@@ -25,7 +25,7 @@
         {{/if}}
         {{#unless this.isMuted}}
           {{#if this.showTopics}}
-            {{#each this.category.topics as |t|}}
+            {{#each this.category.featuredTopics as |t|}}
               <MobileCategoryTopic @topic={{t}} />
             {{/each}}
           {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/subcategories-with-featured-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/subcategories-with-featured-topics.hbs
@@ -7,7 +7,7 @@
         }}</span>
     </div>
     <div class="subcategories">
-      {{#each category.subcategories as |subCategory|}}
+      {{#each category.serializedSubcategories as |subCategory|}}
         <ParentCategoryRow @category={{subCategory}} @showTopics={{true}} />
       {{else}}
         {{! No subcategories... so just show the parent to avoid confusion }}

--- a/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
@@ -78,7 +78,7 @@ acceptance("Categories - 'categories_with_featured_topics'", function (needs) {
 });
 
 acceptance(
-  "Categories - 'subcategories_with_featured_topics'",
+  "Categories - 'subcategories_with_featured_topics' (desktop)",
   function (needs) {
     needs.settings({
       desktop_category_page_style: "subcategories_with_featured_topics",
@@ -97,6 +97,33 @@ acceptance(
       );
       assert.ok(
         exists("table.category-list.with-topics div[data-topic-id=11994]"),
+        "shows a featured topic"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Categories - 'subcategories_with_featured_topics' (mobile)",
+  function (needs) {
+    needs.mobileView();
+    needs.settings({
+      desktop_category_page_style: "subcategories_with_featured_topics",
+    });
+    test("basic functionality", async function (assert) {
+      await visit("/categories");
+      assert.ok(
+        exists("div.subcategory-list.with-topics h3 .category-name"),
+        "shows heading for top-level category"
+      );
+      assert.ok(
+        exists(
+          "div.subcategory-list.with-topics div[data-category-id=26] h3 .category-name"
+        ),
+        "shows element for subcategories"
+      );
+      assert.ok(
+        exists("div.category-list.with-topics a[data-topic-id=11994]"),
         "shows a featured topic"
       );
     });


### PR DESCRIPTION
The featured topics have not been rendered correctly since 2190c9b and it has been fixed for desktop recently in commit d2a52c3. This commit implements similar changes that initialize Category and Topic object instances from the serialized data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
