### PR TITLE
UX: break long words to prevent overflow in activity stream

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -35,6 +35,10 @@
     flex-grow: 1;
   }
 
+  .stream-topic-title {
+    overflow-wrap: anywhere;
+  }
+
   .user-stream-item__metadata {
     align-items: end;
     display: flex;


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/f0146581-8568-40bd-97fd-d9d4c2ac49ef)


after 
![image](https://github.com/user-attachments/assets/17ecb734-cb97-4c9e-bfe2-309333af6524)
