### PR TITLE
UX: fix padding on suggested/related toggle in PMs

### DIFF
--- a/app/assets/stylesheets/desktop/components/more-topics.scss
+++ b/app/assets/stylesheets/desktop/components/more-topics.scss
@@ -7,21 +7,13 @@
       .btn {
         font-size: var(--font-0);
         line-height: var(--line-height-large);
-        padding: 1em 0.65em;
+        padding: 0.75em 0.65em;
       }
     }
   }
   .more-topics__lists:not(.single-list) {
     .topic-list-header .default {
       visibility: hidden;
-    }
-  }
-}
-
-#main-outlet .regular {
-  .more-topics__container .nav {
-    li .btn {
-      padding: 0.75em 0.65em;
     }
   }
 }


### PR DESCRIPTION
This also removes a now redundant style

Before:
![image](https://github.com/user-attachments/assets/a9cd3c2a-46f0-4b09-9ff9-4b18cfbb6fce)

After:
![image](https://github.com/user-attachments/assets/45ea1d87-129a-40e1-ad22-7edc211afae0)
