### PR TITLE
FIX: Return additional message types properly

### DIFF
--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -110,7 +110,7 @@ class PostActionType < ActiveRecord::Base
     end
 
     def additional_message_types
-      return flag_settings.with_additional_message if overridden_by_plugin_or_skipped_db?
+      return flag_settings.additional_message_types if overridden_by_plugin_or_skipped_db?
       flag_enum(all_flags.select(&:require_message))
     end
 

--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -28,4 +28,30 @@ RSpec.describe PostActionType do
       end
     end
   end
+
+  describe ".additional_message_types" do
+    before { described_class.stubs(:overridden_by_plugin_or_skipped_db?).returns(overriden) }
+
+    context "when overridden by plugin or skipped DB" do
+      let(:overriden) { true }
+
+      it "returns additional types from flag settings" do
+        expect(described_class.additional_message_types).to eq(
+          described_class.flag_settings.additional_message_types,
+        )
+      end
+    end
+
+    context "when not overriden by plugin or skipped DB" do
+      let(:overriden) { false }
+
+      it "returns all flags" do
+        expect(described_class.additional_message_types).to eq(
+          illegal: 10,
+          notify_moderators: 7,
+          notify_user: 6,
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Following a recent refactor, some methods from `FlagSettings` have been renamed (`custom_types` -> `additional_message_types`). The `PostActionType` model was using `custom_types` but when the renaming was done, it was renamed to `with_additional_message` instead of `additional_message_types`, which under the right circumstances will raise an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
