### PR TITLE
FEATURE: Add data-tag-groups attribute to tags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/tag.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/tag.hbs
@@ -2,6 +2,6 @@
 {{discourse-tag
   (or @result.id @result)
   tagName="span"
-  tagGroups=@result.groups
+  tagGroups=@result.tag_group_names
   description=@result.description
 }}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/tag.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/tag.hbs
@@ -1,2 +1,7 @@
 {{d-icon "tag"}}
-{{discourse-tag (or @result.id @result) tagName="span"}}
+{{discourse-tag
+  (or @result.id @result)
+  tagName="span"
+  tagGroups=@result.groups
+  description=@result.description
+}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.gjs
@@ -41,17 +41,32 @@ export default class SidebarAnonymousTagsSection extends Component {
       >
 
         {{#each this.sectionLinks as |sectionLink|}}
-          <SectionLink
-            @route={{sectionLink.route}}
-            @content={{sectionLink.text}}
-            @title={{sectionLink.title}}
-            @currentWhen={{sectionLink.currentWhen}}
-            @prefixType={{sectionLink.prefixType}}
-            @prefixValue={{sectionLink.prefixValue}}
-            @prefixColor={{sectionLink.prefixColor}}
-            @models={{sectionLink.models}}
-            data-tag-name={{sectionLink.tagName}}
-          />
+          {{#if sectionLink.tagGroups}}
+            <SectionLink
+              @route={{sectionLink.route}}
+              @content={{sectionLink.text}}
+              @title={{sectionLink.title}}
+              @currentWhen={{sectionLink.currentWhen}}
+              @prefixType={{sectionLink.prefixType}}
+              @prefixValue={{sectionLink.prefixValue}}
+              @prefixColor={{sectionLink.prefixColor}}
+              @models={{sectionLink.models}}
+              data-tag-name={{sectionLink.tagName}}
+              data-tag-groups={{sectionLink.tagGroups}}
+            />
+          {{else}}
+            <SectionLink
+              @route={{sectionLink.route}}
+              @content={{sectionLink.text}}
+              @title={{sectionLink.title}}
+              @currentWhen={{sectionLink.currentWhen}}
+              @prefixType={{sectionLink.prefixType}}
+              @prefixValue={{sectionLink.prefixValue}}
+              @prefixColor={{sectionLink.prefixColor}}
+              @models={{sectionLink.models}}
+              data-tag-name={{sectionLink.tagName}}
+            />
+          {{/if}}
         {{/each}}
 
         <AllTagsSectionLink />

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.gjs
@@ -112,6 +112,7 @@ export default class SidebarUserTagsSection extends Component {
           @suffixValue={{sectionLink.suffixValue}}
           @suffixType={{sectionLink.suffixType}}
           data-tag-name={{sectionLink.tagName}}
+          data-tag-groups={{sectionLink.tagGroups}}
         />
       {{/each}}
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.gjs
@@ -98,22 +98,40 @@ export default class SidebarUserTagsSection extends Component {
       @collapsable={{@collapsable}}
     >
       {{#each this.sectionLinks as |sectionLink|}}
-        <SectionLink
-          @route={{sectionLink.route}}
-          @title={{sectionLink.title}}
-          @content={{sectionLink.text}}
-          @currentWhen={{sectionLink.currentWhen}}
-          @prefixType={{sectionLink.prefixType}}
-          @prefixValue={{sectionLink.prefixValue}}
-          @prefixColor={{sectionLink.prefixColor}}
-          @badgeText={{sectionLink.badgeText}}
-          @models={{sectionLink.models}}
-          @suffixCSSClass={{sectionLink.suffixCSSClass}}
-          @suffixValue={{sectionLink.suffixValue}}
-          @suffixType={{sectionLink.suffixType}}
-          data-tag-name={{sectionLink.tagName}}
-          data-tag-groups={{sectionLink.tagGroups}}
-        />
+        {{#if sectionLink.tagGroups}}
+          <SectionLink
+            @route={{sectionLink.route}}
+            @title={{sectionLink.title}}
+            @content={{sectionLink.text}}
+            @currentWhen={{sectionLink.currentWhen}}
+            @prefixType={{sectionLink.prefixType}}
+            @prefixValue={{sectionLink.prefixValue}}
+            @prefixColor={{sectionLink.prefixColor}}
+            @badgeText={{sectionLink.badgeText}}
+            @models={{sectionLink.models}}
+            @suffixCSSClass={{sectionLink.suffixCSSClass}}
+            @suffixValue={{sectionLink.suffixValue}}
+            @suffixType={{sectionLink.suffixType}}
+            data-tag-name={{sectionLink.tagName}}
+            data-tag-groups={{sectionLink.tagGroups}}
+          />
+        {{else}}
+          <SectionLink
+            @route={{sectionLink.route}}
+            @title={{sectionLink.title}}
+            @content={{sectionLink.text}}
+            @currentWhen={{sectionLink.currentWhen}}
+            @prefixType={{sectionLink.prefixType}}
+            @prefixValue={{sectionLink.prefixValue}}
+            @prefixColor={{sectionLink.prefixColor}}
+            @badgeText={{sectionLink.badgeText}}
+            @models={{sectionLink.models}}
+            @suffixCSSClass={{sectionLink.suffixCSSClass}}
+            @suffixValue={{sectionLink.suffixValue}}
+            @suffixType={{sectionLink.suffixType}}
+            data-tag-name={{sectionLink.tagName}}
+          />
+        {{/if}}
       {{/each}}
 
       <AllTagsSectionLink />

--- a/app/assets/javascripts/discourse/app/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.hbs
@@ -39,7 +39,11 @@
         </div>
       {{else}}
         <div class="tag-name-wrapper">
-          {{discourse-tag this.tagInfo.name tagName="div"}}
+          {{discourse-tag
+            this.tagInfo.name
+            tagName="div"
+            tagGroups=this.tagInfo.tag_group_names
+          }}
           {{#if this.canAdminTag}}
             <a
               href
@@ -89,7 +93,12 @@
         <div class="tag-list">
           {{#each this.tagInfo.synonyms as |tag|}}
             <div class="tag-box">
-              {{discourse-tag tag.id pmOnly=tag.pmOnly tagName="div"}}
+              {{discourse-tag
+                tag.id
+                pmOnly=tag.pmOnly
+                tagName="div"
+                tagGroups=tag.tag_group_names
+              }}
               {{#if this.editSynonymsMode}}
                 <a
                   href

--- a/app/assets/javascripts/discourse/app/components/tag-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-list.hbs
@@ -15,6 +15,7 @@
       isPrivateMessage=this.isPrivateMessage
       pmOnly=tag.pmOnly
       tagsForUser=this.tagsForUser
+      tagGroup=this.tagGroupName
     }}
     {{#if tag.pmOnly}}
       {{d-icon "envelope"}}

--- a/app/assets/javascripts/discourse/app/components/tag-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-list.hbs
@@ -15,7 +15,7 @@
       isPrivateMessage=this.isPrivateMessage
       pmOnly=tag.pmOnly
       tagsForUser=this.tagsForUser
-      tagGroups=tag.groups
+      tagGroups=tag.tag_group_names
     }}
     {{#if tag.pmOnly}}
       {{d-icon "envelope"}}

--- a/app/assets/javascripts/discourse/app/components/tag-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/tag-list.hbs
@@ -15,7 +15,7 @@
       isPrivateMessage=this.isPrivateMessage
       pmOnly=tag.pmOnly
       tagsForUser=this.tagsForUser
-      tagGroup=this.tagGroupName
+      tagGroups=tag.groups
     }}
     {{#if tag.pmOnly}}
       {{d-icon "envelope"}}

--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -71,7 +71,7 @@ export function defaultRenderTag(tag, params, extra) {
     {
       href: path && getURL(path),
       "data-tag-name": tag,
-      "data-tag-groups": params.tagGroup || params.tagGroups?.join(","),
+      "data-tag-groups": params.tagGroups?.join(","),
       title: hoverDescription,
       class: classes.join(" "),
       ...(extra.attrs ?? {}),

--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -71,7 +71,7 @@ export function defaultRenderTag(tag, params, extra) {
     {
       href: path && getURL(path),
       "data-tag-name": tag,
-      "data-tag-groups": params.tagGroups?.join(","),
+      "data-tag-groups": params.tagGroups?.join(", "),
       title: hoverDescription,
       class: classes.join(" "),
       ...(extra.attrs ?? {}),

--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -68,6 +68,7 @@ export default function (topic, params) {
             isPrivateMessage,
             tagsForUser,
             tagName,
+            tagGroups: topic.tags_groups?.[tags[i]],
           }) + "";
       }
     }

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -93,7 +93,7 @@ export function translateResults(results, opts) {
       return EmberObject.create({
         id: tagName,
         url: getURL("/tag/" + tagName),
-        groups: tag.groups,
+        tag_group_names: tag.tag_group_names,
         description: tag.description,
         count: tag.topic_count,
       });

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -93,6 +93,9 @@ export function translateResults(results, opts) {
       return EmberObject.create({
         id: tagName,
         url: getURL("/tag/" + tagName),
+        groups: tag.groups,
+        description: tag.description,
+        count: tag.topic_count,
       });
     })
     .compact();

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
@@ -51,4 +51,8 @@ export default class BaseTagSectionLink {
   get prefixColor() {
     return customTagSectionLinkPrefixIcons[this.tagName]?.prefixColor;
   }
+
+  get tagGroups() {
+    return escape(this.tag.groups?.join(", "));
+  }
 }

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -74,8 +74,16 @@ export async function findTopicList(
   if (list.topic_list?.top_tags) {
     if (list.filter.startsWith("c/") || list.filter.startsWith("tags/c/")) {
       Site.currentProp("category_top_tags", list.topic_list.top_tags);
+      Site.currentProp(
+        "category_top_tags_with_groups",
+        list.topic_list.top_tags_with_groups
+      );
     } else {
       Site.currentProp("top_tags", list.topic_list.top_tags);
+      Site.currentProp(
+        "top_tags_with_groups",
+        list.topic_list.top_tags_with_groups
+      );
     }
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -24,8 +24,8 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     watched_tags: ["tag2", "tag3"],
     watching_first_post_tags: [],
     sidebar_tags: [
-      { name: "tag2", pm_only: false },
-      { name: "tag1", pm_only: false },
+      { name: "tag2", pm_only: false, groups: [] },
+      { name: "tag1", pm_only: false, groups: ["group1", "group2"] },
       {
         name: "tag4",
         pm_only: true,
@@ -80,20 +80,30 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
       "4 section links under the section"
     );
 
+    const tag1 = query(".sidebar-section-link-wrapper[data-tag-name=tag1]");
+
     assert.strictEqual(
-      query(
-        ".sidebar-section-link-wrapper[data-tag-name=tag1]"
-      ).textContent.trim(),
+      tag1.textContent.trim(),
       "tag1",
       "displays the tag1 name for the link text"
     );
+    assert.strictEqual(
+      tag1.dataset.tagGroups,
+      "group1, group2",
+      "have the tag1's groups in the dataset"
+    );
+
+    const tag2 = query(".sidebar-section-link-wrapper[data-tag-name=tag2]");
 
     assert.strictEqual(
-      query(
-        ".sidebar-section-link-wrapper[data-tag-name=tag2]"
-      ).textContent.trim(),
+      tag2.textContent.trim(),
       "tag2",
       "displays the tag2 name for the link text"
+    );
+    assert.strictEqual(
+      tag2.dataset.tagGroups,
+      undefined,
+      "have no tagGroups in tag2's dataset"
     );
 
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -114,6 +114,15 @@ acceptance("Tags", function (needs) {
     );
     assert.ok(exists(`[data-tag-name="eviltrout"]`), "shows the eviltrout tag");
   });
+  test("have the tag-groups data", async function (assert) {
+    await visit("/tags");
+
+    assert.strictEqual(
+      query(`[data-tag-name="escort"]`).dataset.tagGroups,
+      "Ford Cars",
+      "has the correct tag group"
+    );
+  });
 
   test("dismiss notifications", async function (assert) {
     await visit("/tag/test/l/unread");

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -134,6 +134,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "Escort",
                 count: 1,
                 pm_only: false,
+                tag_group_names: ["Ford Cars"],
               },
               {
                 id: "focus",
@@ -141,6 +142,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "focus",
                 count: 3,
                 pm_only: false,
+                tag_group_names: ["Ford Cars"],
               },
             ],
           },
@@ -154,6 +156,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "civic",
                 count: 4,
                 pm_only: false,
+                tag_group_names: ["Honda Cars"],
               },
               {
                 id: "accord",
@@ -161,6 +164,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "accord",
                 count: 2,
                 pm_only: false,
+                tag_group_names: ["Honda Cars"],
               },
             ],
           },
@@ -174,6 +178,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "ford",
                 count: 5,
                 pm_only: false,
+                tag_group_names: ["Makes"],
               },
               {
                 id: "honda",
@@ -181,6 +186,7 @@ export function applyDefaultHandlers(pretender) {
                 text: "honda",
                 count: 6,
                 pm_only: false,
+                tag_group_names: ["Makes"],
               },
             ],
           },

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -23,12 +23,29 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
   hooks.beforeEach(function () {
     this.set("subject", selectKit());
 
-    this.site.set("top_tags", ["jeff", "neil", "arpit", "régis"]);
+    this.site.set("top_tags_with_groups", [
+      {
+        tag_name: "jeff",
+        tag_group_names: ["group1", "group2"],
+        sum_topic_count: 4,
+      },
+      { tag_name: "neil", tag_group_names: ["group1"], sum_topic_count: 3 },
+      { tag_name: "arpit", tag_group_names: [], sum_topic_count: 2 },
+      { tag_name: "régis", tag_group_names: [], sum_topic_count: 1 },
+    ]);
 
     pretender.get("/tags/filter/search", (params) => {
       if (params.queryParams.q === "dav") {
         return response({
-          results: [{ id: "David", name: "David", count: 2, pm_only: false }],
+          results: [
+            {
+              id: "David",
+              name: "David",
+              count: 2,
+              pm_only: false,
+              tag_group_names: ["group1"],
+            },
+          ],
         });
       }
     });
@@ -62,12 +79,32 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
       "it has the translated label for no-tags"
     );
 
+    const rows = this.subject.rows();
+    assert.strictEqual(
+      rows[2].querySelector(".discourse-tag").dataset.tagGroups,
+      "group1, group2",
+      "it has the data-tag-groups for grouped tags"
+    );
+    assert.strictEqual(
+      rows[4].querySelector(".discourse-tag").dataset.tagGroups,
+      undefined,
+      "it does not have data-tag-groups the ungroupped tags"
+    );
+
     await this.subject.fillInFilter("dav");
 
+    const row0 = this.subject.rows()[0];
+
     assert.strictEqual(
-      this.subject.rows()[0].textContent.trim(),
+      row0.textContent.trim(),
       "David",
       "it has no tag count when filtering in a category context"
+    );
+
+    assert.strictEqual(
+      row0.querySelector(".discourse-tag").dataset.tagGroups,
+      "group1",
+      "it has tag groups when filtering in a category context"
     );
   });
 
@@ -77,8 +114,9 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
     await this.subject.expand();
     await this.subject.fillInFilter("dav");
 
+    const row = this.subject.rows()[0];
     assert.strictEqual(
-      this.subject.rows()[0].textContent.trim(),
+      row.textContent.trim(),
       "David x2",
       "it has the tag count"
     );
@@ -90,6 +128,18 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
 
     await this.subject.expand();
     assert.dom(".filter-for-more").exists("it has the 'filter for more' note");
+
+    const rows = this.subject.rows();
+    assert.strictEqual(
+      rows[1].querySelector(".discourse-tag").dataset.tagGroups,
+      "group1, group2",
+      "it has the data-tag-groups for grouped tags"
+    );
+    assert.strictEqual(
+      rows[3].querySelector(".discourse-tag").dataset.tagGroups,
+      undefined,
+      "it does not have data-tag-groups the ungroupped tags"
+    );
 
     await this.subject.fillInFilter("dav");
     assert

--- a/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
@@ -1,6 +1,6 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
-import renderTag from "discourse/lib/render-tag";
+import renderTag, { defaultRenderTag } from "discourse/lib/render-tag";
 
 module("Unit | Utility | render-tag", function (hooks) {
   setupTest(hooks);
@@ -32,6 +32,22 @@ module("Unit | Utility | render-tag", function (hooks) {
       }),
       '<a href="/tag/foo" data-tag-name="foo" data-tag-groups="group1,group2" class="discourse-tag simple">foo</a>',
       "adds the tag-groups to data"
+    );
+
+    assert.strictEqual(
+      defaultRenderTag(
+        "foo",
+        {},
+        {
+          extraClass: "classname1 classname2",
+          contentFn: (c) => `Tag - ${c}`,
+          attrs: {
+            "data-foo": "bar",
+          },
+        }
+      ),
+      '<a href="/tag/foo" data-tag-name="foo" class="discourse-tag simple classname1 classname2" data-foo="bar">Tag - foo</a>',
+      "works fine with extra parameters"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
@@ -30,7 +30,7 @@ module("Unit | Utility | render-tag", function (hooks) {
       renderTag("foo", {
         tagGroups: ["group1", "group2"],
       }),
-      '<a href="/tag/foo" data-tag-name="foo" data-tag-groups="group1,group2" class="discourse-tag simple">foo</a>',
+      '<a href="/tag/foo" data-tag-name="foo" data-tag-groups="group1, group2" class="discourse-tag simple">foo</a>',
       "adds the tag-groups to data"
     );
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
@@ -8,7 +8,7 @@ module("Unit | Utility | render-tag", function (hooks) {
   test("defaultRenderTag", function (assert) {
     assert.strictEqual(
       renderTag("foo", { description: "foo description" }),
-      "<a href='/tag/foo'  data-tag-name=foo title=\"foo description\"  class='discourse-tag simple'>foo</a>",
+      '<a href="/tag/foo" data-tag-name="foo" title="foo description" class="discourse-tag simple">foo</a>',
       "formats tag as link with plain description in hover"
     );
 
@@ -16,8 +16,22 @@ module("Unit | Utility | render-tag", function (hooks) {
       renderTag("foo", {
         description: 'foo description <a href="localhost">link</a>',
       }),
-      "<a href='/tag/foo'  data-tag-name=foo title=\"foo description link\"  class='discourse-tag simple'>foo</a>",
+      '<a href="/tag/foo" data-tag-name="foo" title="foo description link" class="discourse-tag simple">foo</a>',
       "removes any html tags from description"
+    );
+
+    assert.strictEqual(
+      renderTag("foo", { noHref: true }),
+      '<a data-tag-name="foo" class="discourse-tag simple">foo</a>',
+      "allows no href"
+    );
+
+    assert.strictEqual(
+      renderTag("foo", {
+        tagGroups: ["group1", "group2"],
+      }),
+      '<a href="/tag/foo" data-tag-name="foo" data-tag-groups="group1,group2" class="discourse-tag simple">foo</a>',
+      "adds the tag-groups to data"
     );
   });
 });

--- a/app/assets/javascripts/select-kit/addon/components/tag-chooser-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/tag-chooser-row.hbs
@@ -2,6 +2,6 @@
   this.rowValue
   count=this.item.count
   noHref=true
-  tagGroups=this.item.groups
+  tagGroups=this.item.tag_group_names
   descriptiion=this.item.description
 }}

--- a/app/assets/javascripts/select-kit/addon/components/tag-chooser-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/tag-chooser-row.hbs
@@ -1,1 +1,7 @@
-{{discourse-tag this.rowValue count=this.item.count noHref=true}}
+{{discourse-tag
+  this.rowValue
+  count=this.item.count
+  noHref=true
+  tagGroups=this.item.groups
+  descriptiion=this.item.description
+}}

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -125,7 +125,6 @@ export default ComboBoxComponent.extend(TagsMixin, {
         name: t.tag_name,
         id: t.tag_name,
         tag_group_names: t.tag_group_names,
-        count: t.sum_topic_count,
       })) || []
     );
   },

--- a/app/assets/javascripts/select-kit/addon/components/tag-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/tag-row.hbs
@@ -1,5 +1,10 @@
 {{#if this.isTag}}
-  {{discourse-tag this.rowValue noHref=true count=this.item.count}}
+  {{discourse-tag
+    this.rowValue
+    noHref=true
+    count=this.item.count
+    tagGroups=this.item.groups
+  }}
 {{else}}
   <span class="name">{{this.item.name}}</span>
 {{/if}}

--- a/app/assets/javascripts/select-kit/addon/components/tag-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/tag-row.hbs
@@ -3,7 +3,7 @@
     this.rowValue
     noHref=true
     count=this.item.count
-    tagGroups=this.item.groups
+    tagGroups=this.item.tag_group_names
   }}
 {{else}}
   <span class="name">{{this.item.name}}</span>

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -437,6 +437,8 @@ class TagsController < ::ApplicationController
     show_pm_tags = guardian.can_tag_pms?
     target_tags = Tag.where(id: tags.map(&:target_tag_id).compact.uniq).select(:id, :name)
 
+    tag_groups = TagGroup.visible_of_tags(Tag.where(name: tags.map(&:name).compact.uniq), guardian)
+
     tags
       .map do |t|
         topic_count = t.public_send(Tag.topic_count_column(guardian))
@@ -452,6 +454,7 @@ class TagsController < ::ApplicationController
           pm_only: topic_count == 0 && t.pm_topic_count > 0,
           target_tag:
             t.target_tag_id ? target_tags.find { |x| x.id == t.target_tag_id }&.name : nil,
+          groups: tag_groups[t.name],
         }
 
         if show_pm_tags && SiteSetting.display_personal_messages_tag_counts

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -464,10 +464,6 @@ class TagsController < ::ApplicationController
 
         if groups_override != nil
           groups = groups_override
-        elsif t.respond_to? :tag_group_id
-          groups =
-            [TagGroup.find_by(id: t.tag_group_id)&.name] &
-              DiscourseTagging.cached_tag_groups(guardian)
         elsif t.respond_to? :tag_group_names
           groups = t.tag_group_names & DiscourseTagging.cached_tag_groups(guardian)
         elsif t.is_a? Tag

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -96,7 +96,7 @@ class TagsController < ::ApplicationController
           .map do |c|
             category_tags =
               self.class.tag_counts_json(
-                DiscourseTagging.filter_visible(c.none_synonym_tags, guardian),
+                DiscourseTagging.filter_visible(c.none_synonym_tags, guardian).all,
                 guardian,
               )
 
@@ -471,6 +471,8 @@ class TagsController < ::ApplicationController
         elsif t.respond_to? :tag_group_names
           groups = t.tag_group_names & DiscourseTagging.cached_tag_groups(guardian)
         elsif t.is_a? Tag
+          # TODO Try to reduce the number of times this statement is executed,
+          # as it can cause performance issues when there are too many tags.
           groups = t.visible_tag_groups_names(guardian)
         else
           groups = []

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -150,7 +150,7 @@ class Category < ActiveRecord::Base
   has_many :category_tags, dependent: :destroy
   has_many :tags, through: :category_tags
   has_many :none_synonym_tags,
-           -> { where(target_tag_id: nil) },
+           -> { with_groups.where(target_tag_id: nil) },
            through: :category_tags,
            source: :tag
   has_many :category_tag_groups, dependent: :destroy

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -262,6 +262,10 @@ class Tag < ActiveRecord::Base
     end
   end
 
+  def visible_tag_groups_names(guardian)
+    tag_groups.pluck(:name) & DiscourseTagging.cached_tag_groups(guardian)
+  end
+
   private
 
   def sanitize_description

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -38,6 +38,13 @@ class Tag < ActiveRecord::Base
   scope :used_tags_in_regular_topics,
         ->(guardian) { where("tags.#{Tag.topic_count_column(guardian)} > 0") }
 
+  scope :with_groups,
+        -> do
+          left_outer_joins(:tag_groups).select(
+            "tags.*, array_agg(tag_groups.name) as tag_group_names",
+          ).group("tags.id")
+        end
+
   scope :base_tags, -> { where(target_tag_id: nil) }
   scope :visible, ->(guardian = nil) { merge(DiscourseTagging.visible_tags(guardian)) }
 

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -109,6 +109,18 @@ class TagGroup < ActiveRecord::Base
       )
     end
   end
+
+  def self.visible_of_tags(tags, guardian)
+    visible_groups = TagGroup.visible(guardian)
+
+    tags
+      .each
+      .with_object({}) do |tag, obj|
+        group = tag.tag_groups
+        group &= visible_groups unless visible_groups.equal? TagGroup
+        obj[tag.name] = group.map { |g| g.name }
+      end
+  end
 end
 
 # == Schema Information

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -109,18 +109,6 @@ class TagGroup < ActiveRecord::Base
       )
     end
   end
-
-  def self.visible_of_tags(tags, guardian)
-    visible_groups = TagGroup.visible(guardian)
-
-    tags
-      .each
-      .with_object({}) do |tag, obj|
-        group = tag.tag_groups
-        group &= visible_groups unless visible_groups.equal? TagGroup
-        obj[tag.name] = group.map { |g| g.name }
-      end
-  end
 end
 
 # == Schema Information

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2092,7 +2092,7 @@ class Topic < ActiveRecord::Base
   end
 
   def visible_tags(guardian)
-    tags.reject { |tag| guardian.hidden_tag_names.include?(tag[:name]) }
+    tags.with_groups.reject { |tag| guardian.hidden_tag_names.include?(tag[:name]) }
   end
 
   def self.editable_custom_fields(guardian)

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -61,9 +61,13 @@ class TopicList
   end
 
   def top_tags
+    top_tags_with_groups.map { |t| t.tag_name }
+  end
+
+  def top_tags_with_groups
     opts = @category ? { category: @category } : {}
     opts[:guardian] = Guardian.new(@current_user)
-    Tag.top_tags(**opts)
+    Tag.top_tags_query(**opts)
   end
 
   def preload_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -390,7 +390,7 @@ class User < ActiveRecord::Base
     user_guardian ||= guardian
 
     DiscourseTagging.filter_visible(
-      Tag.where(
+      Tag.with_groups.where(
         id: SidebarSectionLink.where(user_id: self.id, linkable_type: "Tag").select(:linkable_id),
       ),
       user_guardian,

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -27,7 +27,9 @@ module TopicTagsMixin
   def tags_groups
     all_tags
       .each
-      .with_object({}) { |tag, acc| acc[tag.name] = tag.visible_tag_groups_names(scope) }
+      .with_object({}) do |tag, acc|
+        acc[tag.name] = tag.tag_group_names & DiscourseTagging.cached_tag_groups(scope)
+      end
       .compact
   end
 

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -25,7 +25,10 @@ module TopicTagsMixin
   end
 
   def tags_groups
-    TagGroup.visible_of_tags(all_tags, scope).select { |_, v| v.size > 0 }
+    all_tags
+      .each
+      .with_object({}) { |tag, acc| acc[tag.name] = tag.visible_tag_groups_names(scope) }
+      .compact
   end
 
   def topic

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -6,6 +6,7 @@ module TopicTagsMixin
   def self.included(klass)
     klass.attributes :tags
     klass.attributes :tags_descriptions
+    klass.attributes :tags_groups
   end
 
   def include_tags?
@@ -21,6 +22,10 @@ module TopicTagsMixin
       .each
       .with_object({}) { |tag, acc| acc[tag.name] = tag.description&.truncate(DESCRIPTION_LIMIT) }
       .compact
+  end
+
+  def tags_groups
+    TagGroup.visible_of_tags(all_tags, scope).select { |_, v| v.size > 0 }
   end
 
   def topic

--- a/app/serializers/detailed_tag_serializer.rb
+++ b/app/serializers/detailed_tag_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DetailedTagSerializer < TagSerializer
-  attributes :synonyms, :tag_group_names, :category_restricted
+  attributes :synonyms, :category_restricted
 
   has_many :categories, serializer: BasicCategorySerializer
 
@@ -19,9 +19,5 @@ class DetailedTagSerializer < TagSerializer
 
   def include_tag_group_names?
     scope.is_admin? || SiteSetting.tags_listed_by_group == true
-  end
-
-  def tag_group_names
-    object.tag_groups.map(&:name)
   end
 end

--- a/app/serializers/sidebar_tag_serializer.rb
+++ b/app/serializers/sidebar_tag_serializer.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class SidebarTagSerializer < ApplicationSerializer
-  attributes :name, :description, :pm_only
+  attributes :name, :description, :pm_only, :groups
 
   def pm_only
     topic_count_column = Tag.topic_count_column(scope)
     object.public_send(topic_count_column) == 0 && object.pm_topic_count > 0
+  end
+
+  def groups
+    object.tag_group_names & DiscourseTagging.cached_tag_groups(scope)
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -269,7 +269,7 @@ class SiteSerializer < ApplicationSerializer
   def navigation_menu_site_top_tags
     if top_tags.present?
       tag_names = top_tags[0...SIDEBAR_TOP_TAGS_TO_SHOW]
-      serialized = serialize_tags(Tag.where(name: tag_names))
+      serialized = serialize_tags(Tag.with_groups.where(name: tag_names))
 
       # Ensures order of top tags is preserved
       serialized.sort_by { |tag| tag_names.index(tag[:name]) }
@@ -289,7 +289,7 @@ class SiteSerializer < ApplicationSerializer
           SiteSetting.default_navigation_menu_tags.split("|") -
             DiscourseTagging.hidden_tag_names(scope)
 
-        serialize_tags(Tag.where(name: tag_names).order(:name))
+        serialize_tags(Tag.with_groups.where(name: tag_names).order(:name))
       end
   end
 

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -23,6 +23,7 @@ class SiteSerializer < ApplicationSerializer
     :can_tag_pms,
     :tags_filter_regexp,
     :top_tags,
+    :top_tags_with_groups,
     :navigation_menu_site_top_tags,
     :can_associate_groups,
     :wizard_required,
@@ -196,8 +197,16 @@ class SiteSerializer < ApplicationSerializer
     Tag.include_tags?
   end
 
+  def include_top_tags_with_groups?
+    Tag.include_tags?
+  end
+
   def top_tags
-    @top_tags ||= Tag.top_tags(guardian: scope)
+    top_tags_with_groups.map { |t| t.tag_name }
+  end
+
+  def top_tags_with_groups
+    @top_tags_with_groups ||= Tag.top_tags_query
   end
 
   def wizard_required

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TagSerializer < ApplicationSerializer
-  attributes :id, :name, :topic_count, :staff, :description
+  attributes :id, :name, :topic_count, :staff, :description, :groups
 
   def topic_count
     object.public_send(Tag.topic_count_column(scope))
@@ -9,5 +9,9 @@ class TagSerializer < ApplicationSerializer
 
   def staff
     DiscourseTagging.staff_tag_names.include?(name)
+  end
+
+  def groups
+    object.visible_tag_groups_names(scope)
   end
 end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TagSerializer < ApplicationSerializer
-  attributes :id, :name, :topic_count, :staff, :description, :groups
+  attributes :id, :name, :topic_count, :staff, :description, :tag_group_names
 
   def topic_count
     object.public_send(Tag.topic_count_column(scope))
@@ -11,7 +11,7 @@ class TagSerializer < ApplicationSerializer
     DiscourseTagging.staff_tag_names.include?(name)
   end
 
-  def groups
+  def tag_group_names
     object.visible_tag_groups_names(scope)
   end
 end

--- a/app/serializers/topic_list_serializer.rb
+++ b/app/serializers/topic_list_serializer.rb
@@ -6,6 +6,7 @@ class TopicListSerializer < ApplicationSerializer
              :for_period,
              :per_page,
              :top_tags,
+             :top_tags_with_groups,
              :tags,
              :shared_drafts
 

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -806,6 +806,7 @@ module DiscourseTagging
       Discourse.cache.write(
         TAGS_GROUP_CACHE_KEY,
         [true, guardian.user&.id, visible_tag_groups_names],
+        expires_in: 1.minute,
       )
     end
 

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -606,6 +606,19 @@ module DiscourseTagging
 
     result = builder.query(builder_params).uniq { |t| t.id }
 
+    tag_groups =
+      Tag
+        .with_groups
+        .where(id: result.map { |t| t.id })
+        .each
+        .with_object({}) { |tag, hash| hash[tag.id] = tag.tag_group_names }
+
+    result.each do |tag|
+      tag.define_singleton_method :tag_group_names do
+        tag_groups[tag.id] || []
+      end
+    end
+
     if opts[:with_context]
       context = {}
       if required_category_tag_group

--- a/spec/requests/api/schemas/json/topic_show_response.json
+++ b/spec/requests/api/schemas/json/topic_show_response.json
@@ -396,6 +396,13 @@
             "additionalProperties": false,
             "properties": {}
           },
+          "tags_groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array"
+            },
+            "properties": {}
+          },
           "like_count": {
             "type": "integer"
           },
@@ -481,6 +488,7 @@
           "liked",
           "tags",
           "tags_descriptions",
+          "tags_groups",
           "like_count",
           "views",
           "category_id",
@@ -496,6 +504,13 @@
     "tags_descriptions": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {}
+    },
+    "tags_groups": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array"
+      },
       "properties": {}
     },
     "id": {
@@ -923,6 +938,7 @@
     "suggested_topics",
     "tags",
     "tags_descriptions",
+    "tags_groups",
     "id",
     "title",
     "fancy_title",

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -234,8 +234,9 @@ RSpec.describe ListController do
           expect(body["topic_list"]["topics"][0]["tags"]).to contain_exactly(tag.name)
         end.count
 
-      tag2 = Fabricate(:tag)
-      topic2 = Fabricate(:topic, tags: [tag2])
+      many_tags = []
+      20.times { many_tags << Fabricate(:tag) }
+      topic2 = Fabricate(:topic, tags: many_tags)
 
       new_sql_queries_count =
         track_sql_queries do
@@ -250,7 +251,9 @@ RSpec.describe ListController do
             topic2.id,
           )
 
-          expect(body["topic_list"]["topics"][0]["tags"]).to contain_exactly(tag2.name)
+          expect(body["topic_list"]["topics"][0]["tags"]).to contain_exactly(
+            *(many_tags.map { |t| t.name }),
+          )
           expect(body["topic_list"]["topics"][1]["tags"]).to contain_exactly(tag.name)
         end.count
 

--- a/spec/serializers/web_hook_topic_view_serializer_spec.rb
+++ b/spec/serializers/web_hook_topic_view_serializer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe WebHookTopicViewSerializer do
       last_poster
       tags
       tags_descriptions
+      tags_groups
       thumbnails
     ]
 


### PR DESCRIPTION
## Overview

This commit adds the `data-tag-groups` attribute to tags, making it easier to use CSS selectors to batch select tags belonging to certain tag groups.

An example:

```html
<a href="/tag/hidden" data-tag-name="hidden" data-tag-groups="Hidden Tag Group, non-hidden tags" class="discourse-tag box">hidden</a>
```

Related meta topic: https://meta.discourse.org/t/add-a-data-tag-group-attribute-for-tags/234410

## Detailed changes

Add data-groups to these...
- [ ] Tags for topics
   - [x] The effect has been shown
   - [ ] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] TagChooser at the top of TopicList
   - [x] The effect has been shown
   - [x] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] Tags on the sidebar
   - [x] The effect has been shown
   - [ ] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] Tags on the `/tags` page
   - [x] The effect has been shown
   - [ ] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] Search bar tags
   - [x] The effect has been shown
   - [ ] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] Composer tags chooser
   - [x] The effect has been shown
   - [ ] Tests already written
   - [ ] Confirms that there are no performance issues
- [ ] ~~Tags in the post body~~ Maybe next PR


## DEV Improvements

Partially rewrote `defaultRenderTag` for better scalability and clarity:

The new `defaultRenderTag` reserves an interface for theme components to avoid the need for components to completely rewrite `defaultRenderTag` to provide custom tag renderer.

For example, you can now replace the tagRenderer like this:

```javascript
api.replaceTagRenderer((tag, params) => {
    return defaultRenderTag(tag, params, {
        extraClass: "custom-tag-class",
        contentFn(old) {
            return `${iconHTML("tag")}${old}`;
        },
    });
});
```

This has a significant benefit for discourse tag icons. Since the [old way of code](https://github.com/discourse/discourse-tag-icons/blob/main/javascripts/discourse/initializers/tag-icons.js#L9-L84) the changes made by this PR will be completely overwritten by discourse tag icons, and the theme component must be updated accordingly.
After applying the new interface, it can automatically synchronize changes with the `defaultRendererTag` in core.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
