### PR TITLE
UX: link edit text to search in badges form

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -29,9 +29,8 @@
         {{this.model.name}}
       </span>
       <LinkTo
-        @route="adminSiteText.edit"
-        @models={{array (concat this.textCustomizationPrefix "name")}}
-        @query={{hash locale="en"}}
+        @route="adminSiteText"
+        @query={{hash q=(concat this.textCustomizationPrefix "name")}}
       >
         {{d-icon "pencil-alt"}}
       </LinkTo>
@@ -113,9 +112,8 @@
           {{this.model.description}}
         </span>
         <LinkTo
-          @route="adminSiteText.edit"
-          @models={{array (concat this.textCustomizationPrefix "description")}}
-          @query={{hash locale="en"}}
+          @route="adminSiteText"
+          @query={{hash q=(concat this.textCustomizationPrefix "description")}}
         >
           {{d-icon "pencil-alt"}}
         </LinkTo>
@@ -141,11 +139,10 @@
         </span>
 
         <LinkTo
-          @route="adminSiteText.edit"
-          @models={{array
-            (concat this.textCustomizationPrefix "long_description")
+          @route="adminSiteText"
+          @query={{hash
+            q=(concat this.textCustomizationPrefix "long_description")
           }}
-          @query={{hash locale="en"}}
         >
           {{d-icon "pencil-alt"}}
         </LinkTo>


### PR DESCRIPTION
During our refactoring of admin badges we decided to link to:

`adminSiteText.edit locale=locale`

Instead of:

`adminSiteText q=key`

After feedback from the community we are reverting this change.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
