### PR TITLE
DEV: Remove noise from `Rails::Rack::Logger` after Rails 7.1 upgrade

### DIFF
--- a/config/initializers/101-lograge.rb
+++ b/config/initializers/101-lograge.rb
@@ -13,6 +13,11 @@ Rails.application.config.to_prepare do
     Rails.application.configure do
       config.lograge.enabled = true
 
+      # Monkey patch Rails::Rack::Logger#logger to silence its logs.
+      # The `lograge` gem is supposed to do this but it broke after we upgraded to Rails 7.1.
+      # This patch is a temporary workaround until we find a proper fix.
+      Rails::Rack::Logger.prepend(Module.new { def logger = (@logger ||= Logger.new(IO::NULL)) })
+
       Lograge.ignore(
         lambda do |event|
           # this is our hijack magic status,


### PR DESCRIPTION
This commit monkey patches `Rails::Rack::Logger` to not log reqeust
information like `Started GET "/service-worker.js" for 127.0.0.1 at 2024-07-05 15:28:12 +0800`
when lograge is enabled. This was previously excluded by a monkey patch
in the `lograge` gem but that monkey patch has since broke and the gem
is unmaintained.
