### PR TITLE
FIX: Render the bottom topic map only if all posts are loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -211,7 +211,7 @@
         />
       </div>
 
-      {{#if this.showBottomTopicMap}}
+      {{#if (and this.showBottomTopicMap this.loadedAllPosts)}}
         <div class="topic-map --bottom">
           <TopicMap
             @model={{this.model}}


### PR DESCRIPTION
Without this, the browser may anchor to the bottom topic map when loading posts, causing the post stream to scroll to the bottom.