### PR TITLE
UX: fix card positioning, allow shrink-to-fit

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -203,6 +203,7 @@ export default Mixin.create({
             bottom: 10,
             left: 10,
           },
+          maxWidth: "unset",
         });
       } else {
         this._menuInstance = await this.menu.show(target, {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -19,7 +19,6 @@
   --d-nav-border-color--active: var(--d-nav-color--active);
   --d-nav-underline-height: 0.125em;
   --safe-area-inset-bottom: env(safe-area-inset-bottom);
-  --d-wrap-padding-h: 0.67em;
 }
 
 // Animation Keyframes
@@ -340,6 +339,7 @@ textarea {
 }
 
 .wrap {
+  --d-wrap-padding-h: 0.67em;
   max-width: var(--d-max-width);
   margin-right: auto;
   margin-left: auto;

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -19,6 +19,7 @@
   --d-nav-border-color--active: var(--d-nav-color--active);
   --d-nav-underline-height: 0.125em;
   --safe-area-inset-bottom: env(safe-area-inset-bottom);
+  --d-wrap-padding-h: 0.67em;
 }
 
 // Animation Keyframes
@@ -339,7 +340,6 @@ textarea {
 }
 
 .wrap {
-  --d-wrap-padding-h: 0.67em;
   max-width: var(--d-max-width);
   margin-right: auto;
   margin-left: auto;

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -38,6 +38,7 @@
 // shared styles for user and group cards
 .user-card,
 .group-card {
+  min-width: 0;
   width: var(--card-width);
   color: var(--primary);
   background: var(--secondary) center center;

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -1,6 +1,6 @@
 .fk-d-menu[data-identifier="card"] {
   z-index: z("usercard");
-  max-width: calc(100vw - (var(--d-wrap-padding-h) * 3));
+  max-width: calc(100vw - 2em);
   .fk-d-menu__inner-content {
     min-width: 0;
   }

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -1,5 +1,9 @@
 .fk-d-menu[data-identifier="card"] {
   z-index: z("usercard");
+  max-width: calc(100vw - (var(--d-wrap-padding-h) * 3));
+  .fk-d-menu__inner-content {
+    min-width: 0;
+  }
 }
 
 .full-page-chat {


### PR DESCRIPTION
This fixes a minor bug and prepares usercards to be scalable at any browser zoom level or viewport width to improve accessibility. 


**Minor bug fix:** 

The default `max-width` on `dMenu` instances is set to `400px`, but the user card is wider. The card overflows the container so this usually doesn't matter on large screens... but on small screens it means the card is improperly positioned and causes horizontal overflow.

This is because it's positioned based on the smaller max-width rather than the real dimensions. 

Before: 
![image](https://github.com/discourse/discourse/assets/1681963/78489fc3-47b2-4639-871f-18006e1d90fc)


After:
![image](https://github.com/discourse/discourse/assets/1681963/14e2405e-a5cd-41f6-b7e2-82a2c72e53b3)


**Scalability:** 

On smaller screens the usercard is just too wide to fit (we have a separate stylesheet for mobile devices)... at the moment it doesn't scale below its default width, but this gets it headed in that direction. With the max-width removed from the dMenu instance, we can set it to `100vw`, which means it will never be wider than the viewport. 

This combined with some `min-width: 0` can allow it to scale.


Before:
![image](https://github.com/discourse/discourse/assets/1681963/22cdd472-7b12-4876-84c5-3e03acd68039)


After: 
![image](https://github.com/discourse/discourse/assets/1681963/dea7a36d-cb88-4934-9331-ad7ff17c3fdf)

This scalability will need more work, because at the moment it sacrifices the username... but this initial step is already more functional. 
