### PR TITLE
DEV: Change number of displayed admins/mods on the new about page to 6

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -227,14 +227,14 @@ export default class AboutPage extends Component {
         {{#if @model.admins.length}}
           <section class="about__admins">
             <h3>{{dIcon "users"}} {{i18n "about.our_admins"}}</h3>
-            <AboutPageUsers @users={{@model.admins}} @truncateAt={{12}} />
+            <AboutPageUsers @users={{@model.admins}} @truncateAt={{6}} />
           </section>
         {{/if}}
 
         {{#if @model.moderators.length}}
           <section class="about__moderators">
             <h3>{{dIcon "users"}} {{i18n "about.our_moderators"}}</h3>
-            <AboutPageUsers @users={{@model.moderators}} @truncateAt={{12}} />
+            <AboutPageUsers @users={{@model.moderators}} @truncateAt={{6}} />
           </section>
         {{/if}}
       </div>

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -207,9 +207,9 @@ describe "About page", type: :system do
     describe "our admins section" do
       before { User.update_all(last_seen_at: 1.month.ago) }
 
-      fab!(:admins) { Fabricate.times(14, :admin) }
+      fab!(:admins) { Fabricate.times(8, :admin) }
 
-      it "displays only the 12 most recently seen admins when there are more than 12 admins" do
+      it "displays only the 6 most recently seen admins when there are more than 6 admins" do
         admins[0].update!(last_seen_at: 4.minutes.ago)
         admins[1].update!(last_seen_at: 1.minutes.ago)
         admins[2].update!(last_seen_at: 10.minutes.ago)
@@ -218,7 +218,7 @@ describe "About page", type: :system do
         expect(about_page.admins_list).to have_expand_button
 
         displayed_admins = about_page.admins_list.users
-        expect(displayed_admins.size).to eq(12)
+        expect(displayed_admins.size).to eq(6)
         expect(displayed_admins.map { |u| u[:username] }.first(3)).to eq(
           [admins[1].username, admins[0].username, admins[2].username],
         )
@@ -228,7 +228,7 @@ describe "About page", type: :system do
         about_page.visit
 
         displayed_admins = about_page.admins_list.users
-        expect(displayed_admins.size).to eq(12)
+        expect(displayed_admins.size).to eq(6)
 
         expect(about_page.admins_list).to be_expandable
 
@@ -237,23 +237,23 @@ describe "About page", type: :system do
         expect(about_page.admins_list).to be_collapsible
 
         displayed_admins = about_page.admins_list.users
-        expect(displayed_admins.size).to eq(15) # 14 fabricated for this spec group and 1 global
+        expect(displayed_admins.size).to eq(9) # 8 fabricated for this spec group and 1 global
 
         about_page.admins_list.collapse
 
         expect(about_page.admins_list).to be_expandable
 
         displayed_admins = about_page.admins_list.users
-        expect(displayed_admins.size).to eq(12)
+        expect(displayed_admins.size).to eq(6)
       end
 
-      it "doesn't show an expand/collapse button when there are fewer than 12 admins" do
-        User.where(id: admins.first(7).map(&:id)).destroy_all
+      it "doesn't show an expand/collapse button when there are fewer than 6 admins" do
+        User.where(id: admins.first(4).map(&:id)).destroy_all
 
         about_page.visit
 
         displayed_admins = about_page.admins_list.users
-        expect(displayed_admins.size).to eq(8)
+        expect(displayed_admins.size).to eq(5)
         expect(about_page.admins_list).to have_no_expand_button
       end
 
@@ -298,20 +298,20 @@ describe "About page", type: :system do
     describe "our moderators section" do
       before { User.update_all(last_seen_at: 1.month.ago) }
 
-      fab!(:moderators) { Fabricate.times(15, :moderator) }
+      fab!(:moderators) { Fabricate.times(9, :moderator) }
 
-      it "displays only the 12 most recently seen moderators when there are more than 12 moderators" do
-        moderators[10].update!(last_seen_at: 5.hours.ago)
-        moderators[3].update!(last_seen_at: 2.hours.ago)
-        moderators[5].update!(last_seen_at: 13.hours.ago)
+      it "displays only the 6 most recently seen moderators when there are more than 6 moderators" do
+        moderators[5].update!(last_seen_at: 5.hours.ago)
+        moderators[4].update!(last_seen_at: 2.hours.ago)
+        moderators[1].update!(last_seen_at: 13.hours.ago)
 
         about_page.visit
         expect(about_page.moderators_list).to have_expand_button
 
         displayed_mods = about_page.moderators_list.users
-        expect(displayed_mods.size).to eq(12)
+        expect(displayed_mods.size).to eq(6)
         expect(displayed_mods.map { |u| u[:username] }.first(3)).to eq(
-          [moderators[3].username, moderators[10].username, moderators[5].username],
+          [moderators[4].username, moderators[5].username, moderators[1].username],
         )
       end
 
@@ -319,7 +319,7 @@ describe "About page", type: :system do
         about_page.visit
 
         displayed_mods = about_page.moderators_list.users
-        expect(displayed_mods.size).to eq(12)
+        expect(displayed_mods.size).to eq(6)
 
         expect(about_page.moderators_list).to be_expandable
 
@@ -328,18 +328,18 @@ describe "About page", type: :system do
         expect(about_page.moderators_list).to be_collapsible
 
         displayed_mods = about_page.moderators_list.users
-        expect(displayed_mods.size).to eq(16) # 15 fabricated for this spec group and 1 global
+        expect(displayed_mods.size).to eq(10) # 9 fabricated for this spec group and 1 global
 
         about_page.moderators_list.collapse
 
         expect(about_page.moderators_list).to be_expandable
 
         displayed_mods = about_page.moderators_list.users
-        expect(displayed_mods.size).to eq(12)
+        expect(displayed_mods.size).to eq(6)
       end
 
-      it "doesn't show an expand/collapse button when there are fewer than 12 moderators" do
-        User.where(id: moderators.first(10).map(&:id)).destroy_all
+      it "doesn't show an expand/collapse button when there are fewer than 6 moderators" do
+        User.where(id: moderators.first(4).map(&:id)).destroy_all
 
         about_page.visit
 


### PR DESCRIPTION
This PR changes the cutoff number for the admins and mods lists on the new /about page from 12 to 6. If the admins or mods lists is bigger than 6, the about page will display the 6 most recently seen admins/mods, and tuck the rest away behind a "view more" button.