### PR TITLE
FIX: show cooked bio in user profile

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -6,7 +6,6 @@ import { isEmpty } from "@ember/utils";
 import FeatureTopicOnProfileModal from "discourse/components/modal/feature-topic-on-profile";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { cook } from "discourse/lib/text";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
@@ -142,23 +141,18 @@ export default Controller.extend({
 
     save() {
       this.set("saved", false);
-      const model = this.model;
 
       // Update the user fields
       this.send("_updateUserFields");
 
-      return model
+      return this.model
         .save(this.saveAttrNames)
-        .then(() => {
-          cook(model.get("bio_raw"))
-            .then(() => {
-              model.set("bio_cooked");
-              this.set("saved", true);
-              this.currentUser.set("needs_required_fields_check", false);
-            })
-            .catch(popupAjaxError);
-        })
-        .catch(popupAjaxError);
+        .then(({ user }) => this.model.set("bio_cooked", user.bio_cooked))
+        .catch(popupAjaxError)
+        .finally(() => {
+          this.currentUser.set("needs_required_fields_check", false);
+          this.set("saved", true);
+        });
     },
   },
 });

--- a/spec/system/page_objects/pages/user_preferences_profile.rb
+++ b/spec/system/page_objects/pages/user_preferences_profile.rb
@@ -7,6 +7,22 @@ module PageObjects
         page.visit("/u/#{user.username}/preferences/profile")
         self
       end
+
+      def expand_profile_details
+        find(".user-main .details .controls .btn-default").click
+      end
+
+      def fill_bio(with:)
+        find(".bio-composer .d-editor-input").fill_in(with:)
+      end
+
+      def save
+        find(".save-button .btn-primary").click
+      end
+
+      def cooked_bio
+        find(".user-main .details .primary .bio")
+      end
     end
   end
 end

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -7,6 +7,18 @@ describe "User preferences | Profile", type: :system do
 
   before { sign_in(user) }
 
+  describe "changing bio" do
+    it "correctly updates the bio" do
+      user_preferences_profile_page.visit(user)
+
+      user_preferences_profile_page.expand_profile_details
+      user_preferences_profile_page.fill_bio(with: "I am a human.")
+      user_preferences_profile_page.save
+
+      expect(user_preferences_profile_page.cooked_bio).to have_text("I am a human.")
+    end
+  end
+
   describe "enforcing required fields" do
     before do
       UserRequiredFieldsVersion.create!


### PR DESCRIPTION
When editing your bio in your user profile and then saving it, it would be removed from the profile header section.

This was broken for over 7 years since ae68795d8206a6a796d7d65e63bd2af3509be704 was merged 😅

Context - https://meta.discourse.org/t/after-saving-changes-to-profile-expanding-full-profile-only-shows-half/314118

