### PR TITLE
UX: Remove bookmark menu title on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -258,13 +258,6 @@ export default class BookmarkMenu extends Component {
           {{/unless}}
 
           {{#if this.showEditDeleteMenu}}
-            {{#if this.site.mobileView}}
-              <dropdown.item class="bookmark-menu__title">
-                {{icon "bookmark"}}
-                <span>{{i18n "bookmarks.bookmark"}}</span>
-              </dropdown.item>
-            {{/if}}
-
             <dropdown.item
               class="bookmark-menu__row -edit"
               data-menu-option-id="edit"


### PR DESCRIPTION
We don't show this when editing on desktop,
so no need to show on mobile (also the label
is wrong)

Old

<img width="192" alt="image" src="https://github.com/user-attachments/assets/d611c37b-5914-4e6b-ac26-e90e754af8c3">

New

<img width="187" alt="image" src="https://github.com/user-attachments/assets/46c00aa2-0145-4156-91a0-39e87568ca54">

