### PR TITLE
FIX: bypass highlighths for long code in auto mode

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -42,11 +42,11 @@ export default async function highlightSyntax(elem, siteSettings, session) {
       }
     }
 
-    const canHighlight = lang && (lang === "auto" || hljs.getLanguage(lang));
-
     if (lang === "auto" && e.innerHTML.length > 1000) {
       return;
     }
+
+    const canHighlight = lang && (lang === "auto" || hljs.getLanguage(lang));
 
     if (canHighlight) {
       e.classList.remove("lang-auto"); // This isn't a real hljs language. HLJS will warn if it's present, so we remove it.

--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -44,6 +44,10 @@ export default async function highlightSyntax(elem, siteSettings, session) {
 
     const canHighlight = lang && (lang === "auto" || hljs.getLanguage(lang));
 
+    if (lang === "auto" && e.innerHTML.length > 1000) {
+      return;
+    }
+
     if (canHighlight) {
       e.classList.remove("lang-auto"); // This isn't a real hljs language. HLJS will warn if it's present, so we remove it.
       hljs.highlightElement(e);


### PR DESCRIPTION
Long code is considered 1000 characters atm. 10000+ characters would take seconds due to how highlightjs will consider every installed lang before choosing the best candidate.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
