### PR TITLE
DEV: Try until success for clipboard copies

### DIFF
--- a/plugins/chat/spec/system/chat_message/channel_spec.rb
+++ b/plugins/chat/spec/system/chat_message/channel_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Chat message - channel", type: :system do
 
       channel_page.messages.copy_text(message_1)
 
-      expect(cdp.read_clipboard.chomp).to eq(message_1.message)
+      cdp.clipboard_has_text?(message_1.message, chomp: true)
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.text_copied"))
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe "Chat message - channel", type: :system do
 
       channel_page.messages.copy_link(message_1)
 
-      expect(cdp.read_clipboard).to include("/chat/c/-/#{channel_1.id}/#{message_1.id}")
+      cdp.clipboard_has_text?("/chat/c/-/#{channel_1.id}/#{message_1.id}", strict: false)
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
     end
 
@@ -57,7 +57,7 @@ RSpec.describe "Chat message - channel", type: :system do
 
       channel_page.messages.copy_link(message_1)
 
-      expect(cdp.read_clipboard).to include("/chat/c/-/#{channel_1.id}/#{message_1.id}")
+      cdp.clipboard_has_text?("/chat/c/-/#{channel_1.id}/#{message_1.id}", strict: false)
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
     end
 
@@ -77,19 +77,21 @@ RSpec.describe "Chat message - channel", type: :system do
 
         channel_page.messages.copy_link(thread_1.original_message)
 
-        expect(cdp.read_clipboard).to include(
+        cdp.clipboard_has_text?(
           "/chat/c/-/#{channel_1.id}/#{thread_1.original_message.id}",
+          strict: false,
         )
         expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
       end
 
-      xit "[mobile] copies the link to the message", mobile: true do
+      it "[mobile] copies the link to the message", mobile: true do
         chat_page.visit_channel(channel_1)
 
         channel_page.messages.copy_link(thread_1.original_message)
 
-        expect(cdp.read_clipboard).to include(
+        cdp.clipboard_has_text?(
           "/chat/c/-/#{channel_1.id}/#{thread_1.original_message.id}",
+          strict: false,
         )
         expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
       end

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Chat message - thread", type: :system do
 
       thread_page.messages.copy_text(thread_message_1)
 
-      expect(cdp.read_clipboard.chomp).to eq(thread_message_1.message)
+      cdp.clipboard_has_text?(thread_message_1.message)
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.text_copied"))
     end
   end
@@ -58,8 +58,9 @@ RSpec.describe "Chat message - thread", type: :system do
 
       thread_page.messages.copy_link(thread_message_1)
 
-      expect(cdp.read_clipboard).to include(
+      cdp.clipboard_has_text?(
         "/chat/c/-/#{channel_1.id}/t/#{thread_message_1.thread.id}/#{thread_message_1.id}",
+        strict: false,
       )
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
     end
@@ -69,8 +70,9 @@ RSpec.describe "Chat message - thread", type: :system do
 
       thread_page.messages.copy_link(thread_message_1)
 
-      expect(cdp.read_clipboard).to include(
+      cdp.clipboard_has_text?(
         "/chat/c/-/#{channel_1.id}/t/#{thread_message_1.thread.id}/#{thread_message_1.id}",
+        strict: false,
       )
       expect(PageObjects::Components::Toasts.new).to have_success(I18n.t("js.chat.link_copied"))
     end

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe "Quoting chat message transcripts", type: :system do
     expect(PageObjects::Components::Toasts.new).to have_success(
       I18n.t("js.chat.quote.copy_success"),
     )
-    clip_text = cdp.read_clipboard
-    expect(clip_text.chomp).to eq(generate_transcript(messages, current_user))
-    clip_text
+    cdp.clipboard_has_text?(generate_transcript(messages, current_user), chomp: true)
+    cdp.read_clipboard
   end
 
   def generate_transcript(messages, acting_user)

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -3,6 +3,8 @@
 module PageObjects
   class CDP
     include Capybara::DSL
+    include SystemHelpers
+    include RSpec::Matchers
 
     def allow_clipboard
       cdp_params = {
@@ -26,6 +28,13 @@ module PageObjects
 
     def read_clipboard
       page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+    end
+
+    def clipboard_has_text?(text, chomp: false, strict: true)
+      try_until_success do
+        clipboard_text = chomp ? read_clipboard.chomp : read_clipboard
+        expect(clipboard_text).to strict ? eq(text) : include(text)
+      end
     end
 
     def with_network_disconnected

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -17,9 +17,7 @@ describe "Post menu", type: :system, js: true do
     it "copies the absolute link to the post when clicked" do
       topic_page.visit_topic(post.topic)
       topic_page.click_post_action_button(post, :copy_link)
-      expect(cdp.read_clipboard).to eq(
-        post.full_url(share_url: true) + "?u=#{current_user.username}",
-      )
+      cdp.clipboard_has_text?(post.full_url(share_url: true) + "?u=#{current_user.username}")
     end
   end
 end

--- a/spec/system/post_selection_copy_quote_spec.rb
+++ b/spec/system/post_selection_copy_quote_spec.rb
@@ -20,7 +20,7 @@ describe "Post selection | Copy quote", type: :system do
       select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
       topic_page.copy_quote_button.click
 
-      expect(cdp.read_clipboard.chomp).to eq(<<~QUOTE.chomp)
+      cdp.clipboard_has_text?(<<~QUOTE.chomp, chomp: true)
     [quote=\"#{post.user.username}, post:1, topic:#{topic.id}\"]\nHello worl\n[/quote]\n
     QUOTE
     end


### PR DESCRIPTION
Retry clipboard copy tests until success. Moving this `try_until_sucecss` into a helper method so it doesn't have to be littered everywhere.

Inspiration from https://github.com/discourse/discourse-ai/blame/ef4b3559cd2b200e319da00bdf26a3e04ca7998a/spec/system/ai_bot/share_spec.rb#L59-L62 thanks to @davidtaylorhq 