### PR TITLE
UX: Poll give Ranked Choice distinctive bullets in Preview

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -446,9 +446,18 @@ div.poll-outer {
       content: "";
     }
 
-    &[data-poll-type="multiple"] {
+    &[data-poll-type="multiple"],
+    &[data-poll-type="ranked_choice"] {
       li[data-poll-option-id]:before {
         border-radius: 3px;
+      }
+    }
+
+    &[data-poll-type="ranked_choice"] {
+      li[data-poll-option-id]:before {
+        padding: 0 0.2em 0.7em 0.2em;
+        content: "\2228";
+        margin: 0.1em 0.5em 0.2em 0.2em;
       }
     }
   }


### PR DESCRIPTION
Currently Ranked Choice bullets show as normal in Composer Preview:

![image](https://github.com/user-attachments/assets/03519030-6280-4356-a130-6662ee5e5a40)

This is suboptimal:

* multiple poll bullets are depicted differently, so why not ranked choice?

This PR gives them a distinctive look which hints at the distinctive functionality:

![image](https://github.com/user-attachments/assets/12978b70-2a64-4619-8d68-9359143438af)



