### PR TITLE
UX: smaller modal headings, shorter flag mdoal title

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -40,6 +40,7 @@
 
     .modal-close {
       margin-left: auto;
+      align-self: start;
       .d-icon {
         font-size: var(--font-up-2);
         color: var(--primary-high);
@@ -52,6 +53,11 @@
     .btn {
       text-transform: capitalize;
     }
+  }
+
+  &__title-text {
+    font-size: var(--font-up-3);
+    line-height: var(--line-height-medium);
   }
 
   &__title-text,

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -224,10 +224,6 @@
 }
 
 .d-modal.topic-bulk-actions-modal {
-  .d-modal__title-text {
-    font-size: var(--font-up-2);
-  }
-
   .d-modal {
     &__container {
       display: flex;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4067,7 +4067,7 @@ en:
       colors_disabled: "You can’t select colors because you have a category style of none."
 
     flagging:
-      title: "Thanks for helping to keep our community civil!"
+      title: "Thanks for keeping our community civil!"
       action: "Flag Post"
       take_action: "Take Action…"
       take_action_options:
@@ -4125,7 +4125,7 @@ en:
           other: "%{count} remaining"
 
     flagging_topic:
-      title: "Thanks for helping to keep our community civil!"
+      title: "Thanks for keeping our community civil!"
       action: "Flag Topic"
       notify_action: "Message"
 


### PR DESCRIPTION
Modal headings are enormous at the moment (on desktop), this makes them smaller and reduces the line height slightly. I also shortened the flag modal title specifically because it can communicate a similar sentiment on one line... 

before: 
![image](https://github.com/user-attachments/assets/ec75df8c-df35-4b3e-b029-def34b0b3eb1)


after: 
![image](https://github.com/user-attachments/assets/1186c3ff-1213-490a-bc92-ee4ffc5be94b)
