### PR TITLE
FIX: not hit Redis cache in seeds

### DIFF
--- a/db/fixtures/003_post_action_types.rb
+++ b/db/fixtures/003_post_action_types.rb
@@ -1,55 +1,44 @@
 # frozen_string_literal: true
-post_action_type_view = PostActionTypeView.new
 
 PostActionType.seed do |s|
-  s.id = post_action_type_view.types[:like]
+  s.id = 2
   s.name_key = "like"
   s.is_flag = false
   s.icon = "heart"
   s.position = 2
 end
 
-if post_action_type_view.types[:off_topic]
-  PostActionType.seed do |s|
-    s.id = post_action_type_view.types[:off_topic]
-    s.name_key = "off_topic"
-    s.is_flag = true
-    s.position = 3
-  end
+PostActionType.seed do |s|
+  s.id = 3
+  s.name_key = "off_topic"
+  s.is_flag = true
+  s.position = 3
 end
 
-if post_action_type_view.types[:inappropriate]
-  PostActionType.seed do |s|
-    s.id = post_action_type_view.types[:inappropriate]
-    s.name_key = "inappropriate"
-    s.is_flag = true
-    s.position = 4
-  end
+PostActionType.seed do |s|
+  s.id = 4
+  s.name_key = "inappropriate"
+  s.is_flag = true
+  s.position = 4
 end
 
-if post_action_type_view.types[:spam]
-  PostActionType.seed do |s|
-    s.id = post_action_type_view.types[:spam]
-    s.name_key = "spam"
-    s.is_flag = true
-    s.position = 6
-  end
+PostActionType.seed do |s|
+  s.id = 8
+  s.name_key = "spam"
+  s.is_flag = true
+  s.position = 6
 end
 
-if post_action_type_view.types[:notify_user]
-  PostActionType.seed do |s|
-    s.id = post_action_type_view.types[:notify_user]
-    s.name_key = "notify_user"
-    s.is_flag = true
-    s.position = 7
-  end
+PostActionType.seed do |s|
+  s.id = 6
+  s.name_key = "notify_user"
+  s.is_flag = true
+  s.position = 7
 end
 
-if post_action_type_view.types[:notify_moderators]
-  PostActionType.seed do |s|
-    s.id = post_action_type_view.types[:notify_moderators]
-    s.name_key = "notify_moderators"
-    s.is_flag = true
-    s.position = 8
-  end
+PostActionType.seed do |s|
+  s.id = 7
+  s.name_key = "notify_moderators"
+  s.is_flag = true
+  s.position = 8
 end


### PR DESCRIPTION
Hardcode IDs because seed in multisite environment is run concurrently which can cause performance problems.

Same as Flags https://github.com/discourse/discourse/blob/main/db/fixtures/003_flags.rb

This seed will be dropped in the foreseeable future so no need to extract those IDs.


