### PR TITLE
FIX: Bookmark reminder was clearing incorrectly

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -119,8 +119,14 @@ class Bookmark < ActiveRecord::Base
     (reminder_at + offset).strftime(I18n.t("datetime_formats.formats.calendar_ics"))
   end
 
-  def clear_reminder!
-    update!(reminder_last_sent_at: Time.zone.now, reminder_set_at: nil, reminder_at: nil)
+  def clear_reminder!(force_clear_reminder_at: false)
+    reminder_update_attrs = { reminder_last_sent_at: Time.zone.now, reminder_set_at: nil }
+
+    if self.auto_clear_reminder_when_reminder_sent? || force_clear_reminder_at
+      reminder_update_attrs[:reminder_at] = nil
+    end
+
+    update!(reminder_update_attrs)
   end
 
   def reminder_at_in_zone(timezone)

--- a/lib/bookmark_reminder_notification_handler.rb
+++ b/lib/bookmark_reminder_notification_handler.rb
@@ -11,7 +11,7 @@ class BookmarkReminderNotificationHandler
     return if bookmark.blank?
     Bookmark.transaction do
       if !bookmark.registered_bookmarkable.can_send_reminder?(bookmark)
-        clear_reminder
+        bookmark.clear_reminder!
       else
         bookmark.registered_bookmarkable.send_reminder_notification(bookmark)
 
@@ -19,18 +19,8 @@ class BookmarkReminderNotificationHandler
           BookmarkManager.new(bookmark.user).destroy(bookmark.id)
         end
 
-        clear_reminder
+        bookmark.clear_reminder!
       end
     end
-  end
-
-  def clear_reminder
-    Rails.logger.debug(
-      "Clearing bookmark reminder for bookmark_id #{bookmark.id}. reminder at: #{bookmark.reminder_at}",
-    )
-
-    bookmark.reminder_at = nil if bookmark.auto_clear_reminder_when_reminder_sent?
-
-    bookmark.clear_reminder!
   end
 end

--- a/spec/lib/bookmark_reminder_notification_handler_spec.rb
+++ b/spec/lib/bookmark_reminder_notification_handler_spec.rb
@@ -87,5 +87,17 @@ RSpec.describe BookmarkReminderNotificationHandler do
         expect(Bookmark.find_by(id: bookmark.id).reminder_at).to eq(nil)
       end
     end
+
+    context "when the auto_delete_preference is never" do
+      before do
+        TopicUser.create!(topic: bookmark.bookmarkable.topic, user: user, bookmarked: true)
+        bookmark.update(auto_delete_preference: Bookmark.auto_delete_preferences[:never])
+      end
+
+      it "does not reset reminder_at after the reminder gets sent" do
+        send_notification
+        expect(Bookmark.find_by(id: bookmark.id).reminder_at).not_to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
Followup 76c56c82845b4fce63c6f1cdf4ac3935bf1747e7

The change introduced above made it so the expired
bookmark reminders were cleared when using the bulk
action menu for bookmarks. However this also affected
clearing reminders for bookmarks when sending notifications.

When clearing bookmark reminders after sending notifications,
we take into account the auto delete preference:

* never          - The bookmark `reminder_at` date should not be cleared,
                   and the bookmark is kept.
* clear_reminder - The bookmark `reminder_at` date is cleared and
                   the bookmark is kept

The `never` option made it so "expired" bookmark reminder show
on the user's bookmark list.

This commit fixes the change from the other commit and only
forces clearing of `reminder_at` if using the bookmark bulk
action service.
