### PR TITLE
FIX: Lost outer context in `#each` block in hbr

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars-helpers.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars-helpers.js
@@ -44,8 +44,8 @@ export function registerRawHelpers(hbs, handlebarsClass, owner) {
       }
       let list = get(this, contextName);
       let output = [];
+      let innerContext = { ...options.contexts[0] };
       for (let i = 0; i < list.length; i++) {
-        let innerContext = {};
         innerContext[localName] = list[i];
         output.push(options.fn(innerContext));
       }

--- a/app/assets/javascripts/discourse/tests/integration/helpers/raw-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/raw-test.gjs
@@ -7,6 +7,7 @@ import RenderGlimmerContainer from "discourse/components/render-glimmer-containe
 import raw from "discourse/helpers/raw";
 import rawRenderGlimmer from "discourse/lib/raw-render-glimmer";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { compile } from "discourse-common/lib/raw-handlebars";
 import {
   addRawTemplate,
   removeRawTemplate,
@@ -103,5 +104,21 @@ module("Integration | Helper | raw", function (hooks) {
     </template>);
 
     assert.dom("span.bar").hasText(/^baz$/);
+  });
+
+  test("#each helper preserves the outer context", async function (assert) {
+    const template = `
+      {{#each items as |item|}}
+        {{string}} {{item}}
+      {{/each}}
+    `;
+    addRawTemplate("raw-test", compile(template));
+
+    const items = [1, 2];
+    await render(<template>
+      <span>{{raw "raw-test" string="foo" items=items}}</span>
+    </template>);
+
+    assert.dom("span").hasText("foo 1 foo 2");
   });
 });


### PR DESCRIPTION
Regressed 3.5 years ago in e80332a2bcc5b9c56e4fd2937ecbc3b3dfff941c :P

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
