### PR TITLE
DEV: Add `d-button-action-string` deprecation to admin warnings

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -17,6 +17,7 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.header-widget-overrides",
   "discourse.plugin-outlet-tag-name",
   "discourse.plugin-outlet-parent-view",
+  "discourse.d-button-action-string",
   /^(?!discourse\.)/, // All unsilenced ember deprecations
 ];
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
