### PR TITLE
DEV: Check for poll element presence

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
@@ -13,6 +13,10 @@ export default class PollResultsPieComponent extends Component {
 
     afterUpdate(chart, args, options) {
       const ul = document.getElementById(options.containerID);
+      if (!ul) {
+        return;
+      }
+
       ul.innerHTML = "";
 
       const items = chart.options.plugins.legend.labels.generateLabels(chart);

--- a/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js
+++ b/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js
@@ -1,5 +1,5 @@
 import { visit } from "@ember/test-helpers";
-import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Rendering polls with pie charts", function (needs) {
@@ -9,7 +9,7 @@ acceptance("Rendering polls with pie charts", function (needs) {
     poll_groupable_user_fields: "something",
   });
 
-  skip("Displays the pie chart", async function (assert) {
+  test("Displays the pie chart", async function (assert) {
     await visit("/t/-/topic_with_pie_chart_poll");
 
     assert

--- a/plugins/poll/test/javascripts/component/poll-results-pie-test.js
+++ b/plugins/poll/test/javascripts/component/poll-results-pie-test.js
@@ -1,6 +1,6 @@
 import { render } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
-import { module, skip } from "qunit";
+import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { count } from "discourse/tests/helpers/qunit-helpers";
 
@@ -15,7 +15,7 @@ const ID = "23";
 module("Poll | Component | poll-results-pie", function (hooks) {
   setupRenderingTest(hooks);
 
-  skip("Renders the pie chart Component correctly", async function (assert) {
+  test("Renders the pie chart Component correctly", async function (assert) {
     this.setProperties({
       id: ID,
       options: OPTIONS,

--- a/plugins/poll/test/javascripts/component/poll-results-standard-test.js
+++ b/plugins/poll/test/javascripts/component/poll-results-standard-test.js
@@ -1,6 +1,6 @@
 import { render } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
-import { module, skip, test } from "qunit";
+import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { exists, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
@@ -36,7 +36,7 @@ const PRELOADEDVOTERS = {
 module("Poll | Component | poll-results-standard", function (hooks) {
   setupRenderingTest(hooks);
 
-  skip("Renders the standard results Component correctly", async function (assert) {
+  test("Renders the standard results Component correctly", async function (assert) {
     this.setProperties({
       options: TWO_OPTIONS,
       pollName: "Two Choice Poll",


### PR DESCRIPTION
`afterUpdate` from chart.js is not integrated with the runloop and component lifecycle, as a result we have no guarantee on when it will happen. The easiest change we can do for now is ensuring we actually have the DOM we expect to have, and if not, we exit early.