### PR TITLE
FEATURE: Add data-tag-groups attribute to tags (Part 1)

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -79,6 +79,10 @@ export function defaultRenderTag(tag, params, extra) {
     extra.contentFn?.(content) ?? content
   );
 
+  if (params.count) {
+    val += " <span class='discourse-tag-count'>x" + params.count + "</span>";
+  }
+
   return val;
 }
 

--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -68,6 +68,7 @@ export default function (topic, params) {
             isPrivateMessage,
             tagsForUser,
             tagName,
+            tagGroups: topic.tags_groups?.[tags[i]],
           }) + "";
       }
     }

--- a/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/render-tag-test.js
@@ -1,6 +1,6 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
-import renderTag from "discourse/lib/render-tag";
+import renderTag, { defaultRenderTag } from "discourse/lib/render-tag";
 
 module("Unit | Utility | render-tag", function (hooks) {
   setupTest(hooks);
@@ -8,7 +8,7 @@ module("Unit | Utility | render-tag", function (hooks) {
   test("defaultRenderTag", function (assert) {
     assert.strictEqual(
       renderTag("foo", { description: "foo description" }),
-      "<a href='/tag/foo'  data-tag-name=foo title=\"foo description\"  class='discourse-tag simple'>foo</a>",
+      '<a href="/tag/foo" data-tag-name="foo" title="foo description" class="discourse-tag simple">foo</a>',
       "formats tag as link with plain description in hover"
     );
 
@@ -16,8 +16,38 @@ module("Unit | Utility | render-tag", function (hooks) {
       renderTag("foo", {
         description: 'foo description <a href="localhost">link</a>',
       }),
-      "<a href='/tag/foo'  data-tag-name=foo title=\"foo description link\"  class='discourse-tag simple'>foo</a>",
+      '<a href="/tag/foo" data-tag-name="foo" title="foo description link" class="discourse-tag simple">foo</a>',
       "removes any html tags from description"
+    );
+
+    assert.strictEqual(
+      renderTag("foo", { noHref: true }),
+      '<a data-tag-name="foo" class="discourse-tag simple">foo</a>',
+      "allows no href"
+    );
+
+    assert.strictEqual(
+      renderTag("foo", {
+        tagGroups: ["group1", "group2"],
+      }),
+      '<a href="/tag/foo" data-tag-name="foo" data-tag-groups="group1, group2" class="discourse-tag simple">foo</a>',
+      "adds the tag-groups to data"
+    );
+
+    assert.strictEqual(
+      defaultRenderTag(
+        "foo",
+        {},
+        {
+          extraClass: "classname1 classname2",
+          contentFn: (c) => `Tag - ${c}`,
+          attrs: {
+            "data-foo": "bar",
+          },
+        }
+      ),
+      '<a href="/tag/foo" data-tag-name="foo" class="discourse-tag simple classname1 classname2" data-foo="bar">Tag - foo</a>',
+      "works fine with extra parameters"
     );
   });
 });

--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -6,6 +6,7 @@ module TopicTagsMixin
   def self.included(klass)
     klass.attributes :tags
     klass.attributes :tags_descriptions
+    klass.attributes :tags_groups
   end
 
   def include_tags?
@@ -20,6 +21,16 @@ module TopicTagsMixin
     all_tags
       .each
       .with_object({}) { |tag, acc| acc[tag.name] = tag.description&.truncate(DESCRIPTION_LIMIT) }
+      .compact
+  end
+
+  def tags_groups
+    all_tags
+      .each
+      .with_object({}) do |tag, acc|
+        acc[tag.name] = DiscourseTagging.tag_groups_for(tag) &
+          DiscourseTagging.visible_tag_groups_for(scope)
+      end
       .compact
   end
 

--- a/spec/requests/api/schemas/json/topic_show_response.json
+++ b/spec/requests/api/schemas/json/topic_show_response.json
@@ -396,6 +396,13 @@
             "additionalProperties": false,
             "properties": {}
           },
+          "tags_groups": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array"
+            },
+            "properties": {}
+          },
           "like_count": {
             "type": "integer"
           },
@@ -481,6 +488,7 @@
           "liked",
           "tags",
           "tags_descriptions",
+          "tags_groups",
           "like_count",
           "views",
           "category_id",
@@ -496,6 +504,13 @@
     "tags_descriptions": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {}
+    },
+    "tags_groups": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array"
+      },
       "properties": {}
     },
     "id": {
@@ -923,6 +938,7 @@
     "suggested_topics",
     "tags",
     "tags_descriptions",
+    "tags_groups",
     "id",
     "title",
     "fancy_title",

--- a/spec/serializers/web_hook_topic_view_serializer_spec.rb
+++ b/spec/serializers/web_hook_topic_view_serializer_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe WebHookTopicViewSerializer do
       last_poster
       tags
       tags_descriptions
+      tags_groups
       thumbnails
     ]
 


### PR DESCRIPTION
Overview
========

This PR is part of a new feature that aims to adds the `data-tag-groups`
attribute to tags, making it easier to use CSS selectors to batch select
tags belonging to certain tag groups.

An example:

```html
<a href="/tag/hidden" data-tag-name="hidden"
data-tag-groups="Hidden Tag Group, non-hidden tags"
class="discourse-tag box">hidden</a>
```

This commit implements adding `data-tag-groups` to tags on TopicList

Related meta topic: https://meta.discourse.org/t/add-a-data-tag-group-attribute-for-tags/234410

ScreenShot
========

The following screenshot shows what happens when custom CSS is 
applied to a tag group:
All tags belonging to the test group have a big border-radius

```css
.discourse-tag[data-tag-groups~="test"] {
    border-radius: 999px !important;
}
```

![image](https://github.com/user-attachments/assets/ae58ba01-a757-4165-a126-00d26a2aeee1)


DEV Improvements
================

Partially rewrote `defaultRenderTag` for better scalability and clarity:

The new `defaultRenderTag` reserves an interface for theme components to
avoid the need for components to completely rewrite `defaultRenderTag`
to provide custom tag renderer.

For example, you can now replace the tagRenderer like this:

```javascript
api.replaceTagRenderer((tag, params) => {
  return defaultRenderTag(tag, params, {
    extraClass: "custom-tag-class",
    contentFn(old) {
      return `${iconHTML("tag")}${old}`;
    },
  });
});
```

This has a significant benefit for discourse tag icons. Since the
[old way of code](https://github.com/discourse/discourse-tag-icons/blob/main/javascripts/discourse/initializers/tag-icons.js#L9-L84)
the changes made by this PR will be completely overwritten by discourse
tag icons, and the theme component must be updated accordingly.
After applying the new interface, it can automatically synchronize
changes with the `defaultRendererTag` in core.