### PR TITLE
DEV: Hide IMAP site settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1335,10 +1335,13 @@ email:
   enable_imap:
     default: false
     client: true
+    hidden: true
   enable_imap_write:
     default: false
+    hidden: true
   enable_imap_idle:
     default: false
+    hidden: true
   enable_smtp:
     default: false
     client: true


### PR DESCRIPTION
We are removing support for IMAP, hiding these site
settings is the first step.

c.f. https://meta.discourse.org/t/imap-support-for-group-inboxes/160588/39
