### PR TITLE
FIX: Specify `@type` for the image uploader in the about config area

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
@@ -102,7 +102,7 @@ export default class AdminConfigAreasAboutGeneralSettings extends Component {
         @onSet={{this.setImage}}
         as |field|
       >
-        <field.Image />
+        <field.Image @type="site_setting" />
       </form.Field>
 
       <form.Submit


### PR DESCRIPTION
Specifying the type is required for the uploader to work on sites that use S3 uploads. 