### PR TITLE
FIX: Do not strip `//` from the middle of URLs in discourse-url

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -214,7 +214,7 @@ class DiscourseURL extends EmberObject {
       return this.redirectTo(path);
     }
 
-    const pathname = path.replace(/(https?\:)?\/\/[^\/]+/, "");
+    const pathname = path.replace(/^(https?\:)?\/\/[^\/]+/, "");
 
     if (!this.isInternal(path)) {
       return this.redirectTo(path);

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -114,6 +114,40 @@ module("Unit | Utility | url", function (hooks) {
     );
   });
 
+  test("routeTo protocol/domain stripping", async function (assert) {
+    sinon.stub(DiscourseURL, "origin").get(() => "http://example.com");
+    sinon.stub(DiscourseURL, "handleURL");
+    sinon.stub(DiscourseURL, "router").get(() => {
+      return {
+        currentURL: "/bar",
+      };
+    });
+
+    DiscourseURL.routeTo("http://example.com/foo1");
+    assert.ok(
+      DiscourseURL.handleURL.calledWith(`/foo1`),
+      "it strips the protocol and domain when http"
+    );
+
+    DiscourseURL.routeTo("https://example.com/foo2");
+    assert.ok(
+      DiscourseURL.handleURL.calledWith(`/foo2`),
+      "it strips the protocol and domain when https"
+    );
+
+    DiscourseURL.routeTo("//example.com/foo3");
+    assert.ok(
+      DiscourseURL.handleURL.calledWith(`/foo3`),
+      "it strips the protocol and domain when protocol-less"
+    );
+
+    DiscourseURL.routeTo("https://example.com//foo4");
+    assert.ok(
+      DiscourseURL.handleURL.calledWith(`//foo4`),
+      "it does not strip double-slash in the middle of urls"
+    );
+  });
+
   test("routeTo does not rewrite routes started with /my", async function (assert) {
     logIn();
     sinon.stub(DiscourseURL, "router").get(() => {


### PR DESCRIPTION
Protocol/domain should only be stripped when they occur at the beginning of a URL

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
