### PR TITLE
DEV: adds a tooltip system spec component

### DIFF
--- a/spec/system/page_objects/components/tooltips.rb
+++ b/spec/system/page_objects/components/tooltips.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class Tooltips < PageObjects::Components::Base
+      SELECTOR = ".fk-d-tooltip__content"
+
+      attr_reader :identifier
+
+      def initialize(identifier)
+        @identifier = identifier
+      end
+
+      def find(selector, **kwargs)
+        page.find("#{SELECTOR}[data-identifier='#{identifier}'] #{selector}", **kwargs)
+      end
+
+      def present?(**kwargs)
+        page.has_selector?("#{SELECTOR}[data-identifier='#{identifier}']", **kwargs)
+      end
+
+      def not_present?(**kwargs)
+        page.has_no_selector?("#{SELECTOR}[data-identifier='#{identifier}']", **kwargs)
+      end
+    end
+  end
+end

--- a/spec/system/user_tips_spec.rb
+++ b/spec/system/user_tips_spec.rb
@@ -5,24 +5,26 @@ describe "Homepage", type: :system do
   fab!(:user)
   fab!(:topics) { Fabricate.times(2, :post).map(&:topic) }
   fab!(:posts) { Fabricate.times(3, :post, topic: topics[0]) }
+
   let(:discovery) { PageObjects::Pages::Discovery.new }
+  let(:tooltip) { PageObjects::Components::Tooltips.new("user-tip") }
 
   context "when user tips are disabled" do
     before { SiteSetting.enable_user_tips = false }
 
     it "does not show the 'first notification' tip to the user when disabled" do
-      sign_in user
-      visit "/"
+      sign_in(user)
+      visit("/")
 
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+      expect(tooltip).to be_not_present
     end
 
     it "does not show the boostrapping tip to an admin user" do
       SiteSetting.bootstrap_mode_enabled = true
-      sign_in admin
-      visit "/"
+      sign_in(admin)
+      visit("/")
 
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+      expect(tooltip).to be_not_present
     end
   end
 
@@ -30,48 +32,47 @@ describe "Homepage", type: :system do
     before { SiteSetting.enable_user_tips = true }
 
     it "shows the 'first notification' tip to the user when enabled" do
-      sign_in user
+      sign_in(user)
+
       expect(user.user_option.seen_popups).to eq(nil)
 
-      visit "/"
+      visit("/")
 
-      expect(page).to have_css(
-        ".fk-d-tooltip__content .user-tip__title",
-        text: "Your first notification!",
-      )
+      expect(tooltip).to be_present(text: "Your first notification!")
 
       # Find an element with no action to simulate clicking outside the user tip
       find("th.topic-list-data span", text: "Topic").click
 
-      expect(page).to have_no_css(
-        ".fk-d-tooltip__content .user-tip__title",
-        text: "Your first notification!",
-      )
+      expect(tooltip).to be_not_present
     end
 
     it "shows a second notification once first is dismissed and user visits a topic" do
-      sign_in user
-      visit "/"
-
+      sign_in(user)
+      visit("/")
       find(".fk-d-tooltip__content .user-tip__buttons .btn-primary").click
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+
+      expect(tooltip).to be_not_present
 
       discovery.topic_list.visit_topic(topics[0])
-      expect(page).to have_css(".fk-d-tooltip__content .user-tip__title", text: "Topic timeline")
 
-      find(".fk-d-tooltip__content .user-tip__buttons .btn-primary").click
-      expect(page).to have_css(".fk-d-tooltip__content .user-tip__title", text: "Keep reading!")
+      expect(tooltip).to be_present(text: "Topic timeline")
+
+      tooltip.find(".user-tip__buttons .btn-primary").click
+
+      expect(tooltip).to be_present(text: "Keep reading!")
     end
 
     it "can skip all tips" do
-      sign_in user
-      visit "/"
+      sign_in(user)
+      visit("/")
 
-      find(".fk-d-tooltip__content .user-tip__buttons .btn", text: "Skip tips").click
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+      tooltip.find(".user-tip__buttons .btn", text: "Skip tips").click
+
+      expect(tooltip).to be_not_present
 
       discovery.topic_list.visit_topic(topics[0])
-      expect(page).to have_no_css(".fk-d-tooltip__content .user-tip__title")
+
+      expect(tooltip).to be_not_present
     end
   end
 end


### PR DESCRIPTION
Usage:

```ruby
tooltip = PageObjects::Components::Tooltips.new(identifier)
expect(tooltip).to be_present(text: "Welcome")
expect(tooltip).to be_not_present(text: "Welcome")
tooltip.find(".my-button").click
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
