### PR TITLE
DEV: adds support for replaceText in toolbarEvent

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -812,6 +812,8 @@ export default Component.extend(TextareaTextManipulation, {
       addText: (text) => this.addText(selected, text),
       getText: () => this.value,
       toggleDirection: () => this._toggleDirection(),
+      replaceText: (oldVal, newVal, opts) =>
+        this.replaceText(oldVal, newVal, opts),
     };
   },
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -646,6 +646,29 @@ third line`
     assert.strictEqual(textarea.getAttribute("dir"), "rtl");
   });
 
+  test("toolbar event supports replaceText", async function (assert) {
+    withPluginApi("0.1", (api) => {
+      api.onToolbarCreate((toolbar) => {
+        toolbar.addButton({
+          id: "replace-text",
+          icon: "times",
+          group: "extras",
+          action: () => {
+            toolbar.context.newToolbarEvent().replaceText("hello", "goodbye");
+          },
+          condition: () => true,
+        });
+      });
+    });
+
+    this.value = "hello";
+
+    await render(hbs`<DEditor @value={{this.value}} />`);
+    await click("button.replace-text");
+
+    assert.strictEqual(this.value, "goodbye");
+  });
+
   testCase(
     `doesn't jump to bottom with long text`,
     async function (assert, textarea) {


### PR DESCRIPTION
This function was available in textarea manipulation mixin, but not exposed as other functions like addText, applySurround, ...

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
