### PR TITLE
UX: view count in topic map should always be at least 1

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -98,6 +98,10 @@ export default class TopicMapSummary extends Component {
     return [this.hasLikes, this.hasUsers, this.hasLinks].every(Boolean);
   }
 
+  get minViewsCount() {
+    return Math.max(this.args.topic.views, 1);
+  }
+
   get shouldShowViewsChart() {
     return this.views.stats.length > 2;
   }
@@ -249,9 +253,9 @@ export default class TopicMapSummary extends Component {
         @onShow={{this.fetchViews}}
       >
         <:trigger>
-          {{number @topic.views noTitle="true"}}
+          {{number this.minViewsCount noTitle="true"}}
           <span class="topic-map__stat-label">
-            {{i18n "views_lowercase" count=@topic.views}}
+            {{i18n "views_lowercase" count=this.minViewsCount}}
           </span>
         </:trigger>
         <:content>

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-views.gjs
@@ -58,6 +58,11 @@ export default class TopicViews extends Component {
       };
     });
 
+    // today should always have at least 1 view
+    // because it's being viewed right now
+    const lastStat = stats[stats.length - 1];
+    lastStat.views = Math.max(lastStat.views, 1);
+
     return stats;
   }
 


### PR DESCRIPTION
This is never really 0, because if you can see the 0... you're number 1!

before:
![image](https://github.com/user-attachments/assets/e6fe8416-0f7e-435d-866a-8288bcd38c61)
![image](https://github.com/user-attachments/assets/a3e1595e-12ed-437e-8d59-82863037b5cc)


after:
![image](https://github.com/user-attachments/assets/da8acdbd-f151-45dc-b3ff-6bc0fcb975fe)
![image](https://github.com/user-attachments/assets/9e684687-01f4-479f-a4ab-d5d57c0147c1)
