### PR TITLE
FIX: Prevent group requests from loading infinitely

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-requests.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-requests.js
@@ -16,7 +16,9 @@ export default class GroupRequestsController extends Controller {
   loading = false;
 
   get canLoadMore() {
-    return this.get("model.requesters")?.length < this.get("model.user_count");
+    return (
+      this.get("model.requesters")?.length < this.get("model.request_count")
+    );
   }
 
   @observes("filterInput")

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -19,7 +19,7 @@ acceptance("Group Requests", function (needs) {
           id: 42,
           automatic: false,
           name: "Macdonald",
-          user_count: 1,
+          user_count: 10,
           mentionable_level: 0,
           messageable_level: 0,
           visibility_level: 0,


### PR DESCRIPTION
In GroupRequestsController, request_count is incorrectly written as user_count, which causes group member requests to be loaded infinitely when user_count is greater than request_count.

meta topic link: https://meta.discourse.org/t/bug-with-group-requests/315353/

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
