### PR TITLE
UX: fix overflowing quote bar

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -584,6 +584,17 @@ aside.quote {
 
   .buttons {
     display: flex;
+    flex-wrap: wrap;
+    @media screen and (max-width: 420px) {
+      flex-direction: column;
+      align-items: flex-start;
+
+      .btn,
+      .ai-post-helper {
+        width: 100%;
+        justify-content: flex-start;
+      }
+    }
   }
 
   .extra {


### PR DESCRIPTION
The quote menu can overflow, especially on smaller screens/mobile and in languages with longer words

<img width="357" alt="image" src="https://github.com/user-attachments/assets/8879adec-c044-4ae8-a990-552be353f9d0">

This commit addresses the issue by:
* letting the menu wrap if needed
* on smaller screens, switch to a stacked view

<img width="471" alt="image" src="https://github.com/user-attachments/assets/3fb211cd-4ed2-4397-ad07-b38ea9e24f7e">

<img width="419" alt="image" src="https://github.com/user-attachments/assets/a488956a-d1b9-411c-8e15-ec01c75afc22">
