### PR TITLE
DEV: add addError method to FormKit onRegisterApi

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -42,6 +42,7 @@ class FKForm extends Component {
       setProperties: this.setProperties,
       submit: this.onSubmit,
       reset: this.onReset,
+      addError: this.addError,
     });
 
     this.router.on("routeWillChange", this.checkIsDirty);

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -137,6 +137,12 @@ module("Integration | Component | FormKit | Form", function (hooks) {
     await formApi.submit();
 
     assert.dom(".bar").hasText("2");
+
+    formApi.addError("bar", { title: "Bar", message: "error_foo" });
+    // assert on the next tick
+    setTimeout(() => {
+      assert.form().hasErrors({ bar: "error_foo" });
+    }, 0);
   });
 
   test("@data", async function (assert) {


### PR DESCRIPTION
This commit adds the addError method to From's onRegisterApi to allow parent components to add errors to a field.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
