### PR TITLE
FIX: `StaticController#enter` should not redirect to invalid paths

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -133,7 +133,8 @@ class StaticController < ApplicationController
         forum_uri = URI(Discourse.base_url)
         uri = URI(redirect_location)
 
-        if uri.path.present? && (uri.host.blank? || uri.host == forum_uri.host) && uri.path !~ /\./
+        if uri.path.present? && (uri.host.blank? || uri.host == forum_uri.host) &&
+             uri.path =~ %r{\A\/{1}[^\.\s]*\z}
           destination = "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
         end
       rescue URI::Error
@@ -141,7 +142,7 @@ class StaticController < ApplicationController
       end
     end
 
-    redirect_to destination
+    redirect_to(destination, allow_other_host: false)
   end
 
   FAVICON ||= -"favicon"

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe StaticController do
       end
     end
 
-    context "with a full url to someone else" do
+    context "with a full url to an external host" do
       it "redirects to the root path" do
         post "/login.json", params: { redirect: "http://eviltrout.com/foo" }
         expect(response).to redirect_to("/")
@@ -317,6 +317,13 @@ RSpec.describe StaticController do
     context "when the redirect path is the login page" do
       it "redirects to the root url" do
         post "/login.json", params: { redirect: login_path }
+        expect(response).to redirect_to("/")
+      end
+    end
+
+    context "when the redirect path is invalid" do
+      it "redirects to the root URL" do
+        post "/login.json", params: { redirect: "test" }
         expect(response).to redirect_to("/")
       end
     end


### PR DESCRIPTION
This commit updates `StaticController#enter` to not redirect to invalid
paths when the `redirect` param is set. Instead it should redirect to `/` when the
`redirect` param is invalid.
