### PR TITLE
DEV: add discourse prefix to deprecation ids to differentiate from ember deprecations

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -106,7 +106,7 @@ export default class TopicList extends RestModel {
     deprecated(
       `TopicList.find is deprecated. Use \`findFiltered("topicList")\` on the \`store\` service instead.`,
       {
-        id: "topic-list-find",
+        id: "discourse.topic-list-find",
         since: "3.1.0.beta5",
         dropFrom: "3.2.0.beta1",
       }

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -447,7 +447,7 @@ export function controllerFor(controller, model) {
   deprecated(
     'controllerFor is deprecated. Use the standard `getOwner(this).lookup("controller:NAME")` instead',
     {
-      id: "controller-for",
+      id: "discourse.controller-for",
       since: "3.0.0.beta14",
     }
   );


### PR DESCRIPTION
Found a couple of deprecations that were missing the proper prefixes while working on a better way to scrape deprecation IDs.