### PR TITLE
FEATURE: use new site setting for onebox custom user agent.

### DIFF
--- a/config/initializers/100-onebox_options.rb
+++ b/config/initializers/100-onebox_options.rb
@@ -5,14 +5,14 @@ Rails.application.config.to_prepare do
     Onebox.options = {
       twitter_client: TwitterApi,
       redirect_limit: 3,
-      user_agent: "Discourse Forum Onebox v#{Discourse::VERSION::STRING}",
+      user_agent: "Discourse Forum Onebox",
       allowed_ports: [80, 443, SiteSetting.port.to_i],
     }
   else
     Onebox.options = {
       twitter_client: TwitterApi,
       redirect_limit: 3,
-      user_agent: "Discourse Forum Onebox v#{Discourse::VERSION::STRING}",
+      user_agent: "Discourse Forum Onebox",
     }
   end
 end

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2106,6 +2106,9 @@ onebox:
     list_type: compact
   enable_inline_onebox_on_all_domains:
     default: true
+  onebox_user_agent:
+    default: ""
+    hidden: true
   force_custom_user_agent_hosts:
     default: "http://codepen.io"
     type: list

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -81,7 +81,7 @@ class FinalDestination
     @user_agent =
       (
         if @force_custom_user_agent_hosts.any? { |host| hostname_matches?(host) }
-          Onebox.options.user_agent
+          Onebox::Helpers.user_agent
         else
           @default_user_agent
         end

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -104,9 +104,7 @@ module Onebox
 
         headers ||= {}
 
-        if Onebox.options.user_agent && !headers["User-Agent"]
-          headers["User-Agent"] = Onebox.options.user_agent
-        end
+        headers["User-Agent"] = user_agent if user_agent && !headers["User-Agent"]
 
         request = Net::HTTP::Get.new(uri.request_uri, headers)
         start_time = Time.now
@@ -230,6 +228,12 @@ module Onebox
       rescue ArgumentError, URI::BadURIError, URI::InvalidURIError
         src
       end
+    end
+
+    def self.user_agent
+      user_agent = SiteSetting.onebox_user_agent.presence || Onebox.options.user_agent
+      user_agent = "#{user_agent} v#{Discourse::VERSION::STRING}"
+      user_agent
     end
 
     # Percent-encodes a URI string per RFC3986 - https://tools.ietf.org/html/rfc3986

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -104,7 +104,7 @@ module Onebox
 
         headers ||= {}
 
-        headers["User-Agent"] = user_agent if user_agent && !headers["User-Agent"]
+        headers["User-Agent"] ||= user_agent if user_agent
 
         request = Net::HTTP::Get.new(uri.request_uri, headers)
         start_time = Time.now

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Onebox::Helpers do
     context "with custom option" do
       around do |example|
         previous_options = Onebox.options.to_h
-        Onebox.options = { user_agent: "EvilTroutBot v0.1" }
+        Onebox.options = { user_agent: "EvilTroutBot" }
 
         example.run
 
@@ -221,7 +221,7 @@ RSpec.describe Onebox::Helpers do
       it "has the custom user agent" do
         stub_request(:get, "http://example.com/some-resource").with(
           headers: {
-            "user-agent" => "EvilTroutBot v0.1",
+            "user-agent" => "EvilTroutBot v#{Discourse::VERSION::STRING}",
           },
         ).to_return(status: 200, body: "test")
 


### PR DESCRIPTION
Previously, we can't change the user agent name dynamically for onebox requests. In this commit, a new hidden site setting `onebox_user_agent` is created to override the default user agent value specified in the [initializer](https://github.com/discourse/discourse/blob/c333e9d6e6a6a0407133eb2d5087605897048f95/config/initializers/100-onebox_options.rb#L15).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
