### PR TITLE
FIX: Respect the End key when last post is already rendered

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -38,7 +38,6 @@ import discourseLater from "discourse-common/lib/later";
 import { deepMerge } from "discourse-common/lib/object";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
-
 let customPostMessageCallbacks = {};
 
 const RETRIES_ON_RATE_LIMIT = 4;
@@ -931,8 +930,16 @@ export default class TopicController extends Controller.extend(
 
   @action
   jumpBottom() {
+    const highestPostNumber = this.model.highest_post_number;
+
+    if (document.getElementById(`post_${highestPostNumber}`)) {
+      // Do nothing when the last post is already rendered.
+      // This ensures the browser handles keyboard shortcuts like End.
+      return;
+    }
+
     // When a topic only has one lengthy post
-    const jumpEnd = this.model.highest_post_number === 1 ? true : false;
+    const jumpEnd = highestPostNumber === 1 ? true : false;
 
     DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
       skipIfOnScreen: false,

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -938,12 +938,9 @@ export default class TopicController extends Controller.extend(
       return;
     }
 
-    // When a topic only has one lengthy post
-    const jumpEnd = highestPostNumber === 1 ? true : false;
-
     DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
       skipIfOnScreen: false,
-      jumpEnd,
+      jumpEnd: false,
       keepFilter: true,
     });
   }

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -86,4 +86,13 @@ describe "Topic page", type: :system do
 
     expect(page).to have_no_css(".topic-admin-menu-content")
   end
+
+  it "loads last post when pressing using the End keyboard shortcut" do
+    fab!(:posts) { Fabricate.times(25, :post, topic: topic) }
+    visit "/t/#{topic.slug}/#{topic.id}/1"
+
+    send_keys(:end)
+    expect(find("#post_#{topic.highest_post_number}")).to be_visible
+  end
+
 end

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -94,5 +94,4 @@ describe "Topic page", type: :system do
     send_keys(:end)
     expect(find("#post_#{topic.highest_post_number}")).to be_visible
   end
-
 end

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -87,11 +87,15 @@ describe "Topic page", type: :system do
     expect(page).to have_no_css(".topic-admin-menu-content")
   end
 
-  it "loads last post when pressing using the End keyboard shortcut" do
+  context "with End keyboard shortcut" do
     fab!(:posts) { Fabricate.times(25, :post, topic: topic) }
-    visit "/t/#{topic.slug}/#{topic.id}/1"
 
-    send_keys(:end)
-    expect(find("#post_#{topic.highest_post_number}")).to be_visible
+    it "loads last post" do
+      visit "/t/#{topic.slug}/#{topic.id}/1"
+
+      send_keys(:end)
+
+      expect(find("#post_#{topic.highest_post_number}")).to be_visible
+    end
   end
 end


### PR DESCRIPTION
Given we are a single-page-app, we hijack the browser's default behavior for keyboard shortcuts like End because on long topics (20+ posts) we need to load the last post before really reaching the end of the page.

However, when the last post is already rendered, the End shortcut currently does nothing, it takes the user to the start of the last post. If that post is too long, the user will have to scroll down manually.

This change ensures that if the last post of a topic is already rendered (whether it is in the viewport or not), pressing End will take the user to the very bottom of the page.

Note for the reviewer: the test added here is for the general case, it is too hard to test the case where the last post is already rendered, that isn't covered here.
