### PR TITLE
FIX: correctly reset form before destroying it

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -202,18 +202,23 @@ export default class AdminBadgesShowController extends Controller {
   }
 
   @action
+  registerApi(api) {
+    this.formApi = api;
+  }
+
+  @action
   async handleDelete() {
     if (!this.model?.id) {
       return this.router.transitionTo("adminBadges.index");
     }
 
-    const adminBadges = this.adminBadges.model;
     return this.dialog.yesNoConfirm({
       message: I18n.t("admin.badges.delete_confirm"),
       didConfirm: async () => {
         try {
+          await this.formApi.reset();
           await this.model.destroy();
-          adminBadges.removeObject(this.model);
+          this.adminBadges.model.removeObject(this.model);
           this.router.transitionTo("adminBadges.index");
         } catch {
           this.dialog.alert(I18n.t("generic_error"));

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -2,6 +2,7 @@
   @data={{this.formData}}
   @onSubmit={{this.handleSubmit}}
   @validate={{this.validateForm}}
+  @onRegisterApi={{this.registerApi}}
   class="badge-form current-badge content-body"
   as |form data|
 >
@@ -295,7 +296,10 @@
     <form.Submit />
 
     {{#unless this.readOnly}}
-      <form.Button @action={{this.handleDelete}} class="btn-danger">
+      <form.Button
+        @action={{this.handleDelete}}
+        class="badge-form__delete-badge-btn btn-danger"
+      >
         {{i18n "admin.badges.delete"}}
       </form.Button>
     {{/unless}}

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -93,4 +93,23 @@ describe "Admin Badges Page", type: :system do
       expect(badges_page.form.field("target_posts")).to be_unchecked
     end
   end
+
+  context "when deleting a badge" do
+    let(:dialog) { PageObjects::Components::Dialog.new }
+
+    it "deletes a badge" do
+      badges_page.new_page
+      badges_page.form.field("enabled").accept
+      badges_page.form.field("name").fill_in("a name")
+      badges_page.form.field("badge_type_id").select(BadgeType::Bronze)
+      badges_page.form.field("icon").select("ambulance")
+      badges_page.submit_form
+      expect(badges_page).to have_saved_form
+      badges_page.form.field("name").fill_in("another name")
+      badges_page.delete_badge
+      dialog.click_yes
+
+      expect(page).to have_current_path("/admin/badges")
+    end
+  end
 end

--- a/spec/system/page_objects/admin_badges.rb
+++ b/spec/system/page_objects/admin_badges.rb
@@ -25,6 +25,12 @@ module PageObjects
 
       def submit_form
         form.submit
+        self
+      end
+
+      def delete_badge
+        page.find(".badge-form__delete-badge-btn").click
+        self
       end
 
       def choose_icon(name)


### PR DESCRIPTION
This change is preventing the "is dirty check" from happening when clicking delete on this form. This was not good UX and was also causing bugs by leaving the form in a unexpected state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
