### PR TITLE
A11Y: Close header dropdown menus on focusout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -125,8 +125,10 @@ export default class GlimmerHeader extends Component {
       this.toggleSearchMenu();
     } else if (this.header.userVisible) {
       this.toggleUserMenu();
+      document.getElementById(USER_BUTTON_ID)?.focus();
     } else if (this.header.hamburgerVisible) {
       this.toggleHamburger();
+      document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
     }
   }
 
@@ -220,7 +222,6 @@ export default class GlimmerHeader extends Component {
     if (this.header.userVisible) {
       this.setupFocusOutListener();
     } else {
-      document.getElementById(USER_BUTTON_ID)?.focus();
       this.teardownFocusOutListener();
     }
   }
@@ -250,7 +251,6 @@ export default class GlimmerHeader extends Component {
     if (this.header.hamburgerVisible) {
       this.setupFocusOutListener();
     } else {
-      document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
       this.teardownFocusOutListener();
     }
   }

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -84,7 +84,7 @@ export default class GlimmerHeader extends Component {
       };
 
       // avoid triggering focusout on click
-      // otherwise we can double-trigger focusout
+      // otherwise we can double-trigger the menu toggle
       const handleMousedown = () => {
         isKeyboardEvent = false;
       };

--- a/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
@@ -97,6 +97,7 @@ export default class HamburgerDropdownWrapper extends Component {
           secondaryTargetSelector=".hamburger-dropdown"
         )
       }}
+      ...attributes
     >
       <SidebarHamburgerDropdown
         @forceMainSidebarPanel={{this.forceMainSidebarPanel}}

--- a/app/assets/javascripts/discourse/app/components/header/search-menu-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/search-menu-wrapper.gjs
@@ -1,7 +1,7 @@
 import SearchMenuPanel from "../search-menu-panel";
 
 const SearchMenuWrapper = <template>
-  <div class="search-menu glimmer-search-menu" aria-live="polite">
+  <div class="search-menu glimmer-search-menu" aria-live="polite" ...attributes>
     <SearchMenuPanel @closeSearchMenu={{@closeSearchMenu}} />
   </div>
 </template>;

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
@@ -36,6 +36,7 @@ export default class UserDropdown extends Component {
     >
       <PluginOutlet @name="user-dropdown-button__before" />
       <button
+        id="toggle-current-user"
         class="icon btn-flat"
         aria-haspopup="true"
         aria-expanded={{@active}}

--- a/app/assets/javascripts/discourse/app/components/header/user-menu-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-menu-wrapper.gjs
@@ -51,6 +51,7 @@ export default class UserMenuWrapper extends Component {
           secondaryTargetSelector=".user-menu-panel"
         )
       }}
+      ...attributes
     >
       <UserMenu @closeUserMenu={{@toggleUserMenu}} />
     </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import { next } from "@ember/runloop";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import DeferredRender from "discourse/components/deferred-render";
@@ -23,7 +23,7 @@ export default class SidebarHamburgerDropdown extends Component {
 
   @action
   focusFirstLink() {
-    next(() => {
+    schedule("afterRender", () => {
       const firstLink = document.querySelector(".sidebar-hamburger-dropdown a");
       if (firstLink) {
         firstLink.focus();

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import DeferredRender from "discourse/components/deferred-render";
@@ -18,6 +19,16 @@ export default class SidebarHamburgerDropdown extends Component {
   @action
   triggerRenderedAppEvent() {
     this.appEvents.trigger("sidebar-hamburger-dropdown:rendered");
+  }
+
+  @action
+  focusFirstLink() {
+    next(() => {
+      const firstLink = document.querySelector(".sidebar-hamburger-dropdown a");
+      if (firstLink) {
+        firstLink.focus();
+      }
+    });
   }
 
   get collapsableSections() {
@@ -41,7 +52,10 @@ export default class SidebarHamburgerDropdown extends Component {
         <div class="panel-body">
           <div class="panel-body-contents">
             <DeferredRender>
-              <div class="sidebar-hamburger-dropdown">
+              <div
+                class="sidebar-hamburger-dropdown"
+                {{didInsert this.focusFirstLink}}
+              >
                 {{#if
                   (or this.sidebarState.showMainPanel @forceMainSidebarPanel)
                 }}

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Glimmer Header", type: :system do
 
     visit "/"
 
-    find(".toggle-hamburger-menu").click
+    find("#toggle-hamburger-menu").click
     expect(page).to have_selector(".panel-body")
     first_link = find(".panel-body a", match: :first)
     first_link_href = first_link[:href]

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -73,6 +73,28 @@ RSpec.describe "Glimmer Header", type: :system do
     expect(page).not_to have_selector(".user-menu.revamped")
   end
 
+  it "closes menu-panel when keyboard focus leaves it" do
+    sign_in(current_user)
+    visit "/"
+    find(".header-dropdown-toggle.current-user").click
+    find("##{header.active_element_id}").send_keys(%i[shift tab])
+    expect(page).not_to have_selector(".user-menu.revamped")
+  end
+
+  it "automatically focuses the first link in the hamburger panel" do
+    SiteSetting.navigation_menu = "header dropdown"
+
+    visit "/"
+
+    find(".toggle-hamburger-menu").click
+    expect(page).to have_selector(".panel-body")
+    first_link = find(".panel-body a", match: :first)
+    first_link_href = first_link[:href]
+    focused_element_href = evaluate_script("document.activeElement.href")
+
+    expect(focused_element_href).to eq(first_link_href)
+  end
+
   it "sets header's height css property" do
     sign_in(current_user)
     visit "/"


### PR DESCRIPTION
When navigating the header menus with a keyboard, as focus leaves the menu, it should automatically close. When closing, focus should return to the menu trigger. 

This listens for `focusout` on `.panel-body` and ensures that it's a keyboard event and not a click to trigger the menu to close on `focusout`. 

The search menu already refocuses the menu button on close, so I've added it to the hamburger menu and user menu as well. 

I also move focus to the first link when the hamburger dropdown is opened, and add an ID for the user menu button. 

https://github.com/user-attachments/assets/32f8a55b-2ea4-4dda-ae28-008f703ba881


