### PR TITLE
UX: Fix restore info link on admin backups page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-backups-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-backups-index.js
@@ -5,6 +5,7 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n, setting } from "discourse/lib/computed";
+import getURL from "discourse-common/lib/get-url";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
@@ -16,6 +17,10 @@ export default class AdminBackupsIndexController extends Controller {
   @i18n("admin.backups.upload.label") uploadLabel;
   @setting("backup_location") backupLocation;
   @equal("backupLocation", "local") localBackupStorage;
+
+  get restoreSettingsUrl() {
+    return getURL("/admin/backups/settings?filter=allow_restore");
+  }
 
   @discourseComputed("status.allowRestore", "status.isOperationRunning")
   restoreTitle(allowRestore, isOperationRunning) {

--- a/app/assets/javascripts/admin/addon/templates/backups-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/backups-index.hbs
@@ -13,10 +13,13 @@
 
 {{#if this.status.restoreDisabled}}
   <div class="backup-message alert alert-info">
-    <a href="site_settings/category/all_results?filter=allow_restore">{{d-icon
-        "info-circle"
-      }}
-      {{i18n "admin.backups.operations.restore.is_disabled"}}</a>
+    {{dIcon "info-circle"}}
+    {{html-safe
+      (i18n
+        "admin.backups.operations.restore.is_disabled"
+        url=this.restoreSettingsUrl
+      )
+    }}
   </div>
 {{/if}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5686,7 +5686,7 @@ en:
           backups: "Backups"
           backup_files: "Backup files"
           logs: "Logs"
-        none: "No backup available."
+        none: "No backup available"
         read_only:
           enable:
             title: "Enable read-only mode"
@@ -5724,12 +5724,12 @@ en:
           download:
             label: "Download"
             title: "Send email with download link"
-            alert: "A link to download this backup has been emailed to you."
+            alert: "A link to download this backup has been emailed to you"
           destroy:
             title: "Remove the backup"
             confirm: "Are you sure you want to destroy this backup?"
           restore:
-            is_disabled: "Restore is disabled in the site settings."
+            is_disabled: "Restore is currently disabled. To enable it, visit the <a href='%{url}'>site settings</a>."
             label: "Restore"
             title: "Restore the backup"
             confirm: "Are you sure you want to restore this backup?"
@@ -5738,7 +5738,7 @@ en:
             title: "Rollback the database to previous working state"
             confirm: "Are you sure you want to rollback the database to the previous working state?"
         location:
-          local: "Local Storage"
+          local: "Local storage"
           s3: "S3"
         backup_storage_error: "Failed to access backup storage: %{error_message}"
 


### PR DESCRIPTION
Followup 14465960893981e8aba49f2cc0620944f2abea53

The link to inform admins that restore is disabled
was not correct. This fixes it and also changes it
to go to /admin/backups/settings

![image](https://github.com/user-attachments/assets/b2fb4b08-0fd3-4697-9c20-4a39b1f43a8a)

