### PR TITLE
FIX: correctly shortcut format on mac

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
+++ b/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
@@ -27,8 +27,8 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             label = I18n.t(content.label);
             if (content.shortcut) {
               label += ` <kbd class="shortcut">${translateModKey(
-                PLATFORM_KEY_MODIFIER
-              )}+${translateModKey(content.shortcut)}</kbd>`;
+                PLATFORM_KEY_MODIFIER + "+" + content.shortcut
+              )}</kbd>`;
             }
           }
 
@@ -37,8 +37,8 @@ export default class ToolbarPopupMenuOptions extends DropdownSelectBoxComponent 
             title = I18n.t(content.title);
             if (content.shortcut) {
               title += ` (${translateModKey(
-                PLATFORM_KEY_MODIFIER
-              )}+${translateModKey(content.shortcut)})`;
+                PLATFORM_KEY_MODIFIER + "+" + content.shortcut
+              )})`;
             }
           }
 


### PR DESCRIPTION
On windows + are shown between keys, not on mac. The fix was to wrap the whole shortcut in `translateModKey`.

