### PR TITLE
DEV: add @submit hook for ace editor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/ace-editor.js
+++ b/app/assets/javascripts/discourse/app/components/ace-editor.js
@@ -142,7 +142,7 @@ export default class AceEditor extends Component {
           exec: () => {
             this.commit();
           },
-          bindKey: { mac: "cmd-return", win: "ctrl-enter" },
+          bindKey: { mac: "cmd-enter", win: "ctrl-enter" },
         });
       }
 

--- a/app/assets/javascripts/discourse/app/components/ace-editor.js
+++ b/app/assets/javascripts/discourse/app/components/ace-editor.js
@@ -136,6 +136,15 @@ export default class AceEditor extends Component {
           bindKey: { mac: "cmd-s", win: "ctrl-s" },
         });
       }
+      if (this.commit) {
+        editor.commands.addCommand({
+          name: "commit",
+          exec: () => {
+            this.commit();
+          },
+          bindKey: { mac: "cmd-return", win: "ctrl-enter" },
+        });
+      }
 
       editor.on("blur", () => {
         this.warnSCSSDeprecations();

--- a/app/assets/javascripts/discourse/app/components/ace-editor.js
+++ b/app/assets/javascripts/discourse/app/components/ace-editor.js
@@ -136,11 +136,11 @@ export default class AceEditor extends Component {
           bindKey: { mac: "cmd-s", win: "ctrl-s" },
         });
       }
-      if (this.commit) {
+      if (this.submit) {
         editor.commands.addCommand({
-          name: "commit",
+          name: "submit",
           exec: () => {
-            this.commit();
+            this.submit();
           },
           bindKey: { mac: "cmd-enter", win: "ctrl-enter" },
         });


### PR DESCRIPTION
Add `@submit` hook to AceEditor to handle "save and run" in Data Explorer

I need to respond to ctrl+enter in AceEditor in Data Explorer and was hoping to introduce a hook for `@submit` in core so that I could simply write code like this

```handlebars
<AceEditor
  @save={{this.save}}
  @submit={{this.saveAndRun}}
/>
```


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
