### PR TITLE
FIX: FormKit: Allow 0 in required number input

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
@@ -104,7 +104,7 @@ export default class Validator {
         }
         break;
       case "input-number":
-        if (!value || typeof value === "undefined" || isNaN(Number(value))) {
+        if ((!value && value !== 0) || isNaN(Number(value))) {
           error = true;
         }
         break;

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-number-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-number-test.gjs
@@ -1,0 +1,59 @@
+import { fillIn, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Form from "discourse/components/form";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import formKit from "discourse/tests/helpers/form-kit-helper";
+
+module(
+  "Integration | Component | FormKit | Controls | Input | Number",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("@type=number", async function (assert) {
+      let data = { foo: "" };
+      const mutateData = (x) => (data = x);
+
+      await render(<template>
+        <Form @onSubmit={{mutateData}} @data={{data}} as |form|>
+          <form.Field @name="foo" @title="Foo" as |field|>
+            <field.Input @type="number" />
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert.form().field("foo").hasValue("");
+
+      await formKit().field("foo").fillIn(1);
+
+      assert.form().field("foo").hasValue("1");
+
+      await formKit().submit();
+
+      assert.deepEqual(data.foo, 1);
+    });
+
+    test("validation of required", async function (assert) {
+      await render(<template>
+        <Form as |form|>
+          <form.Field
+            @name="foo"
+            @title="Foo"
+            @validation="required"
+            as |field|
+          >
+            <field.Input @type="number" />
+          </form.Field>
+        </Form>
+      </template>);
+
+      await formKit().submit();
+
+      assert.form().hasErrors({ foo: ["Required"] });
+      assert.form().field("foo").hasError("Required");
+
+      await fillIn("input", "0");
+      await formKit().submit();
+      assert.form().field("foo").hasNoError();
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-text-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-text-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 
 module(
-  "Integration | Component | FormKit | Controls | Input",
+  "Integration | Component | FormKit | Controls | Input | Text",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -30,29 +30,6 @@ module(
       await formKit().submit();
 
       assert.deepEqual(data.foo, "bar");
-    });
-
-    test("@type", async function (assert) {
-      let data = { foo: "" };
-      const mutateData = (x) => (data = x);
-
-      await render(<template>
-        <Form @onSubmit={{mutateData}} @data={{data}} as |form|>
-          <form.Field @name="foo" @title="Foo" as |field|>
-            <field.Input @type="number" />
-          </form.Field>
-        </Form>
-      </template>);
-
-      assert.form().field("foo").hasValue("");
-
-      await formKit().field("foo").fillIn(1);
-
-      assert.form().field("foo").hasValue("1");
-
-      await formKit().submit();
-
-      assert.deepEqual(data.foo, 1);
     });
   }
 );

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -98,7 +98,7 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     await render(<template>
       <Form as |form|>
         <form.Field @name="foo" @title="Foo" @validation="required" as |field|>
-          <field.Input name="foo" />
+          <field.Input />
         </form.Field>
         <form.Field @name="bar" @title="Bar" @validation="required" as |field|>
           <field.Input />
@@ -111,10 +111,6 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     assert.form().hasErrors({ foo: ["Required"], bar: ["Required"] });
     assert.form().field("foo").hasError("Required");
     assert.form().field("bar").hasError("Required");
-
-    await fillIn("input[name=foo]", "0");
-    await formKit().submit();
-    assert.form().field("foo").hasNoError();
   });
 
   test("@validate", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -98,7 +98,7 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     await render(<template>
       <Form as |form|>
         <form.Field @name="foo" @title="Foo" @validation="required" as |field|>
-          <field.Input />
+          <field.Input name="foo" />
         </form.Field>
         <form.Field @name="bar" @title="Bar" @validation="required" as |field|>
           <field.Input />
@@ -111,6 +111,10 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     assert.form().hasErrors({ foo: ["Required"], bar: ["Required"] });
     assert.form().field("foo").hasError("Required");
     assert.form().field("bar").hasError("Required");
+
+    await fillIn("input[name=foo]", "0");
+    await formKit().submit();
+    assert.form().field("foo").hasNoError();
   });
 
   test("@validate", async function (assert) {


### PR DESCRIPTION
0 is falsy in JavaScript, so the original code would treat 0 as if it were not input. This unique exception was added to prevent 0 from being treated as empty input.

Screenshot before:

![image](https://github.com/user-attachments/assets/6dba3b91-0500-4180-bf7d-6fe2d8327eae)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
