### PR TITLE
FIX: Integer settings wrongly showing overridden from default

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/integer.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/integer.gjs
@@ -13,7 +13,10 @@ export default class SiteSettingsInteger extends Component {
       return;
     }
 
-    this.args.changeValueCallback(num);
+    // Settings are stored as strings, this way the main site setting component
+    // doesn't get confused and think the value has changed from default if the
+    // admin sets it to the same number as the default.
+    this.args.changeValueCallback(num.toString());
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
@@ -101,4 +101,20 @@ module("Integration | Component | site-setting", function (hooks) {
     await typeIn(".input-setting-integer", "90,5", { delay: 1000 });
     assert.dom(".input-setting-integer").hasValue("905");
   });
+
+  test("does not consider an integer setting overridden if the value is the same as the default", async function (assert) {
+    this.set("setting", {
+      setting: "suggested_topics_unread_max_days_old",
+      value: "99",
+      default: "99",
+      type: "integer",
+    });
+    await render(hbs`<SiteSetting @setting={{this.setting}} />`);
+    await fillIn(".input-setting-integer", "90");
+    assert.dom(".input-setting-integer").hasValue("90");
+    await fillIn(".input-setting-integer", "99");
+    assert
+      .dom("[data-setting='suggested_topics_unread_max_days_old']")
+      .hasNoClass("overridden");
+  });
 });


### PR DESCRIPTION
Followup db993cf8fd6b24b967509bbd4b35014e0b6e3749

Since in the above commit we converted integer site settings
to actual integers then set that as the new `buffered.value`,
the overridden indicator technically thinks the value has changed,
even if the user sets it back to the default:

```
overridden: propertyNotEqual("setting.default", "buffered.value"),
```

We can fix this by converting the parsed integer back to a string
before setting the buffered setting value.
