### PR TITLE
FIX: addCommunitySectionLink secondary argument

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
@@ -55,21 +55,27 @@ export default class CommunitySection {
       });
     });
 
-    this.apiLinks = customSectionLinks
-      .concat(secondaryCustomSectionLinks)
-      .map((link) => this.#initializeSectionLink(link, { inMoreDrawer: true }));
+    this.apiPrimaryLinks = customSectionLinks.map((link) =>
+      this.#initializeSectionLink(link, { inMoreDrawer: false })
+    );
 
-    this.links = this.section.links.reduce((filtered, link) => {
-      if (link.segment === "primary") {
-        const generatedLink = this.#generateLink(link);
+    this.apiSecondaryLinks = secondaryCustomSectionLinks.map((link) =>
+      this.#initializeSectionLink(link, { inMoreDrawer: true })
+    );
 
-        if (generatedLink) {
-          filtered.push(generatedLink);
+    this.links = this.section.links
+      .reduce((filtered, link) => {
+        if (link.segment === "primary") {
+          const generatedLink = this.#generateLink(link);
+
+          if (generatedLink) {
+            filtered.push(generatedLink);
+          }
         }
-      }
 
-      return filtered;
-    }, []);
+        return filtered;
+      }, [])
+      .concat(this.apiPrimaryLinks);
 
     this.moreLinks = this.section.links
       .reduce((filtered, link) => {
@@ -83,7 +89,7 @@ export default class CommunitySection {
 
         return filtered;
       }, [])
-      .concat(this.apiLinks);
+      .concat(this.apiSecondaryLinks);
   }
 
   teardown() {

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -176,6 +176,26 @@ acceptance("Admin Sidebar - Sections - Plugin API", function (needs) {
         route: "adminPlugins.index",
         icon: "cog",
       });
+
+      api.addCommunitySectionLink(
+        {
+          name: "primary",
+          route: "discovery.unread",
+          title: "Link in primary",
+          text: "Link in primary",
+        },
+        false
+      );
+
+      api.addCommunitySectionLink(
+        {
+          name: "secondary",
+          route: "discovery.unread",
+          title: "Link in secondary",
+          text: "Link in secondary",
+        },
+        true
+      );
     });
   });
 
@@ -209,6 +229,35 @@ acceptance("Admin Sidebar - Sections - Plugin API", function (needs) {
       ),
       "invalid link with an invalid I18n key is not appended to the root section"
     );
+  });
+
+  test("community section links are added to primary and secondary sections with the plugin API", async function (assert) {
+    await visit("/");
+
+    assert.ok(
+      exists(
+        "#sidebar-section-content-community .sidebar-section-link[data-link-name='primary']"
+      )
+    );
+    assert.notOk(
+      exists(
+        "#sidebar-section-content-community .sidebar-section-link[data-link-name='secondary']"
+      )
+    );
+
+    await click(".sidebar-more-section-links-details-summary");
+
+    assert.notOk(
+      exists(
+        ".sidebar-more-section-links-details-content .sidebar-section-link[data-link-name='primary']"
+      )
+    );
+    assert.ok(
+      exists(
+        ".sidebar-more-section-links-details-content .sidebar-section-link[data-link-name='secondary']"
+      )
+    );
+    assert.ok(true);
   });
 });
 


### PR DESCRIPTION
`addCommunitySectionLink` API function accepts secondary argument to determine if the link should be added to the primary or secondary (more) section. There was a bug and all links were always mounted in the secondary section.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
