### PR TITLE
DEV: Recover @timestamp in unicorn logs when logstash logger is enabled

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,8 @@ Discourse::Application.configure do
 
   config.log_level = ENV["DISCOURSE_DEV_LOG_LEVEL"] if ENV["DISCOURSE_DEV_LOG_LEVEL"]
 
-  config.active_record.logger = nil if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1"
+  config.active_record.logger = nil if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1" ||
+    ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
   config.active_record.verbose_query_logs = true if ENV["RAILS_VERBOSE_QUERY_LOGS"] == "1"
 
   if defined?(BetterErrors)

--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -11,7 +11,11 @@ if enable_logstash_logger
   require_relative "../lib/discourse_logstash_logger"
   require_relative "../lib/unicorn_logstash_patch"
   FileUtils.touch(unicorn_stderr_path) if !File.exist?(unicorn_stderr_path)
-  logger DiscourseLogstashLogger.logger(logdev: unicorn_stderr_path, type: :unicorn)
+  logger DiscourseLogstashLogger.logger(
+           logdev: unicorn_stderr_path,
+           type: :unicorn,
+           customize_event: lambda { |event| event["@timestamp"] = ::Time.now.utc },
+         )
 else
   logger Logger.new(STDOUT)
 end


### PR DESCRIPTION
This is a regression introduced in 28f5550886adc254557eba456c313b7825005120

### Reviewer notes

1. Run `tail -f log/unicorn.stderr.log | grep worker`
1. Run `ENABLE_LOGSTASH_LOGGER=1 bin/rails s` locally
1. See that log lines have a `@timestamp` field