### PR TITLE
FIX: prevents creating post from impacting the app

### DIFF
--- a/plugins/automation/lib/discourse_automation/scripts/topic.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/topic.rb
@@ -60,14 +60,19 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::TOPIC) do
     end
 
     tags = fields.dig("tags", "value") || []
-    new_post =
-      PostCreator.new(
-        creator,
-        raw: topic_raw,
-        title: title,
-        category: category.id,
-        tags: tags,
-      ).create!
+    begin
+      new_post =
+        PostCreator.new(
+          creator,
+          raw: topic_raw,
+          title: title,
+          category: category.id,
+          tags: tags,
+        ).create!
+    rescue StandardError => e
+      Rails.logger.warn "[discourse-automation] couldn't create post: #{e.message}"
+      next
+    end
 
     if context["kind"] == DiscourseAutomation::Triggers::USER_UPDATED && new_post.persisted?
       user.user_custom_fields.create(name: automation.name, value: "true")

--- a/plugins/automation/spec/scripts/topic_spec.rb
+++ b/plugins/automation/spec/scripts/topic_spec.rb
@@ -178,9 +178,9 @@ describe "Topic" do
         expect { UserUpdater.new(user, user).update(location: "Japan") }.to change {
           Topic.count
         }.by(1)
-        expect { UserUpdater.new(user, user).update(location: "Japan") }.to change {
+        expect { UserUpdater.new(user, user).update(location: "Japan") }.not_to change {
           Topic.count
-        }.by(0)
+        }
 
         expect(Rails.logger.warnings.first).to match(/Title has already been used/)
       end

--- a/plugins/automation/spec/scripts/topic_spec.rb
+++ b/plugins/automation/spec/scripts/topic_spec.rb
@@ -165,5 +165,25 @@ describe "Topic" do
         }.by(1)
       end
     end
+
+    context "when creating the post fails" do
+      before do
+        @orig_logger = Rails.logger
+        Rails.logger = @fake_logger = FakeLogger.new
+      end
+
+      after { Rails.logger = @orig_logger }
+
+      it "logs a warning" do
+        expect { UserUpdater.new(user, user).update(location: "Japan") }.to change {
+          Topic.count
+        }.by(1)
+        expect { UserUpdater.new(user, user).update(location: "Japan") }.to change {
+          Topic.count
+        }.by(0)
+
+        expect(Rails.logger.warnings.first).to match(/Title has already been used/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Create a topic can fail in many different ways and we don't want this to impact the rest of the application, the call will now be wrapped in a begin/rescue block and log an error if it fails.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
