### PR TITLE
DEV: Add slug parameter to hashtag-decorator

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
@@ -100,6 +100,7 @@ export function decorateHashtags(element, site) {
         .generateIconHTML({
           icon: site.hashtag_icons[hashtagType],
           id: hashtagEl.dataset.id,
+          slug: hashtagEl.dataset.slug,
         })
         .trim();
       iconPlaceholderEl.replaceWith(domFromString(hashtagIconHTML)[0]);


### PR DESCRIPTION
In order to facilitate discourse-tag-icons and discourse-category-icons to render icons for post content, we need to provide an additional slug parameter here

Then we can easily replace icon render with such code:

```js
class TagHashtagTypeWithIcon extends TagHashtagType {
  constructor(dict, owner) {
    super(owner);
    this.dict = dict;
  }
  generateIconHTML(hashtag) {
    return iconHTML(this.dict[hashtag.slug]?.icon || hashtag.icon, {
      class: `hashtag-color--${this.type}-${hashtag.id}`,
    });
  }
}

// ...

api.registerHashtagType("tag", new TagHashtagTypeWithIcon(tagsMap, owner));
```



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
