### PR TITLE
DEV: Add admins and moderators sections to the redesigned /about page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page-user.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page-user.gjs
@@ -1,69 +1,55 @@
 import Component from "@glimmer/component";
-import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
-import { renderAvatar } from "discourse/helpers/user-avatar";
+import { or } from "truth-helpers";
+import avatar from "discourse/helpers/avatar";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { userPath } from "discourse/lib/url";
 import i18n from "discourse-common/helpers/i18n";
 
 export default class AboutPageUser extends Component {
-  @service siteSettings;
-
-  get template() {
-    const user = this.args.user;
-    return {
-      name: user.name,
-      username: user.username,
-      userPath: userPath(user.username),
-      avatar: renderAvatar(user, {
-        imageSize: "large",
-        siteSettings: this.siteSettings,
-      }),
-      title: user.title || "",
-      prioritizeName: prioritizeNameInUx(user.name),
-    };
+  get prioritizeName() {
+    return prioritizeNameInUx(this.args.user.name);
   }
 
   <template>
-    <div data-username={{this.template.username}} class="user-info small">
+    <div data-username={{@user.username}} class="user-info small">
       <div class="user-image">
         <div class="user-image-inner">
           <a
-            href={{this.template.userPath}}
-            data-user-card={{this.template.username}}
+            href={{userPath @user.username}}
+            data-user-card={{@user.username}}
             aria-hidden="true"
           >
-            {{htmlSafe this.template.avatar}}
+            {{avatar @user imageSize="large"}}
           </a>
         </div>
       </div>
       <div class="user-detail">
         <div class="name-line">
           <a
-            href={{this.template.userPath}}
-            data-user-card={{this.template.username}}
+            href={{userPath @user.username}}
+            data-user-card={{@user.username}}
             aria-label={{i18n
               "user.profile_possessive"
-              username=this.template.username
+              username=@user.username
             }}
           >
             <span class="username">
-              {{#if this.template.prioritizeName}}
-                {{this.template.name}}
+              {{#if this.prioritizeName}}
+                {{@user.name}}
               {{else}}
-                {{this.template.username}}
+                {{@user.username}}
               {{/if}}
             </span>
             <span class="name">
-              {{#if this.template.prioritizeName}}
-                {{this.template.username}}
+              {{#if this.prioritizeName}}
+                {{@user.username}}
               {{else}}
-                {{this.template.name}}
+                {{@user.name}}
               {{/if}}
             </span>
           </a>
         </div>
-        <div class="title">{{this.template.title}}</div>
+        <div class="title">{{or @user.title ""}}</div>
       </div>
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/components/about-page-user.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page-user.gjs
@@ -1,0 +1,70 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
+import { renderAvatar } from "discourse/helpers/user-avatar";
+import { prioritizeNameInUx } from "discourse/lib/settings";
+import { userPath } from "discourse/lib/url";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class AboutPageUser extends Component {
+  @service siteSettings;
+
+  get template() {
+    const user = this.args.user;
+    return {
+      name: user.name,
+      username: user.username,
+      userPath: userPath(user.username),
+      avatar: renderAvatar(user, {
+        imageSize: "large",
+        siteSettings: this.siteSettings,
+      }),
+      title: user.title || "",
+      prioritizeName: prioritizeNameInUx(user.name),
+    };
+  }
+
+  <template>
+    <div data-username={{this.template.username}} class="user-info small">
+      <div class="user-image">
+        <div class="user-image-inner">
+          <a
+            href={{this.template.userPath}}
+            data-user-card={{this.template.username}}
+            aria-hidden="true"
+          >
+            {{htmlSafe this.template.avatar}}
+          </a>
+        </div>
+      </div>
+      <div class="user-detail">
+        <div class="name-line">
+          <a
+            href={{this.template.userPath}}
+            data-user-card={{this.template.username}}
+            aria-label={{i18n
+              "user.profile_possessive"
+              username=this.template.username
+            }}
+          >
+            <span class="username">
+              {{#if this.template.prioritizeName}}
+                {{this.template.name}}
+              {{else}}
+                {{this.template.username}}
+              {{/if}}
+            </span>
+            <span class="name">
+              {{#if this.template.prioritizeName}}
+                {{this.template.username}}
+              {{else}}
+                {{this.template.name}}
+              {{/if}}
+            </span>
+          </a>
+        </div>
+        <div class="title">{{this.template.title}}</div>
+      </div>
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/about-page-user.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page-user.gjs
@@ -1,56 +1,47 @@
-import Component from "@glimmer/component";
-import { or } from "truth-helpers";
 import avatar from "discourse/helpers/avatar";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { userPath } from "discourse/lib/url";
 import i18n from "discourse-common/helpers/i18n";
 
-export default class AboutPageUser extends Component {
-  get prioritizeName() {
-    return prioritizeNameInUx(this.args.user.name);
-  }
-
-  <template>
-    <div data-username={{@user.username}} class="user-info small">
-      <div class="user-image">
-        <div class="user-image-inner">
-          <a
-            href={{userPath @user.username}}
-            data-user-card={{@user.username}}
-            aria-hidden="true"
-          >
-            {{avatar @user imageSize="large"}}
-          </a>
-        </div>
-      </div>
-      <div class="user-detail">
-        <div class="name-line">
-          <a
-            href={{userPath @user.username}}
-            data-user-card={{@user.username}}
-            aria-label={{i18n
-              "user.profile_possessive"
-              username=@user.username
-            }}
-          >
-            <span class="username">
-              {{#if this.prioritizeName}}
-                {{@user.name}}
-              {{else}}
-                {{@user.username}}
-              {{/if}}
-            </span>
-            <span class="name">
-              {{#if this.prioritizeName}}
-                {{@user.username}}
-              {{else}}
-                {{@user.name}}
-              {{/if}}
-            </span>
-          </a>
-        </div>
-        <div class="title">{{or @user.title ""}}</div>
+const AboutPageUser = <template>
+  <div data-username={{@user.username}} class="user-info small">
+    <div class="user-image">
+      <div class="user-image-inner">
+        <a
+          href={{userPath @user.username}}
+          data-user-card={{@user.username}}
+          aria-hidden="true"
+        >
+          {{avatar @user imageSize="large"}}
+        </a>
       </div>
     </div>
-  </template>
-}
+    <div class="user-detail">
+      <div class="name-line">
+        <a
+          href={{userPath @user.username}}
+          data-user-card={{@user.username}}
+          aria-label={{i18n "user.profile_possessive" username=@user.username}}
+        >
+          <span class="username">
+            {{#if (prioritizeNameInUx @user.name)}}
+              {{@user.name}}
+            {{else}}
+              {{@user.username}}
+            {{/if}}
+          </span>
+          <span class="name">
+            {{#if (prioritizeNameInUx @user.name)}}
+              {{@user.username}}
+            {{else}}
+              {{@user.name}}
+            {{/if}}
+          </span>
+        </a>
+      </div>
+      <div class="title">{{@user.title}}</div>
+    </div>
+  </div>
+</template>;
+
+export default AboutPageUser;

--- a/app/assets/javascripts/discourse/app/components/about-page-users.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page-users.gjs
@@ -1,71 +1,49 @@
 import Component from "@glimmer/component";
-import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
-import { renderAvatar } from "discourse/helpers/user-avatar";
-import { prioritizeNameInUx } from "discourse/lib/settings";
-import { userPath } from "discourse/lib/url";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import AboutPageUser from "discourse/components/about-page-user";
+import DButton from "discourse/components/d-button";
 import i18n from "discourse-common/helpers/i18n";
 
 export default class AboutPageUsers extends Component {
-  @service siteSettings;
+  @tracked expanded = false;
 
-  get usersTemplates() {
-    return (this.args.users || []).map((user) => ({
-      name: user.name,
-      username: user.username,
-      userPath: userPath(user.username),
-      avatar: renderAvatar(user, {
-        imageSize: "large",
-        siteSettings: this.siteSettings,
-      }),
-      title: user.title || "",
-      prioritizeName: prioritizeNameInUx(user.name),
-    }));
+  get users() {
+    let users = this.args.users;
+    if (this.showViewMoreButton && !this.expanded) {
+      users = users.slice(0, this.args.truncateAt);
+    }
+    return users;
+  }
+
+  get showViewMoreButton() {
+    return (
+      this.args.truncateAt > 0 && this.args.users.length > this.args.truncateAt
+    );
+  }
+
+  @action
+  toggleExpanded() {
+    this.expanded = !this.expanded;
   }
 
   <template>
-    {{#each this.usersTemplates as |template|}}
-      <div data-username={{template.username}} class="user-info small">
-        <div class="user-image">
-          <div class="user-image-inner">
-            <a
-              href={{template.userPath}}
-              data-user-card={{template.username}}
-              aria-hidden="true"
-            >
-              {{htmlSafe template.avatar}}
-            </a>
-          </div>
-        </div>
-        <div class="user-detail">
-          <div class="name-line">
-            <a
-              href={{template.userPath}}
-              data-user-card={{template.username}}
-              aria-label={{i18n
-                "user.profile_possessive"
-                username=template.username
-              }}
-            >
-              <span class="username">
-                {{#if template.prioritizeName}}
-                  {{template.name}}
-                {{else}}
-                  {{template.username}}
-                {{/if}}
-              </span>
-              <span class="name">
-                {{#if template.prioritizeName}}
-                  {{template.username}}
-                {{else}}
-                  {{template.name}}
-                {{/if}}
-              </span>
-            </a>
-          </div>
-          <div class="title">{{template.title}}</div>
-        </div>
-      </div>
-    {{/each}}
+    <div class="about-page-users-list">
+      {{#each this.users as |user|}}
+        <AboutPageUser @user={{user}} />
+      {{/each}}
+    </div>
+    {{#if this.showViewMoreButton}}
+      <DButton
+        class="btn-flat about-page-users-list__expand-button"
+        @action={{this.toggleExpanded}}
+        @icon={{if this.expanded "chevron-up" "chevron-down"}}
+        @translatedLabel={{if
+          this.expanded
+          (i18n "about.view_less")
+          (i18n "about.view_more")
+        }}
+      />
+    {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
+import AboutPageUsers from "discourse/components/about-page-users";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { number } from "discourse/lib/formatter";
 import dIcon from "discourse-common/helpers/d-icon";
@@ -161,6 +162,20 @@ export default class AboutPage extends Component {
         </div>
         <h3>{{i18n "about.simple_title"}}</h3>
         <div>{{htmlSafe @model.extended_site_description}}</div>
+
+        {{#if @model.admins.length}}
+          <section class="about__admins">
+            <h3>{{dIcon "users"}} {{i18n "about.our_admins"}}</h3>
+            <AboutPageUsers @users={{@model.admins}} @truncateAt={{10}} />
+          </section>
+        {{/if}}
+
+        {{#if @model.moderators.length}}
+          <section class="about__moderators">
+            <h3>{{dIcon "users"}} {{i18n "about.our_moderators"}}</h3>
+            <AboutPageUsers @users={{@model.moderators}} @truncateAt={{10}} />
+          </section>
+        {{/if}}
       </section>
       <section class="about__right-side">
         <h3>{{i18n "about.contact"}}</h3>

--- a/app/assets/javascripts/discourse/app/components/legacy-about-page-users.gjs
+++ b/app/assets/javascripts/discourse/app/components/legacy-about-page-users.gjs
@@ -1,0 +1,14 @@
+import Component from "@glimmer/component";
+import AboutPageUser from "discourse/components/about-page-user";
+
+export default class LegacyAboutPageUsers extends Component {
+  get users() {
+    return this.args.users || [];
+  }
+
+  <template>
+    {{#each this.users as |user|}}
+      <AboutPageUser @user={{user}} />
+    {{/each}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -53,7 +53,7 @@
           <section class="about admins">
             <h3>{{d-icon "users"}} {{i18n "about.our_admins"}}</h3>
             <div class="users">
-              <AboutPageUsers @users={{this.model.admins}} />
+              <LegacyAboutPageUsers @users={{this.model.admins}} />
             </div>
           </section>
         {{/if}}
@@ -70,7 +70,7 @@
           <section class="about moderators">
             <h3>{{d-icon "users"}} {{i18n "about.our_moderators"}}</h3>
             <div class="users">
-              <AboutPageUsers @users={{this.model.moderators}} />
+              <LegacyAboutPageUsers @users={{this.model.moderators}} />
             </div>
           </section>
         {{/if}}
@@ -90,7 +90,7 @@
             >
               <h3>{{category-link cm.category}}{{i18n "about.moderators"}}</h3>
               <div class="users">
-                <AboutPageUsers @users={{cm.moderators}} />
+                <LegacyAboutPageUsers @users={{cm.moderators}} />
               </div>
               <div class="clearfix"></div>
             </section>

--- a/app/assets/stylesheets/common/base/about.scss
+++ b/app/assets/stylesheets/common/base/about.scss
@@ -37,6 +37,25 @@
   &__activities-item-period {
     font-size: var(--font-down-2);
   }
+
+  &__admins,
+  &__moderators {
+    margin-top: 3em;
+
+    h3 {
+      margin-bottom: 1em;
+    }
+  }
+}
+
+.about-page-users-list {
+  display: grid;
+  gap: 1em;
+  grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
+
+  &__expand-button {
+    width: 100%;
+  }
 }
 
 section.about {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -346,6 +346,8 @@ en:
       contact: "Contact us"
       contact_info: "In the event of a critical issue or urgent matter affecting this site, please contact us at %{contact_info}."
       site_activity: "Site activity"
+      view_more: "View more"
+      view_less: "View less"
       activities:
         topics:
           one: "%{formatted_number} topic"

--- a/spec/system/page_objects/components/about_page_users_list.rb
+++ b/spec/system/page_objects/components/about_page_users_list.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AboutPageUsersList < PageObjects::Components::Base
+      attr_reader :container
+
+      def initialize(container)
+        @container = container
+      end
+
+      def has_expand_button?
+        container.has_css?(".about-page-users-list__expand-button")
+      end
+
+      def has_no_expand_button?
+        container.has_no_css?(".about-page-users-list__expand-button")
+      end
+
+      def expandable?
+        container.find(".about-page-users-list__expand-button").has_text?(
+          I18n.t("js.about.view_more"),
+        )
+      end
+
+      def collapsible?
+        container.find(".about-page-users-list__expand-button").has_text?(
+          I18n.t("js.about.view_less"),
+        )
+      end
+
+      def expand
+        container.find(
+          ".about-page-users-list__expand-button",
+          text: I18n.t("js.about.view_more"),
+        ).click
+      end
+
+      def collapse
+        container.find(
+          ".about-page-users-list__expand-button",
+          text: I18n.t("js.about.view_less"),
+        ).click
+      end
+
+      def users
+        container
+          .all(".user-info")
+          .map do |node|
+            {
+              username: node["data-username"],
+              displayed_username: node.find(".name-line .username").text,
+              displayed_name: node.find(".name-line .name").text,
+              node:,
+            }
+          end
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/about.rb
+++ b/spec/system/page_objects/pages/about.rb
@@ -50,6 +50,14 @@ module PageObjects
         PageObjects::Components::AboutPageSiteActivity.new(find(".about__activities"))
       end
 
+      def admins_list
+        PageObjects::Components::AboutPageUsersList.new(find(".about__admins"))
+      end
+
+      def moderators_list
+        PageObjects::Components::AboutPageUsersList.new(find(".about__moderators"))
+      end
+
       private
 
       def site_age_stat_element


### PR DESCRIPTION
This PR continues on work laid out by https://github.com/discourse/discourse/pull/27996 to redesign the /about page. In this PR, we add sections for showing the site admins and moderators. Screenshot:

<img src="https://github.com/user-attachments/assets/5b428770-c294-4831-97fe-e4681ce13851" width=500>

The lists of admins and moderators display the 10 most recently seen admins/moderators, with a button to display the rest of admins or moderators. Admins or moderators that have not logged in to the site in the last year will not be shown. Clicking on an admin's or moderator's name/avatar will show their user card.