### PR TITLE
DEV: Switch back to Chrome for running QUnit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/main/head' }}
       CHEAP_SOURCE_MAPS: "1"
+      TESTEM_DEFAULT_BROWSER: Chrome
 
     strategy:
       fail-fast: false
@@ -150,7 +151,7 @@ jobs:
         if: matrix.target == 'themes'
         run: bin/rake themes:clone_all_official themes:pull_compatible_all
 
-      - name: Add hosts to /etc/hosts, otherwise Chromium cannot reach minio
+      - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
         if: matrix.build_type == 'system' && matrix.target == 'core'
         run: |
           echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
@@ -363,7 +364,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ["Chromium", "Firefox ESR", "Firefox Evergreen"]
+        browser: ["Chrome", "Firefox ESR", "Firefox Evergreen"]
 
     env:
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}


### PR DESCRIPTION
QUnit tests are failing in different ways on Chromium in Debian bookworm. We have no interest in figuring out why as it is not a good use of our time and the long term plan is to switch to Chrome for Testing anyway.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
