### PR TITLE
DEV: Switch to running JS tests on Chrome

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }} # Update fetch-job-id step if changing this
     runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || 'ubuntu-20.04-8core' }}
-    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
+    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}-bookworm
     timeout-minutes: 20
 
     env:
@@ -66,11 +66,6 @@ jobs:
     steps:
       - name: Set working directory owner
         run: chown root:root .
-
-      - name: Remove Chromium
-        continue-on-error: true
-        if: matrix.build_type == 'system'
-        run: apt remove -y chromium-driver chromium
 
       - uses: actions/checkout@v4
         with:
@@ -150,7 +145,7 @@ jobs:
         if: matrix.target == 'themes'
         run: bin/rake themes:clone_all_official themes:pull_compatible_all
 
-      - name: Add hosts to /etc/hosts, otherwise Chromium cannot reach minio
+      - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: |
           echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
@@ -355,7 +350,7 @@ jobs:
     name: core frontend (${{ matrix.browser }})
     runs-on: ubuntu-20.04-8core
     container:
-      image: discourse/discourse_test:slim-browsers
+      image: discourse/discourse_test:slim-browsers-bookworm
       options: --user discourse
 
     timeout-minutes: 35
@@ -363,7 +358,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["Chromium", "Firefox ESR", "Firefox Evergreen"]
+        browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}


### PR DESCRIPTION
The test base image now installs Chrome for Testing which is what
Google recommends.
