### PR TITLE
DEV: Make sure header hidden buttons are valid

### DIFF
--- a/app/assets/javascripts/discourse/app/services/header.js
+++ b/app/assets/javascripts/discourse/app/services/header.js
@@ -4,6 +4,8 @@ import Service, { service } from "@ember/service";
 import { TrackedMap } from "@ember-compat/tracked-built-ins";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 
+const VALID_HEADER_BUTTONS_TO_HIDE = ["search", "login", "signup"];
+
 @disableImplicitInjections
 export default class Header extends Service {
   @service siteSettings;
@@ -35,7 +37,26 @@ export default class Header extends Service {
   }
 
   registerHider(ref, buttons) {
-    this.#hiders.set(ref, buttons);
+    const validButtons = buttons
+      .map((button) => {
+        if (!VALID_HEADER_BUTTONS_TO_HIDE.includes(button)) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Invalid button to hide: ${button}, valid buttons are: ${VALID_HEADER_BUTTONS_TO_HIDE.join(
+              ","
+            )}`
+          );
+        } else {
+          return button;
+        }
+      })
+      .filter(Boolean);
+
+    if (!validButtons.length) {
+      return;
+    }
+
+    this.#hiders.set(ref, validButtons);
 
     registerDestructor(ref, () => {
       this.#hiders.delete(ref);

--- a/app/assets/javascripts/discourse/tests/unit/services/header-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/header-test.js
@@ -1,0 +1,22 @@
+import { getOwner } from "@ember/application";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | header", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.header = getOwner(this).lookup("service:header");
+  });
+
+  test("it registers hiders", function (assert) {
+    this.header.registerHider(this, ["search", "login"]);
+    assert.ok(this.header.headerButtonsHidden.includes("search"));
+    assert.ok(this.header.headerButtonsHidden.includes("login"));
+  });
+
+  test("it does not register invalid buttons for hiders", function (assert) {
+    this.header.registerHider(this, ["search", "blahblah"]);
+    assert.notOk(this.header.headerButtonsHidden.includes("blah"));
+  });
+});


### PR DESCRIPTION
Followup 0434112aa71fc091583d8356a84fbf958f7228fb,
we introduced HideApplicationHeaderButtons there
but didn't validate the buttons passed to it. With this
commit we do, and send an error to the browser console
if an invalid one is used.
