### PR TITLE
DEV: Stop storing theme-transpiler on filesystem in development

### DIFF
--- a/app/assets/javascripts/theme-transpiler/build.js
+++ b/app/assets/javascripts/theme-transpiler/build.js
@@ -3,7 +3,6 @@
 const esbuild = require("esbuild");
 const path = require("node:path");
 const fs = require("node:fs");
-const { argv } = require("node:process");
 
 let wasmPlugin = {
   name: "wasm",
@@ -57,7 +56,6 @@ esbuild
     },
     external: ["fs", "path"],
     entryPoints: ["./app/assets/javascripts/theme-transpiler/transpiler.js"],
-    outfile: argv[2],
     plugins: [wasmPlugin],
   })
   .then(() => {});

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -321,7 +321,7 @@ task "assets:precompile:compress_js": "environment" do
 end
 
 task "assets:precompile:theme_transpiler": "environment" do
-  DiscourseJsProcessor::Transpiler.build_theme_transpiler
+  DiscourseJsProcessor::Transpiler.build_production_theme_transpiler
 end
 
 # Run these tasks **before** Rails' "assets:precompile" task

--- a/spec/tasks/assets_precompile_spec.rb
+++ b/spec/tasks/assets_precompile_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "assets:precompile" do
     it "compiles the js processor" do
       path = Rake::Task["assets:precompile:theme_transpiler"].actions.first.call
 
-      expect(path).to match(%r{tmp/theme-transpiler})
+      expect(path).to end_with("tmp/theme-transpiler.js")
       expect(File.exist?(path)).to eq(true)
     end
   end


### PR DESCRIPTION
We were writing theme-transpiler JS files to the filesystem on a per-process basis, and then immediately reading them back in. Plus, there was no cleanup mechanism, so the tmp directory would grow indefinitely.

This commit refactors things so that the `build.js` script outputs the theme-transpiler source to stdout. That way, we can read it directly into the process, and then into mini-racer, without needing to go via the filesystem. No cleanup required!

In production, the theme-transpiler is still cached in a file during `assets:precompile`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
