### PR TITLE
FIX: Hide heading when there's no custom description

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -218,8 +218,11 @@ export default class AboutPage extends Component {
             </span>
           {{/each}}
         </div>
-        <h3>{{i18n "about.simple_title"}}</h3>
-        <div>{{htmlSafe @model.extended_site_description}}</div>
+
+        {{#if @model.extended_site_description}}
+          <h3>{{i18n "about.simple_title"}}</h3>
+          <div>{{htmlSafe @model.extended_site_description}}</div>
+        {{/if}}
 
         {{#if @model.admins.length}}
           <section class="about__admins">


### PR DESCRIPTION
In the new /about page, when there's no extended description provided by the admin, the "About" heading above the description should not be displayed.