### PR TITLE
UX: Use localized time format in embedded comments

### DIFF
--- a/app/helpers/embed_helper.rb
+++ b/app/helpers/embed_helper.rb
@@ -8,9 +8,9 @@ module EmbedHelper
       distance_of_time_in_words(dt, current)
     else
       if dt.year == current.year
-        dt.strftime("%e %b")
+        dt.strftime I18n.t("datetime_formats.formats.short_no_year")
       else
-        dt.strftime("%b '%y")
+        dt.strftime I18n.t("datetime_formats.formats.no_day")
       end
     end
   end


### PR DESCRIPTION
Previously, the time format for embedded comments was hardcoded. This commit changes it to the time format defined in I18n.

Related meta topic: https://meta.discourse.org/t/embed-dates-are-not-localized/27997/

## Screenshot:

before: 
![image](https://github.com/user-attachments/assets/b7e2d411-d7ca-4fd9-877a-fe6c3ca6ba55)

after

![image](https://github.com/user-attachments/assets/52099768-6459-4108-864b-56befbe41c43)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
