### PR TITLE
DEV: Include post and topic attributes in imported quotes

### DIFF
--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -859,13 +859,22 @@ class BulkImport::Generic < BulkImport::Base
           name = user_full_name_from_id(user_id)
         end
 
+        if quote["post_id"]
+          topic_id = topic_id_from_imported_post_id(quote["post_id"])
+          post_number = post_number_from_imported_id(quote["post_id"])
+        end
+
         bbcode =
-          if username.present? && name.present?
-            %Q|[quote="#{name}, username:#{username}"]|
-          elsif username.present?
-            %Q|[quote="#{username}"]|
-          else
+          if username.blank? && name.blank?
             "[quote]"
+          else
+            bbcode_parts = []
+            bbcode_parts << name.presence || username
+            bbcode_parts << "post:#{post_number}" if post_number.present?
+            bbcode_parts << "topic:#{topic_id}" if topic_id.present?
+            bbcode_parts << "username:#{username}" if username.present? && name.present?
+
+            %Q|[quote="#{bbcode_parts.join(", ")}"]|
           end
 
         raw.gsub!(quote["placeholder"], bbcode)


### PR DESCRIPTION
Currently, quotes imported via generic bulk import script do not include references to the quoted post. This change includes both topic and post attributes in a quote BBCode if the placeholder metadata includes a `post_id`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
