### PR TITLE
DEV: adds chat-drawer-before-content plugin outlet

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
@@ -11,6 +11,14 @@
   >
     <div class="chat-drawer-container">
       <div class="chat-drawer-resizer"></div>
+
+      <PluginOutlet
+        @name="chat-drawer-before-content"
+        @outletArgs={{hash
+          currentRouteName=this.chatDrawerRouter.currentRouteName
+        }}
+      />
+
       <this.chatDrawerRouter.component
         @params={{this.chatDrawerRouter.params}}
         @openURL={{this.openURL}}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -160,6 +160,7 @@ export default class ChatDrawerRouter extends Service {
   @tracked component = null;
   @tracked drawerRoute = null;
   @tracked params = null;
+  @tracked currentRouteName = null;
 
   routeNames = Object.keys(ROUTES);
 


### PR DESCRIPTION
This outlet is rendered before the content of the drawer. The `currentRouteName` is accessible in `outletArgs`.

Example:

```gjs
export default class Test extends Component {
  <template>
    {{#if (eq @outletArgs.currentRouteName "chat.browse")}}
      the browse page
    {{/if}}
  </template>
}
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
