### PR TITLE
FIX: Adjust swc minify options for Safari 15 support

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -145,6 +145,14 @@ module.exports = function (defaults) {
           minimizer: [
             new TerserPlugin({
               minify: TerserPlugin.swcMinify,
+              terserOptions: {
+                compress: {
+                  // Stop swc unwrapping 'unnecessary' IIFE wrappers which are added by Babel
+                  // to workaround a bug in Safari 15 class fields.
+                  inline: false,
+                  reduce_funcs: false,
+                },
+              },
             }),
           ],
         },


### PR DESCRIPTION
By default, the swc minifier seems to unwrap 'unneeded' IIFE. That means it was undoing the 'bugfix' transformation we have for class fields in Safari 15. Disabling the 'inline' and 'reduce_funcs' options seems to stop this behavior.