### PR TITLE
FIX: Don't let table-build automatically fill empty headers with default values

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -28,11 +28,13 @@ export default class SpreadsheetEditor extends Component {
   defaultColWidth = 150;
   isEditingTable = !!this.args.model.tableTokens;
   alignments = null;
+  notitle = null;
 
   constructor() {
     super(...arguments);
     this.loadJspreadsheet();
     KeyboardShortcuts.pause();
+    this.notitle = {};
   }
 
   willDestroy() {
@@ -90,7 +92,12 @@ export default class SpreadsheetEditor extends Component {
 
   @action
   insertTable() {
-    const updatedHeaders = this.spreadsheet.getHeaders().split(","); // keys
+    const updatedHeaders = this.spreadsheet
+      .getHeaders()
+      .split(",")
+      .map((content, index) => {
+        return this.notitle[String(index)] ? "" : content;
+      }); // keys
     const updatedData = this.spreadsheet.getData(); // values
     const markdownTable = this.buildTableMarkdown(updatedHeaders, updatedData);
 
@@ -221,7 +228,10 @@ export default class SpreadsheetEditor extends Component {
       }
     });
 
-    headings.forEach((h, i) => (h.align = this.alignments?.[i] ?? "left"));
+    headings.forEach((h, i) => {
+      h.align = this.alignments?.[i] ?? "left";
+      this.notitle[String(i)] = !h.title;
+    });
 
     return this.buildSpreadsheet(rows, headings);
   }
@@ -241,6 +251,9 @@ export default class SpreadsheetEditor extends Component {
       csvFileName: exportFileName,
       text: this.localeMapping(),
       ...opts,
+      onchangeheader: (_, i) => {
+        this.notitle[i] = false;
+      },
     });
   }
 

--- a/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -28,13 +28,11 @@ export default class SpreadsheetEditor extends Component {
   defaultColWidth = 150;
   isEditingTable = !!this.args.model.tableTokens;
   alignments = null;
-  notitle = null;
 
   constructor() {
     super(...arguments);
     this.loadJspreadsheet();
     KeyboardShortcuts.pause();
-    this.notitle = {};
   }
 
   willDestroy() {
@@ -95,9 +93,7 @@ export default class SpreadsheetEditor extends Component {
     const updatedHeaders = this.spreadsheet
       .getHeaders()
       .split(",")
-      .map((content, index) => {
-        return this.notitle[String(index)] ? "" : content;
-      }); // keys
+      .map((c) => c.trim()); // keys
     const updatedData = this.spreadsheet.getData(); // values
     const markdownTable = this.buildTableMarkdown(updatedHeaders, updatedData);
 
@@ -212,7 +208,7 @@ export default class SpreadsheetEditor extends Component {
         // headings
         headings = this.extractTableContent(row).map((heading) => {
           return {
-            title: heading,
+            title: heading || " ",
             width: Math.max(
               heading.length * rowWidthFactor,
               this.defaultColWidth
@@ -230,7 +226,6 @@ export default class SpreadsheetEditor extends Component {
 
     headings.forEach((h, i) => {
       h.align = this.alignments?.[i] ?? "left";
-      this.notitle[String(i)] = !h.title;
     });
 
     return this.buildSpreadsheet(rows, headings);

--- a/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -246,9 +246,6 @@ export default class SpreadsheetEditor extends Component {
       csvFileName: exportFileName,
       text: this.localeMapping(),
       ...opts,
-      onchangeheader: (_, i) => {
-        this.notitle[i] = false;
-      },
     });
   }
 

--- a/spec/system/table_builder_spec.rb
+++ b/spec/system/table_builder_spec.rb
@@ -5,12 +5,19 @@ describe "Table Builder", type: :system do
   let(:composer) { PageObjects::Components::Composer.new }
   let(:insert_table_modal) { PageObjects::Modals::InsertTable.new }
   fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:topic2) { Fabricate(:topic, user: user) }
   fab!(:post1) { create_post(user: user, topic: topic, raw: <<~RAW) }
         |Make   | Model   | Year|
         |--- | --- | ---|
         |Toyota | Supra   | 1998|
         |Nissan | Skyline | 1999|
         |Honda  | S2000  | 2001|
+        RAW
+  fab!(:post2) { create_post(user: user, topic: topic2, raw: <<~RAW) }
+        | |  | |
+        |--- | --- | ---|
+        |Some | content | here|
+        |1 | 2 | 3|
         RAW
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
@@ -105,6 +112,25 @@ describe "Table Builder", type: :system do
 
       try_until_success do
         expect(normalize_value(post1.reload.raw)).to eq(normalize_value(updated_post))
+      end
+    end
+
+    it "should respect the original empty header" do
+      topic_page.visit_topic(topic2)
+      topic_page.find(".btn-edit-table", visible: :all).click
+      expect(page).to have_selector(".insert-table-modal")
+      insert_table_modal.type_in_cell(0, 0, " updated")
+      insert_table_modal.click_insert_table
+
+      updated_post = <<~RAW
+      | |  | |
+      |--- | --- | ---|
+      |Some updated | content | here|
+      |1 | 2 | 3|
+      RAW
+
+      try_until_success do
+        expect(normalize_value(post2.reload.raw)).to eq(normalize_value(updated_post))
       end
     end
 


### PR DESCRIPTION
The old table builder would fill empty headers with default values A~Z when editing. This commit makes table-builder respect the old empty headers.

This is due to a behavior of jspreadsheet that cannot be turned off (see https://bossanova.uk/jspreadsheet/v4/docs/getting-started#Header-titles ). We have to pass in a value that cannot be implicitly converted to false in the JavaScript sense. In this case, we pass in a space, which is the same as the empty string in the visual sense.

before: 

The table-builder will fill the empty header with the default values ​​of A~Z and save it.

after:

Allows an empty header (strictly speaking, it is a space `" "`)

![image](https://github.com/user-attachments/assets/7b9d72ce-92a4-4959-ac09-2d164d45a80d)


related meta topic: https://meta.discourse.org/t/editing-a-table-with-empty-headers-fills-them-in-with-the-default-text-column-a-column-b/268472

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
