### PR TITLE
PERF: skip reset flag callbacks on seed

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -14,7 +14,9 @@ class Flag < ActiveRecord::Base
 
   before_save :set_position
   before_save :set_name_key
-  after_commit :reset_flag_settings!
+  after_commit { reset_flag_settings! if !skip_reset_flag_callback }
+
+  attr_accessor :skip_reset_flag_callback
 
   default_scope do
     order(:position).where(score_type: false).where.not(id: PostActionType::LIKE_POST_ACTION_ID)

--- a/db/fixtures/003_flags.rb
+++ b/db/fixtures/003_flags.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 Flag.seed do |s|
   s.id = 6
   s.name = "notify_user"
@@ -7,6 +6,7 @@ Flag.seed do |s|
   s.auto_action_type = false
   s.require_message = true
   s.applies_to = %w[Post Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.seed do |s|
   s.id = 3
@@ -15,6 +15,7 @@ Flag.seed do |s|
   s.auto_action_type = true
   s.require_message = false
   s.applies_to = %w[Post Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.seed do |s|
   s.id = 4
@@ -23,6 +24,7 @@ Flag.seed do |s|
   s.auto_action_type = true
   s.require_message = false
   s.applies_to = %w[Post Topic Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.seed do |s|
   s.id = 8
@@ -31,6 +33,7 @@ Flag.seed do |s|
   s.auto_action_type = true
   s.require_message = false
   s.applies_to = %w[Post Topic Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.seed do |s|
   s.id = 10
@@ -39,6 +42,7 @@ Flag.seed do |s|
   s.auto_action_type = false
   s.require_message = true
   s.applies_to = %w[Post Topic Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.seed do |s|
   s.id = 7
@@ -47,6 +51,7 @@ Flag.seed do |s|
   s.auto_action_type = false
   s.require_message = true
   s.applies_to = %w[Post Topic Chat::Message]
+  s.skip_reset_flag_callback = true
 end
 Flag.unscoped.seed do |s|
   s.id = 9
@@ -56,6 +61,7 @@ Flag.unscoped.seed do |s|
   s.require_message = false
   s.score_type = true
   s.applies_to = %w[]
+  s.skip_reset_flag_callback = true
 end
 Flag.unscoped.seed do |s|
   s.id = 2
@@ -65,4 +71,6 @@ Flag.unscoped.seed do |s|
   s.require_message = false
   s.score_type = false
   s.applies_to = %w[Post]
+  s.skip_reset_flag_callback = true
 end
+Flag.reset_flag_settings!


### PR DESCRIPTION
When flags are seeded, we don't need to reset the cache for each record.

We should instead create all flags and reset the cache at the very end.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
