### PR TITLE
FIX: allow chat sound when notifications are disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -135,7 +135,7 @@ function canUserReceiveNotifications(user) {
     return false;
   }
 
-  if (keyValueStore.getItem("notifications-disabled", "disabled")) {
+  if (keyValueStore.getItem("notifications-disabled") === "disabled") {
     return false;
   }
 
@@ -156,7 +156,6 @@ async function onNotification(data, siteSettings, user, appEvents) {
         group_name: data.group_name,
       });
 
-    const notificationBody = data.excerpt;
     const notificationIcon =
       siteSettings.site_logo_small_url || siteSettings.site_logo_url;
     const notificationTag =
@@ -167,17 +166,23 @@ async function onNotification(data, siteSettings, user, appEvents) {
 
     await requestPermission();
 
-    // create new notification using Notifications API
     const notification = new Notification(notificationTitle, {
-      body: notificationBody,
+      body: data.excerpt,
       icon: notificationIcon,
       tag: notificationTag,
     });
-    notification.onclick = () => {
-      DiscourseURL.routeTo(data.post_url);
-      appEvents.trigger("desktop-notification-opened", { url: data.post_url });
-      notification.close();
-    };
+
+    notification.addEventListener(
+      "click",
+      () => {
+        DiscourseURL.routeTo(data.post_url);
+        appEvents.trigger("desktop-notification-opened", {
+          url: data.post_url,
+        });
+        notification.close();
+      },
+      { once: true }
+    );
   }
 
   desktopNotificationHandlers.forEach((handler) =>

--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -144,44 +144,41 @@ function canUserReceiveNotifications(user) {
 
 // Call-in point from message bus
 async function onNotification(data, siteSettings, user, appEvents) {
-  if (!canUserReceiveNotifications(user)) {
-    return false;
-  }
+  const showNotifications = canUserReceiveNotifications(user) && liveEnabled;
 
-  if (!liveEnabled) {
-    return false;
-  }
+  if (showNotifications) {
+    const notificationTitle =
+      data.translated_title ||
+      I18n.t(i18nKey(data.notification_type), {
+        site_title: siteSettings.title,
+        topic: data.topic_title,
+        username: formatUsername(data.username),
+        group_name: data.group_name,
+      });
 
-  const notificationTitle =
-    data.translated_title ||
-    I18n.t(i18nKey(data.notification_type), {
-      site_title: siteSettings.title,
-      topic: data.topic_title,
-      username: formatUsername(data.username),
-      group_name: data.group_name,
+    const notificationBody = data.excerpt;
+    const notificationIcon =
+      siteSettings.site_logo_small_url || siteSettings.site_logo_url;
+    const notificationTag =
+      "discourse-notification-" +
+      siteSettings.title +
+      "-" +
+      (data.topic_id || 0);
+
+    await requestPermission();
+
+    // create new notification using Notifications API
+    const notification = new Notification(notificationTitle, {
+      body: notificationBody,
+      icon: notificationIcon,
+      tag: notificationTag,
     });
-
-  const notificationBody = data.excerpt;
-
-  const notificationIcon =
-    siteSettings.site_logo_small_url || siteSettings.site_logo_url;
-
-  const notificationTag =
-    "discourse-notification-" + siteSettings.title + "-" + (data.topic_id || 0);
-
-  await requestPermission();
-
-  // This shows the notification!
-  const notification = new Notification(notificationTitle, {
-    body: notificationBody,
-    icon: notificationIcon,
-    tag: notificationTag,
-  });
-  notification.onclick = () => {
-    DiscourseURL.routeTo(data.post_url);
-    appEvents.trigger("desktop-notification-opened", { url: data.post_url });
-    notification.close();
-  };
+    notification.onclick = () => {
+      DiscourseURL.routeTo(data.post_url);
+      appEvents.trigger("desktop-notification-opened", { url: data.post_url });
+      notification.close();
+    };
+  }
 
   desktopNotificationHandlers.forEach((handler) =>
     handler(data, siteSettings, user)


### PR DESCRIPTION
Desktop chat notification sounds have stopped working on most desktop browsers.

This is due to Notifications API being disabled when Push Notifications are supported in the browser, which means that we never iterate on the `desktopNotificationHandlers` and trigger the callback since we return early.

I haven't added tests in this PR as this is fairy complex to test based on device type and audio playback.