### PR TITLE
DEV: Remove `git_version` from `DiscourseLogstashLogger` log event

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -2,12 +2,10 @@
 
 require "json"
 require "socket"
-require_relative "git_utils"
 
 class DiscourseLogstashLogger < Logger
   PROCESS_PID = Process.pid
   HOST = Socket.gethostname
-  GIT_VERSION = GitUtils.git_version
 
   attr_accessor :customize_event, :type
 
@@ -67,7 +65,6 @@ class DiscourseLogstashLogger < Logger
       "pid" => PROCESS_PID,
       "type" => @type.to_s,
       "host" => HOST,
-      "git_version" => GitUtils.git_version,
     }
 
     # Only log backtrace and env for Logger::WARN and above.

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe DiscourseLogstashLogger do
           "pid" => described_class::PROCESS_PID,
           "type" => "test",
           "host" => described_class::HOST,
-          "git_version" => described_class::GIT_VERSION,
           "method" => "GET",
           "path" => "/",
           "format" => "html",


### PR DESCRIPTION
This is a very partial revert of a change introduced in 8e10878e1a37a608b0e1705bf9d0a06a295b8a63

In our official Docker image, running git commands results in the
following error:

```
fatal: detected dubious ownership in repository at '/var/www/discourse'
To add an exception for this directory, call:

	git config --global --add safe.directory /var/www/discourse
```
