### PR TITLE
FEATURE: Change default for push_notification_time_window_mins

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -363,7 +363,7 @@ basic:
     default: true
     client: true
   push_notification_time_window_mins:
-    default: 10
+    default: 1
     min: 0
   short_title:
     default: ""

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1360,6 +1360,7 @@ RSpec.describe PostAlerter do
     end
 
     it "delays push notification for active online user" do
+      SiteSetting.push_notification_time_window_mins = 10
       evil_trout.update!(last_seen_at: 5.minutes.ago)
 
       expect { mention_post }.to change { Jobs::PushNotification.jobs.count }


### PR DESCRIPTION
Currently the push_notification_time_window_mins is set to 10
minutes by default. We want to change this to 1 minute, which is the
delay it has been set to on meta and our internal site already for over
a year now.

This conforms to the expectation users have that notifications are
delivered close to immediately.
