### PR TITLE
UX: Add missing title to notifications-button

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/notifications-button.js
@@ -16,16 +16,23 @@ export default DropdownSelectBoxComponent.extend({
     i18nPostfix: "",
   },
 
-  modifyComponentForRow() {
+  getTitle(key) {
+    const { i18nPrefix, i18nPostfix } = this.selectKit.options;
+    return I18n.t(`${i18nPrefix}.${key}${i18nPostfix}.title`);
+  },
+
+  modifyComponentForRow(_, content) {
+    if (content) {
+      setProperties(content, {
+        title: this.getTitle(content.key),
+      });
+    }
     return "notifications-button/notifications-button-row";
   },
 
   modifySelection(content) {
     content = content || {};
-    const { i18nPrefix, i18nPostfix } = this.selectKit.options;
-    const title = I18n.t(
-      `${i18nPrefix}.${this.buttonForValue.key}${i18nPostfix}.title`
-    );
+    const title = this.getTitle(this.buttonForValue.key);
     setProperties(content, {
       title,
       label: title,


### PR DESCRIPTION
This commit adds the missing title for notifications-button. In the past, it was automatically fallbacked to the button's key.

Related meta topic: https://meta.discourse.org/t/tracking-toggle-text-on-hover-sometimes-not-translated/315727

before: 
![image](https://github.com/discourse/discourse/assets/41134017/34ee58a8-f698-4261-a945-ca124c52b490)

after:
![image](https://github.com/discourse/discourse/assets/41134017/e9b81633-ecad-4e28-9f5c-be60aab4623e)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
