### PR TITLE
FIX: deleted topic author in crawler view

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -52,10 +52,12 @@
       </div>
 
       <% if @topic_view.crawler_posts&.first && !@topic_view.crawler_posts.first.is_first_post? %>
-        <span itemprop='author' itemscope itemtype="http://schema.org/Person">
-          <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
-          <link itemprop='url' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
-        </span>
+        <% if @topic_view.topic.user.present? %>
+          <span itemprop='author' itemscope itemtype="http://schema.org/Person">
+            <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
+            <link itemprop='url' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
+          </span>
+        <% end %>
         <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
       <% end %>
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5382,6 +5382,12 @@ RSpec.describe TopicsController do
         )
       end
 
+      it "works even when the author has been deleted" do
+        topic.update!(user_id: nil)
+
+        get "#{topic.relative_url}/2"
+      end
+
       context "with canonical_url" do
         fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
         let!(:user_agent) do


### PR DESCRIPTION
When a crawler visits a topic that has a deleted author, it would error because the `show.html.erb` view was expecting a user to be always present.

This ensure we don't render the "author" meta data when the author of the topic has been deleted.

Internal ref t/132508

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
