### PR TITLE
UX: plugins may have underscore in the name

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-plugin.js
+++ b/app/assets/javascripts/admin/addon/models/admin-plugin.js
@@ -55,7 +55,7 @@ export default class AdminPlugin {
       name = this.translatedCategoryName;
     } else {
       name = this.name
-        .split("-")
+        .split(/[-_]/)
         .map((word) => {
           return capitalize(word);
         })

--- a/app/assets/javascripts/discourse/tests/unit/models/admin-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/admin-plugin-test.js
@@ -1,0 +1,19 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import AdminPlugin from "admin/models/admin-plugin";
+
+module("Unit | Model | admin plugin", function (hooks) {
+  setupTest(hooks);
+
+  test("nameTitleized", function (assert) {
+    const adminPlugin = AdminPlugin.create({
+      name: "docker_manager",
+    });
+
+    assert.strictEqual(
+      adminPlugin.nameTitleized,
+      "Docker Manager",
+      "it should return titleized name replacing underscores with spaces"
+    );
+  });
+});


### PR DESCRIPTION
For example, https://github.com/discourse/docker_manager

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
