### PR TITLE
PERF: do not expire cache when PostActionType is seed

### DIFF
--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -5,8 +5,10 @@ class PostActionType < ActiveRecord::Base
   POST_ACTION_TYPE_PUBLIC_TYPE_IDS_KEY = "post_action_public_type_ids"
   LIKE_POST_ACTION_ID = 2
 
-  after_save :expire_cache
-  after_destroy :expire_cache
+  after_save { expire_cache if !skip_expire_cache_callback }
+  after_destroy { expire_cache if !skip_expire_cache_callback }
+
+  attr_accessor :skip_expire_cache_callback
 
   include AnonCacheInvalidator
 

--- a/db/fixtures/003_post_action_types.rb
+++ b/db/fixtures/003_post_action_types.rb
@@ -6,6 +6,7 @@ PostActionType.seed do |s|
   s.is_flag = false
   s.icon = "heart"
   s.position = 2
+  s.skip_expire_cache_callback = true
 end
 
 PostActionType.seed do |s|
@@ -13,6 +14,7 @@ PostActionType.seed do |s|
   s.name_key = "off_topic"
   s.is_flag = true
   s.position = 3
+  s.skip_expire_cache_callback = true
 end
 
 PostActionType.seed do |s|
@@ -20,6 +22,7 @@ PostActionType.seed do |s|
   s.name_key = "inappropriate"
   s.is_flag = true
   s.position = 4
+  s.skip_expire_cache_callback = true
 end
 
 PostActionType.seed do |s|
@@ -27,6 +30,7 @@ PostActionType.seed do |s|
   s.name_key = "spam"
   s.is_flag = true
   s.position = 6
+  s.skip_expire_cache_callback = true
 end
 
 PostActionType.seed do |s|
@@ -34,6 +38,7 @@ PostActionType.seed do |s|
   s.name_key = "notify_user"
   s.is_flag = true
   s.position = 7
+  s.skip_expire_cache_callback = true
 end
 
 PostActionType.seed do |s|
@@ -41,4 +46,5 @@ PostActionType.seed do |s|
   s.name_key = "notify_moderators"
   s.is_flag = true
   s.position = 8
+  s.skip_expire_cache_callback = true
 end


### PR DESCRIPTION
Reload is too expensive in a multisite environment. A proper way to expire cache is coming with the next PR.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
