### PR TITLE
DEV: Specs for redeliver_web_hook_events job

### DIFF
--- a/spec/fabricators/redelivering_webhook_event_fabricator.rb
+++ b/spec/fabricators/redelivering_webhook_event_fabricator.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-Fabricator(:redelivering_webhook_event) { web_hook_event_id { Fabricate(:web_hook_event).id } }
+Fabricator(:redelivering_webhook_event) do
+  web_hook_event_id { Fabricate(:web_hook_event).id }
+  processing false
+end

--- a/spec/jobs/redeliver_web_hook_events_spec.rb
+++ b/spec/jobs/redeliver_web_hook_events_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
         },
       ).to_return(status: 400, body: "", headers: {})
 
-      job.execute(web_hook: web_hook, web_hook_event: web_hook_event2)
+      job.execute({})
 
       expect(RedeliveringWebhookEvent.count).to eq(1)
       expect(

--- a/spec/jobs/redeliver_web_hook_events_spec.rb
+++ b/spec/jobs/redeliver_web_hook_events_spec.rb
@@ -6,7 +6,16 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
   subject(:job) { described_class.new }
 
   fab!(:web_hook)
-  fab!(:web_hook_event) do
+  fab!(:web_hook_event1) do
+    Fabricate(
+      :web_hook_event,
+      web_hook: web_hook,
+      payload: "abc",
+      headers: JSON.dump(aa: "1", bb: "2"),
+    )
+  end
+
+  fab!(:web_hook_event2) do
     Fabricate(
       :web_hook_event,
       web_hook: web_hook,
@@ -16,7 +25,7 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
   end
 
   fab!(:redelivering_webhook_event) do
-    Fabricate(:redelivering_webhook_event, web_hook_event_id: web_hook_event.id)
+    Fabricate(:redelivering_webhook_event, web_hook_event_id: web_hook_event1.id)
   end
 
   it "redelivers webhook events" do
@@ -29,10 +38,37 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
     ).to_return(status: 400, body: "", headers: {})
 
     messages =
-      MessageBus.track_publish { job.execute(web_hook: web_hook, web_hook_event: web_hook_event) }
+      MessageBus.track_publish { job.execute(web_hook: web_hook, web_hook_event: web_hook_event1) }
 
     expect(RedeliveringWebhookEvent.count).to eq(0)
     expect(messages.count).to eq(1)
     expect(messages.first.data).to include(type: "redelivered")
+  end
+
+  context "when there is a redelivering_webhook_event in process" do
+    fab!(:redelivering_webhook_event_in_process) do
+      Fabricate(
+        :redelivering_webhook_event,
+        web_hook_event_id: web_hook_event2.id,
+        processing: true,
+      )
+    end
+
+    it "does not delete the webhook event in process" do
+      stub_request(:post, web_hook.payload_url).with(
+        body: "abc",
+        headers: {
+          "aa" => 1,
+          "bb" => 2,
+        },
+      ).to_return(status: 400, body: "", headers: {})
+
+      job.execute(web_hook: web_hook, web_hook_event: web_hook_event2)
+
+      expect(RedeliveringWebhookEvent.count).to eq(1)
+      expect(
+        RedeliveringWebhookEvent.find_by(id: redelivering_webhook_event_in_process.id),
+      ).to be_present
+    end
   end
 end


### PR DESCRIPTION
It is a PR to add a test for checking redeliver_web_hook_events job not to delete webhook event in process.