### PR TITLE
FIX: prevents topic hot scope error on future topics

### DIFF
--- a/app/models/topic_hot_score.rb
+++ b/app/models/topic_hot_score.rb
@@ -141,7 +141,7 @@ class TopicHotScore < ActiveRecord::Base
       FROM topics
       WHERE topics.id IN (
         SELECT topic_id FROM topic_ids
-      ) AND ths.topic_id = topics.id
+      ) AND ths.topic_id = topics.id AND topics.created_at <= :now
     SQL
 
     DB.exec(sql, args)

--- a/spec/models/topic_hot_scores_spec.rb
+++ b/spec/models/topic_hot_scores_spec.rb
@@ -111,5 +111,18 @@ RSpec.describe TopicHotScore do
       expect(TopicHotScore.find_by(topic_id: topic1.id).score).to be_within(0.0001).of(0.0005)
       expect(TopicHotScore.find_by(topic_id: topic2.id).score).to be_within(0.001).of(0.001)
     end
+
+    it "ignores topics in the future" do
+      freeze_time
+
+      topic1 = Fabricate(:topic, like_count: 3, created_at: 2.days.from_now)
+      post1 = Fabricate(:post, topic: topic1, created_at: 1.minute.ago)
+      PostActionCreator.like(user, post1)
+      TopicHotScore.create!(topic_id: topic1.id, score: 0.0, recent_likes: 0, recent_posters: 0)
+
+      expect { TopicHotScore.update_scores }.not_to change {
+        TopicHotScore.where(topic_id: topic1.id).pluck(:recent_likes)
+      }
+    end
   end
 end


### PR DESCRIPTION
Prior this fix a topic created in the future could generate this exception:

```
Job exception: ERROR:  a negative number raised to a non-integer power yields a complex result
```

This fix and spec should ensure we don't consider topics in the future as the rest of the `update_scores` function is doing at other places.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
