### PR TITLE
FIX: db_timestamps_mover errors from discourse-voting plugin

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -133,7 +133,12 @@ def is_date?(string)
 end
 
 def create_updater
-  ignore_tables = %w[user_second_factors]
+  ignore_tables = %w[
+    user_second_factors
+    discourse_voting_topic_vote_count
+    discourse_voting_votes
+    discourse_voting_category_settings
+  ]
   TimestampsUpdater.new "public", ignore_tables
 end
 


### PR DESCRIPTION
https://github.com/discourse/discourse-topic-voting/pull/196

Some tables in that plugin are read-only, so the script fails when trying to update rows in those tables. Add them to the ignore list.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
