### PR TITLE
FIX: Bold admin sidebar headings

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -1045,6 +1045,7 @@ a.inline-editable-field {
 
 // Styles for subtabs in admin
 @import "common/admin/dashboard";
+@import "common/admin/sidebar";
 @import "common/admin/settings";
 @import "common/admin/users";
 @import "common/admin/penalty";

--- a/app/assets/stylesheets/common/admin/sidebar.scss
+++ b/app/assets/stylesheets/common/admin/sidebar.scss
@@ -1,0 +1,6 @@
+.admin-area .sidebar-wrapper .admin-panel {
+  background-color: var(--d-sidebar-admin-background);
+  .sidebar-section-header-text {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
We lost these by mistake in fed90558188a03690010feb7239c0945808f384e,
this reinstates them.
