### PR TITLE
DEV: Add missing `@ember/string` dependencies

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@ember/string": "^4.0.0",
     "discourse-common": "1.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@ember/string": "^4.0.0",
     "@uppy/aws-s3": "3.0.6",
     "@uppy/aws-s3-multipart": "3.1.3",
     "@uppy/core": "3.0.4",

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@ember/string": "^4.0.0",
     "ember-auto-import": "^2.7.4",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",


### PR DESCRIPTION
All those addons import it but didn't have it in their package.jsons. And because the only thing that had it as a dependency (ember-cli-deprecation-workflow) removed it in the latest version, the build breaks.

File it under: problem we wouldn't have with pnpm :P

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
