### PR TITLE
DEV: add deprecation ids for base-url, fa-icon and chat service

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/helpers/base-url.js
+++ b/app/assets/javascripts/discourse-common/addon/helpers/base-url.js
@@ -5,6 +5,8 @@ import { registerRawHelper } from "discourse-common/lib/helpers";
 registerRawHelper("base-url", baseUrl);
 
 export default function baseUrl() {
-  deprecated("Use `{{base-path}}` instead of `{{base-url}}`");
+  deprecated("Use `{{base-path}}` instead of `{{base-url}}`", {
+    id: "discourse.base-url",
+  });
   return getUrl("");
 }

--- a/app/assets/javascripts/discourse-common/addon/helpers/fa-icon.js
+++ b/app/assets/javascripts/discourse-common/addon/helpers/fa-icon.js
@@ -9,6 +9,8 @@ export function iconHTML(id, params) {
 
 registerRawHelper("fa-icon", faIcon);
 export default function faIcon(icon, params) {
-  deprecated("Use `{{d-icon}}` instead of `{{fa-icon}}");
+  deprecated("Use `{{d-icon}}` instead of `{{fa-icon}}", {
+    id: "discourse.fa-icon",
+  });
   return htmlSafe(iconHTML(icon, params));
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -391,7 +391,8 @@ export default class Chat extends Service {
 
   addToolbarButton() {
     deprecated(
-      "Use the new chat API `api.registerChatComposerButton` instead of `chat.addToolbarButton`"
+      "Use the new chat API `api.registerChatComposerButton` instead of `chat.addToolbarButton`",
+      { id: "discourse.chat.addToolbarButton" }
     );
   }
 


### PR DESCRIPTION
Found deprecations that were missing IDs while working on a better way to scrape deprecation IDs.