### PR TITLE
UX: Insert a space before the featured link on mobile topic list view

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
@@ -23,7 +23,7 @@
       {{~raw "topic-status" topic=topic~}}
       {{~topic-link topic class="raw-link raw-topic-link"}}
       {{~#if topic.featured_link~}}
-      {{~topic-featured-link topic~}}
+      &nbsp;{{~topic-featured-link topic~}}
       {{~/if~}}
       {{~raw-plugin-outlet name="topic-list-after-title"}}
       {{~#if topic.unseen~}}


### PR DESCRIPTION
On the topic list and mobile view, this adds a missing space before the featured link.

Before:
![NVIDIA_Share_8uUNXA9pmz](https://github.com/discourse/discourse/assets/360640/07de6653-57b5-473d-935a-e538d0c75410)

After:
![NVIDIA_Share_H6lWDeXXsR](https://github.com/discourse/discourse/assets/360640/fca47497-f149-45b2-8eba-1a76f5387b92)
