### PR TITLE
UX: Hide/show preview button title attribute fix

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -332,7 +332,7 @@
               class="btn btn-default no-text mobile-preview"
               title={{i18n "composer.show_preview"}}
               {{on "click" this.composer.togglePreview}}
-              aria-label={{i18n "preview"}}
+              aria-label={{i18n "composer.show_preview"}}
             >
               {{d-icon "desktop"}}
             </a>
@@ -340,6 +340,7 @@
             {{#if this.composer.showPreview}}
               <DButton
                 @action={{this.composer.togglePreview}}
+                @title="composer.hide_preview"
                 @ariaLabel="composer.hide_preview"
                 @icon="pencil-alt"
                 class="hide-preview"


### PR DESCRIPTION
Use “show preview” instead of “preview” as the `aria-label` for toggling the preview on, and add the `title` attribute with “hide preview” for toggling the preview off.