### PR TITLE
FIX: flaky flags specs when moving up or down

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
@@ -74,18 +74,18 @@ export default class AdminFlagItem extends Component {
   @action
   moveUp() {
     this.isSaving = true;
-    this.dMenu.close();
     this.args.moveFlagCallback(this.args.flag, "up").finally(() => {
       this.isSaving = false;
+      this.dMenu.close();
     });
   }
 
   @action
   moveDown() {
     this.isSaving = true;
-    this.dMenu.close();
     this.args.moveFlagCallback(this.args.flag, "down").finally(() => {
       this.isSaving = false;
+      this.dMenu.close();
     });
   }
   @action

--- a/spec/system/page_objects/pages/admin_flags.rb
+++ b/spec/system/page_objects/pages/admin_flags.rb
@@ -68,17 +68,21 @@ module PageObjects
         has_no_css?(".admin-flag-item.#{key}.saving")
       end
 
+      def has_closed_flag_menu?
+        has_no_css?(".flag-menu-content")
+      end
+
       def move_down(key)
         open_flag_menu(key)
         find(".admin-flag-item__move-down").click
-        has_saved_flag?(key)
+        has_closed_flag_menu?
         self
       end
 
       def move_up(key)
         open_flag_menu(key)
         find(".admin-flag-item__move-up").click
-        has_saved_flag?(key)
+        has_closed_flag_menu?
         self
       end
 


### PR DESCRIPTION
Those are the steps to move the flag:
1. open menu;
2. click move up - `saving` CSS class is added;
3. request to backend;
4. `saving` CSS class is removed.

To check if the action was finished we are using this method:
```ruby
def move_up(key)
  open_flag_menu(key)
  find(".admin-flag-item__move-up").click
  has_saved_flag?(key)
  self
end

def has_saved_flag?(key)
  has_css?(".admin-flag-item.#{key}.saving")
  has_no_css?(".admin-flag-item.#{key}.saving")
end
```

However, sometimes specs were failing with `expected to find CSS ".admin-flag-item.spam.saving" but there were no matches`

I think that the problem is with those 2 lines:
```ruby
  find(".admin-flag-item__move-up").click
  has_closed_flag_menu?
```
If the save action is very fast, then the `saving` class is removed before the first check.

Therefore, to determine that the move action is finished, I am checking if the menu is closed.

