### PR TITLE
FIX: Trigger user_logged_out event when the user logs out

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -338,6 +338,7 @@ class Auth::DefaultCurrentUserProvider
       user.logged_out
     elsif user && @user_token
       @user_token.destroy
+      DiscourseEvent.trigger(:user_logged_out, user)
     end
 
     cookie_jar.delete("authentication_data")

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -753,7 +753,7 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
       expect(UserAuthToken.find_by(user_id: user.id)).to be_nil
     end
 
-    it "should triggers user_logged_out event" do
+    it "should trigger user_logged_out event" do
       event_triggered_user = nil
       event_handler = Proc.new { |user| event_triggered_user = user.id }
       DiscourseEvent.on(:user_logged_out, &event_handler)

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -736,18 +736,14 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
   end
 
   describe "#log_off_user" do
-    event_triggered_user = nil
-    let(:event_handler) { Proc.new { |user| event_triggered_user = user.id } }
-    before { DiscourseEvent.on(:user_logged_out, &event_handler) }
-    after { DiscourseEvent.off(:user_logged_out, &event_handler) }
-
-    it "should work when the current user was cached by a different provider instance" do
+    let(:env) do
       user_provider = provider("/")
       user_provider.log_on_user(user, {}, user_provider.cookie_jar)
       cookie = CGI.escape(user_provider.cookie_jar["_t"])
-      env =
-        create_request_env(path: "/").merge({ :method => "GET", "HTTP_COOKIE" => "_t=#{cookie}" })
+      create_request_env(path: "/").merge({ :method => "GET", "HTTP_COOKIE" => "_t=#{cookie}" })
+    end
 
+    it "should work when the current user was cached by a different provider instance" do
       user_provider = TestProvider.new(env)
       expect(user_provider.current_user).to eq(user)
       expect(UserAuthToken.find_by(user_id: user.id)).to be_present
@@ -755,7 +751,18 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
       user_provider = TestProvider.new(env)
       user_provider.log_off_user({}, user_provider.cookie_jar)
       expect(UserAuthToken.find_by(user_id: user.id)).to be_nil
+    end
+
+    it "should triggers user_logged_out event" do
+      event_triggered_user = nil
+      event_handler = Proc.new { |user| event_triggered_user = user.id }
+      DiscourseEvent.on(:user_logged_out, &event_handler)
+
+      user_provider = TestProvider.new(env)
+      user_provider.log_off_user({}, user_provider.cookie_jar)
       expect(event_triggered_user).to eq(user.id)
+
+      DiscourseEvent.off(:user_logged_out, &event_handler)
     end
   end
 


### PR DESCRIPTION
What did this fix?
===============

Previously, we only triggered this event in the `user.logged_out` method. This resulted in the event being triggered only when the user was logged out by the administrator or the site had log_out_strict mode enabled. This bug affected customers who managed user status via webhooks.

meta topic: https://meta.discourse.org/t/user-log-out-event-not-triggered-in-webhooks/249464

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
