### PR TITLE
UX: Do not delete narrative bot PM when skipping user tips

### DIFF
--- a/plugins/discourse-narrative-bot/spec/system/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/system/user_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe "Narrative Bot PM", type: :system do
+  fab!(:admin)
+  fab!(:user)
+  fab!(:topics) { Fabricate.times(2, :post).map(&:topic) }
+  fab!(:posts) { Fabricate.times(3, :post, topic: topics[0]) }
+
+  context "when user tips are enabled" do
+    before do
+      Jobs.run_immediately!
+      SiteSetting.enable_user_tips = true
+      SiteSetting.discourse_narrative_bot_enabled = true
+      # shortcut to generate welcome post since we're not going through user creation or first login
+      user.enqueue_bot_welcome_post
+    end
+
+    it "does not delete the narrative bot PM when skipping all tips" do
+      sign_in user
+      visit "/"
+
+      find(".fk-d-tooltip__content .user-tip__buttons .btn", text: "Skip tips").click
+      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+
+      expect(page).to have_css(".badge-notification.new-pms")
+
+      find("#toggle-current-user").click
+
+      expect(page).to have_css(".notification.unread.private-message", text: "Greetings!")
+    end
+  end
+end

--- a/plugins/discourse-narrative-bot/spec/system/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/system/user_spec.rb
@@ -19,13 +19,13 @@ describe "Narrative Bot PM", type: :system do
       sign_in user
       visit "/"
 
-      find(".fk-d-tooltip__content .user-tip__buttons .btn", text: "Skip tips").click
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+      tooltip = PageObjects::Components::Tooltips.new("user-tip")
+      tooltip.find(".btn", text: "Skip tips").click
 
+      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
       expect(page).to have_css(".badge-notification.new-pms")
 
       find("#toggle-current-user").click
-
       expect(page).to have_css(".notification.unread.private-message", text: "Greetings!")
     end
   end

--- a/plugins/discourse-narrative-bot/spec/system/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/system/user_spec.rb
@@ -22,7 +22,7 @@ describe "Narrative Bot PM", type: :system do
       tooltip = PageObjects::Components::Tooltips.new("user-tip")
       tooltip.find(".btn", text: "Skip tips").click
 
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+      expect(tooltip).to be_not_present
       expect(page).to have_css(".badge-notification.new-pms")
 
       find("#toggle-current-user").click

--- a/plugins/discourse-narrative-bot/spec/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/user_spec.rb
@@ -111,16 +111,6 @@ RSpec.describe User do
         SiteSetting.default_other_skip_new_user_tips = true
         expect { user }.to_not change { Post.count }
       end
-
-      it "should delete the existing PM" do
-        user.user_option.skip_new_user_tips = true
-
-        expect { user.user_option.save! }.to change { Topic.count }.by(-1).and not_change {
-                UserHistory.count
-              }.and change { user.unread_high_priority_notifications }.by(-1).and change {
-                            user.notifications.count
-                          }.by(-1)
-      end
     end
 
     context "when user is anonymous?" do


### PR DESCRIPTION
Should fix https://meta.discourse.org/t/skip-tips-option-in-user-tip-should-not-delete-welcome-message/303420

