### PR TITLE
DEV: Add class to span wrapping `after-topic-list` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery/topics.hbs
@@ -141,7 +141,7 @@
     {{/if}}
   {{/if}}
 
-  <span>
+  <span class="after-topic-list-plugin-outlet-wrapper">
     <PluginOutlet
       @name="after-topic-list"
       @connectorTagName="div"


### PR DESCRIPTION
This is an important wrapper for CSS customizations, and currently there is no clean way to select it. This adds a class so we select that spannnnn