### PR TITLE
FIX: Don't clear inline problems when loading admin dashboard

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -48,6 +48,13 @@ class ProblemCheck
   #
   config_accessor :max_blips, default: 0, instance_writer: false
 
+  # Indicates that the problem check is an "inline" check. This provides a
+  # low level construct for registering problems ad-hoc within application
+  # code, without having to extract the checking logic into a dedicated
+  # problem check.
+  #
+  config_accessor :inline, default: false, instance_writer: false
+
   # Problem check classes need to be registered here in order to be enabled.
   #
   # Note: This list must come after the `config_accessor` declarations.
@@ -111,9 +118,14 @@ class ProblemCheck
   delegate :scheduled?, to: :class
 
   def self.realtime?
-    !scheduled?
+    !scheduled? && !inline?
   end
   delegate :realtime?, to: :class
+
+  def self.inline?
+    inline
+  end
+  delegate :inline?, to: :class
 
   def self.call(data = {})
     new(data).call

--- a/app/services/problem_check/inline_problem_check.rb
+++ b/app/services/problem_check/inline_problem_check.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ProblemCheck::InlineProblemCheck < ProblemCheck
+  self.inline = true
+
   def call
     # The logic of this problem check is performed inline, so this class is
     # purely here to support its configuration.

--- a/spec/services/problem_check_spec.rb
+++ b/spec/services/problem_check_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProblemCheck do
   around do |example|
     ScheduledCheck = Class.new(described_class) { self.perform_every = 30.minutes }
     RealtimeCheck = Class.new(described_class)
+    InlineCheck = Class.new(described_class) { self.inline = true }
     PluginCheck = Class.new(described_class)
     FailingCheck =
       Class.new(described_class) do
@@ -29,12 +30,13 @@ RSpec.describe ProblemCheck do
     stub_const(
       described_class,
       "CORE_PROBLEM_CHECKS",
-      [ScheduledCheck, RealtimeCheck, FailingCheck, PassingCheck],
+      [ScheduledCheck, RealtimeCheck, InlineCheck, FailingCheck, PassingCheck],
       &example
     )
 
     Object.send(:remove_const, ScheduledCheck.name)
     Object.send(:remove_const, RealtimeCheck.name)
+    Object.send(:remove_const, InlineCheck.name)
     Object.send(:remove_const, PluginCheck.name)
     Object.send(:remove_const, FailingCheck.name)
     Object.send(:remove_const, PassingCheck.name)
@@ -42,6 +44,7 @@ RSpec.describe ProblemCheck do
 
   let(:scheduled_check) { ScheduledCheck }
   let(:realtime_check) { RealtimeCheck }
+  let(:inline_check) { InlineCheck }
   let(:plugin_check) { PluginCheck }
   let(:failing_check) { FailingCheck }
   let(:passing_check) { PassingCheck }
@@ -56,27 +59,37 @@ RSpec.describe ProblemCheck do
   end
 
   describe ".checks" do
-    it { expect(described_class.checks).to include(scheduled_check, realtime_check) }
+    it { expect(described_class.checks).to include(scheduled_check, realtime_check, inline_check) }
   end
 
   describe ".scheduled" do
     it { expect(described_class.scheduled).to include(scheduled_check) }
     it { expect(described_class.scheduled).not_to include(realtime_check) }
+    it { expect(described_class.scheduled).not_to include(inline_check) }
   end
 
   describe ".realtime" do
     it { expect(described_class.realtime).to include(realtime_check) }
     it { expect(described_class.realtime).not_to include(scheduled_check) }
+    it { expect(described_class.realtime).not_to include(inline_check) }
   end
 
   describe ".scheduled?" do
     it { expect(scheduled_check).to be_scheduled }
     it { expect(realtime_check).to_not be_scheduled }
+    it { expect(inline_check).to_not be_scheduled }
   end
 
   describe ".realtime?" do
     it { expect(realtime_check).to be_realtime }
     it { expect(scheduled_check).to_not be_realtime }
+    it { expect(inline_check).to_not be_realtime }
+  end
+
+  describe ".inline?" do
+    it { expect(inline_check).to be_inline }
+    it { expect(realtime_check).to_not be_inline }
+    it { expect(scheduled_check).to_not be_inline }
   end
 
   describe "plugin problem check registration" do


### PR DESCRIPTION
### Background

We support a low-level construct called "inline checks", which you can use to register a problem ad-hoc from within application code.

### What is the problem?

Problems registered by inline checks never show up in the admin dashboard, this is because when loading the dashboard, we run all realtime checks and look for problems. Because of an oversight, we considered inline checks to be "realtime", causing them to be run and clear their problem status.

### How does this fix it?

Don't consider inline checks to be realtime, to prevent them from running when loading the admin dashboard.