### PR TITLE
FEATURE: Add `live_slots_(start|finish)` for Sidekiq perf logging

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -69,6 +69,7 @@ module Jobs
 
           MethodProfiler.ensure_discourse_instrumentation!
           MethodProfiler.start
+          @data["live_slots_start"] = GC.stat[:heap_live_slots]
         end
       end
 
@@ -86,6 +87,7 @@ module Jobs
           @data["redis_calls"] = profile.dig(:redis, :calls) || 0 # Redis commands
           @data["net_duration"] = profile.dig(:net, :duration) || 0 # Redis Duration (s)
           @data["net_calls"] = profile.dig(:net, :calls) || 0 # Redis commands
+          @data["live_slots_finish"] = GC.stat[:heap_live_slots]
 
           if exception.present?
             @data["exception"] = exception # Exception - if job fails a json encoded exception


### PR DESCRIPTION
This information is helpful in debugging memory spikes when Sidekiq
processes jobs.

### Reviewer notes

We have 0 test coverage here and I'm just adding two simple and new fields. Shall not invest my time into figuring how to test this.

To test this locally:

1. Run `tail -f log/sidekiq.log`
1. Run `UNICORN_SIDEKIQS=1 DISCOURSE_LOG_SIDEKIQ=1 bin/rails s`
1. Check that `live_slots_start` and `live_slots_finish` fields are present.