### PR TITLE
DEV: Add `DISCOURSE_WEBPACK_MINIMIZE` to reenable webpack minimize.

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -140,8 +140,8 @@ module.exports = function (defaults) {
           chunkFilename: `assets/chunk.[chunkhash].${cachebusterHash}.js`,
         },
         optimization: {
-          // Disable webpack minimization. Embroider automatically applies terser after webpack.
-          minimize: false,
+          // TODO: Minimization being disabled is a bug and we are currently working to restore it.
+          minimize: process.env.DISCOURSE_WEBPACK_MINIMIZE === "1",
         },
         cache: isProduction
           ? false


### PR DESCRIPTION
Disabling webpack minimize is a bug we are working to resolve as we
have to consider self-hosters that deploy on low cost hardware
and reenabling this for them drastically increases the build time.
For now, add a  `DISCOURSE_WEBPACK_MINIMIZE` env to allow sites to opt
back in.
