### PR TITLE
DEV: prevents route action to crash in tests

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/route-action.js
+++ b/app/assets/javascripts/discourse/app/helpers/route-action.js
@@ -31,7 +31,7 @@ function getRouteWithAction(router, actionName) {
 function routeAction(actionName, router, ...params) {
   assert("[ember-route-action-helper] Unable to lookup router", router);
 
-  if (!isTesting() || (isTesting() && router.currentRoute)) {
+  if (!isTesting() || router.currentRoute) {
     runInDebug(() => {
       let { handler } = getRouteWithAction(router, actionName);
       assert(

--- a/app/assets/javascripts/discourse/app/helpers/route-action.js
+++ b/app/assets/javascripts/discourse/app/helpers/route-action.js
@@ -5,6 +5,7 @@ import { assert, runInDebug } from "@ember/debug";
 import { computed, get } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { join } from "@ember/runloop";
+import { isTesting } from "discourse-common/config/environment";
 
 function getCurrentRouteInfos(router) {
   let routerLib = router._routerMicrolib || router.router;
@@ -30,13 +31,15 @@ function getRouteWithAction(router, actionName) {
 function routeAction(actionName, router, ...params) {
   assert("[ember-route-action-helper] Unable to lookup router", router);
 
-  runInDebug(() => {
-    let { handler } = getRouteWithAction(router, actionName);
-    assert(
-      `[ember-route-action-helper] Unable to find action ${actionName}`,
-      handler
-    );
-  });
+  if (!isTesting() || (isTesting() && router.currentRoute)) {
+    runInDebug(() => {
+      let { handler } = getRouteWithAction(router, actionName);
+      assert(
+        `[ember-route-action-helper] Unable to find action ${actionName}`,
+        handler
+      );
+    });
+  }
 
   return function (...invocationArgs) {
     let { action, handler } = getRouteWithAction(router, actionName);


### PR DESCRIPTION
`routeAction` is testing at runtime that a route exists when in debug mode. However in the case of components tested in isolation there's no existing route which was causing an exception, this commit prevents this check in this case as it's irrelevant.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
