### PR TITLE
UX: tell 1Password to ignore the link name input

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-form-link.gjs
@@ -130,6 +130,7 @@ export default class SectionFormLink extends Component {
           name="link-name"
           aria-label={{i18n "sidebar.sections.custom.links.name.label"}}
           class={{@link.nameCssClass}}
+          data-1p-ignore
         />
 
         {{#if @link.invalidNameMessage}}


### PR DESCRIPTION
1Password tries to fill this input because it contains `name` within its name attribute

![image](https://github.com/user-attachments/assets/aab237f0-ccbb-4d85-b851-7a6648121783)

Their documentation suggests turning this off by adding the attribute `data-1p-ignore`, which works! I attempted `autocomplete="off"` first but this does not work. 


![image](https://github.com/user-attachments/assets/958e4c43-f10b-4cc3-a77f-11bcbdfd4708)
