### PR TITLE
PERF: Reduce memory footprint of `Chat::AutoRemove::HandleCategoryUpdated.call`

### DIFF
--- a/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
@@ -59,16 +59,11 @@ module Chat
       end
 
       def remove_users_without_channel_permission(users:, category_channel_ids:)
-        memberships_to_remove = []
-
-        users.find_in_batches do |batch_users|
-          memberships_to_remove.concat(
-            Chat::Action::CalculateMembershipsForRemoval.call(
-              scoped_users: batch_users,
-              channel_ids: category_channel_ids,
-            ),
+        memberships_to_remove =
+          Chat::Action::CalculateMembershipsForRemoval.call(
+            scoped_users_query: users,
+            channel_ids: category_channel_ids,
           )
-        end
 
         return if memberships_to_remove.blank?
 

--- a/plugins/chat/app/services/chat/auto_remove/handle_destroyed_group.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_destroyed_group.rb
@@ -98,7 +98,7 @@ module Chat
 
       def remove_users_without_channel_permission(scoped_users:)
         memberships_to_remove =
-          Chat::Action::CalculateMembershipsForRemoval.call(scoped_users: scoped_users)
+          Chat::Action::CalculateMembershipsForRemoval.call(scoped_users_query: scoped_users)
 
         return if memberships_to_remove.empty?
 

--- a/plugins/chat/app/services/chat/auto_remove/handle_user_removed_from_group.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_user_removed_from_group.rb
@@ -77,7 +77,9 @@ module Chat
 
       def remove_from_private_channels(user:)
         memberships_to_remove =
-          Chat::Action::CalculateMembershipsForRemoval.call(scoped_users: [user])
+          Chat::Action::CalculateMembershipsForRemoval.call(
+            scoped_users_query: User.where(id: user.id),
+          )
 
         return if memberships_to_remove.empty?
 


### PR DESCRIPTION
This is a follow up to ed11ee9d057160e5c1b0d1a86c9e94582d8fafd0.

In `Chat::AutoRemove::HandleCategoryUpdated`, we are currently loading
the related users record in batches and then handing it off to
`Chat::Action::CalculateMembershipsForRemoval.call`. However, we are
still seeing memory spike as a result of this.

This commit eliminates the allocation of `User` ActiveRecord objects until
absolutely necessary. `Chat::Action::CalculateMembershipsForRemoval.call` has been
updated to accept an ActiveRecord relation instead which allows us to
avoid the ActiveRecord allocations.
