### PR TITLE
FIX: Make category filter in review page clearable

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -71,7 +71,7 @@
         <CategoryChooser
           @value={{this.filterCategoryId}}
           @onChange={{fn (mut this.filterCategoryId)}}
-          @options={{hash none="review.filters.all_categories"}}
+          @options={{hash none="review.filters.all_categories" clearable=true}}
         />
       </div>
 


### PR DESCRIPTION
### What is the problem?

On the review page, once you select a category to filter by, while you can still change the category, you can not clear it.

### How does this fix it?

Pass the "clearable" select-kit option through.

### Show me!

**Before:**

![clearable-review-category-filter-before](https://github.com/discourse/discourse/assets/5259935/5e96898f-f5d7-4937-87eb-baef937e880b)

**After:**

![clearable-review-category-filter](https://github.com/discourse/discourse/assets/5259935/4dbe439b-254e-4589-be0f-b4b9a7f9a59b)
