### PR TITLE
FIX: Exclude reply count on posts due to required Comment nesting

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -108,11 +108,6 @@
               <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
             </div>
 
-            <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-                <meta itemprop="interactionType" content="http://schema.org/CommentAction"/>
-                <meta itemprop="userInteractionCount" content="<%= post.reply_count %>" />
-              </div>
-
               <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].filter { |l| l[:reflection] }.length > 0 %>
                 <div class='crawler-linkback-list' itemscope itemtype='http://schema.org/ItemList'>
                   <% @topic_view.link_counts[post.id].each_with_index do |link, i| %>


### PR DESCRIPTION
We're seeing a new glaring error on Google Search Console where we are getting warned the following:

<img width="450" alt="Screenshot 2024-07-12 at 7 55 16 PM" src="https://github.com/user-attachments/assets/0a015233-37fd-4394-8e1e-7a430ed74c4a">


The reason for this is because we report post replies as a "CommentAction". In a recent change by Google Search Console, they've required that we nest another "Comment" (post) in each post that has >1 "CommentActions" (reply). 

<img width="450" alt="image" src="https://github.com/user-attachments/assets/f78ef788-8b90-4613-800f-280c711a3ee9">

"Replies" in non-crawler view makes a request when clicked to get all replies, however this does not make sense in the crawler view where we load everything per post number. 

So the solution here is to exclude the reply number so we can avoid having to nest all replies in a post.

Meta: https://meta.discourse.org/t/missing-comment-field-in-comment/313624