### PR TITLE
FIX: stop injecting uneeded margin

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/sticky-avatars.js
+++ b/app/assets/javascripts/discourse/app/modifiers/sticky-avatars.js
@@ -83,18 +83,6 @@ export default class StickyAvatars extends Modifier {
     schedule("afterRender", () => {
       this.element.querySelectorAll(TOPIC_POST_SELECTOR).forEach((postNode) => {
         this.intersectionObserver.observe(postNode);
-
-        const topicAvatarNode = postNode.querySelector(".topic-avatar");
-        if (!topicAvatarNode || !postNode.querySelector("#post_1")) {
-          return;
-        }
-
-        const topicMapNode = postNode.querySelector(".topic-map");
-        if (!topicMapNode) {
-          return;
-        }
-
-        topicAvatarNode.style.marginBottom = `${topicMapNode.clientHeight}px`;
       });
     });
   }


### PR DESCRIPTION
This margin hack appears to have only been needed when old topic map existed.

Now that the new topic map is there it leads to a weird blank space at the end of topics.
