### PR TITLE
A11Y: usercard resizing for high zoom levels

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -1,5 +1,13 @@
 @use "sass:math";
 
+.fk-d-menu[data-identifier="card"] {
+  max-width: calc(100vw - 2em);
+  width: auto;
+  .fk-d-menu__inner-content {
+    min-width: 0;
+  }
+}
+
 .user-card {
   --card-width: 39em;
   --avatar-width: 8em;

--- a/app/assets/stylesheets/desktop/components/user-card.scss
+++ b/app/assets/stylesheets/desktop/components/user-card.scss
@@ -24,6 +24,33 @@
   h3 {
     font-size: var(--font-0);
   }
+
+  @include breakpoint("mobile-extra-large") {
+    // important for keeping the usercard uncropped
+    // at 200% - 400% zoom levels
+    --avatar-width: 4em;
+    --avatar-margin: 0;
+    .names h1 {
+      font-size: var(--font-up-2);
+    }
+    .first-row {
+      gap: 0.5em 0;
+      flex-wrap: wrap;
+      .usercard-controls {
+        max-width: unset;
+        width: 100%;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0 0.5em;
+      }
+      li {
+        flex: 1 1 0;
+        &:empty {
+          display: none;
+        }
+      }
+    }
+  }
 }
 
 // styles for user cards only

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -1,9 +1,5 @@
 .fk-d-menu[data-identifier="card"] {
   z-index: z("usercard");
-  max-width: calc(100vw - 2em);
-  .fk-d-menu__inner-content {
-    min-width: 0;
-  }
 }
 
 .full-page-chat {


### PR DESCRIPTION
This allows usercards to function at high zoom levels without cropping 


Before:
![image](https://github.com/discourse/discourse/assets/1681963/a57f649b-3dd8-450d-ba9b-d7eb0b9b4df9)


After:
![image](https://github.com/discourse/discourse/assets/1681963/f7671ac1-93ea-496d-aff1-47421e73d96c)
