### PR TITLE
FIX: Poll: allow safe html in options, not just text

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import routeAction from "discourse/helpers/route-action";
+import { htmlSafe } from "@ember/template";
 import icon from "discourse-common/helpers/d-icon";
 
 export default class PollOptionsComponent extends Component {
@@ -37,7 +38,7 @@ export default class PollOptionsComponent extends Component {
                   {{icon "far-circle"}}
                 {{/if}}
               {{/if}}
-              <span class="option-text">{{option.html}}</span>
+              <span class="option-text">{{htmlSafe option.html}}</span>
             </button>
           {{else}}
             <button onclick={{routeAction "showLogin"}}>
@@ -54,7 +55,7 @@ export default class PollOptionsComponent extends Component {
                   {{icon "far-circle"}}
                 {{/if}}
               {{/if}}
-              <span class="option-text">{{option.html}}</span>
+              <span class="option-text">{{htmlSafe option.html}}</span>
             </button>
           {{/if}}
         </li>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
@@ -3,8 +3,8 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import routeAction from "discourse/helpers/route-action";
 import { htmlSafe } from "@ember/template";
+import routeAction from "discourse/helpers/route-action";
 import icon from "discourse-common/helpers/d-icon";
 
 export default class PollOptionsComponent extends Component {

--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
@@ -74,7 +74,7 @@ export default class PollResultsStandardComponent extends Component {
                   "number.percent"
                   count=option.percentage
                 }}</span>
-              <span class="option-text">{{option.html}}</span>
+              <span class="option-text">{{htmlSafe option.html}}</span>
             </p>
             <div class="bar-back">
               <div

--- a/plugins/poll/test/javascripts/component/poll-options-test.js
+++ b/plugins/poll/test/javascripts/component/poll-options-test.js
@@ -10,6 +10,21 @@ const OPTIONS = [
   { id: "6c986ebcde3d5822a6e91a695c388094", html: "Other", votes: 0, rank: 0 },
 ];
 
+const IMAGE_OPTIONS = [
+  {
+    id: "1ddc47be0d2315b9711ee8526ca9d83f",
+    html: "<img src='upload://tpbXHFLPCTLWjyGvtyekmXQN49A.jpeg'></img>",
+    votes: 0,
+    rank: 0,
+  },
+  {
+    id: "70e743697dac09483d7b824eaadb91e1",
+    html: "<img src='upload://eurierXHFETLWjHsdfLKKJDFLKJ.jpeg'></img>",
+    votes: 0,
+    rank: 0,
+  },
+];
+
 module("Poll | Component | poll-options", function (hooks) {
   setupRenderingTest(hooks);
 
@@ -79,5 +94,22 @@ module("Poll | Component | poll-options", function (hooks) {
     />`);
 
     assert.strictEqual(count("li .d-icon-far-check-square:nth-of-type(1)"), 1);
+  });
+
+  test("single with images", async function (assert) {
+    this.setProperties({
+      isCheckbox: false,
+      options: IMAGE_OPTIONS,
+      votes: [],
+    });
+
+    await render(hbs`<PollOptions
+      @isCheckbox={{this.isCheckbox}}
+      @options={{this.options}}
+      @votes={{this.votes}}
+      @sendRadioClick={{this.toggleOption}}
+    />`);
+
+    assert.strictEqual(count("li img"), 2);
   });
 });


### PR DESCRIPTION
Relates to recent Glimmer migration of Poll plugin. #27204 

See discussion: 

* https://meta.discourse.org/t/polls-causing-issues/315088/6?u=merefield
* https://meta.discourse.org/t/polls-with-markup-show-html-tags/315253?u=merefield

Images and rich text styling were being blocked in options html.

@ZogStriP 
