### PR TITLE
A11Y: aria-current="page" is more appropriate for navigation bar links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.hbs
@@ -1,7 +1,7 @@
 <a
   href={{this.hrefLink}}
   class={{this.activeClass}}
-  aria-current={{if this.activeClass "true"}}
+  aria-current={{if this.activeClass "page"}}
 >
   {{#if this.hasIcon}}
     <span class={{this.content.name}}></span>


### PR DESCRIPTION
this concerns the latest/top/categories nav:

![image](https://github.com/discourse/discourse/assets/1681963/d6edd934-d8b1-4b9c-aeb2-47a40c98c55e)



"page" is a more specific value than "true", and indicates that this is the currently active page 

"true" is more appropriate for an active state that doesn't necessarily correspond with a page change, like the currently selected state in a list 