### PR TITLE
FIX: correctly apply translate mod key

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1459,6 +1459,8 @@ acceptance("composer buttons API", function (needs) {
           ` ${translateModKey(PLATFORM_KEY_MODIFIER + "+alt+b")}`,
         "it shows the label with shortcut"
       );
+
+    await this.pauseTest();
   });
 
   test("buttons can be added conditionally", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1459,8 +1459,6 @@ acceptance("composer buttons API", function (needs) {
           ` ${translateModKey(PLATFORM_KEY_MODIFIER + "+alt+b")}`,
         "it shows the label with shortcut"
       );
-
-    await this.pauseTest();
   });
 
   test("buttons can be added conditionally", async function (assert) {

--- a/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
+++ b/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
@@ -27,7 +27,7 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             label = I18n.t(content.label);
             if (content.shortcut) {
               label += ` <kbd class="shortcut">${translateModKey(
-                PLATFORM_KEY_MODIFIER + content.shortcut
+                PLATFORM_KEY_MODIFIER + "+" + content.shortcut
               )}</kbd>`;
             }
           }
@@ -37,7 +37,7 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             title = I18n.t(content.title);
             if (content.shortcut) {
               title += ` (${translateModKey(
-                PLATFORM_KEY_MODIFIER + content.shortcut
+                PLATFORM_KEY_MODIFIER + "+" + content.shortcut
               )})`;
             }
           }

--- a/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
+++ b/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
@@ -27,8 +27,8 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             label = I18n.t(content.label);
             if (content.shortcut) {
               label += ` <kbd class="shortcut">${translateModKey(
-                PLATFORM_KEY_MODIFIER
-              )}+${translateModKey(content.shortcut)}</kbd>`;
+                PLATFORM_KEY_MODIFIER + content.shortcut
+              )}</kbd>`;
             }
           }
 
@@ -37,8 +37,8 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             title = I18n.t(content.title);
             if (content.shortcut) {
               title += ` (${translateModKey(
-                PLATFORM_KEY_MODIFIER
-              )}+${translateModKey(content.shortcut)})`;
+                PLATFORM_KEY_MODIFIER + content.shortcut
+              )})`;
             }
           }
 


### PR DESCRIPTION
We were applying it separately on each part of the shortcut when it needs to be applied once on the whole shortcut.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
