### PR TITLE
DEV: migrates empty-state to gjs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/empty-state.gjs
+++ b/app/assets/javascripts/discourse/app/components/empty-state.gjs
@@ -1,0 +1,12 @@
+const EmptyState = <template>
+  <div class="empty-state-container">
+    <div class="empty-state">
+      <span data-test-title class="empty-state-title">{{@title}}</span>
+      <div class="empty-state-body">
+        <p data-test-body>{{@body}}</p>
+      </div>
+    </div>
+  </div>
+</template>;
+
+export default EmptyState;

--- a/app/assets/javascripts/discourse/app/components/empty-state.hbs
+++ b/app/assets/javascripts/discourse/app/components/empty-state.hbs
@@ -1,8 +1,0 @@
-<div class="empty-state-container">
-  <div class="empty-state">
-    <span data-test-title class="empty-state-title">{{@title}}</span>
-    <div class="empty-state-body">
-      <p data-test-body>{{@body}}</p>
-    </div>
-  </div>
-</div>

--- a/app/assets/javascripts/discourse/app/components/empty-state.js
+++ b/app/assets/javascripts/discourse/app/components/empty-state.js
@@ -1,3 +1,0 @@
-import Component from "@ember/component";
-
-export default Component.extend({});


### PR DESCRIPTION
Technically there was a wrapping div here, but that shouldn't be necessary.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
