### PR TITLE
FIX: poll ranked choice voter expansion fix

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -489,10 +489,7 @@ export default class PollComponent extends Component {
       }
     });
 
-    this.preloadedVoters = Object.assign(preloadedVoters);
-    let voters = optionId
-          ? this.preloadedVoters[optionId].voters
-          : this.preloadedVoters;
+    let voters = optionId ? preloadedVoters[optionId].voters : preloadedVoters;
     const votersCount = voters.length;
 
     return ajax("/polls/voters.json", {
@@ -527,12 +524,11 @@ export default class PollComponent extends Component {
           });
           // remove users who changed their vote
           if (this.poll.type === REGULAR) {
-            Object.keys(this.preloadedVoters).forEach((otherOptionId) => {
+            Object.keys(preloadedVoters).forEach((otherOptionId) => {
               if (optionId !== otherOptionId) {
-                this.preloadedVoters[otherOptionId].voters =
-                  this.preloadedVoters[otherOptionId].voters.filter(
-                    (voter) => !votersSet.has(voter.username)
-                  );
+                preloadedVoters[otherOptionId].voters = preloadedVoters[
+                  otherOptionId
+                ].voters.filter((voter) => !votersSet.has(voter.username));
               }
             });
           }
@@ -546,9 +542,8 @@ export default class PollComponent extends Component {
         }
       })
       .finally(() => {
-        preloadedVoters = this.preloadedVoters;
         preloadedVoters[optionId].loading = false;
-        this.preloadedVoters = Object.assign(preloadedVoters);
+        this.preloadedVoters = Object.assign({}, preloadedVoters);
       });
   }
 

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -481,7 +481,6 @@ export default class PollComponent extends Component {
 
   @action
   fetchVoters(optionId) {
-    let votersCount;
     let preloadedVoters = this.preloadedVoters;
 
     Object.keys(preloadedVoters).forEach((key) => {
@@ -491,8 +490,10 @@ export default class PollComponent extends Component {
     });
 
     this.preloadedVoters = Object.assign(preloadedVoters);
-
-    votersCount = this.options.find((option) => option.id === optionId).votes;
+    let voters = optionId
+          ? this.preloadedVoters[optionId].voters
+          : this.preloadedVoters;
+    const votersCount = voters.length;
 
     return ajax("/polls/voters.json", {
       data: {
@@ -505,14 +506,19 @@ export default class PollComponent extends Component {
     })
       .then((result) => {
         this.voterListExpanded = true;
-        const voters = optionId
-          ? this.preloadedVoters[optionId].voters
-          : this.preloadedVoters;
         const newVoters = optionId ? result.voters[optionId] : result.voters;
+        let votersSet = new Set([]);
+
         if (this.isRankedChoice) {
-          this.preloadedVoters[optionId].voters = [...new Set([...newVoters])];
+          votersSet = new Set(voters.map((voter) => voter.user.username));
+          newVoters.forEach((voter) => {
+            if (!votersSet.has(voter.user.username)) {
+              votersSet.add(voter.user.username);
+              voters.push(voter);
+            }
+          });
         } else {
-          const votersSet = new Set(voters.map((voter) => voter.username));
+          votersSet = new Set(voters.map((voter) => voter.username));
           newVoters.forEach((voter) => {
             if (!votersSet.has(voter.username)) {
               votersSet.add(voter.username);

--- a/plugins/poll/test/javascripts/acceptance/poll-results-test.js
+++ b/plugins/poll/test/javascripts/acceptance/poll-results-test.js
@@ -981,14 +981,6 @@ acceptance("Poll results", function (needs) {
           voters: {
             db753fe0bc4e72869ac1ad8765341764: [
               {
-                id: 1,
-                username: "bianca",
-                name: null,
-                avatar_template:
-                  "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png",
-                title: null,
-              },
-              {
                 id: 7,
                 username: "foo",
                 name: null,
@@ -1005,16 +997,6 @@ acceptance("Poll results", function (needs) {
         return helper.response({
           voters: {
             def034c6770c6fd3754c054ef9ec4721: [
-              {
-                rank: 1,
-                user: {
-                  id: 1,
-                  username: "bianca",
-                  name: null,
-                  avatar_template:
-                    "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png",
-                },
-              },
               {
                 rank: 1,
                 user: {


### PR DESCRIPTION
Currently, for Ranked Choice voter expansion, the code is replacing the voter list with the new page of voters instead of appending the existing voter list.  This is resolved in this PR.