### PR TITLE
DEV: correctly position below-direct-chat-channels

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
@@ -57,11 +57,6 @@ export default class ChannelsListDirect extends Component {
   }
 
   <template>
-    <PluginOutlet
-      @name="below-direct-chat-channels"
-      @tagName=""
-      @outletArgs={{hash inSidebar=this.inSidebar}}
-    />
     {{#if
       (and
         this.showDirectMessageChannels
@@ -127,5 +122,11 @@ export default class ChannelsListDirect extends Component {
         {{/each}}
       {{/if}}
     </div>
+
+    <PluginOutlet
+      @name="below-direct-chat-channels"
+      @tagName=""
+      @outletArgs={{hash inSidebar=this.inSidebar}}
+    />
   </template>
 }


### PR DESCRIPTION
It should be below channels, not above.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
