### PR TITLE
DEV: show admin moderation flags UI

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -103,6 +103,12 @@ export const ADMIN_NAV_MAP = [
         label: "admin.community.sidebar_link.legal",
         icon: "gavel",
       },
+      {
+        name: "admin_moderation_flags",
+        route: "adminConfig.flags",
+        label: "admin.community.sidebar_link.moderation_flags",
+        icon: "flag",
+      },
     ],
   },
   {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -325,17 +325,6 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         });
     }
 
-    if (currentUser.show_experimental_flags_admin_page) {
-      navMap
-        .find((section) => section.name === "community")
-        .links.push({
-          name: "admin_moderation_flags",
-          route: "adminConfig.flags",
-          label: "admin.community.sidebar_link.moderation_flags",
-          icon: "flag",
-        });
-    }
-
     navMap.forEach((section) =>
       section.links.forEach((link) => {
         if (link.keywords) {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -76,7 +76,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_view_raw_email,
              :use_glimmer_topic_list?,
              :login_method,
-             :show_experimental_flags_admin_page,
              :render_experimental_about_page
 
   delegate :user_stat, to: :object, private: true
@@ -142,16 +141,8 @@ class CurrentUserSerializer < BasicUserSerializer
     object.staff?
   end
 
-  def show_experimental_flags_admin_page
-    object.in_any_groups?(SiteSetting.experimental_flags_admin_page_enabled_groups_map)
-  end
-
   def render_experimental_about_page
     object.in_any_groups?(SiteSetting.experimental_redesigned_about_page_groups_map)
-  end
-
-  def include_show_experimental_flags_admin_page?
-    object.admin?
   end
 
   def can_post_anonymously

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2428,12 +2428,6 @@ developer:
     default: ""
     client: true
     hidden: true
-  experimental_flags_admin_page_enabled_groups:
-    default: ""
-    type: group_list
-    list_type: compact
-    allow_any: false
-    refresh: true
   experimental_redesigned_about_page_groups:
     default: ""
     type: group_list

--- a/db/migrate/20240725042522_remove_experimental_flags_admin_page_site_setting.rb
+++ b/db/migrate/20240725042522_remove_experimental_flags_admin_page_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveExperimentalFlagsAdminPageSiteSetting < ActiveRecord::Migration[7.1]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'experimental_flags_admin_page_enabled_groups'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -8,7 +8,6 @@ describe "Admin Flags Page", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:admin_flags_page) { PageObjects::Pages::AdminFlags.new }
   let(:admin_flag_form_page) { PageObjects::Pages::AdminFlagForm.new }
-  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
   before { sign_in(admin) }
 
@@ -161,18 +160,5 @@ describe "Admin Flags Page", type: :system do
     visit "/admin/config/flags"
     admin_flags_page.open_flag_menu("off_topic")
     expect(page).not_to have_css(".dropdown-menu__item .move-up")
-  end
-
-  it "does not show the moderation flags link in the sidebar by default" do
-    visit "/admin"
-    sidebar.toggle_all_sections
-    expect(sidebar).to have_no_section_link(
-      I18n.t("admin_js.admin.community.sidebar_link.moderation_flags"),
-    )
-    SiteSetting.experimental_flags_admin_page_enabled_groups = Group::AUTO_GROUPS[:admins]
-    visit "/admin"
-    expect(sidebar).to have_section_link(
-      I18n.t("admin_js.admin.community.sidebar_link.moderation_flags"),
-    )
   end
 end


### PR DESCRIPTION
The page was hidden behind a feature flag in this PR https://github.com/discourse/discourse/pull/27756

It is now in a shippable state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
