### PR TITLE
UX: adjust software update banner for headerless pages

### DIFF
--- a/app/assets/stylesheets/common/software-update-prompt.scss
+++ b/app/assets/stylesheets/common/software-update-prompt.scss
@@ -4,6 +4,11 @@
   right: 0;
   left: 0;
   top: var(--header-offset, 60px);
+  .static-login &,
+  .wizard &,
+  .invite-page & {
+    top: 0;
+  }
   background-color: var(--tertiary-low);
   max-height: 0;
   overflow: hidden;


### PR DESCRIPTION
avoids this space issue by setting the top offset to 0 on relevant pages 

![image](https://github.com/user-attachments/assets/b9e44467-ae1b-485c-9db1-3d31193ed11a)


