### PR TITLE
UX: fix overflow usercard

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -8,6 +8,12 @@
   }
 }
 
+.fk-d-menu:has(.user-card) {
+  .fk-d-menu__inner-content {
+    overflow: visible;
+  }
+}
+
 .user-card,
 .group-card {
   --card-width: 39em;


### PR DESCRIPTION
The usercard is using the `fk-d- menu` component, but needs a specific overrule for the overflow behaviour.
