### PR TITLE
FIX: Add plural definitions for Hungarian

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -42,7 +42,8 @@
   he: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   hi: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| [0, 1].include?(n) ? :one : :other } } } },
   hr: { i18n: { plural: { keys: [:one, :few, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : :other } } } },
-  hu: { i18n: { plural: { keys: [:other], rule: lambda { |n| :other } } } },
+  # The next line has a fix for ruby-i18n. Hungarian has plural forms. See https://meta.discourse.org/t/issue-with-pluralized-count-translation-override/316019/8
+  hu: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   hy: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   id: { i18n: { plural: { keys: [:other], rule: lambda { |n| :other } } } },
   is: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },


### PR DESCRIPTION
Hungarian actually has a plural form (See: https://meta.discourse.org/t/issue-with-pluralized-count-translation-override/316019/8)

In a past commit we introduced an external JS library to describe the plural form of the language. (https://github.com/discourse/discourse/commit/301713ef9631e52975781b60b8b4c4a0d75530cf) 

https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse-i18n/src/index.js#L7
```javascript
import * as Cardinals from "make-plural/cardinals";
```

But this JS library actually has a slightly different pluralization definition than what we use in the backend (`plurals.rb`). ruby-i18n incorrectly assumes that Hungarian does not have plural forms. This resulted in singular text being used on the front end for Hungarian, but admins were unable to find and edit the singular text in customization.



This commit adds a singular definition for Hungarian to the backend, compatible with the  "make-plural/cardinals" library, thus fixing the above issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
