### PR TITLE
DEV: Fix flaky site text spec

### DIFF
--- a/spec/system/admin_site_texts_spec.rb
+++ b/spec/system/admin_site_texts_spec.rb
@@ -7,6 +7,11 @@ describe "Admin Site Texts Page", type: :system do
 
   before { sign_in(admin) }
 
+  after do
+    TranslationOverride.delete_all
+    I18n.reload!
+  end
+
   it "can search for client text using the default locale" do
     site_texts_page.visit
     site_texts_page.search("skip to main content")


### PR DESCRIPTION
Followup a16faa27cd0088361c1a486a68c98e731ab57878

I18n and translation overrides were not reset
between specs which led to the wrong text being
searched for in assertions
