### PR TITLE
UX: Fix button syntax in preferences

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -91,25 +91,31 @@
     </div>
 
     {{#if this.canShowAllAuthTokens}}
-      <a href {{on "click" this.toggleShowAllAuthTokens}}>
+      <a {{on "click" this.toggleShowAllAuthTokens}}>
         {{#if this.showAllAuthTokens}}
           {{d-icon "caret-up"}}
-          {{i18n "user.auth_tokens.show_few"}}
+          <span>{{i18n "user.auth_tokens.show_few"}}</span>
         {{else}}
           {{d-icon "caret-down"}}
-          {{i18n
-            "user.auth_tokens.show_all"
-            count=this.model.user_auth_tokens.length
-          }}
+          <span>
+            {{i18n
+              "user.auth_tokens.show_all"
+              count=this.model.user_auth_tokens.length
+            }}
+          </span>
         {{/if}}
       </a>
     {{/if}}
 
     <a
-      href
       {{on "click" (fn this.revokeAuthToken null)}}
       class="pull-right text-danger"
-    >{{d-icon "sign-out-alt"}} {{i18n "user.auth_tokens.log_out_all"}}</a>
+    >
+      {{d-icon "sign-out-alt"}}
+      <span>
+        {{i18n "user.auth_tokens.log_out_all"}}
+      </span>
+    </a>
   </div>
 {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -91,7 +91,7 @@
     </div>
 
     {{#if this.canShowAllAuthTokens}}
-      <a {{on "click" this.toggleShowAllAuthTokens}}>
+      <a href {{on "click" this.toggleShowAllAuthTokens}}>
         {{#if this.showAllAuthTokens}}
           {{d-icon "caret-up"}}
           <span>{{i18n "user.auth_tokens.show_few"}}</span>
@@ -108,6 +108,7 @@
     {{/if}}
 
     <a
+      href
       {{on "click" (fn this.revokeAuthToken null)}}
       class="pull-right text-danger"
     >


### PR DESCRIPTION
<s>Remove empty `href` attributes</s> and wrap labels with `span`s

I see the `href` attributes were added to bypass `Interaction added to non-interactive element  no-invalid-interactive`, so we can just add the `span`s