### PR TITLE
DEV: Allow disabling problem checks programatically (stable)

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -13,7 +13,7 @@ class ProblemCheck
     end
 
     def run_all
-      each(&:run)
+      select(&:enabled?).each(&:run)
     end
 
     private
@@ -23,6 +23,7 @@ class ProblemCheck
 
   include ActiveSupport::Configurable
 
+  config_accessor :enabled, default: true, instance_writer: false
   config_accessor :priority, default: "low", instance_writer: false
 
   # Determines if the check should be performed at a regular interval, and if
@@ -104,6 +105,11 @@ class ProblemCheck
     name.demodulize.underscore.to_sym
   end
   delegate :identifier, to: :class
+
+  def self.enabled?
+    enabled
+  end
+  delegate :enabled?, to: :class
 
   def self.scheduled?
     perform_every.present?

--- a/spec/services/problem_check_spec.rb
+++ b/spec/services/problem_check_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ProblemCheck do
     ScheduledCheck = Class.new(described_class) { self.perform_every = 30.minutes }
     RealtimeCheck = Class.new(described_class)
     PluginCheck = Class.new(described_class)
+    DisabledCheck = Class.new(described_class) { self.enabled = false }
     FailingCheck =
       Class.new(described_class) do
         def call
@@ -29,12 +30,13 @@ RSpec.describe ProblemCheck do
     stub_const(
       described_class,
       "CORE_PROBLEM_CHECKS",
-      [ScheduledCheck, RealtimeCheck, FailingCheck, PassingCheck],
+      [ScheduledCheck, RealtimeCheck, FailingCheck, DisabledCheck, PassingCheck],
       &example
     )
 
     Object.send(:remove_const, ScheduledCheck.name)
     Object.send(:remove_const, RealtimeCheck.name)
+    Object.send(:remove_const, DisabledCheck.name)
     Object.send(:remove_const, PluginCheck.name)
     Object.send(:remove_const, FailingCheck.name)
     Object.send(:remove_const, PassingCheck.name)
@@ -42,6 +44,8 @@ RSpec.describe ProblemCheck do
 
   let(:scheduled_check) { ScheduledCheck }
   let(:realtime_check) { RealtimeCheck }
+  let(:enabled_check) { RealtimeCheck }
+  let(:disabled_check) { DisabledCheck }
   let(:plugin_check) { PluginCheck }
   let(:failing_check) { FailingCheck }
   let(:passing_check) { PassingCheck }
@@ -77,6 +81,11 @@ RSpec.describe ProblemCheck do
   describe ".realtime?" do
     it { expect(realtime_check).to be_realtime }
     it { expect(scheduled_check).to_not be_realtime }
+  end
+
+  describe ".enabled?" do
+    it { expect(enabled_check).to be_enabled }
+    it { expect(disabled_check).not_to be_enabled }
   end
 
   describe "plugin problem check registration" do


### PR DESCRIPTION
### What is this change?

We need a way to disable certain checks programatically, e.g. on Discourse hosting. This PR adds a configuration option for this, and makes it so that disabled checks aren't run as part of #run_all.

Backport of: #28440