### PR TITLE
FEATURE: participating users statistics

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -46,6 +46,9 @@ class Stat
       Stat.new("users", show_in_ui: true, expose_via_api: true) { Statistics.users },
       Stat.new("active_users", show_in_ui: true, expose_via_api: true) { Statistics.active_users },
       Stat.new("likes", show_in_ui: true, expose_via_api: true) { Statistics.likes },
+      Stat.new("participating_users", show_in_ui: false, expose_via_api: true) do
+        Statistics.participating_users
+      end,
     ]
   end
 

--- a/plugins/chat/spec/lib/statistics_spec.rb
+++ b/plugins/chat/spec/lib/statistics_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Statistics do
+  describe "#participating_users" do
+    it "returns users who have sent a chat message" do
+      Fabricate(:chat_message)
+      expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+
+    it "returns users who have reacted to a chat message" do
+      Fabricate(:chat_message_reaction)
+      expect(described_class.participating_users[:last_day]).to eq(2) # 2 because the chat message creator is also counted
+    end
+  end
+end

--- a/spec/lib/discourse_hub_spec.rb
+++ b/spec/lib/discourse_hub_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe DiscourseHub do
         expect(json["likes_count"]).to be_present
         expect(json["likes_7_days"]).to be_present
         expect(json["likes_30_days"]).to be_present
+        expect(json["participating_users_7_days"]).to be_present
+        expect(json["participating_users_30_days"]).to be_present
         expect(json["installed_version"]).to be_present
         expect(json["branch"]).to be_present
       end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -105,6 +105,9 @@ TEXT
         :likes_7_days,
         :likes_30_days,
         :likes_count,
+        :participating_users_last_day,
+        :participating_users_7_days,
+        :participating_users_30_days,
       )
     end
 

--- a/spec/lib/statistics_spec.rb
+++ b/spec/lib/statistics_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Statistics do
+  describe "#participating_users" do
+    it "returns no participating users by default" do
+      pu = described_class.participating_users
+      expect(pu[:last_day]).to eq(0)
+      expect(pu[:"7_days"]).to eq(0)
+      expect(pu[:"30_days"]).to eq(0)
+    end
+
+    it "returns users who have reacted to a post" do
+      Fabricate(:user_action, action_type: UserAction::LIKE)
+      expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+
+    it "returns users who have created a new topic" do
+      Fabricate(:user_action, action_type: UserAction::NEW_TOPIC)
+      expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+
+    it "returns users who have replied to a post" do
+      Fabricate(:user_action, action_type: UserAction::REPLY)
+      expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+
+    it "returns users who have created a new PM" do
+      Fabricate(:user_action, action_type: UserAction::NEW_PRIVATE_MESSAGE)
+      expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+  end
+end

--- a/spec/requests/site_controller_spec.rb
+++ b/spec/requests/site_controller_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe SiteController do
       expect(json["likes_count"]).to be_present
       expect(json["likes_7_days"]).to be_present
       expect(json["likes_30_days"]).to be_present
+      expect(json["participating_users_7_days"]).to be_present
+      expect(json["participating_users_30_days"]).to be_present
     end
 
     it "is not visible if site setting share_anonymized_statistics is disabled" do


### PR DESCRIPTION
Adds a new statistics (hidden from the UI, but available via the API) that tracks daily participating users.

A user is considered as "participating" if they have

- Reacted to a post
- Replied to a topic
- Created a new topic
- Created a new PM
- Sent a chat message
- Reacted to a chat message

Internal ref - t/131013

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
