### PR TITLE
DEV: Drop unused column `translation_overrides.compiled_js`

### DIFF
--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class TranslationOverride < ActiveRecord::Base
+  # TODO: Remove once
+  # 20240711123755_drop_compiled_js_from_translation_overrides has been
+  # promoted to pre-deploy
+  self.ignored_columns = %w[compiled_js]
+
   # Allowlist i18n interpolation keys that can be included when customizing translations
   ALLOWED_CUSTOM_INTERPOLATION_KEYS = {
     %w[
@@ -197,7 +202,6 @@ end
 #  value                :string           not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  compiled_js          :text
 #  original_translation :text
 #  status               :integer          default("up_to_date"), not null
 #

--- a/db/post_migrate/20240711123755_drop_compiled_js_from_translation_overrides.rb
+++ b/db/post_migrate/20240711123755_drop_compiled_js_from_translation_overrides.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropCompiledJsFromTranslationOverrides < ActiveRecord::Migration[7.1]
+  DROPPED_COLUMNS ||= { translation_overrides: %i[compiled_js] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
