### PR TITLE
FIX: backup_restore.rb wants db user from user, not username

### DIFF
--- a/lib/backup_restore.rb
+++ b/lib/backup_restore.rb
@@ -135,7 +135,7 @@ module BackupRestore
     DatabaseConfiguration.new(
       config["backup_host"] || config["host"],
       config["backup_port"] || config["port"],
-      config["username"] || username || ENV["USER"] || "postgres",
+      config["user"] || username || ENV["USER"] || "postgres",
       config["password"] || password,
       config["database"],
     )


### PR DESCRIPTION
ActiveRecord::Base.connection_pool.db_config.configuration_hash has the username in `user`, not `username`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
