### PR TITLE
FIX: Destroy draft when clicking the Discard button

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1405,6 +1405,8 @@ export default class ComposerService extends Service {
         composerModel.setProperties({ unlistTopic: false, whisper: false });
       }
 
+      await this._setModel(composerModel, opts);
+
       // we need a draft sequence for the composer to work
       if (opts.draftSequence === undefined) {
         let data = await Draft.get(opts.draftKey);
@@ -1417,8 +1419,6 @@ export default class ComposerService extends Service {
 
         opts.draft ||= data.draft;
         opts.draftSequence = data.draft_sequence;
-
-        await this._setModel(composerModel, opts);
         return;
       }
 
@@ -1433,8 +1433,6 @@ export default class ComposerService extends Service {
           await this.open(opts);
         }
       }
-
-      await this._setModel(composerModel, opts);
     } finally {
       this.skipAutoSave = false;
       this.appEvents.trigger("composer:open", { model: this.model });

--- a/spec/system/composer/discard_draft_spec.rb
+++ b/spec/system/composer/discard_draft_spec.rb
@@ -68,4 +68,31 @@ describe "Composer - discard draft modal", type: :system do
       expect(composer).to be_opened
     end
   end
+
+  context "when clicking abandon draft" do
+    let(:dialog) { PageObjects::Components::Dialog.new }
+
+    before { Jobs.run_immediately! }
+
+    it "destroys draft" do
+      visit "/new-topic"
+
+      composer.fill_content("a b c d e f g")
+      composer.close
+
+      expect(discard_draft_modal).to be_open
+      discard_draft_modal.click_save
+
+      wait_for(timeout: 5) { Draft.last != nil }
+      draft_key = Draft.last.draft_key
+
+      visit "/new-topic"
+
+      expect(dialog).to be_open
+      expect(page).to have_content(I18n.t("js.drafts.abandon.confirm"))
+      dialog.click_danger
+
+      wait_for(timeout: 5) { Draft.find_by(draft_key: draft_key) == nil }
+    end
+  end
 end

--- a/spec/system/page_objects/modals/discard_draft.rb
+++ b/spec/system/page_objects/modals/discard_draft.rb
@@ -11,6 +11,10 @@ module PageObjects
       def closed?
         has_no_css?(".modal.d-modal#{MODAL_SELECTOR}")
       end
+
+      def click_save
+        footer.find("button.save-draft").click
+      end
     end
   end
 end


### PR DESCRIPTION
The model needs to be loaded before the dialog is opened