### PR TITLE
UX: fix issue with long usernames wrapping in mobile user cards

### DIFF
--- a/app/assets/stylesheets/mobile/components/user-card.scss
+++ b/app/assets/stylesheets/mobile/components/user-card.scss
@@ -13,7 +13,7 @@
   .first-row {
     flex-wrap: wrap;
     .names {
-      flex: 1 1 auto;
+      flex: 1 1 0;
       box-sizing: border-box;
     }
     .user-card-avatar {


### PR DESCRIPTION
This fixes an issue where long usernames would wrap under the avatar for mobile user cards.

Before:
![image](https://github.com/user-attachments/assets/ab16eccc-ac59-4e4d-8727-479a935b4ef7)


After:
![image](https://github.com/user-attachments/assets/4b807944-90e8-4ce6-8962-c174130e31d0)

– Awesomerob