### PR TITLE
DEV: Fixes for `modifyClass`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -61,7 +61,9 @@ import {
   PLUGIN_NAV_MODE_TOP,
   registerAdminPluginConfigNav,
 } from "discourse/lib/admin-plugin-config-nav";
-import classPrepend from "discourse/lib/class-prepend";
+import classPrepend, {
+  withPrependsRolledBack,
+} from "discourse/lib/class-prepend";
 import { addPopupMenuOption } from "discourse/lib/composer/custom-popup-menu-options";
 import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
 import { downloadCalendar } from "discourse/lib/download-calendar";
@@ -172,9 +174,15 @@ const DEPRECATED_HEADER_WIDGETS = [
   "user-dropdown",
 ];
 
+const appliedModificationIds = new WeakMap();
+
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
-  if (typeof changes !== "function" && !changes.pluginId) {
+  if (typeof changes === "function") {
+    return true;
+  }
+
+  if (!changes.pluginId) {
     // eslint-disable-next-line no-console
     console.warn(
       consolePrefix(),
@@ -184,10 +192,13 @@ function canModify(klass, type, resolverName, changes) {
   }
 
   let key = "_" + type + "/" + changes.pluginId + "/" + resolverName;
-  if (klass.class[key]) {
+
+  if (appliedModificationIds.get(klass.class)?.includes(key)) {
     return false;
   } else {
-    klass.class[key] = 1;
+    const modificationIds = appliedModificationIds.get(klass.class) || [];
+    modificationIds.push(key);
+    appliedModificationIds.set(klass.class, modificationIds);
     return true;
   }
 }
@@ -296,7 +307,9 @@ class PluginApi {
       if (typeof changes === "function") {
         classPrepend(klass.class, changes);
       } else if (klass.class.reopen) {
-        klass.class.reopen(changes);
+        withPrependsRolledBack(klass.class, () => {
+          klass.class.reopen(changes);
+        });
       } else {
         Object.defineProperties(
           klass.class.prototype || klass.class,
@@ -327,7 +340,9 @@ class PluginApi {
 
     if (canModify(klass, "static", resolverName, changes)) {
       delete changes.pluginId;
-      klass.class.reopenClass(changes);
+      withPrependsRolledBack(klass.class, () => {
+        klass.class.reopenClass(changes);
+      });
     }
 
     return klass;

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -32,7 +32,7 @@ import { clearHTMLCache } from "discourse/helpers/custom-html";
 import { resetUsernameDecorators } from "discourse/helpers/decorate-username-selector";
 import { resetBeforeAuthCompleteCallbacks } from "discourse/instance-initializers/auth-complete";
 import { resetAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
-import { rollbackAllModifications } from "discourse/lib/class-prepend";
+import { rollbackAllPrepends } from "discourse/lib/class-prepend";
 import { clearPopupMenuOptions } from "discourse/lib/composer/custom-popup-menu-options";
 import { clearDesktopNotificationHandlers } from "discourse/lib/desktop-notifications";
 import { cleanUpHashtagTypeClasses } from "discourse/lib/hashtag-type-registry";
@@ -248,7 +248,7 @@ export function testCleanup(container, app) {
   clearAdditionalAdminSidebarSectionLinks();
   resetAdminPluginConfigNav();
   resetTransformers();
-  rollbackAllModifications();
+  rollbackAllPrepends();
 }
 
 function cleanupCssGeneratorTags() {

--- a/app/assets/javascripts/discourse/tests/unit/lib/class-prepend-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/class-prepend-test.js
@@ -1,9 +1,7 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { module, test } from "qunit";
-import classPrepend, {
-  rollbackAllModifications,
-} from "discourse/lib/class-prepend";
+import classPrepend, { rollbackAllPrepends } from "discourse/lib/class-prepend";
 
 module("Unit | class-prepend", function () {
   test("can override function, with super support", function (assert) {
@@ -273,7 +271,7 @@ module("Unit | class-prepend", function () {
 
     assert.strictEqual(new Topic().someFunction(), 2, "change is applied");
 
-    rollbackAllModifications();
+    rollbackAllPrepends();
 
     assert.strictEqual(new Topic().someFunction(), 1, "change is rolled back");
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -2,6 +2,7 @@ import EmberObject from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import { rollbackAllPrepends } from "discourse/lib/class-prepend";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import discourseComputed from "discourse-common/utils/decorators";
 
@@ -153,15 +154,85 @@ module("Unit | Utility | plugin-api", function (hooks) {
           }
       );
 
+      api.modifyClass(
+        "test-thingy:main",
+        (Superclass) =>
+          class extends Superclass {
+            someFunction() {
+              return `${super.someFunction()} twice`;
+            }
+          }
+      );
+
       const thingyKlass =
         getOwner(this).resolveRegistration("test-thingy:main");
       const thingy = new thingyKlass();
-      assert.strictEqual(thingy.someFunction(), "original function modified");
+      assert.strictEqual(
+        thingy.someFunction(),
+        "original function modified twice"
+      );
       assert.strictEqual(thingy.someGetter, "original getter modified");
       assert.strictEqual(
         TestThingy.someStaticMethod(),
         "original static method modified"
       );
     });
+  });
+
+  test("modifyClass works with a combination of callback and legacy syntax", function (assert) {
+    class TestThingy extends EmberObject {
+      someMethod() {
+        return "original";
+      }
+    }
+
+    getOwner(this).register("test-thingy:main", TestThingy);
+
+    const fakeInit = () => {
+      withPluginApi("1.1.0", (api) => {
+        api.modifyClass("test-thingy:main", {
+          someMethod() {
+            return `${this._super()} reopened`;
+          },
+          pluginId: "one",
+        });
+
+        api.modifyClass(
+          "test-thingy:main",
+          (Superclass) =>
+            class extends Superclass {
+              someMethod() {
+                return `${super.someMethod()}, prepended`;
+              }
+            }
+        );
+
+        api.modifyClass("test-thingy:main", {
+          someMethod() {
+            return `${this._super()}, reopened2`;
+          },
+          pluginId: "two",
+        });
+      });
+    };
+
+    fakeInit();
+
+    assert.strictEqual(
+      new TestThingy().someMethod(),
+      "original reopened, reopened2, prepended",
+      "it works after first application"
+    );
+
+    for (let i = 0; i < 3; i++) {
+      rollbackAllPrepends();
+      fakeInit();
+    }
+
+    assert.strictEqual(
+      new TestThingy().someMethod(),
+      "original reopened, reopened2, prepended",
+      "it works when rolled back and re-applied multiple times"
+    );
   });
 });


### PR DESCRIPTION
This resolves issues when a mix of callback-based modifications and Ember-reopen-based modifications are used on the same target. In summary:

- Fixes `pluginId` exception logic for callback-based modifications

- Moves `pluginId` storage to a WeakMap so it doesn't pollute the target's descriptors

- When applying a legacy modifyClass, we will temporarily rollback any modern callback-based modifications. This means all of Ember's reopen calls apply to un-prepended classes, and then we add our modern prepends on top.

- Calls `.proto()` on CoreObject descendants before prepending, to ensure that pending Ember mixins have been applied