### PR TITLE
DEV: Ensure plugin outlet `parentView` deprecation cannot be avoided

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -50,7 +50,6 @@ const ARGS_DEPRECATION_MSG =
 
 export default class PluginOutletComponent extends GlimmerComponentWithDeprecatedParentView {
   @service clientErrorHandler;
-
   context = {
     ...helperContext(),
     get parentView() {
@@ -63,6 +62,8 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
       return get(this, ...arguments);
     },
   };
+
+  #parentView;
 
   constructor() {
     const result = super(...arguments);
@@ -136,10 +137,13 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
     deprecated(`${PARENT_VIEW_DEPRECATION_MSG} (outlet: ${this.args.name})`, {
       id: "discourse.plugin-outlet-parent-view",
     });
-    return this._parentView;
+    return this.#parentView;
   }
   set parentView(value) {
-    this._parentView = value;
+    this.#parentView = value;
+  }
+  get _parentView() {
+    return this.parentView;
   }
 
   // Older plugin outlets have a `tagName` which we need to preserve for backwards-compatibility
@@ -149,16 +153,21 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
 }
 
 class PluginOutletWithTagNameWrapper extends ClassicComponent {
+  #parentView;
+
   // Overridden parentView to make this wrapper 'transparent'
   // Calling this will trigger the deprecation notice in PluginOutletComponent
   get parentView() {
     // init() of CoreView calls `this.parentView`. That would trigger the deprecation notice,
     // so skip it until this component is initialized.
     if (this._state) {
-      return this._parentView.parentView;
+      return this.#parentView.parentView;
     }
   }
   set parentView(value) {
-    this._parentView = value;
+    this.#parentView = value;
+  }
+  get _parentView() {
+    return this.parentView;
   }
 }


### PR DESCRIPTION
We'd implemented the deprecation by overriding `get parentView`, and storing the real value on `_parentView`. Unfortunately that meant people could access `_parentView` directly, thereby bypassing the deprecation message.

This commit moves the internal storage to a private field, which cannot be accessed from outside the class. A deprecated getter for `_parentView` is introduced to avoid immediate breakage for any code using this workaround.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
