### PR TITLE
DEV: migrates group-activity-filter to gjs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-activity-filter.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-activity-filter.gjs
@@ -1,0 +1,16 @@
+import { concat, hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
+import i18n from "discourse-common/helpers/i18n";
+
+const GroupActivityFilter = <template>
+  <li>
+    <LinkTo
+      @route={{concat "group.activity." @filter}}
+      @query={{hash category_id=@categoryId}}
+    >
+      {{i18n (concat "groups." @filter)}}
+    </LinkTo>
+  </li>
+</template>;
+
+export default GroupActivityFilter;

--- a/app/assets/javascripts/discourse/app/components/group-activity-filter.hbs
+++ b/app/assets/javascripts/discourse/app/components/group-activity-filter.hbs
@@ -1,6 +1,0 @@
-<LinkTo
-  @route={{concat "group.activity." this.filter}}
-  @query={{hash category_id=this.categoryId}}
->
-  {{i18n (concat "groups." this.filter)}}
-</LinkTo>

--- a/app/assets/javascripts/discourse/app/components/group-activity-filter.js
+++ b/app/assets/javascripts/discourse/app/components/group-activity-filter.js
@@ -1,4 +1,0 @@
-import Component from "@ember/component";
-export default Component.extend({
-  tagName: "li",
-});


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
