### PR TITLE
FIX: Don’t log an error when rendering a 404

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -50,7 +50,7 @@ class ListController < ApplicationController
                 ].flatten
 
   rescue_from ActionController::Redirecting::UnsafeRedirectError do
-    raise Discourse::NotFound
+    rescue_discourse_actions(:not_found, 404)
   end
 
   # Create our filters

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1227,16 +1227,26 @@ RSpec.describe ListController do
     end
 
     context "when redirect raises an unsafe redirect error" do
+      let(:fake_logger) { FakeLogger.new }
+
       before do
         ListController
           .any_instance
           .stubs(:redirect_to)
           .raises(ActionController::Redirecting::UnsafeRedirectError)
+        Rails.logger.broadcast_to(fake_logger)
       end
+
+      after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
       it "renders a 404" do
         get "/c/hello/world/bye/#{subsubcategory.id}"
         expect(response).to have_http_status :not_found
+      end
+
+      it "doesn’t log an error" do
+        get "/c/hello/world/bye/#{subsubcategory.id}"
+        expect(fake_logger.fatals).to be_empty
       end
     end
 


### PR DESCRIPTION
Currently, in the list controller, when encountering an unsafe redirect error, a 404 is rendered. The problem is that it’s done in a way that it also logs a fatal error (because a `Discourse::NotFound` exception was raised inside a `rescue_from` block).

This PR addresses that issue by simply rendering a 404 without raising any error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
