### PR TITLE
DEV: Fix flaky profile spec by waiting for request to finish

### DIFF
--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -71,6 +71,8 @@ describe "User preferences | Profile", type: :system do
       find(".user-field-favourite-pokemon input").fill_in(with: "Mudkip")
       find(".save-button .btn-primary").click
 
+      expect(page).to have_selector(".pref-bio")
+
       visit("/")
 
       expect(page).to have_current_path("/")


### PR DESCRIPTION
### What is this change?

To test the restricted routing when filling up required fields, we fill up the field and then navigate to the root path and checking that we're not redirected.

This is somewhat flaky, and the screenshot shows we are back at the profile page, without any prompt to fill up fields.

My hypothesis is in cases where the backend is "slow" to respond, we're navigating away from the page before the request finishes (which will redirect back to the profile page.)

This PR adds an expectation after saving, to wait until the unrestricted profile page is rendered, before navigating away.