### PR TITLE
DEV: Add `addLogSearchLinkClickedCallbacks` to plugin API

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.35.0";
+export const PLUGIN_API_VERSION = "1.36.0";
 
 import $ from "jquery";
 import { h } from "virtual-dom";
@@ -83,7 +83,10 @@ import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer
 import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { addTagsHtmlCallback } from "discourse/lib/render-tags";
 import { addFeaturedLinkMetaDecorator } from "discourse/lib/render-topic-featured-link";
-import { addSearchResultsCallback } from "discourse/lib/search";
+import {
+  addLogSearchLinkClickedCallbacks,
+  addSearchResultsCallback,
+} from "discourse/lib/search";
 import Sharing from "discourse/lib/sharing";
 import { addAdminSidebarSectionLink } from "discourse/lib/sidebar/admin-sidebar";
 import { addSectionLink as addCustomCommunitySectionLink } from "discourse/lib/sidebar/custom-community-section-links";
@@ -2311,6 +2314,22 @@ class PluginApi {
    */
   addSearchResultsCallback(callback) {
     addSearchResultsCallback(callback);
+  }
+
+  /**
+   * Add a callback to search before logging the search record. Return false to prevent logging.
+   *
+   * ```
+   * api.addLogSearchLinkClickedCallbacks((params) => {
+   *  if (params.searchResultId === "foo") {
+   *   return false;
+   *  }
+   * });
+   * ```
+   *
+   */
+  addLogSearchLinkClickedCallbacks(callback) {
+    addLogSearchLinkClickedCallbacks(callback);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -20,6 +20,15 @@ import I18n from "discourse-i18n";
 const translateResultsCallbacks = [];
 const MAX_RECENT_SEARCHES = 5; // should match backend constant with the same name
 
+const logSearchLinkClickedCallbacks = [];
+
+export function addLogSearchLinkClickedCallbacks(fn) {
+  logSearchLinkClickedCallbacks.push(fn);
+}
+export function resetLogSearchLinkClickedCallbacks() {
+  logSearchLinkClickedCallbacks.clear();
+}
+
 export function addSearchResultsCallback(callback) {
   translateResultsCallbacks.push(callback);
 }
@@ -259,6 +268,14 @@ export function updateRecentSearches(currentUser, term) {
 }
 
 export function logSearchLinkClick(params) {
+  if (
+    logSearchLinkClickedCallbacks.length &&
+    !logSearchLinkClickedCallbacks.some((fn) => fn(params))
+  ) {
+    // Return early if any callbacks return false
+    return;
+  }
+
   ajax("/search/click", {
     type: "POST",
     data: {

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -53,6 +53,7 @@ import PreloadStore from "discourse/lib/preload-store";
 import { clearTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
 import { clearTopicFooterDropdowns } from "discourse/lib/register-topic-footer-dropdown";
 import { clearTagsHtmlCallbacks } from "discourse/lib/render-tags";
+import { resetLogSearchLinkClickedCallbacks } from "discourse/lib/search";
 import { clearAdditionalAdminSidebarSectionLinks } from "discourse/lib/sidebar/admin-sidebar";
 import { resetDefaultSectionLinks as resetTopicsSectionLinks } from "discourse/lib/sidebar/custom-community-section-links";
 import { resetSidebarPanels } from "discourse/lib/sidebar/custom-sections";
@@ -236,6 +237,7 @@ export function testCleanup(container, app) {
   clearExtraHeaderIcons();
   clearExtraHeaderButtons();
   resetOnKeyUpCallbacks();
+  resetLogSearchLinkClickedCallbacks();
   resetItemSelectCallbacks();
   resetUserMenuTabs();
   resetLinkLookup();

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,10 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.36.0] - 2024-08-06
+
+- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked and before a search log is created 
+
 ## [1.35.0] - 2024-07-30
 
 - Added `registerBehaviorTransformer` which allows registering a transformer callback to override behavior defined in Discourse modules


### PR DESCRIPTION
- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked and before a search log is created