### PR TITLE
FIX: Video uploads sometimes hang indefinitely

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
@@ -162,5 +162,13 @@ export default class ComposerVideoThumbnailUppy extends EmberObject.extend(
         }
       }, 100);
     };
+
+    video.onerror = () => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Video could not be loaded or decoded for thumbnail generation"
+      );
+      callback();
+    };
   }
 }


### PR DESCRIPTION
If there is a codec issue or something trying to process a video file
for thumbnail generation, uploads could hang indefinitely. This fix
  ensures that we continue the upload process even if we encounter an
  error trying to generate a thumbnail for it.
