### PR TITLE
FIX: Perform topics merge in a background thread

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -855,8 +855,11 @@ class TopicsController < ApplicationController
         params[:archetype] == "private_message"
     end
 
-    destination_topic = topic.move_posts(current_user, topic.posts.pluck(:id), args)
-    render_topic_changes(destination_topic)
+    acting_user = current_user
+    hijack(info: "merging topic #{topic_id.inspect} into #{destination_topic_id.inspect}") do
+      destination_topic = topic.move_posts(acting_user, topic.posts.pluck(:id), args)
+      render_topic_changes(destination_topic)
+    end
   end
 
   def move_posts


### PR DESCRIPTION
Similar to https://github.com/discourse/discourse/pull/28061, merging topics with many posts can exceed the 30 seconds timeout that Unicorn workers are limited to, so we should move the operation into a background thread to get around this limit.

Internal topic: t/133710.