### PR TITLE
DEV: Add plugin outlet for below wizard field

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
@@ -90,6 +90,15 @@ export default class WizardFieldComponent extends Component {
           }}
         />
       {{/if}}
+
+      <PluginOutlet
+        @name="below-wizard-field"
+        @outletArgs={{hash
+          id=@field.id
+          disabled=@field.disabled
+          value=@field.value
+        }}
+      />
     </div>
   </template>
 }


### PR DESCRIPTION
### What is this change?

We changed the design of the member access wizard step to use toggle groups instead of switches. To support existing designs for notices, we need another plugin outlet.

### Screenshot

Here's a demo of the new plugin outlet in use. It's used to render the notice at the bottom:

<img width="680" alt="Screenshot 2024-08-14 at 2 53 10 PM" src="https://github.com/user-attachments/assets/1b439c83-d469-4f41-90ce-cfc1913b9bba">
