### PR TITLE
UX: omit fav badges count if max is 0

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -1,13 +1,15 @@
 {{body-class "user-badges-page"}}
 
 <section class="user-content" id="user-content">
-  <p class="favorite-count">
-    {{i18n
-      "badges.favorite_count"
-      count=this.favoriteBadges.length
-      max=this.siteSettings.max_favorite_badges
-    }}
-  </p>
+  {{#if this.siteSettings.max_favorite_badges}}
+    <p class="favorite-count">
+      {{i18n
+        "badges.favorite_count"
+        count=this.favoriteBadges.length
+        max=this.siteSettings.max_favorite_badges
+      }}
+    </p>
+  {{/if}}
 
   <div class="badge-group-list">
     {{#each this.sortedBadges as |ub|}}


### PR DESCRIPTION
Omits the "0/0 badges marked as favorite" notice when max favorites badge is 0.