### PR TITLE
DEV: Promote modifyClass warning to error

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -115,10 +115,6 @@ const DEPRECATED_MODULES = new Map(
   })
 );
 
-export function normalizeDeprecatedModule(name) {
-  return DEPRECATED_MODULES.get(name)?.newName || name;
-}
-
 export function setResolverOption(name, value) {
   _options[name] = value;
 }


### PR DESCRIPTION
This message indicates broken behavior, so it should be an error rather than a warning.

An early-return is added, so that we don't even attempt to make the modification. This will make the behavior consistent, and easier to understand.

Also updates the normalization logic to use the resolver's own logic. This will handle all sorts of normalization in addition to our deprecations.