### PR TITLE
FIX: broken mentioned users with capitalized usernames

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -591,7 +591,7 @@ class PostSerializer < BasicPostSerializer
       else
         query = User.includes(:user_option)
         query = query.includes(:user_status) if SiteSetting.enable_user_status
-        query = query.where(username: object.mentions)
+        query = query.where(username_lower: object.mentions)
       end
 
     users.map { |user| BasicUserSerializer.new(user, root: false, include_status: true).as_json }

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -744,7 +744,8 @@ class TopicView
         usernames.flatten!
         usernames.uniq!
 
-        users = User.where(username: usernames).includes(:user_status).index_by(&:username)
+        users =
+          User.where(username_lower: usernames).includes(:user_status).index_by(&:username_lower)
 
         mentions.reduce({}) do |hash, (post_id, post_mentioned_usernames)|
           hash[post_id] = post_mentioned_usernames.map { |username| users[username] }.compact

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -950,6 +950,17 @@ RSpec.describe TopicView do
     end
   end
 
+  describe "#mentioned_users" do
+    it "works with capitalized usernames" do
+      user = Fabricate(:user, username: "JoJo")
+      post_1 = Fabricate(:post, topic: topic, raw: "Hey @#{user.username}")
+
+      view = TopicView.new(topic.id, user).mentioned_users
+
+      expect(view[post_1.id]).to eq([user])
+    end
+  end
+
   describe "#image_url" do
     fab!(:op_upload) { Fabricate(:image_upload) }
     fab!(:post3_upload) { Fabricate(:image_upload) }

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -365,29 +365,42 @@ RSpec.describe PostSerializer do
   context "with mentions" do
     fab!(:user_status)
     fab!(:user)
-    fab!(:user1) { Fabricate(:user, user_status: user_status) }
-    fab!(:post) { Fabricate(:post, user: user, raw: "Hey @#{user1.username}") }
+
+    let(:username) { "joffrey" }
+    let(:user1) { Fabricate(:user, user_status: user_status, username: username) }
+    let(:post) { Fabricate(:post, user: user, raw: "Hey @#{user1.username}") }
     let(:serializer) { described_class.new(post, scope: Guardian.new(user), root: false) }
+    let(:subject) { serializer.as_json }
 
-    it "returns mentioned users with user status when user status is enabled" do
-      SiteSetting.enable_user_status = true
+    context "when user status is enabled" do
+      before { SiteSetting.enable_user_status = true }
 
-      json = serializer.as_json
+      it "returns mentioned users with user status" do
+        expect(subject[:mentioned_users]).to be_present
+        expect(subject[:mentioned_users].length).to be(1)
+        expect(subject[:mentioned_users][0]).to_not be_nil
+        expect(subject[:mentioned_users][0][:id]).to eq(user1.id)
+        expect(subject[:mentioned_users][0][:username]).to eq(user1.username)
+        expect(subject[:mentioned_users][0][:name]).to eq(user1.name)
+        expect(subject[:mentioned_users][0][:status][:description]).to eq(user_status.description)
+        expect(subject[:mentioned_users][0][:status][:emoji]).to eq(user_status.emoji)
+      end
 
-      expect(json[:mentioned_users]).to be_present
-      expect(json[:mentioned_users].length).to be(1)
-      expect(json[:mentioned_users][0]).to_not be_nil
-      expect(json[:mentioned_users][0][:id]).to eq(user1.id)
-      expect(json[:mentioned_users][0][:username]).to eq(user1.username)
-      expect(json[:mentioned_users][0][:name]).to eq(user1.name)
-      expect(json[:mentioned_users][0][:status][:description]).to eq(user_status.description)
-      expect(json[:mentioned_users][0][:status][:emoji]).to eq(user_status.emoji)
+      context "when username has a capital letter" do
+        let(:username) { "JoJo" }
+
+        it "returns mentioned users with user status" do
+          expect(subject[:mentioned_users][0][:username]).to eq(user1.username)
+        end
+      end
     end
 
-    it "doesn't return mentioned users when user status is disabled" do
-      SiteSetting.enable_user_status = false
-      json = serializer.as_json
-      expect(json[:mentioned_users]).to be_nil
+    context "when user status is disabled" do
+      before { SiteSetting.enable_user_status = false }
+
+      it "doesn't return mentioned users" do
+        expect(subject[:mentioned_users]).to be_nil
+      end
     end
   end
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -370,27 +370,27 @@ RSpec.describe PostSerializer do
     let(:user1) { Fabricate(:user, user_status: user_status, username: username) }
     let(:post) { Fabricate(:post, user: user, raw: "Hey @#{user1.username}") }
     let(:serializer) { described_class.new(post, scope: Guardian.new(user), root: false) }
-    let(:subject) { serializer.as_json }
 
     context "when user status is enabled" do
       before { SiteSetting.enable_user_status = true }
 
       it "returns mentioned users with user status" do
-        expect(subject[:mentioned_users]).to be_present
-        expect(subject[:mentioned_users].length).to be(1)
-        expect(subject[:mentioned_users][0]).to_not be_nil
-        expect(subject[:mentioned_users][0][:id]).to eq(user1.id)
-        expect(subject[:mentioned_users][0][:username]).to eq(user1.username)
-        expect(subject[:mentioned_users][0][:name]).to eq(user1.name)
-        expect(subject[:mentioned_users][0][:status][:description]).to eq(user_status.description)
-        expect(subject[:mentioned_users][0][:status][:emoji]).to eq(user_status.emoji)
+        json = serializer.as_json
+        expect(json[:mentioned_users]).to be_present
+        expect(json[:mentioned_users].length).to be(1)
+        expect(json[:mentioned_users][0]).to_not be_nil
+        expect(json[:mentioned_users][0][:id]).to eq(user1.id)
+        expect(json[:mentioned_users][0][:username]).to eq(user1.username)
+        expect(json[:mentioned_users][0][:name]).to eq(user1.name)
+        expect(json[:mentioned_users][0][:status][:description]).to eq(user_status.description)
+        expect(json[:mentioned_users][0][:status][:emoji]).to eq(user_status.emoji)
       end
 
       context "when username has a capital letter" do
         let(:username) { "JoJo" }
 
         it "returns mentioned users with user status" do
-          expect(subject[:mentioned_users][0][:username]).to eq(user1.username)
+          expect(serializer.as_json[:mentioned_users][0][:username]).to eq(user1.username)
         end
       end
     end
@@ -399,7 +399,7 @@ RSpec.describe PostSerializer do
       before { SiteSetting.enable_user_status = false }
 
       it "doesn't return mentioned users" do
-        expect(subject[:mentioned_users]).to be_nil
+        expect(serializer.as_json[:mentioned_users]).to be_nil
       end
     end
   end


### PR DESCRIPTION
This commit fixes two codepaths which where incorrectly working with capitalized usernames as we were doing a mix of username_lower and non lower username.

Also adds two specs for these cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
