### PR TITLE
DEV: replace imagemagick convert commands with magick

### DIFF
--- a/app/services/problem_check/image_magick.rb
+++ b/app/services/problem_check/image_magick.rb
@@ -5,7 +5,7 @@ class ProblemCheck::ImageMagick < ProblemCheck
 
   def call
     return no_problem if !SiteSetting.create_thumbnails
-    return no_problem if Kernel.system("command -v convert >/dev/null;")
+    return no_problem if Kernel.system("command -v magick >/dev/null;")
 
     problem
   end

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -91,7 +91,7 @@ class LetterAvatar
         #{filename}
       ]
 
-      Discourse::Utils.execute_command("convert", *instructions)
+      Discourse::Utils.execute_command("magick", *instructions)
 
       ## do not optimize image, it will end up larger than original
       filename
@@ -109,7 +109,7 @@ class LetterAvatar
             sleep 2
             cleanup_old
           end
-          Digest::MD5.hexdigest(`convert --version` << `convert -list font`)
+          Digest::MD5.hexdigest(`magick --version` << `magick -list font`)
         end
     end
 

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -418,7 +418,7 @@ class UploadCreator
 
   MAX_CONVERT_FORMAT_SECONDS = 20
   def execute_convert(from, to, opts = {})
-    command = ["convert", from, "-auto-orient", "-background", "white", "-interlace", "none"]
+    command = ["magick", from, "-auto-orient", "-background", "white", "-interlace", "none"]
     command << "-flatten" unless opts[:flatten] == false
     command << "-debug" << "all" if opts[:debug]
     command << "-quality" << opts[:quality].to_s if opts[:quality]
@@ -526,7 +526,7 @@ class UploadCreator
     path = OptimizedImage.prepend_decoder!(path, nil, filename: "image.#{@image_info.type}")
 
     Discourse::Utils.execute_command(
-      "convert",
+      "magick",
       path,
       "-auto-orient",
       path,

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -35,7 +35,7 @@ Fabricator(:image_upload, from: :upload) do
 
   after_create do |upload, transients|
     file = Tempfile.new(%w[fabricated .png])
-    `convert -size #{upload.width}x#{upload.height} -depth #{transients[:color_depth]} xc:#{transients[:color]} "#{file.path}"`
+    `magick -size #{upload.width}x#{upload.height} -depth #{transients[:color_depth]} xc:#{transients[:color]} "#{file.path}"`
 
     upload.url = Discourse.store.store_upload(file, upload)
     upload.sha1 = Upload.generate_digest(file.path)
@@ -84,7 +84,7 @@ end
 Fabricator(:s3_image_upload, from: :upload_s3) do
   after_create do |upload|
     file = Tempfile.new(%w[fabricated .png])
-    `convert -size #{upload.width}x#{upload.height} xc:white "#{file.path}"`
+    `magick -size #{upload.width}x#{upload.height} xc:white "#{file.path}"`
 
     upload.url = Discourse.store.store_upload(file, upload)
     upload.sha1 = Upload.generate_digest(file.path)


### PR DESCRIPTION
We've been supporting IM7 installs in our docker image since July 2018, and calls to the `convert` binary resolve to `magick` (the binary install on UNIX machines automatically creates a symlink to `magick`).