### PR TITLE
FIX: Allow invalid plural keys in MF translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     memory_profiler (1.0.2)
     message_bus (4.3.8)
       rack (>= 1.1.3)
-    messageformat-wrapper (1.0.0)
+    messageformat-wrapper (1.1.0)
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)

--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -150,7 +150,7 @@ module JsLocaleHelper
           )
         end
         .compact_blank
-    compiled = MessageFormat.compile(message_formats.keys, message_formats)
+    compiled = MessageFormat.compile(message_formats.keys, message_formats, strict: false)
     transpiled = DiscourseJsProcessor.transpile(<<~JS, "", "discourse-mf")
       import Messages from '@messageformat/runtime/messages';
       #{compiled.sub("export default", "const msgData =")};


### PR DESCRIPTION
We can get translations with invalid plural keys from Crowdin or from custom overrides. Currently, this will raise an error and the locales won’t be outputted at all.

This PR addresses this issue by using the new `strict: false` option of our `messageformat-wrapper` gem, allowing to generate locales even if there are invalid plural keys present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
