### PR TITLE
UX: add max-width to social auth section

### DIFF
--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -70,6 +70,11 @@
   .login-right-side {
     background: var(--tertiary-or-tertiary-low);
     padding: 3.5rem 3rem;
+    max-width: 16em;
+  }
+
+  .btn-social-title {
+    @include ellipsis;
   }
 
   #login-buttons {
@@ -146,6 +151,7 @@
         }
         .login-right-side {
           padding: 1em;
+          max-width: unset;
         }
         #login-form {
           margin: 1.5em 0;


### PR DESCRIPTION
Fixes this issue with long translations:

![image](https://github.com/discourse/discourse/assets/1681963/5854bb6d-ffa6-426a-87e8-a41b1af1a935)


After:
![image](https://github.com/discourse/discourse/assets/1681963/63762c97-197d-483b-b5ed-84beb40bf3d7)

Truncating here isn't *ideal* but at least prevents the layout from breaking. Perhaps in this specific instance a shorter translation could also be possible for Spanish. 