### PR TITLE
FIX: Ensure do-not-disturb icon updates correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -52,7 +52,8 @@ export default {
 
     this.messageBus.subscribe(
       `/do-not-disturb/${this.currentUser.id}`,
-      this.onDoNotDisturb
+      this.onDoNotDisturb,
+      this.currentUser.do_not_disturb_channel_position
     );
 
     this.messageBus.subscribe(

--- a/app/assets/javascripts/discourse/app/services/notifications.js
+++ b/app/assets/javascripts/discourse/app/services/notifications.js
@@ -20,7 +20,8 @@ export default class NotificationsService extends Service {
     clearTimeout(this.#dndTimer);
 
     if (this.currentUser?.do_not_disturb_until) {
-      const remainingMs = this.currentUser.do_not_disturb_until - Date.now();
+      const remainingMs =
+        new Date(this.currentUser.do_not_disturb_until) - Date.now();
 
       if (remainingMs <= 0) {
         this.isInDoNotDisturb = false;

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -12,6 +12,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :read_first_notification?,
              :admin?,
              :notification_channel_position,
+             :do_not_disturb_channel_position,
              :moderator?,
              :staff?,
              :whisperer?,
@@ -319,5 +320,9 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def use_glimmer_topic_list?
     scope.user.in_any_groups?(SiteSetting.experimental_glimmer_topic_list_groups_map)
+  end
+
+  def do_not_disturb_channel_position
+    MessageBus.last_id("/do-not-disturb/#{object.id}")
   end
 end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -300,5 +300,20 @@ RSpec.describe "Glimmer Header", type: :system do
       expect(page).not_to have_css("header.d-header .auth-buttons .login-button") # No header buttons
       expect(page).to have_css("header.d-header .title-wrapper .topic-link") # Title is shown in header
     end
+
+    it "shows and hides do-not-disturb icon" do
+      sign_in current_user
+      visit "/"
+
+      header = find(".d-header")
+      expect(header).not_to have_css(".do-not-disturb-background")
+
+      current_user.publish_do_not_disturb(ends_at: 1.hour.from_now)
+      expect(header).to have_css(".d-header .do-not-disturb-background")
+
+      current_user.publish_do_not_disturb(ends_at: 1.second.from_now)
+
+      expect(header).not_to have_css(".d-header .do-not-disturb-background")
+    end
   end
 end


### PR DESCRIPTION
`currentUser.do_not_disturb_until` is a string, so we need to parse it before comparing to the current timestamp

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
