### PR TITLE
DEV: follow-up to avoid using schedule when opening modal from dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -92,7 +92,12 @@ export default class GlimmerHeader extends Component {
         return;
       }
 
-      if (!panelBody.contains(event.relatedTarget)) {
+      // don't remove focus from newly opened modal
+      const isFocusInModal = document
+        .querySelector(".d-modal")
+        ?.contains(event.relatedTarget);
+
+      if (!panelBody.contains(event.relatedTarget) && !isFocusInModal) {
         this.closeCurrentMenu();
       }
     };

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { getOwner } from "@ember/application";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
-import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import { and, eq, not, or } from "truth-helpers";
@@ -115,17 +114,15 @@ export default class GlimmerHeader extends Component {
 
   @action
   closeCurrentMenu() {
-    schedule("afterRender", () => {
-      if (this.search.visible) {
-        this.toggleSearchMenu();
-      } else if (this.header.userVisible) {
-        this.toggleUserMenu();
-        document.getElementById(USER_BUTTON_ID)?.focus();
-      } else if (this.header.hamburgerVisible) {
-        this.toggleHamburger();
-        document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
-      }
-    });
+    if (this.search.visible) {
+      this.toggleSearchMenu();
+    } else if (this.header.userVisible) {
+      this.toggleUserMenu();
+      document.getElementById(USER_BUTTON_ID)?.focus();
+    } else if (this.header.hamburgerVisible) {
+      this.toggleHamburger();
+      document.getElementById(HAMBURGER_BUTTON_ID)?.focus();
+    }
   }
 
   @action


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/6344e3f9379d048fef2c486423dcd4d2a7a6f443

This avoids the issue entirely by not triggering close when a modal is opened from a header dropdown... this also fixes an issue where focus was being removed from the modal due to the refocusing done in `closeCurrentMenu`