### PR TITLE
DEV: fixup select-kit pluginApiIdentifiers typo

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -61,7 +61,7 @@ export function selectKitOptions(options) {
  */
 export function pluginApiIdentifiers(identifiers) {
   return function (target) {
-    concatProtoProperty(target, "pluginIdIdentifiers", identifiers);
+    concatProtoProperty(target, "pluginApiIdentifiers", identifiers);
   };
 }
 


### PR DESCRIPTION
Followup to 3e3c051164c4c32962d0a725b201784bb9a1f6a1

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
