### PR TITLE
FIX: Restore `propertyEqual` following native-class conversions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-tab.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-tab.js
@@ -1,9 +1,10 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
-import { empty, equal } from "@ember/object/computed";
+import { empty } from "@ember/object/computed";
 import { scheduleOnce } from "@ember/runloop";
 import { underscore } from "@ember/string";
 import { classNameBindings, tagName } from "@ember-decorators/component";
+import { propertyEqual } from "discourse/lib/computed";
 import DiscourseURL from "discourse/lib/url";
 import getURL from "discourse-common/lib/get-url";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -13,7 +14,7 @@ import I18n from "discourse-i18n";
 @classNameBindings("active", "tabClassName")
 export default class EditCategoryTab extends Component {
   @empty("params.slug") newCategory;
-  @equal("selectedTab", "tab") active;
+  @propertyEqual("selectedTab", "tab") active;
 
   @discourseComputed("tab")
   tabClassName(tab) {

--- a/app/assets/javascripts/discourse/app/components/group-post.js
+++ b/app/assets/javascripts/discourse/app/components/group-post.js
@@ -1,6 +1,6 @@
 import Component from "@ember/component";
-import { equal } from "@ember/object/computed";
 import { classNameBindings } from "@ember-decorators/component";
+import { propertyEqual } from "discourse/lib/computed";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { userPath } from "discourse/lib/url";
 import getURL from "discourse-common/lib/get-url";
@@ -14,7 +14,7 @@ import I18n from "discourse-i18n";
   "primaryGroup"
 )
 export default class GroupPost extends Component {
-  @equal("post.post_type", "site.post_types.moderator_action")
+  @propertyEqual("post.post_type", "site.post_types.moderator_action")
   moderatorAction;
 
   @discourseComputed("post.url")


### PR DESCRIPTION
I mistakenly replaced these with `@equal`, thinking the behavior was the same. It's not. `@propertyEqual` compares two properties, while `@equal` compares a single property with a constant.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
