### PR TITLE
DEV: Hide admin Moderation Flags UI behind feature flag for now

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -103,12 +103,6 @@ export const ADMIN_NAV_MAP = [
         label: "admin.community.sidebar_link.legal",
         icon: "gavel",
       },
-      {
-        name: "admin_moderation_flags",
-        route: "adminConfig.flags",
-        label: "admin.community.sidebar_link.moderation_flags",
-        icon: "flag",
-      },
     ],
   },
   {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -318,6 +318,15 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
       });
     }
 
+    if (currentUser.show_experimental_flags_admin_page) {
+      navMap.findBy("name", "community").links.push({
+        name: "admin_moderation_flags",
+        route: "adminConfig.flags",
+        label: "admin.community.sidebar_link.moderation_flags",
+        icon: "flag",
+      });
+    }
+
     navMap.forEach((section) =>
       section.links.forEach((link) => {
         if (link.keywords) {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -138,13 +138,12 @@ class CurrentUserSerializer < BasicUserSerializer
     object.staff? && object.in_any_groups?(SiteSetting.admin_sidebar_enabled_groups_map)
   end
 
-  def include_user_admin_sidebar?
-    object.admin?
+  def include_use_admin_sidebar?
+    object.staff?
   end
 
   def show_experimental_flags_admin_page
-    object.admin? &&
-      object.in_any_groups?(SiteSetting.experimental_flags_admin_page_enabled_groups_map)
+    object.in_any_groups?(SiteSetting.experimental_flags_admin_page_enabled_groups_map)
   end
 
   def include_show_experimental_flags_admin_page?

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -76,7 +76,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_admin_sidebar,
              :can_view_raw_email,
              :use_glimmer_topic_list?,
-             :login_method
+             :login_method,
+             :show_experimental_flags_admin_page
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -138,6 +139,15 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_user_admin_sidebar?
+    object.admin?
+  end
+
+  def show_experimental_flags_admin_page
+    object.admin? &&
+      object.in_any_groups?(SiteSetting.experimental_flags_admin_page_enabled_groups_map)
+  end
+
+  def include_show_experimental_flags_admin_page?
     object.admin?
   end
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2427,6 +2427,12 @@ developer:
     list_type: compact
     allow_any: false
     refresh: true
+  experimental_flags_admin_page_enabled_groups:
+    default: ""
+    type: group_list
+    list_type: compact
+    allow_any: false
+    refresh: true
 
 navigation:
   navigation_menu:

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -8,6 +8,7 @@ describe "Admin Flags Page", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:admin_flags_page) { PageObjects::Pages::AdminFlags.new }
   let(:admin_flag_form_page) { PageObjects::Pages::AdminFlagForm.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
   before { sign_in(admin) }
 
@@ -147,5 +148,18 @@ describe "Admin Flags Page", type: :system do
     visit "/admin/config/flags"
     admin_flags_page.open_flag_menu("off_topic")
     expect(page).not_to have_css(".dropdown-menu__item .move-up")
+  end
+
+  it "does not show the moderation flags link in the sidebar by default" do
+    visit "/admin"
+    sidebar.toggle_all_sections
+    expect(sidebar).to have_no_section_link(
+      I18n.t("admin_js.admin.community.sidebar_link.moderation_flags"),
+    )
+    SiteSetting.experimental_flags_admin_page_enabled_groups = Group::AUTO_GROUPS[:admins]
+    visit "/admin"
+    expect(sidebar).to have_section_link(
+      I18n.t("admin_js.admin.community.sidebar_link.moderation_flags"),
+    )
   end
 end


### PR DESCRIPTION
Adds experimental_flags_admin_page_enabled_groups (default "")
to remove the Moderation Flags link from the admin sidebar for now,
there are still a few bugfixes that need to be done before we
are comfortable with turning this on more widely. This is
a _temporary_ flag, we will be removing this once the feature
is more stable.
