### PR TITLE
UX: Only `scrollIntoView` if sidebar items are not already visible

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.gjs
@@ -115,13 +115,21 @@ export default class SectionLink extends Component {
 
   @bind
   maybeScrollIntoView(element) {
-    if (this.args.scrollIntoView) {
-      schedule("afterRender", () => {
-        element.scrollIntoView({
-          block: "center",
-        });
-      });
+    if (!this.args.scrollIntoView) {
+      return;
     }
+
+    schedule("afterRender", () => {
+      const rect = element.getBoundingClientRect();
+      const alreadyVisible = rect.top <= window.innerHeight && rect.bottom >= 0;
+      if (alreadyVisible) {
+        return;
+      }
+
+      element.scrollIntoView({
+        block: "center",
+      });
+    });
   }
 
   <template>


### PR DESCRIPTION
When browsing through a sidebar with this feature enabled (i.e. admin, or docs), it's weird to have the scroll jump around when you click an item. This commit adds a check, so that we only `scrollIntoView` for items which are not already in the viewport.

Followup to b7cce1a0dcae18b3b8e4ed3bb06db43b5b71180d

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
