### PR TITLE
UX: fix spacing in topic map views menu

### DIFF
--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -464,7 +464,7 @@ body:not(.archetype-private_message) {
 
       &__wrapper {
         display: flex;
-        justify-content: center;
+        justify-content: space-evenly;
         padding: 0 1rem;
       }
       &__count {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d85aeb52-9e5d-400c-89a7-f3efd53274a2)

After:
![image](https://github.com/user-attachments/assets/8612a075-0bf7-4abb-9f1f-764165a75d71)
