### PR TITLE
PERF: Reduce memory footprint of `Chat::AutoRemove::HandleCategoryUpdated`

### DIFF
--- a/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
@@ -59,11 +59,16 @@ module Chat
       end
 
       def remove_users_without_channel_permission(users:, category_channel_ids:)
-        memberships_to_remove =
-          Chat::Action::CalculateMembershipsForRemoval.call(
-            scoped_users: users,
-            channel_ids: category_channel_ids,
+        memberships_to_remove = []
+
+        users.find_in_batches do |batch_users|
+          memberships_to_remove.concat(
+            Chat::Action::CalculateMembershipsForRemoval.call(
+              scoped_users: batch_users,
+              channel_ids: category_channel_ids,
+            ),
           )
+        end
 
         return if memberships_to_remove.blank?
 


### PR DESCRIPTION
This commit seeks to reduce the memory footprint of `Chat::AutoRemove::HandleCategoryUpdated.call`
by optimizing the
`Chat::AutoRemove::HandleCategoryUpdated#remove_users_without_channel_permission` method which was
loading all the ActiveRecord users objects into memory at once. This
change updates the method call to load the ActiveRecord user objects in
batches instead.
