### PR TITLE
UX: Fix page content overflow when the setting category list is expanded on mobile

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
@@ -11,6 +11,7 @@ import i18n from "discourse-common/helpers/i18n";
 export default class AdminSiteSettingsFilterControls extends Component {
   @tracked filter = this.args.initialFilter || "";
   @tracked onlyOverridden = false;
+  @tracked isMenuOpen = false;
 
   @action
   clearFilter() {
@@ -47,6 +48,12 @@ export default class AdminSiteSettingsFilterControls extends Component {
     this.onChangeFilter();
   }
 
+  @action
+  toggleMenu() {
+    this.isMenuOpen = !this.isMenuOpen;
+    this.args.onToggleMenu();
+  }
+
   <template>
     <div
       class="admin-controls admin-site-settings-filter-controls"
@@ -57,8 +64,8 @@ export default class AdminSiteSettingsFilterControls extends Component {
         <div class="inline-form">
           {{#if @showMenu}}
             <DButton
-              @action={{@onToggleMenu}}
-              @icon="bars"
+              @action={{this.toggleMenu}}
+              @icon={{if this.isMenuOpen "times" "bars"}}
               class="menu-toggle"
             />
           {{/if}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -84,7 +84,7 @@ $mobile-breakpoint: 700px;
   position: relative;
   .nav-stacked {
     @media screen and (max-width: 700px) {
-      margin: 0 15px 0 -10px;
+      margin: 0;
     }
   }
 
@@ -95,6 +95,14 @@ $mobile-breakpoint: 700px;
   }
   .row:after {
     clear: both;
+  }
+
+  &.admin-site-settings-category {
+    overflow: hidden;
+
+    @media (max-width: 500px) {
+      background-color: var(--primary-very-low);
+    }
   }
 }
 
@@ -710,7 +718,7 @@ $mobile-breakpoint: 700px;
   width: 82%;
   box-sizing: border-box;
   @media (max-width: $mobile-breakpoint) {
-    width: 95%;
+    width: 100%;
     border: none;
   }
 }
@@ -730,7 +738,7 @@ $mobile-breakpoint: 700px;
   @media (max-width: $mobile-breakpoint) {
     transition: transform 0.3s ease;
     @include transform(translateX(0));
-    margin-left: -10px;
+    padding: 30px 20px;
   }
 }
 


### PR DESCRIPTION
On mobile, when the settings category list is expanded, the page content gets pushed to the right.

This PR fixes:
- Prevents the page content from being pushed to the right when the settings category list is expanded
- Adds visual separation between the settings category list and the page content
- Displays a close icon when the menu is open

### Before
<img src="https://github.com/user-attachments/assets/8d16f2a5-e452-4e8d-a353-b105b67e6ab6" width="300">
<img src="https://github.com/user-attachments/assets/89626eb9-330a-46e3-acb8-9f6d744924a0" width="300">

### After
<img src="https://github.com/user-attachments/assets/16841457-c317-49ef-abe0-73694de7689c" width="300">
