### PR TITLE
DEV: Ensure deprecation warning banner works in development builds

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -2,16 +2,16 @@ import Component from "@ember/component";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
-import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import { tagName } from "@ember-decorators/component";
 import cookie, { removeCookie } from "discourse/lib/cookie";
+import { DeferredTrackedSet } from "discourse/lib/tracked-tools";
 import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
-const _pluginNotices = new TrackedArray();
+const _pluginNotices = new DeferredTrackedSet();
 
 export function addGlobalNotice(text, id, options = {}) {
-  _pluginNotices.push(Notice.create({ text, id, options }));
+  _pluginNotices.add(Notice.create({ text, id, options }));
 }
 
 const GLOBAL_NOTICE_DISMISSED_PROMPT_KEY = "dismissed-global-notice-v2";
@@ -153,7 +153,7 @@ export default class GlobalNotice extends Component {
       notices.push(this.get("logNotice"));
     }
 
-    return notices.concat(_pluginNotices).filter((notice) => {
+    return notices.concat(Array.from(_pluginNotices)).filter((notice) => {
       if (notice.options.visibility) {
         return notice.options.visibility(notice);
       }


### PR DESCRIPTION
In development, Ember raises an error when previously-used values are updated during a render. This is to avoid 'backtracking', where parts of templates have to be re-rendered multiple times. In general, this kind of pattern should be avoided, and Ember's warning helps us do that.

However, for the deprecation warning banner, it is quite reasonable for some rendering to trigger a deprecation, and thereby require the global-notice to be re-rendered. We can use our `DeferredTrackedSet` to achieve that. Its `.add` method will delay adding an item to the Set until after the current render has completed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
