### PR TITLE
UX: fix name & username width on profile summary

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -478,10 +478,11 @@
   .user-info .user-detail {
     width: 100%;
     .name-line {
-      .username {
+      span {
         width: auto;
+      }
+      .username {
         overflow-wrap: anywhere;
-        flex: 1 0 auto;
       }
       > a {
         flex-wrap: nowrap;


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/27877, this needed an additional fix for `prioritize username in ux` being disabled


Before:
![image](https://github.com/user-attachments/assets/b220044e-ea3f-4241-baa5-81944f7b0df9)




After: 
![image](https://github.com/user-attachments/assets/8b32aab9-742c-4bca-b26e-4379f5672338)