### PR TITLE
UX: remove poll button bg color to avoid highlight issue

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -23,7 +23,7 @@ div.poll-outer {
       padding: 0.5em 0;
       word-break: break-word;
       button {
-        background-color: var(--secondary);
+        background-color: transparent;
         border: none;
         text-align: left;
         padding-left: 23px;


### PR DESCRIPTION
the background color here would noticeably clash with post highlights 

before:
![image](https://github.com/user-attachments/assets/691b4012-15d7-4fde-b4d7-5cda18f9411b)


after:
![image](https://github.com/user-attachments/assets/b0af73f8-308a-4125-8001-ca1c64eb87a3)
