### PR TITLE
DEV: fix chat message grace edit period flaky

### DIFF
--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -871,7 +871,7 @@ RSpec.describe Chat::UpdateMessage do
     end
 
     before do
-      SiteSetting.chat_editing_grace_period = 10
+      SiteSetting.chat_editing_grace_period = 30
       SiteSetting.chat_editing_grace_period_max_diff_low_trust = 10
       SiteSetting.chat_editing_grace_period_max_diff_high_trust = 40
 
@@ -949,7 +949,7 @@ RSpec.describe Chat::UpdateMessage do
       let(:low_trust_char_limit) { SiteSetting.chat_editing_grace_period_max_diff_low_trust }
       let(:high_trust_char_limit) { SiteSetting.chat_editing_grace_period_max_diff_high_trust }
 
-      xit "does not create a revision when under (n) seconds" do
+      it "does not create a revision when under (n) seconds" do
         freeze_time 5.seconds.from_now
         message_1.update!(message: "hello")
 
@@ -963,7 +963,7 @@ RSpec.describe Chat::UpdateMessage do
       end
 
       it "creates a revision when over (n) seconds" do
-        freeze_time 30.seconds.from_now
+        freeze_time 40.seconds.from_now
         message_1.update!(message: "welcome")
 
         expect { result }.to change { Chat::MessageRevision.count }.by(1)


### PR DESCRIPTION
The message grace edit window (10 seconds) was too short after freezing time, possibly causing the test to fail occasionally if the record is not updated within 5 seconds.