### PR TITLE
DEV: Fix RSpec service matchers when a model is not found

### DIFF
--- a/spec/support/service_matchers.rb
+++ b/spec/support/service_matchers.rb
@@ -99,7 +99,7 @@ module ServiceMatchers
     end
 
     def step_failed?
-      super && result[name].blank?
+      super && result[step].not_found
     end
   end
 


### PR DESCRIPTION
This is a follow-up of d749227e87bfc5df96a5b2fbace7601a83351633.

This PR checks if the key `not_found` is present on the result object instead of calling `#blank?` on the model, as it can trigger an `ActiveRecord` relation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
