### PR TITLE
FIX: Don't count draft views towards topic view stats

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1308,6 +1308,7 @@ class TopicsController < ApplicationController
     Scheduler::Defer.later "Topic View" do
       topic = Topic.find_by(id: topic_id)
       next if topic.blank?
+      next if topic.shared_draft?
 
       # We need to make sure that we aren't allowing recording
       # random topic views against topics the user cannot see.

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -56,6 +56,10 @@ class Topic < ActiveRecord::Base
       )
   end
 
+  def shared_draft?
+    SharedDraft.exists?(topic_id: id)
+  end
+
   def thumbnail_job_redis_key(sizes)
     "generate_topic_thumbnail_enqueue_#{id}_#{sizes.inspect}"
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe Topic do
 
   it { is_expected.to rate_limit }
 
+  describe "#shared_draft?" do
+    fab!(:topic)
+
+    context "when topic does not have a shared draft record" do
+      it { expect(topic).not_to be_shared_draft }
+    end
+
+    context "when topic has a shared draft record" do
+      before { Fabricate(:shared_draft, topic: topic) }
+
+      it { expect(topic).to be_shared_draft }
+    end
+  end
+
   describe "#visible_post_types" do
     let(:types) { Post.types }
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5779,6 +5779,15 @@ RSpec.describe TopicsController do
       }.not_to change { TopicViewItem.count }
     end
 
+    it "does nothing if the topic is a shared draft" do
+      topic.shared_draft = Fabricate(:shared_draft)
+
+      expect {
+        TopicsController.defer_topic_view(topic.id, "1.2.3.4", user.id)
+        Scheduler::Defer.do_all_work
+      }.not_to change { TopicViewItem.count }
+    end
+
     it "does nothing if user cannot see topic" do
       topic.update!(category: Fabricate(:private_category, group: Fabricate(:group)))
 


### PR DESCRIPTION
### What is the problem?

When creating a shared draft, we're recording topic view stats on the draft and then pass those on when the draft is published, conflating the actual view count.

### How does this fix it?

Don't register topic views if the topic is a shared draft.