### PR TITLE
FIX: Return properly interpolated translations for flags

### DIFF
--- a/app/serializers/flag_serializer.rb
+++ b/app/serializers/flag_serializer.rb
@@ -24,7 +24,11 @@ class FlagSerializer < ApplicationSerializer
   end
 
   def description
-    I18n.t("#{i18n_prefix}.description", default: object.description)
+    I18n.t(
+      "#{i18n_prefix}.description",
+      default: object.description.to_s,
+      base_path: Discourse.base_path,
+    )
   end
 
   def short_description

--- a/spec/serializers/flag_serializer_spec.rb
+++ b/spec/serializers/flag_serializer_spec.rb
@@ -54,4 +54,15 @@ RSpec.describe FlagSerializer do
     serialized = described_class.new(flag, used_flag_ids: []).as_json
     expect(serialized[:flag][:applies_to]).to eq(%w[Post Topic Chat::Message])
   end
+
+  describe "#description" do
+    let(:serializer) { described_class.new(flag, scope: Guardian.new, root: false) }
+    let(:flag) { Flag.find_by(name_key: :inappropriate) }
+
+    before { allow(Discourse).to receive(:base_path).and_return("discourse.org") }
+
+    it "returns properly interpolated translation" do
+      expect(serializer.description).to match(%r{discourse\.org/guidelines})
+    end
+  end
 end


### PR DESCRIPTION
Currently, `FlagSerializer#short_description` properly provides `base_path` to its translations, but `FlagSerializer#description` does not. This breaks the link to guidelines when flagging a post, for example.

This PR provides `base_path` for `FlagSerializer#description` too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
