### PR TITLE
FIX: Don’t list values from disabled plugins

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -66,14 +66,11 @@ class Reviewable < ActiveRecord::Base
   end
 
   def self.valid_type?(type)
-    return false if Reviewable.types.exclude?(type)
-    type.constantize <= Reviewable
-  rescue NameError
-    false
+    type.to_s.safe_constantize.in?(types)
   end
 
   def self.types
-    %w[ReviewableFlaggedPost ReviewableQueuedPost ReviewableUser ReviewablePost]
+    [ReviewableFlaggedPost, ReviewableQueuedPost, ReviewableUser, ReviewablePost]
   end
 
   def self.custom_filters


### PR DESCRIPTION
Currently, when a plugin registers a new reviewable type or extends a list method (through `register_reviewble_type` and `extend_list_method` respectively), the new array is statically computed and always returns the same value. It will continue to return the same value even if the plugin is disabled (it can be a problem in a multisite env too).

To address this issue, this PR changes how `extend_list_method` works. It’s now using `DiscoursePluginRegistry.define_filtered_register` to create a register on the fly and store the extra values from various plugins. It then combines the original values with the ones from the registry. The registry is already aware of disabled plugins, so when a plugin is disabled, its registered values won’t be returned.
