### PR TITLE
FIX: Unescape URI properly when redirecting to a category

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -421,7 +421,7 @@ class ListController < ApplicationController
     end
     real_slug = @category.full_slug("/")
     if CGI.unescape(current_slug) != CGI.unescape(real_slug)
-      url = request.fullpath.gsub(current_slug, real_slug)
+      url = CGI.unescape(request.fullpath).gsub(current_slug, real_slug)
       if ActionController::Base.config.relative_url_root
         url = url.sub(ActionController::Base.config.relative_url_root, "")
       end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1239,6 +1239,14 @@ RSpec.describe ListController do
         expect(response).to have_http_status :not_found
       end
     end
+
+    context "when provided slug is gibberish" do
+      it "redirects to the proper category" do
+        get "/c/summit'%22()&%25%3Czzz%3E%3CScRiPt%20%3EqlJ2(9585)%3C%2FScRiPt%3E/#{category.id}"
+        expect(response).to have_http_status :moved_permanently
+        expect(response).to redirect_to("/c/#{category.slug}/#{category.id}")
+      end
+    end
   end
 
   describe "shared drafts" do


### PR DESCRIPTION
Currently, when a badly named category slug is provided, it can lead to an infinite redirect.

This patch addresses the issue by properly unescaping `request.fullpath` so the path is successfully rewritten and the redirect happens as expected.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
