### PR TITLE
FIX: Add new/missing email templates to the email templates editor

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -3,8 +3,10 @@
 class Admin::EmailTemplatesController < Admin::AdminController
   def self.email_keys
     @email_keys ||= %w[
+      admin_confirmation_mailer
       custom_invite_forum_mailer
       custom_invite_mailer
+      download_backup_mailer
       invite_forum_mailer
       invite_mailer
       invite_password_instructions
@@ -18,52 +20,103 @@ class Admin::EmailTemplatesController < Admin::AdminController
       system_messages.csv_export_succeeded
       system_messages.download_remote_images_disabled
       system_messages.email_error_notification
+      system_messages.email_reject_attachment
       system_messages.email_reject_auto_generated
       system_messages.email_reject_bad_destination_address
       system_messages.email_reject_empty
+      system_messages.email_reject_inactive_user
+      system_messages.email_reject_insufficient_trust_level
       system_messages.email_reject_invalid_access
+      system_messages.email_reject_invalid_post
+      system_messages.email_reject_invalid_post_action
+      system_messages.email_reject_invalid_post_specified
+      system_messages.email_reject_not_allowed_email
+      system_messages.email_reject_old_destination
       system_messages.email_reject_parsing
+      system_messages.email_reject_post_too_short
       system_messages.email_reject_reply_key
+      system_messages.email_reject_reply_not_allowed
+      system_messages.email_reject_reply_to_digest
+      system_messages.email_reject_reply_user_not_matching
       system_messages.email_reject_screened_email
+      system_messages.email_reject_silenced_user
+      system_messages.email_reject_strangers_not_allowed
+      system_messages.email_reject_too_many_recipients
       system_messages.email_reject_topic_closed
       system_messages.email_reject_topic_not_found
       system_messages.email_reject_unrecognized_error
       system_messages.email_reject_user_not_found
       system_messages.email_revoked
+      system_messages.flags_agreed_and_post_deleted
+      system_messages.flags_agreed_and_post_deleted_for_responders
+      system_messages.flags_disagreed
+      system_messages.ignored_users_summary
+      system_messages.new_user_of_the_month
       system_messages.pending_users_reminder
       system_messages.post_hidden
       system_messages.post_hidden_again
+      system_messages.queued_by_staff
       system_messages.queued_posts_reminder
       system_messages.restore_failed
       system_messages.restore_succeeded
+      system_messages.reviewable_queued_post_revise_and_reject
+      system_messages.reviewable_queued_post_revise_and_reject_new_topic
       system_messages.silenced_by_staff
       system_messages.spam_post_blocked
+      system_messages.tl2_promotion_message
       system_messages.too_many_spam_flags
+      system_messages.too_many_tl3_flags
       system_messages.unsilenced
+      system_messages.user_added_to_group_as_member
+      system_messages.user_added_to_group_as_owner
       system_messages.user_automatically_silenced
       system_messages.welcome_invite
-      system_messages.welcome_user
       system_messages.welcome_staff
+      system_messages.welcome_tl1_user
+      system_messages.welcome_user
       test_mailer
+      unsubscribe_mailer
       user_notifications.account_created
+      user_notifications.account_exists
+      user_notifications.account_second_factor_disabled
+      user_notifications.account_silenced
+      user_notifications.account_silenced_forever
+      user_notifications.account_suspended
+      user_notifications.account_suspended_forever
+      user_notifications.activation_reminder
       user_notifications.admin_login
       user_notifications.confirm_new_email
+      user_notifications.confirm_new_email_via_admin
+      user_notifications.confirm_old_email
+      user_notifications.confirm_old_email_add
       user_notifications.email_login
       user_notifications.forgot_password
       user_notifications.notify_old_email
+      user_notifications.notify_old_email_add
+      user_notifications.post_approved
       user_notifications.set_password
       user_notifications.signup
       user_notifications.signup_after_approval
+      user_notifications.signup_after_reject
       user_notifications.suspicious_login
+      user_notifications.user_group_mentioned
+      user_notifications.user_group_mentioned_pm
+      user_notifications.user_group_mentioned_pm_group
       user_notifications.user_invited_to_private_message_pm
       user_notifications.user_invited_to_private_message_pm_group
+      user_notifications.user_invited_to_private_message_pm_staged
       user_notifications.user_invited_to_topic
       user_notifications.user_linked
       user_notifications.user_mentioned
+      user_notifications.user_mentioned_pm
       user_notifications.user_posted
       user_notifications.user_posted_pm
+      user_notifications.user_posted_pm_staged
       user_notifications.user_quoted
       user_notifications.user_replied
+      user_notifications.user_replied_pm
+      user_notifications.user_watching_category_or_tag
+      user_notifications.user_watching_first_post
     ]
   end
 

--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::EmailTemplatesController < Admin::AdminController
+  # to update the list of keys below, run the `list_email_templates_strings`
+  # rake task and replace the list below with the output from the rake task
   def self.email_keys
     @email_keys ||= %w[
       admin_confirmation_mailer

--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -63,6 +63,7 @@ class Admin::EmailTemplatesController < Admin::AdminController
       system_messages.restore_succeeded
       system_messages.reviewable_queued_post_revise_and_reject
       system_messages.reviewable_queued_post_revise_and_reject_new_topic
+      system_messages.reviewables_reminder
       system_messages.silenced_by_staff
       system_messages.spam_post_blocked
       system_messages.tl2_promotion_message

--- a/lib/email_templates_finder.rb
+++ b/lib/email_templates_finder.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class EmailTemplatesFinder
+  def self.list
+    path = File.join(Rails.root, "config", "locales", "server.en.yml")
+    yaml = YAML.load_file(path, aliases: true)
+    new(yaml).list
+  end
+
+  attr_reader :list
+
+  def initialize(obj)
+    @obj = obj
+    @list = []
+    check(@obj, "")
+    @list.sort!
+  end
+
+  private
+
+  def check(obj, path)
+    obj.each do |key, val|
+      if Hash === val
+        next_path = "#{path}#{key}"
+        if val.key?("text_body_template") && val.key?("subject_template")
+          @list << next_path.sub("en.", "")
+        else
+          check(val, "#{next_path}.")
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/list_email_templates_strings.rake
+++ b/lib/tasks/list_email_templates_strings.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+def check(obj, path, result)
+  obj.each do |key, val|
+    if Hash === val
+      next_path = "#{path}#{key}"
+      if val.key?("text_body_template") && val.key?("subject_template")
+        result << next_path.sub("en.", "")
+      else
+        check(val, "#{next_path}.", result)
+      end
+    end
+  end
+end
+
+task "list_email_templates_strings" => :environment do
+  path = File.join(Rails.root, "config", "locales", "server.en.yml")
+  yaml = YAML.load_file(path, aliases: true)
+  result = []
+  check(yaml, "", result)
+  puts result.sort
+end

--- a/lib/tasks/list_email_templates_strings.rake
+++ b/lib/tasks/list_email_templates_strings.rake
@@ -1,22 +1,5 @@
 # frozen_string_literal: true
 
-def check(obj, path, result)
-  obj.each do |key, val|
-    if Hash === val
-      next_path = "#{path}#{key}"
-      if val.key?("text_body_template") && val.key?("subject_template")
-        result << next_path.sub("en.", "")
-      else
-        check(val, "#{next_path}.", result)
-      end
-    end
-  end
-end
-
 task "list_email_templates_strings" => :environment do
-  path = File.join(Rails.root, "config", "locales", "server.en.yml")
-  yaml = YAML.load_file(path, aliases: true)
-  result = []
-  check(yaml, "", result)
-  puts result.sort
+  puts EmailTemplatesFinder.list
 end

--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -453,4 +453,12 @@ RSpec.describe Admin::EmailTemplatesController do
       expect(I18n.t(key)).to_not include("Translation missing")
     end
   end
+
+  describe ".email_keys" do
+    it "returns a list that contains all the email templates in the server.en.yml file" do
+      expect(Admin::EmailTemplatesController.email_keys).to contain_exactly(
+        *EmailTemplatesFinder.list,
+      )
+    end
+  end
 end


### PR DESCRIPTION
We have a dedicated admin page (`/admin/customize/email_templates`) that lets admins customize all emails that Discourse sends to users. The way this page works is that it lists all translations strings that are used for emails, and the list of translation strings is currently hardcoded and hasn't been updated in years. We've had a number of new emails that Discourse sends, so we should add those templates to the list to let admins easily customize those templates.

Meta topic: https://meta.discourse.org/t/3-2-x-still-ignores-some-custom-email-templates/308203.