### PR TITLE
DEV: Update webhook site setting for topic voting

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -103,7 +103,7 @@ class WebHookEventType < ActiveRecord::Base
     unless defined?(SiteSetting.assign_enabled) && SiteSetting.assign_enabled
       ids_to_exclude.concat([TYPES[:assign_assigned], TYPES[:assign_unassigned]])
     end
-    unless defined?(SiteSetting.voting_enabled) && SiteSetting.voting_enabled
+    unless defined?(SiteSetting.topic_voting_enabled) && SiteSetting.topic_voting_enabled
       ids_to_exclude.concat([TYPES[:voting_topic_upvote], TYPES[:voting_topic_unvote]])
     end
     unless defined?(SiteSetting.chat_enabled) && SiteSetting.chat_enabled

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe WebHookEventType do
   describe "#active" do
     it "returns only active types" do
       core_event_types = WebHookEventType.active.map(&:name)
-      expect(core_event_types).to eq(
+      expect(core_event_types).to match_array(
         %w[
           topic_created
           topic_revised
@@ -47,10 +47,10 @@ RSpec.describe WebHookEventType do
 
       SiteSetting.stubs(:solved_enabled).returns(true)
       SiteSetting.stubs(:assign_enabled).returns(true)
-      SiteSetting.stubs(:voting_enabled).returns(true)
+      SiteSetting.stubs(:topic_voting_enabled).returns(true)
       SiteSetting.stubs(:chat_enabled).returns(true)
       plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
-      expect(plugins_event_types).to eq(
+      expect(plugins_event_types).to match_array(
         %w[
           accepted_solution
           unaccepted_solution

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe WebHook do
       assign_event_types = WebHookEventType.active.where(group: "assign").pluck(:name)
       expect(assign_event_types).to eq(%w[assigned unassigned])
 
-      SiteSetting.stubs(:voting_enabled).returns(true)
+      SiteSetting.stubs(:topic_voting_enabled).returns(true)
       voting_event_types = WebHookEventType.active.where(group: "voting").pluck(:name)
       expect(voting_event_types).to eq(%w[topic_upvote topic_unvote])
       #


### PR DESCRIPTION
Related: https://github.com/discourse/discourse-topic-voting/pull/196. Ideally to be merged around the same time.