### PR TITLE
DEV: Version bump for stable: v3.2.5

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   # work around reloader
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
-      STRING = "3.2.4"
+      STRING = "3.2.5"
 
       PARTS = STRING.split(".")
       private_constant :PARTS


### PR DESCRIPTION
> :warning: This PR should not be merged via the GitHub web interface
>
> It should only be merged (via fast-forward) using the associated `bin/rake version_bump:*` task.
