### PR TITLE
UX: fix textarea height on mobile

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_control-textarea.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-textarea.scss
@@ -6,10 +6,10 @@
   margin: 0 !important;
   min-width: auto !important;
   padding: 0.5em !important;
+  height: 150px !important;
 
   // prevents firefox/chrome to add spacing under textarea
   display: block;
 
-  height: 150px;
   border-radius: var(--d-input-border-radius);
 }


### PR DESCRIPTION
This existing rule needed an important because of the mixin upstream 

Before:
![image](https://github.com/user-attachments/assets/13636073-005d-41b8-96da-276ca3328e51)


After:
![image](https://github.com/user-attachments/assets/f61c3e6e-e8ce-4dfe-89ac-9d442a9cef0c)
