### PR TITLE
DEV: Drop `Firefox Evergreen` from `core_frontend_tests` matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -363,11 +363,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["Chromium", "Firefox ESR", "Firefox Evergreen"]
+        browser: ["Chromium", "Firefox ESR"]
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
-      TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
       CHEAP_SOURCE_MAPS: "1"
 
     steps:


### PR DESCRIPTION
We only want to ensure that Discourse always works with Firefox ESR.
Technically, we want it to work with Firefox Evergreen too but we don't
think that the extra costs to run the tests is worth it.
