### PR TITLE
FIX: Don't show blank space when there's no banner image

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
@@ -59,7 +59,7 @@ export default class AdminConfigAreasAboutGeneralSettings extends Component {
 
   @action
   setImage(upload, { set }) {
-    set("aboutBannerImage", upload.url);
+    set("aboutBannerImage", upload?.url);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -141,7 +141,9 @@ export default class AboutPage extends Component {
 
   <template>
     <section class="about__header">
-      <img class="about__banner" src={{@model.banner_image}} />
+      {{#if @model.banner_image}}
+        <img class="about__banner" src={{@model.banner_image}} />
+      {{/if}}
       <h3>{{@model.title}}</h3>
       <p class="short-description">{{@model.description}}</p>
       <PluginOutlet

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -64,6 +64,13 @@ describe "About page", type: :system do
       expect(about_page).to have_moderators_count(1, "1")
     end
 
+    it "doesn't render banner image when it's not set" do
+      SiteSetting.about_banner_image = nil
+
+      about_page.visit
+      expect(about_page).to have_no_banner_image
+    end
+
     describe "displayed site age" do
       it "says less than 1 month if the site is less than 1 month old" do
         Discourse.stubs(:site_creation_date).returns(1.week.ago)

--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -95,6 +95,20 @@ describe "Admin About Config Area Page", type: :system do
       )
       expect(SiteSetting.about_banner_image.sha1).to eq(Upload.generate_digest(image_file))
     end
+
+    describe "the banner image field" do
+      it "can remove the uploaded image" do
+        SiteSetting.about_banner_image = image_upload
+
+        config_area.visit
+
+        config_area.general_settings_section.banner_image_uploader.remove_image
+
+        config_area.general_settings_section.submit
+        expect(config_area.general_settings_section).to have_saved_successfully
+        expect(SiteSetting.about_banner_image).to eq(nil)
+      end
+    end
   end
 
   describe "the contact information card" do

--- a/spec/system/page_objects/components/uppy_image_uploader.rb
+++ b/spec/system/page_objects/components/uppy_image_uploader.rb
@@ -18,6 +18,10 @@ module PageObjects
         # called immediately after selecting an image.
         @element.has_css?(".btn-danger", wait: 10)
       end
+
+      def remove_image
+        @element.find(".btn-danger").click
+      end
     end
   end
 end

--- a/spec/system/page_objects/pages/about.rb
+++ b/spec/system/page_objects/pages/about.rb
@@ -19,6 +19,10 @@ module PageObjects
         has_css?("img.about__banner[src=\"#{GlobalPath.full_cdn_url(upload.url)}\"]")
       end
 
+      def has_no_banner_image?
+        has_no_css?("img.about__banner")
+      end
+
       def has_members_count?(count, formatted_number)
         element = find(".about__stats-item.members span")
         element.has_text?(I18n.t("js.about.member_count", count:, formatted_number:))


### PR DESCRIPTION
This PR fixes a bug in the redesigned about page where if there's no banner image configured for the page, the top of the page where the banner goes is occupied with large white space.

Before:

<img src=https://github.com/user-attachments/assets/02b14424-f04d-4c62-9ca8-2252f79f279e width=500>

After:

<img src=https://github.com/user-attachments/assets/e9c9a760-c0e0-43f5-9012-d029db513d9a width=500>

Additionally, this PR also fixes a related bug in the admin config area for the /about page where it's not possible to remove the uploaded banner image.