### PR TITLE
FIX: delay chat notify watching job

### DIFF
--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -370,7 +370,8 @@ module Chat
     end
 
     def notify_watching_users(except: [])
-      Jobs.enqueue(
+      Jobs.enqueue_in(
+        5.seconds,
         Jobs::Chat::NotifyWatching,
         { chat_message_id: @chat_message.id, except_user_ids: except, timestamp: @timestamp.to_s },
       )


### PR DESCRIPTION
This change delays the notify watching job to allow time for message to be marked as seen within chat.

Without a slight delay the job fires straight away and often means that messages are seen on screen but the user also receives a notification due to `Chat::Notifier.user_has_seen_message?` returning false.

I've omited a test since the change doesn't introduce new changes aside from delaying the job.