### PR TITLE
A11Y: improve topic entrance aria-label, title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-entrance.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-entrance.hbs
@@ -1,6 +1,9 @@
 <DButton
   @action={{action "enterTop"}}
-  @translatedAriaLabel={{this.ariaLabel "top"}}
+  @translatedAriaLabel={{i18n
+    "topic_entrance.sr_jump_top_button"
+    date=this.topDate
+  }}
   title={{i18n "topic_entrance.jump_top_button_title"}}
   class="btn-default full jump-top"
 >
@@ -10,7 +13,10 @@
 
 <DButton
   @action={{action "enterBottom"}}
-  @translatedAriaLabel={{this.ariaLabel "bottom"}}
+  @translatedAriaLabel={{i18n
+    "topic_entrance.sr_jump_bottom_button"
+    date=this.bottomDate
+  }}
   title={{i18n "topic_entrance.jump_bottom_button_title"}}
   class="btn-default full jump-bottom"
 >

--- a/app/assets/javascripts/discourse/app/components/topic-entrance.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-entrance.hbs
@@ -1,6 +1,7 @@
 <DButton
   @action={{action "enterTop"}}
-  @ariaLabel="topic_entrance.sr_jump_top_button"
+  @translatedAriaLabel={{this.ariaLabel "top"}}
+  title={{i18n "topic_entrance.jump_top_button_title"}}
   class="btn-default full jump-top"
 >
   {{d-icon "step-backward"}}
@@ -9,7 +10,8 @@
 
 <DButton
   @action={{action "enterBottom"}}
-  @ariaLabel="topic_entrance.sr_jump_bottom_button"
+  @translatedAriaLabel={{this.ariaLabel "bottom"}}
+  title={{i18n "topic_entrance.jump_bottom_button_title"}}
   class="btn-default full jump-bottom"
 >
   {{html-safe this.bottomDate}}

--- a/app/assets/javascripts/discourse/app/components/topic-entrance.js
+++ b/app/assets/javascripts/discourse/app/components/topic-entrance.js
@@ -98,6 +98,15 @@ export default Component.extend(CleansUp, {
     }
   },
 
+  @bind
+  ariaLabel(position) {
+    return position === "top"
+      ? I18n.t("topic_entrance.sr_jump_top_button", { date: this.topDate })
+      : I18n.t("topic_entrance.sr_jump_bottom_button", {
+          date: this.bottomDate,
+        });
+  },
+
   _jumpTopButton() {
     return this.element.querySelector(".jump-top");
   },

--- a/app/assets/javascripts/discourse/app/components/topic-entrance.js
+++ b/app/assets/javascripts/discourse/app/components/topic-entrance.js
@@ -98,15 +98,6 @@ export default Component.extend(CleansUp, {
     }
   },
 
-  @bind
-  ariaLabel(position) {
-    return position === "top"
-      ? I18n.t("topic_entrance.sr_jump_top_button", { date: this.topDate })
-      : I18n.t("topic_entrance.sr_jump_bottom_button", {
-          date: this.bottomDate,
-        });
-  },
-
   _jumpTopButton() {
     return this.element.querySelector(".jump-top");
   },

--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-entrance.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-entrance.gjs
@@ -6,6 +6,8 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DiscourseURL from "discourse/lib/url";
 import icon from "discourse-common/helpers/d-icon";
+import i18n from "discourse-common/helpers/i18n";
+import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
@@ -58,6 +60,15 @@ export default class TopicEntrance extends Component {
     return entranceDate(this.bumpedDate, this.showTime);
   }
 
+  @bind
+  ariaLabel(position) {
+    return position === "top"
+      ? I18n.t("topic_entrance.sr_jump_top_button", { date: this.topDate })
+      : I18n.t("topic_entrance.sr_jump_bottom_button", {
+          date: this.bottomDate,
+        });
+  }
+
   @action
   jumpTo(destination) {
     this.historyStore.set("lastTopicIdViewed", this.args.topic.id);
@@ -79,7 +90,8 @@ export default class TopicEntrance extends Component {
         <div id="topic-entrance" class="--glimmer">
           <button
             {{on "click" (fn this.jumpTo @topic.url)}}
-            aria-label="topic_entrance.sr_jump_top_button"
+            aria-label={{this.ariaLabel "top"}}
+            title={{i18n "topic_entrance.jump_top_button_title"}}
             class="btn btn-default full jump-top"
           >
             {{icon "step-backward"}}
@@ -88,7 +100,8 @@ export default class TopicEntrance extends Component {
 
           <button
             {{on "click" (fn this.jumpTo @topic.lastPostUrl)}}
-            aria-label="topic_entrance.sr_jump_bottom_button"
+            aria-label={{this.ariaLabel "bottom"}}
+            title={{i18n "topic_entrance.jump_bottom_button_title"}}
             class="btn btn-default full jump-bottom"
           >
             {{htmlSafe this.bottomDate}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-entrance.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-entrance.gjs
@@ -7,7 +7,6 @@ import { htmlSafe } from "@ember/template";
 import DiscourseURL from "discourse/lib/url";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
-import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
@@ -60,15 +59,6 @@ export default class TopicEntrance extends Component {
     return entranceDate(this.bumpedDate, this.showTime);
   }
 
-  @bind
-  ariaLabel(position) {
-    return position === "top"
-      ? I18n.t("topic_entrance.sr_jump_top_button", { date: this.topDate })
-      : I18n.t("topic_entrance.sr_jump_bottom_button", {
-          date: this.bottomDate,
-        });
-  }
-
   @action
   jumpTo(destination) {
     this.historyStore.set("lastTopicIdViewed", this.args.topic.id);
@@ -90,7 +80,10 @@ export default class TopicEntrance extends Component {
         <div id="topic-entrance" class="--glimmer">
           <button
             {{on "click" (fn this.jumpTo @topic.url)}}
-            aria-label={{this.ariaLabel "top"}}
+            aria-label={{i18n
+              "topic_entrance.sr_jump_top_button"
+              date=this.topDate
+            }}
             title={{i18n "topic_entrance.jump_top_button_title"}}
             class="btn btn-default full jump-top"
           >
@@ -100,7 +93,10 @@ export default class TopicEntrance extends Component {
 
           <button
             {{on "click" (fn this.jumpTo @topic.lastPostUrl)}}
-            aria-label={{this.ariaLabel "bottom"}}
+            aria-label={{i18n
+              "topic_entrance.sr_jump_bottom_button"
+              date=this.bottomDate
+            }}
             title={{i18n "topic_entrance.jump_bottom_button_title"}}
             class="btn btn-default full jump-bottom"
           >

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -74,7 +74,7 @@
       <a
         class="start-date"
         onClick={{this.updatePercentage}}
-        title={{i18n "topic_entrance.sr_jump_top_button"}}
+        title={{i18n "topic_entrance.jump_top_button_title"}}
       >
         <span>
           {{this.startDate}}

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -193,7 +193,7 @@ export default class TopicTimelineScrollArea extends Component {
 
   get nowDateOptions() {
     return {
-      customTitle: I18n.t("topic_entrance.sr_jump_bottom_button"),
+      customTitle: I18n.t("topic_entrance.jump_bottom_button_title"),
       addAgo: true,
       defaultFormat: timelineDate,
     };

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4645,8 +4645,10 @@ en:
     no_group_messages_title: "No group messages found"
 
     topic_entrance:
-      sr_jump_top_button: "Jump to the first post"
-      sr_jump_bottom_button: "Jump to the last post"
+      sr_jump_top_button: "Jump to the first post - %{date}"
+      sr_jump_bottom_button: "Jump to the last post - %{date}"
+      jump_top_button_title: "Jump to the first post"
+      jump_bottom_button_title: "Jump to the last post"
     fullscreen_table:
       expand_btn: "Expand Table"
       view_table: "View Table"


### PR DESCRIPTION
For the topic entrance menu, when clicking reply counts on topic lists

![image](https://github.com/discourse/discourse/assets/1681963/04e9fe14-a42d-42b2-8d01-6ced106a4d60)


* includes date in aria-label
* includes title that says "jump to first/last post"

This makes the information consistent between both experiences, previously the date was omitted from the aria-label (which only said "jump to first/last post") and the title describing the functionality wasn't present in the menu itself (just the visible dates)