### PR TITLE
FIX: Improve error handling for messageformat compilation

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -162,6 +162,11 @@ module JsLocaleHelper
       #{transpiled}
       require("discourse-mf");
     JS
+  rescue => e
+    Rails.logger.error("Failed to compile message formats for #{locale} '#{e}'")
+    <<~JS
+      console.error("Failed to compile message formats for #{locale}. Some translation strings will be missing.");
+    JS
   end
 
   def self.output_locale(locale)


### PR DESCRIPTION
We are investigating reports of errors with messageformat compilation following 301713ef. This commit does not fix the issue, but it introduces some basic error handling to avoid completely breaking affected sites.

We will have a fix for the root cause soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
