### PR TITLE
FEATURE: enable chat with dms only

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-footer.gjs
@@ -45,21 +45,22 @@ export default class ChatFooter extends Component {
   <template>
     {{#if this.shouldRenderFooter}}
       <nav class="c-footer">
-        <DButton
-          @route="chat.channels"
-          @icon="comments"
-          @translatedLabel={{i18n "chat.channel_list.title"}}
-          aria-label={{i18n "chat.channel_list.aria_label"}}
-          id="c-footer-channels"
-          class={{concatClass
-            "btn-transparent"
-            "c-footer__item"
-            (if (eq this.currentRouteName "chat.channels") "--active")
-          }}
-        >
-          <UnreadChannelsIndicator />
-        </DButton>
-
+        {{#if this.siteSettings.chat_public_channels_enabled}}
+          <DButton
+            @route="chat.channels"
+            @icon="comments"
+            @translatedLabel={{i18n "chat.channel_list.title"}}
+            aria-label={{i18n "chat.channel_list.aria_label"}}
+            id="c-footer-channels"
+            class={{concatClass
+              "btn-transparent"
+              "c-footer__item"
+              (if (eq this.currentRouteName "chat.channels") "--active")
+            }}
+          >
+            <UnreadChannelsIndicator />
+          </DButton>
+        {{/if}}
         {{#if this.directMessagesEnabled}}
           <DButton
             @route="chat.direct-messages"

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
@@ -48,7 +48,7 @@ export default class ChatIndexRoute extends DiscourseRoute {
 
     // We are on desktop. Check for last visited channel and transition if so
     const id = this.currentUser.custom_fields.last_chat_channel_id;
-    if (id) {
+    if (id /** && this.siteSettings.chat_public_channels_enabled **/) {
       return this.chatChannelsManager.find(id).then((c) => {
         return this.router.replaceWith("chat.channel", ...c.routeModels);
       });


### PR DESCRIPTION
When `enable public channels` is disabled, we will hide those channel references. 

## TODO

- [ ] decide how it should behave in desktop.
- [ ] decide how it should behave in desktop mobile chat