### PR TITLE
FIX: prevent desktop notification callbacks on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -3,7 +3,7 @@ import {
   alertChannel,
   disable as disableDesktopNotifications,
   init as initDesktopNotifications,
-  onNotification,
+  onNotification as onDesktopNotification,
 } from "discourse/lib/desktop-notifications";
 import {
   isPushNotificationsEnabled,
@@ -260,11 +260,13 @@ export default {
 
   @bind
   onAlert(data) {
-    return onNotification(
-      data,
-      this.siteSettings,
-      this.currentUser,
-      this.appEvents
-    );
+    if (this.site.desktopView) {
+      return onDesktopNotification(
+        data,
+        this.siteSettings,
+        this.currentUser,
+        this.appEvents
+      );
+    }
   },
 };

--- a/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -1,7 +1,7 @@
 import Service, { service } from "@ember/service";
 import {
   alertChannel,
-  onNotification,
+  onNotification as onDesktopNotification,
 } from "discourse/lib/desktop-notifications";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { isTesting } from "discourse-common/config/environment";
@@ -13,6 +13,7 @@ export default class ChatNotificationManager extends Service {
   @service chatStateManager;
   @service currentUser;
   @service appEvents;
+  @service site;
 
   _subscribedToCore = true;
   _subscribedToChat = false;
@@ -149,12 +150,14 @@ export default class ChatNotificationManager extends Service {
       return;
     }
 
-    return onNotification(
-      data,
-      this.siteSettings,
-      this.currentUser,
-      this.appEvents
-    );
+    if (this.site.desktopView) {
+      return onDesktopNotification(
+        data,
+        this.siteSettings,
+        this.currentUser,
+        this.appEvents
+      );
+    }
   }
 
   _shouldRun() {


### PR DESCRIPTION
Small follow up to #28385 to prevent attempting to create desktop notifications (and notification handlers) on mobile.

We shouldn't attempt to process any desktop notification tasks when not on mobile. This change fixes an issue where chat desktop sounds would be played on mobile hub.

There is no test coverage for JS Notifications API and since it requires browser and system level permissions by the user I've omitted adding tests for now due to complexity.