### PR TITLE
FEATURE: Clean up previously logged information after permanently deleting posts

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -150,6 +150,8 @@ class UserHistory < ActiveRecord::Base
         topic_slow_mode_removed: 111,
         custom_emoji_create: 112,
         custom_emoji_destroy: 113,
+        delete_post_permanently: 114,
+        delete_topic_permanently: 115,
       )
   end
 
@@ -262,6 +264,8 @@ class UserHistory < ActiveRecord::Base
       topic_slow_mode_removed
       custom_emoji_create
       custom_emoji_destroy
+      delete_post_permanently
+      delete_topic_permanently
     ]
   end
 
@@ -364,6 +368,7 @@ end
 #  index_user_histories_on_acting_user_id_and_action_and_id        (acting_user_id,action,id)
 #  index_user_histories_on_action_and_id                           (action,id)
 #  index_user_histories_on_category_id                             (category_id)
+#  index_user_histories_on_post_id                                 (post_id)
 #  index_user_histories_on_subject_and_id                          (subject,id)
 #  index_user_histories_on_target_user_id_and_id                   (target_user_id,id)
 #  index_user_histories_on_topic_id_and_target_user_id_and_action  (topic_id,target_user_id,action)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -74,15 +74,18 @@ class StaffActionLogger
     name = deleted_post.user.try(:name) || I18n.t("staff_action_logs.unknown")
     topic_title = topic.try(:title) || I18n.t("staff_action_logs.not_found")
 
-    details = [
-      "id: #{deleted_post.id}",
-      "created_at: #{deleted_post.created_at}",
-      "user: #{username} (#{name})",
-      "topic: #{topic_title}",
-      "post_number: #{deleted_post.post_number}",
-      "raw: #{truncate(deleted_post.raw)}",
-    ]
-    details = [] if opts[:permanent]
+    if opts[:permanent]
+      details = []
+    else
+      details = [
+        "id: #{deleted_post.id}",
+        "created_at: #{deleted_post.created_at}",
+        "user: #{username} (#{name})",
+        "topic: #{topic_title}",
+        "post_number: #{deleted_post.post_number}",
+        "raw: #{truncate(deleted_post.raw)}",
+      ]
+    end
 
     UserHistory.create!(
       params(opts).merge(
@@ -98,18 +101,20 @@ class StaffActionLogger
 
     user = topic.user ? "#{topic.user.username} (#{topic.user.name})" : "(deleted user)"
 
-    details = [
-      "id: #{topic.id}",
-      "created_at: #{topic.created_at}",
-      "user: #{user}",
-      "title: #{topic.title}",
-    ]
+    if action == "delete_topic_permanently"
+      details = []
+    else
+      details = [
+        "id: #{topic.id}",
+        "created_at: #{topic.created_at}",
+        "user: #{user}",
+        "title: #{topic.title}",
+      ]
 
-    if first_post = topic.ordered_posts.with_deleted.first
-      details << "raw: #{truncate(first_post.raw)}"
+      if first_post = topic.ordered_posts.with_deleted.first
+        details << "raw: #{truncate(first_post.raw)}"
+      end
     end
-
-    details = [] if action == "delete_topic_permanently"
 
     UserHistory.create!(
       params(opts).merge(

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -82,10 +82,11 @@ class StaffActionLogger
       "post_number: #{deleted_post.post_number}",
       "raw: #{truncate(deleted_post.raw)}",
     ]
+    details = [] if opts[:permanent]
 
     UserHistory.create!(
       params(opts).merge(
-        action: UserHistory.actions[:delete_post],
+        action: UserHistory.actions[opts[:permanent] ? :delete_post_permanently : :delete_post],
         post_id: deleted_post.id,
         details: details.join("\n"),
       ),
@@ -107,6 +108,8 @@ class StaffActionLogger
     if first_post = topic.ordered_posts.with_deleted.first
       details << "raw: #{truncate(first_post.raw)}"
     end
+
+    details = [] if action == "delete_topic_permanently"
 
     UserHistory.create!(
       params(opts).merge(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6250,6 +6250,8 @@ en:
             topic_slow_mode_removed: "remove topic slow mode"
             custom_emoji_create: "create custom emoji"
             custom_emoji_destroy: "delete custom emoji"
+            delete_post_permanently: "permanently delete post"
+            delete_topic_permanently: "permanently delete topic"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/db/migrate/20240723030506_add_post_id_index_to_user_histories.rb
+++ b/db/migrate/20240723030506_add_post_id_index_to_user_histories.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 class AddPostIdIndexToUserHistories < ActiveRecord::Migration[7.1]
-  def change
-    add_index :user_histories, :post_id
+  disable_ddl_transaction!
+
+  def up
+    remove_index :user_histories, :post_id, if_exists: true
+    add_index :user_histories, :post_id, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :user_histories, :post_id
   end
 end

--- a/db/migrate/20240723030506_add_post_id_index_to_user_histories.rb
+++ b/db/migrate/20240723030506_add_post_id_index_to_user_histories.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddPostIdIndexToUserHistories < ActiveRecord::Migration[7.1]
+  def change
+    add_index :user_histories, :post_id
+  end
+end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -313,14 +313,14 @@ RSpec.describe PostsController do
           delete "/posts/#{post.id}.json", params: { force_destroy: true }
           expect(response.status).to eq(200)
 
-          UserHistory.last.tap do |h|
-            expect(h.action).to eq(UserHistory.actions[:delete_post_permanently])
-            expect(h.acting_user_id).to eq(admin.id)
-          end
+          expect(UserHistory.last).to have_attributes(
+            action: UserHistory.actions[:delete_post_permanently],
+            acting_user_id: admin.id,
+          )
 
-          UserHistory
-            .where(post_id: post.id)
-            .each { |h| expect(h.details).to eq("(permanently deleted)") }
+          expect(UserHistory.where(post_id: post.id, details: "(permanently deleted)").count).to eq(
+            2,
+          )
         end
       end
     end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1544,14 +1544,14 @@ RSpec.describe TopicsController do
 
         expect(response.status).to eq(200)
 
-        UserHistory.last.tap do |h|
-          expect(h.action).to eq(UserHistory.actions[:delete_topic_permanently])
-          expect(h.acting_user_id).to eq(admin.id)
-        end
+        expect(UserHistory.last).to have_attributes(
+          action: UserHistory.actions[:delete_topic_permanently],
+          acting_user_id: admin.id,
+        )
 
-        UserHistory
-          .where(topic_id: topic.id)
-          .each { |h| expect(h.details).to eq("(permanently deleted)") }
+        expect(UserHistory.where(topic_id: topic.id, details: "(permanently deleted)").count).to eq(
+          2,
+        )
       end
 
       it "does not allow to destroy topic if not all posts were force destroyed" do


### PR DESCRIPTION
When soft deleteing a topic or post, we will log some details in the staff log, including the raw content of the post. Before this commit, we will not clear the information in these records. Therefore, after permanently deleting the post, `UserHistory` still retains copy of the permanently deleted post. This is an unexpected behaviour and may raise some potential legal issues.

This commit adds a behavior that when a post is permanently deleted, the details column of the `UserHistory` associated with the post will be overwritten to "(permanently deleted)". At the same time, for permanent deletion, a new `action_id` is introduced to distinguish it from soft deletion.

## Screenshots:

![image](https://github.com/user-attachments/assets/6c3cb0d6-077b-42bd-adf5-b7e9a9054e21)

Related meta topic: https://meta.discourse.org/t/introduce-a-way-to-also-permanently-delete-the-sensitive-info-from-the-staff-logs/292546

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
