### PR TITLE
DEV: Replace silent theme-install fails with exceptions

### DIFF
--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -115,20 +115,21 @@ class ThemeStore::GitImporter < ThemeStore::BaseImporter
 
     addresses = FinalDestination::SSRFDetector.lookup_and_filter_ips(uri.host)
 
-    unless addresses.empty?
-      env = { "GIT_TERMINAL_PROMPT" => "0" }
+    raise_import_error! if addresses.empty?
 
-      args =
-        clone_args(
-          uri.to_s,
-          "http.followRedirects" => "false",
-          "http.curloptResolve" => "#{uri.host}:#{uri.port}:#{addresses.join(",")}",
-        )
+    env = { "GIT_TERMINAL_PROMPT" => "0" }
 
-      begin
-        Discourse::Utils.execute_command(env, *args, timeout: COMMAND_TIMEOUT_SECONDS)
-      rescue RuntimeError
-      end
+    args =
+      clone_args(
+        uri.to_s,
+        "http.followRedirects" => "false",
+        "http.curloptResolve" => "#{uri.host}:#{uri.port}:#{addresses.join(",")}",
+      )
+
+    begin
+      Discourse::Utils.execute_command(env, *args, timeout: COMMAND_TIMEOUT_SECONDS)
+    rescue RuntimeError
+      raise_import_error!
     end
   end
 


### PR DESCRIPTION
Previously, we were silently failing when a theme hit SSRF protection, or the `git clone` command failed for some reason. This commit updates them to be exceptions, so they provide more useful error messages

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
