### PR TITLE
FIX: Show the SMTP authentication error for group UI

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1123,8 +1123,7 @@ en:
     pop3_authentication_error: "There was an issue with the POP3 credentials provided, check the username and password and try again."
     imap_authentication_error: "There was an issue with the IMAP credentials provided, check the username and password and try again."
     imap_no_response_error: "An error occurred when communicating with the IMAP server. %{message}"
-    smtp_authentication_error: "There was an issue with the SMTP credentials provided, check the username and password and try again."
-    authentication_error_gmail_app_password: 'Application-specific password required. Learn more at <a target="_blank" href="https://support.google.com/accounts/answer/185833">this Google Help article</a>'
+    smtp_authentication_error: "There was an issue with the SMTP credentials provided, check the username and password and try again. %{message}"
     smtp_server_busy_error: "The SMTP server is currently busy, try again later."
     smtp_unhandled_error: "There was an unhandled error when communicating with the SMTP server. %{message}"
     imap_unhandled_error: "There was an unhandled error when communicating with the IMAP server. %{message}"

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2799,7 +2799,7 @@ RSpec.describe GroupsController do
           post "/groups/#{group.id}/test_email_settings.json", params: params
           expect(response.status).to eq(422)
           expect(response.parsed_body["errors"]).to include(
-            I18n.t("email_settings.smtp_authentication_error"),
+            I18n.t("email_settings.smtp_authentication_error", message: "Invalid credentials"),
           )
         end
       end

--- a/spec/services/email_settings_exception_handler_spec.rb
+++ b/spec/services/email_settings_exception_handler_spec.rb
@@ -23,28 +23,10 @@ RSpec.describe EmailSettingsExceptionHandler do
       )
     end
 
-    it "formats a general Net::IMAP::NoResponseError with application-specific password Gmail error" do
-      exception =
-        Net::IMAP::NoResponseError.new(
-          stub(data: stub(text: "NO Application-specific password required")),
-        )
-      expect(described_class.friendly_exception_message(exception, "imap.gmail.com")).to eq(
-        I18n.t("email_settings.authentication_error_gmail_app_password"),
-      )
-    end
-
     it "formats a Net::SMTPAuthenticationError" do
       exception = Net::SMTPAuthenticationError.new("invalid credentials")
       expect(described_class.friendly_exception_message(exception, "smtp.test.com")).to eq(
-        I18n.t("email_settings.smtp_authentication_error"),
-      )
-    end
-
-    it "formats a Net::SMTPAuthenticationError with application-specific password Gmail error" do
-      exception =
-        Net::SMTPAuthenticationError.new(nil, message: "Application-specific password required")
-      expect(described_class.friendly_exception_message(exception, "smtp.gmail.com")).to eq(
-        I18n.t("email_settings.authentication_error_gmail_app_password"),
+        I18n.t("email_settings.smtp_authentication_error", message: "invalid credentials"),
       )
     end
 

--- a/spec/services/problem_check/group_email_credentials_spec.rb
+++ b/spec/services/problem_check/group_email_credentials_spec.rb
@@ -45,7 +45,14 @@ RSpec.describe ProblemCheck::GroupEmailCredentials do
             target: group2.id,
             priority: "high",
             message:
-              "There was an issue with the email credentials for the group <a href=\"/g/#{group2.name}/manage/email\"></a>. No emails will be sent from the group inbox until this problem is addressed. There was an issue with the SMTP credentials provided, check the username and password and try again.",
+              I18n.t(
+                "dashboard.problem.group_email_credentials",
+                base_path: Discourse.base_path,
+                group_name: group2.name,
+                group_full_name: group2.full_name,
+                error:
+                  I18n.t("email_settings.smtp_authentication_error", message: "bad credentials"),
+              ),
           ),
         )
       end
@@ -63,7 +70,14 @@ RSpec.describe ProblemCheck::GroupEmailCredentials do
             target: group3.id,
             priority: "high",
             message:
-              "There was an issue with the email credentials for the group <a href=\"/g/#{group3.name}/manage/email\"></a>. No emails will be sent from the group inbox until this problem is addressed. There was an issue with the IMAP credentials provided, check the username and password and try again.",
+              I18n.t(
+                "dashboard.problem.group_email_credentials",
+                base_path: Discourse.base_path,
+                group_name: group3.name,
+                group_full_name: group3.full_name,
+                error:
+                  I18n.t("email_settings.imap_authentication_error", message: "bad credentials"),
+              ),
           ),
         )
       end


### PR DESCRIPTION
Originally in 964da218173db007fefe6357e96292f5545c513e
we hid the SMTPAuthenticationError message except in
very specific cases. However this message often contains
helpful information from the mail provider, for example
here is a response from Office365:

> 535 5.7.139 Authentication unsuccessful, user is locked by your
organization's security defaults policy. Contact your administrator.

So, we will show the error message in the modal UI instead
of supressing it with a generic message to be more helpful.
