### PR TITLE
DEV: Fix flakey user tips test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/user-tips-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-tips-test.js
@@ -1,5 +1,6 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "discourse-i18n";
 
@@ -10,10 +11,29 @@ acceptance("User Tips - first_notification", function (needs) {
   test("Shows first notification user tip", async function (assert) {
     this.siteSettings.enable_user_tips = true;
 
+    let requestsCount = 0;
+    pretender.put("/u/eviltrout.json", () => {
+      requestsCount += 1;
+
+      return response(200, {
+        user: {
+          user_option: {
+            seen_popups: [1],
+          },
+        },
+      });
+    });
+
     await visit("/t/internationalization-localization/280");
     assert.equal(
       query(".user-tip__title").textContent.trim(),
       I18n.t("user_tips.first_notification.title")
+    );
+
+    assert.strictEqual(
+      requestsCount,
+      1,
+      "Seeing the user tip updates the user option via a background request"
     );
   });
 });

--- a/spec/system/user_tips_spec.rb
+++ b/spec/system/user_tips_spec.rb
@@ -47,13 +47,6 @@ describe "Homepage", type: :system do
         ".fk-d-tooltip__content .user-tip__title",
         text: "Your first notification!",
       )
-
-      page.refresh
-
-      expect(page).to have_no_css(
-        ".fk-d-tooltip__content .user-tip__title",
-        text: "Your first notification!",
-      )
     end
 
     it "shows a second notification once first is dismissed and user visits a topic" do


### PR DESCRIPTION
When we show user tips, we immediately send an AJAX request to mark the tiup as seen. This is done in the background. However, when system tests are run, sometimes that request is not completed before the test ends. This causes the test to be flakey.

One way to fix this is to force the system test run to wait for the AJAX request to complete. However, this is not ideal because it makes the test suite slower on each run.

Instead, this commit removes the flakey assertion and adds an alternative assertion in the frontend tests that ensures the background request is sent when the user tip is shown.