### PR TITLE
DEV: Drop old notification id columns

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,7 +2,7 @@
 
 class Notification < ActiveRecord::Base
   self.ignored_columns = [
-    :old_id, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been writted.
+    :old_id, # TODO: Remove once 20240829140226_drop_old_notification_id_columns has been promoted to pre-deploy
   ]
 
   attr_accessor :acting_user

--- a/app/models/shelved_notification.rb
+++ b/app/models/shelved_notification.rb
@@ -2,7 +2,7 @@
 
 class ShelvedNotification < ActiveRecord::Base
   self.ignored_columns = [
-    :old_notification_id, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been writted.
+    :old_notification_id, # TODO: Remove once 20240829140226_drop_old_notification_id_columns has been promoted to pre-deploy
   ]
 
   belongs_to :notification

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
     :salt, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
     :password_hash, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
     :password_algorithm, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
+    :old_seen_notification_id, # TODO: Remove once 20240829140226_drop_old_notification_id_columns has been promoted to pre-deploy
   ]
 
   include Searchable

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -2,7 +2,7 @@
 
 class UserBadge < ActiveRecord::Base
   self.ignored_columns = [
-    :old_notification_id, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been writted.
+    :old_notification_id, # TODO: Remove once 20240829140226_drop_old_notification_id_columns has been promoted to pre-deploy
   ]
 
   belongs_to :badge

--- a/db/post_migrate/20240829140226_drop_old_notification_id_columns.rb
+++ b/db/post_migrate/20240829140226_drop_old_notification_id_columns.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DropOldNotificationIdColumns < ActiveRecord::Migration[7.1]
+  DROPPED_COLUMNS ||= {
+    notifications: %i[old_id],
+    shelved_notifications: %i[old_notification_id],
+    users: %i[old_seen_notification_id],
+    user_badges: %i[old_notification_id],
+  }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20240829140226_drop_old_notification_id_columns.rb
+++ b/db/post_migrate/20240829140226_drop_old_notification_id_columns.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DropOldNotificationIdColumns < ActiveRecord::Migration[7.1]
-  DROPPED_COLUMNS ||= {
+  DROPPED_COLUMNS = {
     notifications: %i[old_id],
     shelved_notifications: %i[old_notification_id],
     users: %i[old_seen_notification_id],

--- a/plugins/chat/app/models/chat/mention_notification.rb
+++ b/plugins/chat/app/models/chat/mention_notification.rb
@@ -2,11 +2,11 @@
 
 module Chat
   class MentionNotification < ActiveRecord::Base
-    self.table_name = "chat_mention_notifications"
-
     self.ignored_columns = [
-      :old_notification_id, # TODO remove once this column is removed. Migration to drop the column has not been written.
+      :old_notification_id, # TODO: Remove once 20240829140227_drop_chat_mention_notifications_old_id_column has been promoted to pre-deploy
     ]
+
+    self.table_name = "chat_mention_notifications"
 
     belongs_to :chat_mention, class_name: "Chat::Mention"
     belongs_to :notification, dependent: :destroy

--- a/plugins/chat/db/post_migrate/20240829140227_drop_chat_mention_notifications_old_id_column.rb
+++ b/plugins/chat/db/post_migrate/20240829140227_drop_chat_mention_notifications_old_id_column.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropChatMentionNotificationsOldIdColumn < ActiveRecord::Migration[7.1]
+  DROPPED_COLUMNS ||= { chat_mention_notifications: %i[old_notification_id] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/db/post_migrate/20240829140227_drop_chat_mention_notifications_old_id_column.rb
+++ b/plugins/chat/db/post_migrate/20240829140227_drop_chat_mention_notifications_old_id_column.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DropChatMentionNotificationsOldIdColumn < ActiveRecord::Migration[7.1]
-  DROPPED_COLUMNS ||= { chat_mention_notifications: %i[old_notification_id] }
+  DROPPED_COLUMNS = { chat_mention_notifications: %i[old_notification_id] }
 
   def up
     DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }


### PR DESCRIPTION
The `id` column of `notifications` table and `notification_id` columns of `shelved_notifications` and `user_badges` tables have been migrated to bigint in previous commits (for example, 799a45a).

In order to run the migrations with zero downtime, the data had to be copied to new columns and swapped, but the old columns have been kept to allow for rollback.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
