### PR TITLE
FIX: ensures tags/categories are present

### DIFF
--- a/plugins/automation/lib/discourse_automation/stalled_topic_finder.rb
+++ b/plugins/automation/lib/discourse_automation/stalled_topic_finder.rb
@@ -7,7 +7,7 @@ class DiscourseAutomation::StalledTopicFinder
       FROM topics t
     SQL
 
-    sql += <<~SQL if tags
+    sql += <<~SQL if tags.present?
         JOIN topic_tags ON topic_tags.topic_id = t.id
         JOIN tags
           ON tags.name IN (:tags)
@@ -31,7 +31,7 @@ class DiscourseAutomation::StalledTopicFinder
       )
     SQL
 
-    sql += <<~SQL if categories
+    sql += <<~SQL if categories.present?
         AND t.category_id IN (:categories)
       SQL
 

--- a/plugins/automation/spec/lib/discourse_automation/stalled_topic_finder_spec.rb
+++ b/plugins/automation/spec/lib/discourse_automation/stalled_topic_finder_spec.rb
@@ -56,6 +56,14 @@ describe DiscourseAutomation::StalledTopicFinder do
         described_class.call(2.hours.from_now, tags: [tag_1.name]).map(&:id),
       ).to contain_exactly(topic_1.id)
     end
+
+    it "still finds topics if tags is empty" do
+      create_post(topic: topic_4, user: user)
+
+      expect(described_class.call(2.hours.from_now, tags: []).map(&:id)).to contain_exactly(
+        topic_4.id,
+      )
+    end
   end
 
   describe "filter by categories" do
@@ -79,6 +87,14 @@ describe DiscourseAutomation::StalledTopicFinder do
       expect(
         described_class.call(2.hours.from_now, categories: [category_1.id]).map(&:id),
       ).to contain_exactly(topic_1.id)
+    end
+
+    it "still finds topics if categories is empty" do
+      create_post(topic: topic_1, user: user)
+
+      expect(described_class.call(2.hours.from_now, categories: []).map(&:id)).to contain_exactly(
+        topic_1.id,
+      )
     end
   end
 


### PR DESCRIPTION
Prior to this fix the query in stalled_topic_finder would assume that tags/categories would be nil or an array of ids. However it can be an empty array, in this case the query will not return results.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
