### PR TITLE
UX: fix top-list spacing on user summary

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -475,6 +475,20 @@
     color: var(--primary-medium);
   }
 
+  .user-info .user-detail {
+    width: 100%;
+    .name-line {
+      .username {
+        width: auto;
+        overflow-wrap: anywhere;
+        flex: 1 0 auto;
+      }
+      > a {
+        flex-wrap: nowrap;
+      }
+    }
+  }
+
   @media all and (max-width: 600px) {
     float: none;
     width: 100%;


### PR DESCRIPTION
Fixes minor issue caused by https://github.com/discourse/discourse/pull/25576

Before:
![image](https://github.com/user-attachments/assets/a8c95c1f-c4f1-432a-80a1-2d09f6d9a268)


After:
![image](https://github.com/user-attachments/assets/c859ffaa-070c-4b47-83b1-5404c442179c)
