### PR TITLE
PERF: Avoid using `ObjectSpace.each_object` in  `Jobs::Onceoff.enqueue_all`

### DIFF
--- a/spec/integrity/onceoff_integrity_spec.rb
+++ b/spec/integrity/onceoff_integrity_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe ::Jobs::Onceoff do
       require_relative "../../app/jobs/onceoff/" + File.basename(f)
     end
 
-    ObjectSpace
-      .each_object(Class)
-      .select { |klass| klass.superclass == ::Jobs::Onceoff }
-      .each { |job| job.new.execute_onceoff(nil) }
+    described_class.onceoff_job_klasses.each { |job| job.new.execute_onceoff(nil) }
   end
 end


### PR DESCRIPTION
We are investigating a memory leak in Sidekiq and saw the following line
when comparing heap dumps over time.

`Allocated IMEMO 14775 objects of size 591000/7389528 (in bytes) at:
/var/www/discourse/app/jobs/onceoff/onceoff.rb:36`

That line in question was doing a `.select { |klass| klass < self  }` on
`ObjectSpace.each_object(Class)`. This for some reason is allocating a
whole bunch of `IMEMO` objects which are instruction sequence objects.

Instead of diving deeper into why this might be leaking, we can just
save our time by switching to an implementation that is more efficient
and does not require looping through a ton of objects.
