### PR TITLE
DEV: Add hidden `s3_inventory_bucket_region` site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2517,6 +2517,9 @@ backups:
     hidden: true
     default: ""
     regex: '^[a-z0-9\-\/_]+$' # can't use '.' when using HTTPS
+  s3_inventory_bucket_region:
+    hidden: true
+    default: ""
   s3_disable_cleanup:
     default: false
   backup_time_of_day:

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -298,7 +298,13 @@ module FileStore
 
     def list_missing_uploads(skip_optimized: false)
       if s3_inventory_bucket = SiteSetting.s3_inventory_bucket
-        S3Inventory.new(:upload, s3_inventory_bucket:).backfill_etags_and_list_missing
+        s3_options = {}
+
+        if (s3_inventory_bucket_region = SiteSetting.s3_inventory_bucket_region).present?
+          s3_options[:region] = s3_inventory_bucket_region
+        end
+
+        S3Inventory.new(:upload, s3_inventory_bucket:, s3_options:).backfill_etags_and_list_missing
 
         unless skip_optimized
           S3Inventory.new(:optimized, s3_inventory_bucket:).backfill_etags_and_list_missing

--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -16,9 +16,10 @@ class S3Inventory
     type,
     s3_inventory_bucket:,
     preloaded_inventory_file: nil,
-    preloaded_inventory_date: nil
+    preloaded_inventory_date: nil,
+    s3_options: {}
   )
-    @s3_helper = S3Helper.new(s3_inventory_bucket)
+    @s3_helper = S3Helper.new(s3_inventory_bucket, "", s3_options)
 
     if preloaded_inventory_file && preloaded_inventory_date
       # Data preloaded, so we don't need to fetch it again

--- a/spec/lib/s3_inventory_spec.rb
+++ b/spec/lib/s3_inventory_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe S3Inventory do
     expect(output).to eq("Failed to list inventory from S3\n")
   end
 
+  it "should forward custom s3 options to the S3Helper when initializing" do
+    inventory =
+      S3Inventory.new(
+        :upload,
+        s3_inventory_bucket: "some-inventory-bucket",
+        s3_options: {
+          region: "us-west-1",
+        },
+      )
+
+    inventory.s3_helper.stub_client_responses!
+
+    expect(inventory.s3_helper.s3_client.config.region).to eq("us-west-1")
+  end
+
   describe "verifying uploads" do
     before do
       freeze_time


### PR DESCRIPTION
This commit adds a hidden `s3_inventory_bucket_region` site setting to
specify the region of the `s3_inventory_bucket` when the `S3Inventory`
class initializes an instance of the `S3Helper`. By default, the
`S3Helper` class uses the value of the `s3_region` site setting but the
region of the `s3_inventory_bucket` is not always the same as the
`s3_region` configured.
