### PR TITLE
DEV: Restore `missing_s3_uploads` stats count if site was restored

### DIFF
--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -155,7 +155,7 @@ class S3Inventory
               end
             end
 
-            Discourse.stats.set("missing_s3_#{table_name}", missing_count)
+            set_missing_s3_discourse_stats(missing_count)
           ensure
             connection.exec("DROP TABLE #{tmp_table_name}") unless connection.nil?
           end
@@ -250,6 +250,7 @@ class S3Inventory
         if BackupMetadata.last_restore_date.present? &&
              (symlink_file.last_modified - WAIT_AFTER_RESTORE_DAYS.days) <
                BackupMetadata.last_restore_date
+          set_missing_s3_discourse_stats(0)
           return []
         end
 
@@ -316,5 +317,9 @@ class S3Inventory
 
   def error(message)
     log(message, StandardError.new(message))
+  end
+
+  def set_missing_s3_discourse_stats(count)
+    Discourse.stats.set("missing_s3_#{@model.table_name}", count)
   end
 end

--- a/spec/lib/s3_inventory_spec.rb
+++ b/spec/lib/s3_inventory_spec.rb
@@ -169,7 +169,9 @@ RSpec.describe S3Inventory do
       capture_stdout { inventory.backfill_etags_and_list_missing }
     end
 
-    it "should not run if inventory files are not at least #{described_class::WAIT_AFTER_RESTORE_DAYS.days} days older than the last restore date" do
+    it "should not run if inventory files are not at least #{described_class::WAIT_AFTER_RESTORE_DAYS.days} days older than the last restore date and reset stats count" do
+      Discourse.stats.set("missing_s3_uploads", 2)
+
       inventory.s3_client.stub_responses(
         :list_objects_v2,
         {
@@ -186,6 +188,8 @@ RSpec.describe S3Inventory do
       inventory.s3_client.expects(:get_object).never
 
       capture_stdout { inventory.backfill_etags_and_list_missing }
+
+      expect(Discourse.stats.get("missing_s3_uploads")).to eq(0)
     end
   end
 


### PR DESCRIPTION
This commit ensures that we reset the `missing_s3_uploads` status count
if there are no inventory files which are at least 2 days older than the
site's restored date.

Otherwise, a site with missing uploads but was subsequntly restored will
be continue to report missing uploads for 2 days.
