### PR TITLE
FIX: store information about the login method in session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -609,7 +609,7 @@ class ApplicationController < ActionController::Base
 
   def login_method
     return if current_user.anonymous?
-    secure_session["oauth"] == "true" ? Auth::LOGIN_METHOD_OAUTH : Auth::LOGIN_METHOD_LOCAL
+    session[:oauth] == true ? Auth::LOGIN_METHOD_OAUTH : Auth::LOGIN_METHOD_LOCAL
   end
 
   private

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -370,7 +370,7 @@ class SessionController < ApplicationController
     return render(json: @second_factor_failure_payload) if !second_factor_auth_result.ok
 
     if user.active && user.email_confirmed?
-      secure_session["oauth"] = false if !SiteSetting.persistent_sessions
+      session[:oauth] = false if !SiteSetting.persistent_sessions
       login(user, second_factor_auth_result)
     else
       not_activated(user)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -29,6 +29,8 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     authenticator = self.class.find_authenticator(params[:provider])
 
+    session[:oauth] = true
+
     if session.delete(:auth_reconnect) && authenticator.can_connect_existing_user? && current_user
       path = persist_auth_token(auth)
       return redirect_to path
@@ -86,7 +88,6 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     cookies["_bypass_cache"] = true
     cookies[:authentication_data] = { value: client_hash.to_json, path: Discourse.base_path("/") }
-    secure_session.set("oauth", true, expires: SiteSetting.maximum_session_age.hours)
     redirect_to @origin
   end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe ApplicationController do
 
     it "should redirect users when enforce_second_factor is 'all' and authenticated via oauth" do
       SiteSetting.enforce_second_factor = "all"
-      write_secure_session("oauth", true)
       sign_in(user)
+      session[:oauth] = true
 
       get "/"
       expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
@@ -162,8 +162,8 @@ RSpec.describe ApplicationController do
     it "should not redirect users when enforce_second_factor is 'all', authenticated via oauth but enforce_second_factor_on_external_auth is false" do
       SiteSetting.enforce_second_factor = "all"
       SiteSetting.enforce_second_factor_on_external_auth = false
-      write_secure_session("oauth", true)
       sign_in(user)
+      session[:oauth] = true
 
       get "/"
       expect(response.status).to eq(200)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe ApplicationController do
     let(:admin) { Fabricate(:admin) }
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
+    let(:store) { ActionDispatch::Session::CookieStore.new({}) }
+    let(:session_stub) do
+      ActionDispatch::Request::Session.create(store, ActionDispatch::TestRequest.create, {})
+    end
+
+    before do
+      session_stub[:oauth] = true
+      ActionDispatch::Request.any_instance.stubs(:session).returns(session_stub)
+    end
+
     before do
       admin # to skip welcome wizard at home page `/`
     end
@@ -153,7 +163,6 @@ RSpec.describe ApplicationController do
     it "should redirect users when enforce_second_factor is 'all' and authenticated via oauth" do
       SiteSetting.enforce_second_factor = "all"
       sign_in(user)
-      session[:oauth] = true
 
       get "/"
       expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
@@ -163,7 +172,6 @@ RSpec.describe ApplicationController do
       SiteSetting.enforce_second_factor = "all"
       SiteSetting.enforce_second_factor_on_external_auth = false
       sign_in(user)
-      session[:oauth] = true
 
       get "/"
       expect(response.status).to eq(200)

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -236,11 +236,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["email_valid"]).to eq(true)
         expect(data["can_edit_username"]).to eq(true)
         expect(data["destination_url"]).to eq(destination_url)
-        expect(read_secure_session["oauth"]).to eq("true")
-        expect(Discourse.redis.ttl("#{session[:secure_session_id]}oauth")).to be_between(
-          SiteSetting.maximum_session_age.hours.seconds - 10,
-          SiteSetting.maximum_session_age.hours.seconds,
-        )
+        expect(session[:oauth]).to be true
       end
 
       it "should return the right response for staged users" do


### PR DESCRIPTION
Previously in these 2 PRs, we introduced a new site setting `SiteSetting.enforce_second_factor_on_external_auth`.

https://github.com/discourse/discourse/pull/27547
https://github.com/discourse/discourse/pull/27674

When disabled, it should enforce 2FA for local login with username and password and skip the requirement when authenticating with oauth2.

We stored information about the login method in a secure session but it is not reliable. Therefore, information about the login method is moved to session.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
