### PR TITLE
FIX: stop memoize PostActionTypes

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -290,7 +290,10 @@ class PostSerializer < BasicPostSerializer
     result = []
     can_see_post = scope.can_see_post?(object)
 
-    PostActionType.types.each do |sym, id|
+    public_flag_types =
+      (@topic_view.present? ? @topic_view.public_flag_types : PostActionType.public_types)
+
+    (@topic_view.present? ? @topic_view.flag_types : PostActionType.types).each do |sym, id|
       count_col = "#{sym}_count".to_sym
 
       count = object.public_send(count_col) if object.respond_to?(count_col)
@@ -327,7 +330,7 @@ class PostSerializer < BasicPostSerializer
       end
 
       # only show public data
-      unless scope.is_staff? || PostActionType.public_types.values.include?(id)
+      unless scope.is_staff? || public_flag_types.values.include?(id)
         summary[:count] = summary[:acted] ? 1 : 0
       end
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -304,6 +304,22 @@ class PostSerializer < BasicPostSerializer
            sym,
            opts: {
              taken_actions: actions,
+             notify_flag_types:
+               (
+                 if @topic_view.present?
+                   @topic_view.notify_flag_types
+                 else
+                   PostActionType.notify_flag_types
+                 end
+               ),
+             additional_message_types:
+               (
+                 if @topic_view.present?
+                   @topic_view.additional_message_types
+                 else
+                   PostActionType.additional_message_types
+                 end
+               ),
            },
            can_see_post: can_see_post,
          )

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -111,13 +111,17 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def post_action_types
-    types = ordered_flags(PostActionType.types.values)
-    ActiveModel::ArraySerializer.new(types).as_json
+    cache_fragment("post_action_types_#{I18n.locale}") do
+      types = ordered_flags(PostActionType.types.values)
+      ActiveModel::ArraySerializer.new(types).as_json
+    end
   end
 
   def topic_flag_types
-    types = ordered_flags(PostActionType.topic_flag_types.values)
-    ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
+    cache_fragment("post_action_flag_types_#{I18n.locale}") do
+      types = ordered_flags(PostActionType.topic_flag_types.values)
+      ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
+    end
   end
 
   def default_archetype

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -38,8 +38,12 @@ module PostGuardian
 
     taken = opts[:taken_actions].try(:keys).to_a
     is_flag =
-      PostActionType.notify_flag_types[action_key] ||
-        PostActionType.additional_message_types[action_key]
+      if (opts[:notify_flag_types] && opts[:additional_message_types])
+        opts[:notify_flag_types][action_key] || opts[:additional_message_types][action_key]
+      else
+        PostActionType.notify_flag_types[action_key] ||
+          PostActionType.additional_message_types[action_key]
+      end
     already_taken_this_action = taken.any? && taken.include?(PostActionType.types[action_key])
     already_did_flagging = taken.any? && (taken & PostActionType.notify_flag_types.values).any?
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -623,6 +623,14 @@ class TopicView
     @pm_params ||= TopicQuery.new(@user).get_pm_params(topic)
   end
 
+  def flag_types
+    @flag_types ||= PostActionType.types
+  end
+
+  def public_flag_types
+    @public_flag_types ||= PostActionType.public_types
+  end
+
   def suggested_topics
     if @include_suggested
       @suggested_topics ||=

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -631,6 +631,14 @@ class TopicView
     @public_flag_types ||= PostActionType.public_types
   end
 
+  def notify_flag_types
+    @notify_flag_types ||= PostActionType.notify_flag_types
+  end
+
+  def additional_message_types
+    @additional_message_types ||= PostActionType.additional_message_types
+  end
+
   def suggested_topics
     if @include_suggested
       @suggested_topics ||=

--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe PostActionType do
+  describe "Callbacks" do
+    describe "#expiry_cache" do
+      it "should clear the cache on save" do
+        cache = ApplicationSerializer.fragment_cache
+
+        cache["post_action_types_#{I18n.locale}"] = "test"
+        cache["post_action_flag_types_#{I18n.locale}"] = "test2"
+
+        PostActionType.new(name_key: "some_key").save!
+
+        expect(cache["post_action_types_#{I18n.locale}"]).to eq(nil)
+        expect(cache["post_action_flag_types_#{I18n.locale}"]).to eq(nil)
+      ensure
+        ApplicationSerializer.fragment_cache.clear
+      end
+    end
+  end
+
   describe "#types" do
     context "when verifying enum sequence" do
       before { @types = PostActionType.types }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2353,7 +2353,7 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(200)
     end
 
-    it "does not result in N+1 queries problem when multiple topic participants have primary or flair group configured" do
+    xit "does not result in N+1 queries problem when multiple topic participants have primary or flair group configured" do
       Group.user_trust_level_change!(post_author1.id, post_author1.trust_level)
       user2 = Fabricate(:user)
       user3 = Fabricate(:user)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2353,7 +2353,7 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(200)
     end
 
-    xit "does not result in N+1 queries problem when multiple topic participants have primary or flair group configured" do
+    it "does not result in N+1 queries problem when multiple topic participants have primary or flair group configured" do
       Group.user_trust_level_change!(post_author1.id, post_author1.trust_level)
       user2 = Fabricate(:user)
       user3 = Fabricate(:user)


### PR DESCRIPTION
Memoizing all_flags on PostActionType was a mistake. This commit brings back the cache on the serialize level - reverts https://github.com/discourse/discourse/pull/28001
