### PR TITLE
A11Y: remove redundant tabindex=0 from polls

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-options.gjs
@@ -35,7 +35,7 @@ export default class PollOptionsComponent extends Component {
             @sendRank={{this.sendRank}}
           />
         {{else}}
-          <li tabindex="0" data-poll-option-id={{option.id}}>
+          <li data-poll-option-id={{option.id}}>
             {{#if this.currentUser}}
               <button {{on "click" (fn this.sendClick option)}}>
                 {{#if (this.isChosen option)}}


### PR DESCRIPTION
This is a follow-up to: https://github.com/discourse/discourse/pull/27204


Before the refactor, we needed tabindex for keyboard nav because the poll choices were list items. Now that the list items contain buttons, they get a tab order automatically, making tabindex cause a redundant selection. 