### PR TITLE
FIX: Update do-not-disturb icon in real-time on glimmer header

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1215,6 +1215,7 @@ export default class User extends RestModel.extend(Evented) {
   updateDoNotDisturbStatus(ends_at) {
     this.set("do_not_disturb_until", ends_at);
     this.appEvents.trigger("do-not-disturb:changed", this.do_not_disturb_until);
+    getOwner(this).lookup("service:notifications")._checkDoNotDisturb();
   }
 
   updateDraftProperties(properties) {
@@ -1228,10 +1229,11 @@ export default class User extends RestModel.extend(Evented) {
   }
 
   isInDoNotDisturb() {
-    return (
-      this.do_not_disturb_until &&
-      new Date(this.do_not_disturb_until) >= new Date()
-    );
+    if (this !== getOwner(this).lookup("service:current-user")) {
+      throw "isInDoNotDisturb is only supported for currentUser";
+    }
+
+    return getOwner(this).lookup("service:notifications").isInDoNotDisturb;
   }
 
   @discourseComputed(

--- a/app/assets/javascripts/discourse/app/services/notifications.js
+++ b/app/assets/javascripts/discourse/app/services/notifications.js
@@ -1,0 +1,44 @@
+import { tracked } from "@glimmer/tracking";
+import Service, { service } from "@ember/service";
+import { disableImplicitInjections } from "discourse/lib/implicit-injections";
+
+@disableImplicitInjections
+export default class NotificationsService extends Service {
+  @service currentUser;
+
+  @tracked isInDoNotDisturb;
+
+  #dndTimer;
+
+  constructor() {
+    super(...arguments);
+
+    this._checkDoNotDisturb();
+  }
+
+  _checkDoNotDisturb() {
+    clearTimeout(this.#dndTimer);
+
+    if (this.currentUser?.do_not_disturb_until) {
+      const remainingMs = this.currentUser.do_not_disturb_until - Date.now();
+
+      if (remainingMs <= 0) {
+        this.isInDoNotDisturb = false;
+        return;
+      }
+
+      this.isInDoNotDisturb = true;
+
+      this.#dndTimer = setTimeout(
+        () => this._checkDoNotDisturb(),
+        Math.min(remainingMs, 60000)
+      );
+    } else {
+      this.isInDoNotDisturb = false;
+    }
+  }
+
+  willDestroy() {
+    clearTimeout(this.#dndTimer);
+  }
+}


### PR DESCRIPTION
To achieve this, a new notifications service is set up with an `isInDoNotDisturb` tracked property. While a user is in do-not-disturb mode, it runs a regular timer until do-not-disturb is over.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
