### PR TITLE
FIX: Endless loading post history

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history.js
+++ b/app/assets/javascripts/discourse/app/components/modal/history.js
@@ -24,6 +24,7 @@ export default class History extends Component {
   @service site;
   @service currentUser;
   @service siteSettings;
+  @service appEvents;
 
   @tracked loading;
   @tracked postRevision;
@@ -169,13 +170,29 @@ export default class History extends Component {
     }
   }
 
-  refresh(postId, postVersion) {
+  async refresh(postId, postVersion) {
     this.loading = true;
-    Post.loadRevision(postId, postVersion).then((result) => {
+    try {
+      const result = await Post.loadRevision(postId, postVersion);
       this.postRevision = result;
+    } catch (error) {
+      this.args.closeModal();
+      this.dialog.alert(error.jqXHR.responseJSON.errors[0]);
+
+      const postStream = this.args.model.post?.topic?.postStream;
+      if (!postStream) {
+        return;
+      }
+
+      postStream
+        .triggerChangedPost(postId, this.args.model)
+        .then(() =>
+          this.appEvents.trigger("post-stream:refresh", { id: postId })
+        );
+    } finally {
       this.loading = false;
       this.initialLoad = false;
-    });
+    }
   }
 
   hide(postId, postVersion) {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -469,6 +469,8 @@ class PostsController < ApplicationController
     post.public_version -= 1
     post.save
 
+    post.publish_change_to_clients!(:revised)
+
     render body: nil
   end
 
@@ -508,6 +510,8 @@ class PostsController < ApplicationController
     post = find_post_from_params
     post.public_version += 1
     post.save
+
+    post.publish_change_to_clients!(:revised)
 
     render body: nil
   end


### PR DESCRIPTION
Showing or hiding the revision on a post will update the clients through MessageBus. If, for some reason, the post does not get updated, attempting to fetch a hidden or nonexistent revision will yield the proper error and refresh the post to hide the revision button.