### PR TITLE
EXPERIMENTAL: Add param to allow async CSS loading

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -54,9 +54,51 @@ class Discourse extends Application {
     _pluginCallbacks.push({ version, code });
   }
 
+  _cssReady() {
+    const stylesheetElements =
+      document.getElementsByClassName("async-css-loading");
+
+    if (stylesheetElements.length === 0) {
+      return true;
+    }
+
+    const processed = [...stylesheetElements].every((stylesheetElement) => {
+      return stylesheetElement.dataset.processed === "true";
+    });
+
+    if (processed) {
+      [...stylesheetElements].forEach((stylesheetElement) => {
+        stylesheetElement.media = stylesheetElement.dataset.media;
+        delete stylesheetElement.dataset["media"];
+      });
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  _displayApp() {
+    document.querySelector("#d-splash")?.remove();
+    document.getElementById("main").classList.remove("app-hidden");
+    document.getElementById("app-hidden-style")?.remove();
+  }
+
   ready() {
     performance.mark("discourse-ready");
-    document.querySelector("#d-splash")?.remove();
+
+    if (this._cssReady()) {
+      return this._displayApp();
+    }
+
+    let interval;
+
+    interval = setInterval(() => {
+      if (this._cssReady()) {
+        clearInterval(interval);
+        this._displayApp();
+      }
+    }, 50);
   }
 }
 

--- a/app/assets/javascripts/discourse/scripts/async-stylesheets.js
+++ b/app/assets/javascripts/discourse/scripts/async-stylesheets.js
@@ -1,0 +1,17 @@
+// This script is inlined in `_discourse_stylesheet.html.erb
+const links = document.getElementsByClassName("async-css-loading");
+
+const processEvent = function (element, eventListenerCallback) {
+  element.dataset["processed"] = true;
+  element.removeEventListener("error", eventListenerCallback);
+  element.removeEventListener("load", eventListenerCallback);
+};
+
+[...links].forEach(function (element) {
+  const elementProcessEvent = function () {
+    return processEvent(element, elementProcessEvent);
+  };
+
+  element.addEventListener("error", elementProcessEvent, { once: true });
+  element.addEventListener("load", elementProcessEvent, { once: true });
+});

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -536,6 +536,10 @@ module ApplicationHelper
     end
   end
 
+  def async_stylesheets
+    params["async_stylesheets"].to_s == "true"
+  end
+
   def stylesheet_manager
     return @stylesheet_manager if defined?(@stylesheet_manager)
     @stylesheet_manager = Stylesheet::Manager.new(theme_id: theme_id)
@@ -627,7 +631,12 @@ module ApplicationHelper
         stylesheet_manager
       end
 
-    manager.stylesheet_link_tag(name, "all", self.method(:add_resource_preload_list))
+    manager.stylesheet_link_tag(
+      name,
+      "all",
+      self.method(:add_resource_preload_list),
+      async_stylesheets,
+    )
   end
 
   def discourse_preload_color_scheme_stylesheets
@@ -650,6 +659,7 @@ module ApplicationHelper
       scheme_id,
       "all",
       self.method(:add_resource_preload_list),
+      async_stylesheets,
     )
 
     if dark_scheme_id != -1
@@ -657,6 +667,7 @@ module ApplicationHelper
         dark_scheme_id,
         "(prefers-color-scheme: dark)",
         self.method(:add_resource_preload_list),
+        async_stylesheets,
       )
     end
 

--- a/app/helpers/async_stylesheets_helper.rb
+++ b/app/helpers/async_stylesheets_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module AsyncStylesheetsHelper
+  def self.raw_js
+    if Rails.env.development?
+      load_js
+    else
+      @loaded_js ||= load_js
+    end.html_safe
+  end
+
+  private
+
+  def self.load_js
+    File.read(
+      "#{Rails.root}/app/assets/javascripts/discourse/dist/assets/async-stylesheets.js",
+    ).sub("//# sourceMappingURL=async-stylesheets.map", "")
+  rescue Errno::ENOENT
+    Rails.logger.error("Unable to load async stylesheets JS") if Rails.env.production?
+    "console.log('Unable to load async stylesheets JS')"
+  end
+end

--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -29,3 +29,9 @@
 <%- if theme_id.present? %>
   <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
 <%- end %>
+
+<%- if async_stylesheets %>
+  <script nonce="<%= csp_nonce_placeholder %>">
+    <%= AsyncStylesheetsHelper.raw_js %>
+  </script>
+<%- end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,7 +121,15 @@
       <%= build_plugin_html 'server:header' %>
     <%- end %>
 
-    <section id='main'>
+    <%- if async_stylesheets %>
+      <style id="app-hidden-style">
+        .app-hidden {
+          display: none;
+        }
+      </style>
+    <%- end %>
+
+    <section id='main' <%= async_stylesheets ? "class=app-hidden" : "" %> >
     </section>
 
     <% unless current_user %>

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -257,7 +257,7 @@ class Stylesheet::Manager
       .html_safe
   end
 
-  def stylesheet_link_tag(target = :desktop, media = "all", preload_callback = nil)
+  def stylesheet_link_tag(target = :desktop, media = "all", preload_callback = nil, async = false)
     stylesheets = stylesheet_details(target, media)
     stylesheets
       .map do |stylesheet|
@@ -267,7 +267,12 @@ class Stylesheet::Manager
         data_theme_id = theme_id ? "data-theme-id=\"#{theme_id}\"" : ""
         theme_name = stylesheet[:theme_name]
         data_theme_name = theme_name ? "data-theme-name=\"#{CGI.escapeHTML(theme_name)}\"" : ""
-        %[<link href="#{href}" media="#{media}" rel="stylesheet" data-target="#{target}" #{data_theme_id} #{data_theme_name}/>]
+
+        if async
+          %[<link class='async-css-loading' href="#{href}" media="print" rel="stylesheet" type="text/css" data-media="#{media}" data-target="#{target}" #{data_theme_id} #{data_theme_name}/>]
+        else
+          %[<link href="#{href}" media="#{media}" rel="stylesheet" data-target="#{target}" #{data_theme_id} #{data_theme_name}/>]
+        end
       end
       .join("\n")
       .html_safe
@@ -382,7 +387,12 @@ class Stylesheet::Manager
     %[<link href="#{href}" rel="preload" as="style"/>].html_safe
   end
 
-  def color_scheme_stylesheet_link_tag(color_scheme_id = nil, media = "all", preload_callback = nil)
+  def color_scheme_stylesheet_link_tag(
+    color_scheme_id = nil,
+    media = "all",
+    preload_callback = nil,
+    async = false
+  )
     stylesheet = color_scheme_stylesheet_details(color_scheme_id, media)
 
     return "" if !stylesheet
@@ -392,6 +402,10 @@ class Stylesheet::Manager
 
     css_class = media == "all" ? "light-scheme" : "dark-scheme"
 
-    %[<link href="#{href}" media="#{media}" rel="stylesheet" class="#{css_class}"/>].html_safe
+    if async
+      %[<link class="async-css-loading #{css_class}" href="#{href}" media="print" data-media="#{media}" rel="stylesheet" type="text/css" />].html_safe
+    else
+      %[<link href="#{href}" media="#{media}" rel="stylesheet" class="#{css_class}"/>].html_safe
+    end
   end
 end

--- a/spec/system/async_stylesheets_spec.rb
+++ b/spec/system/async_stylesheets_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+describe "Async StyleSheets", type: :system do
+  it "should display the Ember app when `async_stylesheets` param is `true`" do
+    visit("/?async_stylesheets=true")
+
+    expect(page).to have_css(".ember-application", visible: true)
+    expect(page).to have_css("link.async-css-loading.light-scheme[media=\"all\"]", visible: false)
+  end
+end


### PR DESCRIPTION
This commit adds a `async_stylesheets` param which when present and set
to `true` will result in the app loading the CSS files in an
asynchronous manner. The asynchronous loading is achieved by first
setting the `media` attribute of the CSS `link` tag to `print` which
tells the browser not to prioritise loading the CSS files. When the file
is loading, the `media` attribute is then set to the original intended
`media` attribute which will make the browser apply the CSS.

The motivation for introducing asynchronous loading of CSS is to improve
our lighthouse score on mobile. Loading and parsing of CSS has
consistently been flagged as blocking render as the browser is unable to
paint any element until all the CSS files have been downloaded and
parsed. This means that even though the HTML elements for the splash
screen are defined before stylesheet `<link>` tags, the splash screen
image cannot be painted until the stylesheets have been downloaded and
parsed. Because the stylesheets are blocking the rendering of the splash
screen, we believe this change will have a positive impact on our LCP and FCP core web
vitals.

To prevent Flash Of Unstyled Content (FOUC, we are hiding the Ember app with a 
`display: none` until all the CSS has been loaded.

### Webpage test report of meta.discourse.org flagging render-blocking resources

<img width="963" alt="Screenshot 2024-07-24 at 2 37 20 PM" src="https://github.com/user-attachments/assets/3dc771a8-32da-46e1-b92d-0470a9447a9f">


### Before local lighthouse score on mobile 

<img width="788" alt="Screenshot 2024-07-24 at 2 35 15 PM" src="https://github.com/user-attachments/assets/c9029dc8-ceff-4386-8497-af7284a5cd27">
### After local lighthouse score on mobile

<img width="778" alt="Screenshot 2024-07-24 at 2 35 09 PM" src="https://github.com/user-attachments/assets/a37d3610-a655-4733-b6e3-6ac60c92f152">
