### PR TITLE
A11Y: add aria-label to avatar link on categories page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
@@ -6,9 +6,9 @@
 <div class="topic-poster">
   <UserLink
     @user={{this.topic.lastPosterUser}}
-    aria-label={{i18n
-      "latest_poster_link"
-      username=this.topic.lastPosterUser.username
+    aria-label={{if
+      this.topic.lastPosterUser.username
+      (i18n "latest_poster_link" username=this.topic.lastPosterUser.username)
     }}
   >
     {{avatar this.topic.lastPosterUser imageSize="large"}}

--- a/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/latest-topic-list-item.hbs
@@ -4,7 +4,13 @@
   @outletArgs={{hash topic=this.topic}}
 />
 <div class="topic-poster">
-  <UserLink @user={{this.topic.lastPosterUser}}>
+  <UserLink
+    @user={{this.topic.lastPosterUser}}
+    aria-label={{i18n
+      "latest_poster_link"
+      username=this.topic.lastPosterUser.username
+    }}
+  >
     {{avatar this.topic.lastPosterUser imageSize="large"}}
   </UserLink>
   <UserAvatarFlair @user={{this.topic.lastPosterUser}} />


### PR DESCRIPTION
This is for the avatars in the latest/top topic list on the /categories page:

![image](https://github.com/user-attachments/assets/d091b0d1-f000-4079-b9e2-71ca50e7831b)

This ensures the link has a properly accessible label, screenreaders will read "username's profile, latest poster, link" 

