### PR TITLE
FIX: typo in poll "closed"

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
@@ -118,7 +118,7 @@ export default class PollInfoComponent extends Component {
   }
 
   get resultsOnCloseTitle() {
-    return htmlSafe(I18n.t("poll.results.close.title"));
+    return htmlSafe(I18n.t("poll.results.closed.title"));
   }
 
   get resultsStaffOnly() {


### PR DESCRIPTION
Reference to string poll.results.close.title should be "closed" instead of "close"

Very small typo in I18n string name:  https://github.com/discourse/discourse/blob/6022cc2af883323449092f3ad128b96c68fae9a3/plugins/poll/config/locales/client.en.yml#L21
