### PR TITLE
FIX: Some button clicks on iOS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -1,12 +1,12 @@
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { empty, equal, notEmpty } from "@ember/object/computed";
+import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";
 import GlimmerComponentWithDeprecatedParentView from "discourse/components/glimmer-component-with-deprecated-parent-view";
 import concatClass from "discourse/helpers/concat-class";
-import runAfterFramePaint from "discourse/lib/after-frame-paint";
 import icon from "discourse-common/helpers/d-icon";
 import deprecated from "discourse-common/lib/deprecated";
 import I18n from "discourse-i18n";
@@ -119,13 +119,15 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             );
           }
         } else if (typeof actionVal === "object" && actionVal.value) {
-          runAfterFramePaint(() =>
+          // Using `next()` to optimise INP
+          next(() =>
             forwardEvent
               ? actionVal.value(actionParam, event)
               : actionVal.value(actionParam)
           );
         } else if (typeof actionVal === "function") {
-          runAfterFramePaint(() =>
+          // Using `next()` to optimise INP
+          next(() =>
             forwardEvent
               ? actionVal(actionParam, event)
               : actionVal(actionParam)

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -1,8 +1,7 @@
 import { alias, match } from "@ember/object/computed";
 import Mixin from "@ember/object/mixin";
-import { schedule, throttle } from "@ember/runloop";
+import { next, schedule, throttle } from "@ember/runloop";
 import { service } from "@ember/service";
-import runAfterFramePaint from "discourse/lib/after-frame-paint";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import DiscourseURL from "discourse/lib/url";
@@ -87,7 +86,8 @@ export default Mixin.create({
     document.querySelector(".card-cloak")?.classList.remove("hidden");
 
     this.appEvents.trigger("user-card:show", { username });
-    runAfterFramePaint(() => {
+    // Using `next()` to optimise INP
+    next(() => {
       this._positionCard(target, event);
       this._showCallback(username).then((user) => {
         this.appEvents.trigger("user-card:after-show", { user });


### PR DESCRIPTION
Followup to bc3e8a9963cf9a64d114ec751c875025af169690

We were using our custom `runAfterFramePaint` function, which aims to run something IMMEDIATELY after the next frame is painted. That was important for its original use case of recording render performance.

However, it seems that Safari's "in response to user action" check cannot follow the chain of interaction -> requestAnimationFrame -> messageChannel, and so some sensitive browser APIs (e.g. clipboard, upload, etc.) were blocked.

Ember's `next()` does not offer the same timing optimizations, but for this use-case it should work fine. Under the covers, Ember's runloop uses `setTimeout`, which does not seem to have the same issues with Safari's user interaction detection.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
