### PR TITLE
FEATURE: Show bookmark note in notification

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.hbs
@@ -29,5 +29,8 @@
       <this.endComponent />
     {{/if}}
   </a>
+  {{#if this.note}}
+    <span class="item-note">{{this.note}}</span>
+  {{/if}}
   <PluginOutlet @name="menu-item-end" @outletArgs={{this.endOutletArgs}} />
 </li>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
@@ -65,6 +65,10 @@ export default class UserMenuItem extends Component {
     return this.#item.endOutletArgs;
   }
 
+  get note() {
+    return this.#item.note;
+  }
+
   get #item() {
     return this.args.item;
   }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/base.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/base.js
@@ -88,6 +88,10 @@ export default class NotificationTypeBase {
     }
   }
 
+  get note() {
+    return null;
+  }
+
   /**
    * @returns {string[]} Include additional classes to the label.
    */

--- a/app/assets/javascripts/discourse/app/lib/notification-types/bookmark-reminder.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/bookmark-reminder.js
@@ -20,6 +20,10 @@ export default class extends NotificationTypeBase {
     return null;
   }
 
+  get note() {
+    return this.notification.data.bookmark_name;
+  }
+
   get linkHref() {
     let linkHref = super.linkHref;
     if (linkHref) {

--- a/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
@@ -27,6 +27,8 @@ export default class UserMenuBaseItem {
 
   get labelClass() {}
 
+  get note() {}
+
   get description() {
     throw new Error("not implemented");
   }

--- a/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
@@ -38,4 +38,8 @@ export default class UserMenuBookmarkItem extends UserMenuBaseItem {
   get avatarTemplate() {
     return this.bookmark.user.avatar_template;
   }
+
+  get note() {
+    return this.bookmark.name;
+  }
 }

--- a/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
@@ -50,6 +50,10 @@ export default class UserMenuNotificationItem extends UserMenuBaseItem {
     return this.renderDirector.label;
   }
 
+  get note() {
+    return this.renderDirector.note;
+  }
+
   get labelClass() {
     return this.renderDirector.labelClasses?.join(" ") || "";
   }


### PR DESCRIPTION
This commit allows for a new `note` to be specified for
user menu items and user menu notification items. Then,
we also use it to show the note that a user has attached
to a bookmark.

![image](https://github.com/user-attachments/assets/e755242a-7a41-4764-a8e6-08075aa1aae4)
