### PR TITLE
FIX: adds chat-draw-expanded class to body

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
@@ -1,4 +1,12 @@
 {{#if this.chatStateManager.isDrawerActive}}
+  {{bodyClass "chat-drawer-active"}}
+{{/if}}
+
+{{#if this.chatStateManager.isDrawerExpanded}}
+  {{bodyClass "chat-drawer-expanded"}}
+{{/if}}
+
+{{#if this.chatStateManager.isDrawerActive}}
   <div
     data-chat-channel-id={{this.chat.activeChannel.id}}
     data-chat-thread-id={{this.chat.activeChannel.activeThread.id}}

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -157,14 +157,6 @@ export default {
         id: "chat",
       });
 
-      api.addChatDrawerStateCallback(({ isDrawerActive }) => {
-        if (isDrawerActive) {
-          document.body.classList.add("chat-drawer-active");
-        } else {
-          document.body.classList.remove("chat-drawer-active");
-        }
-      });
-
       api.addAboutPageActivity("chat_messages", (periods) => {
         const count = periods["7_days"];
         if (count) {

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe "Drawer", type: :system do
       visit("/")
       chat_page.open_from_header
       expect(page).to have_selector(".chat-drawer.is-expanded")
+      expect(page).to have_selector(".body.chat-drawer-expanded")
 
       page.find(".c-navbar").click
 

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -112,13 +112,14 @@ RSpec.describe "Drawer", type: :system do
     it "collapses the drawer" do
       visit("/")
       chat_page.open_from_header
+
       expect(page).to have_selector(".chat-drawer.is-expanded")
-      expect(page).to have_selector(".body.chat-drawer-expanded")
+      expect(page).to have_selector("body.chat-drawer-expanded")
 
       page.find(".c-navbar").click
 
       expect(page).to have_selector(".chat-drawer:not(.is-expanded)")
-      expect(page).to have_selector(".body:not(.chat-drawer-expanded)")
+      expect(page).to have_selector("body:not(.chat-drawer-expanded)")
     end
   end
 

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe "Drawer", type: :system do
       page.find(".c-navbar").click
 
       expect(page).to have_selector(".chat-drawer:not(.is-expanded)")
+      expect(page).to have_selector(".body:not(.chat-drawer-expanded)")
     end
   end
 


### PR DESCRIPTION
To achieve this, the code is now using bodyClass instead of relying on the addChatDrawerStateCallback`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
