### PR TITLE
UX: remove extra margin from flag description links

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -380,6 +380,9 @@
     width: 100%;
     // max-width: 500px;
     line-height: var(--line-height-large);
+    a {
+      margin: 0;
+    }
   }
   .flag-confirmation {
     margin-top: 0.5em;


### PR DESCRIPTION
Before (extra margin before "our community guidelines"): 

![image](https://github.com/user-attachments/assets/7713144e-17aa-4fc7-8534-4a67fe15c102)



After:

![image](https://github.com/user-attachments/assets/34daf18b-33fd-4354-aaf8-c15a20380923)
