### PR TITLE
DEV: Update ember-cli-deprecation-workflow from 2.2.0 to 3.0.1

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse-common/addon/deprecation-workflow.js
@@ -1,0 +1,14 @@
+const DEPRECATION_WORKFLOW = [
+  {
+    handler: "silence",
+    matchId: "ember-this-fallback.this-property-fallback",
+  },
+  { handler: "silence", matchId: "discourse.select-kit" },
+  { handler: "silence", matchId: "discourse.d-section" },
+  {
+    handler: "silence",
+    matchId: "discourse.decorate-widget.hamburger-widget-links",
+  },
+];
+
+export default DEPRECATION_WORKFLOW;

--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -52,7 +52,7 @@ export default function deprecated(msg, options = {}) {
   if (
     raiseError ||
     matchedWorkflow?.handler === "throw" ||
-    (!matchedWorkflow && window.EmberENV.RAISE_ON_DEPRECATION)
+    (!matchedWorkflow && globalThis.EmberENV?.RAISE_ON_DEPRECATION)
   ) {
     throw msg;
   }

--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -1,4 +1,4 @@
-import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
+import DEPRECATION_WORKFLOW from "../deprecation-workflow";
 
 const handlers = [];
 const disabledDeprecations = new Set();

--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -1,7 +1,7 @@
+import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
+
 const handlers = [];
 const disabledDeprecations = new Set();
-const deprecationWorkflow = window.deprecationWorkflow;
-const workflows = deprecationWorkflow?.config?.workflow;
 
 let emberDeprecationSilencer;
 
@@ -47,12 +47,12 @@ export default function deprecated(msg, options = {}) {
 
   handlers.forEach((h) => h(msg, options));
 
-  const matchedWorkflow = workflows?.find((w) => w.matchId === id);
+  const matchedWorkflow = DEPRECATION_WORKFLOW.find((w) => w.matchId === id);
 
   if (
     raiseError ||
     matchedWorkflow?.handler === "throw" ||
-    (!matchedWorkflow && deprecationWorkflow?.throwOnUnhandled)
+    (!matchedWorkflow && window.EmberENV.RAISE_ON_DEPRECATION)
   ) {
     throw msg;
   }

--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -1,4 +1,5 @@
 /* eslint-disable simple-import-sort/imports */
+import "./deprecation-workflow";
 import "decorator-transforms/globals";
 import "./loader-shims";
 import "./global-compat";

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -13,10 +13,8 @@ const DEPRECATION_WORKFLOW = [
   },
 ];
 
-setupDeprecationWorkflow({
-  // We're using RAISE_ON_DEPRECATION in environment.js instead of
-  // `throwOnUnhandled` here since it is easier to toggle.
-  workflow: DEPRECATION_WORKFLOW,
-});
+// We're using RAISE_ON_DEPRECATION in environment.js instead of
+// `throwOnUnhandled` here since it is easier to toggle.
+setupDeprecationWorkflow({ workflow: DEPRECATION_WORKFLOW });
 
 export default DEPRECATION_WORKFLOW;

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -1,5 +1,6 @@
-globalThis.deprecationWorkflow = globalThis.deprecationWorkflow || {};
-globalThis.deprecationWorkflow.config = {
+import setupDeprecationWorkflow from "ember-cli-deprecation-workflow";
+
+setupDeprecationWorkflow({
   // We're using RAISE_ON_DEPRECATION in environment.js instead of
   // `throwOnUnhandled` here since it is easier to toggle.
   workflow: [
@@ -14,4 +15,4 @@ globalThis.deprecationWorkflow.config = {
       matchId: "discourse.decorate-widget.hamburger-widget-links",
     },
   ],
-};
+});

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -1,20 +1,6 @@
 import setupDeprecationWorkflow from "ember-cli-deprecation-workflow";
-
-const DEPRECATION_WORKFLOW = [
-  {
-    handler: "silence",
-    matchId: "ember-this-fallback.this-property-fallback",
-  },
-  { handler: "silence", matchId: "discourse.select-kit" },
-  { handler: "silence", matchId: "discourse.d-section" },
-  {
-    handler: "silence",
-    matchId: "discourse.decorate-widget.hamburger-widget-links",
-  },
-];
+import DEPRECATION_WORKFLOW from "discourse-common/deprecation-workflow";
 
 // We're using RAISE_ON_DEPRECATION in environment.js instead of
 // `throwOnUnhandled` here since it is easier to toggle.
 setupDeprecationWorkflow({ workflow: DEPRECATION_WORKFLOW });
-
-export default DEPRECATION_WORKFLOW;

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -1,18 +1,22 @@
 import setupDeprecationWorkflow from "ember-cli-deprecation-workflow";
 
+const DEPRECATION_WORKFLOW = [
+  {
+    handler: "silence",
+    matchId: "ember-this-fallback.this-property-fallback",
+  },
+  { handler: "silence", matchId: "discourse.select-kit" },
+  { handler: "silence", matchId: "discourse.d-section" },
+  {
+    handler: "silence",
+    matchId: "discourse.decorate-widget.hamburger-widget-links",
+  },
+];
+
 setupDeprecationWorkflow({
   // We're using RAISE_ON_DEPRECATION in environment.js instead of
   // `throwOnUnhandled` here since it is easier to toggle.
-  workflow: [
-    {
-      handler: "silence",
-      matchId: "ember-this-fallback.this-property-fallback",
-    },
-    { handler: "silence", matchId: "discourse.select-kit" },
-    { handler: "silence", matchId: "discourse.d-section" },
-    {
-      handler: "silence",
-      matchId: "discourse.decorate-widget.hamburger-widget-links",
-    },
-  ],
+  workflow: DEPRECATION_WORKFLOW,
 });
+
+export default DEPRECATION_WORKFLOW;

--- a/app/assets/javascripts/discourse/app/initializers/deprecation-error-mode.js
+++ b/app/assets/javascripts/discourse/app/initializers/deprecation-error-mode.js
@@ -2,7 +2,7 @@ export default {
   initialize() {
     const params = new URLSearchParams(window.location.search);
     if (params.get("safe_mode")?.split(",").includes("deprecation_errors")) {
-      window.deprecationWorkflow.throwOnUnhandled = true;
+      window.EmberENV.RAISE_ON_DEPRECATION = true;
       return;
     }
   },

--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -1,9 +1,9 @@
 import { registerDeprecationHandler } from "@ember/debug";
 import Service, { service } from "@ember/service";
 import { addGlobalNotice } from "discourse/components/global-notice";
-import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
 import identifySource from "discourse/lib/source-identifier";
 import { escapeExpression } from "discourse/lib/utilities";
+import DEPRECATION_WORKFLOW from "discourse-common/deprecation-workflow";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";

--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -1,6 +1,7 @@
 import { registerDeprecationHandler } from "@ember/debug";
 import Service, { service } from "@ember/service";
 import { addGlobalNotice } from "discourse/components/global-notice";
+import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
 import identifySource from "discourse/lib/source-identifier";
 import { escapeExpression } from "discourse/lib/utilities";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
@@ -49,12 +50,11 @@ export default class DeprecationWarningHandler extends Service {
 
   @bind
   handle(message, opts) {
-    const workflowConfigs = window.deprecationWorkflow?.config?.workflow;
-    const matchingConfig = workflowConfigs.find(
+    const matchingConfig = DEPRECATION_WORKFLOW.find(
       (config) => config.matchId === opts.id
     );
 
-    if (matchingConfig && matchingConfig.handler === "silence") {
+    if (matchingConfig?.handler === "silence") {
       return;
     }
 

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -88,7 +88,7 @@
     "ember-cli": "~5.10.0",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
-    "ember-cli-deprecation-workflow": "^2.2.0",
+    "ember-cli-deprecation-workflow": "^3.0.1",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-progress-ci": "1.0.0",

--- a/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
+++ b/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
@@ -1,4 +1,5 @@
 import { registerDeprecationHandler } from "@ember/debug";
+import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 import { bind } from "discourse-common/utils/decorators";
 
@@ -79,8 +80,7 @@ function reportToTestem(id) {
 }
 
 export function setupDeprecationCounter(qunit) {
-  const config = window.deprecationWorkflow?.config?.workflow || {};
-  const deprecationCounter = new DeprecationCounter(config);
+  const deprecationCounter = new DeprecationCounter(DEPRECATION_WORKFLOW);
 
   qunit.begin(() => deprecationCounter.start());
 

--- a/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
+++ b/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
@@ -1,5 +1,5 @@
 import { registerDeprecationHandler } from "@ember/debug";
-import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
+import DEPRECATION_WORKFLOW from "discourse-common/deprecation-workflow";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 import { bind } from "discourse-common/utils/decorators";
 

--- a/app/assets/javascripts/discourse/tests/helpers/raise-on-deprecation.js
+++ b/app/assets/javascripts/discourse/tests/helpers/raise-on-deprecation.js
@@ -1,6 +1,6 @@
 import { registerDeprecationHandler } from "@ember/debug";
 import QUnit from "qunit";
-import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
+import DEPRECATION_WORKFLOW from "discourse-common/deprecation-workflow";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 
 let disabled = false;

--- a/app/assets/javascripts/discourse/tests/helpers/raise-on-deprecation.js
+++ b/app/assets/javascripts/discourse/tests/helpers/raise-on-deprecation.js
@@ -1,28 +1,30 @@
 import { registerDeprecationHandler } from "@ember/debug";
 import QUnit from "qunit";
+import DEPRECATION_WORKFLOW from "discourse/deprecation-workflow";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 
 let disabled = false;
 
 export function configureRaiseOnDeprecation() {
-  const workflows = window.deprecationWorkflow?.config?.workflow;
-  if (!workflows) {
-    return;
-  }
-
   if (window.EmberENV.RAISE_ON_DEPRECATION !== undefined) {
     return;
   }
 
   registerDeprecationHandler((message, options, next) => {
-    if (disabled || workflows.find((w) => w.matchId === options.id)) {
+    if (
+      disabled ||
+      DEPRECATION_WORKFLOW.find((w) => w.matchId === options.id)
+    ) {
       return next(message, options);
     }
     raiseDeprecationError(message, options);
   });
 
   registerDiscourseDeprecationHandler((message, options) => {
-    if (disabled || workflows.find((w) => w.matchId === options?.id)) {
+    if (
+      disabled ||
+      DEPRECATION_WORKFLOW.find((w) => w.matchId === options?.id)
+    ) {
       return;
     }
     raiseDeprecationError(message, options);

--- a/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
+++ b/app/assets/javascripts/ember-production-deprecations/vendor/ember-production-deprecations/deprecate-shim.js
@@ -29,7 +29,8 @@ define("discourse/lib/deprecate-shim", ["exports"], function (exports) {
 
     require("@ember/debug").registerDeprecationHandler(
       function shimLogDeprecationToConsole(message, options) {
-        var updatedMessage = formatMessage(message, options);
+        const updatedMessage = formatMessage(message, options);
+        // eslint-disable-next-line no-console
         console.warn(`DEPRECATION: ${updatedMessage}`);
       }
     );

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -86,6 +86,7 @@ module PrettyText
     )
 
     %w[
+      discourse-common/addon/deprecation-workflow
       discourse-common/addon/lib/get-url
       discourse-common/addon/lib/object
       discourse-common/addon/lib/deprecated

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.2.tgz#e41928bd33475305c586f6acbbb7e3ade7a6f7f5"
   integrity sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==
 
-"@babel/core@^7.12.0", "@babel/core@^7.14.5", "@babel/core@^7.16.10", "@babel/core@^7.16.7", "@babel/core@^7.18.6", "@babel/core@^7.20.12", "@babel/core@^7.23.6", "@babel/core@^7.24.6", "@babel/core@^7.25.2", "@babel/core@^7.3.4":
+"@babel/core@^7.12.0", "@babel/core@^7.14.5", "@babel/core@^7.16.10", "@babel/core@^7.16.7", "@babel/core@^7.18.6", "@babel/core@^7.20.12", "@babel/core@^7.23.2", "@babel/core@^7.23.6", "@babel/core@^7.24.6", "@babel/core@^7.25.2", "@babel/core@^7.3.4":
   version "7.25.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.2.tgz#ed8eec275118d7613e77a352894cd12ded8eba77"
   integrity sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==
@@ -3923,7 +3923,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.3, broccoli-funnel@^3.0.7, broccoli-funnel@^3.0.8:
+broccoli-funnel@^3.0.7, broccoli-funnel@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
   integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==
@@ -4088,7 +4088,7 @@ broccoli-plugin@^2.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.5, broccoli-plugin@^4.0.7:
+broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
   integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
@@ -5400,15 +5400,14 @@ ember-cli-babel@^8.2.0:
     resolve-package-path "^4.0.3"
     semver "^7.3.8"
 
-ember-cli-deprecation-workflow@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.2.0.tgz#277d56bdafc15dbdb7a58dee598402cdf50e0d08"
-  integrity sha512-23bXZqZJBJSKBTfT0LK7qzSJX861TgafL6RVdMfn/iubpLnoZIWergYwEdgs24CNTUbuehVbHy2Q71o8jYfwfw==
+ember-cli-deprecation-workflow@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-3.0.1.tgz#2891ed87df1a0f076f0b6db813e2b8e0e8fc0e80"
+  integrity sha512-d5wM5IHu+HjIK2TucQWOTFD9725Dx+xBZ3oBc0ZLaB8mdTV3wrAOrQ1vyzcuZEe/uvFBhr5TIy5QP+UNJ2q8Hg==
   dependencies:
+    "@babel/core" "^7.23.2"
     "@ember/string" "^3.0.0"
-    broccoli-funnel "^3.0.3"
-    broccoli-merge-trees "^4.2.0"
-    broccoli-plugin "^4.0.5"
+    ember-cli-babel "^8.2.0"
 
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
@@ -11609,7 +11608,16 @@ string-template@~0.2.0, string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11696,7 +11704,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11716,6 +11724,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12829,7 +12844,7 @@ workerpool@^6.0.0, workerpool@^6.0.2, workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.4.1.tgz#1398eb5f8f44fb2d21ed9225cf34bb0131504c1d"
   integrity sha512-zIK7qRgM1Mk+ySxOJl7ZpjX6SlKt5gugxzl8eXHPdbpXX8iDAaVIxYJz4Apn6JdDxP2buY/Ekqg0bOLNSf0u0g==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12842,6 +12857,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
From dependabot PR:

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/ember-cli/ember-cli-deprecation-workflow/releases">ember-cli-deprecation-workflow's releases</a>.</em></p>
<blockquote>
<h2>v3.0.1-ember-cli-deprecation-workflow</h2>
<h2>Release (2024-07-11)</h2>
<p>ember-cli-deprecation-workflow 3.0.1 (patch)</p>
<h4>:house: Internal</h4>
<ul>
<li><code>ember-cli-deprecation-workflow</code>
<ul>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/192">#192</a> fix repository link in package.json (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/191">#191</a> update release plan workflow (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
</ul>
</li>
</ul>
<h4>Committers: 1</h4>
<ul>
<li>Chris Manson (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
</ul>
<h2>v3.0.0</h2>
<h2>Release (2024-06-25)</h2>
<p>ember-cli-deprecation-workflow 3.0.0 (major)</p>
<h4>:boom: Breaking Change</h4>
<ul>
<li><code>ember-cli-deprecation-workflow</code>
<ul>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/159">#159</a> [BREAKING] Convert to a module. Drops support for Ember &lt; 3.28, requires manual initialization (<a href="https://github.com/lolmaus"><code>@​lolmaus</code></a>)</li>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/175">#175</a> Node 16 is the minimum supported version (<a href="https://github.com/mixonic"><code>@​mixonic</code></a>)</li>
</ul>
</li>
</ul>
<h4>:bug: Bug Fix</h4>
<ul>
<li><code>ember-cli-deprecation-workflow</code>
<ul>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/181">#181</a> Remove unused broccoli magic (<a href="https://github.com/simonihmig"><code>@​simonihmig</code></a>)</li>
</ul>
</li>
</ul>
<h4>:memo: Documentation</h4>
<ul>
<li><code>ember-cli-deprecation-workflow</code>
<ul>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/184">#184</a> Update configuration paths in documentation (<a href="https://github.com/backspace"><code>@​backspace</code></a>)</li>
</ul>
</li>
</ul>
<h4>:house: Internal</h4>
<ul>
<li><code>ember-cli-deprecation-workflow</code>
<ul>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/189">#189</a> start using release-plan (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/188">#188</a> start using pnpm (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/178">#178</a> Upgrade Ember CLI to 5.4 (<a href="https://github.com/lolmaus"><code>@​lolmaus</code></a>)</li>
<li><a href="https://redirect.github.com/ember-cli/ember-cli-deprecation-workflow/pull/170">#170</a> Bump Node, swap to npm, update CI pipeline (<a href="https://github.com/mixonic"><code>@​mixonic</code></a>)</li>
</ul>
</li>
</ul>
<h4>Committers: 5</h4>
<ul>
<li>Andrey Mikhaylov (lolmaus) (<a href="https://github.com/lolmaus"><code>@​lolmaus</code></a>)</li>
<li>Buck Doyle (<a href="https://github.com/backspace"><code>@​backspace</code></a>)</li>
<li>Chris Manson (<a href="https://github.com/mansona"><code>@​mansona</code></a>)</li>
<li>Matthew Beale (<a href="https://github.com/mixonic"><code>@​mixonic</code></a>)</li>
<li>Simon Ihmig (<a href="https://github.com/simonihmig"><code>@​simonihmig</code></a>)</li>
</ul>
</blockquote>
</details>