### PR TITLE
FIX: Regression with bookmarks filtering in user activity page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -22,11 +22,10 @@ export default class UserActivityBookmarksController extends Controller {
   loading = false;
   loadingMore = false;
   permissionDenied = false;
-
   bulkSelectHelper = new BulkSelectHelper(this);
-
   @notEmpty("q") inSearchMode;
   @equal("model.bookmarks.length", 0) noContent;
+  _searchTerm = null;
 
   @computed("q")
   get searchTerm() {
@@ -34,7 +33,7 @@ export default class UserActivityBookmarksController extends Controller {
   }
 
   set searchTerm(value) {
-    /* noop */
+    this._searchTerm = value;
   }
 
   @discourseComputed()
@@ -59,7 +58,7 @@ export default class UserActivityBookmarksController extends Controller {
   @action
   search() {
     this.router.transitionTo({
-      queryParams: { q: this.searchTerm },
+      queryParams: { q: this._searchTerm },
     });
   }
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -6834,6 +6834,16 @@ RSpec.describe UsersController do
       expect(response.parsed_body["bookmarks"]).to eq([])
     end
 
+    it "can filter bookmarks using a keyword" do
+      bookmark1.name = "Override bookmark name for filtering purposes"
+      bookmark1.save!
+      sign_in(user1)
+      get "/u/#{user1.username}/bookmarks.json", params: { q: "override" }
+      response_bookmarks = response.parsed_body["user_bookmark_list"]["bookmarks"]
+      expect(response.status).to eq(200)
+      expect(response_bookmarks.map { |b| b["id"] }).to match_array([bookmark1.id])
+    end
+
     it "shows a helpful message if no bookmarks are found for the search" do
       sign_in(user1)
       get "/u/#{user1.username}/bookmarks.json", params: { q: "badsearch" }


### PR DESCRIPTION
This regressed in https://github.com/discourse/discourse/pull/28225. 