### PR TITLE
DEV: Improve safari-class-fields-bugfix transform

### DIFF
--- a/app/assets/javascripts/discourse/lib/babel-plugin-safari-class-fields-bugfix.js
+++ b/app/assets/javascripts/discourse/lib/babel-plugin-safari-class-fields-bugfix.js
@@ -1,19 +1,79 @@
 function wrapInitializer(path, babel) {
+  function needsWrapping(node) {
+    if (t.isLiteral(node) && !t.isTemplateLiteral(node)) {
+      return false;
+    }
+
+    if (
+      t.isCallExpression(node) ||
+      t.isOptionalCallExpression(node) ||
+      t.isNewExpression(node)
+    ) {
+      return needsWrapping(node.callee) || node.arguments.some(needsWrapping);
+    }
+
+    if (t.isTemplateLiteral(node)) {
+      return node.expressions.some(needsWrapping);
+    }
+
+    if (t.isTaggedTemplateExpression(node)) {
+      return needsWrapping(node.tag) || needsWrapping(node.quasi);
+    }
+
+    if (t.isArrayExpression(node)) {
+      return node.elements.some(needsWrapping);
+    }
+
+    if (t.isObjectExpression(node)) {
+      return node.properties.some((prop) => {
+        if (t.isObjectProperty(prop)) {
+          return (
+            needsWrapping(prop.value) ||
+            (prop.computed && needsWrapping(prop.key))
+          );
+        }
+        if (t.isObjectMethod(prop)) {
+          return false;
+        }
+        return false;
+      });
+    }
+
+    if (t.isMemberExpression(node) || t.isOptionalMemberExpression(node)) {
+      return (
+        needsWrapping(node.object) ||
+        (node.computed && needsWrapping(node.property))
+      );
+    }
+
+    if (
+      t.isFunctionExpression(node) ||
+      t.isArrowFunctionExpression(node) ||
+      t.isClassExpression(node)
+    ) {
+      return false;
+    }
+
+    if (t.isThisExpression(node)) {
+      return false;
+    }
+
+    if (t.isSequenceExpression(node)) {
+      return node.expressions.some(needsWrapping);
+    }
+
+    // Is an identifier, or anything else not covered above
+    return true;
+  }
+
   const { types: t } = babel;
   const { value } = path.node;
 
-  // Check if the node has already been transformed
-  if (path.node.__wrapped) {
-    return;
-  }
-
-  if (value && !(t.isLiteral(value) && !t.isTemplateLiteral(value))) {
+  if (value && needsWrapping(value)) {
     path.node.value = t.callExpression(
       t.arrowFunctionExpression([], value),
       []
     );
-    // Mark the node as transformed
-    path.node.__wrapped = true;
   }
 }
 


### PR DESCRIPTION
This tightens things up to reduce the number of initializers which need to be wrapped in an IIFE.

Mirrors the changes made in https://github.com/babel/babel/pull/16569

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
