### PR TITLE
PERF: Reduce memory footprint of `Chat::AutoRemove::HandleCategoryUpdated`

### DIFF
--- a/plugins/chat/app/services/chat/action/calculate_memberships_for_removal.rb
+++ b/plugins/chat/app/services/chat/action/calculate_memberships_for_removal.rb
@@ -59,12 +59,14 @@ module Chat
         scoped_memberships =
           Chat::UserChatChannelMembership
             .joins(:chat_channel)
-            .where(user: scoped_users)
+            .where(user_id: scoped_users.select(:id))
             .where(chat_channel_id: channel_permissions_map.map(&:channel_id))
 
         memberships_to_remove = []
+
         scoped_memberships.find_each do |membership|
-          scoped_user = scoped_users.find { |su| su.id == membership.user_id }
+          scoped_user = scoped_users.where(id: membership.user_id).first
+
           channel_permission =
             channel_permissions_map.find { |cpm| cpm.channel_id == membership.chat_channel_id }
 


### PR DESCRIPTION
This commit seeks to reduce the memory footprint of `Chat::AutoRemove::HandleCategoryUpdated`.
by optimising how `Chat::AutoRemove::CalculateMembershipsForRemoval.call` works with the
`scoped_users` argument.

Before this change,
`Chat::AutoRemove::CalculateMembershipsForRemoval.call` method call
would load the ActiveRecord User objects given by the `scoped_users`
argument all at once. After this change, the method call will no longer
load everything into memory at once and instead only create the
ActiveRecord object when it is needed.`
