### PR TITLE
FIX: Poll: Clickable, hoverable avatars

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
@@ -38,12 +38,12 @@ export default class PollVotersComponent extends Component {
         {{/if}}
         {{#each rank.voters as |user|}}
           <li>
-            <a data-user-card="{{user.username}}">{{avatar
-                user.avatar_template
+            <a data-user-card={{user.user.username}}>{{avatar
+                user.user.avatar_template
                 "tiny"
-                usernamePath=user.username
-                namePath=user.name
-                title=user.username
+                usernamePath=user.user.username
+                namePath=user.user.name
+                title=user.user.username
               }}</a>
           </li>
         {{/each}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
@@ -36,14 +36,14 @@ export default class PollVotersComponent extends Component {
         {{else}}
           <span class="rank">{{rank.rank}}</span>
         {{/if}}
-        {{#each rank.voters as |user|}}
+        {{#each rank.voters as |voter|}}
           <li>
-            <a data-user-card={{user.user.username}}>{{avatar
-                user.user.avatar_template
+            <a data-user-card={{voter.user.username}}>{{avatar
+                voter.user.avatar_template
                 "tiny"
-                usernamePath=user.user.username
-                namePath=user.user.name
-                title=user.user.username
+                usernamePath=voter.user.username
+                namePath=voter.user.name
+                title=voter.user.username
               }}</a>
           </li>
         {{/each}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
@@ -38,7 +38,7 @@ export default class PollVotersComponent extends Component {
         {{/if}}
         {{#each rank.voters as |user|}}
           <li>
-            {{avatar user.user.avatar_template "tiny"}}
+            <a data-user-card="{{user.username}}" >{{avatar user.avatar_template "tiny" usernamePath=user.username namePath=user.name title=user.username}}</a>
           </li>
         {{/each}}
       </ul>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters-ranked-choice.gjs
@@ -38,7 +38,13 @@ export default class PollVotersComponent extends Component {
         {{/if}}
         {{#each rank.voters as |user|}}
           <li>
-            <a data-user-card="{{user.username}}" >{{avatar user.avatar_template "tiny" usernamePath=user.username namePath=user.name title=user.username}}</a>
+            <a data-user-card="{{user.username}}">{{avatar
+                user.avatar_template
+                "tiny"
+                usernamePath=user.username
+                namePath=user.name
+                title=user.username
+              }}</a>
           </li>
         {{/each}}
       </ul>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
@@ -18,7 +18,7 @@ export default class PollVotersComponent extends Component {
         {{else}}
           {{#each @voters as |user|}}
             <li>
-              {{avatar user.avatar_template "tiny"}}
+              <a data-user-card="{{user.username}}" >{{avatar user.avatar_template "tiny" usernamePath=user.username namePath=user.name title=user.username}}</a>
             </li>
           {{/each}}
         {{/if}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
@@ -18,7 +18,13 @@ export default class PollVotersComponent extends Component {
         {{else}}
           {{#each @voters as |user|}}
             <li>
-              <a data-user-card="{{user.username}}" >{{avatar user.avatar_template "tiny" usernamePath=user.username namePath=user.name title=user.username}}</a>
+              <a data-user-card="{{user.username}}">{{avatar
+                  user.avatar_template
+                  "tiny"
+                  usernamePath=user.username
+                  namePath=user.name
+                  title=user.username
+                }}</a>
             </li>
           {{/each}}
         {{/if}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-voters.gjs
@@ -18,7 +18,7 @@ export default class PollVotersComponent extends Component {
         {{else}}
           {{#each @voters as |user|}}
             <li>
-              <a data-user-card="{{user.username}}">{{avatar
+              <a data-user-card={{user.username}}>{{avatar
                   user.avatar_template
                   "tiny"
                   usernamePath=user.username


### PR DESCRIPTION
Glimmer migration may have dropped support for clickable (User Card invoking) and titled avatars in Poll results.  This PR restores this functionality.

@davidtaylorhq 
