### PR TITLE
DEV: Allow disabling problem checks programatically

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -13,7 +13,7 @@ class ProblemCheck
     end
 
     def run_all
-      each(&:run)
+      select(&:enabled?).each(&:run)
     end
 
     private
@@ -23,6 +23,7 @@ class ProblemCheck
 
   include ActiveSupport::Configurable
 
+  config_accessor :enabled, default: true, instance_writer: false
   config_accessor :priority, default: "low", instance_writer: false
 
   # Determines if the check should be performed at a regular interval, and if
@@ -111,6 +112,11 @@ class ProblemCheck
     name.demodulize.underscore.to_sym
   end
   delegate :identifier, to: :class
+
+  def self.enabled?
+    enabled
+  end
+  delegate :enabled?, to: :class
 
   def self.scheduled?
     perform_every.present?

--- a/spec/services/problem_check_spec.rb
+++ b/spec/services/problem_check_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProblemCheck do
     RealtimeCheck = Class.new(described_class)
     InlineCheck = Class.new(described_class) { self.inline = true }
     PluginCheck = Class.new(described_class)
+    DisabledCheck = Class.new(described_class) { self.enabled = false }
     FailingCheck =
       Class.new(described_class) do
         def call
@@ -30,13 +31,14 @@ RSpec.describe ProblemCheck do
     stub_const(
       described_class,
       "CORE_PROBLEM_CHECKS",
-      [ScheduledCheck, RealtimeCheck, InlineCheck, FailingCheck, PassingCheck],
+      [ScheduledCheck, RealtimeCheck, InlineCheck, DisabledCheck, FailingCheck, PassingCheck],
       &example
     )
 
     Object.send(:remove_const, ScheduledCheck.name)
     Object.send(:remove_const, RealtimeCheck.name)
     Object.send(:remove_const, InlineCheck.name)
+    Object.send(:remove_const, DisabledCheck.name)
     Object.send(:remove_const, PluginCheck.name)
     Object.send(:remove_const, FailingCheck.name)
     Object.send(:remove_const, PassingCheck.name)
@@ -45,6 +47,8 @@ RSpec.describe ProblemCheck do
   let(:scheduled_check) { ScheduledCheck }
   let(:realtime_check) { RealtimeCheck }
   let(:inline_check) { InlineCheck }
+  let(:enabled_check) { RealtimeCheck }
+  let(:disabled_check) { DisabledCheck }
   let(:plugin_check) { PluginCheck }
   let(:failing_check) { FailingCheck }
   let(:passing_check) { PassingCheck }
@@ -90,6 +94,11 @@ RSpec.describe ProblemCheck do
     it { expect(inline_check).to be_inline }
     it { expect(realtime_check).to_not be_inline }
     it { expect(scheduled_check).to_not be_inline }
+  end
+
+  describe ".enabled?" do
+    it { expect(enabled_check).to be_enabled }
+    it { expect(disabled_check).not_to be_enabled }
   end
 
   describe "plugin problem check registration" do


### PR DESCRIPTION
### What is this change?

We need a way to disable certain checks programatically, e.g. on Discourse hosting. This PR adds a configuration option for this, and makes it so that disabled checks aren't run as part of `#run_all`.