### PR TITLE
DEV: Fix ordering of `freeze-valid-transformers`

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/freeze-valid-transformers.js
+++ b/app/assets/javascripts/discourse/app/initializers/freeze-valid-transformers.js
@@ -2,6 +2,7 @@ import { _freezeValidTransformerNames } from "discourse/lib/transformer";
 
 export default {
   before: "inject-discourse-objects",
+  after: "discourse-bootstrap",
 
   initialize() {
     _freezeValidTransformerNames();


### PR DESCRIPTION
plugins/themes need to use `withPluginApi` to register transformers, and that only works after `discourse-bootstrap` has been run

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
