### PR TITLE
FIX: Return properly interpolated translations for flag types

### DIFF
--- a/app/serializers/post_action_type_serializer.rb
+++ b/app/serializers/post_action_type_serializer.rb
@@ -31,16 +31,14 @@ class PostActionTypeSerializer < ApplicationSerializer
   def description
     i18n(
       "description",
-      vars: {
-        tos_url:,
-        base_path: Discourse.base_path,
-      },
+      tos_url:,
+      base_path: Discourse.base_path,
       default: object.class.descriptions[object.id],
     )
   end
 
   def short_description
-    i18n("short_description", vars: { tos_url: tos_url, base_path: Discourse.base_path })
+    i18n("short_description", tos_url:, base_path: Discourse.base_path, default: "")
   end
 
   def name_key
@@ -60,10 +58,14 @@ class PostActionTypeSerializer < ApplicationSerializer
       ReviewableScore.exists?(reviewable_score_type: object.id)
   end
 
-  protected
+  private
 
-  def i18n(field, default: nil, vars: nil)
-    key = "post_action_types.#{name_key}.#{field}"
-    vars ? I18n.t(key, vars, default: default) : I18n.t(key, default: default)
+  def i18n(field, **args)
+    key = "#{i18n_prefix}.#{name_key}.#{field}"
+    I18n.t(key, **args)
+  end
+
+  def i18n_prefix
+    "post_action_types"
   end
 end

--- a/app/serializers/topic_flag_type_serializer.rb
+++ b/app/serializers/topic_flag_type_serializer.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class TopicFlagTypeSerializer < PostActionTypeSerializer
-  protected
+  private
 
-  def i18n(field, default: nil, vars: nil)
-    key = "topic_flag_types.#{name_key}.#{field}"
-    vars ? I18n.t(key, vars, default: default) : I18n.t(key, default: default)
+  def i18n_prefix
+    "topic_flag_types"
   end
 end

--- a/spec/serializers/post_action_type_serializer_spec.rb
+++ b/spec/serializers/post_action_type_serializer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe PostActionTypeSerializer do
+  subject(:serializer) { described_class.new(post_action_type, scope: Guardian.new, root: false) }
+
+  let(:post_action_type) { PostActionType.find_by(name_key: :inappropriate) }
+
+  describe "#description" do
+    before { Discourse.stubs(:base_path).returns("discourse.org") }
+
+    it "returns properly interpolated translation" do
+      expect(serializer.description).to match(%r{discourse\.org/guidelines})
+    end
+  end
+end


### PR DESCRIPTION
Currently, descriptions for flag types aren’t interpolated, returning `%{base_path}` in their string, for example. This breaks the navigation on the sites.

The behavior changed probably because of an upgrade of Ruby, as two hashes were passed to `I18n.t` (`vars` and `default`) without using the splat operator.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
