### PR TITLE
DEV: Skip flaky topic map

### DIFF
--- a/spec/system/topic_map_spec.rb
+++ b/spec/system/topic_map_spec.rb
@@ -71,8 +71,8 @@ describe "Topic Map", type: :system do
     # expect(topic_map.views_count).to eq(2)
 
     # likes count
-    expect(topic_map).to have_no_likes
-    topic_page.click_like_reaction_for(original_post)
-    expect(topic_map.likes_count).to eq 1
+    # expect(topic_map).to have_no_likes
+    # topic_page.click_like_reaction_for(original_post)
+    # expect(topic_map.likes_count).to eq 1
   end
 end


### PR DESCRIPTION
Followup https://github.com/discourse/discourse/commit/72fd509fd482351807488c7b590995b422ed1c92

Also skips the like counter part of this
spec which is flaky
