### PR TITLE
FIX: access correct name and description

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -1,6 +1,7 @@
 import { get } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import categoryVariables from "discourse/helpers/category-variables";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
@@ -112,7 +113,13 @@ function buildTopicCount(count) {
 }
 
 export function defaultCategoryLinkRenderer(category, opts) {
-  let descriptionText = escapeExpression(get(category, "description_text"));
+  // not ideal as we have to call it manually and we pass a fake category object
+  // but there's not way around it for now
+  let descriptionText = applyValueTransformer(
+    "category-description-text",
+    escapeExpression(get(category, "description_text")),
+    { category }
+  );
   let restricted = get(category, "read_restricted");
   let url = opts.url
     ? opts.url
@@ -156,7 +163,13 @@ export function defaultCategoryLinkRenderer(category, opts) {
     ${descriptionText ? 'title="' + descriptionText + '" ' : ""}
   >`;
 
-  let categoryName = escapeExpression(get(category, "name"));
+  // not ideal as we have to call it manually and we pass a fake category object
+  // but there's not way around it for now
+  let categoryName = applyValueTransformer(
+    "category-display-name",
+    escapeExpression(get(category, "name")),
+    { category }
+  );
 
   if (siteSettings.support_mixed_text_direction) {
     categoryDir = 'dir="auto"';

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -112,7 +112,7 @@ function buildTopicCount(count) {
 }
 
 export function defaultCategoryLinkRenderer(category, opts) {
-  let descriptionText = escapeExpression(get(category, "descriptionText"));
+  let descriptionText = escapeExpression(get(category, "description_text"));
   let restricted = get(category, "read_restricted");
   let url = opts.url
     ? opts.url
@@ -156,7 +156,7 @@ export function defaultCategoryLinkRenderer(category, opts) {
     ${descriptionText ? 'title="' + descriptionText + '" ' : ""}
   >`;
 
-  let categoryName = escapeExpression(get(category, "displayName"));
+  let categoryName = escapeExpression(get(category, "name"));
 
   if (siteSettings.support_mixed_text_direction) {
     categoryDir = 'dir="auto"';

--- a/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.js
@@ -1,0 +1,22 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { assert, module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Helper | category-link", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("name", async function () {
+    await render(hbs`{{category-link (hash name="foo")}}`);
+
+    assert.dom(".badge-category__name").hasText("foo");
+  });
+
+  test("description_text", async function () {
+    await render(
+      hbs`{{category-link (hash name="foo" description_text="bar")}}`
+    );
+
+    assert.dom(".badge-category").hasAttribute("title", "bar");
+  });
+});


### PR DESCRIPTION
`defaultCategoryLinkRenderer` is using a fake category object which doesn’t have access to the functions and getters of category model.

This had been incorrectly set in https://github.com/discourse/discourse/commit/c197daa04c3114184cbd3ec2f1cfade1b5701793

As we don't get a real category object, we have to call the transformers manually and also pass the fake category object as context, this is not ideal as people might try to access properties in the transformer which are not available on the category object given they will be different based on the context. Hopefully one day this helper and all the chain can be refactored to use a real category model.

This commit also adds tests for these two properties in the category-link helper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
