### PR TITLE
Revert "FIX: backup_restore.rb wants db user from user, not username …

### DIFF
--- a/lib/backup_restore.rb
+++ b/lib/backup_restore.rb
@@ -135,7 +135,7 @@ module BackupRestore
     DatabaseConfiguration.new(
       config["backup_host"] || config["host"],
       config["backup_port"] || config["port"],
-      config["user"] || username || ENV["USER"] || "postgres",
+      config["username"] || username || ENV["USER"] || "postgres",
       config["password"] || password,
       config["database"],
     )


### PR DESCRIPTION
…(#28229)"

This reverts commit 2e8273dcb47dbe8e66a9e1d24cfb52cdc963b155. We're seeing this cause issues in production multisite environments. Reverting while we investigate

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
