### PR TITLE
DEV: Skip flaky poll QUnit acceptance tests

### DIFF
--- a/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js
+++ b/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { test } from "qunit";
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Rendering polls with pie charts", function (needs) {
@@ -9,7 +9,7 @@ acceptance("Rendering polls with pie charts", function (needs) {
     poll_groupable_user_fields: "something",
   });
 
-  test("Displays the pie chart", async function (assert) {
+  skip("Displays the pie chart", async function (assert) {
     await visit("/t/-/topic_with_pie_chart_poll");
 
     assert
@@ -20,7 +20,9 @@ acceptance("Rendering polls with pie charts", function (needs) {
       .dom(".poll .poll-info_counts-count:last-child .info-number")
       .hasText("5", "it should display the right number of votes");
 
-    assert.dom(".poll-outer").hasClass("pie", "pie class is present on poll div");
+    assert
+      .dom(".poll-outer")
+      .hasClass("pie", "pie class is present on poll div");
 
     assert
       .dom(".poll .poll-results-chart")

--- a/plugins/poll/test/javascripts/component/poll-results-standard-test.js
+++ b/plugins/poll/test/javascripts/component/poll-results-standard-test.js
@@ -1,6 +1,6 @@
 import { render } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
-import { module, test } from "qunit";
+import { module, skip, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { exists, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
@@ -36,7 +36,7 @@ const PRELOADEDVOTERS = {
 module("Poll | Component | poll-results-standard", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("Renders the standard results Component correctly", async function (assert) {
+  skip("Renders the standard results Component correctly", async function (assert) {
     this.setProperties({
       options: TWO_OPTIONS,
       pollName: "Two Choice Poll",


### PR DESCRIPTION
The skipped tests have become flaky after
e3b6be15b88a9b61b409ec3f266ba7b076efb1d7, skip those tests for now while
we sort things out.

Evidence of the test being flaky: https://github.com/discourse/discourse/actions/runs/9802263684/job/27066725334