### PR TITLE
FIX: Allow error handling for formats besides JSON

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -168,7 +168,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
-    if request.format && request.format.json?
+    if request.format
       render_json_error e, type: :record_invalid, status: 422
     else
       raise e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -168,7 +168,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from ActiveRecord::RecordInvalid do |e|
-    if request.format
+    if request.format && request.format.json?
       render_json_error e, type: :record_invalid, status: 422
     else
       raise e

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1105,7 +1105,7 @@ Discourse::Application.routes.draw do
 
     put "bookmarks/bulk"
 
-    resources :posts, only: %i[show update create destroy] do
+    resources :posts, only: %i[show update create destroy], defaults: { format: "json" } do
       delete "bookmark", to: "posts#destroy_bookmark"
       put "wiki"
       put "post_type"

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -642,6 +642,24 @@ RSpec.describe PostsController do
       expect(post.topic.reload.category_id).not_to eq(category.id)
     end
 
+    describe "trying to add a link without permission" do
+      it "returns an error message if links are added to posts when not allowed" do
+        post = create_post
+        sign_in(post.user)
+        SiteSetting.post_links_allowed_groups = Group::AUTO_GROUPS[:admins]
+
+        put "/posts/#{post.id}",
+            params: {
+              post: {
+                raw: "I'm editing this post to add www.linkhere.com",
+              },
+            }
+
+        expect(response.status).to eq(422)
+        expect(response.body).to include("Sorry, you can't include links in your posts.")
+      end
+    end
+
     describe "with Post.plugin_permitted_update_params" do
       before do
         plugin = Plugin::Instance.new


### PR DESCRIPTION
Our global error handler for `ActiveRecord::RecordInvalid` only handles JSON requests. This causes multiple errors on the backend that are not properly exposed to the user.

<img width="707" alt="Screenshot 2024-07-09 at 19 57 31" src="https://github.com/discourse/discourse/assets/15239141/167d831b-564f-4028-8c76-4538a3421d88">

My change assumes that the default format will be JSON, as this is what our FE expects.

Alternatively, we could explicitly add the JSON format to the request, but I think handling this at the BE is a better solution.