### PR TITLE
UX: restyle main nav on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.hbs
@@ -1,8 +1,10 @@
 {{#if this.site.mobileView}}
   <li class="navigation-toggle">
     <a href {{on "click" this.toggleDrop}} class="toggle-link">
-      {{this.selectedNavItem.displayName}}
-      {{d-icon "caret-down"}}
+      <span
+        class="toggle-link__text"
+      >{{this.selectedNavItem.displayName}}</span>
+      {{d-icon "discourse-chevron-expand"}}
     </a>
   </li>
   {{#if this.expanded}}

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -480,7 +480,7 @@ td .main-link {
 }
 .topic-list {
   &-body {
-    border-top: 0;
+    border-width: 1px;
   }
   .num.posts-map {
     font-size: var(--font-up-2);

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -36,11 +36,6 @@
         flex: 1 1 auto;
       }
     }
-
-    .navigation-controls .bulk-select,
-    .plugin-outlet-component {
-      display: none;
-    }
   }
 
   .nav-pills {

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -36,6 +36,11 @@
         flex: 1 1 auto;
       }
     }
+
+    .navigation-controls .bulk-select,
+    .plugin-outlet-component {
+      display: none;
+    }
   }
 
   .nav-pills {
@@ -45,6 +50,25 @@
     position: relative;
     .navigation-toggle {
       flex: 0 1 auto;
+      border: 0;
+
+      .toggle-link {
+        font-size: var(--font-up-1-rem);
+        font-weight: bold;
+        color: var(--primary-high);
+        padding: 0;
+
+        &:hover,
+        &:focus {
+          background: none;
+        }
+
+        .d-icon {
+          color: inherit;
+          font-size: var(--font-down-2);
+          margin-left: 0.5em;
+        }
+      }
     }
     > li {
       margin-right: 0;
@@ -460,6 +484,9 @@ td .main-link {
   }
 }
 .topic-list {
+  &-body {
+    border-top: 0;
+  }
   .num.posts-map {
     font-size: var(--font-up-2);
     padding: 0;


### PR DESCRIPTION
In anticipation of the bigger rework of the navigation, this commit does a first touch-up to the area on mobile by restyling the navigation dropdown to feel lighter


### Before
<img width="389" alt="image" src="https://github.com/user-attachments/assets/9da001af-c422-41a4-9f40-01f8b8f3f585">


### After
<img width="397" alt="image" src="https://github.com/user-attachments/assets/1f724fd5-6fbd-472e-8cd0-0c5998487269">


