### PR TITLE
DEV: supports setProperties

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -36,6 +36,7 @@ class FKForm extends Component {
 
     this.args.onRegisterApi?.({
       set: this.set,
+      setProperties: this.setProperties,
       submit: this.onSubmit,
       reset: this.onReset,
     });
@@ -118,6 +119,13 @@ class FKForm extends Component {
 
     if (this.fieldValidationEvent === VALIDATION_TYPES.change) {
       await this.triggerRevalidationFor(name);
+    }
+  }
+
+  @action
+  async setProperties(object) {
+    for (const [name, value] of Object.entries(object)) {
+      await this.set(name, value);
     }
   }
 
@@ -283,6 +291,7 @@ class FKForm extends Component {
             triggerRevalidationFor=this.triggerRevalidationFor
           )
           set=this.set
+          setProperties=this.setProperties
           addItemToCollection=this.addItemToCollection
         )
         this.formData.draftData

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -213,4 +213,22 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     assert.dom(".foo").hasText("2");
   });
+
+  test("yielded setProperties", async function (assert) {
+    await render(<template>
+      <Form @data={{hash foo=1 bar=1}} as |form data|>
+        <div class="foo">{{data.foo}}</div>
+        <div class="bar">{{data.bar}}</div>
+        <form.Button
+          class="test"
+          @action={{fn form.setProperties (hash foo=2 bar=2)}}
+        />
+      </Form>
+    </template>);
+
+    await click(".test");
+
+    assert.dom(".foo").hasText("2");
+    assert.dom(".bar").hasText("2");
+  });
 });


### PR DESCRIPTION
This is a convenience for when you have multiple properties to set in form kit.

```
// before
set("foo", 1);
set("bar", 2);

//after
setProperties({foo: 1, bar: 2});
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
