### PR TITLE
FIX: Reduce default timeouts for `FinalDestination::HTTP` requests

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -405,3 +405,11 @@ log_line_max_chars = 160000
 # Updating the value will allow site operators to invalidate all asset urls
 # to recover from configuration issues which may have been cached by CDNs/browsers.
 asset_url_salt =
+
+# Timeout settings for Net::HTTP requests
+# The maximum time to wait for a response after a request is sent.
+http_read_timeout_seconds = 10
+# The maximum time to wait for the request to be written to the server.
+http_write_timeout_seconds = 5
+# The maximum time to wait for the connection to be established.
+http_open_timeout_seconds = 5

--- a/config/initializers/100-http.rb
+++ b/config/initializers/100-http.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  # Ensures that the default adapter used for Faraday is our SSRF safe adapter which uses FinalDestination::HTTP
+  Faraday.default_adapter = FinalDestination::FaradayAdapter
+
+  # Uncomment when https://github.com/ruby/net-http/commit/fed3dcd0c2b1270a1f0eb9c4a58bed8497989c9a is released. Monkey
+  # patch FinalDestination::HTTP for now.
+  #
+  # Net::HTTP.default_configuration = {
+  #   read_timeout: GlobalSetting.http_read_timeout_seconds,
+  #   open_timeout: GlobalSetting.http_open_timeout_seconds,
+  #   write_timeout: GlobalSetting.http_write_timeout_seconds,
+  # }
+end

--- a/lib/final_destination/http.rb
+++ b/lib/final_destination/http.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 class FinalDestination::HTTP < Net::HTTP
+  def initialize(*args, &block)
+    super(*args, &block)
+
+    ## START PATCH
+    # Remove this patch once https://github.com/ruby/net-http/commit/fed3dcd0c2b1270a1f0eb9c4a58bed8497989c9a has been
+    # released in a new `net-http` version. See `config/initializers/100-http.rb` for more information.
+    self.read_timeout = GlobalSetting.http_read_timeout_seconds.to_f
+    self.open_timeout = GlobalSetting.http_open_timeout_seconds.to_f
+    self.write_timeout = GlobalSetting.http_write_timeout_seconds.to_f
+    ## END PATCH
+  end
+
   def connect
     raise ArgumentError.new("address cannot be nil or empty") if @address.blank?
 

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -29,6 +29,18 @@ describe FinalDestination::HTTP do
     TCPSocket.stubs(:open).with { |addr| addr == stub_addr }.once.raises(exception)
   end
 
+  it "sets the right default timeouts" do
+    global_setting :http_read_timeout_seconds, 0.001
+    global_setting :http_open_timeout_seconds, 0.002
+    global_setting :http_write_timeout_seconds, 0.003
+
+    http = FinalDestination::HTTP.new("example.com")
+
+    expect(http.read_timeout).to eq(0.001)
+    expect(http.open_timeout).to eq(0.002)
+    expect(http.write_timeout).to eq(0.003)
+  end
+
   it "works through each IP address until success" do
     stub_ip_lookup("example.com", %w[1.1.1.1 2.2.2.2 3.3.3.3])
     stub_tcp_to_raise("1.1.1.1", Errno::ETIMEDOUT)


### PR DESCRIPTION
This commit patches `FinalDestination::HTTP#initialize` to reduce the
default timeouts.

`read_timeout` is reduced from the [default 60 seconds](https://github.com/ruby/net-http/blob/d22211d48907486d8a768c4549875314ff2fdfbb/lib/net/http.rb#L1159) to 10 seconds
`write_timeout` is reduced from the [default 60 seconds](https://github.com/ruby/net-http/blob/d22211d48907486d8a768c4549875314ff2fdfbb/lib/net/http.rb#L1160) to 5 seconds
`open_timeout` is reduced from the [default 60 seconds](https://github.com/ruby/net-http/blob/d22211d48907486d8a768c4549875314ff2fdfbb/lib/net/http.rb#L1158) to 5 seconds

The default timeouts are selected such that a request can only block for
at most 20 seconds. This is important because our Unicorn workers are
timed out after 30 seconds while processing a request and Omniauth
middleware has to make network calls. We do not want the network calls
to end up causing Unicorn workers to timeout.

This commit also sets `Faraday.default_adapter` to `FinalDestination::FaradayAdapter`. This
ensures that gems that uses `Faraday` like `oauth2` uses an adapter that
is SSRF safe and also has sane timeouts.
