### PR TITLE
FIX: return is invalid inside a block

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1301,13 +1301,13 @@ class TopicsController < ApplicationController
   def self.defer_topic_view(topic_id, ip, user_id = nil)
     Scheduler::Defer.later "Topic View" do
       topic = Topic.find_by(id: topic_id)
-      return if topic.blank?
+      next if topic.blank?
 
       # We need to make sure that we aren't allowing recording
       # random topic views against topics the user cannot see.
       user = User.find_by(id: user_id) if user_id.present?
-      return if user_id.present? && user.blank?
-      return if !Guardian.new(user).can_see_topic?(topic)
+      next if user_id.present? && user.blank?
+      next if !Guardian.new(user).can_see_topic?(topic)
 
       TopicViewItem.add(topic_id, ip, user_id)
     end


### PR DESCRIPTION
Fixed using next instead. It was causing this kind of errors:

```
Job exception: unexpected return

/var/www/discourse/app/controllers/topics_controller.rb:1304:in `block in defer_topic_view'
/var/www/discourse/lib/scheduler/defer.rb:115:in `block in do_work'
rails_multisite-6.0.0/lib/rails_multisite/connection_management/null_instance.rb:49:in `with_connection'
rails_multisite-6.0.0/lib/rails_multisite/connection_management.rb:21:in `with_connection'
/var/www/discourse/lib/scheduler/defer.rb:109:in `do_work'
/var/www/discourse/lib/scheduler/defer.rb:97:in `block (2 levels) in start_thread'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
