### PR TITLE
FIX: proper rename of custom_type flags column

### DIFF
--- a/db/migrate/20240714231226_duplicate_flags_custom_type_to_require_message.rb
+++ b/db/migrate/20240714231226_duplicate_flags_custom_type_to_require_message.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DuplicateFlagsCustomTypeToRequireMessage < ActiveRecord::Migration[7.1]
+  def up
+    add_column :flags, :require_message, :boolean, default: false, null: false
+
+    Migration::ColumnDropper.mark_readonly("flags", "custom_type")
+
+    DB.exec <<~SQL
+      UPDATE flags
+      SET require_message = custom_type
+    SQL
+  end
+
+  def down
+    remove_column :flags, :require_message
+  end
+end

--- a/db/post_migrate/20240703232446_rename_flags_custom_type_to_require_message.rb
+++ b/db/post_migrate/20240703232446_rename_flags_custom_type_to_require_message.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class RenameFlagsCustomTypeToRequireMessage < ActiveRecord::Migration[7.0]
-  def change
-    rename_column :flags, :custom_type, :require_message
-  end
-end

--- a/db/post_migrate/20240714231516_drop_custom_type_from_flags.rb
+++ b/db/post_migrate/20240714231516_drop_custom_type_from_flags.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropCustomTypeFromFlags < ActiveRecord::Migration[7.1]
+  DROPPED_COLUMNS ||= { flags: %i[custom_type] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Bug introduced https://github.com/discourse/discourse/pull/27706

To rename column we need to duplicate it first and then drop.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
