### PR TITLE
DEV: Remove object-property-decorators from admin mixins

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/period-computation.js
+++ b/app/assets/javascripts/admin/addon/mixins/period-computation.js
@@ -1,7 +1,7 @@
+import { computed } from "@ember/object";
 import Mixin from "@ember/object/mixin";
 import DiscourseURL from "discourse/lib/url";
 import deprecated from "discourse-common/lib/deprecated";
-import discourseComputed from "discourse-common/utils/decorators";
 
 export default Mixin.create({
   queryParams: ["period"],
@@ -20,9 +20,9 @@ export default Mixin.create({
     this.availablePeriods = ["yearly", "quarterly", "monthly", "weekly"];
   },
 
-  @discourseComputed("period")
-  startDate: {
-    get(period) {
+  startDate: computed("period", {
+    get() {
+      const period = this.period;
       const fullDay = moment().locale("en").utc().endOf("day");
 
       switch (period) {
@@ -42,31 +42,24 @@ export default Mixin.create({
     set(period) {
       return period;
     },
-  },
+  }),
 
-  @discourseComputed()
-  lastWeek() {
+  get lastWeek() {
     return moment().locale("en").utc().endOf("day").subtract(1, "week");
   },
 
-  @discourseComputed()
-  lastMonth() {
+  get lastMonth() {
     return moment().locale("en").utc().startOf("day").subtract(1, "month");
   },
 
-  @discourseComputed()
-  endDate: {
-    get() {
-      return moment().locale("en").utc().endOf("day");
-    },
-
-    set(endDate) {
-      return endDate;
-    },
+  get endDate() {
+    return moment().locale("en").utc().endOf("day");
+  },
+  set endDate(value) {
+    /* noop */
   },
 
-  @discourseComputed()
-  today() {
+  get today() {
     return moment().locale("en").utc().endOf("day");
   },
 

--- a/app/assets/javascripts/admin/addon/mixins/setting-object.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-object.js
@@ -3,12 +3,13 @@ import { readOnly } from "@ember/object/computed";
 import Mixin from "@ember/object/mixin";
 import { isPresent } from "@ember/utils";
 import { deepEqual } from "discourse-common/lib/object";
-import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
 export default Mixin.create({
-  @discourseComputed("value", "default")
-  overridden(val, defaultVal) {
+  overridden: computed("value", "default", function () {
+    let val = this.value;
+    let defaultVal = this.default;
+
     if (val === null) {
       val = "";
     }
@@ -17,7 +18,7 @@ export default Mixin.create({
     }
 
     return !deepEqual(val, defaultVal);
-  },
+  }),
 
   computedValueProperty: computed(
     "valueProperty",
@@ -47,8 +48,9 @@ export default Mixin.create({
     }
   }),
 
-  @discourseComputed("valid_values")
-  validValues(validValues) {
+  validValues: computed("valid_values", function () {
+    const validValues = this.valid_values;
+
     const values = [];
     const translateNames = this.translate_names;
 
@@ -60,14 +62,13 @@ export default Mixin.create({
       }
     });
     return values;
-  },
+  }),
 
-  @discourseComputed("valid_values")
-  allowsNone(validValues) {
-    if (validValues?.includes("")) {
+  allowsNone: computed("valid_values", function () {
+    if (this.valid_values?.includes("")) {
       return "admin.settings.none";
     }
-  },
+  }),
 
   anyValue: readOnly("allow_any"),
 });


### PR DESCRIPTION
Ember's legacy mixin system does not support native-class syntax, so we have to use the non-decorator syntaxes for `action()` and `computed()`.

Eventually, we will need to refactor things to remove these mixins... but today is not that day.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
