### PR TITLE
FIX: Flaky flags spec

### DIFF
--- a/spec/lib/guardian/flag_guardian_spec.rb
+++ b/spec/lib/guardian/flag_guardian_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe FlagGuardian do
       expect(Guardian.new(admin).can_create_flag?).to eq(true)
       expect(Guardian.new(user).can_create_flag?).to eq(false)
 
-      Fabricate(:flag)
+      flag = Fabricate(:flag)
 
       expect(Guardian.new(admin).can_create_flag?).to eq(false)
       expect(Guardian.new(user).can_create_flag?).to eq(false)
+
+      flag.destroy!
     end
   end
 

--- a/spec/serializers/flag_serializer_spec.rb
+++ b/spec/serializers/flag_serializer_spec.rb
@@ -16,16 +16,12 @@ RSpec.describe FlagSerializer do
   end
 
   context "when custom flag" do
-    fab!(:flag) { Fabricate(:flag, name: "custom title", description: "custom description") }
-
-    it "returns translated name" do
+    it "returns translated name and description" do
+      flag = Fabricate(:flag, name: "custom title", description: "custom description")
       serialized = described_class.new(flag, used_flag_ids: []).as_json
       expect(serialized[:flag][:name]).to eq("custom title")
-    end
-
-    it "returns translated description" do
-      serialized = described_class.new(flag, used_flag_ids: []).as_json
       expect(serialized[:flag][:description]).to eq("custom description")
+      flag.destroy!
     end
   end
 


### PR DESCRIPTION
Because of caching, whenever flags are created, they have to be destroyed to not modify the state.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
