### PR TITLE
FIX: Add constraints to `title_max_word_length`

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1012,6 +1012,8 @@ posting:
     refresh: true
   title_max_word_length:
     default: 30
+    min: 1
+    max: 255
     locale_default:
       ja: 50
       ko: 50

--- a/db/migrate/20240802103448_add_min_max_constraints_to_title_max_word_length.rb
+++ b/db/migrate/20240802103448_add_min_max_constraints_to_title_max_word_length.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddMinMaxConstraintsToTitleMaxWordLength < ActiveRecord::Migration[7.1]
+  def up
+    DB.exec <<~SQL
+        UPDATE site_settings SET value = '255' WHERE name = 'title_max_word_length' and value::int > 255;
+      SQL
+    DB.exec <<~SQL
+        UPDATE site_settings SET value = '1' WHERE name = 'title_max_word_length' and value::int < 1;
+      SQL
+  end
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This adds contraints to `title_max_word_length` which otherwise could be arbitrary large or set to 0, which would effectively block topic creation. The max value is set to the max of `max_topic_title_length` (255).

Related meta topic: https://meta.discourse.org/t/large-value-for-title-max-word-length-causes-server-error/319656