### PR TITLE
DEV: Fix unsafe binding warnings

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/code.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/code.gjs
@@ -19,7 +19,7 @@ export default class FKControlCode extends Component {
       return;
     }
 
-    return `height: ${htmlSafe(escapeExpression(this.args.height) + "px")}`;
+    return htmlSafe(`height: ${escapeExpression(this.args.height)}px`);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/composer.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/composer.gjs
@@ -17,7 +17,7 @@ export default class FKControlComposer extends Component {
       return;
     }
 
-    return `height: ${htmlSafe(escapeExpression(this.args.height) + "px")}`;
+    return htmlSafe(`height: ${escapeExpression(this.args.height)}px`);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -17,7 +17,7 @@ export default class FKControlTextarea extends Component {
       return;
     }
 
-    return `height: ${htmlSafe(escapeExpression(this.args.height) + "px")}`;
+    return htmlSafe(`height: ${escapeExpression(this.args.height)}px`);
   }
 
   <template>


### PR DESCRIPTION
e.g.

```
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see https://deprecations.emberjs.com/v1.x/#toc_binding-style-attributes. Style affected: \"height: 60px\"
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
