### PR TITLE
FIX: correctly filter user bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -30,11 +30,11 @@ export default class UserActivityBookmarksController extends Controller {
 
   @computed("q")
   get searchTerm() {
-    return this.q;
+    return this._searchTerm || this.q;
   }
 
   set searchTerm(value) {
-    /* noop */
+    this._searchTerm = value;
   }
 
   @discourseComputed()

--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -59,7 +59,7 @@ export default class UserActivityBookmarksController extends Controller {
   @action
   search() {
     this.router.transitionTo({
-      queryParams: { q: this.searchTerm },
+      queryParams: { q: this._searchTerm },
     });
   }
 

--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -18,7 +18,7 @@
         @type="text"
         @value={{this.searchTerm}}
         placeholder={{i18n "bookmarks.search_placeholder"}}
-        @enter={{action "search"}}
+        @enter={{this.search}}
         id="bookmark-search"
         autocomplete="off"
       />

--- a/spec/system/page_objects/pages/user_activity_bookmarks.rb
+++ b/spec/system/page_objects/pages/user_activity_bookmarks.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class UserActivityBookmarks < PageObjects::Pages::Base
+      def visit(user, q: nil)
+        url = "/u/#{user.username_lower}/activity/bookmarks"
+        url += "?q=#{q}" if q
+        page.visit(url)
+        self
+      end
+
+      def search_for(query)
+        fill_in("bookmark-search", with: query)
+        page.find(".bookmark-search-form button").click
+        self
+      end
+
+      def has_topic?(topic)
+        has_content?(topic.title)
+      end
+
+      def has_no_topic?(topic)
+        has_no_content?(topic.title)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/user_activity_bookmarks.rb
+++ b/spec/system/page_objects/pages/user_activity_bookmarks.rb
@@ -11,8 +11,17 @@ module PageObjects
       end
 
       def search_for(query)
+        fill_in_search(query).submit_button.click
+        self
+      end
+
+      def clear_query
+        fill_in_search("").submit_button.click
+        self
+      end
+
+      def fill_in_search(query)
         fill_in("bookmark-search", with: query)
-        page.find(".bookmark-search-form button").click
         self
       end
 
@@ -22,6 +31,10 @@ module PageObjects
 
       def has_no_topic?(topic)
         has_no_content?(topic.title)
+      end
+
+      def submit_button
+        @submit_button ||= page.find(".bookmark-search-form button")
       end
     end
   end

--- a/spec/system/user_activity_bookmarks_spec.rb
+++ b/spec/system/user_activity_bookmarks_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe "User activity bookmarks", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:bookmark_1) do
+    Fabricate(
+      :bookmark,
+      user: current_user,
+      name: "Bookmark 1",
+      bookmarkable: Fabricate(:post, raw: "a nice event"),
+    )
+  end
+  fab!(:bookmark_2) do
+    Fabricate(
+      :bookmark,
+      user: current_user,
+      name: "Bookmark 2",
+      bookmarkable: Fabricate(:post, raw: "a pretty cat"),
+    )
+  end
+
+  let(:user_activity_bookmarks) { PageObjects::Pages::UserActivityBookmarks.new }
+
+  before do
+    SearchIndexer.enable
+    SearchIndexer.index(bookmark_1.bookmarkable, force: true)
+    SearchIndexer.index(bookmark_2.bookmarkable, force: true)
+    Fabricate(:topic_user, user: current_user, topic: bookmark_1.bookmarkable.topic)
+    Fabricate(:topic_user, user: current_user, topic: bookmark_2.bookmarkable.topic)
+
+    sign_in(current_user)
+  end
+
+  after { SearchIndexer.disable }
+
+  it "can filter the list of bookmarks from the URL" do
+    user_activity_bookmarks.visit(current_user, q: bookmark_1.bookmarkable.raw)
+
+    expect(user_activity_bookmarks).to have_no_topic(bookmark_2.bookmarkable.topic)
+    expect(user_activity_bookmarks).to have_topic(bookmark_1.bookmarkable.topic)
+  end
+
+  it "can filter the list of bookmarks" do
+    user_activity_bookmarks.visit(current_user).search_for(bookmark_2.bookmarkable.raw)
+
+    expect(user_activity_bookmarks).to have_no_topic(bookmark_1.bookmarkable.topic)
+    expect(user_activity_bookmarks).to have_topic(bookmark_2.bookmarkable.topic)
+  end
+end

--- a/spec/system/user_activity_bookmarks_spec.rb
+++ b/spec/system/user_activity_bookmarks_spec.rb
@@ -46,4 +46,16 @@ describe "User activity bookmarks", type: :system do
     expect(user_activity_bookmarks).to have_no_topic(bookmark_1.bookmarkable.topic)
     expect(user_activity_bookmarks).to have_topic(bookmark_2.bookmarkable.topic)
   end
+
+  it "can clear the query" do
+    user_activity_bookmarks.visit(current_user).search_for(bookmark_2.bookmarkable.raw)
+
+    expect(user_activity_bookmarks).to have_no_topic(bookmark_1.bookmarkable.topic)
+    expect(user_activity_bookmarks).to have_topic(bookmark_2.bookmarkable.topic)
+
+    user_activity_bookmarks.clear_query
+
+    expect(user_activity_bookmarks).to have_topic(bookmark_1.bookmarkable.topic)
+    expect(user_activity_bookmarks).to have_topic(bookmark_2.bookmarkable.topic)
+  end
 end


### PR DESCRIPTION
We were not updating `searchTerm` when changing the input which was making us always send an empty q parameter.

This commit is also adding tests for:
- initial url with q param
- filtering the bookmarks through the input

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
