### PR TITLE
DEV: Add exception class and message fields to `DiscourseLogstashLogger`

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -74,6 +74,17 @@ class DiscourseLogstashLogger < Logger
         event["backtrace"] = backtrace
       end
 
+      # `web-exception` is a log message triggered by logster.
+      # The exception class and message are extracted from the message based on the format logged by logster in
+      # https://github.com/discourse/logster/blob/25375250fb8a5c312e9c55a75f6048637aad2c69/lib/logster/middleware/debug_exceptions.rb#L22.
+      #
+      # In theory we could get logster to include the exception class and message in opts but logster currently does not
+      # need those options so we are parsing it from the message for now and not making a change in logster.
+      if progname == "web-exception" && message =~ /^(\w+) \((.+)\)\n/
+        event["exception.class"] = $1
+        event["exception.message"] = $2
+      end
+
       if (env = opts&.dig(:env)).present?
         ALLOWED_HEADERS_FROM_ENV.each do |header|
           event["request.headers.#{header.downcase}"] = opts[:env][header]

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe DiscourseLogstashLogger do
       expect(parsed["message"]).to eq("error message")
     end
 
+    it "logs a JSON string with the `exception_class` and `exception_message` fields when `progname` is `web-exception`" do
+      logger = described_class.logger(logdev: output, type: "test")
+      logger.add(Logger::ERROR, "StandardError (some error message)\ntest", "web-exception")
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed["exception.class"]).to eq("StandardError")
+      expect(parsed["exception.message"]).to eq("some error message")
+    end
+
     it "logs a JSON string with the right fields when `customize_event` attribute is set" do
       logger =
         described_class.logger(


### PR DESCRIPTION
This commit updates `DiscourseLogstashlogger` to add the
`exception_class` and `exception_message` field to the log line when the
`progname` of the log message is `web-exception` which is Logster's
logging of exceptions during a web request.

The `exception_class` and `exception_message` fields allows consumers of
the logs to easily group logs together.

## Reviewer Notes

1. Run `RAILS_DISABLE_ACTIVERECORD_LOGS=1 ENABLE_LOGSTASH_LOGGER=1 bin/rails s`
2. Run `tail -f log/development.log | grep "exception_field"`
3. Go to `application_controller` and just trigger a syntax error in one of the `before_action`
4. See that the error log line contains the `exception_class` and `exception_message`fields