### PR TITLE
DEV: Log sidekiq job opts as string instead of hash

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -99,7 +99,7 @@ class DiscourseLogstashLogger < Logger
 
       if progname == "sidekiq-exception"
         event["job.class"] = opts.dig(:context, :job)
-        event["job.opts"] = opts.dig(:context, :opts)
+        event["job.opts"] = opts.dig(:context, :opts)&.stringify_keys&.to_s
         event["job.problem_db"] = opts.dig(:context, :problem_db)
         event["exception.class"] = opts[:exception_class]
         event["exception.message"] = opts[:exception_message]

--- a/spec/lib/discourse_logstash_logger_spec.rb
+++ b/spec/lib/discourse_logstash_logger_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DiscourseLogstashLogger do
         expect(parsed["exception.class"]).to eq("Some::StandardError")
         expect(parsed["exception.message"]).to eq("some job error message")
         expect(parsed["job.class"]).to eq("SomeJob")
-        expect(parsed["job.opts"]).to eq({ "user_id" => 1 })
+        expect(parsed["job.opts"]).to eq("{\"user_id\"=>1}")
         expect(parsed["job.problem_db"]).to eq("some_db")
       end
     end


### PR DESCRIPTION
This ensures that elasticsearch doesn't parse it as an object. There are
too many combination of job opts so we don't want elasticsearch to be
parsing and indexing this field as an object.
