### PR TITLE
FIX: flag valid type inclusion should be lambda

### DIFF
--- a/app/services/flags/create_flag.rb
+++ b/app/services/flags/create_flag.rb
@@ -22,7 +22,7 @@ class Flags::CreateFlag
     validates :description, presence: true
     validates :name, length: { maximum: Flag::MAX_NAME_LENGTH }
     validates :description, length: { maximum: Flag::MAX_DESCRIPTION_LENGTH }
-    validates :applies_to, inclusion: { in: Flag.valid_applies_to_types }, allow_nil: false
+    validates :applies_to, inclusion: { in: -> { Flag.valid_applies_to_types } }, allow_nil: false
   end
 
   private

--- a/app/services/flags/update_flag.rb
+++ b/app/services/flags/update_flag.rb
@@ -24,7 +24,7 @@ class Flags::UpdateFlag
     validates :description, presence: true
     validates :name, length: { maximum: Flag::MAX_NAME_LENGTH }
     validates :description, length: { maximum: Flag::MAX_DESCRIPTION_LENGTH }
-    validates :applies_to, inclusion: { in: Flag.valid_applies_to_types }, allow_nil: false
+    validates :applies_to, inclusion: { in: -> { Flag.valid_applies_to_types } }, allow_nil: false
   end
 
   private

--- a/spec/services/flags/create_flag_spec.rb
+++ b/spec/services/flags/create_flag_spec.rb
@@ -61,7 +61,14 @@ RSpec.describe(Flags::CreateFlag) do
 
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
+    let(:applies_to) { ["Topic::Custom"] }
 
+    before do
+      DiscoursePluginRegistry.register_flag_applies_to_type(
+        "Topic::Custom",
+        OpenStruct.new(enabled?: true),
+      )
+    end
     after { Flag.destroy_by(name: "custom flag name") }
 
     it "sets the service result as successful" do
@@ -73,7 +80,7 @@ RSpec.describe(Flags::CreateFlag) do
       flag = Flag.last
       expect(flag.name).to eq("custom flag name")
       expect(flag.description).to eq("custom flag description")
-      expect(flag.applies_to).to eq(["Topic"])
+      expect(flag.applies_to).to eq(["Topic::Custom"])
       expect(flag.require_message).to be true
       expect(flag.enabled).to be true
     end
@@ -83,7 +90,7 @@ RSpec.describe(Flags::CreateFlag) do
       expect(UserHistory.last).to have_attributes(
         custom_type: "create_flag",
         details:
-          "name: custom flag name\ndescription: custom flag description\napplies_to: [\"Topic\"]\nrequire_message: true\nenabled: true",
+          "name: custom flag name\ndescription: custom flag description\napplies_to: [\"Topic::Custom\"]\nrequire_message: true\nenabled: true",
       )
     end
   end


### PR DESCRIPTION
There is a bug with chat type flags - "An error occurred: Applies to is not included in the list"

Flag.valid_applies_to_types is a set of core types and types registered by plugins `Set.new(DEFAULT_VALID_APPLIES_TO | DiscoursePluginRegistry.flag_applies_to_types)`

Using lamba should ensure that valid values are calculated dynamically.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
