### PR TITLE
UX: Avoid header topic-info flicker when using `?page=` params

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -239,7 +239,7 @@ const SiteHeaderComponent = MountWidget.extend(
 
       const headerService = getOwner(this).lookup("service:header");
       headerService.addObserver("topicInfoVisible", this, "setTopic");
-      headerService.topicInfoVisible; // Access property to set up observer
+      this.setTopic();
 
       this.appEvents.on("user-menu:rendered", this, "_animateMenu");
 

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -46,7 +46,10 @@ export default class TopicFromParams extends DiscourseRoute {
       this.pmTopicTrackingState.startTracking();
     }
 
-    this.header.enterTopic(topic, model.nearPost);
+    const isLoadingFirstPost =
+      topic.postStream.firstPostPresent &&
+      !(model.nearPost && model.nearPost > 1);
+    this.header.enterTopic(topic, isLoadingFirstPost);
   }
 
   deactivate() {

--- a/app/assets/javascripts/discourse/app/services/header.js
+++ b/app/assets/javascripts/discourse/app/services/header.js
@@ -133,9 +133,9 @@ export default class Header extends Service {
    * and makes a guess about whether the main topic title is likely to be visible
    * on initial load. The IntersectionObserver will correct this later if needed.
    */
-  enterTopic(topic, postNumber) {
+  enterTopic(topic, isLoadingFirstPost) {
     this.topicInfo = topic;
-    this.mainTopicTitleVisible = !postNumber || postNumber === 1;
+    this.mainTopicTitleVisible = isLoadingFirstPost;
   }
 
   clearTopic() {


### PR DESCRIPTION
In this case, there is no 'nearPost' param in the URL. Instead, the server preloads a post-stream with whichever page of posts is requested. We can check for that situation using `postStream.firstPostPresent`.

Also updates the widget-header version to fetch a value from the service on initial render, instead of relying on the observer triggering.

Followup to bdec564d1417c51ef6958784fdd6375fd05da4fc

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
