### PR TITLE
FIX: Ensure JsLocaleHelper to not output deprecated translations

### DIFF
--- a/app/jobs/scheduled/check_translation_overrides.rb
+++ b/app/jobs/scheduled/check_translation_overrides.rb
@@ -19,9 +19,9 @@ module Jobs
         end
       end
 
-      TranslationOverride.where(id: deprecated_ids).update_all(status: "deprecated")
       TranslationOverride.where(id: outdated_ids).update_all(status: "outdated")
       TranslationOverride.where(id: invalid_ids).update_all(status: "invalid_interpolation_keys")
+      TranslationOverride.where(id: deprecated_ids).update_all(status: "deprecated")
     end
   end
 end

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -50,11 +50,12 @@ class TranslationOverride < ActiveRecord::Base
 
   scope :mf_locales,
         ->(locale) do
-          where(locale: locale, status: "up_to_date").where("translation_key LIKE '%_MF'")
+          where(locale: locale).where.not(status: "deprecated").where("translation_key LIKE '%_MF'")
         end
   scope :client_locales,
         ->(locale) do
-          where(locale: locale, status: "up_to_date")
+          where(locale: locale)
+            .where.not(status: "deprecated")
             .where("translation_key LIKE 'js.%' OR translation_key LIKE 'admin_js.%'")
             .where.not("translation_key LIKE '%_MF'")
         end

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -48,7 +48,10 @@ class TranslationOverride < ActiveRecord::Base
   attribute :status, :integer
   enum status: { up_to_date: 0, outdated: 1, invalid_interpolation_keys: 2, deprecated: 3 }
 
-  scope :mf_locales, ->(locale) { where(locale: locale).where("translation_key LIKE '%_MF'") }
+  scope :mf_locales,
+        ->(locale) do
+          where(locale: locale, status: "up_to_date").where("translation_key LIKE '%_MF'")
+        end
   scope :client_locales,
         ->(locale) do
           where(locale: locale, status: "up_to_date")

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -51,7 +51,7 @@ class TranslationOverride < ActiveRecord::Base
   scope :mf_locales, ->(locale) { where(locale: locale).where("translation_key LIKE '%_MF'") }
   scope :client_locales,
         ->(locale) do
-          where(locale: locale)
+          where(locale: locale, status: "up_to_date")
             .where("translation_key LIKE 'js.%' OR translation_key LIKE 'admin_js.%'")
             .where.not("translation_key LIKE '%_MF'")
         end

--- a/lib/i18n/i18n_interpolation_keys_finder.rb
+++ b/lib/i18n/i18n_interpolation_keys_finder.rb
@@ -2,6 +2,7 @@
 
 class I18nInterpolationKeysFinder
   def self.find(text)
+    return [] unless text.is_a? String
     pattern = Regexp.union([*I18n.config.interpolation_patterns, /\{\{(\w+)\}\}/])
     keys = text.scan(pattern)
     keys.flatten!

--- a/spec/lib/js_locale_helper_spec.rb
+++ b/spec/lib/js_locale_helper_spec.rb
@@ -228,4 +228,25 @@ RSpec.describe JsLocaleHelper do
       end
     end
   end
+
+  describe ".output_client_overrides" do
+    it "should not output deprecated or outdated translation overrides" do
+      Fabricate(
+        :translation_override,
+        locale: "en",
+        translation_key: "js.user.preferences.title",
+        value: "SHOULD_SHOW",
+      )
+      Fabricate(
+        :translation_override,
+        locale: "en",
+        translation_key: "js.user.preferences",
+        value: "SHOULD_NOT_SHOW",
+        status: "deprecated",
+      )
+
+      expect(described_class.output_client_overrides("en").include? "SHOULD_SHOW").to eq(true)
+      expect(described_class.output_client_overrides("en").include? "SHOULD_NOT_SHOW").to eq(false)
+    end
+  end
 end

--- a/spec/lib/js_locale_helper_spec.rb
+++ b/spec/lib/js_locale_helper_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe JsLocaleHelper do
   end
 
   describe ".output_client_overrides" do
-    it "should not output deprecated or outdated translation overrides" do
+    it "should not output deprecated translation overrides" do
       Fabricate(
         :translation_override,
         locale: "en",


### PR DESCRIPTION
The old implementation did not filter out deprecated translations, causing these translations to incorrectly override the new locale in the frontend.

This commit fills in the forgotten where clause, filtering only the up-to-date part.

Related meta topic: https://meta.discourse.org/t/outdated-translation-replacement-causing-missing-translation/314352

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
