### PR TITLE
FIX: drop fragment cache for flags

### DIFF
--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -1,15 +1,7 @@
 # frozen_string_literal: true
 
 class PostActionType < ActiveRecord::Base
-  after_save :expire_cache
-  after_destroy :expire_cache
-
   include AnonCacheInvalidator
-
-  def expire_cache
-    ApplicationSerializer.expire_cache_fragment!(/\Apost_action_types_/)
-    ApplicationSerializer.expire_cache_fragment!(/\Apost_action_flag_types_/)
-  end
 
   class << self
     attr_reader :flag_settings
@@ -35,7 +27,6 @@ class PostActionType < ActiveRecord::Base
       @all_flags = nil
       @flag_settings = FlagSettings.new
       ReviewableScore.reload_types
-      PostActionType.new.expire_cache
     end
 
     def overridden_by_plugin_or_skipped_db?

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -111,17 +111,13 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def post_action_types
-    cache_fragment("post_action_types_#{I18n.locale}") do
-      types = ordered_flags(PostActionType.types.values)
-      ActiveModel::ArraySerializer.new(types).as_json
-    end
+    types = ordered_flags(PostActionType.types.values)
+    ActiveModel::ArraySerializer.new(types).as_json
   end
 
   def topic_flag_types
-    cache_fragment("post_action_flag_types_#{I18n.locale}") do
-      types = ordered_flags(PostActionType.topic_flag_types.values)
-      ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
-    end
+    types = ordered_flags(PostActionType.topic_flag_types.values)
+    ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
   end
 
   def default_archetype

--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -1,24 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe PostActionType do
-  describe "Callbacks" do
-    describe "#expiry_cache" do
-      it "should clear the cache on save" do
-        cache = ApplicationSerializer.fragment_cache
-
-        cache["post_action_types_#{I18n.locale}"] = "test"
-        cache["post_action_flag_types_#{I18n.locale}"] = "test2"
-
-        PostActionType.new(name_key: "some_key").save!
-
-        expect(cache["post_action_types_#{I18n.locale}"]).to eq(nil)
-        expect(cache["post_action_flag_types_#{I18n.locale}"]).to eq(nil)
-      ensure
-        ApplicationSerializer.fragment_cache.clear
-      end
-    end
-  end
-
   describe "#types" do
     context "when verifying enum sequence" do
       before { @types = PostActionType.types }


### PR DESCRIPTION
Flags are stored in the memory of the process and a fragment cache is not necessary.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
