### PR TITLE
DEV: Add `user_agent` to `search_logs`

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -46,6 +46,7 @@ class SearchController < ApplicationController
 
     search_args[:search_type] = :full_page
     search_args[:ip_address] = request.remote_ip
+    search_args[:user_agent] = request.user_agent
     search_args[:user_id] = current_user.id if current_user.present?
 
     if rate_limit_search
@@ -99,6 +100,7 @@ class SearchController < ApplicationController
 
     search_args[:search_type] = :header
     search_args[:ip_address] = request.remote_ip
+    search_args[:user_agent] = request.user_agent
     search_args[:user_id] = current_user.id if current_user.present?
     search_args[:restrict_to_archetype] = params[:restrict_to_archetype] if params[
       :restrict_to_archetype

--- a/db/migrate/20240705153533_add_user_agent_to_search_logs.rb
+++ b/db/migrate/20240705153533_add_user_agent_to_search_logs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserAgentToSearchLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :search_logs, :user_agent, :string, null: true, limit: 2000
+  end
+end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -306,6 +306,7 @@ class Search
           term: @clean_term,
           search_type: @opts[:search_type],
           ip_address: @opts[:ip_address],
+          user_agent: @opts[:user_agent],
           user_id: @opts[:user_id],
         )
       @results.search_log_id = search_log_id unless status == :error

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -7,13 +7,30 @@ RSpec.describe SearchLog, type: :model do
     context "with invalid arguments" do
       it "no search type returns error" do
         status, _ =
-          SearchLog.log(term: "bounty hunter", search_type: :missing, ip_address: "127.0.0.1")
+          SearchLog.log(
+            term: "bounty hunter",
+            search_type: :missing,
+            ip_address: "127.0.0.1",
+            user_agent: "Mozilla",
+          )
         expect(status).to eq(:error)
       end
 
       it "no IP returns error" do
-        status, _ = SearchLog.log(term: "bounty hunter", search_type: :header, ip_address: nil)
+        status, _ =
+          SearchLog.log(
+            term: "bounty hunter",
+            search_type: :header,
+            ip_address: nil,
+            user_agent: "Mozilla",
+          )
         expect(status).to eq(:error)
+      end
+
+      it "does not error when no user_agent" do
+        status, _ =
+          SearchLog.log(term: "bounty hunter", search_type: :header, ip_address: "127.0.0.1")
+        expect(status).to eq(:created)
       end
     end
 
@@ -21,12 +38,18 @@ RSpec.describe SearchLog, type: :model do
       it "logs and updates the search" do
         freeze_time
         action, log_id =
-          SearchLog.log(term: "jabba", search_type: :header, ip_address: "192.168.0.33")
+          SearchLog.log(
+            term: "jabba",
+            search_type: :header,
+            ip_address: "192.168.0.33",
+            user_agent: "Mozilla",
+          )
         expect(action).to eq(:created)
         log = SearchLog.find(log_id)
         expect(log.term).to eq("jabba")
         expect(log.search_type).to eq(SearchLog.search_types[:header])
-        expect(log.ip_address).to eq("192.168.0.33")
+        expect(log.ip_address).to eq(nil)
+        expect(log.user_agent).to eq("Mozilla")
 
         action, updated_log_id =
           SearchLog.log(term: "jabba the hut", search_type: :header, ip_address: "192.168.0.33")
@@ -63,13 +86,15 @@ RSpec.describe SearchLog, type: :model do
             term: "hello",
             search_type: :full_page,
             ip_address: "192.168.0.1",
+            user_agent: "Mozilla",
             user_id: user.id,
           )
         expect(action).to eq(:created)
         log = SearchLog.find(log_id)
         expect(log.term).to eq("hello")
         expect(log.search_type).to eq(SearchLog.search_types[:full_page])
-        expect(log.ip_address).to eq(nil)
+        expect(log.ip_address).to eq("192.168.0.1")
+        expect(log.user_agent).to eq("Mozilla")
         expect(log.user_id).to eq(user.id)
 
         action, updated_log_id =

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SearchLog, type: :model do
         log = SearchLog.find(log_id)
         expect(log.term).to eq("jabba")
         expect(log.search_type).to eq(SearchLog.search_types[:header])
-        expect(log.ip_address).to eq(nil)
+        expect(log.ip_address).to eq("192.168.0.33")
         expect(log.user_agent).to eq("Mozilla")
 
         action, updated_log_id =
@@ -93,7 +93,7 @@ RSpec.describe SearchLog, type: :model do
         log = SearchLog.find(log_id)
         expect(log.term).to eq("hello")
         expect(log.search_type).to eq(SearchLog.search_types[:full_page])
-        expect(log.ip_address).to eq("192.168.0.1")
+        expect(log.ip_address).to eq(nil)
         expect(log.user_agent).to eq("Mozilla")
         expect(log.user_id).to eq(user.id)
 


### PR DESCRIPTION
Add a new column - `user_agent` - to the `SearchLog` table. 

This column can be null as we are only allowing a the user-agent string to have a max length of 2000 characters. In the case the user-agent string surpasses the max characters allowed, we simply nullify the value, and save/write the log as normal.
