### PR TITLE
DEV: `check_pending` -> `check_all_pending!`

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -124,15 +124,11 @@ module TurboTests
 
       ActiveRecord::Tasks::DatabaseTasks.migrations_paths = %w[db/migrate db/post_migrate]
 
-      conn = ActiveRecord::Base.establish_connection(config).connection
-
       begin
-        ActiveRecord::Migration.check_pending!(conn)
+        ActiveRecord::Migration.check_all_pending!
       rescue ActiveRecord::PendingMigrationError
         puts "There are pending migrations, run rake parallel:migrate"
         exit 1
-      ensure
-        conn.close
       end
     end
 


### PR DESCRIPTION
Fixes the following deprecation warning:

> DEPRECATION WARNING: The `check_pending!` method is deprecated in favor of `check_all_pending!`. The new implementation will loop through all available database configurations and find pending migrations. The prior implementation did not permit this.
