### PR TITLE
FIX: Office365/Outlook auth method for group SMTP

### DIFF
--- a/spec/services/email_settings_validator_spec.rb
+++ b/spec/services/email_settings_validator_spec.rb
@@ -275,6 +275,52 @@ RSpec.describe EmailSettingsValidator do
       }.to raise_error(ArgumentError)
     end
 
+    it "corrects tls settings for gmail based on port 587" do
+      net_smtp_stub.expects(:enable_starttls_auto).once
+      net_smtp_stub.expects(:enable_tls).never
+      described_class.validate_smtp(
+        host: host,
+        port: 587,
+        username: username,
+        password: password,
+        domain: domain,
+      )
+    end
+
+    it "corrects tls settings for gmail based on port 465" do
+      net_smtp_stub.expects(:enable_starttls_auto).never
+      net_smtp_stub.expects(:enable_tls).once
+      described_class.validate_smtp(
+        host: host,
+        port: 465,
+        username: username,
+        password: password,
+        domain: domain,
+      )
+    end
+
+    it "corrects authentication method to login for office365" do
+      net_smtp_stub.expects(:start).with("office365.com", username, password, :login)
+      described_class.validate_smtp(
+        host: "smtp.office365.com",
+        port: port,
+        username: username,
+        password: password,
+        domain: "office365.com",
+      )
+    end
+
+    it "corrects authentication method to login for outlook" do
+      net_smtp_stub.expects(:start).with("outlook.com", username, password, :login)
+      described_class.validate_smtp(
+        host: "smtp-mail.outlook.com",
+        port: port,
+        username: username,
+        password: password,
+        domain: "outlook.com",
+      )
+    end
+
     context "when the domain is not provided" do
       let(:domain) { nil }
       it "gets the domain from the host" do


### PR DESCRIPTION
Both office365 and outlook SMTP servers need LOGIN
SMTP authentication instead of PLAIN (which is what
we are using by default). This commit uses that
unconditionally for these servers, and also makes
sure to use STARTTLS for them too.

Also extends the `read_timeout` for testing SMTP
email settings, since some servers (like outlook) add
artificial error delays.
