### PR TITLE
UX: do not show footer nav if no actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/footer-nav.gjs
+++ b/app/assets/javascripts/discourse/app/components/footer-nav.gjs
@@ -66,7 +66,9 @@ export default class FooterNav extends Component {
     return (
       [UNSCROLLED, SCROLLED_UP].includes(
         this.scrollDirection.lastScrollDirection
-      ) && !this.composer.isOpen
+      ) &&
+      !this.composer.isOpen &&
+      (this.capabilities.isAppWebview || this.canGoBack || this.canGoForward)
     );
   }
 


### PR DESCRIPTION
This commit is a minor optimisation to only start showing the footer nav once one of these conditions is valid:
- discourse is in the context of discourse hub
- user can go back
- user can go forward

No tests as it's a lot of stuff related to routing and discourse hub which would be hard to test. Although we could try writing a system spec in the feature for this whole footer-nav behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
