### PR TITLE
DEV: Drop `logging_provider` site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2346,13 +2346,6 @@ developer:
   bypass_wizard_check:
     default: false
     hidden: true
-  logging_provider:
-    hidden: true
-    default: "default"
-    type: "list"
-    choices:
-      - "default"
-      - "lograge"
   bootstrap_error_pages:
     hidden: true
     default: false

--- a/db/migrate/20240709015048_remove_logging_provider_site_setting.rb
+++ b/db/migrate/20240709015048_remove_logging_provider_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveLoggingProviderSiteSetting < ActiveRecord::Migration[7.1]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'logging_provider'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This site setting has always been experimental and hidden since it was
added 7 years ago. Drop it to simplify the way we enable logging in a
logstash friendly way.

Also dropping `ENABLE_LOGRAGE` env in favor of just `ENABLE_LOGSTASH_LOGGER`. There is almost no use case where we only want lograge to be enabled.