### PR TITLE
UX: remove baseline alignment from chat timestamp

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -135,7 +135,6 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   .chat-time {
     color: var(--primary-high);
     font-size: var(--font-down-2);
-    vertical-align: bottom;
   }
 
   .emoji-picker {


### PR DESCRIPTION
Few px alignment for the chat timestamp:

### Before
<img width="312" alt="CleanShot 2024-08-13 at 10 45 44@2x" src="https://github.com/user-attachments/assets/172dfca3-45f3-482a-9553-ef129b8bb3e3">

### After
<img width="334" alt="CleanShot 2024-08-13 at 10 46 07@2x" src="https://github.com/user-attachments/assets/72f131f5-2e33-45dd-833e-c7b8f667e3b5">
