### PR TITLE
DEV: Fix app-cache regression in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,13 +167,18 @@ jobs:
           echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
           echo "127.0.0.1 discoursetest.minio.local" | sudo tee -a /etc/hosts
 
+      - name: Get CPU cores
+        id: cpu-info
+        run: echo "cpu-cores=$(nproc)" >> $GITHUB_OUTPUT
+
       - name: Fetch app state cache
         uses: actions/cache@v4
         id: app-cache
         with:
           path: tmp/app-cache
           key: >-
-            ${{ runner.name }}-
+            ${{ runner.os }}-
+            ${{ steps.cpu-info.outputs.cpu-cores }}-
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
             ${{ hashFiles('config/environments/test.rb') }}-


### PR DESCRIPTION
This regressed in b83a2a34a4cb303b5b4936a325d93e1c63f5d214 because the
Github actions docs doesn't make it clear that `runner.name` is actually
the runner's name plus some unique string appended at the end. Why they
would do that is beyond me.

This is an example cache key without this fix: `ubuntu-22.04-8core_402c36492b1a- 3823af50517f70be1da4e4be845b1eb7dbf5816d06d185c7e3a26f1f67471a83- d93984824c3f1b6961dfd9538cb8cde3024d3c18c7a5e7dd62c8312291eaf3ff- 7a3af9a582fe31b60784143841031476cd4a50960f16e060adfddd69c201efd7- true`. See how `_402c36492b1a` is appended to `ubuntu-22.04-8core`.
