### PR TITLE
FIX: Fix incorrect check for required custom fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1873,7 +1873,7 @@ class User < ActiveRecord::Base
 
   def populated_required_custom_fields?
     UserField
-      .required
+      .for_all_users
       .pluck(:id)
       .all? { |field_id| custom_fields["#{User::USER_FIELD_PREFIX}#{field_id}"].present? }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3587,7 +3587,10 @@ RSpec.describe User do
   end
 
   describe "#populated_required_fields?" do
-    let!(:required_field) { Fabricate(:user_field, name: "hairstyle") }
+    let!(:required_field) do
+      Fabricate(:user_field, name: "hairstyle", requirement: "for_all_users")
+    end
+    let!(:signup_field) { Fabricate(:user_field, name: "haircolor", requirement: "on_signup") }
     let!(:optional_field) { Fabricate(:user_field, name: "haircolor", requirement: "optional") }
 
     context "when all required fields are populated" do


### PR DESCRIPTION
### What is the problem?

This check was checking the wrong scope, causing problems in certain edge conditions, for example:

1. Admin adds an "on signup" field that isn't editable after signup.
2. Admin adds a "for all users" field.
3. User goes and fills up the "for all users" field from 2.
4. User is now stuck on the required fields page without any fields showing.

### How does this fix it?

We only consider "for all users" fields when asking if required custom fields are filled in.