### PR TITLE
DEV: Fix flaky test

### DIFF
--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -211,8 +211,8 @@ RSpec.describe Admin::SiteTextsController do
         get "/admin/customize/site_texts.json", params: params
         expect(response.status).to eq(200)
         expect(response.parsed_body["site_texts"].size).to eq(0)
-
-        I18n.config.available_locales = available_locales
+      ensure
+        I18n.config.available_locales = nil
       end
 
       context "with plural keys" do


### PR DESCRIPTION
Before this commit, running `rspec --seed 22953 --format documentation spec/requests/admin/site_texts_controller_spec.rb:191 spec/lib/freedom_patches/translate_accelerator_spec.rb:109` will fail.

Setting `I18n.config.available_locales` is equivalent to hard coding the
locales for the entire process. It should not be set so that `I18n` will
fallback to `backend.locales`.
