### PR TITLE
FIX: fallback to custom type for flags

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Flag < ActiveRecord::Base
-  # TODO(2025-01-15): krisk remove
-  self.ignored_columns = ["custom_type"]
-
   DEFAULT_VALID_APPLIES_TO = %w[Post Topic]
   MAX_SYSTEM_FLAG_ID = 1000
   MAX_NAME_LENGTH = 200
@@ -24,6 +21,15 @@ class Flag < ActiveRecord::Base
 
   def self.valid_applies_to_types
     Set.new(DEFAULT_VALID_APPLIES_TO | DiscoursePluginRegistry.flag_applies_to_types)
+  end
+
+  # TODO(2025-01-15): krisk remove
+  def require_message
+    if ActiveRecord::Base.connection.column_exists?(:flags, :require_message)
+      super
+    else
+      self.custom_type
+    end
   end
 
   def self.reset_flag_settings!


### PR DESCRIPTION
Before migration is run flags code is evaluated. It is causing error:
```
NoMethodError: undefined method `require_message' for an instance of Flag (NoMethodError)
Did you mean?  require_dependency
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/activemodel-7.1.3.4/lib/active_model/attribute_methods.rb:489:in `method_missing'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/relation/delegation.rb:100:in `each'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/relation/delegation.rb:100:in `each'
/var/www/discourse/app/models/post_action_type.rb:64:in `reject'
```

The solution is to temporarily fall back to old column name - custom_type

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
