### PR TITLE
DEV: Use `run_successfully` matcher in service specs

### DIFF
--- a/app/services/update_site_setting.rb
+++ b/app/services/update_site_setting.rb
@@ -4,14 +4,10 @@ class UpdateSiteSetting
   include Service::Base
 
   policy :current_user_is_admin
-
   contract
-
   step :convert_name_to_sym
-
   policy :setting_is_visible
   policy :setting_is_configurable
-
   step :cleanup_value
   step :save
 

--- a/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Chat::AddUsersToChannel do
     context "when all steps pass" do
       before { channel.add(current_user) }
 
+      it { is_expected.to run_successfully }
+
       it "fetches users to add" do
         expect(result.target_users.map(&:username)).to contain_exactly(*users.map(&:username))
       end

--- a/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_join_channel_batch_spec.rb
@@ -86,6 +86,8 @@ describe Chat::AutoJoinChannelBatch do
         context "when more than one membership is created" do
           let(:user_ids) { Fabricate.times(2, :user).map(&:id) }
 
+          it { is_expected.to run_successfully }
+
           it "does not recalculate user count" do
             ::Chat::ChannelMembershipManager.any_instance.expects(:recalculate_user_count).never
             result
@@ -101,6 +103,8 @@ describe Chat::AutoJoinChannelBatch do
         end
 
         context "when only one membership is created" do
+          it { is_expected.to run_successfully }
+
           it "recalculates user count" do
             ::Chat::ChannelMembershipManager.any_instance.expects(:recalculate_user_count).once
             result

--- a/plugins/chat/spec/services/chat/create_category_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_category_channel_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Chat::CreateCategoryChannel do
       end
 
       context "when all steps pass" do
+        it { is_expected.to run_successfully }
+
         it "creates the channel" do
           expect { result }.to change { Chat::Channel.count }.by(1)
           expect(result.channel).to have_attributes(

--- a/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_direct_message_channel_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Chat::CreateDirectMessageChannel do
         expect(contract.target_usernames).to eq(%w[lechuck elaine])
       end
     end
+
     context "when the target_groups argument is a string" do
       let(:params) { { target_groups: "admins,moderators" } }
 
@@ -42,6 +43,8 @@ RSpec.describe Chat::CreateDirectMessageChannel do
     let(:params) { { guardian: guardian, target_usernames: target_usernames, name: name } }
 
     context "when all steps pass" do
+      it { is_expected.to run_successfully }
+
       it "sets the service result as successful" do
         expect(result).to be_a_success
       end

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Chat::CreateMessage do
           context "when user is a bot" do
             fab!(:user) { Discourse.system_user }
 
-            it { is_expected.to be_a_success }
+            it { is_expected.to run_successfully }
           end
 
           context "when membership is enforced" do
@@ -248,7 +248,7 @@ RSpec.describe Chat::CreateMessage do
               params[:enforce_membership] = true
             end
 
-            it { is_expected.to be_a_success }
+            it { is_expected.to run_successfully }
           end
 
           context "when user can join channel" do
@@ -291,6 +291,8 @@ RSpec.describe Chat::CreateMessage do
                       it_behaves_like "creating a new message"
                       it_behaves_like "a message in a thread"
 
+                      it { is_expected.to run_successfully }
+
                       it "assigns the thread to the new message" do
                         expect(message).to have_attributes(
                           in_reply_to: an_object_having_attributes(thread: thread),
@@ -311,6 +313,8 @@ RSpec.describe Chat::CreateMessage do
                       it_behaves_like "a message in a thread" do
                         let(:original_user) { reply_to.user }
                       end
+
+                      it { is_expected.to run_successfully }
 
                       it "creates a new thread" do
                         expect { result }.to change { Chat::Thread.count }.by(1)
@@ -389,6 +393,8 @@ RSpec.describe Chat::CreateMessage do
                         it_behaves_like "creating a new message"
                         it_behaves_like "a message in a thread"
 
+                        it { is_expected.to run_successfully }
+
                         it "does not publish the thread" do
                           Chat::Publisher.expects(:publish_thread_created!).never
                           result
@@ -399,6 +405,8 @@ RSpec.describe Chat::CreateMessage do
                     context "when not replying to an existing message" do
                       it_behaves_like "creating a new message"
                       it_behaves_like "a message in a thread"
+
+                      it { is_expected.to run_successfully }
 
                       it "does not publish the thread" do
                         Chat::Publisher.expects(:publish_thread_created!).never
@@ -417,6 +425,8 @@ RSpec.describe Chat::CreateMessage do
 
                   context "when message is valid" do
                     it_behaves_like "creating a new message"
+
+                    it { is_expected.to run_successfully }
 
                     it "updates membership last_read_message attribute" do
                       expect { result }.to change { membership.reload.last_read_message }

--- a/plugins/chat/spec/services/chat/create_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/create_thread_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Chat::CreateThread do
     end
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "creates a thread" do
         result

--- a/plugins/chat/spec/services/chat/flag_message_spec.rb
+++ b/plugins/chat/spec/services/chat/flag_message_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Chat::FlagMessage do
     context "when all steps pass" do
       fab!(:current_user) { Fabricate(:admin) }
 
+      it { is_expected.to run_successfully }
+
       it "flags the message" do
         expect { result }.to change { Reviewable.count }.by(1)
 

--- a/plugins/chat/spec/services/chat/invite_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/invite_users_to_channel_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Chat::InviteUsersToChannel do
   end
 
   context "when all steps pass" do
-    it "sets the service result as successful" do
-      expect(result).to run_service_successfully
-    end
+    it { is_expected.to run_successfully }
 
     it "creates the notifications for allowed users" do
       result

--- a/plugins/chat/spec/services/chat/leave_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/leave_channel_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Chat::LeaveChannel do
             Chat::Channel.ensure_consistency!
           end
 
+          it { is_expected.to run_successfully }
+
           it "unfollows the channel" do
             membership = channel_1.membership_for(current_user)
 
@@ -40,6 +42,8 @@ RSpec.describe Chat::LeaveChannel do
         end
 
         context "with no existing membership" do
+          it { is_expected.to run_successfully }
+
           it "does nothing" do
             expect { result }.to_not change { Chat::UserChatChannelMembership }
           end
@@ -53,6 +57,8 @@ RSpec.describe Chat::LeaveChannel do
           end
 
           before { Chat::Channel.ensure_consistency! }
+
+          it { is_expected.to run_successfully }
 
           it "leaves the channel" do
             membership = channel_1.membership_for(current_user)
@@ -71,6 +77,8 @@ RSpec.describe Chat::LeaveChannel do
         end
 
         context "with no existing membership" do
+          it { is_expected.to run_successfully }
+
           it "does nothing" do
             expect { result }.to_not change { Chat::UserChatChannelMembership }
           end
@@ -84,6 +92,8 @@ RSpec.describe Chat::LeaveChannel do
           end
 
           before { Chat::Channel.ensure_consistency! }
+
+          it { is_expected.to run_successfully }
 
           it "unfollows the channel" do
             membership = channel_1.membership_for(current_user)
@@ -100,6 +110,8 @@ RSpec.describe Chat::LeaveChannel do
         end
 
         context "with no existing membership" do
+          it { is_expected.to run_successfully }
+
           it "does nothing" do
             expect { result }.to_not change { Chat::UserChatChannelMembership }
           end

--- a/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_messages_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Chat::ListChannelMessages do
     end
 
     context "when channel exists" do
+      it { is_expected.to run_successfully }
+
       it "finds the correct channel" do
         expect(result.channel).to eq(channel)
       end
@@ -37,6 +39,8 @@ RSpec.describe Chat::ListChannelMessages do
 
   context "when fetch_eventual_membership" do
     context "when user has membership" do
+      it { is_expected.to run_successfully }
+
       it "finds the correct membership" do
         expect(result.membership).to eq(channel.membership_for(user))
       end
@@ -44,6 +48,8 @@ RSpec.describe Chat::ListChannelMessages do
 
     context "when user has no membership" do
       before { channel.membership_for(user).destroy! }
+
+      it { is_expected.to run_successfully }
 
       it "finds no membership" do
         expect(result.membership).to be_blank
@@ -86,7 +92,7 @@ RSpec.describe Chat::ListChannelMessages do
 
   context "when target_message_exists" do
     context "when no target_message_id is given" do
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
     end
 
     context "when target message is not found" do
@@ -99,7 +105,7 @@ RSpec.describe Chat::ListChannelMessages do
       fab!(:target_message) { Fabricate(:chat_message, chat_channel: channel) }
       let(:optional_params) { { target_message_id: target_message.id } }
 
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
     end
 
     context "when target message is trashed" do
@@ -117,13 +123,13 @@ RSpec.describe Chat::ListChannelMessages do
       context "when user is the message creator" do
         fab!(:target_message) { Fabricate(:chat_message, chat_channel: channel, user: user) }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
 
       context "when user is admin" do
         fab!(:user) { Fabricate(:admin) }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
   end
@@ -131,6 +137,8 @@ RSpec.describe Chat::ListChannelMessages do
   context "when fetch_messages" do
     context "with no params" do
       fab!(:messages) { Fabricate.times(20, :chat_message, chat_channel: channel) }
+
+      it { is_expected.to be_a_success }
 
       it "returns messages" do
         expect(result.can_load_more_past).to eq(false)
@@ -149,6 +157,8 @@ RSpec.describe Chat::ListChannelMessages do
 
       let(:optional_params) { { target_date: 2.days.ago } }
 
+      it { is_expected.to be_a_success }
+
       it "includes past and future messages" do
         expect(result.messages).to eq([past_message, future_message])
       end
@@ -164,6 +174,8 @@ RSpec.describe Chat::ListChannelMessages do
         thread_1.add(user)
       end
 
+      it { is_expected.to be_a_success }
+
       it "returns tracking" do
         Fabricate(:chat_message, chat_channel: channel, thread: thread_1)
 
@@ -174,6 +186,8 @@ RSpec.describe Chat::ListChannelMessages do
 
       context "when thread is forced" do
         before { thread_1.update!(force: true) }
+
+        it { is_expected.to be_a_success }
 
         it "returns tracking" do
           Fabricate(:chat_message, chat_channel: channel, thread: thread_1)
@@ -192,6 +206,8 @@ RSpec.describe Chat::ListChannelMessages do
         channel.update!(threading_enabled: true)
         thread_1.add(user)
       end
+
+      it { is_expected.to be_a_success }
 
       it "returns tracking" do
         Fabricate(:chat_message, chat_channel: channel, thread: thread_1)

--- a/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Chat::ListChannelThreadMessages do
     end
 
     context "when thread exists" do
+      it { is_expected.to run_successfully }
+
       it "finds the correct channel" do
         expect(result.thread).to eq(thread)
       end
@@ -44,7 +46,7 @@ RSpec.describe Chat::ListChannelThreadMessages do
       context "with system user" do
         fab!(:user) { Discourse.system_user }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
   end
@@ -80,7 +82,7 @@ RSpec.describe Chat::ListChannelThreadMessages do
 
   context "when target_message_exists" do
     context "when no target_message_id is given" do
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
     end
 
     context "when target message is not found" do
@@ -95,7 +97,7 @@ RSpec.describe Chat::ListChannelThreadMessages do
       end
       let(:optional_params) { { target_message_id: target_message.id } }
 
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
     end
 
     context "when target message is trashed" do
@@ -115,13 +117,13 @@ RSpec.describe Chat::ListChannelThreadMessages do
           Fabricate(:chat_message, chat_channel: thread.channel, thread: thread, user: user)
         end
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
 
       context "when user is admin" do
         fab!(:user) { Fabricate(:admin) }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
   end

--- a/plugins/chat/spec/services/chat/list_user_channels_spec.rb
+++ b/plugins/chat/spec/services/chat/list_user_channels_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Chat::ListUserChannels do
 
   before { channel_1.add(current_user) }
 
+  it { is_expected.to run_successfully }
+
   it "returns the structured data" do
     expect(result.structured[:post_allowed_category_ids]).to eq(nil)
     expect(result.structured[:unread_thread_overview]).to eq({})

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
     describe "model - threads" do
       before { channel_1.add(current_user) }
 
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
 
       it "orders threads by the last reply created_at timestamp" do
         [

--- a/plugins/chat/spec/services/chat/lookup_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_thread_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe Chat::LookupThread do
     let(:params) { { guardian: guardian, thread_id: thread.id, channel_id: thread.channel_id } }
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "fetches the thread" do
         expect(result.thread).to eq(thread)
@@ -60,7 +58,7 @@ RSpec.describe Chat::LookupThread do
       context "when thread is forced" do
         before { thread.update!(force: true) }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
   end

--- a/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
+++ b/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
@@ -56,12 +56,10 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
     context "when the user has no memberships" do
       let(:guardian) { Guardian.new(Fabricate(:user)) }
 
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "returns the updated_memberships in context" do
-        expect(result.updated_memberships).to eq([])
+        expect(result.updated_memberships).to be_empty
       end
     end
 
@@ -96,9 +94,7 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
         )
       end
 
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "updates the last_read_message_ids" do
         result

--- a/plugins/chat/spec/services/chat/mark_thread_title_prompt_seen_spec.rb
+++ b/plugins/chat/spec/services/chat/mark_thread_title_prompt_seen_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe Chat::MarkThreadTitlePromptSeen do
     before { thread.update!(last_message: last_reply) }
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       context "when the user is a member of the thread" do
         fab!(:membership) { thread.add(current_user) }

--- a/plugins/chat/spec/services/chat/restore_message_spec.rb
+++ b/plugins/chat/spec/services/chat/restore_message_spec.rb
@@ -41,9 +41,7 @@ RSpec.describe Chat::RestoreMessage do
       end
 
       context "when the user has permission to restore" do
-        it "sets the service result as successful" do
-          expect(result).to be_a_success
-        end
+        it { is_expected.to run_successfully }
 
         it "restores the message" do
           result

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe Chat::SearchChatable do
     end
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "cleans the term" do
         params[:term] = "#bob"

--- a/plugins/chat/spec/services/chat/stop_message_streaming_spec.rb
+++ b/plugins/chat/spec/services/chat/stop_message_streaming_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Chat::StopMessageStreaming do
     context "with valid params" do
       fab!(:current_user) { Fabricate(:admin) }
 
-      it { is_expected.to be_a_success }
+      it { is_expected.to run_successfully }
 
       it "updates the streaming attribute to false" do
         expect { result }.to change { message_1.reload.streaming }.to eq(false)
@@ -42,7 +42,7 @@ RSpec.describe Chat::StopMessageStreaming do
       context "when the user is a bot" do
         fab!(:current_user) { Discourse.system_user }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Chat::StopMessageStreaming do
 
         before { params[:message_id] = reply.id }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
 
       context "when the OM is not from current user" do
@@ -89,13 +89,13 @@ RSpec.describe Chat::StopMessageStreaming do
         context "when current user is a bot" do
           fab!(:current_user) { Discourse.system_user }
 
-          it { is_expected.to be_a_success }
+          it { is_expected.to run_successfully }
         end
 
         context "when current user is an admin" do
           fab!(:current_user) { Fabricate(:admin) }
 
-          it { is_expected.to be_a_success }
+          it { is_expected.to run_successfully }
         end
       end
     end
@@ -112,13 +112,13 @@ RSpec.describe Chat::StopMessageStreaming do
       context "when current user is a bot" do
         fab!(:current_user) { Discourse.system_user }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
 
       context "when current user is an admin" do
         fab!(:current_user) { Fabricate(:admin) }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to run_successfully }
       end
     end
   end

--- a/plugins/chat/spec/services/chat/trash_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_channel_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe(Chat::TrashChannel) do
     context "when user is allowed to perform the action" do
       fab!(:current_user) { Fabricate(:admin) }
 
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "trashes the channel" do
         expect(result[:channel]).to be_trashed

--- a/plugins/chat/spec/services/chat/trash_message_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_message_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe Chat::TrashMessage do
       end
 
       context "when the user has permission to delete" do
-        it "sets the service result as successful" do
-          expect(result).to be_a_success
-        end
+        it { is_expected.to run_successfully }
 
         it "trashes the message" do
           result

--- a/plugins/chat/spec/services/chat/trash_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_messages_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe Chat::TrashMessages do
       end
 
       context "when the user has permission to delete" do
-        it "sets the service result as successful" do
-          expect(result).to be_a_success
-        end
+        it { is_expected.to run_successfully }
 
         it "trashes the messages" do
           result

--- a/plugins/chat/spec/services/chat/unfollow_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/unfollow_channel_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Chat::UnfollowChannel do
       context "with existing membership" do
         before { channel_1.add(current_user) }
 
+        it { is_expected.to run_successfully }
+
         it "unfollows the channel" do
           membership = channel_1.membership_for(current_user)
 
@@ -32,6 +34,8 @@ RSpec.describe Chat::UnfollowChannel do
       end
 
       context "with no existing membership" do
+        it { is_expected.to run_successfully }
+
         it "does nothing" do
           expect { result }.to_not change { Chat::UserChatChannelMembership }
         end

--- a/plugins/chat/spec/services/chat/update_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/update_channel_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe Chat::UpdateChannel do
           .first
       end
 
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "updates the channel accordingly" do
         result

--- a/plugins/chat/spec/services/chat/update_channel_status_spec.rb
+++ b/plugins/chat/spec/services/chat/update_channel_status_spec.rb
@@ -42,9 +42,7 @@ RSpec.describe(Chat::UpdateChannelStatus) do
   context "when status is allowed" do
     let(:status) { "closed" }
 
-    it "sets the service result as successful" do
-      expect(result).to be_a_success
-    end
+    it { is_expected.to run_successfully }
 
     it "changes the status" do
       result

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -879,9 +879,7 @@ RSpec.describe Chat::UpdateMessage do
     end
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to run_service_successfully
-      end
+      it { is_expected.to run_successfully }
 
       it "updates the message" do
         expect(result.message.message).to eq("new")

--- a/plugins/chat/spec/services/chat/update_thread_notification_settings_spec.rb
+++ b/plugins/chat/spec/services/chat/update_thread_notification_settings_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Chat::UpdateThreadNotificationSettings do
     before { thread.update!(last_message: last_reply) }
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       context "when the user is a member of the thread" do
         fab!(:membership) { thread.add(current_user) }

--- a/plugins/chat/spec/services/chat/update_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/update_thread_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe Chat::UpdateThread do
     let(:params) { { guardian: guardian, thread_id: thread.id, title: title } }
 
     context "when all steps pass" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "updates the title of the thread" do
         result

--- a/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
@@ -91,9 +91,7 @@ RSpec.describe Chat::UpdateUserChannelLastRead do
           )
         end
 
-        it "sets the service result as successful" do
-          expect(result).to be_a_success
-        end
+        it { is_expected.to run_successfully }
 
         it "updates the last_read message id" do
           expect { result }.to change { membership.reload.last_read_message_id }.to(message_1.id)

--- a/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe Chat::UpdateUserThreadLastRead do
     end
 
     context "when params are valid" do
-      it "sets the service result as successful" do
-        expect(result).to be_a_success
-      end
+      it { is_expected.to run_successfully }
 
       it "publishes new last read to clients" do
         messages = MessageBus.track_publish { result }

--- a/plugins/chat/spec/services/chat/upsert_draft_spec.rb
+++ b/plugins/chat/spec/services/chat/upsert_draft_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Chat::UpsertDraft do
     end
 
     context "when all steps pass" do
+      it { is_expected.to run_successfully }
+
       it "creates draft if data provided and not existing draft" do
         params[:data] = MultiJson.dump(message: "a")
 

--- a/spec/services/flags/create_flag_spec.rb
+++ b/spec/services/flags/create_flag_spec.rb
@@ -69,11 +69,10 @@ RSpec.describe(Flags::CreateFlag) do
         OpenStruct.new(enabled?: true),
       )
     end
+
     after { Flag.destroy_by(name: "custom flag name") }
 
-    it "sets the service result as successful" do
-      expect(result).to be_a_success
-    end
+    it { is_expected.to run_successfully }
 
     it "creates the flag" do
       result

--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe(Flags::DestroyFlag) do
-  fab!(:flag)
-
   subject(:result) { described_class.call(id: flag.id, guardian: current_user.guardian) }
+
+  fab!(:flag)
 
   after { flag.destroy }
 
@@ -15,6 +15,8 @@ RSpec.describe(Flags::DestroyFlag) do
 
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
+
+    it { is_expected.to run_successfully }
 
     it "sets the service result as successful" do
       expect(result).to be_a_success

--- a/spec/services/flags/reorder_flag_spec.rb
+++ b/spec/services/flags/reorder_flag_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe(Flags::ReorderFlag) do
       described_class.call(flag_id: flag.id, guardian: current_user.guardian, direction: "down")
     end
 
-    it "sets the service result as successful" do
-      expect(result).to be_a_success
-    end
+    it { is_expected.to run_successfully }
 
     it "moves the flag" do
       expect(Flag.order(:position).map(&:name)).to eq(

--- a/spec/services/flags/toggle_flag_spec.rb
+++ b/spec/services/flags/toggle_flag_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe(Flags::ToggleFlag) do
 
     after { flag.reload.update!(enabled: true) }
 
-    it "sets the service result as successful" do
-      expect(result).to be_a_success
-    end
+    it { is_expected.to run_successfully }
 
     it "toggles the flag" do
       expect(result[:flag].enabled).to be false

--- a/spec/services/flags/update_flag_spec.rb
+++ b/spec/services/flags/update_flag_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe(Flags::UpdateFlag) do
-  fab!(:flag)
-
   subject(:result) do
     described_class.call(
       id: flag.id,
@@ -14,6 +12,8 @@ RSpec.describe(Flags::UpdateFlag) do
       enabled: enabled,
     )
   end
+
+  fab!(:flag)
 
   after { flag.destroy }
 
@@ -67,9 +67,7 @@ RSpec.describe(Flags::UpdateFlag) do
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
 
-    it "sets the service result as successful" do
-      expect(result).to be_a_success
-    end
+    it { is_expected.to run_successfully }
 
     it "updates the flag" do
       result

--- a/spec/support/service_matchers.rb
+++ b/spec/support/service_matchers.rb
@@ -10,8 +10,24 @@ module ServiceMatchers
     end
 
     def failure_message
+      message = "Expected the service to succeed but it failed."
+      error_message_with_inspection(message)
+    end
+
+    def failure_message_when_negated
+      message = "Expected the service to fail but it succeeded."
+      error_message_with_inspection(message)
+    end
+
+    def description
+      "run the service successfully"
+    end
+
+    private
+
+    def error_message_with_inspection(message)
       inspector = StepsInspector.new(result)
-      "Expected to run the service sucessfully but failed:\n\n#{inspector.inspect}\n\n#{inspector.error}"
+      "#{message}\n\n#{inspector.inspect}\n\n#{inspector.error}"
     end
   end
 
@@ -137,7 +153,7 @@ module ServiceMatchers
     FailStep.new(name)
   end
 
-  def run_service_successfully
+  def run_successfully
     RunServiceSuccessfully.new
   end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
