### PR TITLE
FIX: subfolder account activation

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/activate-account.gjs
+++ b/app/assets/javascripts/discourse/app/templates/activate-account.gjs
@@ -10,6 +10,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { wavingHandURL } from "discourse/lib/waving-hand-url";
 import i18n from "discourse-common/helpers/i18n";
+import getURL from "discourse-common/lib/get-url";
 
 export default RouteTemplate(
   class extends Component {
@@ -26,12 +27,7 @@ export default RouteTemplate(
 
       let hp;
       try {
-        const response = await fetch("/session/hp", {
-          headers: {
-            Accept: "application/json",
-          },
-        });
-        hp = await response.json();
+        hp = await ajax("/session/hp");
       } catch (error) {
         this.isLoading = false;
         popupAjaxError(error);
@@ -62,11 +58,16 @@ export default RouteTemplate(
         } else if (response.needs_approval) {
           this.needsApproval = true;
         } else {
-          setTimeout(() => (window.location.href = "/"), 2000);
+          setTimeout(this.loadHomepage, 2000);
         }
       } catch (error) {
         this.errorMessage = i18n("user.activate_account.already_done");
       }
+    }
+
+    @action
+    loadHomepage() {
+      window.location.href = getURL("/");
     }
 
     <template>
@@ -106,7 +107,7 @@ export default RouteTemplate(
                         "user.activate_account.continue_button"
                         site_name=this.siteSettings.title
                       }}
-                      @href="/"
+                      @action={{this.loadHomepage}}
                     />
                   </p>
                 {{/if}}

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -183,6 +183,33 @@ shared_examples "signup scenarios" do
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
     end
+
+    context "when site has subfolder install" do
+      before { set_subfolder "/discuss" }
+
+      it "can signup and activate account" do
+        visit("/discuss/signup")
+        signup_modal.fill_email("johndoe@example.com")
+        signup_modal.fill_username("john")
+        signup_modal.fill_password("supersecurepassword")
+        expect(signup_modal).to have_valid_fields
+
+        signup_modal.click_create_account
+        expect(page).to have_css(".account-created")
+
+        mail = ActionMailer::Base.deliveries.first
+        expect(mail.to).to contain_exactly("johndoe@example.com")
+        activation_link = mail.body.to_s[%r{\S+/u/activate-account/\S+}]
+
+        visit activation_link
+
+        activate_account.click_activate_account
+        activate_account.click_continue
+
+        expect(page).to have_current_path("/discuss/")
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
   end
 
   context "when the email domain is blocked" do


### PR DESCRIPTION
The user activation flow is currently broken within subfolder installs because `fetch`ing `/session/hp` will 404.

This PR changes it to use `ajax` instead (which already handles subfolders) and makes the "continue" flow take the user to the subfolder landing page.