### PR TITLE
UX: remove whitespace from rendered localdate

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -40,12 +40,10 @@ export function applyLocalDates(dates, siteSettings) {
     element.innerText = "";
     element.insertAdjacentHTML(
       "beforeend",
-      `
-        <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
+      `<svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
           <use href="#globe-americas"></use>
         </svg>
-        <span class="relative-time">${localDateBuilder.formatted}</span>
-      `
+        <span class="relative-time">${localDateBuilder.formatted}</span>`
     );
     element.setAttribute("aria-label", localDateBuilder.textPreview);
 


### PR DESCRIPTION
Removes a hardcoded whitespace from rendered dates in the composer preview and posts 


Before:
![image](https://github.com/user-attachments/assets/f9592a40-0139-4af2-9d36-7cbc6669245a)


After:
![image](https://github.com/user-attachments/assets/4457ac21-571d-40ab-bcdf-4f2cebb23ffd)
