### PR TITLE
FEATURE: Add creator and logging for CustomEmoji

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -2,16 +2,26 @@
 
 class CustomEmoji < ActiveRecord::Base
   belongs_to :upload
+  belongs_to :user
 
   has_many :upload_references, as: :target, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :upload_id, presence: true
+  validates :user_id, presence: true
+
+  before_validation :set_default_user_id, on: :create
 
   after_save do
     if saved_change_to_upload_id?
       UploadReference.ensure_exist!(upload_ids: [self.upload_id], target: self)
     end
+  end
+
+  private
+
+  def set_default_user_id
+    self.user_id ||= Discourse.system_user.id
   end
 end
 
@@ -25,6 +35,7 @@ end
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  group      :string(20)
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -35,7 +35,7 @@ end
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  group      :string(20)
-#  user_id    :integer          not null
+#  user_id    :integer          default(-1), not null
 #
 # Indexes
 #

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -148,6 +148,8 @@ class UserHistory < ActiveRecord::Base
         filled_in_required_fields: 109,
         topic_slow_mode_set: 110,
         topic_slow_mode_removed: 111,
+        custom_emoji_create: 112,
+        custom_emoji_destroy: 113,
       )
   end
 
@@ -258,6 +260,8 @@ class UserHistory < ActiveRecord::Base
       delete_watched_word_group
       topic_slow_mode_set
       topic_slow_mode_removed
+      custom_emoji_create
+      custom_emoji_destroy
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -1030,6 +1030,20 @@ class StaffActionLogger
     )
   end
 
+  def log_custom_emoji_create(name, opts = {})
+    opts[:details] = "Group: #{opts[:group]}" if opts[:group].present?
+
+    UserHistory.create!(
+      params(opts).merge(action: UserHistory.actions[:custom_emoji_create], new_value: name),
+    )
+  end
+
+  def log_custom_emoji_destroy(name, opts = {})
+    UserHistory.create!(
+      params(opts).merge(action: UserHistory.actions[:custom_emoji_destroy], previous_value: name),
+    )
+  end
+
   private
 
   def json_params(previous_value, new_value)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6226,6 +6226,8 @@ en:
             delete_flag: "delete flag"
             topic_slow_mode_set: "set topic slow mode"
             topic_slow_mode_removed: "remove topic slow mode"
+            custom_emoji_create: "create custom emoji"
+            custom_emoji_destroy: "delete custom emoji"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/db/migrate/20240722025822_add_user_id_to_custom_emojis.rb
+++ b/db/migrate/20240722025822_add_user_id_to_custom_emojis.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddUserIdToCustomEmojis < ActiveRecord::Migration[7.1]
+  def change
+    add_column :custom_emojis, :user_id, :integer, null: false, default: -1
+  end
+end

--- a/spec/requests/admin/emojis_controller_spec.rb
+++ b/spec/requests/admin/emojis_controller_spec.rb
@@ -101,6 +101,23 @@ RSpec.describe Admin::EmojisController do
         expect(data["name"]).to eq(custom_emoji.name)
         expect(data["url"]).to eq(upload.url)
         expect(custom_emoji.group).to eq(nil)
+        expect(custom_emoji.user_id).to eq(admin.id)
+      end
+
+      it "should log the action" do
+        Emoji.expects(:clear_cache)
+
+        post "/admin/customize/emojis.json",
+             params: {
+               name: "test",
+               file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
+             }
+
+        last_log = UserHistory.last
+
+        expect(last_log.action).to eq(UserHistory.actions[:custom_emoji_create])
+        expect(last_log.acting_user_id).to eq(admin.id)
+        expect(last_log.new_value).to eq("test")
       end
 
       it "should allow an admin to add a custom emoji with a custom group" do
@@ -195,6 +212,19 @@ RSpec.describe Admin::EmojisController do
         expect do
           delete "/admin/customize/emojis/#{custom_emoji.name}.json", params: { name: "test" }
         end.to change { CustomEmoji.count }.by(-1)
+      end
+
+      it "should log the action" do
+        custom_emoji = CustomEmoji.create!(name: "test", upload: upload)
+        Emoji.clear_cache
+
+        delete "/admin/customize/emojis/#{custom_emoji.name}.json", params: { name: "test" }
+
+        last_log = UserHistory.last
+
+        expect(last_log.action).to eq(UserHistory.actions[:custom_emoji_destroy])
+        expect(last_log.acting_user_id).to eq(admin.id)
+        expect(last_log.previous_value).to eq("test")
       end
     end
 


### PR DESCRIPTION
We didn't provide any logs for CustomEmoji before, nor did we record the person who added any emoji in the database. As a result, the staff had no way to trace back who added a certain emoji.

This commit adds a new column `user_id` to `custom_emojis` to record the creator of an emoji. At the same time, a log is added for staff logs to record who added or deleted a custom emoji.

## Screenshot

Staff actions log:

![image](https://github.com/user-attachments/assets/be69b855-dc0c-4e27-a257-9b2f1bb7faf2)

Data Explorer:

![image](https://github.com/user-attachments/assets/d86c7c5e-e08d-45d7-a3ec-9938ca265072)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
