### PR TITLE
UX: don't use split subcategory color in docked header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
@@ -148,6 +148,7 @@ export default class Info extends Component {
                   }}
                     {{categoryLink
                       @topicInfo.category.parentCategory.parentCategory
+                      (hash hideParent="true")
                     }}
                   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
@@ -156,7 +156,7 @@ export default class Info extends Component {
                     (hash hideParent="true")
                   }}
                 {{/if}}
-                {{categoryLink @topicInfo.category}}
+                {{categoryLink @topicInfo.category (hash hideParent="true")}}
               </div>
             {{/if}}
 


### PR DESCRIPTION
We should match the style in the undocked title:

![image](https://github.com/user-attachments/assets/70c76ef1-e37d-4644-b02b-cb8ac4aaeae0)


Before:
![image](https://github.com/user-attachments/assets/a4e4c1c0-420e-4b8e-8d9a-46ec73afe6ab)


After:
![image](https://github.com/user-attachments/assets/10a2f3be-de06-4ac9-bb49-e1e2f5d54930)

I've also covered this for sub-subcategories