### PR TITLE
DEV: "Downgrade" `@ember/string` from 4.x to 3.x

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
-    "@ember/string": "^4.0.0",
+    "@ember/string": "^3.1.1",
     "discourse-common": "1.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
-    "@ember/string": "^4.0.0",
+    "@ember/string": "^3.1.1",
     "@uppy/aws-s3": "3.0.6",
     "@uppy/aws-s3-multipart": "3.1.3",
     "@uppy/core": "3.0.4",

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -46,7 +46,7 @@
     "@ember/legacy-built-in-components": "^0.5.0",
     "@ember/optional-features": "^2.1.0",
     "@ember/render-modifiers": "^2.1.0",
-    "@ember/string": "^4.0.0",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.6.0",
     "@embroider/core": "^3.4.14",

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
-    "@ember/string": "^4.0.0",
+    "@ember/string": "^3.1.1",
     "ember-auto-import": "^2.7.4",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,17 +1355,12 @@
     ember-cli-babel "^7.26.11"
     ember-modifier-manager-polyfill "^1.2.0"
 
-"@ember/string@^3.0.0":
+"@ember/string@^3.0.0", "@ember/string@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.1.1.tgz#0a5ac0d1e4925259e41d5c8d55ef616117d47ff0"
   integrity sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==
   dependencies:
     ember-cli-babel "^7.26.6"
-
-"@ember/string@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/string/-/string-4.0.0.tgz#24fe5cda227c9e6634e6e0b550944a3a13437878"
-  integrity sha512-IMVyVE72twuAMSYcHzWSgtgYTtzlHlKSGW8vEbztnnmkU6uo7kVHmiqSN9R4RkBhzvh0VD4G76Eph+55t3iNIA==
 
 "@ember/test-helpers@^3.3.1":
   version "3.3.1"


### PR DESCRIPTION
A follow-up to dd1abf91ef2176f0a9edf54c31870c573fda4a72.

Because `ember-cli-deprecation-workflow` relied on `@ember/string` 3.1.1, that was the effective version used in the app.

Turns out there's a compatiblity issue with 4.0.0. Let's lock it to 3.x so we can easily update deprecation-workflow and then we can look into the ember/string issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
