### PR TITLE
FIX: chat mailer log noise

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -383,11 +383,13 @@ module Jobs
 
     # Simulate the args being dumped/parsed through JSON
     parsed_opts = JSON.parse(JSON.dump(opts))
-    Discourse.deprecate(<<~TEXT.squish, since: "2.9", drop_from: "3.0") if opts != parsed_opts
+    if opts != parsed_opts
+      Discourse.deprecate(<<~TEXT.squish, since: "2.9", drop_from: "3.0", output_in_test: true)
         #{klass.name} was enqueued with argument values which do not cleanly serialize to/from JSON.
         This means that the job will be run with slightly different values than the ones supplied to `enqueue`.
         Argument values should be strings, booleans, numbers, or nil (or arrays/hashes of those value types).
       TEXT
+    end
     opts = parsed_opts
 
     if ::Jobs.run_later?

--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -15,7 +15,7 @@ module Chat
           if DiscoursePluginRegistry.apply_modifier(:chat_mailer_send_summary_to_user, true, user)
             Jobs.enqueue(
               :user_email,
-              type: :chat_summary,
+              type: "chat_summary",
               user_id: user.id,
               force_respect_seen_recently: true,
             )

--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -23,7 +23,9 @@ describe Chat::Mailer do
   end
 
   def expect_enqueued
-    expect_enqueued_with(job:, args:) { described_class.send_unread_mentions_summary }
+    expect {
+      expect_enqueued_with(job:, args:) { described_class.send_unread_mentions_summary }
+    }.to_not output.to_stderr_from_any_process
     expect(Jobs::UserEmail.jobs.size).to eq(1)
   end
 


### PR DESCRIPTION
Fixes the log noise caused by a deprecation notice

> Jobs::UserEmail was enqueued with argument values which do not cleanly serialize to/from JSON. This means that the job will be run with slightly different values than the ones supplied to `enqueue`. Argument values should be strings, booleans, numbers, or nil (or arrays/hashes of those value types). (deprecated since Discourse 2.9) (removal in Discourse 3.0)