### PR TITLE
FIX: do not reload identical route in drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -34,6 +34,10 @@ export default class ChatRoute extends DiscourseRoute {
     ) {
       transition.abort();
 
+      if (this.chatDrawerRouter.currentRouteName === transition.targetName) {
+        return;
+      }
+
       let url = transition.intent.url;
       if (transition.targetName.startsWith("chat.channel")) {
         url ??= this.router.urlFor(

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -146,6 +146,7 @@ export default class ChatDrawerRouter extends Service {
     this.drawerRoute = ROUTES[route.name];
     this.params = this.drawerRoute?.extractParams?.(route) || route.params;
     this.component = this.drawerRoute?.name || ChatDrawerRoutesChannels;
+    this.currentRouteName = route.name;
 
     this.drawerRoute.activate?.(route);
   }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -26,6 +26,7 @@ export default class ChatStateManager extends Service {
   @service chatHistory;
   @service router;
   @service site;
+  @service chatDrawerRouter;
 
   @tracked isSidePanelExpanded = false;
   @tracked isDrawerExpanded = false;
@@ -118,6 +119,7 @@ export default class ChatStateManager extends Service {
       }
     });
 
+    this.chatDrawerRouter.currentRouteName = null;
     this.isDrawerActive = false;
     this.isDrawerExpanded = false;
     this.chat.updatePresence();


### PR DESCRIPTION
This is a performance optimisation to prevent the same route to keep reloading the same endpoint.

No tests as it's not changing behavior and is also quite complex to test efficiently.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
