### PR TITLE
DEV: Improve TagGroup.resolve_permissions method arg type handling

### DIFF
--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -55,7 +55,9 @@ class TagGroup < ActiveRecord::Base
   def self.resolve_permissions(permissions)
     permissions.map do |group, permission|
       group_id = Group.group_id_from_param(group)
-      permission = TagGroupPermission.permission_types[permission] unless permission.is_a?(Integer)
+      permission = TagGroupPermission.permission_types[permission.to_sym] unless permission.is_a?(
+        Integer,
+      )
       [group_id, permission]
     end
   end


### PR DESCRIPTION
In a plugin we were trying to test the tag_groups controller for permission handling... it was weird how the param of `:full` or `:readonly` was passing from the controller down to this method in the diff and the permission type was `nil` at the end of it... Reason was the hash we are looking into has symbol keys and we are checking
* If value is an integer, return it
* If value is **anything else** lookup the key/value pair.... but the keys are symbols...

So this adds a .to_sym :)