### PR TITLE
UX: respect current locale on topic map views date format

### DIFF
--- a/app/assets/javascripts/discourse-i18n/src/index.js
+++ b/app/assets/javascripts/discourse-i18n/src/index.js
@@ -33,6 +33,10 @@ export class I18n {
     return this.locale || this.defaultLocale;
   }
 
+  get currentBcp47Locale() {
+    return this.currentLocale().replace("_", "-");
+  }
+
   get pluralizationNormalizedLocale() {
     if (this.currentLocale() === "pt") {
       return "pt_PT";

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-views-chart.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-views-chart.gjs
@@ -161,7 +161,7 @@ export default class TopicViewsChart extends Component {
               maxTicksLimit: 15,
               callback: function (value) {
                 const date = new Date(value + oneDay);
-                return date.toLocaleDateString(undefined, {
+                return date.toLocaleDateString(I18n.currentBcp47Locale, {
                   month: "2-digit",
                   day: "2-digit",
                 });
@@ -189,7 +189,7 @@ export default class TopicViewsChart extends Component {
                   const today = new Date();
                   date = today.getUTCDate();
                 }
-                return date.toLocaleDateString(undefined, {
+                return date.toLocaleDateString(I18n.currentBcp47Locale, {
                   month: "2-digit",
                   day: "2-digit",
                   year: "numeric",

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import I18n from "I18n";
 
 export default class TopicViews extends Component {
   adjustAggregatedData(stats) {

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
@@ -6,11 +6,14 @@ export default class TopicViews extends Component {
 
     stats.forEach((stat) => {
       const localDate = new Date(`${stat.viewed_at}T00:00:00Z`);
-      const localDateStr = localDate.toLocaleDateString(undefined, {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      });
+      const localDateStr = localDate.toLocaleDateString(
+        I18n.currentBcp47Locale,
+        {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        }
+      );
 
       const existingStat = adjustedStats.find(
         (s) => s.dateStr === localDateStr
@@ -34,7 +37,7 @@ export default class TopicViews extends Component {
   }
 
   formatDate(date) {
-    return date.toLocaleDateString(undefined, {
+    return date.toLocaleDateString(I18n.currentBcp47Locale, {
       month: "2-digit",
       day: "2-digit",
     });

--- a/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
@@ -373,4 +373,22 @@ module("Unit | Utility | i18n", function (hooks) {
       "Degrades gracefully if MF definitions are not available."
     );
   });
+
+  test("currentBcp47Locale", function (assert) {
+    Object.entries({
+      pt_BR: "pt-BR",
+      en_GB: "en-GB",
+      bs_BA: "bs-BA",
+      en: "en",
+      it: "it",
+      es: "es",
+    }).forEach(([input, output]) => {
+      I18n.locale = input;
+      assert.strictEqual(
+        I18n.currentBcp47Locale,
+        output,
+        `returns '${output}' for '${input}'`
+      );
+    });
+  });
 });


### PR DESCRIPTION
We're using the default browser locale instead of Discourse's locale on the new topic map views when formatting the date.

![image](https://github.com/user-attachments/assets/fc7b82c8-34c5-4bb1-a11c-5340580b970d)

This PR introduces a simple conversion from our standard locale format to a BCP 47 language tag and passes it to `toLocaleDateString` – similar to [how we did it](https://github.com/discourse/discourse-calendar/blob/908ad614bc412f831f929ca726a4bda0b9ccaab6/assets/javascripts/discourse/initializers/discourse-calendar.js#L133) when passing a locale to `discourse-calendar`'s `FullCalendar` instance.