### PR TITLE
FIX: Use correct subtitle for Site contact name field

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/contact-information.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/contact-information.gjs
@@ -126,7 +126,7 @@ export default class AdminConfigAreasAboutContactInformation extends Component {
       <form.Field
         @name="contactUsername"
         @title={{i18n "admin.config_areas.about.site_contact_name"}}
-        @subtitle={{i18n "admin.config_areas.about.site_contact_group_help"}}
+        @subtitle={{i18n "admin.config_areas.about.site_contact_name_help"}}
         @onSet={{this.setContactUsername}}
         @format="large"
         as |field|


### PR DESCRIPTION
A copy-and-paste error resulted in using the wrong subtitle for the "Site contact name" field in the admin config area for the /about page.