### PR TITLE
PERF: no redis calls when running migrations

### DIFF
--- a/db/fixtures/003_flags.rb
+++ b/db/fixtures/003_flags.rb
@@ -73,4 +73,3 @@ Flag.unscoped.seed do |s|
   s.applies_to = %w[Post]
   s.skip_reset_flag_callback = true
 end
-Flag.reset_flag_settings!


### PR DESCRIPTION
Avoid reaching Redis cache while running migrations

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
