### PR TITLE
DEV: give sidebar link buttons a data-list-item-name

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-button.gjs
@@ -7,6 +7,7 @@ const SidebarSectionLinkButton = <template>
       {{on "click" @action}}
       type="button"
       class="sidebar-section-link sidebar-row --link-button"
+      data-list-item-name={{@text}}
     >
       <span class="sidebar-section-link-prefix icon">
         {{icon @icon}}


### PR DESCRIPTION
The `section-link` component gets a data attribute with the link name, like `data-list-item-name="My cool link"` — the `section-link-button` component is missing this. 

I've added it here to make these easier to target with CSS individually. 