### PR TITLE
UX: improve mention colors for dark color schemes

### DIFF
--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -264,11 +264,11 @@ $hpad: 0.65em;
   text-wrap: nowrap;
 
   &.--bot {
-    background: var(--highlight-low-or-medium);
+    background: var(--success-low);
   }
 
   &.--wide {
-    background: var(--highlight);
+    background: var(--highlight-low-or-medium);
   }
 
   &.--current {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -272,7 +272,7 @@ $hpad: 0.65em;
   }
 
   &.--current {
-    background: var(--tertiary-low);
+    background: var(--tertiary-400);
   }
 }
 


### PR DESCRIPTION
Some of the after colors feel similar (bot vs wide mention) but these color palettes intentionally use very similar colors so there aren't a lot of alternatives 

Before:
![image](https://github.com/user-attachments/assets/755da5be-a88b-46c1-b1d5-db18309a0385)
![image](https://github.com/user-attachments/assets/0c5c1a4c-454a-4055-a371-58bd00c5adaa)
![image](https://github.com/user-attachments/assets/1559ad9c-1c81-4e1f-8e98-16b87bc97791)
![image](https://github.com/user-attachments/assets/9463f120-e04b-45a3-bfc0-6610d3e25757)



After: 
![image](https://github.com/user-attachments/assets/a50ea504-3102-4a76-b5ac-8cf0d1f807cf)
![image](https://github.com/user-attachments/assets/62d78740-4559-4a02-ba13-d7be18241d84)
![image](https://github.com/user-attachments/assets/e57f98e3-c736-4643-908f-19c5ab3e74ba)
![image](https://github.com/user-attachments/assets/86993841-ee60-480e-8ccc-6bb9cc456718)
