### PR TITLE
DEV: Use Redis cache for flags

### DIFF
--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -7,8 +7,8 @@ class PostActionType < ActiveRecord::Base
   include AnonCacheInvalidator
 
   def expire_cache
-    ApplicationSerializer.expire_cache_fragment!(/\Apost_action_types_/)
-    ApplicationSerializer.expire_cache_fragment!(/\Apost_action_flag_types_/)
+    Discourse.redis.keys("post_action_types_*").each { |key| Discourse.redis.del(key) }
+    Discourse.redis.keys("post_action_flag_types_*").each { |key| Discourse.redis.del(key) }
   end
 
   DiscourseEvent.on(:reload_post_action_types) { self.reload_types }

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -95,6 +95,7 @@ class TranslationOverride < ActiveRecord::Base
   def self.clear_cached_keys!(locale, keys)
     should_clear_anon_cache = false
     keys.each { |key| should_clear_anon_cache |= expire_cache(locale, key) }
+    PostActionType.new.expire_cache
     Site.clear_anon_cache! if should_clear_anon_cache
   end
 

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -111,17 +111,25 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def post_action_types
-    cache_fragment("post_action_types_#{I18n.locale}") do
-      types = ordered_flags(PostActionType.types.values)
-      ActiveModel::ArraySerializer.new(types).as_json
-    end
+    types = Discourse.redis.get("post_action_types_#{I18n.locale}")
+    return JSON.parse(types) if types.present?
+
+    types = ordered_flags(PostActionType.types.values)
+    json = ActiveModel::ArraySerializer.new(types).as_json
+
+    Discourse.redis.set("post_action_types_#{I18n.locale}", JSON.dump(json))
+    json
   end
 
   def topic_flag_types
-    cache_fragment("post_action_flag_types_#{I18n.locale}") do
-      types = ordered_flags(PostActionType.topic_flag_types.values)
-      ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
-    end
+    types = Discourse.redis.get("post_action_flag_types_#{I18n.locale}")
+    return JSON.parse(types) if types.present?
+
+    types = ordered_flags(PostActionType.topic_flag_types.values)
+    json = ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
+
+    Discourse.redis.set("post_action_flag_types_#{I18n.locale}", JSON.dump(json))
+    json
   end
 
   def default_archetype

--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -4,17 +4,13 @@ RSpec.describe PostActionType do
   describe "Callbacks" do
     describe "#expiry_cache" do
       it "should clear the cache on save" do
-        cache = ApplicationSerializer.fragment_cache
-
-        cache["post_action_types_#{I18n.locale}"] = "test"
-        cache["post_action_flag_types_#{I18n.locale}"] = "test2"
+        Discourse.redis.set("post_action_types_#{I18n.locale}", "test")
+        Discourse.redis.set("post_action_flag_types_#{I18n.locale}", "test")
 
         PostActionType.new(name_key: "some_key").save!
 
-        expect(cache["post_action_types_#{I18n.locale}"]).to eq(nil)
-        expect(cache["post_action_flag_types_#{I18n.locale}"]).to eq(nil)
-      ensure
-        ApplicationSerializer.fragment_cache.clear
+        expect(Discourse.redis.get("post_action_types_#{I18n.locale}")).to eq(nil)
+        expect(Discourse.redis.get("post_action_flag_types_#{I18n.locale}")).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
There are some problems with clearing the fragment cache with all servers. It is an experiment to move that cache to Redis.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
