### PR TITLE
FIX: prevents exception when showing replacements

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-watched-word.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-watched-word.gjs
@@ -9,7 +9,7 @@ export default class AdminWatchedWord extends Component {
   @service dialog;
 
   get tags() {
-    return this.args.word.replacement.replacement.split(",");
+    return this.args.word.replacement.split(",");
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -147,6 +147,18 @@ acceptance("Admin - Watched Words", function (needs) {
     assert.dom(".d-modal__body li .match").hasText("Hello");
     assert.dom(".d-modal__body li .tag").hasText("greeting");
   });
+
+  test("showing/hidding words - tag", async function (assert) {
+    await visit("/admin/customize/watched_words/action/tag");
+
+    await click(".show-words-checkbox");
+
+    assert.dom(".watched-word").hasText("​ hello → greeting");
+
+    await click(".show-words-checkbox");
+
+    assert.dom(".watched-word").doesNotExist();
+  });
 });
 
 acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {


### PR DESCRIPTION
This was a recent error due to a mistake in https://github.com/discourse/discourse/commit/eccfc946f164983055a72fc4a60898499f645d58

This commit also adds a test which would have caught this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
