### PR TITLE
DEV: Add backup helpers for specs

### DIFF
--- a/spec/lib/backup_restore/local_backup_store_spec.rb
+++ b/spec/lib/backup_restore/local_backup_store_spec.rb
@@ -7,12 +7,9 @@ RSpec.describe BackupRestore::LocalBackupStore do
   subject(:store) { BackupRestore::BackupStore.create(root_directory: @root_directory) }
 
   before do
-    @root_directory = Dir.mktmpdir
     @paths = []
-    SiteSetting.backup_location = BackupLocationSiteSetting::LOCAL
+    @root_directory = setup_local_backups
   end
-
-  after { FileUtils.remove_dir(@root_directory, true) }
 
   let(:expected_type) { BackupRestore::LocalBackupStore }
 
@@ -23,44 +20,51 @@ RSpec.describe BackupRestore::LocalBackupStore do
   end
 
   def create_backups
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "default",
       filename: "b.tar.gz",
       last_modified: "2018-09-13T15:10:00Z",
       size_in_bytes: 17,
     )
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "default",
       filename: "a.tgz",
       last_modified: "2018-02-11T09:27:00Z",
       size_in_bytes: 29,
     )
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "default",
       filename: "r.sql.gz",
       last_modified: "2017-12-20T03:48:00Z",
       size_in_bytes: 11,
     )
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "default",
       filename: "no-backup.txt",
       last_modified: "2018-09-05T14:27:00Z",
       size_in_bytes: 12,
     )
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "default/subfolder",
       filename: "c.tar.gz",
       last_modified: "2019-01-24T18:44:00Z",
       size_in_bytes: 23,
     )
 
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "second",
       filename: "multi-2.tar.gz",
       last_modified: "2018-11-27T03:16:54Z",
       size_in_bytes: 19,
     )
-    create_file(
+    create_local_backup_file(
+      root_directory: @root_directory,
       db_name: "second",
       filename: "multi-1.tar.gz",
       last_modified: "2018-11-26T03:17:09Z",
@@ -69,23 +73,7 @@ RSpec.describe BackupRestore::LocalBackupStore do
   end
 
   def remove_backups
-    @paths.each { |path| File.delete(path) if File.exist?(path) }
-    @paths.clear
-  end
-
-  def create_file(db_name:, filename:, last_modified:, size_in_bytes:)
-    path = File.join(@root_directory, db_name)
-    Dir.mkdir(path) unless Dir.exist?(path)
-
-    path = File.join(path, filename)
-    return if File.exist?(path)
-
-    @paths << path
-    FileUtils.touch(path)
-    File.truncate(path, size_in_bytes)
-
-    time = Time.parse(last_modified)
-    File.utime(time, time, path)
+    teardown_local_backups(root_directory: @root_directory)
   end
 
   def source_regex(db_name, filename, multisite:)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -211,6 +211,7 @@ RSpec.configure do |config|
   config.include SiteSettingsHelpers
   config.include SidekiqHelpers
   config.include UploadsHelpers
+  config.include BackupsHelpers
   config.include OneboxHelpers
   config.include FastImageHelpers
   config.include WithServiceHelper

--- a/spec/support/backups_helpers.rb
+++ b/spec/support/backups_helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module BackupsHelpers
+  def setup_local_backups
+    root_directory = Dir.mktmpdir
+    SiteSetting.backup_location = BackupLocationSiteSetting::LOCAL
+    root_directory
+  end
+
+  def teardown_local_backups(root_directory:)
+    FileUtils.remove_dir(root_directory, true)
+  end
+
+  def create_local_backup_file(root_directory:, db_name:, filename:, last_modified:, size_in_bytes:)
+    path = File.join(root_directory, db_name)
+    Dir.mkdir(path) unless Dir.exist?(path)
+
+    path = File.join(path, filename)
+    return if File.exist?(path)
+
+    FileUtils.touch(path)
+    File.truncate(path, size_in_bytes)
+
+    time = Time.parse(last_modified)
+    File.utime(time, time, path)
+
+    path
+  end
+end


### PR DESCRIPTION
This has been split out from https://github.com/discourse/discourse/pull/28051
so we can use this same code in plugin specs before merging the core PR,
adds some helpers for creating local backup temp files
and cleaning them up.
