### PR TITLE
FIX: Sum pageviews with number instead of string

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.gjs
@@ -42,7 +42,8 @@ export default class AdminReportStackedChart extends Component {
             callbacks: {
               beforeFooter: (tooltipItem) => {
                 const total = tooltipItem.reduce(
-                  (sum, item) => sum + parseInt(item.parsed.y || 0, 10)
+                  (sum, item) => sum + parseInt(item.parsed.y || 0, 10),
+                  0
                 );
                 return `= ${total}`;
               },


### PR DESCRIPTION
When the tooltip items are `tooltipItem = [{parsed: {y:12} }, {parsed: {y:10} } ]`, reducing without a initial value as a number would result in Javascript thinking it is a string. Thanks, Javascript!

There are no tests here yet since this makes use of an external library Chart.js.