### PR TITLE
FIX: Include permissions in the tag serializer

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -243,6 +243,18 @@ class Tag < ActiveRecord::Base
     end
   end
 
+  def all_category_ids
+    @all_category_ids ||=
+      categories.pluck(:id) +
+        tag_groups.includes(:categories).map { |tg| tg.categories.map(&:id) }.flatten
+  end
+
+  def all_categories(guardian)
+    categories = Category.secured(guardian).where(id: all_category_ids)
+    Category.preload_user_fields!(guardian, categories)
+    categories
+  end
+
   %i[tag_created tag_updated tag_destroyed].each do |event|
     define_method("trigger_#{event}_event") do
       DiscourseEvent.trigger(event, self)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -246,7 +246,7 @@ class Tag < ActiveRecord::Base
   def all_category_ids
     @all_category_ids ||=
       categories.pluck(:id) +
-        tag_groups.includes(:categories).map { |tg| tg.categories.map(&:id) }.flatten
+        tag_groups.includes(:categories).flat_map { |tg| tg.categories.map(&:id) }
   end
 
   def all_categories(guardian)

--- a/app/serializers/detailed_tag_serializer.rb
+++ b/app/serializers/detailed_tag_serializer.rb
@@ -10,11 +10,11 @@ class DetailedTagSerializer < TagSerializer
   end
 
   def categories
-    Category.secured(scope).where(id: category_ids)
+    object.all_categories(scope)
   end
 
   def category_restricted
-    !category_ids.empty?
+    !object.all_category_ids.empty?
   end
 
   def include_tag_group_names?
@@ -23,13 +23,5 @@ class DetailedTagSerializer < TagSerializer
 
   def tag_group_names
     object.tag_groups.map(&:name)
-  end
-
-  private
-
-  def category_ids
-    @_category_ids ||=
-      object.categories.pluck(:id) +
-        object.tag_groups.includes(:categories).map { |tg| tg.categories.map(&:id) }.flatten
   end
 end

--- a/app/serializers/detailed_tag_serializer.rb
+++ b/app/serializers/detailed_tag_serializer.rb
@@ -14,7 +14,7 @@ class DetailedTagSerializer < TagSerializer
   end
 
   def category_restricted
-    !object.all_category_ids.empty?
+    object.all_category_ids.present?
   end
 
   def include_tag_group_names?


### PR DESCRIPTION
The 'permissions' field is used by the composer and the category chooser to render the category.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
