### PR TITLE
DEV: Ensure implicit injections shim is run early

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -2,16 +2,19 @@
 import "decorator-transforms/globals";
 import "./loader-shims";
 import "./global-compat";
+import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-injections";
 /* eslint-enable simple-import-sort/imports */
 
+// Register Discourse's standard implicit injections on common framework classes.
+registerDiscourseImplicitInjections();
+
 import Application from "@ember/application";
+import { VERSION } from "@ember/version";
 import require from "require";
 import { normalizeEmberEventHandling } from "discourse/lib/ember-events";
-import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-injections";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { isTesting } from "discourse-common/config/environment";
 import { buildResolver } from "discourse-common/resolver";
-import { VERSION } from "@ember/version";
 
 const _pluginCallbacks = [];
 let _unhandledThemeErrors = [];
@@ -35,9 +38,6 @@ class Discourse extends Application {
     // Rewire event handling to eliminate event delegation for better compat
     // between Glimmer and Classic components.
     normalizeEmberEventHandling(this);
-
-    // Register Discourse's standard implicit injections on common framework classes.
-    registerDiscourseImplicitInjections();
 
     if (Error.stackTraceLimit) {
       // We need Errors to have full stack traces for `lib/source-identifier`


### PR DESCRIPTION
This needs to run before any component files are `import`'d. In traditional resolver-based tests, this was working previously because component files would only be loaded 'at runtime'. However, in gjs-based tests (e.g. those introduced in the formkit PR), component files are imported before the application is booted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
