### PR TITLE
FIX: Ensure we dispose of MiniRacer::Context before forking daemons

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -64,15 +64,7 @@ initialized = false
 before_fork do |server, worker|
   unless initialized
     Discourse.preload_rails!
-
-    # V8 does not support forking, make sure all contexts are disposed
-    ObjectSpace.each_object(MiniRacer::Context) { |c| c.dispose }
-
-    # get rid of rubbish so we don't share it
-    # longer term we will use compact! here
-    GC.start
-    GC.start
-    GC.start
+    Discourse.before_fork
 
     initialized = true
 

--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -154,6 +154,8 @@ class Demon::Base
   end
 
   def run
+    Discourse.before_fork if defined?(Discourse)
+
     @pid =
       fork do
         Process.setproctitle("discourse #{self.class.prefix}")
@@ -161,6 +163,7 @@ class Demon::Base
         establish_app
         after_fork
       end
+
     write_pid_file
   end
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -897,6 +897,20 @@ module Discourse
   end
 
   # all forking servers must call this
+  # before forking, otherwise the forked process might
+  # be in a bad state
+  def self.before_fork
+    # V8 does not support forking, make sure all contexts are disposed
+    ObjectSpace.each_object(MiniRacer::Context) { |c| c.dispose }
+
+    # get rid of rubbish so we don't share it
+    # longer term we will use compact! here
+    GC.start
+    GC.start
+    GC.start
+  end
+
+  # all forking servers must call this
   # after fork, otherwise Discourse will be
   # in a bad state
   def self.after_fork


### PR DESCRIPTION
This commit updates `Demon::Base#start` to call `Discourse.before_fork`
before forking. According to the docs in `mini_racer`, we need to
"Dispose manually of all MiniRacer::Context objects prior to forking".

This commit is motivated by a segmentation fault which we are seeing in
production when killing a daemon process. Backtrace of the core dump
includes traces of `mini_racer` so we think this is the cause. Note that
we are not 100% sure if this will fix the issue.
