### PR TITLE
DEV: exposes isDirty api

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -2,7 +2,6 @@
   @data={{this.formData}}
   @onSubmit={{this.handleSubmit}}
   @validate={{this.validateForm}}
-  @onRegisterApi={{this.registerApi}}
   class="badge-form current-badge content-body"
   as |form data|
 >

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -2,10 +2,10 @@
   @data={{this.formData}}
   @onSubmit={{this.handleSubmit}}
   @validate={{this.validateForm}}
+  @onRegisterApi={{this.registerApi}}
   class="badge-form current-badge content-body"
   as |form data|
 >
-
   <h1 class="current-badge-header">
     {{iconOrImage data}}
     <span class="badge-display-name">{{data.name}}</span>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -35,9 +35,7 @@ class FKForm extends Component {
   constructor() {
     super(...arguments);
 
-    const isDirtyCheck = () => {
-      return this.formData.isDirty;
-    };
+    const isDirtyCheck = () => this.formData.isDirty;
     next(() => {
       this.args.onRegisterApi?.({
         set: this.set,

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { array, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import FKAlert from "discourse/form-kit/components/fk/alert";
@@ -34,11 +35,19 @@ class FKForm extends Component {
   constructor() {
     super(...arguments);
 
-    this.args.onRegisterApi?.({
-      set: this.set,
-      setProperties: this.setProperties,
-      submit: this.onSubmit,
-      reset: this.onReset,
+    const isDirtyCheck = () => {
+      return this.formData.isDirty;
+    };
+    next(() => {
+      this.args.onRegisterApi?.({
+        set: this.set,
+        setProperties: this.setProperties,
+        submit: this.onSubmit,
+        reset: this.onReset,
+        get isDirty() {
+          return isDirtyCheck();
+        },
+      });
     });
 
     this.router.on("routeWillChange", this.checkIsDirty);

--- a/app/assets/javascripts/discourse/app/form-kit/lib/fk-form-data.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/fk-form-data.js
@@ -3,6 +3,7 @@
  */
 import { tracked } from "@glimmer/tracking";
 import { next } from "@ember/runloop";
+import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import { applyPatches, enablePatches, produce } from "immer";
 
 enablePatches();
@@ -30,13 +31,13 @@ export default class FKFormData {
    * The patches to be applied.
    * @type {Array}
    */
-  patches = [];
+  patches = new TrackedArray();
 
   /**
    * The inverse patches to be applied, useful for rollback.
    * @type {Array}
    */
-  inversePatches = [];
+  inversePatches = new TrackedArray();
 
   /**
    * Creates an instance of Changeset.
@@ -201,7 +202,7 @@ export default class FKFormData {
    * Resets the patches and inverse patches.
    */
   resetPatches() {
-    this.patches = [];
-    this.inversePatches = [];
+    this.patches = new TrackedArray();
+    this.inversePatches = new TrackedArray();
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -1,4 +1,7 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { array, fn, hash } from "@ember/helper";
+import { action } from "@ember/object";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
@@ -230,5 +233,34 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     assert.dom(".foo").hasText("2");
     assert.dom(".bar").hasText("2");
+  });
+
+  test("@onRegisterApi - isDirty", async function (assert) {
+    class TrackedComponent extends Component {
+      @tracked formApi;
+
+      @action
+      registerApi(api) {
+        this.formApi = api;
+      }
+
+      <template>
+        <Form @onRegisterApi={{this.registerApi}} as |form|>
+          <form.Field @title="Foo" @name="foo" as |field|>
+            <field.Input />
+          </form.Field>
+        </Form>
+
+        <div class="is-dirty">{{this.formApi.isDirty}}</div>
+      </template>
+    }
+
+    await render(<template><TrackedComponent /></template>);
+
+    assert.dom(".is-dirty").hasText("false");
+
+    await formKit().field("foo").fillIn("bar");
+
+    assert.dom(".is-dirty").hasText("true");
   });
 });


### PR DESCRIPTION
`onRegisterApi` will now expose an object which a tracked property to the internal `formData.isDirty`. This property allows components external to the form to track its state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
