### PR TITLE
UX: allow category names in select-kit to truncate if needed

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -30,6 +30,7 @@
     align-items: baseline;
     gap: 0.33em;
     color: var(--primary-high);
+    min-width: 0;
 
     &:before {
       content: "";
@@ -43,6 +44,7 @@
       color: currentColor;
       text-overflow: ellipsis;
       overflow: hidden;
+      min-width: 0;
     }
 
     &.--has-parent {

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -112,6 +112,7 @@
       color: inherit;
       display: flex;
       outline: none;
+      min-width: 0;
 
       &:focus .d-icon-times {
         color: var(--danger);
@@ -124,6 +125,7 @@
       .name {
         display: inline-flex;
         gap: 0.5em;
+        min-width: 0;
         > .d-icon {
           margin-left: 0.5em;
           margin-right: 0;


### PR DESCRIPTION
this allows long names to truncate, if needed — `min-width: 0` needs to be applied to all the flex descendants until you reach the final text node

Before:
![image](https://github.com/user-attachments/assets/47f57fc8-3d47-4a06-9bde-5515396a0b9d)
![image](https://github.com/user-attachments/assets/f33239a5-5c35-4797-bb57-4b22bd58b833)


After:
![image](https://github.com/user-attachments/assets/d0492290-97e4-4645-afbe-852c15911624)
![image](https://github.com/user-attachments/assets/ff89f019-59e0-483d-8260-49da374e26de)
