### PR TITLE
FIX: correct zh_TW invite link

### DIFF
--- a/config/locales/server.zh_TW.yml
+++ b/config/locales/server.zh_TW.yml
@@ -2451,8 +2451,8 @@ zh_TW:
       text_body_template: |
         歡迎來到 %{site_name}！
 
-        請點擊以下連結，以確認和啟用你的新帳戶：
-        %{base_url}/users/activate-account/%{email_token}
+        請點擊以下連結，以確認和啟用你的新帳戶
+        %{base_url}/u/activate-account/%{email_token}
 
         如果上面的連結無法點擊，請複製該連結，並貼到瀏覽器的網址列中開啟。
     activation_reminder:


### PR DESCRIPTION
All other locales are using `%{base_url}/u/activate-account/%{email_token}` it seems like this one has not been updated for some reason. Clicking this old `%{base_url}/users/activate-account/%{email_token}` not show the expected page, and instead show an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
