### PR TITLE
FIX: Poll: option text wrapping behaviour styling improvement

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -25,6 +25,9 @@ div.poll-outer {
       button {
         background-color: var(--secondary);
         border: none;
+        text-align: left;
+        padding-left: 23px;
+        text-indent: -23px;
       }
     }
 


### PR DESCRIPTION
Long option text was not wrapping nicely as new Glimmer based options are buttons where, by default, text wraps centre aligned.  This PR resolves the issue.

The issue affects both mobile and desktop.

![image](https://github.com/discourse/discourse/assets/35533304/ea4d1c64-e95e-4566-ae50-f39816fee92a)

becomes:

![image](https://github.com/discourse/discourse/assets/35533304/964f3da1-04c8-49be-a79e-e85de1dc52ac)


@ZogStriP 
