### PR TITLE
FIX: Allow all caps within CJK text

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -75,10 +75,13 @@ class TextSentinel
   end
 
   def seems_quiet?
-    return true if skipped_locale.include?(SiteSetting.default_locale)
     # We don't allow all upper case content
-    SiteSetting.allow_uppercase_posts || @text == @text.mb_chars.downcase.to_s ||
-      @text != @text.mb_chars.upcase.to_s
+    # It's not all upper case if
+    #  a) it has a single lower case letter, or,
+    #  b) it has a letter or ideograph character without an uppercase variant (CJK)
+    #  c) has no letters at all
+    SiteSetting.allow_uppercase_posts || @text.match?(/\p{Lowercase_Letter}/) ||
+      @text.match?(/\p{Other_Letter}/) || !@text.match?(/\p{Letter}/)
   end
 
   private

--- a/spec/lib/text_sentinel_spec.rb
+++ b/spec/lib/text_sentinel_spec.rb
@@ -108,8 +108,7 @@ RSpec.describe TextSentinel do
       expect(TextSentinel.new("去年十二月，北韓不顧國際社會警告")).to be_valid
     end
 
-    it "skips uppercase text for CJK locale" do
-      SiteSetting.default_locale = "zh_CN"
+    it "allows all caps if within CJK text" do
       expect(TextSentinel.new("去年SHIER月，北韓不顧國際社會警告")).to be_valid
     end
 


### PR DESCRIPTION
Currently the all caps check in text is skipped if the forum instance uses a CJK language as the default locale, as there's no upper/lower case variants in CJK characters like in the latin script.

However, in forum instances with English (or any other non-CJK) as their default locale, the all caps check will run normally and fail for CJK text that has upper case latin letters within it. For example, the following text currently doesn't pass the all caps check because of the acronym in it, even though the text is not all caps:

```
它可以是任意長且複雜的，包含字母和 0-9 數字。但是，如果其中包含諸如 ETA 之類的首字母縮略詞，即使文本本身並非全部大寫，也會失敗。
``` 

This currently returns the confusing error `An error occurred: Body seems unclear, is it a complete sentence?` and the only workaround is to disable the all caps check for the whole forum.

By using a different approach, there's no need to skip the all caps check on forums with a CJK locale (as they may have some content in the latin script too) while still allowing CJK text that has acronyms in it on non-CJK forums.

A text can be considered not all caps if it has:

a) any lower case letter, or,
b) any letter or ideograph character that doesn't have an uppercase variant (CJK)
c) no letters at all (e.g. numbers, punctuation, spaces, etc)


Related meta topic: https://meta.discourse.org/t/body-seems-unclear-error-when-users-are-typing-in-chinese/88715/1