### PR TITLE
FEATURE: Allow completely custom score reasons.

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -42,9 +42,9 @@ class ReviewableScoreSerializer < ApplicationSerializer
 
     if link_text
       link = build_link_for(object.reason, link_text)
-      text = I18n.t("reviewables.reasons.#{object.reason}", link: link, default: nil)
+      text = I18n.t("reviewables.reasons.#{object.reason}", link: link, default: object.reason)
     else
-      text = I18n.t("reviewables.reasons.#{object.reason}", default: nil)
+      text = I18n.t("reviewables.reasons.#{object.reason}", default: object.reason)
     end
 
     text

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe ReviewableScoreSerializer do
         end
       end
     end
+
+    context "with custom reasons" do
+      it "serializes it without doing any translation" do
+        custom = "completely custom flag reason"
+        serialized = serialized_score(custom)
+
+        expect(serialized.reason).to eq(custom)
+      end
+    end
   end
 
   describe "#setting_name_for_reason" do


### PR DESCRIPTION
After this change, a reason won't exclusively be a translation key anymore, but now, it can display a custom reason as well. We will escape HTML elements as a precaution. The string can come from a 3rd party and shouldn't be trusted.


<img width="721" alt="Screenshot 2024-08-13 at 2 39 17 PM" src="https://github.com/user-attachments/assets/25f50926-21d3-4781-aad9-78ec35a41bfb">
