### PR TITLE
UX: set "topics" link in sidebar as active for hot, unseen, and my posts filters

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
@@ -51,7 +51,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get currentWhen() {
-    return "discovery.latest discovery.new discovery.unread discovery.top";
+    return "discovery.latest discovery.new discovery.unread discovery.top discovery.hot discovery.unseen discovery.posted";
   }
 
   get badgeText() {

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -42,6 +42,7 @@ export default {
         "search",
         "bookmarks",
         "hot",
+        "unseen"
       ],
       periods: ["all", "yearly", "quarterly", "monthly", "weekly", "daily"],
       top_menu_items: [
@@ -54,6 +55,7 @@ export default {
         "categories",
         "hot",
         "bookmarks",
+        "unseen",
       ],
       anonymous_top_menu_items: ["latest", "hot", "categories"],
       uncategorized_category_id: 17,

--- a/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
@@ -52,6 +52,7 @@ export default {
           "read",
           "posted",
           "bookmarks",
+          "unseen",
         ],
         list_type: "compact",
       },

--- a/app/assets/javascripts/discourse/tests/helpers/site.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site.js
@@ -44,6 +44,7 @@ PreloadStore.store("site", {
     "read",
     "posted",
     "bookmarks",
+    "unseen",
   ],
   periods: ["all", "yearly", "monthly", "weekly", "daily"],
   top_menu_items: [
@@ -55,6 +56,7 @@ PreloadStore.store("site", {
     "posted",
     "categories",
     "hot",
+    "unseen",
   ],
   anonymous_top_menu_items: ["latest", "categories", "hot"],
   uncategorized_category_id: 17,


### PR DESCRIPTION
Hot, Unseen, and My Posts (posted) are filters of the "all topics" feed so should highlight the sidebar link similar to new/unread/latest

before:
![image](https://github.com/user-attachments/assets/1384f3b7-b458-4151-a600-0d5a0d5a201c)



after:
![image](https://github.com/user-attachments/assets/f4d37b96-0372-4b3d-b69b-93461c058e56)
