### PR TITLE
FIX: ensures href is not set two times

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -180,10 +180,6 @@ export default class NavItem extends EmberObject {
         item.init(item, category, args);
       }
 
-      if (item.href) {
-        item.href = getURL(item.href);
-      }
-
       const before = item.before;
       if (before) {
         let i = 0;
@@ -198,7 +194,9 @@ export default class NavItem extends EmberObject {
       }
 
       if (item.customHref) {
-        item.set("href", item.customHref(category, args));
+        item.href = item.customHref(category, args);
+      } else if (item.href) {
+        item.href = getURL(item.href);
       }
 
       if (item.forceActive && item.forceActive(category, args)) {


### PR DESCRIPTION
This would cause the infamous error:

```
index.js:118 Uncaught (in promise)
Error: Assertion Failed: You attempted to update `href` on `<ExtraNavItem:ember384>`, but it had already been used previously in the same computation.
```

Moreover, set didnt seem necessary here.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
