### PR TITLE
DEV: Forward the actual event into the sidebar header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-header.gjs
@@ -5,6 +5,7 @@ const SidebarSectionHeader = <template>
     <DButton
       @title="sidebar.toggle_section"
       @action={{@toggleSectionDisplay}}
+      @forwardEvent={{true}}
       aria-controls={{@sidebarSectionContentId}}
       aria-expanded={{if @isExpanded "true" "false"}}
       class="sidebar-section-header sidebar-section-header-collapsable btn-transparent"

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.gjs
@@ -71,7 +71,7 @@ export default class SidebarSection extends Component {
   }
 
   @action
-  toggleSectionDisplay() {
+  toggleSectionDisplay(_, event) {
     if (this.displaySectionContent) {
       this.sidebarState.collapseSection(this.args.sectionName);
     } else {


### PR DESCRIPTION
This is weird but the following line is not actually using the event we think it should be using, so we're making sure DButton passes in the correct one.

https://github.com/discourse/discourse/blob/278ae6e5fd1f79481ea30af7d0466cb5d7911f27/app/assets/javascripts/discourse/app/components/sidebar/section.gjs#L82