### PR TITLE
FIX: Use login SMTP auth for office365 in group mailer

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -15,7 +15,9 @@ class GroupSmtpMailer < ActionMailer::Base
       domain: from_group.email_username_domain,
       user_name: from_group.email_username,
       password: from_group.email_password,
-      authentication: GlobalSetting.smtp_authentication,
+      # NOTE: Might be better at some point to store this authentication method in the database
+      # against the group.
+      authentication: SmtpProviderOverrides.authentication_override(from_group.smtp_server),
       enable_starttls_auto: from_group.smtp_ssl,
       return_response: true,
       open_timeout: GlobalSetting.group_smtp_open_timeout,

--- a/lib/smtp_provider_overrides.rb
+++ b/lib/smtp_provider_overrides.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class SmtpProviderOverrides
+  # Ideally we (or net-smtp) would automatically detect the correct authentication
+  # method, but this is sufficient for our purposes because we know certain providers
+  # need certain authentication methods. This may need to change when we start to
+  # use XOAUTH2 for SMTP.
+  def self.authentication_override(host)
+    return "login" if %w[smtp.office365.com smtp-mail.outlook.com].include?(host)
+    GlobalSetting.smtp_authentication
+  end
+
+  def self.ssl_override(host, port, enable_tls, enable_starttls_auto)
+    # Certain mail servers act weirdly if you do not use the correct combinations of
+    # TLS settings based on the port, we clean these up here for the user.
+    if %w[smtp.gmail.com smtp.office365.com smtp-mail.outlook.com].include?(host)
+      if port.to_i == 587
+        enable_starttls_auto = true
+        enable_tls = false
+      elsif port.to_i == 465
+        enable_starttls_auto = false
+        enable_tls = true
+      end
+    end
+
+    [port, enable_tls, enable_starttls_auto]
+  end
+end

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -135,6 +135,18 @@ RSpec.describe GroupSmtpMailer do
     )
   end
 
+  it "uses the login SMTP authentication method for office365" do
+    group.update!(smtp_server: "smtp.office365.com")
+    mail = GroupSmtpMailer.send_mail(group, user.email, Fabricate(:post))
+    expect(mail.delivery_method.settings[:authentication]).to eq("login")
+  end
+
+  it "uses the login SMTP authentication method for outlook" do
+    group.update!(smtp_server: "smtp-mail.outlook.com")
+    mail = GroupSmtpMailer.send_mail(group, user.email, Fabricate(:post))
+    expect(mail.delivery_method.settings[:authentication]).to eq("login")
+  end
+
   context "when the site has a reply by email address configured" do
     before do
       SiteSetting.manual_polling_enabled = true


### PR DESCRIPTION
Followup 7b627dc14b934430f62a59fbcf09b0595ee94567

In this other commit, I changed the email settings validator
to always use the `login` authentication method for
office365 and outlook, but I didn't change the actual
group SMTP mailer to do this.

This commit fixes that issue and does some minor refactoring.
