### PR TITLE
DEV: Drop `Ember` 'barrel file' import

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ember-events.js
+++ b/app/assets/javascripts/discourse/app/lib/ember-events.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line ember/no-classic-components
+import { EventDispatcher } from "@ember/-internals/views";
 import Component from "@ember/component";
 import EmberObject from "@ember/object";
-import Ember from "ember";
 import { actionModifier } from "./ember-action-modifier";
 
 /**
@@ -55,7 +55,7 @@ export function normalizeEmberEventHandling(app) {
  */
 function eliminateClassicEventDelegation() {
   // eslint-disable-next-line no-undef
-  Ember.EventDispatcher.reopen({
+  EventDispatcher.reopen({
     events: {},
   });
 }

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -1,4 +1,3 @@
-import Ember from "ember";
 import loadEmberExam from "ember-exam/test-support/load";
 import { start } from "ember-qunit";
 import * as QUnit from "qunit";
@@ -7,8 +6,7 @@ import setupTests from "discourse/tests/setup-tests";
 import config from "../config/environment";
 
 document.addEventListener("discourse-init", () => {
-  // eslint-disable-next-line no-undef
-  if (!EmberENV.TESTS_FILE_LOADED) {
+  if (!window.EmberENV.TESTS_FILE_LOADED) {
     throw new Error(
       'The tests file was not loaded. Make sure your tests index.html includes "assets/tests.js".'
     );
@@ -27,7 +25,7 @@ document.addEventListener("discourse-init", () => {
   const testingCore = !testingTheme && (!target || target === "core");
   const disableAutoStart = params.get("qunit_disable_auto_start") === "1";
 
-  Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = false;
+  window.EmberENV.LOG_STACKTRACE_ON_DEPRECATION = false;
 
   document.body.insertAdjacentHTML(
     "afterbegin",


### PR DESCRIPTION
`import Ember from "Ember"` will be deprecated in an upcoming version of Ember

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
