### PR TITLE
DEV: refactor live notifications setting in user preferences

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -61,8 +61,7 @@ function init(messageBus) {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn(
-      "Unexpected error, Notification is defined on window but not a responding correctly " +
-        e
+      "Notification is defined on window but is not responding correctly " + e
     );
   }
 
@@ -136,7 +135,7 @@ function canUserReceiveNotifications(user) {
     return false;
   }
 
-  if (keyValueStore.getItem("notifications-disabled")) {
+  if (keyValueStore.getItem("notifications-disabled", "disabled")) {
     return false;
   }
 
@@ -150,6 +149,8 @@ async function onNotification(data, siteSettings, user, appEvents) {
   }
 
   if (!liveEnabled) {
+    // eslint-disable-next-line no-console
+    console.warn("Desktop notifications are not enabled");
     return false;
   }
 
@@ -168,7 +169,7 @@ async function onNotification(data, siteSettings, user, appEvents) {
     siteSettings.site_logo_small_url || siteSettings.site_logo_url;
 
   const notificationTag =
-    "discourse-notification-" + siteSettings.title + "-" + data.topic_id;
+    "discourse-notification-" + siteSettings.title + "-" + (data.topic_id || 0);
 
   await requestPermission();
 

--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -149,8 +149,6 @@ async function onNotification(data, siteSettings, user, appEvents) {
   }
 
   if (!liveEnabled) {
-    // eslint-disable-next-line no-console
-    console.warn("Desktop notifications are not enabled");
     return false;
   }
 

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -26,26 +26,20 @@ export default class DesktopNotificationsService extends Service {
   @service site;
   @service siteSettings;
 
-  @tracked isEnabledBrowser;
-  @tracked isEnabledPush;
+  @tracked isEnabledBrowser = false;
+  @tracked isEnabledPush = false;
 
   constructor() {
     super(...arguments);
 
-    if (!this.currentUser) {
-      this.isEnabledPush = false;
-      this.isEnabledBrowser = false;
-
-      return;
-    }
-
     this.isEnabledBrowser = this.isGrantedPermission
       ? keyValueStore.getItem("notifications-disabled") === ENABLED
       : false;
-    this.isEnabledPush =
-      pushNotificationKeyValueStore.getItem(
-        pushNotificationUserSubscriptionKey(this.currentUser)
-      ) === SUBSCRIBED;
+    this.isEnabledPush = this.currentUser
+      ? pushNotificationKeyValueStore.getItem(
+          pushNotificationUserSubscriptionKey(this.currentUser)
+        ) === SUBSCRIBED
+      : false;
   }
 
   get isNotSupported() {

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -139,10 +139,14 @@ export default class DesktopNotificationsService extends Service {
 
       return true;
     } else {
-      this.setIsEnabledBrowser(true);
       await Notification.requestPermission((permission) => {
         confirmNotification(this.siteSettings);
-        return permission === "granted";
+        if (permission === "granted") {
+          this.setIsEnabledBrowser(true);
+          return true;
+        } else {
+          return false;
+        }
       });
     }
   }

--- a/app/assets/javascripts/discourse/app/services/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/services/desktop-notifications.js
@@ -120,7 +120,7 @@ export default class DesktopNotificationsService extends Service {
     if (this.isPushNotificationsPreferred) {
       if (this.isEnabledPush === "subscribed") {
         await unsubscribePushNotification(this.currentUser, () => {
-          this.setIsEnabledPush("");
+          this.setIsEnabledPush(false);
         });
       }
     } else if (this.isEnabledDesktop) {

--- a/app/jobs/regular/send_push_notification.rb
+++ b/app/jobs/regular/send_push_notification.rb
@@ -4,7 +4,8 @@ module Jobs
   class SendPushNotification < ::Jobs::Base
     def execute(args)
       user = User.find_by(id: args[:user_id])
-      return if !user
+      push_window = SiteSetting.push_notification_time_window_mins
+      return if !user || (push_window > 0 && user.seen_since?(push_window.minutes.ago))
 
       PushNotificationPusher.push(user, args[:payload])
     end

--- a/app/jobs/regular/send_push_notification.rb
+++ b/app/jobs/regular/send_push_notification.rb
@@ -4,9 +4,7 @@ module Jobs
   class SendPushNotification < ::Jobs::Base
     def execute(args)
       user = User.find_by(id: args[:user_id])
-      if !user || user.seen_since?(SiteSetting.push_notification_time_window_mins.minutes.ago)
-        return
-      end
+      return if !user
 
       PushNotificationPusher.push(user, args[:payload])
     end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -84,7 +84,8 @@ class PostAlerter
     end
 
     if user.push_subscriptions.exists?
-      if user.seen_since?(SiteSetting.push_notification_time_window_mins.minutes.ago)
+      push_window = SiteSetting.push_notification_time_window_mins
+      if push_window > 0 && user.seen_since?(push_window.minutes.ago)
         delay =
           (SiteSetting.push_notification_time_window_mins - (Time.now - user.last_seen_at) / 60)
         Jobs.enqueue_in(delay.minutes, :send_push_notification, user_id: user.id, payload: payload)

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -27,7 +27,6 @@ class PushNotificationPusher
         tag: payload[:tag] || "#{Discourse.current_hostname}-#{payload[:topic_id]}",
         base_url: Discourse.base_url,
         url: payload[:post_url],
-        hide_when_active: true,
       }
 
       subscriptions(user).each { |subscription| send_notification(user, subscription, message) }

--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -97,8 +97,9 @@ module Jobs
           end
         end
 
-        # if membership.mobile_notifications_always? && !membership.muted?
-        ::PostAlerter.push_notification(user, payload) if !membership.muted?
+        if membership.mobile_notifications_always? && !membership.muted?
+          ::PostAlerter.push_notification(user, payload) if !membership.muted?
+        end
       end
     end
   end

--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -97,9 +97,8 @@ module Jobs
           end
         end
 
-        if membership.mobile_notifications_always? && !membership.muted?
-          ::PostAlerter.push_notification(user, payload)
-        end
+        # if membership.mobile_notifications_always? && !membership.muted?
+        ::PostAlerter.push_notification(user, payload) if !membership.muted?
       end
     end
   end

--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -98,7 +98,7 @@ module Jobs
         end
 
         if membership.mobile_notifications_always? && !membership.muted?
-          ::PostAlerter.push_notification(user, payload) if !membership.muted?
+          ::PostAlerter.push_notification(user, payload)
         end
       end
     end

--- a/spec/jobs/send_push_notification_spec.rb
+++ b/spec/jobs/send_push_notification_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe Jobs::SendPushNotification do
   end
 
   context "with valid user" do
-    it "sends push notification when user is online" do
+    it "does not send push notification when user is online" do
       user.update!(last_seen_at: 2.minutes.ago)
 
-      PushNotificationPusher.expects(:push).with(user, payload)
+      PushNotificationPusher.expects(:push).with(user, payload).never
 
       Jobs::SendPushNotification.new.execute(user_id: user, payload: payload)
     end
 
     it "sends push notification when user is offline" do
-      user.update!(last_seen_at: 30.minutes.ago)
+      user.update!(last_seen_at: 20.minutes.ago)
 
       PushNotificationPusher.expects(:push).with(user, payload)
 

--- a/spec/jobs/send_push_notification_spec.rb
+++ b/spec/jobs/send_push_notification_spec.rb
@@ -10,23 +10,29 @@ RSpec.describe Jobs::SendPushNotification do
     SiteSetting.push_notification_time_window_mins = 10
   end
 
-  context "with active online user" do
-    it "does not send push notification" do
-      user.update!(last_seen_at: 5.minutes.ago)
+  context "with valid user" do
+    it "sends push notification when user is online" do
+      user.update!(last_seen_at: 2.minutes.ago)
 
-      PushNotificationPusher.expects(:push).with(user, payload).never
+      PushNotificationPusher.expects(:push).with(user, payload)
+
+      Jobs::SendPushNotification.new.execute(user_id: user, payload: payload)
+    end
+
+    it "sends push notification when user is offline" do
+      user.update!(last_seen_at: 30.minutes.ago)
+
+      PushNotificationPusher.expects(:push).with(user, payload)
 
       Jobs::SendPushNotification.new.execute(user_id: user, payload: payload)
     end
   end
 
-  context "with inactive offline user" do
-    it "sends push notification" do
-      user.update!(last_seen_at: 40.minutes.ago)
+  context "with invalid user" do
+    it "does not send push notification" do
+      PushNotificationPusher.expects(:push).with(user, payload).never
 
-      PushNotificationPusher.expects(:push).with(user, payload)
-
-      Jobs::SendPushNotification.new.execute(user_id: user, payload: payload)
+      Jobs::SendPushNotification.new.execute(user_id: -999, payload: payload)
     end
   end
 end


### PR DESCRIPTION
This change is mainly a refactor of the desktop notifications service to improve readability and have standardised values for tracking state for current user in regards to the Notification API and Push API.

Also improves readability when handling push notification jobs, especially in scenarios where the `push_notification_time_window_mins` site setting is set to `0`, which will allow sending push notifications instantly.