### PR TITLE
FIX: system badges can be disabled

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -11,24 +11,17 @@
     <span class="badge-display-name">{{data.name}}</span>
   </h1>
 
-  {{#if this.readOnly}}
-    <form.Alert @icon="info-circle">
-      {{i18n "admin.badges.disable_system"}}
-    </form.Alert>
-  {{else}}
-    <form.Field
-      @name="enabled"
-      @disabled={{this.readOnly}}
-      @validation="required"
-      @title={{i18n "admin.badges.status"}}
-      as |field|
-    >
-      <field.Question
-        @yesLabel={{i18n "admin.badges.enabled"}}
-        @noLabel={{i18n "admin.badges.disabled"}}
-      />
-    </form.Field>
-  {{/if}}
+  <form.Field
+    @name="enabled"
+    @validation="required"
+    @title={{i18n "admin.badges.status"}}
+    as |field|
+  >
+    <field.Question
+      @yesLabel={{i18n "admin.badges.enabled"}}
+      @noLabel={{i18n "admin.badges.disabled"}}
+    />
+  </form.Field>
 
   {{#if this.readOnly}}
     <form.Container data-name="name" @title={{i18n "admin.badges.name"}}>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6931,7 +6931,6 @@ en:
             confirm: "Yes, update password policy"
 
       badges:
-        disable_system: This badge is a system badge and cannot be disabled and/or deleted.
         status: Status
         title: Badges
         new_badge: New Badge

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -16,7 +16,7 @@ describe "Admin Badges Page", type: :system do
 
       badge = Badge.find(Badge::Autobiographer)
 
-      expect(form).to have_an_alert(I18n.t("admin_js.admin.badges.disable_system"))
+      expect(form.field("enabled")).to be_enabled
       expect(form.field("badge_type_id")).to be_disabled
       expect(form.field("badge_type_id")).to have_value(BadgeType::Bronze.to_s)
       expect(form.field("badge_grouping_id")).to be_disabled


### PR DESCRIPTION
[A previous commit](https://github.com/discourse/discourse/commit/2ca06ba2360c200b2be8e0718fcc04c64ca14935) mistakenly assumed system badges couldn't be disabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
