### PR TITLE
FIX: Restore missing modal scss

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -75,6 +75,24 @@
       width: 100%;
       height: 80px;
     }
+
+    .password-confirmation {
+      display: none;
+    }
+
+    section.field {
+      padding: 0.25em 0;
+      margin-bottom: 5px;
+      &.with-items {
+        display: flex;
+        align-items: flex-start;
+      }
+      .field-item {
+        display: inline-block;
+        margin-right: 10px;
+      }
+    }
+
     pre code {
       white-space: pre-wrap;
       max-width: 100%;


### PR DESCRIPTION
Regressed in https://github.com/discourse/discourse/pull/28047

Should fix issue reported in https://meta.discourse.org/t/broken-password-confirmation-box-on-registration/318386
