### PR TITLE
DEV: Update `app-cache` cache key for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
         with:
           path: tmp/app-cache
           key: >-
-            ${{ runner.os }}-
+            ${{ runner.name }}-
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
             ${{ hashFiles('config/environments/test.rb') }}-


### PR DESCRIPTION
We cannot just key on `runner.os` the number of CPU cores matter as
well. Therefore, we need to key on `runner.name` instead since each
runner has its own unique OS and CPU cores. Technically, two different
runner with different names can have the same `os` and `cpu cores` but
we don't have that problem now.
