### PR TITLE
FIX: Set overflow-x to auto to prevent scroll bar from always showing

### DIFF
--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -21,7 +21,7 @@
     font-size: var(--font-up-1);
     white-space: nowrap;
     flex-wrap: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     // Fade-out for horizontal scroll nav
     &:before {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

### Before
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/12c9d370-e139-498b-a60c-6d10a08eb5de">


### After
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/3b3a0aa9-8d86-4efc-a27e-498e7eec5a6f">
