### PR TITLE
UX: spacing fix for related topics on mobile

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -5,6 +5,7 @@
 
   .nav {
     margin-block: 0;
+    top: 2px;
     li {
       .btn {
         color: var(--primary);

--- a/app/assets/stylesheets/desktop/components/more-topics.scss
+++ b/app/assets/stylesheets/desktop/components/more-topics.scss
@@ -1,7 +1,6 @@
 .more-topics__container {
   .nav {
     position: absolute;
-    top: 2px;
     li {
       margin-right: 0;
       .btn {


### PR DESCRIPTION
This positioning can also be applied to mobile, so I've moved it from /desktop to /common 

This fixes this minor mobile alignment issue...

before:
![image](https://github.com/user-attachments/assets/f9a81239-6f48-4c30-ae98-863c8ef8e386)

after: 
![image](https://github.com/user-attachments/assets/45aacf6a-87df-4e29-a2e6-5dee25d8d5ba)
