### PR TITLE
FIX: Validate MF strings when adding overrides

### DIFF
--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -135,14 +135,7 @@ class Admin::SiteTextsController < Admin::AdminController
 
     raise Discourse::NotFound if override.blank?
 
-    if override.outdated?
-      override.update!(
-        status: "up_to_date",
-        original_translation:
-          I18n.overrides_disabled do
-            I18n.t(TranslationOverride.transform_pluralized_key(params[:id]), locale: :en)
-          end,
-      )
+    if override.make_up_to_date!
       render json: success_json
     else
       render json: failed_json.merge(message: "Can only dismiss outdated translations"), status: 422

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -170,6 +170,12 @@ class TranslationOverride < ActiveRecord::Base
     translation_key.to_s.end_with?("_MF")
   end
 
+  def make_up_to_date!
+    return unless outdated?
+    self.original_translation = current_default
+    update_attribute!(:status, :up_to_date)
+  end
+
   private
 
   def transformed_key

--- a/spec/lib/js_locale_helper_spec.rb
+++ b/spec/lib/js_locale_helper_spec.rb
@@ -155,20 +155,10 @@ RSpec.describe JsLocaleHelper do
       )
     end
     fab!(:overriden_translation_ja) do
-      Fabricate(
-        :translation_override,
-        locale: "ja",
-        translation_key: "js.posts_likes_MF",
-        value: "{ count, plural, one {返信 # 件、} other {返信 # 件、} }",
-      )
+      Fabricate(:translation_override, locale: "ja", translation_key: "js.posts_likes_MF")
     end
     fab!(:overriden_translation_he) do
-      Fabricate(
-        :translation_override,
-        locale: "he",
-        translation_key: "js.posts_likes_MF",
-        value: "{ count, plural, ",
-      )
+      Fabricate(:translation_override, locale: "he", translation_key: "js.posts_likes_MF")
     end
     let(:output) { described_class.output_MF(locale).gsub(/^import.*$/, "") }
     let(:generated_locales) { v8_ctx.eval("Object.keys(I18n._mfMessages._data)") }
@@ -176,7 +166,13 @@ RSpec.describe JsLocaleHelper do
       v8_ctx.eval("I18n._mfMessages.get('posts_likes_MF', {count: 3, ratio: 'med'})")
     end
 
-    before { v8_ctx.eval(output) }
+    before do
+      overriden_translation_ja.update_columns(
+        value: "{ count, plural, one {返信 # 件、} other {返信 # 件、} }",
+      )
+      overriden_translation_he.update_columns(value: "{ count, plural, ")
+      v8_ctx.eval(output)
+    end
 
     context "when locale is 'en'" do
       let(:locale) { "en" }

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -382,4 +382,36 @@ RSpec.describe TranslationOverride do
       it { is_expected.not_to be_a_message_format }
     end
   end
+
+  describe "#make_up_to_date!" do
+    fab!(:override) { Fabricate(:translation_override, translation_key: "js.posts_likes_MF") }
+
+    context "when override is not outdated" do
+      it "does nothing" do
+        expect { override.make_up_to_date! }.not_to change { override.reload.attributes }
+      end
+
+      it "returns a falsy value" do
+        expect(override.make_up_to_date!).to be_falsy
+      end
+    end
+
+    context "when override is outdated" do
+      before { override.update_columns(status: :outdated, value: "{ Invalid MF syntax") }
+
+      it "updates its original translation to match the current default" do
+        expect { override.make_up_to_date! }.to change { override.reload.original_translation }.to(
+          I18n.t("js.posts_likes_MF"),
+        )
+      end
+
+      it "sets its status to 'up_to_date'" do
+        expect { override.make_up_to_date! }.to change { override.reload.up_to_date? }.to(true)
+      end
+
+      it "returns a truthy value" do
+        expect(override.make_up_to_date!).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -148,6 +148,32 @@ RSpec.describe TranslationOverride do
         end
       end
     end
+
+    describe "MessageFormat translations" do
+      subject(:override) do
+        described_class.new(
+          translation_key: "admin_js.admin.user.delete_all_posts_confirm_MF",
+          locale: "en",
+        )
+      end
+
+      it do
+        is_expected.to allow_value(
+          "This has {COUNT, plural, one{one member} other{# members}}.",
+        ).for(:value).against(:base)
+      end
+      it do
+        is_expected.not_to allow_value(
+          "This has {COUNT, plural, one{one member} many{# members} other{# members}}.",
+        ).for(:value).with_message(/plural case many is not valid/, against: :base)
+      end
+      it do
+        is_expected.not_to allow_value("This has {COUNT, ").for(:value).with_message(
+          /invalid syntax/,
+          against: :base,
+        )
+      end
+    end
   end
 
   it "upserts values" do
@@ -338,6 +364,22 @@ RSpec.describe TranslationOverride do
       translation.update_attribute("value", "Hello, %{name}! Welcome to %{site_name}. %{foo}")
 
       expect(translation.invalid_interpolation_keys).to contain_exactly("foo")
+    end
+  end
+
+  describe "#message_format?" do
+    subject(:override) { described_class.new(translation_key: key) }
+
+    context "when override is for a MessageFormat translation" do
+      let(:key) { "admin_js.admin.user.delete_all_posts_confirm_MF" }
+
+      it { is_expected.to be_a_message_format }
+    end
+
+    context "when override is not for a MessageFormat translation" do
+      let(:key) { "admin_js.type_to_filter" }
+
+      it { is_expected.not_to be_a_message_format }
     end
   end
 end


### PR DESCRIPTION
Currently, when adding translation overrides, values aren’t validated for MF strings. This results in being able to add invalid plural keys or even strings containing invalid syntax.

This PR addresses this issue by compiling the string when saving an override if the key is detected as an MF one.

If there’s an error from the compiler, it’s added to the model errors, which in turn is displayed to the user in the admin UI, helping them to understand what went wrong.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->


----

![image](https://github.com/user-attachments/assets/7315f643-b764-411b-b962-92dac0cd0b20)
![image](https://github.com/user-attachments/assets/bb22c536-5bda-4f5f-8be6-6171b4427245)
