### PR TITLE
FIX: Fix `Jobs::Onceoff.enqueue_all` undefined method for nilClass error

### DIFF
--- a/app/jobs/onceoff/onceoff.rb
+++ b/app/jobs/onceoff/onceoff.rb
@@ -4,11 +4,14 @@ class Jobs::Onceoff < ::Jobs::Base
   sidekiq_options retry: false
 
   class << self
-    attr_reader :onceoff_job_klasses
+    @@onceoff_job_klasses = Set.new
 
     def inherited(klass)
-      @onceoff_job_klasses ||= Set.new
-      @onceoff_job_klasses << klass
+      @@onceoff_job_klasses << klass
+    end
+
+    def onceoff_job_klasses
+      @@onceoff_job_klasses
     end
   end
 


### PR DESCRIPTION
In development, classes are lazy loaded so `Jobs::Onceoff.onceoff_job_klasses`
may not have been set. This is not a problem in production cause stuff
is eager loaded.

Follow-up to f4d06f195d583794313943e73b1b31d28151b85c
