### PR TITLE
FIX: Destroy Drafts when increasing sequences

### DIFF
--- a/app/models/draft_sequence.rb
+++ b/app/models/draft_sequence.rb
@@ -20,12 +20,7 @@ class DraftSequence < ActiveRecord::Base
         RETURNING sequence
       SQL
 
-    DB.exec(
-      "DELETE FROM drafts WHERE user_id = :user_id AND draft_key = :draft_key AND sequence < :sequence",
-      draft_key: key,
-      user_id: user_id,
-      sequence: sequence,
-    )
+    Draft.where(user_id: user_id).where(draft_key: key).where("sequence < ?", sequence).destroy_all
 
     UserStat.update_draft_count(user_id)
 

--- a/db/migrate/20240705134114_clear_orphaned_draft_upload_references2.rb
+++ b/db/migrate/20240705134114_clear_orphaned_draft_upload_references2.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ClearOrphanedDraftUploadReferences2 < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL
+      DELETE
+      FROM
+        "upload_references"
+      WHERE
+        "upload_references"."target_type" = 'Draft' AND
+        "upload_references"."target_id" NOT IN (
+          SELECT "drafts"."id" FROM "drafts"
+        )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Drafts used to be deleted instead of being destroyed. The callbacks that clean up the upload references were not being called. As a result, the upload references were not cleaned up and uploads were not deleted either. This has been partially fixed in 9655bf3e.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
