### PR TITLE
FIX: make poll voter list expansion persistent

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -45,6 +45,7 @@ export default class PollComponent extends Component {
   @tracked vote = this.args.attrs.vote || [];
   @tracked poll = this.args.attrs.poll;
   @tracked preloadedVoters = this.defaultPreloadedVoters();
+  @tracked preloadedVotersExpanded = false;
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
 
   @tracked
@@ -473,7 +474,9 @@ export default class PollComponent extends Component {
 
   @action
   updatedVoters() {
-    this.preloadedVoters = this.defaultPreloadedVoters();
+    if (!this.preloadedVotersExpanded) {
+      this.preloadedVoters = this.defaultPreloadedVoters();
+    }
   }
 
   @action
@@ -501,6 +504,7 @@ export default class PollComponent extends Component {
       },
     })
       .then((result) => {
+        this.preloadedVotersExpanded = true;
         const voters = optionId
           ? this.preloadedVoters[optionId].voters
           : this.preloadedVoters;

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -45,7 +45,7 @@ export default class PollComponent extends Component {
   @tracked vote = this.args.attrs.vote || [];
   @tracked poll = this.args.attrs.poll;
   @tracked preloadedVoters = this.defaultPreloadedVoters();
-  @tracked preloadedVotersExpanded = false;
+  @tracked voterListExpanded = false;
   @tracked hasSavedVote = this.args.attrs.hasSavedVote;
 
   @tracked
@@ -474,7 +474,7 @@ export default class PollComponent extends Component {
 
   @action
   updatedVoters() {
-    if (!this.preloadedVotersExpanded) {
+    if (!this.voterListExpanded) {
       this.preloadedVoters = this.defaultPreloadedVoters();
     }
   }
@@ -504,7 +504,7 @@ export default class PollComponent extends Component {
       },
     })
       .then((result) => {
-        this.preloadedVotersExpanded = true;
+        this.voterListExpanded = true;
         const voters = optionId
           ? this.preloadedVoters[optionId].voters
           : this.preloadedVoters;

--- a/plugins/poll/test/javascripts/acceptance/poll-results-test.js
+++ b/plugins/poll/test/javascripts/acceptance/poll-results-test.js
@@ -551,7 +551,7 @@ acceptance("Poll results", function (needs) {
               readers_count: 1,
               score: 0,
               yours: true,
-              topic_id: 134,
+              topic_id: 135,
               topic_slug: "load-more-poll-voters-ranked-choice",
               display_username: null,
               primary_group_name: null,
@@ -610,7 +610,7 @@ acceptance("Poll results", function (needs) {
                       votes: 0,
                     },
                   ],
-                  voters: 1,
+                  voters: 2,
                   preloaded_voters: {
                     def034c6770c6fd3754c054ef9ec4721: [
                       {
@@ -654,7 +654,7 @@ acceptance("Poll results", function (needs) {
                     votes: 2,
                   },
                   {
-                    digest: "def034c6770c6fd3754c054ef9ec4721",
+                    digest: "d8c22ff912e03740d9bc19e133e581e0",
                     votes: 0,
                   },
                 ],
@@ -864,7 +864,7 @@ acceptance("Poll results", function (needs) {
           },
         ],
         tags: [],
-        id: 134,
+        id: 135,
         title: "Load more poll voters",
         fancy_title: "Load more poll voters",
         posts_count: 1,
@@ -890,7 +890,7 @@ acceptance("Poll results", function (needs) {
         image_url: null,
         slow_mode_seconds: 0,
         draft: null,
-        draft_key: "topic_134",
+        draft_key: "topic_135",
         draft_sequence: 7,
         posted: true,
         unpinned: null,
@@ -898,7 +898,7 @@ acceptance("Poll results", function (needs) {
         current_post_number: 1,
         highest_post_number: 1,
         last_read_post_number: 1,
-        last_read_post_id: 156,
+        last_read_post_id: 158,
         deleted_by: null,
         has_deleted: false,
         actions_summary: [
@@ -1177,6 +1177,78 @@ acceptance("Poll results", function (needs) {
       ),
       2,
       "after clicking fetch voters button, two voters shown on first option"
+    );
+
+    await publishToMessageBus("/polls/135", {
+      post_id: "158",
+      polls: [
+        {
+          name: "poll",
+          type: "ranked_choice",
+          status: "open",
+          public: true,
+          results: "always",
+          options: [
+            {
+              id: "def034c6770c6fd3754c054ef9ec4721",
+              html: "This",
+              votes: 3,
+            },
+            {
+              id: "d8c22ff912e03740d9bc19e133e581e0",
+              html: "That",
+              votes: 0,
+            },
+          ],
+          voters: 3,
+          preloaded_voters: {
+            def034c6770c6fd3754c054ef9ec4721: [
+              {
+                rank: 1,
+                user: {
+                  id: 1,
+                  username: "bianca",
+                  name: null,
+                  avatar_template:
+                    "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png",
+                },
+              },
+              {
+                rank: 1,
+                user: {
+                  id: 7,
+                  username: "foo",
+                  name: null,
+                  avatar_template:
+                    "/letter_avatar_proxy/v4/letter/f/b19c9b/{size}.png",
+                  title: null,
+                },
+              },
+              {
+                rank: 1,
+                user: {
+                  id: 11,
+                  username: "bar",
+                  name: null,
+                  avatar_template:
+                    "/letter_avatar_proxy/v4/letter/f/f33bef/{size}.png",
+                  title: null,
+                },
+              },
+            ],
+          },
+          chart_type: "bar",
+          title: null,
+        },
+      ],
+    });
+
+    assert.strictEqual(
+      count(
+        ".poll-container .discourse-poll-ranked_choice-results .results li:nth-child(1) .poll-voters li"
+      ),
+      2,
+      "after incoming message containing 3 voters, only 2 voters shown on first option as bus updates are not supported once voters are expanded"
     );
   });
 


### PR DESCRIPTION
An additional follow-up change on top of #28315 (which is still a valid improvement)  is required as currently expanded voter lists are almost immediately overwritten by incoming data on the message bus and post stream and effectively cancels the expansion leading to an uncomfortable user experience.  This was unfortunately not picked up during unit testing nor by manual testing because in dev the refresh cycle is so long.

So to prevent this and allow a user time to examine the expanded voter list, this change renders incoming updates for voter user lists disabled as soon as any option's voters list is expanded.  This only impacts big polls with > 25 voters on an option,

I believe this is a reasonable compromise and it still allows polls with fewer than 26 votes on an option to continue  to be streamed updates to voter population as this change does not affect that scale of poll as there is never any expansion action.

Background:

`preloadedVoters` is a list of all users who have voted.  It is maintained locally on the client because the data can change from incoming updates from remote voting events _and_ from local events, such as voting or expansion of the collapsed list of voters.

In order to save resources, the server by default will initially only serialize the first 25 voters (per option) down to the client.  If the user wishes to see more, they hit the provided expand button.  This will pull down an additional page of voters.  There are therefore two paths for update and the server does not keep track of the state of the local user interface.

More on the fix:

A user can restore the update process by navigating away from the Topic and returning or refreshing the browser (and that will revert the expanded list to the collapsed view - no change in that behaviour).

It obviously has no downside on Closed polls.

Test updated to reflect the change.