### PR TITLE
A11Y: improve notification panel layout for high zoom levels

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -56,6 +56,10 @@ export default class GlimmerSiteHeader extends Component {
     return !this.sidebarEnabled || this.site.narrowDesktopView;
   }
 
+  get slideInMode() {
+    return this.site.mobileView || this.site.narrowDesktopView;
+  }
+
   get leftMenuClass() {
     if (isDocumentRTL()) {
       return "user-menu";
@@ -182,14 +186,11 @@ export default class GlimmerSiteHeader extends Component {
     const menuPanels = document.querySelectorAll(".menu-panel");
 
     if (menuPanels.length === 0) {
-      this._animate = this.site.mobileView || this.site.narrowDesktopView;
+      this._animate = this.slideInMode;
       return;
     }
 
-    let viewMode =
-      this.site.mobileView || this.site.narrowDesktopView
-        ? "slide-in"
-        : "drop-down";
+    let viewMode = this.slideInMode ? "slide-in" : "drop-down";
 
     menuPanels.forEach((panel) => {
       if (menuPanelContainsClass(panel)) {
@@ -208,7 +209,7 @@ export default class GlimmerSiteHeader extends Component {
         let finalPosition = PANEL_WIDTH;
         this._swipeMenuOrigin = "right";
         if (
-          (this.site.mobileView || this.site.narrowDesktopView) &&
+          this.slideInMode &&
           panel.parentElement.classList.contains(this.leftMenuClass)
         ) {
           this._swipeMenuOrigin = "left";
@@ -418,7 +419,7 @@ export default class GlimmerSiteHeader extends Component {
   <template>
     <div
       class={{concatClass
-        (if this.site.desktopView "drop-down-mode")
+        (unless this.slideInMode "drop-down-mode")
         "d-header-wrap"
       }}
       {{didInsert this.setupHeader}}

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -126,9 +126,14 @@
 
     .btn {
       display: flex;
-      padding: 0.857em;
       position: relative;
-      border-radius: 0px;
+      border-radius: 0;
+      padding: 0.857em;
+      @media screen and (max-height: 400px) {
+        // helps with 400% zoom level
+        font-size: var(--font-down-1);
+        padding: 0.5em 0.875em;
+      }
 
       .d-icon {
         color: var(--primary-medium);
@@ -140,6 +145,11 @@
         right: 6px;
         top: 6px;
         font-size: var(--font-down-3);
+        @media screen and (max-height: 400px) {
+          // helps with 400% zoom level
+          right: 0;
+          top: 0;
+        }
       }
 
       &.active {

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -3,8 +3,11 @@
     width: unset;
   }
 
-  .panel-body {
-    max-height: calc(100vh - 100px);
+  &.drop-down {
+    .panel-body {
+      max-height: calc(100vh - var(--header-offset));
+      max-width: calc(100vw - 2em);
+    }
   }
 }
 


### PR DESCRIPTION
Made some adjustments for both drop-down and slide-in modes, as you can remain in drop-down mode if you open the panel and then zoom (slide-in mode activates when you zoom first, then open the panel) 


before

![image](https://github.com/discourse/discourse/assets/1681963/968ae418-1444-4b8a-84be-2456ed36b42f)

after

![image](https://github.com/discourse/discourse/assets/1681963/4ab52cbb-80de-4b55-904d-9e5a32743409)


before

![image](https://github.com/discourse/discourse/assets/1681963/acb18dfe-4837-4192-8aeb-1a3386d53583)


after

![image](https://github.com/discourse/discourse/assets/1681963/a89ba1ae-84e9-49ef-8621-2367f7df6197)

