### PR TITLE
FIX: Write stylesheet cache atomically

### DIFF
--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -71,7 +71,7 @@ class StylesheetsController < ApplicationController
     unless File.exist?(location)
       if current = query.pick(source_map ? :source_map : :content)
         FileUtils.mkdir_p(cache_path)
-        File.write(location, current)
+        Discourse::Utils.atomic_write_file(location, current)
       else
         raise Discourse::NotFound
       end


### PR DESCRIPTION
In some situations, the filesystem cache will be read and persisted to the database. If the file being read is still being written, then that can lead to empty/partial caches being stored in the database.

This commit ensures that cannot happen by switching to our `atomic_write_file` helper (which writes to a temp file, and then does an atomic `mv` operation to move it to the destination)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
