### PR TITLE
FIX: Rescue and warn when error is encountered in `DiscourseIpInfo.mmdb_download`

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -55,31 +55,27 @@ class DiscourseIpInfo
         end
       end
 
-    begin
-      gz_file =
-        FileHelper.download(
-          url,
-          max_file_size: 100.megabytes,
-          tmp_file_name: "#{name}.gz",
-          validate_uri: false,
-          follow_redirect: true,
-          extra_headers:,
-        )
+    gz_file =
+      FileHelper.download(
+        url,
+        max_file_size: 100.megabytes,
+        tmp_file_name: "#{name}.gz",
+        validate_uri: false,
+        follow_redirect: true,
+        extra_headers:,
+      )
 
-      filename = File.basename(gz_file.path)
+    filename = File.basename(gz_file.path)
 
-      dir = "#{Dir.tmpdir}/#{SecureRandom.hex}"
+    dir = "#{Dir.tmpdir}/#{SecureRandom.hex}"
 
-      Discourse::Utils.execute_command("mkdir", "-p", dir)
+    Discourse::Utils.execute_command("mkdir", "-p", dir)
+    Discourse::Utils.execute_command("cp", gz_file.path, "#{dir}/#{filename}")
+    Discourse::Utils.execute_command("tar", "-xzvf", "#{dir}/#{filename}", chdir: dir)
 
-      Discourse::Utils.execute_command("cp", gz_file.path, "#{dir}/#{filename}")
-
-      Discourse::Utils.execute_command("tar", "-xzvf", "#{dir}/#{filename}", chdir: dir)
-
-      Dir["#{dir}/**/*.mmdb"].each { |f| FileUtils.mv(f, mmdb_path(name)) }
-    rescue => e
-      Discourse.warn_exception(e, message: "MaxMind database download failed.")
-    end
+    Dir["#{dir}/**/*.mmdb"].each { |f| FileUtils.mv(f, mmdb_path(name)) }
+  rescue => e
+    Discourse.warn_exception(e, message: "MaxMind database #{name} download failed.")
   ensure
     FileUtils.rm_r(dir, force: true) if dir
     gz_file&.close!


### PR DESCRIPTION
Since switching to Maxmind permalinks to download the databases in
7079698cdfb6f0cd73cdfd305b15350634fcd56a, we have received multiple
reports about rebuilds failing as `maxminddb:refresh` runs during
the rebuilds and failing to download the databases cases the rebuilds to
fail.

Downloading Maxmind databases should not sit in the critical rebuild
path but since we are close to the Discourse 3.3 release, we have opted
to just rescue all errors encountered when downloading the databases.

In the near future after the Discourse 3.3 release, we will be looking
at moving the downloading of maxmind databases out of the rebuild path.
