### PR TITLE
FIX: show too long message error on client

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -18,6 +18,7 @@ import {
 import i18n from "discourse-common/helpers/i18n";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
+import I18n from "I18n";
 import ChatChannelStatus from "discourse/plugins/chat/discourse/components/chat-channel-status";
 import firstVisibleMessageId from "discourse/plugins/chat/discourse/helpers/first-visible-message-id";
 import ChatChannelSubscriptionManager from "discourse/plugins/chat/discourse/lib/chat-channel-subscription-manager";
@@ -62,9 +63,11 @@ export default class ChatChannel extends Component {
   @service("chat-channel-composer") composer;
   @service("chat-channel-pane") pane;
   @service currentUser;
+  @service dialog;
   @service messageBus;
   @service router;
   @service site;
+  @service siteSettings;
 
   @tracked sending = false;
   @tracked showChatQuoteSuccess = false;
@@ -496,6 +499,17 @@ export default class ChatChannel extends Component {
 
   @action
   async onSendMessage(message) {
+    if (
+      message.message.length > this.siteSettings.chat_maximum_message_length
+    ) {
+      this.dialog.alert(
+        I18n.t("chat.message_too_long", {
+          count: this.siteSettings.chat_maximum_message_length,
+        })
+      );
+      return;
+    }
+
     await message.cook();
     if (message.editing) {
       await this.#sendEditMessage(message);

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -11,6 +11,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
+import I18n from "I18n";
 import ChatThreadTitlePrompt from "discourse/plugins/chat/discourse/components/chat-thread-title-prompt";
 import firstVisibleMessageId from "discourse/plugins/chat/discourse/helpers/first-visible-message-id";
 import ChatChannelThreadSubscriptionManager from "discourse/plugins/chat/discourse/lib/chat-channel-thread-subscription-manager";
@@ -49,6 +50,7 @@ export default class ChatThread extends Component {
   @service chatDraftsManager;
   @service chatThreadComposer;
   @service chatThreadPane;
+  @service dialog;
   @service currentUser;
   @service router;
   @service siteSettings;
@@ -359,6 +361,17 @@ export default class ChatThread extends Component {
 
   @action
   async onSendMessage(message) {
+    if (
+      message.message.length > this.siteSettings.chat_maximum_message_length
+    ) {
+      this.dialog.alert(
+        I18n.t("chat.message_too_long", {
+          count: this.siteSettings.chat_maximum_message_length,
+        })
+      );
+      return;
+    }
+
     await message.cook();
     if (message.editing) {
       await this.#sendEditMessage(message);

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -259,6 +259,7 @@ en:
       copy_link: "Copy link"
       copy_text: "Copy text"
       rebake_message: "Rebuild HTML"
+      message_too_long: "Message is too long, messages must be a maximum of %{count} characters."
       retry_staged_message:
         title: "Network error"
         action: "Send again?"

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -35,6 +35,7 @@ module PageObjects
       end
 
       def click_composer
+        return if has_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
         find(".chat-channel .chat-composer__input").click # ensures autocomplete is closed and not masking anything
       end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -35,8 +35,9 @@ module PageObjects
       end
 
       def click_composer
-        return if has_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
-        find(".chat-channel .chat-composer__input").click # ensures autocomplete is closed and not masking anything
+        if has_no_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
+          find(".chat-channel .chat-composer__input").click # ensures autocomplete is closed and not masking anything
+        end
       end
 
       def click_send_message

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -35,7 +35,7 @@ module PageObjects
       end
 
       def click_composer
-        if has_no_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
+        if has_no_css?(".dialog-overlay", wait: 0) # we can't click composer if a dialog is open, in case of error for exampel
           find(".chat-channel .chat-composer__input").click # ensures autocomplete is closed and not masking anything
         end
       end

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -94,7 +94,7 @@ module PageObjects
       end
 
       def click_composer
-        if has_no_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
+        if has_no_css?(".dialog-overlay", wait: 0) # we can't click composer if a dialog is open, in case of error for exampel
           find(".chat-thread .chat-composer__input").click # ensures autocomplete is closed and not masking anything
         end
       end

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -94,8 +94,9 @@ module PageObjects
       end
 
       def click_composer
-        return if has_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
-        find(".chat-thread .chat-composer__input").click # ensures autocomplete is closed and not masking anything
+        if has_no_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
+          find(".chat-thread .chat-composer__input").click # ensures autocomplete is closed and not masking anything
+        end
       end
 
       def send_message(text = nil)

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -94,6 +94,7 @@ module PageObjects
       end
 
       def click_composer
+        return if has_css?(".dialog-overlay") # we can't click composer if a dialog is open, in case of error for exampel
         find(".chat-thread .chat-composer__input").click # ensures autocomplete is closed and not masking anything
       end
 

--- a/plugins/chat/spec/system/page_objects/chat/components/composer.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/composer.rb
@@ -48,6 +48,10 @@ module PageObjects
           input.value
         end
 
+        def has_value?(expected)
+          value == expected
+        end
+
         def reply_to_last_message_shortcut
           input.click
           input.send_keys(%i[shift arrow_up])


### PR DESCRIPTION
Prior to this fix we would show the message after a round trip to the server. If you had a too long message error, at this point your input would be empty and we would show an error in chat. It's important to have this sever side safety net, but we can have a better UX by showing an error on the frontend before sending the message, that way you can correct your message before sending it and not lose it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
