### PR TITLE
FIX: do not enforce 2fa when an account is created with OAuth

### DIFF
--- a/app/services/user_activator.rb
+++ b/app/services/user_activator.rb
@@ -67,7 +67,7 @@ class LoginActivator < UserActivator
   include CurrentUser
 
   def activate
-    log_on_user(user)
+    log_on_user(user, { authenticated_with_oauth: @session["authenticated_with_oauth"] })
     user.enqueue_welcome_message("welcome_user")
     success_message
   end

--- a/app/services/user_authenticator.rb
+++ b/app/services/user_authenticator.rb
@@ -36,7 +36,10 @@ class UserAuthenticator
       authenticator.after_create_account(@user, @auth_result)
       confirm_email
     end
-    @session[:authentication] = @auth_result = nil if @session&.dig(:authentication)
+    if @session&.dig(:authentication)
+      @session[:authentication] = @auth_result = nil
+      @session[:authenticated_with_oauth] = true
+    end
   end
 
   def email_valid?

--- a/spec/services/user_authenticator_spec.rb
+++ b/spec/services/user_authenticator_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe UserAuthenticator do
       expect(session[:authentication]).to eq(nil)
     end
 
+    it "sets the authenticated_with_oauth flag in the session" do
+      user = Fabricate(:user, email: "user53@discourse.org")
+      session = { authentication: github_auth(true) }
+
+      UserAuthenticator.new(user, session).finish
+
+      expect(session[:authenticated_with_oauth]).to be true
+    end
+
     it "raises an error for non-boolean values" do
       user = Fabricate(:user, email: "user53@discourse.org")
       session = { authentication: github_auth("string") }


### PR DESCRIPTION
In this PR we introduced a new setting `enforce_second_factor_on_external_auth` which disables enforce 2FA when the user is authenticated with an external provider.

https://github.com/discourse/discourse/pull/27506

However, with the first registration with an external provider, we authenticate the user right after activation. In that case, we need to also keep information that the user was authenticated with an external OAuth provider to potentially skip 2FA (when  `enforce_second_factor_on_external_auth` is false).
