### PR TITLE
A11Y: do not skip heading levels in keyboard shortcut modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.hbs
@@ -13,9 +13,9 @@
             class="shortcut-category span-{{shortcutCategory.count}}
               shortcut-category-{{category}}"
           >
-            <h4>{{i18n
+            <h2>{{i18n
                 (concat "keyboard_shortcuts_help." category ".title")
-              }}</h4>
+              }}</h2>
             <ul>
               {{#each-in shortcutCategory.shortcuts as |name shortcut|}}
                 <li>{{html-safe shortcut}}</li>

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -43,7 +43,8 @@
 .shortcut-category {
   border: 1px solid var(--primary-low);
 
-  h4 {
+  h2 {
+    font-size: var(--font-0);
     background-color: var(--primary-very-low);
     padding: 0.5rem 1rem;
   }


### PR DESCRIPTION
No visual changes here... this just switches the headings to be sequential. The modal heading is an H1 so "jump to" "navigation" etc should be H2. 


![image](https://github.com/user-attachments/assets/677b6575-b631-42b6-aea8-4ae9dec7030c)
