### PR TITLE
FIX: when replacing text in composer maintain history

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -152,10 +152,11 @@ export default Mixin.create({
         i++;
         return i === opts.index ? newVal : match;
       });
-      this.set("value", newValue);
+
+      this._insertAt(0, val.length, newValue);
     } else {
-      // Replace value (side effect: cursor at the end).
-      this.set("value", val.replace(oldVal, newVal));
+      const replacedValue = val.replace(oldVal, newVal);
+      this._insertAt(0, val.length, replacedValue);
     }
 
     if (


### PR DESCRIPTION
Replacing value in the composer will not maintain history, this migrates
us to the new pattern used throughout this file
