### PR TITLE
DEV: Add plugin outlet for below wizard field (stable)

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
@@ -90,6 +90,15 @@ export default class WizardFieldComponent extends Component {
           }}
         />
       {{/if}}
+
+      <PluginOutlet
+        @name="below-wizard-field"
+        @outletArgs={{hash
+          id=@field.id
+          disabled=@field.disabled
+          value=@field.value
+        }}
+      />
     </div>
   </template>
 }


### PR DESCRIPTION
### What is this change?

We changed the design of the member access wizard step to use toggle groups instead of switches. To support existing designs for notices, we need another plugin outlet.

Merged in `main` [here](https://github.com/discourse/discourse/pull/28371). This is a backport to `stable`.
