### PR TITLE
DEV: Fix the I18n integrity spec

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2685,6 +2685,7 @@ en:
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
+    experimental_flags_admin_page_enabled_groups: "EXPERIMENTAL: Remove the Moderation Flags link from the admin sidebar."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/spec/integrity/i18n_spec.rb
+++ b/spec/integrity/i18n_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "i18n integrity checks" do
   it "has an i18n key for each Site Setting" do
     SiteSetting.all_settings.each do |s|
       next if s[:plugin] == SiteSetting::SAMPLE_TEST_PLUGIN.name
-      expect(s[:description]).not_to match(/Translation missing/)
+      expect(s[:description]).not_to be_blank
     end
   end
 


### PR DESCRIPTION
Before Rails 7.1, the `config.i18n.raise_on_missing_translations` option was raising only in controllers and views, now it’s anywhere in the app.
It means it raises each time `#description` is called for a setting that is missing a proper description (and we have a ton of them). Most of the time it’s fine, as those are usually settings that aren’t shown to the user.

We can’t just let the code blow up every time there’s a setting with a missing description, that’s why it’s currently returning an empty string when the translation is missing.

However, this silently broke our I18n integrity spec that was relying on the old “Translation missing” message to detect missing translations.

This PR addresses this issue by checking the description isn’t an empty string. It caught a missing translation by the way.
