### PR TITLE
FIX: Poll: visibility of gear button

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
-import { action } from "@ember/object";
+import { action, get } from "@ember/object";
 import { inject as service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
@@ -130,13 +130,12 @@ export default class PollButtonsDropdownComponent extends Component {
         </DMenu>
       {{else if this.showDropdownAsButton}}
         <DButton
-          class="widget-button
-            {{this.getDropdownContent.firstObject.className}}"
-          @icon={{this.getDropdownContent.firstObject.icon}}
-          @label={{this.getDropdownContent.firstObject.label}}
+          class="widget-button {{get this.getDropdownContent '0.className'}}"
+          @icon={{get this.getDropdownContent "0.icon"}}
+          @label={{get this.getDropdownContent "0.label"}}
           @action={{fn
             this.dropDownClick
-            this.getDropdownContent.firstObject.action
+            (get this.getDropdownContent "0.action")
           }}
         />
       {{/if}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
@@ -130,10 +130,14 @@ export default class PollButtonsDropdownComponent extends Component {
         </DMenu>
       {{else if this.showDropdownAsButton}}
         <DButton
-          class="widget-button {{this.getDropdownContent.firstObject.className}}"
+          class="widget-button
+            {{this.getDropdownContent.firstObject.className}}"
           @icon={{this.getDropdownContent.firstObject.icon}}
           @label={{this.getDropdownContent.firstObject.label}}
-          @action={{fn this.dropDownClick this.getDropdownContent.firstObject.action}}
+          @action={{fn
+            this.dropDownClick
+            this.getDropdownContent.firstObject.action
+          }}
         />
       {{/if}}
     </div>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
@@ -107,26 +107,35 @@ export default class PollButtonsDropdownComponent extends Component {
 
   <template>
     <div class="poll-buttons-dropdown">
-      <DMenu class="widget-dropdown-header">
-        <:trigger>
-          {{icon "cog"}}
-        </:trigger>
-        <:content>
-          <DropdownMenu as |dropdown|>
-            {{#each this.getDropdownContent as |content|}}
-              <dropdown.item>
-                <DButton
-                  class="widget-button {{content.className}}"
-                  @icon={{content.icon}}
-                  @label={{content.label}}
-                  @action={{fn this.dropDownClick content.action}}
-                />
-              </dropdown.item>
-              <dropdown.divider />
-            {{/each}}
-          </DropdownMenu>
-        </:content>
-      </DMenu>
+      {{#if this.showDropdown}}
+        <DMenu class="widget-dropdown-header">
+          <:trigger>
+            {{icon "cog"}}
+          </:trigger>
+          <:content>
+            <DropdownMenu as |dropdown|>
+              {{#each this.getDropdownContent as |content|}}
+                <dropdown.item>
+                  <DButton
+                    class="widget-button {{content.className}}"
+                    @icon={{content.icon}}
+                    @label={{content.label}}
+                    @action={{fn this.dropDownClick content.action}}
+                  />
+                </dropdown.item>
+                <dropdown.divider />
+              {{/each}}
+            </DropdownMenu>
+          </:content>
+        </DMenu>
+      {{else if this.showDropdownAsButton}}
+        <DButton
+          class="widget-button {{this.getDropdownContent.firstObject.className}}"
+          @icon={{this.getDropdownContent.firstObject.icon}}
+          @label={{this.getDropdownContent.firstObject.label}}
+          @action={{fn this.dropDownClick this.getDropdownContent.firstObject.action}}
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/plugins/poll/test/javascripts/component/poll-buttons-dropdown-test.js
+++ b/plugins/poll/test/javascripts/component/poll-buttons-dropdown-test.js
@@ -9,9 +9,13 @@ module("Poll | Component | poll-buttons-dropdown", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders a clickable dropdown menu with a close option", async function (assert) {
+    this.siteSettings.data_explorer_enabled = true;
+    this.siteSettings.poll_export_data_explorer_query_id = 18;
+    this.currentUser.setProperties({ admin: true });
+
     this.setProperties({
-      closed: false,
-      voters: [],
+      closed: true,
+      voters: 3,
       isStaff: true,
       isMe: false,
       topicArchived: false,
@@ -33,12 +37,74 @@ module("Poll | Component | poll-buttons-dropdown", function (hooks) {
 
     await click(".widget-dropdown-header");
 
-    assert.strictEqual(count("li.dropdown-menu__item"), 1);
+    assert.strictEqual(count("li.dropdown-menu__item"), 2);
 
     assert.strictEqual(
       query("li.dropdown-menu__item span").textContent.trim(),
-      I18n.t("poll.close.label"),
+      I18n.t("poll.export-results.label"),
+      "displays the poll Export action"
+    );
+  });
+
+  test("Renders a single button when there is only one authorised action", async function (assert) {
+    this.setProperties({
+      closed: false,
+      voters: 2,
+      isStaff: false,
+      isMe: false,
+      topicArchived: false,
+      groupableUserFields: ["stuff"],
+      isAutomaticallyClosed: false,
+      dropDownClick: () => {},
+    });
+
+    await render(hbs`<PollButtonsDropdown
+      @closed={{this.closed}}
+      @voters={{this.voters}}
+      @isStaff={{this.isStaff}}
+      @isMe={{this.isMe}}
+      @topicArchived={{this.topicArchived}}
+      @groupableUserFields={{this.groupableUserFields}}
+      @isAutomaticallyClosed={{this.isAutomaticallyClosed}}
+      @dropDownClick={{this.dropDownClick}}
+    />`);
+
+    assert.strictEqual(count(".widget-dropdown-header"), 0);
+
+    assert.strictEqual(count("button.widget-button"), 1);
+
+    assert.strictEqual(
+      query("button.widget-button span.d-button-label").textContent.trim(),
+      I18n.t("poll.breakdown.breakdown"),
       "displays the poll Close action"
     );
+  });
+
+  test("Doesn't render a button when user has no authorised actions", async function (assert) {
+    this.setProperties({
+      closed: false,
+      voters: 0,
+      isStaff: false,
+      isMe: false,
+      topicArchived: false,
+      groupableUserFields: [],
+      isAutomaticallyClosed: false,
+      dropDownClick: () => {},
+    });
+
+    await render(hbs`<PollButtonsDropdown
+      @closed={{this.closed}}
+      @voters={{this.voters}}
+      @isStaff={{this.isStaff}}
+      @isMe={{this.isMe}}
+      @topicArchived={{this.topicArchived}}
+      @groupableUserFields={{this.groupableUserFields}}
+      @isAutomaticallyClosed={{this.isAutomaticallyClosed}}
+      @dropDownClick={{this.dropDownClick}}
+    />`);
+
+    assert.strictEqual(count(".widget-dropdown-header"), 0);
+
+    assert.strictEqual(count("button.widget-button"), 0);
   });
 });


### PR DESCRIPTION
relates to #27204 

see: https://meta.discourse.org/t/what-is-the-gear-button-under-the-poll-for/315477/2

During migration of Poll plugin from widget basis to glimmer, some functionality was inadvertently dropped:

* A single button should appear instead of the dropdown menu when there is only one valid "poll admin" action
* No button should appear when there are no valid "poll admin" actions for current user

This PR restores the original behaviour and adds test coverage (that didn't exist prior to migration, partly why it wasn't caught earlier)
