### PR TITLE
UX: Change copy for FormKit "not an integer" error

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2105,7 +2105,7 @@ en:
       errors:
         required: "Required"
         invalid_url: "Must be a valid URL"
-        not_an_integer: "Must be an integer"
+        not_an_integer: "Must be a whole number with no decimal places"
         not_accepted: "Must be accepted"
         not_a_number: "Must be a number"
         too_high: "Must be at most %{count}"


### PR DESCRIPTION
Most people will not know what an integer is,
refer to this as a whole number for the human-readable
error message.
