### PR TITLE
DEV: Log live slots of Sidekiq jobs

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -137,11 +137,13 @@ module Jobs
         @data["duration"] = current_duration if @data["status"] == "pending"
         self.class.raw_log("#{@data.to_json}\n")
 
-        if @data["live_slots_start"].present? && @data["live_slots_finish"].present?
+        if live_slots_limit > 0 && @data["live_slots_start"].present? &&
+             @data["live_slots_finish"].present?
           live_slots = @data["live_slots_finish"] - @data["live_slots_start"]
-          if live_slots_limit > 0 && live_slots >= live_slots_limit
+
+          if live_slots >= live_slots_limit
             Rails.logger.warn(
-              "Sidekiq Job '#{@data["job_name"]}' used #{live_slots} slots: #{@data.inspect}",
+              "Sidekiq Job '#{@data["job_name"]}' allocated #{live_slots} objects in the heap: #{@data.inspect}",
             )
           end
         end

--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -136,10 +136,23 @@ module Jobs
         @data["@timestamp"] = Time.now
         @data["duration"] = current_duration if @data["status"] == "pending"
         self.class.raw_log("#{@data.to_json}\n")
+
+        if @data["live_slots_start"].present? && @data["live_slots_finish"].present?
+          live_slots = @data["live_slots_finish"] - @data["live_slots_start"]
+          if live_slots_limit > 0 && live_slots >= live_slots_limit
+            Rails.logger.warn(
+              "Sidekiq Job '#{@data["job_name"]}' used #{live_slots} slots: #{@data.inspect}",
+            )
+          end
+        end
       end
 
       def enabled?
         ENV["DISCOURSE_LOG_SIDEKIQ"] == "1"
+      end
+
+      def live_slots_limit
+        @live_slots_limit ||= ENV["DISCOURSE_LIVE_SLOTS_SIDEKIQ_LIMIT"].to_i
       end
 
       def self.mutex


### PR DESCRIPTION
Introduce a new log line for Sidekiq jobs that consume more than `DISCOURSE_LIVE_SLOTS_SIDEKIQ_LIMIT` live slots. This is useful to track down jobs that may leak memory.

This is enabled only when Sidekiq's job instrumenter is enabled (set `DISCOURSE_LOG_SIDEKIQ` to `1`).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
