### PR TITLE
UX: do not check for dimensions in video filename

### DIFF
--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -31,11 +31,9 @@ function isUpload(token) {
 }
 
 function hasMetadata(token) {
-  return (
-    token.content
-      .split("|")
-      .find((part) => /^\d{1,4}x\d{1,4}(,\s*\d{1,3}%)?$/.test(part)) || null
-  );
+  return !!token.content
+    .split("|")
+    .find((part) => /^\d{1,4}x\d{1,4}(,\s*\d{1,3}%)?$/.test(part));
 }
 
 function appendMetaData(index, token) {

--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -31,7 +31,11 @@ function isUpload(token) {
 }
 
 function hasMetadata(token) {
-  return token.content.split("|")[1]?.match(/\d{1,4}x\d{1,4}/) || null;
+  return (
+    token.content
+      .split("|")
+      .find((part) => /^\d{1,4}x\d{1,4}(,\s*\d{1,3}%)?$/.test(part)) || null
+  );
 }
 
 function appendMetaData(index, token) {

--- a/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/features/image-controls.js
@@ -31,7 +31,7 @@ function isUpload(token) {
 }
 
 function hasMetadata(token) {
-  return token.content.match(/(\d{1,4}x\d{1,4})/);
+  return token.content.split("|")[1]?.match(/\d{1,4}x\d{1,4}/) || null;
 }
 
 function appendMetaData(index, token) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-image-preview-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-image-preview-test.js
@@ -70,8 +70,6 @@ acceptance("Composer - Image Preview", function (needs) {
       "[img]/images/avatar.png[/img]",
       // 12 Image with data attributes
       "![test|foo=bar|690x313,50%|bar=baz](upload://test.png)",
-      // 13 Video with dimensions - should not work
-      "![SampleVideo_1280x720|video](upload://test.mp4)",
     ];
 
     await fillIn(".d-editor-input", uploads.join("\n"));
@@ -142,6 +140,13 @@ acceptance("Composer - Image Preview", function (needs) {
 \`<script>alert("xss")</script>\`
     `
     );
+
+    // don't add controls to video uploads with dimensions in name
+    await fillIn(
+      ".d-editor-input",
+      "![SampleVideo_1280x720|video](upload://test.mp4)"
+    );
+    assert.dom(".button-wrapper").doesNotExist();
 
     assert.ok(
       !exists("script"),

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-image-preview-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-image-preview-test.js
@@ -70,6 +70,8 @@ acceptance("Composer - Image Preview", function (needs) {
       "[img]/images/avatar.png[/img]",
       // 12 Image with data attributes
       "![test|foo=bar|690x313,50%|bar=baz](upload://test.png)",
+      // 13 Video with dimensions - should not work
+      "![SampleVideo_1280x720|video](upload://test.mp4)",
     ];
 
     await fillIn(".d-editor-input", uploads.join("\n"));


### PR DESCRIPTION
When adding a video/image/audio to a post, we check the token content for dimensions. If dimensions are found, we assume the content can be resized and give it image controls in the composer preview. 

The problem is that we check the entire token, including filename, for dimensions. This means if a video has dimensions in its filename, we show broken controls: 

![image](https://github.com/user-attachments/assets/93f3bbc9-1c0f-4ac3-b541-aab854624824)


This PR updates the `hasMetadata` function so it checks the area dedicated to dimensions specifically, which comes after the `|` in markdown. 

Now images get the controls, and videos with dimensions in their filename do not: 

![image](https://github.com/user-attachments/assets/92d64c52-f4d5-4ecc-9567-c0737f724ae7)
