### PR TITLE
FIX: Missing model return in admin-backups route

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-backups.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-backups.js
@@ -33,7 +33,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
       ajax("/admin/backups/status.json")
     );
 
-    BackupStatus.create({
+    return BackupStatus.create({
       isOperationRunning: status.is_operation_running,
       canRollback: status.can_rollback,
       allowRestore: status.allow_restore,


### PR DESCRIPTION
Followup dd3046327684ce98f0c3a7430f5d22fd35f1d9ca

We missed the explicit `return` when we changed to
async/await, so the model ends up being null on admin
backups.

This means we also have no tests for the backup UI, that
will be fixed in a subsequent PR.
