### PR TITLE
PERF: automatically join users to channels more efficiently

### DIFF
--- a/plugins/chat/app/jobs/scheduled/chat/auto_join_users.rb
+++ b/plugins/chat/app/jobs/scheduled/chat/auto_join_users.rb
@@ -5,7 +5,6 @@ module Jobs
     class AutoJoinUsers < ::Jobs::Scheduled
       every 1.hour
 
-      MAX_USERS = 10_000
       LAST_SEEN_DAYS = 30
 
       def execute(_args)
@@ -60,7 +59,7 @@ module Jobs
           last_seen_at: LAST_SEEN_DAYS.days.ago,
           allowed_group_permissions: allowed_group_permissions,
           join_mode: join_mode,
-          max_users: MAX_USERS,
+          max_users: SiteSetting.max_chat_auto_joined_users,
         )
       end
     end

--- a/plugins/chat/app/jobs/scheduled/chat/auto_join_users.rb
+++ b/plugins/chat/app/jobs/scheduled/chat/auto_join_users.rb
@@ -5,14 +5,63 @@ module Jobs
     class AutoJoinUsers < ::Jobs::Scheduled
       every 1.hour
 
+      MAX_USERS = 10_000
+      LAST_SEEN_DAYS = 30
+
       def execute(_args)
         return if !SiteSetting.chat_enabled
 
-        ::Chat::Channel
-          .where(auto_join_users: true)
-          .each do |channel|
-            ::Chat::ChannelMembershipManager.new(channel).enforce_automatic_channel_memberships
-          end
+        allowed_group_permissions = [
+          CategoryGroup.permission_types[:create_post],
+          CategoryGroup.permission_types[:full],
+        ]
+
+        join_mode = ::Chat::UserChatChannelMembership.join_modes[:automatic]
+
+        sql = <<~SQL
+          WITH users AS (
+            SELECT id FROM users u
+            JOIN user_options uo ON uo.user_id = u.id
+            WHERE id > 0  AND (u.suspended_till IS NULL OR u.suspended_till <= :now)
+                          AND (u.last_seen_at IS NULL OR u.last_seen_at > :last_seen_at)
+                          AND u.active
+                          AND NOT u.staged
+                          AND uo.chat_enabled
+                          AND NOT EXISTS (SELECT 1 FROM anonymous_users a WHERE a.user_id = u.id)
+            ORDER BY last_seen_at desc
+            LIMIT :max_users
+          )
+
+          INSERT INTO user_chat_channel_memberships (user_id, chat_channel_id, following, created_at, updated_at, join_mode)
+          SELECT DISTINCT users.id AS user_id,
+                          chat_channels.id AS chat_channel_id,
+                          TRUE AS following,
+                          :now::timestamp AS created_at,
+                          :now::timestamp AS updated_at,
+                          :join_mode AS join_mode
+          FROM users
+          JOIN chat_channels on auto_join_users AND chatable_type = 'Category'
+          JOIN categories c on c.id = chat_channels.chatable_id
+
+          LEFT OUTER JOIN user_chat_channel_memberships uccm ON uccm.chat_channel_id = chat_channels.id
+                                                              AND uccm.user_id = users.id
+          LEFT OUTER JOIN group_users gu ON gu.user_id = users.id
+          LEFT OUTER JOIN category_groups cg ON cg.group_id = gu.group_id
+                                              AND cg.permission_type in (:allowed_group_permissions)
+                                              AND c.id = cg.category_id
+
+          WHERE  (cg.group_id is NOT null OR NOT c.read_restricted) AND uccm.id IS NULL
+          ON CONFLICT DO NOTHING
+        SQL
+
+        DB.exec(
+          sql,
+          now: Time.zone.now,
+          last_seen_at: LAST_SEEN_DAYS.days.ago,
+          allowed_group_permissions: allowed_group_permissions,
+          join_mode: join_mode,
+          max_users: MAX_USERS,
+        )
       end
     end
   end

--- a/plugins/chat/spec/jobs/scheduled/auto_join_users_spec.rb
+++ b/plugins/chat/spec/jobs/scheduled/auto_join_users_spec.rb
@@ -3,8 +3,18 @@
 describe Jobs::Chat::AutoJoinUsers do
   subject(:job) { described_class.new }
 
+  before { Jobs.run_immediately! }
+
   it "works" do
-    Jobs.run_immediately!
+    _staged_user = Fabricate(:user, staged: true)
+    _suspended_user = Fabricate(:user, suspended_till: 1.day.from_now)
+    _inactive_user = Fabricate(:user, active: false)
+
+    # this is just to avoid test fragility, we should always have negative users
+    bot_id = (User.minimum(:id) - 1)
+    bot_id = -1 if bot_id > 0
+    _bot_user = Fabricate(:user, id: bot_id)
+
     channel = Fabricate(:category_channel, auto_join_users: true)
     user = Fabricate(:user, last_seen_at: 1.minute.ago, active: true)
 
@@ -13,7 +23,25 @@ describe Jobs::Chat::AutoJoinUsers do
 
     job.execute({})
 
+    # should exclude bot / inactive / staged / suspended users
+    expect(Chat::UserChatChannelMembership.where(chat_channel: channel).count).to eq(
+      User.real.not_suspended.not_staged.where(active: true).count,
+    )
+
     membership = Chat::UserChatChannelMembership.find_by(user: user, chat_channel: channel)
     expect(membership.following).to eq(true)
+
+    membership.update!(following: false)
+    job.execute({})
+
+    membership.reload
+    expect(membership.following).to eq(false)
+
+    channel = Fabricate(:category_channel, auto_join_users: false)
+    job.execute({})
+
+    membership = Chat::UserChatChannelMembership.find_by(user: user, chat_channel: channel)
+
+    expect(membership).to be_nil
   end
 end

--- a/plugins/chat/spec/jobs/scheduled/auto_join_users_spec.rb
+++ b/plugins/chat/spec/jobs/scheduled/auto_join_users_spec.rb
@@ -11,6 +11,10 @@ describe Jobs::Chat::AutoJoinUsers do
     user.user_option.update!(chat_enabled: false)
     user
   end
+  fab!(:stage_user) { Fabricate(:user, staged: true) }
+  fab!(:suspended_user) { Fabricate(:user, suspended_till: 1.day.from_now) }
+  fab!(:inactive_user) { Fabricate(:user, active: false) }
+  fab!(:anonymous_user) { Fabricate(:anonymous) }
 
   before { Jobs.run_immediately! }
 
@@ -33,11 +37,6 @@ describe Jobs::Chat::AutoJoinUsers do
   end
 
   it "works for simple workflows" do
-    _staged_user = Fabricate(:user, staged: true)
-    _suspended_user = Fabricate(:user, suspended_till: 1.day.from_now)
-    _inactive_user = Fabricate(:user, active: false)
-    _anonymous_user = Fabricate(:anonymous)
-
     # this is just to avoid test fragility, we should always have negative users
     bot_id = (User.minimum(:id) - 1)
     bot_id = -1 if bot_id > 0


### PR DESCRIPTION
- Only ever auto join 10k users to channels (ordered by last seen)
- Join users to all channels at once, instead of batching and splitting
