### PR TITLE
FIX: experimental topics filter should allow tags with underscore

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -408,7 +408,7 @@ class TopicsFilter
       break if key_prefix && key_prefix != "-"
 
       value.scan(
-        /\A(?<tag_names>([\p{N}\p{L}\-]+)(?<delimiter>[,+])?([\p{N}\p{L}\-]+)?(\k<delimiter>[\p{N}\p{L}\-]+)*)\z/,
+        /\A(?<tag_names>([\p{N}\p{L}\-_]+)(?<delimiter>[,+])?([\p{N}\p{L}\-]+)?(\k<delimiter>[\p{N}\p{L}\-]+)*)\z/,
       ) do |tag_names, delimiter|
         match_all =
           if delimiter == ","

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -964,6 +964,18 @@ RSpec.describe TopicsFilter do
           ).to contain_exactly(topic_with_tag.id, topic_with_tag_and_tag2.id)
         end
       end
+
+      describe "when query string is `tags:tag_name`" do
+        before { tag.update!(name: "tag_with_underscore") }
+        it "should return topics even when tag contains underscore" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("tags:#{tag.name}")
+              .pluck(:id),
+          ).to contain_exactly(topic_with_tag.id, topic_with_tag_and_tag2.id)
+        end
+      end
     end
 
     describe "when filtering by tag_groups" do


### PR DESCRIPTION
When tags contain an underscore we should allow filtering in the same way, previously due to the regex those with underscores were not being found when filtering.

/t/-/133637