### PR TITLE
DEV: Remove unneeded `next()`

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { array, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import DButton from "discourse/components/d-button";
@@ -137,8 +136,6 @@ class FKForm extends Component {
     if (this.fieldValidationEvent === VALIDATION_TYPES.change) {
       await this.handleFieldValidation(name);
     }
-
-    await new Promise((resolve) => next(resolve));
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -3,6 +3,7 @@ import {
   fillIn,
   render,
   resetOnerror,
+  settled,
   setupOnerror,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
@@ -135,12 +136,16 @@ module("Integration | Component | FormKit | Field", function (hooks) {
   });
 
   test("@onSet", async function (assert) {
+    const onSetWasCalled = assert.async();
+
     const onSet = async (value, { set }) => {
       assert.form().field("foo").hasValue("bar");
 
       await set("foo", "baz");
+      await settled();
 
       assert.form().field("foo").hasValue("baz");
+      onSetWasCalled();
     };
 
     await render(<template>


### PR DESCRIPTION
This only affected one test. And in that case, when changing a value in JS, it is perfectly normal to make the developer write a manual `await settled()` before asserting the state of the DOM.

Also adds `assert.async()` to the test so that we can be sure the callback was triggered.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
