### PR TITLE
DEV: Generate correct i18n keys for wizard radio choices

### DIFF
--- a/app/serializers/wizard_field_choice_serializer.rb
+++ b/app/serializers/wizard_field_choice_serializer.rb
@@ -10,7 +10,7 @@ class WizardFieldChoiceSerializer < ApplicationSerializer
   def i18nkey
     field = object.field
     step = field.step
-    "wizard.step.#{step.id}.fields.#{field.id}.choices.#{id}"
+    "wizard.step.#{step.id}.fields.#{field.id}.choices.#{id}".underscore
   end
 
   def label


### PR DESCRIPTION
### What is the problem?

If your wizard step has a dash in it, e.g. `foo-bar`, the wrong i18n key will be inferred for selects. This PR ensures the key is `underscore`d.