### PR TITLE
DEV: Fix flaky admin confirmation spec

### DIFF
--- a/spec/system/admin_site_setting_requires_confirmation_spec.rb
+++ b/spec/system/admin_site_setting_requires_confirmation_spec.rb
@@ -26,6 +26,7 @@ describe "Admin Site Setting Requires Confirmation", type: :system do
     )
     dialog.click_yes
     expect(dialog).to be_closed
+    expect(settings_page).to have_overridden_setting("min_password_length")
     expect(SiteSetting.min_password_length).to eq(12)
   end
 

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -22,8 +22,10 @@ module PageObjects
         self
       end
 
-      def find_setting(setting_name)
-        find(".admin-detail .row.setting[data-setting='#{setting_name}']")
+      def find_setting(setting_name, overridden: false)
+        find(
+          ".admin-detail .row.setting[data-setting='#{setting_name}']#{overridden ? ".overridden" : ""}",
+        )
       end
 
       def toggle_setting(setting_name, text = "")
@@ -47,6 +49,10 @@ module PageObjects
 
       def save_setting(setting_element)
         setting_element.find(".setting-controls button.ok").click
+      end
+
+      def has_overridden_setting?(setting_name)
+        find_setting(setting_name, overridden: true)
       end
 
       def values_in_list(setting_name)


### PR DESCRIPTION
Waiting for the dialog to close was not enough,
need to wait for the overridden indicator to
show on the site setting.
