### PR TITLE
UX: Remove automatic composer prompt when draft exists

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages.js
@@ -1,7 +1,5 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import Composer from "discourse/models/composer";
-import Draft from "discourse/models/draft";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class UserPrivateMessages extends DiscourseRoute {
@@ -15,19 +13,6 @@ export default class UserPrivateMessages extends DiscourseRoute {
 
   setupController() {
     super.setupController(...arguments);
-
-    if (this.currentUser) {
-      Draft.get("new_private_message").then((data) => {
-        if (data.draft) {
-          this.composer.open({
-            draft: data.draft,
-            draftKey: Composer.NEW_PRIVATE_MESSAGE_KEY,
-            ignoreIfChanged: true,
-            draftSequence: data.draft_sequence,
-          });
-        }
-      });
-    }
   }
 
   @action


### PR DESCRIPTION
The composer automatically prompting when you visit your messages is unexpected behavior. For ease of use, the composer should only prompt if the user intentionally wants to open a draft or start a new topic.