### PR TITLE
UX: Wrap text in span

### DIFF
--- a/app/assets/javascripts/discourse/app/components/desktop-notification-config.gjs
+++ b/app/assets/javascripts/discourse/app/components/desktop-notification-config.gjs
@@ -23,7 +23,9 @@ export default class DesktopNotificationsConfig extends Component {
           @disabled="true"
           class="btn-default"
         />
-        {{i18n "user.desktop_notifications.perm_denied_expl"}}
+        <span>
+          {{i18n "user.desktop_notifications.perm_denied_expl"}}
+        </span>
       {{else}}
         {{#if this.desktopNotifications.isSubscribed}}
           <DButton


### PR DESCRIPTION
This localization string is missing a wrapping `span` for cleaner styling. Text should not be unwrapped if siblings exist within the same parent, in this case `DButton`.