### PR TITLE
UX: Add sidebar DM list back when public channels are disabled

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/controllers/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/chat.js
@@ -17,13 +17,7 @@ export default class ChatController extends Controller {
     if (this.shouldUseCoreSidebar) {
       return false;
     }
-    if (
-      this.publicMessageChannelsEmpty &&
-      this.enabledRouteCount === 1 &&
-      this.chat.userCanAccessDirectMessages
-    ) {
-      return false;
-    }
+
     return true;
   }
 


### PR DESCRIPTION
This deleted `if` statement was added to avoid a double CTA when no DMs were present and public channels disabled. The check was wrong, and ended up causing no channel list to be rendered :(

OLD:
![Screenshot 2024-08-09 at 8 46 26 AM](https://github.com/user-attachments/assets/1b0d7558-31f5-4acf-b64c-ee64277c2a28)

NEW: 
![Screenshot 2024-08-09 at 8 46 13 AM](https://github.com/user-attachments/assets/35c50a79-52a5-4f0e-a697-0f00acf6c270)
