### PR TITLE
FIX: Poll: critical display issue when results are only shown upon vote

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
@@ -109,8 +109,16 @@ export default class PollInfoComponent extends Component {
     );
   }
 
+  get resultsOnVoteTitle() {
+    return htmlSafe(I18n.t("poll.results.vote.title"));
+  }
+
   get resultsOnClose() {
     return this.args.results === ON_CLOSE && !this.args.closed;
+  }
+
+  get resultsOnCloseTitle() {
+    return htmlSafe(I18n.t("poll.results.close.title"));
   }
 
   get resultsStaffOnly() {
@@ -118,6 +126,10 @@ export default class PollInfoComponent extends Component {
       this.args.results === STAFF_ONLY &&
       !(this.currentUser && this.currentUser.staff)
     );
+  }
+
+  get resultsStaffOnlyTitle() {
+    return htmlSafe(I18n.t("poll.results.staff.title"));
   }
 
   get publicTitle() {
@@ -179,21 +191,21 @@ export default class PollInfoComponent extends Component {
             {{/if}}
           {{/if}}
           {{#if this.resultsOnVote}}
-            <li>
+            <li class="results-on-vote">
               {{icon "check"}}
-              <span>{{I18n "poll.results.vote.title"}}</span>
+              <span>{{this.resultsOnVoteTitle}}</span>
             </li>
           {{/if}}
           {{#if this.resultsOnClose}}
-            <li>
+            <li class="results-on-close">
               {{icon "lock"}}
-              <span>{{I18n "poll.results.closed.title"}}</span>
+              <span>{{this.resultsOnCloseTitle}}</span>
             </li>
           {{/if}}
           {{#if this.resultsStaffOnly}}
-            <li>
+            <li class="results-staff-only">
               {{icon "shield-alt"}}
-              <span>{{I18n "poll.results.staff.title"}}</span>
+              <span>{{this.resultsStaffOnlyTitle}}</span>
             </li>
           {{/if}}
           {{#if this.publicTitle}}

--- a/plugins/poll/test/javascripts/component/poll-info-test.js
+++ b/plugins/poll/test/javascripts/component/poll-info-test.js
@@ -14,7 +14,7 @@ const OPTIONS = [
 module("Poll | Component | poll-info", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("multiple poll", async function (assert) {
+  test("public multiple poll with results anytime", async function (assert) {
     this.setProperties({
       isMultiple: true,
       min: 1,
@@ -51,6 +51,60 @@ module("Poll | Component | poll-info", function (hooks) {
         count: this.max,
       }).replace(/<\/?[^>]+(>|$)/g, ""),
       "displays the multiple help text"
+    );
+
+    assert.strictEqual(
+      query(".poll-info_instructions li.is-public").textContent.trim(),
+      I18n.t("poll.public.title").replace(/<\/?[^>]+(>|$)/g, ""),
+      "displays the public label"
+    );
+  });
+
+  test("public multiple poll with results only shown on vote", async function (assert) {
+    this.setProperties({
+      isMultiple: true,
+      min: 1,
+      max: 2,
+      options: OPTIONS,
+      close: null,
+      closed: false,
+      results: "on_vote",
+      showResults: false,
+      postUserId: 59,
+      isPublic: true,
+      hasVoted: false,
+      voters: [],
+    });
+
+    await render(hbs`<PollInfo
+      @options={{this.options}}
+      @min={{this.min}}
+      @max={{this.max}}
+      @isMultiple={{this.isMultiple}}
+      @close={{this.close}}
+      @closed={{this.closed}}
+      @results={{this.results}}
+      @showResults={{this.showResults}}
+      @postUserId={{this.postUserId}}
+      @isPublic={{this.isPublic}}
+      @hasVoted={{this.hasVoted}}
+      @voters={{this.voters}}
+    />`);
+
+    assert.strictEqual(
+      query(".poll-info_instructions li.multiple-help-text").textContent.trim(),
+      I18n.t("poll.multiple.help.up_to_max_options", {
+        count: this.max,
+      }).replace(/<\/?[^>]+(>|$)/g, ""),
+      "displays the multiple help text"
+    );
+
+    assert.strictEqual(
+      query(
+        ".poll-info_instructions li.results-on-vote span"
+      ).textContent.trim(),
+      I18n.t("poll.results.vote.title").replace(/<\/?[^>]+(>|$)/g, ""),
+      "displays the results on vote label"
     );
 
     assert.strictEqual(


### PR DESCRIPTION
See: https://meta.discourse.org/t/polls-causing-issues/315088?u=merefield

This critical issue began with a simple typo (`I18n` versus `i18n` in template - note this is now more of a risk in `.gjs` files), but needed a little extra work to ensure correct rich formatting of all Component labels were fully implemented.

@nattsw @ZogStriP 