### PR TITLE
UX: Insert a space before the featured link on mobile topic list view…

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-list-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-list-item.gjs
@@ -445,7 +445,8 @@ export default class TopicListItem extends Component {
                 class="raw-link raw-topic-link"
               />
               {{~#if @topic.featured_link~}}
-                {{topicFeaturedLink @topic}}
+                &nbsp;
+                {{~topicFeaturedLink @topic}}
               {{~/if~}}
               <PluginOutlet @name="topic-list-after-title" />
               {{~#if @topic.unseen~}}


### PR DESCRIPTION
… (glimmer)

A followup to 16a8a31c5200e212f4b91375d926e2d8cc9f79a6

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
