### PR TITLE
DEV: Use `yarn`-installed terser in assets.rake

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -57,7 +57,7 @@ task "assets:precompile:before": %w[
   # is recompiled
   Emoji.clear_cache
 
-  $node_compress = `which terser`.present? && !ENV["SKIP_NODE_UGLIFY"]
+  $node_compress = !ENV["SKIP_NODE_UGLIFY"]
 
   unless ENV["USE_SPROCKETS_UGLIFY"]
     $bypass_sprockets_uglify = true
@@ -158,7 +158,7 @@ def compress_node(from, to)
   base_source_map = assets_path + assets_additional_path
 
   cmd = <<~SH
-    terser '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}',includeSources=true"
+    yarn terser '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}',includeSources=true"
   SH
 
   STDERR.puts cmd

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prettier": "^2.8.8",
     "puppeteer-core": "^23.1.0",
     "squoosh": "discourse/squoosh#dc9649d",
+    "terser": "^5.31.6",
     "typescript": "^5.5.4"
   },
   "scripts": {


### PR DESCRIPTION
This was previously relying on a globally-installed terser, which comes from a time before Discourse had proper JS dependency management

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
