### PR TITLE
DEV: Support adding a custom filter on `/filter`

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -72,6 +72,7 @@ class DiscoursePluginRegistry
   define_register :demon_processes, Set
   define_register :groups_callback_for_users_search_controller_action, Hash
   define_register :mail_pollers, Set
+  define_register :custom_filters, Hash
 
   define_filtered_register :staff_user_custom_fields
   define_filtered_register :public_user_custom_fields
@@ -210,6 +211,10 @@ class DiscoursePluginRegistry
   def self.register_html_builder(name, &block)
     html_builders[name] ||= []
     html_builders[name] << block
+  end
+
+  def self.register_custom_filter(filter_name, &block)
+    self.custom_filters[filter_name] = block
   end
 
   def self.build_html(name, ctx = nil)

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -72,7 +72,6 @@ class DiscoursePluginRegistry
   define_register :demon_processes, Set
   define_register :groups_callback_for_users_search_controller_action, Hash
   define_register :mail_pollers, Set
-  define_register :custom_filters, Hash
 
   define_filtered_register :staff_user_custom_fields
   define_filtered_register :public_user_custom_fields
@@ -127,6 +126,8 @@ class DiscoursePluginRegistry
   define_filtered_register :problem_checks
 
   define_filtered_register :flag_applies_to_types
+
+  define_filtered_register :custom_filter_mappings
 
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
@@ -211,10 +212,6 @@ class DiscoursePluginRegistry
   def self.register_html_builder(name, &block)
     html_builders[name] ||= []
     html_builders[name] << block
-  end
-
-  def self.register_custom_filter(filter_name, &block)
-    self.custom_filters[filter_name] = block
   end
 
   def self.build_html(name, ctx = nil)

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -247,7 +247,8 @@ class Plugin::Instance
   #     scope.where(word_count: value)
   #   end
   def register_custom_filter(filter_name, &block)
-    TopicsFilter.add_filter(filter_name, &block)
+    plugin = self
+    DiscoursePluginRegistry.register_custom_filter(filter_name, &block) if plugin.enabled?
   end
 
   # Allows to define custom "status:" filter. Example usage:

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -243,12 +243,11 @@ class Plugin::Instance
   # Ensure proper input sanitization before using it in a query.
   #
   # Example usage:
-  #   register_custom_filter("word_count") do |scope, value|
+  #   add_filter_custom_filter("word_count") do |scope, value|
   #     scope.where(word_count: value)
   #   end
-  def register_custom_filter(filter_name, &block)
-    plugin = self
-    DiscoursePluginRegistry.register_custom_filter(filter_name, &block) if plugin.enabled?
+  def add_filter_custom_filter(name, &block)
+    DiscoursePluginRegistry.register_custom_filter_mapping({ name => block }, self)
   end
 
   # Allows to define custom "status:" filter. Example usage:

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -239,6 +239,17 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_editable_group_custom_field(field, self)
   end
 
+  # Allows to define custom filter utilizing the user's input.
+  # Ensure proper input sanitization before using it in a query.
+  #
+  # Example usage:
+  #   register_custom_filter("word_count") do |scope, value|
+  #     scope.where(word_count: value)
+  #   end
+  def register_custom_filter(filter_name, &block)
+    TopicsFilter.add_filter(filter_name, &block)
+  end
+
   # Allows to define custom "status:" filter. Example usage:
   #   register_custom_filter_by_status("foobar") do |scope|
   #     scope.where("word_count = 42")

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -82,10 +82,22 @@ class TopicsFilter
         filter_by_number_of_views(min: filter_values)
       when "views-max"
         filter_by_number_of_views(max: filter_values)
+      else
+        if custom_filter = TopicsFilter.custom_filters[filter]
+          @scope = custom_filter.call(@scope, filter_values)
+        end
       end
     end
 
     @scope
+  end
+
+  def self.add_filter(filter_name, &blk)
+    custom_filters[filter_name] = blk
+  end
+
+  def self.custom_filters
+    @custom_filters ||= {}
   end
 
   def self.add_filter_by_status(status, &blk)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -83,21 +83,13 @@ class TopicsFilter
       when "views-max"
         filter_by_number_of_views(max: filter_values)
       else
-        if custom_filter = TopicsFilter.custom_filters[filter]
+        if custom_filter = DiscoursePluginRegistry.custom_filters[filter]
           @scope = custom_filter.call(@scope, filter_values)
         end
       end
     end
 
     @scope
-  end
-
-  def self.add_filter(filter_name, &blk)
-    custom_filters[filter_name] = blk
-  end
-
-  def self.custom_filters
-    @custom_filters ||= {}
   end
 
   def self.add_filter_by_status(status, &blk)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -83,8 +83,9 @@ class TopicsFilter
       when "views-max"
         filter_by_number_of_views(max: filter_values)
       else
-        if custom_filter = DiscoursePluginRegistry.custom_filters[filter]
-          @scope = custom_filter.call(@scope, filter_values)
+        if custom_filter =
+             DiscoursePluginRegistry.custom_filter_mappings.find { |hash| hash.key?(filter) }
+          @scope = custom_filter[filter].call(@scope, filter_values)
         end
       end
     end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -212,6 +212,38 @@ RSpec.describe TopicsFilter do
       end
     end
 
+    describe "when filtering with custom filters" do
+      fab!(:topic)
+      fab!(:word_count_topic) { Fabricate(:topic, word_count: 42) }
+      fab!(:word_count_topic_2) { Fabricate(:topic, word_count: 42) }
+
+      after { TopicsFilter.custom_filters.clear }
+
+      it "supports a custom filter" do
+        TopicsFilter.add_filter("word_count") { |scope, value| scope.where(word_count: value) }
+
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("word_count:42")
+            .pluck(:id),
+        ).to contain_exactly(word_count_topic.id, word_count_topic_2.id)
+      end
+
+      it "supports multiple custom filters" do
+        TopicsFilter.add_filter("word_count") { |scope, value| scope.where(word_count: value) }
+
+        TopicsFilter.add_filter("id") { |scope, value| scope.where(id: value) }
+
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("word_count:42 id:#{word_count_topic.id}")
+            .pluck(:id),
+        ).to contain_exactly(word_count_topic.id)
+      end
+    end
+
     describe "when filtering by categories" do
       fab!(:category) { Fabricate(:category, name: "category") }
 

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -219,9 +219,10 @@ RSpec.describe TopicsFilter do
 
       let(:word_count_block) { Proc.new { |scope, value| scope.where(word_count: value) } }
       let(:id_block) { Proc.new { |scope, value| scope.where(id: value) } }
+      let(:plugin) { Plugin::Instance.new }
 
       it "supports a custom filter" do
-        DiscoursePluginRegistry.register_custom_filter("word_count", &word_count_block)
+        plugin.add_filter_custom_filter("word_count", &word_count_block)
 
         expect(
           TopicsFilter
@@ -230,12 +231,12 @@ RSpec.describe TopicsFilter do
             .pluck(:id),
         ).to contain_exactly(word_count_topic.id, word_count_topic_2.id)
       ensure
-        DiscoursePluginRegistry.reset_register!(:custom_filters)
+        DiscoursePluginRegistry.reset_register!(:custom_filter_mappings)
       end
 
       it "supports multiple custom filters" do
-        DiscoursePluginRegistry.register_custom_filter("word_count", &word_count_block)
-        DiscoursePluginRegistry.register_custom_filter("id", &id_block)
+        plugin.add_filter_custom_filter("word_count", &word_count_block)
+        plugin.add_filter_custom_filter("id", &id_block)
 
         expect(
           TopicsFilter
@@ -244,7 +245,7 @@ RSpec.describe TopicsFilter do
             .pluck(:id),
         ).to contain_exactly(word_count_topic.id)
       ensure
-        DiscoursePluginRegistry.reset_register!(:custom_filters)
+        DiscoursePluginRegistry.reset_register!(:custom_filter_mappings)
       end
     end
 


### PR DESCRIPTION
# Context

Currently there is no way to add a custom filter to the experimental `/filter` endpoint. While you can implement a custom `status:` there is no way to include the user's input in a custom query. 

# PR

This PR adds the ability to implement a custom filter. eg. `CUSTOM_FILTER:foo`

- Add `add_filter_custom_filter` for extension
- Add specs