### PR TITLE
UX: Make keyboard shortcut styling more subtle

### DIFF
--- a/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
@@ -45,6 +45,14 @@
           color: var(--primary-medium);
         }
 
+        .shortcut {
+          border: none;
+          background: var(--primary-200);
+          font-size: var(--font-down-2);
+          color: var(--primary-high);
+          margin-left: 1.8rem;
+        }
+
         &.is-highlighted,
         &.is-selected,
         &:hover {


### PR DESCRIPTION
## This PR updates the keyboard shortcut styling inside the toolbar popup menu options to be more subtle.

### Before:
![Screenshot 2024-08-23 at 09 42 52](https://github.com/user-attachments/assets/ba8bdbab-dbef-4d07-8a24-f9a6962f8376) ![Screenshot 2024-08-23 at 09 34 58](https://github.com/user-attachments/assets/95b007ce-9309-4697-a909-afe9633d11e0)


### After:
![Screenshot 2024-08-23 at 09 57 07](https://github.com/user-attachments/assets/c356e684-5e32-4e8c-9724-e17890b0e647)![Screenshot 2024-08-23 at 09 56 50](https://github.com/user-attachments/assets/0dc4b394-87b6-4437-897a-44a6cd15c4fe)
