### PR TITLE
FIX: Ignore unresolvable breadcrumb routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
 
 export default class DBreadcrumbsItem extends Component {
@@ -17,25 +16,30 @@ export default class DBreadcrumbsItem extends Component {
   }
 
   get url() {
-    if (this.args.model) {
-      return this.router.urlFor(this.args.route, this.args.model);
-    } else {
-      return this.router.urlFor(this.args.route);
+    try {
+      if (this.args.model) {
+        return this.router.urlFor(this.args.route, this.args.model);
+      } else {
+        return this.router.urlFor(this.args.route);
+      }
+    } catch {
+      // if the route can't be resolved, ignore
     }
   }
 
-  @cached
   get templateForContainer() {
     // Those are evaluated in a different context than the `@linkClass`
     const { label } = this.args;
     const url = this.url;
 
     return <template>
-      <li ...attributes>
-        <a href={{url}} class={{@linkClass}}>
-          {{label}}
-        </a>
-      </li>
+      {{#if url}}
+        <li ...attributes>
+          <a href={{url}} class={{@linkClass}}>
+            {{label}}
+          </a>
+        </li>
+      {{/if}}
     </template>;
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/d-breadcrumbs-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-breadcrumbs-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { tracked } from "@glimmer/tracking";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DBreadcrumbsContainer from "discourse/components/d-breadcrumbs-container";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
@@ -10,7 +11,7 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test("it renders a DBreadcrumbsContainer with multiple DBreadcrumbsItems", async function (assert) {
+    test("renders a DBreadcrumbsContainer with multiple DBreadcrumbsItems", async function (assert) {
       await render(<template>
         <DBreadcrumbsContainer />
         <DBreadcrumbsItem @route="admin" @label={{i18n "admin_title"}} />
@@ -22,7 +23,7 @@ module(
         .exists({ count: 2 });
     });
 
-    test("it renders a DBreadcrumbsItem with additional link and item classes", async function (assert) {
+    test("renders a DBreadcrumbsItem with additional link and item classes", async function (assert) {
       await render(<template>
         <DBreadcrumbsContainer
           @additionalLinkClasses="some-class"
@@ -39,7 +40,7 @@ module(
         .exists();
     });
 
-    test("it renders multiple DBreadcrumbsContainer elements with the same DBreadcrumbsItem links", async function (assert) {
+    test("renders multiple DBreadcrumbsContainer elements with the same DBreadcrumbsItem links", async function (assert) {
       await render(<template>
         <DBreadcrumbsContainer />
         <DBreadcrumbsContainer />
@@ -48,6 +49,39 @@ module(
 
       assert.dom(".d-breadcrumbs").exists({ count: 2 });
       assert.dom(".d-breadcrumbs .d-breadcrumbs__item").exists({ count: 2 });
+    });
+
+    test("ignores temporarily invalid/unresolvable routes", async function (assert) {
+      class TestState {
+        @tracked flag = true;
+        @tracked id = 123;
+      }
+
+      const testState = new TestState();
+
+      await render(<template>
+        <DBreadcrumbsContainer />
+
+        {{#if testState.flag}}
+          <DBreadcrumbsItem
+            @route="post"
+            @model={{testState.id}}
+            @label="my post"
+          />
+        {{else}}
+          <DBreadcrumbsItem @route="about" @label="about" />
+        {{/if}}
+      </template>);
+
+      assert.dom(".d-breadcrumbs a[href='/p/123']").exists();
+      assert.dom(".d-breadcrumbs a[href='/about']").doesNotExist();
+
+      testState.flag = false;
+      testState.id = null;
+      await settled();
+
+      assert.dom(".d-breadcrumbs a[href='/p/123']").doesNotExist();
+      assert.dom(".d-breadcrumbs a[href='/about']").exists();
     });
   }
 );


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
