### PR TITLE
FIX: update voter information upon remote change

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-option-ranked-choice-dropdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-option-ranked-choice-dropdown.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
@@ -9,13 +8,6 @@ import I18n from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
 export default class PollOptionsDropdownComponent extends Component {
-  @tracked rank;
-
-  constructor() {
-    super(...arguments);
-    this.rank = this.args.rank;
-  }
-
   @action
   onRegisterApi(api) {
     this.dMenu = api;
@@ -24,15 +16,13 @@ export default class PollOptionsDropdownComponent extends Component {
   @action
   selectRank(option, rank) {
     this.args.sendRank(option, rank);
-    this.rank =
-      rank === 0 ? I18n.t("poll.options.ranked_choice.abstain") : rank;
     this.dMenu.close();
   }
 
   get rankLabel() {
-    return this.rank === 0
+    return this.args.rank === 0
       ? I18n.t("poll.options.ranked_choice.abstain")
-      : this.rank;
+      : this.args.rank;
   }
 
   <template>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
@@ -27,7 +27,7 @@ export default class PollOptionsComponent extends Component {
   }
   <template>
     <ul class={{concatClass (if @isRankedChoice "ranked-choice-poll-options")}}>
-      {{#each @options as |option|}}
+      {{#each @options key="rank" as |option|}}
         {{#if @isRankedChoice}}
           <PollOptionRankedChoice
             @option={{option}}

--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-standard.gjs
@@ -40,8 +40,13 @@ export default class PollResultsStandardComponent extends Component {
       const chosen = (this.args.vote || []).includes(option.id);
       option.percentage = per;
       option.chosen = chosen;
-      let voters = this.args.isPublic ? this.args.voters[option.id] || [] : [];
+      let voters = this.args.isPublic
+        ? this.args.voters[option.id]?.voters || []
+        : [];
       option.voters = [...voters];
+      option.loading = this.args.isPublic
+        ? this.args.voters[option.id]?.loading || false
+        : false;
     });
 
     return ordered;

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -46,44 +46,6 @@ export default class PollComponent extends Component {
     (this.topicArchived && !this.staffOnly) ||
     (this.closed && !this.staffOnly);
 
-  get isStaff() {
-    return this.currentUser && this.currentUser.staff;
-  }
-
-  get titleHTML() {
-    return htmlSafe(this.args.attrs.titleHTML);
-  }
-
-  get topicArchived() {
-    return this.args.attrs.post.get("topic.archived");
-  }
-
-  get isRankedChoice() {
-    return this.args.attrs.poll.type === RANKED_CHOICE;
-  }
-
-  get staffOnly() {
-    return this.args.attrs.poll.results === STAFF_ONLY;
-  }
-
-  get isMultiple() {
-    return this.args.attrs.poll.type === MULTIPLE;
-  }
-
-  get isNumber() {
-    return this.args.attrs.poll.type === NUMBER;
-  }
-
-  get post() {
-    return this.args.attrs.post;
-  }
-
-  get isMe() {
-    return (
-      this.currentUser && this.args.attrs.post.user_id === this.currentUser.id
-    );
-  }
-
   checkUserGroups = (user, poll) => {
     const pollGroups =
       poll && poll.groups && poll.groups.split(",").map((g) => g.toLowerCase());
@@ -155,8 +117,47 @@ export default class PollComponent extends Component {
     this.post = this.args.attrs.post;
     this.groupableUserFields = this.args.attrs.groupableUserFields;
   }
+
+  get isStaff() {
+    return this.currentUser && this.currentUser.staff;
+  }
+
+  get titleHTML() {
+    return htmlSafe(this.args.attrs.titleHTML);
+  }
+
+  get topicArchived() {
+    return this.args.attrs.post.get("topic.archived");
+  }
+
+  get isRankedChoice() {
+    return this.args.attrs.poll.type === RANKED_CHOICE;
+  }
+
+  get staffOnly() {
+    return this.args.attrs.poll.results === STAFF_ONLY;
+  }
+
+  get isMultiple() {
+    return this.args.attrs.poll.type === MULTIPLE;
+  }
+
+  get isNumber() {
+    return this.args.attrs.poll.type === NUMBER;
+  }
+
+  get post() {
+    return this.args.attrs.post;
+  }
+
+  get isMe() {
+    return (
+      this.currentUser && this.args.attrs.post.user_id === this.currentUser.id
+    );
+  }
+
   @action
-  castVotes() {
+  castVotes(option) {
     if (!this.canCastVotes) {
       return;
     }
@@ -318,7 +319,7 @@ export default class PollComponent extends Component {
     this._toggleOption(option, rank);
 
     if (!this.isMultiple && !this.isRankedChoice) {
-      this.castVotes();
+      this.castVotes(option);
     }
   }
 

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -34,7 +34,6 @@ export default class PollComponent extends Component {
   @service appEvents;
   @service dialog;
   @service modal;
-
   @tracked vote = this.args.attrs.vote || [];
   @tracked poll = this.args.attrs.poll;
   @tracked preloadedVoters = this.defaultPreloadedVoters();
@@ -59,7 +58,7 @@ export default class PollComponent extends Component {
 
     return userGroups && pollGroups.some((g) => userGroups.includes(g));
   };
-areRanksValid = (arr) => {
+  areRanksValid = (arr) => {
     let ranks = new Set(); // Using a Set to keep track of unique ranks
     let hasNonZeroDuplicate = false;
 
@@ -77,7 +76,7 @@ areRanksValid = (arr) => {
 
     return !hasNonZeroDuplicate;
   };
-_toggleOption = (option, rank = 0) => {
+  _toggleOption = (option, rank = 0) => {
     let vote = this.vote;
 
     if (this.isMultiple) {
@@ -111,7 +110,7 @@ _toggleOption = (option, rank = 0) => {
 
     this.vote = [...vote];
   };
-defaultPreloadedVoters() {
+  defaultPreloadedVoters() {
     let preloadedVoters = {};
 
     if (this.args.attrs.poll.public && this.args.preloadedVoters) {
@@ -134,10 +133,6 @@ defaultPreloadedVoters() {
 
     return preloadedVoters;
   }
-
-
-
-
 
   get id() {
     return this.args.attrs.id;

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -45,13 +45,11 @@ export default class PollComponent extends Component {
   @tracked staffOnly = this.poll.results === STAFF_ONLY;
   @tracked isMultiple = this.poll.type === MULTIPLE;
   @tracked isNumber = this.poll.type === NUMBER;
-  @tracked showingResults = false;
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
   @tracked status = this.poll.status;
   @tracked
   showResults =
     this.hasSavedVote ||
-    this.showingResults ||
     (this.topicArchived && !this.staffOnly) ||
     (this.closed && !this.staffOnly);
   post = this.args.attrs.post;
@@ -303,7 +301,7 @@ export default class PollComponent extends Component {
   }
 
   get canCastVotes() {
-    if (this.closed || this.showingResults || !this.currentUser) {
+    if (this.closed || !this.currentUser) {
       return false;
     }
 

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -168,7 +168,7 @@ export default class PollComponent extends Component {
       .catch((error) => {
         if (error) {
           if (!this.isMultiple && !this.isRankedChoice) {
-            this.vote = [...this.vote];
+            this._toggleOption(option);
           }
           popupAjaxError(error);
         } else {
@@ -290,7 +290,7 @@ export default class PollComponent extends Component {
     this._toggleOption(option, rank);
 
     if (!this.isMultiple && !this.isRankedChoice) {
-      this.castVotes(option);
+      this.castVotes();
     }
   }
 

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -152,10 +152,6 @@ export default class PollComponent extends Component {
     return this.args.attrs.poll.type === NUMBER;
   }
 
-  get post() {
-    return this.args.attrs.post;
-  }
-
   get isMe() {
     return (
       this.currentUser && this.args.attrs.post.user_id === this.currentUser.id

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
@@ -38,6 +39,7 @@ export default class PollComponent extends Component {
 
   @tracked vote = this.args.attrs.vote || [];
   @tracked poll = this.args.attrs.poll;
+  @tracked preloadedVoters = this.defaultPreloadedVoters();
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
 
   @tracked
@@ -112,10 +114,10 @@ export default class PollComponent extends Component {
     this.vote = [...this.vote];
   };
 
-  get preloadedVoters() {
+  defaultPreloadedVoters() {
     const preloadedVoters = {};
 
-    if (this.poll.get("public") && this.args.preloadedVoters) {
+    if (this.poll.public && this.args.preloadedVoters) {
       Object.keys(this.args.preloadedVoters).forEach((key) => {
         preloadedVoters[key] = {
           voters: this.args.preloadedVoters[key],
@@ -451,6 +453,11 @@ export default class PollComponent extends Component {
   }
 
   @action
+  updatedVoters() {
+    this.preloadedVoters = this.defaultPreloadedVoters();
+  }
+
+  @action
   fetchVoters(optionId) {
     let votersCount;
     let preloadedVoters = this.preloadedVoters;
@@ -634,7 +641,10 @@ export default class PollComponent extends Component {
       });
   }
   <template>
-    <div class="poll-container">
+    <div
+      {{didUpdate this.updatedVoters @preloadedVoters}}
+      class="poll-container"
+    >
       {{this.titleHTML}}
       {{#if this.notInVotingGroup}}
         <div class="alert alert-danger">{{this.pollGroups}}</div>

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -82,42 +82,40 @@ export default class PollComponent extends Component {
   };
 
   _toggleOption = (option, rank = 0) => {
-    let vote = this.vote;
-
     if (this.isMultiple) {
-      const chosenIdx = vote.indexOf(option.id);
+      const chosenIdx = this.vote.indexOf(option.id);
 
       if (chosenIdx !== -1) {
-        vote.splice(chosenIdx, 1);
+        this.vote.splice(chosenIdx, 1);
       } else {
-        vote.push(option.id);
+        this.vote.push(option.id);
       }
     } else if (this.isRankedChoice) {
       this.options.forEach((candidate) => {
-        const chosenIdx = vote.findIndex(
+        const chosenIdx = this.vote.findIndex(
           (object) => object.digest === candidate.id
         );
 
         if (chosenIdx === -1) {
-          vote.push({
+          this.vote.push({
             digest: candidate.id,
             rank: candidate.id === option ? rank : 0,
           });
         } else {
           if (candidate.id === option) {
-            vote[chosenIdx].rank = rank;
+            this.vote[chosenIdx].rank = rank;
           }
         }
       });
     } else {
-      vote = [option.id];
+      this.vote = [option.id];
     }
 
-    this.vote = [...vote];
+    this.vote = [...this.vote];
   };
 
   defaultPreloadedVoters() {
-    let preloadedVoters = {};
+    const preloadedVoters = {};
 
     if (this.poll.public && this.args.preloadedVoters) {
       Object.keys(this.args.preloadedVoters).forEach((key) => {

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -46,30 +46,6 @@ export default class PollComponent extends Component {
     (this.topicArchived && !this.staffOnly) ||
     (this.closed && !this.staffOnly);
 
-  defaultPreloadedVoters() {
-    let preloadedVoters = {};
-
-    if (this.args.attrs.poll.public && this.args.preloadedVoters) {
-      Object.keys(this.args.preloadedVoters).forEach((key) => {
-        preloadedVoters[key] = {
-          voters: this.args.preloadedVoters[key],
-          loading: false,
-        };
-      });
-    }
-
-    this.options.forEach((option) => {
-      if (!preloadedVoters[option.id]) {
-        preloadedVoters[option.id] = {
-          voters: [],
-          loading: false,
-        };
-      }
-    });
-
-    return preloadedVoters;
-  }
-
   checkUserGroups = (user, poll) => {
     const pollGroups =
       poll && poll.groups && poll.groups.split(",").map((g) => g.toLowerCase());
@@ -83,7 +59,7 @@ export default class PollComponent extends Component {
 
     return userGroups && pollGroups.some((g) => userGroups.includes(g));
   };
-  areRanksValid = (arr) => {
+areRanksValid = (arr) => {
     let ranks = new Set(); // Using a Set to keep track of unique ranks
     let hasNonZeroDuplicate = false;
 
@@ -101,7 +77,7 @@ export default class PollComponent extends Component {
 
     return !hasNonZeroDuplicate;
   };
-  _toggleOption = (option, rank = 0) => {
+_toggleOption = (option, rank = 0) => {
     let vote = this.vote;
 
     if (this.isMultiple) {
@@ -135,6 +111,33 @@ export default class PollComponent extends Component {
 
     this.vote = [...vote];
   };
+defaultPreloadedVoters() {
+    let preloadedVoters = {};
+
+    if (this.args.attrs.poll.public && this.args.preloadedVoters) {
+      Object.keys(this.args.preloadedVoters).forEach((key) => {
+        preloadedVoters[key] = {
+          voters: this.args.preloadedVoters[key],
+          loading: false,
+        };
+      });
+    }
+
+    this.options.forEach((option) => {
+      if (!preloadedVoters[option.id]) {
+        preloadedVoters[option.id] = {
+          voters: [],
+          loading: false,
+        };
+      }
+    });
+
+    return preloadedVoters;
+  }
+
+
+
+
 
   get id() {
     return this.args.attrs.id;
@@ -503,9 +506,10 @@ export default class PollComponent extends Component {
           if (this.poll.type === REGULAR) {
             Object.keys(this.preloadedVoters).forEach((otherOptionId) => {
               if (optionId !== otherOptionId) {
-                this.preloadedVoters[otherOptionId].voters = this.preloadedVoters[
-                  otherOptionId
-                ].voters.filter((voter) => !votersSet.has(voter.username));
+                this.preloadedVoters[otherOptionId].voters =
+                  this.preloadedVoters[otherOptionId].voters.filter(
+                    (voter) => !votersSet.has(voter.username)
+                  );
               }
             });
           }

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -210,11 +210,11 @@ export default class PollComponent extends Component {
       this.poll.setProperties(poll);
       this.appEvents.trigger("poll:voted", poll, this.post, this.vote);
 
-      if (this.poll.results !== "on_close") {
+      if (this.poll.results !== ON_CLOSE) {
         this.showResults = true;
       }
 
-      if (this.poll.results === "staff_only") {
+      if (this.poll.results === STAFF_ONLY) {
         if (this.currentUser && this.currentUser.staff) {
           this.showResults = true;
         } else {
@@ -257,7 +257,7 @@ export default class PollComponent extends Component {
   }
 
   get rankedChoiceOutcome() {
-    return this.poll.ranked_choice_outcome || [];
+    return this.poll.get("ranked_choice_outcome") || [];
   }
 
   get min() {
@@ -428,11 +428,7 @@ export default class PollComponent extends Component {
   }
 
   get isCheckbox() {
-    if (this.isMultiple) {
-      return true;
-    } else {
-      return false;
-    }
+    return this.isMultiple;
   }
 
   get resultsWidgetTypeClass() {
@@ -577,7 +573,7 @@ export default class PollComponent extends Component {
             this.poll.set("status", status);
 
             if (
-              this.poll.results === "on_close" ||
+              this.poll.results === ON_CLOSE ||
               this.poll.results === "always"
             ) {
               this.showResults = this.status === CLOSED_STATUS;

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -111,11 +111,17 @@ export default class PollComponent extends Component {
 
     this.vote = [...vote];
   };
-  constructor() {
-    super(...arguments);
-    this.id = this.args.attrs.id;
-    this.post = this.args.attrs.post;
-    this.groupableUserFields = this.args.attrs.groupableUserFields;
+
+  get id() {
+    return this.args.attrs.id;
+  }
+
+  get post() {
+    return this.args.attrs.post;
+  }
+
+  get groupableUserFields() {
+    return this.args.attrs.groupableUserFields;
   }
 
   get isStaff() {

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -253,7 +253,7 @@ export default class PollComponent extends Component {
   }
 
   get voters() {
-    return this.poll.voters;
+    return this.poll.get("voters");
   }
 
   get rankedChoiceOutcome() {

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -34,17 +34,10 @@ export default class PollComponent extends Component {
   @service appEvents;
   @service dialog;
   @service modal;
-  @tracked isStaff = this.currentUser && this.currentUser.staff;
+
   @tracked vote = this.args.attrs.vote || [];
-  @tracked titleHTML = htmlSafe(this.args.attrs.titleHTML);
-  @tracked topicArchived = this.args.attrs.post.get("topic.archived");
   @tracked poll = this.args.attrs.poll;
   @tracked preloadedVoters = this.args.preloadedVoters || [];
-  @tracked isRankedChoice = this.poll.type === RANKED_CHOICE;
-  @tracked isMultiVoteType = this.isRankedChoice || this.isMultiple;
-  @tracked staffOnly = this.poll.results === STAFF_ONLY;
-  @tracked isMultiple = this.poll.type === MULTIPLE;
-  @tracked isNumber = this.poll.type === NUMBER;
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
   @tracked status = this.poll.status;
   @tracked
@@ -52,9 +45,44 @@ export default class PollComponent extends Component {
     this.hasSavedVote ||
     (this.topicArchived && !this.staffOnly) ||
     (this.closed && !this.staffOnly);
-  post = this.args.attrs.post;
-  isMe =
-    this.currentUser && this.args.attrs.post.user_id === this.currentUser.id;
+
+  get isStaff() {
+    return this.currentUser && this.currentUser.staff;
+  }
+
+  get titleHTML() {
+    return htmlSafe(this.args.attrs.titleHTML);
+  }
+
+  get topicArchived() {
+    return this.args.attrs.post.get("topic.archived");
+  }
+
+  get isRankedChoice() {
+    return this.args.attrs.poll.type === RANKED_CHOICE;
+  }
+
+  get staffOnly() {
+    return this.args.attrs.poll.results === STAFF_ONLY;
+  }
+
+  get isMultiple() {
+    return this.args.attrs.poll.type === MULTIPLE;
+  }
+
+  get isNumber() {
+    return this.args.attrs.poll.type === NUMBER;
+  }
+
+  get post() {
+    return this.args.attrs.post;
+  }
+
+  get isMe() {
+    return (
+      this.currentUser && this.args.attrs.post.user_id === this.currentUser.id
+    );
+  }
 
   checkUserGroups = (user, poll) => {
     const pollGroups =

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
@@ -39,7 +38,6 @@ export default class PollComponent extends Component {
 
   @tracked vote = this.args.attrs.vote || [];
   @tracked poll = this.args.attrs.poll;
-  @tracked preloadedVoters = this.defaultPreloadedVoters();
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
 
   @tracked
@@ -114,10 +112,10 @@ export default class PollComponent extends Component {
     this.vote = [...this.vote];
   };
 
-  defaultPreloadedVoters() {
+  get preloadedVoters() {
     const preloadedVoters = {};
 
-    if (this.poll.public && this.args.preloadedVoters) {
+    if (this.poll.get("public") && this.args.preloadedVoters) {
       Object.keys(this.args.preloadedVoters).forEach((key) => {
         preloadedVoters[key] = {
           voters: this.args.preloadedVoters[key],
@@ -453,11 +451,6 @@ export default class PollComponent extends Component {
   }
 
   @action
-  updatedVoters() {
-    this.preloadedVoters = this.defaultPreloadedVoters();
-  }
-
-  @action
   fetchVoters(optionId) {
     let votersCount;
     let preloadedVoters = this.preloadedVoters;
@@ -641,10 +634,7 @@ export default class PollComponent extends Component {
       });
   }
   <template>
-    <div
-      {{didUpdate this.updatedVoters @preloadedVoters}}
-      class="poll-container"
-    >
+    <div class="poll-container">
       {{this.titleHTML}}
       {{#if this.notInVotingGroup}}
         <div class="alert alert-danger">{{this.pollGroups}}</div>

--- a/plugins/poll/assets/javascripts/discourse/widgets/discourse-poll.js
+++ b/plugins/poll/assets/javascripts/discourse/widgets/discourse-poll.js
@@ -29,7 +29,6 @@ export default createWidget("discourse-poll", {
         {
           attrs,
           preloadedVoters: attrs.poll.preloaded_voters,
-          options: attrs.poll.options,
         }
       ),
     ];

--- a/plugins/poll/assets/javascripts/discourse/widgets/discourse-poll.js
+++ b/plugins/poll/assets/javascripts/discourse/widgets/discourse-poll.js
@@ -25,7 +25,7 @@ export default createWidget("discourse-poll", {
       new RenderGlimmer(
         this,
         "div.poll",
-        hbs`<Poll @attrs={{@data.attrs}} @preloadedVoters={{@data.preloadedVoters}} @options={{@data.options}} />`,
+        hbs`<Poll @attrs={{@data.attrs}} @preloadedVoters={{@data.preloadedVoters}} />`,
         {
           attrs,
           preloadedVoters: attrs.poll.preloaded_voters,

--- a/plugins/poll/lib/ranked_choice.rb
+++ b/plugins/poll/lib/ranked_choice.rb
@@ -115,7 +115,7 @@ class DiscoursePoll::RankedChoice
   def self.majority_check(tally, potential_winners, max_votes)
     total_votes = tally.values.sum
 
-    max_votes > total_votes / 2 || potential_winners.count == 1
+    max_votes && (max_votes > total_votes / 2 || potential_winners.count == 1)
   end
 
   def self.identify_losers(tally)

--- a/plugins/poll/lib/ranked_choice.rb
+++ b/plugins/poll/lib/ranked_choice.rb
@@ -115,7 +115,7 @@ class DiscoursePoll::RankedChoice
   def self.majority_check(tally, potential_winners, max_votes)
     total_votes = tally.values.sum
 
-    max_votes && (max_votes > total_votes / 2 || potential_winners.count == 1)
+    max_votes > total_votes / 2 || potential_winners.count == 1
   end
 
   def self.identify_losers(tally)

--- a/plugins/poll/test/javascripts/component/poll-test.js
+++ b/plugins/poll/test/javascripts/component/poll-test.js
@@ -46,6 +46,46 @@ module("Poll | Component | poll", function (hooks) {
     });
   });
 
+  test("shows vote", async function (assert) {
+    this.setProperties({
+      attributes: EmberObject.create({
+        post: EmberObject.create({
+          id: 42,
+          topic: {
+            archived: false,
+          },
+          user_id: 29,
+        }),
+        poll: EmberObject.create({
+          name: "poll",
+          type: "regular",
+          status: "closed",
+          results: "always",
+          options: [
+            { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 1 },
+            { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+          ],
+          voters: 1,
+          chart_type: "bar",
+        }),
+        vote: [],
+        groupableUserFields: [],
+      }),
+      preloadedVoters: [],
+    });
+
+    await render(
+      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} />`
+    );
+
+    assert.deepEqual(
+      Array.from(queryAll(".results li .option p")).map(
+        (span) => span.innerText
+      ),
+      ["100% yes", "0% no"]
+    );
+  });
+
   test("can vote", async function (assert) {
     this.setProperties({
       attributes: EmberObject.create({
@@ -72,14 +112,10 @@ module("Poll | Component | poll", function (hooks) {
         groupableUserFields: [],
       }),
       preloadedVoters: [],
-      options: [
-        { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
-        { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
-      ],
     });
 
     await render(
-      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} @options={{this.options}} />`
+      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} />`
     );
 
     requests = 0;
@@ -89,10 +125,6 @@ module("Poll | Component | poll", function (hooks) {
     );
     assert.strictEqual(requests, 1);
     assert.strictEqual(count(".chosen"), 1);
-    assert.deepEqual(
-      Array.from(queryAll(".chosen span")).map((span) => span.innerText),
-      ["100%", "yes"]
-    );
 
     await click(".toggle-results");
     assert.strictEqual(
@@ -128,14 +160,10 @@ module("Poll | Component | poll", function (hooks) {
         groupableUserFields: [],
       }),
       preloadedVoters: [],
-      options: [
-        { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
-        { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
-      ],
     });
 
     await render(
-      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} @options={{this.options}} />`
+      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} />`
     );
 
     requests = 0;
@@ -178,13 +206,9 @@ module("Poll | Component | poll", function (hooks) {
         groupableUserFields: [],
       }),
       preloadedVoters: [],
-      options: [
-        { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
-        { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
-      ],
     });
     await render(
-      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} @options={{this.options}} />`
+      hbs`<Poll @attrs={{this.attributes}} @preloadedVoters={{this.preloadedVoters}} />`
     );
 
     assert.ok(exists(".poll-buttons .cast-votes:disabled"));


### PR DESCRIPTION
Fixes issue with polls not being fully updated by remote vote contributions in (semi-) real-time.

This was down to too great a focus on tracking local state and not accommodating a more data down approach with responsive getters. 

This is now implemented.

I've tried hard to minimise the changes whilst making sure the paradigm is properly followed through.