### PR TITLE
Revert "DEV: Remove `git_version` from `DiscourseLogstashLogger` log event (#27730)"

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -2,10 +2,12 @@
 
 require "json"
 require "socket"
+require_relative "git_utils"
 
 class DiscourseLogstashLogger < Logger
   PROCESS_PID = Process.pid
   HOST = Socket.gethostname
+  GIT_VERSION = GitUtils.git_version
 
   attr_accessor :customize_event, :type
 
@@ -65,6 +67,7 @@ class DiscourseLogstashLogger < Logger
       "pid" => PROCESS_PID,
       "type" => @type.to_s,
       "host" => HOST,
+      "git_version" => GitUtils.git_version,
     }
 
     # Only log backtrace and env for Logger::WARN and above.

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe DiscourseLogstashLogger do
           "pid" => described_class::PROCESS_PID,
           "type" => "test",
           "host" => described_class::HOST,
+          "git_version" => described_class::GIT_VERSION,
           "method" => "GET",
           "path" => "/",
           "format" => "html",


### PR DESCRIPTION
This reverts commit bb0daa33cd93eeffb230689d1daacd737f61b2e7.

This commit was not causing the problems we thought it was.
