### PR TITLE
FIX: Refresh the edit tag section when navigating to another tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -59,6 +59,12 @@ export default Component.extend({
     this.loadTagInfo();
   },
 
+  didUpdateAttrs() {
+    this._super(...arguments);
+    this.set("tagInfo", null);
+    this.loadTagInfo();
+  },
+
   loadTagInfo() {
     if (this.loading) {
       return;

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -388,6 +388,23 @@ acceptance("Tag info", function (needs) {
       });
     });
 
+    server.get("/tag/happy-monkey2/info", () => {
+      return helper.response({
+        __rest_serializer: "1",
+        tag_info: {
+          id: 13,
+          name: "happy-monkey2",
+          description: "happy monkey description",
+          topic_count: 1,
+          staff: false,
+          synonyms: [],
+          tag_group_names: [],
+          category_ids: [],
+        },
+        categories: [],
+      });
+    });
+
     server.delete("/tag/planters/synonyms/containers", () =>
       helper.response({ success: true })
     );

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -45,6 +45,14 @@ module PageObjects
       def tag_box(tag)
         find(".tag-box div[data-tag-name='#{tag}']")
       end
+
+      def tag_name_within_tag_info
+        find(".tag-info .tag-name-wrapper .discourse-tag").text
+      end
+
+      def tags_dropdown
+        PageObjects::Components::SelectKit.new(".select-kit.tag-drop")
+      end
     end
   end
 end

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -53,10 +53,6 @@ module PageObjects
       def tags_dropdown
         PageObjects::Components::SelectKit.new(".select-kit.tag-drop")
       end
-
-      def has_tag_info_section_loading?
-        find(".tag-info").has_text?(I18n.t("js.loading"))
-      end
     end
   end
 end

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -53,6 +53,10 @@ module PageObjects
       def tags_dropdown
         PageObjects::Components::SelectKit.new(".select-kit.tag-drop")
       end
+
+      def has_tag_info_section_loading?
+        find(".tag-info").has_text?(I18n.t("js.loading"))
+      end
     end
   end
 end

--- a/spec/system/tag_view_spec.rb
+++ b/spec/system/tag_view_spec.rb
@@ -20,6 +20,7 @@ describe "Tag view", type: :system do
         tags_page.tags_dropdown.search(tag_2.name)
 
         tags_page.tags_dropdown.select_row_by_value(tag_2.name)
+        expect(tags_page).to have_tag_info_section_loading
         expect(tags_page.tag_name_within_tag_info).to eq(tag_2.name)
       end
     end

--- a/spec/system/tag_view_spec.rb
+++ b/spec/system/tag_view_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 describe "Tag view", type: :system do
-  let(:tags_page) { PageObjects::Pages::Tag.new }
   fab!(:tag_1) { Fabricate(:tag, name: "design") }
   fab!(:tag_2) { Fabricate(:tag, name: "art") }
+  fab!(:topic) { Fabricate(:topic, tags: [tag_2]) }
   fab!(:current_user) { Fabricate(:admin) }
+
+  let(:tags_page) { PageObjects::Pages::Tag.new }
+  let(:topic_list) { PageObjects::Components::TopicList.new }
 
   before { sign_in(current_user) }
 
@@ -18,9 +21,9 @@ describe "Tag view", type: :system do
 
         tags_page.tags_dropdown.expand
         tags_page.tags_dropdown.search(tag_2.name)
-
         tags_page.tags_dropdown.select_row_by_value(tag_2.name)
-        expect(tags_page).to have_tag_info_section_loading
+
+        expect(topic_list).to have_topic(topic)
         expect(tags_page.tag_name_within_tag_info).to eq(tag_2.name)
       end
     end

--- a/spec/system/tag_view_spec.rb
+++ b/spec/system/tag_view_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe "Tag view", type: :system do
+  let(:tags_page) { PageObjects::Pages::Tag.new }
+  fab!(:tag_1) { Fabricate(:tag, name: "design") }
+  fab!(:tag_2) { Fabricate(:tag, name: "art") }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before { sign_in(current_user) }
+
+  describe "the tag info section" do
+    context "when navigating to another tag" do
+      it "shows the details of the new tag" do
+        tags_page.visit_tag(tag_1)
+
+        tags_page.tag_info_btn.click
+        expect(tags_page.tag_name_within_tag_info).to eq(tag_1.name)
+
+        tags_page.tags_dropdown.expand
+        tags_page.tags_dropdown.search(tag_2.name)
+
+        tags_page.tags_dropdown.select_row_by_value(tag_2.name)
+        expect(tags_page.tag_name_within_tag_info).to eq(tag_2.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you’re viewing a tag and you switch to a different tag via the sidebar or the tags dropdown, after expanding the info section of the tag page via the wrench button, the info section keeps showing the previous tag's details instead of the new one.

This happens because the tag info section makes an ajax request to load the tag's details, and this request is made inside the `didInsertElement` hook which is only fired once when the component is rendered. To fix this, we need to set the result from the ajax request to null and add a `didUpdateAttrs` hook to trigger another request to load the info of the new tag.

Internal topic: t/134809.