### PR TITLE
DEV: Fix bigint notifications id migration to deal with public schema

### DIFF
--- a/db/migrate/20240820123404_copy_notifications_id_indexes.rb
+++ b/db/migrate/20240820123404_copy_notifications_id_indexes.rb
@@ -15,7 +15,7 @@ class CopyNotificationsIdIndexes < ActiveRecord::Migration[7.0]
     # Copy existing indexes and suffix them with `_bigint`
     results =
       execute(
-        "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'notifications' AND indexdef SIMILAR TO '%\\mid\\M%'",
+        "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'notifications' AND indexdef SIMILAR TO '%\\mid\\M%' AND schemaname = 'public'",
       )
     results.each do |res|
       indexname, indexdef = res["indexname"], res["indexdef"]

--- a/db/migrate/20240820123406_drop_old_notification_id_indexes.rb
+++ b/db/migrate/20240820123406_drop_old_notification_id_indexes.rb
@@ -17,7 +17,7 @@ class DropOldNotificationIdIndexes < ActiveRecord::Migration[7.0]
     # Remove `_bigint` suffix from indexes
     results =
       execute(
-        "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'notifications' AND indexdef SIMILAR TO '%\\mid\\M%'",
+        "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'notifications' AND indexdef SIMILAR TO '%\\mid\\M%' AND schemaname = 'public'",
       )
     results.each do |res|
       indexname, indexdef = res["indexname"], res["indexdef"]


### PR DESCRIPTION
Follow up to 799a45a291e9f2bd94278f565e58874458768079
