### PR TITLE
DEV: print modifyClass warning correctly for deprecated lookups

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -115,6 +115,10 @@ const DEPRECATED_MODULES = new Map(
   })
 );
 
+export function normalizeDeprecatedModule(name) {
+  return DEPRECATED_MODULES.get(name)?.newName || name;
+}
+
 export function setResolverOption(name, value) {
   _options[name] = value;
 }

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -159,6 +159,7 @@ import {
   registerIconRenderer,
   replaceIcon,
 } from "discourse-common/lib/icon-library";
+import { normalizeDeprecatedModule } from "discourse-common/resolver";
 import { addImageWrapperButton } from "discourse-markdown-it/features/image-controls";
 import { CUSTOM_USER_SEARCH_OPTIONS } from "select-kit/components/user-chooser";
 import { modifySelectKit } from "select-kit/mixins/plugin-api";
@@ -255,14 +256,14 @@ class PluginApi {
     opts = opts || {};
 
     if (
-      this.container.cache[resolverName] ||
+      this.container.cache[normalizeDeprecatedModule(resolverName)] ||
       (resolverName === "model:user" &&
         this.container.lookup("service:current-user"))
     ) {
       // eslint-disable-next-line no-console
       console.warn(
         consolePrefix(),
-        `"${resolverName}" has already been initialized and registered as a singleton. Move the modifyClass call earlier in the boot process for changes to take effect. https://meta.discourse.org/t/262064`
+        `Attempted to modify "${resolverName}", but it was already initialized earlier in the boot process (e.g. via a lookup()). Remove that lookup, or move the modifyClass call earlier in the boot process for changes to take effect. https://meta.discourse.org/t/262064`
       );
     }
 


### PR DESCRIPTION
e.g. we map `controller:composer` to `service:composer` in resolver lookups. So, when doing the cache check in modifyClass, we need to check against the normalized name, not the deprecated name.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
