### PR TITLE
UX: user page copy change responses -> replies

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -21,7 +21,7 @@
       class="user-nav__notifications-responses"
     >
       {{d-icon "reply"}}
-      <span>{{i18n "user_action_groups.6"}}</span>
+      <span>{{i18n "user_action_groups.5"}}</span>
     </DNavigationItem>
 
     <DNavigationItem


### PR DESCRIPTION
Changing the copy to `replies` to be consistent with other places.
