### PR TITLE
DEV: Add select_range to composer page object

### DIFF
--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -237,6 +237,14 @@ module PageObjects
         JS
       end
 
+      def select_range(start_index, length)
+        execute_script(<<~JS, text)
+          const composer = document.querySelector("#{COMPOSER_ID} .d-editor-input");
+          composer.focus();
+          composer.setSelectionRange(#{start_index}, #{length});
+        JS
+      end
+
       def submit
         find("#{COMPOSER_ID} .save-or-cancel .create").click
       end


### PR DESCRIPTION
Covers the use case of doing this in composer:

```javascript
page.execute_script("document.querySelector('.d-editor-input').setSelectionRange(6, 12);")
```
