### PR TITLE
DEV: Redirect `/theme-tests` to `/theme-qunit`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1614,6 +1614,7 @@ Discourse::Application.routes.draw do
     post "/safe-mode" => "safe_mode#enter", :as => "safe_mode_enter"
 
     get "/theme-qunit" => "qunit#theme"
+    get "/theme-tests", to: redirect("/theme-qunit")
 
     # This is a special route that is used when theme QUnit tests are run through testem which appends a testem_id to the
     # path. Unfortunately, testem's proxy support does not allow us to easily remove this from the path, so we have to


### PR DESCRIPTION
The name `/theme-qunit` comes from the days when we served the main qunit tests at `/qunit`. Nowadays, with ember-cli, the core tests are on `/tests`, so `/theme-tests` makes more sense, and might be what people think to try.

Changing the name would be a fairly large refactor. But we can add a redirect very easily.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
