### PR TITLE
DEV: add before-sidebar-sections outlet to dropdown mode too

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -5,6 +5,7 @@ import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import DeferredRender from "discourse/components/deferred-render";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import ApiPanels from "./api-panels";
 import Footer from "./footer";
 import Sections from "./sections";
@@ -56,6 +57,7 @@ export default class SidebarHamburgerDropdown extends Component {
                 class="sidebar-hamburger-dropdown"
                 {{didInsert this.focusFirstLink}}
               >
+                <PluginOutlet @name="before-sidebar-sections" />
                 {{#if
                   (or this.sidebarState.showMainPanel @forceMainSidebarPanel)
                 }}


### PR DESCRIPTION
This outlet is in the same place in sidebar mode, so we need it here to support the same customizations in dropdown mode as well. 