### PR TITLE
FEATURE: Log topic slow mode changes

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1186,6 +1186,13 @@ class TopicsController < ApplicationController
 
     topic.set_or_create_timer(slow_mode_type, time, by_user: timer&.user)
 
+    StaffActionLogger.new(current_user).log_topic_slow_mode(
+      topic,
+      enabled:,
+      seconds: params[:seconds],
+      until: time,
+    )
+
     head :ok
   end
 

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -146,6 +146,8 @@ class UserHistory < ActiveRecord::Base
         delete_watched_word_group: 107,
         redirected_to_required_fields: 108,
         filled_in_required_fields: 109,
+        topic_slow_mode_set: 110,
+        topic_slow_mode_removed: 111,
       )
   end
 
@@ -254,6 +256,8 @@ class UserHistory < ActiveRecord::Base
       create_watched_word_group
       update_watched_word_group
       delete_watched_word_group
+      topic_slow_mode_set
+      topic_slow_mode_removed
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -204,6 +204,21 @@ class StaffActionLogger
     )
   end
 
+  def log_topic_slow_mode(topic, opts = {})
+    raise Discourse::InvalidParameters.new(:topic) unless topic && topic.is_a?(Topic)
+
+    details = opts[:enabled] ? ["interval: #{opts[:seconds]}", "until: #{opts[:until]}"] : []
+
+    UserHistory.create!(
+      params(opts).merge(
+        action:
+          UserHistory.actions[opts[:enabled] ? :topic_slow_mode_set : :topic_slow_mode_removed],
+        topic_id: topic.id,
+        details: details.join("\n"),
+      ),
+    )
+  end
+
   def log_post_staff_note(post, opts = {})
     raise Discourse::InvalidParameters.new(:post) unless post && post.is_a?(Post)
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6196,6 +6196,8 @@ en:
             create_flag: "create flag"
             update_flag: "update flag"
             delete_flag: "delete flag"
+            topic_slow_mode_set: "set topic slow mode"
+            topic_slow_mode_removed: "remove topic slow mode"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5031,6 +5031,26 @@ RSpec.describe TopicsController do
         expect(execute_at).to eq(updated_timestamp)
       end
     end
+
+    describe "changes slow mode" do
+      before { sign_in(admin) }
+
+      it "should create a staff log entry" do
+        put "/t/#{topic.id}/slow_mode.json", params: { seconds: "3600" }
+
+        log = UserHistory.last
+        expect(log.acting_user_id).to eq(admin.id)
+        expect(log.topic_id).to eq(topic.id)
+        expect(log.action).to eq(UserHistory.actions[:topic_slow_mode_set])
+
+        put "/t/#{topic.id}/slow_mode.json", params: { seconds: "0" }
+
+        log = UserHistory.last
+        expect(log.acting_user_id).to eq(admin.id)
+        expect(log.topic_id).to eq(topic.id)
+        expect(log.action).to eq(UserHistory.actions[:topic_slow_mode_removed])
+      end
+    end
   end
 
   describe "#invite" do


### PR DESCRIPTION
Previously, we did not log any topic slow mode changes. This allowed some malicious (or just careless) TL4 users to delete slow modes created by moderators at will. Administrators could not see who changed the slow mode unless they had SQL knowledge and used Data Explorer.

This commit enables logging who turns slow mode on, off, or changes it.

Related meta topic: https://meta.discourse.org/t/why-is-there-no-record-of-who-added-or-removed-slow-mode/316354

## Screenshot

![image](https://github.com/user-attachments/assets/e4edfc7d-da1f-4e71-8b7d-5b2fdaea45e3)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
