### PR TITLE
FIX: double reviewable items bug

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -108,6 +108,7 @@ class ReviewableQueuedPost < Reviewable
         skip_jobs: true,
         skip_events: true,
         skip_guardian: true,
+        reviewed_queued_post: true,
       )
     opts.merge!(guardian: Guardian.new(performed_by)) if performed_by.staff?
 

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -222,7 +222,7 @@ class PostCreator
       auto_close
     end
 
-    if !opts[:import_mode]
+    if !opts[:import_mode] && !opts[:reviewed_queued_post]
       handle_spam if (@spam || @post)
 
       ReviewablePost.queue_for_review_if_possible(@post, @user) if !@spam && @post && errors.blank?

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -2167,4 +2167,28 @@ RSpec.describe PostCreator do
       expect { post_creator.create }.not_to change(ReviewablePost, :count)
     end
   end
+
+  context "when the review_every_post setting is enabled and category requires topic approval" do
+    fab!(:category)
+
+    before do
+      category.require_topic_approval = true
+      category.save!
+    end
+
+    before { SiteSetting.review_every_post = true }
+
+    it "creates single reviewable item" do
+      manager =
+        NewPostManager.new(
+          user,
+          title: "this is a new title",
+          raw: "this is a new post",
+          category: category.id,
+        )
+      reviewable = manager.perform.reviewable
+
+      expect { reviewable.perform(admin, :approve_post) }.not_to change(ReviewablePost, :count)
+    end
+  end
 end


### PR DESCRIPTION
### Problem
When `SiteSetting.review_every_post` is true and the category `require_topic_approval` system creates two reviewable items.
1. Firstly, because the category needs approval, the `ReviewableQueuePost` record is created - at this stage, no `Topic` is created.
2. Admin is approving the `Review`. The `Topic` and first `Post` are created.
3. Because `review_every_post` is true `queue_for_review_if_possible` callback is evaluated and `ReviewablePost` is created.
4. Then `ReviewableQueuePost` is linked to the newly generated topic and post.

### Solution
At the beginning, we were thinking about hooking to those guards:
```ruby
  def self.queue_for_review_if_possible(post, created_or_edited_by)
    return unless SiteSetting.review_every_post
    return if post.post_type != Post.types[:regular] || post.topic.private_message?
    return if Reviewable.pending.where(target: post).exists?
...
```
And add something like
```ruby
 return if ReviewableQueuePost.approved.where(target: post).exists?
```

However, because the callback happens in point 3. before the `ReviewableQueuePost` is linked to the `Topic`, it was not possible.

Therefore, when `ReviewableQueuePost` is creating a `Topic`, a new option called `:reviewed_queued_post` is passed to `PostCreator` to avoid creating a second `Reviewable`.