### PR TITLE
DEV: Move user-profile-secondary outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -444,12 +444,12 @@
                     class="btn-danger btn-delete-user"
                   /></div>
               {{/if}}
+
+              <PluginOutlet
+                @name="user-profile-secondary"
+                @outletArgs={{hash model=this.model}}
+              />
             </dl>
-            <PluginOutlet
-              @name="user-profile-secondary"
-              @connectorTagName="div"
-              @outletArgs={{hash model=this.model}}
-            />
           </div>
         {{/unless}}
       </div>


### PR DESCRIPTION
Move it into the preceding `dl` element and remove the `div` wrapper.

The two plugins that use this outlet:
* d-follow - actually jumps through hacky hoops to get its elements into that `dl` anyway
* d-gamification - would look better if its element was in that `dl`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
