### PR TITLE
FIX: Make table builder escape `|`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -666,10 +666,9 @@ export function arrayToTable(array, cols, colPrefix = "col", alignments) {
     table +=
       cols
         .map(function (_key, index) {
-          return String(item[`${colPrefix}${index}`] || "").replace(
-            /\r?\n|\r/g,
-            " "
-          );
+          return String(item[`${colPrefix}${index}`] || "")
+            .replace(/\r?\n|\r/g, " ")
+            .replaceAll("|", "\\|");
         })
         .join(" | ") + "|\n";
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -430,6 +430,23 @@ module("Unit | Utilities | table-builder", function (hooks) {
     );
   });
 
+  test("arrayToTable should escape `|`", function (assert) {
+    const tableData = [
+      {
+        col0: "`a|b`",
+        col1: "![image|200x50](/images/discourse-logo-sketch.png)",
+        col2: "",
+        col3: "|",
+      },
+      { col0: "1|1", col1: "2|2", col2: "3|3", col3: "4|4" },
+    ];
+    assert.strictEqual(
+      arrayToTable(tableData, ["Col 1", "Col 2", "Col 3", "Col 4"]),
+      "|Col 1 | Col 2 | Col 3 | Col 4|\n|--- | --- | --- | ---|\n|`a\\|b` | ![image\\|200x50](/images/discourse-logo-sketch.png) |  | \\||\n|1\\|1 | 2\\|2 | 3\\|3 | 4\\|4|\n",
+      "it creates a valid table"
+    );
+  });
+
   test("findTableRegex", function (assert) {
     const oneTable = `|Make|Model|Year|\n|--- | --- | ---|\n|Toyota|Supra|1998|`;
 


### PR DESCRIPTION
The original table builder does not escape `|`, which causes syntax like `![image|50x50](url)` to be recognized as two different cells. This PR fixes this issue.

Before: https://d11a6trkgmumsb.cloudfront.net/original/4X/0/9/5/09570ed7865ea704722528520d074378accf534c.mp4

After:
![image](https://github.com/discourse/discourse/assets/41134017/10811ec0-a58f-4c21-a9b0-075ebf021f5a)
![image](https://github.com/discourse/discourse/assets/41134017/d39ec59b-457f-43c7-b4a2-5726192bbf96)
![image](https://github.com/discourse/discourse/assets/41134017/9339eea2-6271-4f0d-95da-7ef2209c8de2)

Related meta topic: https://meta.discourse.org/t/table-editor-breaks-embedded-images/314831

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
