### PR TITLE
DEV: Apply `Logster.store.ignore` to `DiscourseLogstashLogger` as well

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -83,9 +83,14 @@ class DiscourseLogstashLogger < Logger
       #
       # In theory we could get logster to include the exception class and message in opts but logster currently does not
       # need those options so we are parsing it from the message for now and not making a change in logster.
-      if progname == "web-exception" && message =~ /\A([^\(\)]+)\s{1}\(([\s\S]+)\)/
-        event["exception.class"] = $1
-        event["exception.message"] = $2.strip
+      if progname == "web-exception"
+        # `Logster.store.ignore` is set in the logster initializer and is an array of regex patterns.
+        return if Logster.store&.ignore&.any? { |pattern| pattern.match(message) }
+
+        if message =~ /\A([^\(\)]+)\s{1}\(([\s\S]+)\)/
+          event["exception.class"] = $1
+          event["exception.message"] = $2.strip
+        end
       end
 
       if (env = opts&.dig(:env)).present?

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -173,5 +173,21 @@ RSpec.describe DiscourseLogstashLogger do
 
       expect(parsed).not_to have_key("request.headers.some_random_header")
     end
+
+    it "does not log the event if message matches a pattern configured by `Logster.store.ignore`" do
+      original_logster_store_ignore = Logster.store.ignore
+      Logster.store.ignore = [/^Some::StandardError/]
+
+      logger.add(
+        Logger::ERROR,
+        "Some::StandardError (this is a normal message)\ntest",
+        "web-exception",
+      )
+
+      output.rewind
+      expect(output.read.chomp).to be_empty
+    ensure
+      Logster.store.ignore = original_logster_store_ignore
+    end
   end
 end


### PR DESCRIPTION
This commit updates `DiscourseLogstashLogger#add_with_opts` to avoid
logging messages that matches regexp patterns configured in
`Logster.store.ignore`. Those error logs are mostly triggered by clients
and do not serve any useful purpose.
