### PR TITLE
DEV: Add spec to ensure app works with multiple tagged loggers

### DIFF
--- a/spec/integrity/having_multiple_tagged_loggers_spec.rb
+++ b/spec/integrity/having_multiple_tagged_loggers_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe "Having multiple tagged loggers", type: :request do
+  let(:loggers) { 2.times.map { ActiveSupport::TaggedLogging.new(Logger.new(nil)) } }
+
+  before { loggers.each { Rails.logger.broadcast_to(_1) } }
+
+  after { loggers.each { Rails.logger.stop_broadcasting_to(_1) } }
+
+  it "does not execute request twice" do
+    expect_any_instance_of(SilenceLogger).to receive(:call_app).once.and_call_original
+    get "/user_actions.json"
+  end
+end


### PR DESCRIPTION
When upgrading to Rails 7.1, we had some problems because we were using several tagged loggers at the same time. They were all added to the main broadcast logger shipped with Rails, but the Rails 7.1 codebase contains a bug making a request being run as many times as there are tagged loggers.

The fix was to use the code from the Rails 7.2 codebase.

This PR adds a small spec to ensure the behavior will stay the proper one in the future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
