### PR TITLE
DEV: Ensure MF locales are checked properly

### DIFF
--- a/lib/i18n/locale_file_checker.rb
+++ b/lib/i18n/locale_file_checker.rb
@@ -140,21 +140,15 @@ class LocaleFileChecker
   end
 
   def check_message_format
-    mf_locale, mf_filename =
-      JsLocaleHelper.find_message_format_locale([@locale], fallback_to_english: true)
+    require "messageformat"
 
     traverse_hash(@locale_yaml, []) do |keys, value|
       next unless keys.last.ends_with?("_MF")
 
       begin
-        JsLocaleHelper.with_context do |ctx|
-          ctx.load(mf_filename) if File.exist?(mf_filename)
-          ctx.eval("mf = new MessageFormat('#{mf_locale}');")
-          ctx.eval("mf.precompile(mf.parse(#{value.to_s.inspect}))")
-        end
-      rescue MiniRacer::EvalError => error
-        error_message = error.message.sub(/at undefined[:\d]+/, "").strip
-        add_error(keys, TYPE_INVALID_MESSAGE_FORMAT, error_message, pluralized: false)
+        MessageFormat.compile(@locale, { key: value }, strict: true)
+      rescue MessageFormat::Compiler::CompileError => e
+        add_error(keys, TYPE_INVALID_MESSAGE_FORMAT, e.cause.message, pluralized: false)
       end
     end
   end

--- a/spec/lib/js_locale_helper_spec.rb
+++ b/spec/lib/js_locale_helper_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe JsLocaleHelper do
         expect(content).to_not eq("")
       end
     end
+
+    it "generates valid MF locales for the '#{locale[:value]}' locale" do
+      expect(described_class.output_MF(locale[:value])).not_to match(/Failed to compile/)
+    end
   end
 
   describe ".output_MF" do


### PR DESCRIPTION
This PR fixes the `i18n:check` rake task which has been broken by the `MessageFormat` upgrade.

It also adds a spec to ensure we generate valid MF code for all our available locales.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
