### PR TITLE
FIX: poll ranked choice results not showing on first vote

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-ranked-choice.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-ranked-choice.gjs
@@ -5,14 +5,14 @@ import I18n from "discourse-i18n";
 export default class PollResultsRankedChoiceComponent extends Component {
   get rankedChoiceWinnerText() {
     return I18n.t("poll.ranked_choice.winner", {
-      count: this.args.rankedChoiceOutcome.round_activity.length,
-      winner: this.args.rankedChoiceOutcome.winning_candidate.html,
+      count: this.args.rankedChoiceOutcome?.round_activity?.length,
+      winner: this.args.rankedChoiceOutcome?.winning_candidate?.html,
     });
   }
 
   get rankedChoiceTiedText() {
     return I18n.t("poll.ranked_choice.tied", {
-      count: this.args.rankedChoiceOutcome.round_activity.length,
+      count: this.args.rankedChoiceOutcome?.round_activity?.length,
     });
   }
 


### PR DESCRIPTION
Currently a javascript exception is raised on very first vote, preventing the results from being rendered.

Resolves: `TypeError: this.args.rankedChoiceOutcome.round_activity is undefined`


