### PR TITLE
PERF: improves TextSentinel's seems_unpretentious check

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -59,7 +59,7 @@ class TextSentinel
   # Ensure maximum word length
   def seems_unpretentious?
     skipped_locales.include?(SiteSetting.default_locale) || @opts[:max_word_length].nil? ||
-      @text.scan(/\p{Alnum}+/).map(&:size).max.to_i <= @opts[:max_word_length]
+      !@text.match?(/\p{Alnum}{#{@opts[:max_word_length] + 1},}/)
   end
 
   # Ensure at least one lowercase letter


### PR DESCRIPTION
by scanning the text for the first word that is bigger than `max_word_length` instead of extracting (segmenting) all the words, computing their size, and comparing the maximum with `max_word_length`.

Idea from @mentalstring in https://meta.discourse.org/t/body-seems-unclear-error-when-users-are-typing-in-chinese/88715/14
