### PR TITLE
FIX: Perform topics bulk action in a background thread

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1028,9 +1028,12 @@ class TopicsController < ApplicationController
         .symbolize_keys
 
     raise ActionController::ParameterMissing.new(:operation_type) if operation[:type].blank?
+
     operator = TopicsBulkAction.new(current_user, topic_ids, operation, group: operation[:group])
-    changed_topic_ids = operator.perform!
-    render_json_dump topic_ids: changed_topic_ids
+    hijack(info: "topics bulk action #{operation[:type]}") do
+      changed_topic_ids = operator.perform!
+      render_json_dump topic_ids: changed_topic_ids
+    end
   end
 
   def private_message_reset_new


### PR DESCRIPTION
Performing a bulk action on many topics can exceed the 30 seconds timeout that Unicorn workers have which results in the request failing and the operation getting aborted. To get around this 30 seconds timeout, we can push the operation into a background thread using the rack `hijack` API.

Internal topic: t/133779.