### PR TITLE
FIX: correct return isForever value

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -394,7 +394,7 @@ export default class User extends RestModel.extend(Evented) {
 
   @discourseComputed("silenced_till")
   silencedForever(silencedTill) {
-    isForever(silencedTill);
+    return isForever(silencedTill);
   }
 
   @discourseComputed("suspended_till")


### PR DESCRIPTION
[Following a refactor](https://github.com/discourse/discourse/commit/061e79297fb986a2c2d08558416126992d3e1e39#diff-bd99ef6b155af0dab90541be2ed856f3521f78adef81e378f528d1c9e74615fc) we forgot to return the value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
