### PR TITLE
UX: remove formkit css bleeding into every dropdown

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_control-menu.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-menu.scss
@@ -10,11 +10,5 @@
     &:hover {
       background: var(--d-hover);
     }
-
-    &:last-child {
-      .btn {
-        color: var(--tertiary);
-      }
-    }
   }
 }


### PR DESCRIPTION
The recent formkit css had an unintended bleed into every `fk-d-menu`.
