### PR TITLE
DEV: Renaming TopicsController defer track visit

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1285,15 +1285,14 @@ class TopicsController < ApplicationController
     TopicsController.defer_track_visit_v2(topic_id, user_id) if should_track_visit_to_topic?
   end
 
-  # TODO (martin) Remove this once discourse-docs is updated.
-  def self.defer_track_visit(topic_id, ip, user_id, track_visit)
-    self.defer_track_visit_v2(topic_id, user_id) if track_visit
-    self.defer_topic_view(topic_id, ip, user_id)
-  end
-  def self.defer_track_visit_v2(topic_id, user_id)
+  def self.defer_track_visit(topic_id, user_id)
     Scheduler::Defer.later "Track Visit" do
       TopicUser.track_visit!(topic_id, user_id)
     end
+  end
+  # TODO (martin) Remove this once discourse-docs is updated.
+  def self.defer_track_visit_v2(topic_id, user_id)
+    defer_track_visit(topic_id, user_id)
   end
 
   def self.defer_topic_view(topic_id, ip, user_id = nil)


### PR DESCRIPTION
Followup to 527f02e99fee782f53e206f739fb4f12d63b6d2a,
I had to introduce defer_track_visit_v2 because discourse-docs
relied on defer_track_visit. Now that discourse-docs
is using the new method as of
discourse/discourse-docs@0d9365571ba8fed69302f0351b3ccc924d6773c1,
we can rename it in core. Then we will need one more PR
in both core and docs to remove usage of the "v2" method.
