### PR TITLE
FEATURE: Add option for faster disk space calculation on upload heavy instances

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2085,6 +2085,8 @@ en:
 
     simultaneous_uploads: "Maximum number of files that can be dragged & dropped in the composer"
 
+    enable_precise_disk_space_calculation: "Calculates the precise disk usage of a directory by using the 'du' command (slower) rather than the 'df' command (faster but often incorrect) which calculates partition usage."
+
     default_invitee_trust_level: "Default trust level (0-4) for invited users."
     default_trust_level: "Default trust level (0-4) for all new users. WARNING! Changing this will put you at serious risk for spam."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1695,6 +1695,8 @@ files:
     default: 5
     min: 0
     max: 20
+  enable_precise_disk_space_calculation:
+    default: true
   decompressed_theme_max_file_size_mb:
     default: 1000
     hidden: true

--- a/lib/disk_space.rb
+++ b/lib/disk_space.rb
@@ -30,7 +30,13 @@ class DiskSpace
   end
 
   def self.used(path)
-    Discourse::Utils.execute_command("du", "-s", path).to_i * 1024
+    if SiteSetting.enable_precise_disk_space_calculation?
+      Discourse::Utils.execute_command("du", "-s", path).to_i * 1024
+    else
+      output = Discourse::Utils.execute_command("df", "-Pk", path)
+      size_line = output.split("\n")[1]
+      size_line.split(/\s+/)[2].to_i * 1024
+    end
   end
 
   def self.uploads_path


### PR DESCRIPTION
This commit introduces the 'enable_precise_disk_space_calculation' feature that allows admins to choose between using the 'du' command, which provides precise disk usage but is slower, and the 'df' command, which is faster but often inaccurate. This option is particularly useful for instances with 100,000+ uploads where the 'du' command can be detrimental.

The 'used' method now dynamically calculates disk usage based on the chosen option, ensuring accurate reporting of disk space on directories.


