### PR TITLE
UX: change sidebar background to secondary

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
@@ -3,7 +3,7 @@
     .channels-list {
       height: calc(100vh - var(--header-offset));
       border-right: 1px solid var(--primary-low);
-      background: var(--primary-very-low);
+      background: var(--secondary);
       overflow-y: auto;
 
       .channel-list-empty-message {


### PR DESCRIPTION
Changing the sidebar bg colour of full-page chat mode without sidebar enabled, to be consistent with the other sidebar-esk variations.
