### PR TITLE
DEV: Add exception class/message to `DiscourseLogstashLogger` take 2

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -80,9 +80,9 @@ class DiscourseLogstashLogger < Logger
       #
       # In theory we could get logster to include the exception class and message in opts but logster currently does not
       # need those options so we are parsing it from the message for now and not making a change in logster.
-      if progname == "web-exception" && message =~ /^(\w+) \((.+)\)\n/
+      if progname == "web-exception" && message =~ /\A([^\(\)]+)\s{1}\(([\s\S]+)\)/
         event["exception.class"] = $1
-        event["exception.message"] = $2
+        event["exception.message"] = $2.strip
       end
 
       if (env = opts&.dig(:env)).present?

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -50,12 +50,34 @@ RSpec.describe DiscourseLogstashLogger do
 
     it "logs a JSON string with the `exception_class` and `exception_message` fields when `progname` is `web-exception`" do
       logger = described_class.logger(logdev: output, type: "test")
-      logger.add(Logger::ERROR, "StandardError (some error message)\ntest", "web-exception")
+
+      logger.add(
+        Logger::ERROR,
+        "Some::StandardError (this is a normal message)\ntest",
+        "web-exception",
+      )
+
       output.rewind
       parsed = JSON.parse(output.read.chomp)
 
-      expect(parsed["exception.class"]).to eq("StandardError")
-      expect(parsed["exception.message"]).to eq("some error message")
+      expect(parsed["exception.class"]).to eq("Some::StandardError")
+      expect(parsed["exception.message"]).to eq("this is a normal message")
+    end
+
+    it "logs a JSON string with the `exception_class` and `exception_message` fields when `progname` is `web-exception` and the exception message contains newlines" do
+      logger = described_class.logger(logdev: output, type: "test")
+
+      logger.add(
+        Logger::ERROR,
+        "Some::StandardError (\n\nsome error message\n\nsomething else\n\n)\ntest",
+        "web-exception",
+      )
+
+      output.rewind
+      parsed = JSON.parse(output.read.chomp)
+
+      expect(parsed["exception.class"]).to eq("Some::StandardError")
+      expect(parsed["exception.message"]).to eq("some error message\n\nsomething else")
     end
 
     it "logs a JSON string with the right fields when `customize_event` attribute is set" do


### PR DESCRIPTION
This is the second take of af2bd4cc5097501ff0f11f497b8d6f6984cea9ae to
account for messages which contains newlines.
