### PR TITLE
PERF: Delete `I18n._overrides` after they have been applied

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/localization.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/localization.js
@@ -38,6 +38,8 @@ export default {
           node[segs[segs.length - 1]] = value;
         }
       }
+
+      delete I18n._overrides;
     }
   },
 };


### PR DESCRIPTION
There's no need to keep them around. This might just bloat memory if there are lots of translation overrides.