### PR TITLE
DEV: Don't run `yarn` related commands on `core annotations` job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Yarn cache
+        if: matrix.build_type != 'annotations'
         uses: actions/cache@v4
         id: yarn-cache
         with:
@@ -125,6 +126,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-cachev2
 
       - name: Yarn install
+        if: matrix.build_type != 'annotations'
         run: yarn install --frozen-lockfile
 
       - name: Checkout official plugins


### PR DESCRIPTION
We spend about 40 seconds running `yarn` related command on `core annotations` job. This costs us roughly $0.008 which is not much but can add up over the long run. Anyway, the change is easy and we get to save money so ¯\_(ツ)_/¯