### PR TITLE
FIX: avoid updating `hamburgerVisible` in the same computation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { getOwner } from "@ember/application";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import { and, eq, not, or } from "truth-helpers";
@@ -109,15 +110,17 @@ export default class GlimmerHeader extends Component {
 
   @action
   closeCurrentMenu() {
-    if (this.search.visible) {
-      this.toggleSearchMenu();
-    } else if (this.header.userVisible) {
-      this.toggleUserMenu();
-      document.getElementById(USER_BUTTON_ID)?.focus();
-    } else if (this.header.hamburgerVisible) {
-      this.toggleHamburger();
-      document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
-    }
+    schedule("afterRender", () => {
+      if (this.search.visible) {
+        this.toggleSearchMenu();
+      } else if (this.header.userVisible) {
+        this.toggleUserMenu();
+        document.getElementById(USER_BUTTON_ID)?.focus();
+      } else if (this.header.hamburgerVisible) {
+        this.toggleHamburger();
+        document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
+      }
+    });
   }
 
   @action


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/0d4492c7b743c0eb609e24663b52c85fe1e4d03f

When triggering a modal within a dropdown using keyboard nav, an error would occur: 

> Uncaught Error: Assertion Failed: You attempted to update `hamburgerVisible` on `<Header:ember767>`, but it had already been used previously in the same computation. Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

Using `schedule("afterRender")` defers this update and avoids the issue 