### PR TITLE
DEV: Attempt at fixing ImageTooLargeError despite image not being too large

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -5,7 +5,6 @@ module Jobs
     sidekiq_options queue: "low"
 
     def initialize
-      @max_size = SiteSetting.max_image_size_kb.kilobytes
     end
 
     def execute(args)
@@ -101,7 +100,7 @@ module Jobs
         downloaded =
           FileHelper.download(
             src,
-            max_file_size: @max_size,
+            max_file_size: SiteSetting.max_image_size_kb.kilobytes,
             retain_on_max_file_size_exceeded: true,
             tmp_file_name: "discourse-hotlinked",
             follow_redirect: true,
@@ -137,7 +136,9 @@ module Jobs
 
       hotlinked = download(src)
       raise ImageBrokenError if !hotlinked
-      raise ImageTooLargeError if File.size(hotlinked.path) > @max_size
+      if File.size(hotlinked.path) > SiteSetting.max_image_size_kb.kilobytes
+        raise ImageTooLargeError
+      end
 
       filename = File.basename(URI.parse(src).path)
       filename << File.extname(hotlinked.path) unless filename["."]


### PR DESCRIPTION
There is a current bug where pulling a hotlinked image after bumping up the SiteSetting.max_image_size_kb.kilobytes results in no change.

Repro:

A site has `SiteSetting.max_image_size_kb.kilobytes` at a default of `4194304`. A post is created with an image that is slightly larger (`4937596`), resulting in the following.

<img width="583" alt="Screenshot 2024-08-02 at 10 34 09 PM" src="https://github.com/user-attachments/assets/c58a62ae-b77b-4058-b9a9-b072b61bda38">

We change `SiteSetting.max_image_size_kb.kilobytes` to 5MB, and rebuild HTML, but the post then shows

<img width="580" alt="Screenshot 2024-08-02 at 10 36 20 PM" src="https://github.com/user-attachments/assets/a8fb9367-e96b-4d36-b594-f6e04d37c21c">

Note, this bug does not appear on some sites.