### PR TITLE
DEV: Update `Guardian#is_developer` to only require admin for Developer

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -155,9 +155,9 @@ class Guardian
   end
 
   def is_developer?
-    @user && is_admin? &&
+    @user &&
       (
-        Rails.env.development? || Developer.user_ids.include?(@user.id) ||
+        Rails.env.development? || (is_admin? && Developer.user_ids.include?(@user.id)) ||
           (
             Rails.configuration.respond_to?(:developer_emails) &&
               Rails.configuration.developer_emails.include?(@user.email)


### PR DESCRIPTION
In development mode and when a developer's email is configured as part
of `Rails.configuration.developer_emails`, the user can be trusted and
should not be required to be an admin user.