### PR TITLE
DEV: Defer button actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -6,6 +6,7 @@ import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";
 import GlimmerComponentWithDeprecatedParentView from "discourse/components/glimmer-component-with-deprecated-parent-view";
 import concatClass from "discourse/helpers/concat-class";
+import runAfterFramePaint from "discourse/lib/after-frame-paint";
 import icon from "discourse-common/helpers/d-icon";
 import deprecated from "discourse-common/lib/deprecated";
 import I18n from "discourse-i18n";
@@ -106,7 +107,13 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
     if (actionVal || route) {
       if (actionVal) {
-        const { actionParam, forwardEvent } = this.args;
+        const { actionParam, forwardEvent, triggerImmediately } = this.args;
+
+        const triggerFn = triggerImmediately
+          ? runAfterFramePaint
+          : (value) => {
+              value();
+            };
 
         if (typeof actionVal === "string") {
           deprecated(...ACTION_AS_STRING_DEPRECATION_ARGS);
@@ -118,17 +125,17 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             );
           }
         } else if (typeof actionVal === "object" && actionVal.value) {
-          if (forwardEvent) {
-            actionVal.value(actionParam, event);
-          } else {
-            actionVal.value(actionParam);
-          }
+          triggerFn(() =>
+            forwardEvent
+              ? actionVal.value(actionParam, event)
+              : actionVal.value(actionParam)
+          );
         } else if (typeof actionVal === "function") {
-          if (forwardEvent) {
-            actionVal(actionParam, event);
-          } else {
-            actionVal(actionParam);
-          }
+          triggerFn(() =>
+            forwardEvent
+              ? actionVal(actionParam, event)
+              : actionVal(actionParam)
+          );
         }
       } else if (route) {
         this.router.transitionTo(route);

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -2,6 +2,7 @@ import { alias, match } from "@ember/object/computed";
 import Mixin from "@ember/object/mixin";
 import { schedule, throttle } from "@ember/runloop";
 import { service } from "@ember/service";
+import runAfterFramePaint from "discourse/lib/after-frame-paint";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import DiscourseURL from "discourse/lib/url";
@@ -86,9 +87,11 @@ export default Mixin.create({
     document.querySelector(".card-cloak")?.classList.remove("hidden");
 
     this.appEvents.trigger("user-card:show", { username });
-    this._positionCard(target, event);
-    this._showCallback(username).then((user) => {
-      this.appEvents.trigger("user-card:after-show", { user });
+    runAfterFramePaint(() => {
+      this._positionCard(target, event);
+      this._showCallback(username).then((user) => {
+        this.appEvents.trigger("user-card:after-show", { user });
+      });
     });
 
     // We bind scrolling on mobile after cards are shown to hide them if user scrolls

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-mobile.gjs
@@ -106,6 +106,7 @@ export default class ChatMessageActionsMobile extends Component {
                 <DButton
                   @translatedLabel={{button.name}}
                   @icon={{button.icon}}
+                  @triggerImmediately={{true}}
                   @action={{fn this.actAndCloseMenu button.id}}
                   class="chat-message-action"
                 />


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/27967, we attempted the following

> Currently, user actions can trigger functions that render changes to the screen within the same cycle (e.g. pressing the reply button will cause the login modal to pop up), potentially impacting performance and causing some jank on slower devices.
>
> This change inserts runAfterFramePaint where certain actions are triggered. Below are some screenshots indicating an improved INP for some of the buttons affected on controls with the highest INPs. The two places where this is added help with several actions, e.g. user + group cards, generic button action usage.

But the work had to be reverted due to an iOS bug in deferring certain actions like "copy".

This PR adds on that earlier one by allowing a short-circuit. The video below indicates a working "Copy Link" on iOS.


Uploading IMG_5289.MP4…

