### PR TITLE
DEV: Do not attempt to install theme dependencies in specs

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -86,7 +86,8 @@ class RemoteTheme < ActiveRecord::Base
   if Rails.env.test? || Rails.env.development?
     def self.import_theme_from_directory(directory, update_components: false)
       update_theme(
-        ThemeStore::DirectoryImporter.new(directory, update_components: update_components),
+        ThemeStore::DirectoryImporter.new(directory),
+        update_components: update_components,
       )
     end
   end

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -84,8 +84,10 @@ class RemoteTheme < ActiveRecord::Base
 
   # This is only used in the development and test environment and is currently not supported for other environments
   if Rails.env.test? || Rails.env.development?
-    def self.import_theme_from_directory(directory)
-      update_theme(ThemeStore::DirectoryImporter.new(directory))
+    def self.import_theme_from_directory(directory, update_components: false)
+      update_theme(
+        ThemeStore::DirectoryImporter.new(directory, update_components: update_components),
+      )
     end
   end
 


### PR DESCRIPTION
This fails because WebMock restricts access to the internet. So for now, let's skip it entirely. In future, we may want to consider adding support for dependent components in system specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
