### PR TITLE
DEV: Improve external upload debugging

### DIFF
--- a/app/models/external_upload_stub.rb
+++ b/app/models/external_upload_stub.rb
@@ -21,7 +21,7 @@ class ExternalUploadStub < ActiveRecord::Base
           where(
             "status = ? AND created_at <= ?",
             ExternalUploadStub.statuses[:created],
-            CREATED_EXPIRY_HOURS.hours.ago,
+            (SiteSetting.enable_upload_debug_mode ? 48 : CREATED_EXPIRY_HOURS).hours.ago,
           )
         end
 

--- a/lib/external_upload_helpers.rb
+++ b/lib/external_upload_helpers.rb
@@ -162,12 +162,14 @@ module ExternalUploadHelpers
         max_parts: 1,
       )
     rescue Aws::S3::Errors::NoSuchUpload => err
-      debug_upload_error(
-        err,
-        I18n.t(
-          "upload.external_upload_not_found",
-          additional_detail: "path: #{external_upload_stub.key}",
-        ),
+      return(
+        debug_upload_error(
+          err,
+          I18n.t(
+            "upload.external_upload_not_found",
+            additional_detail: "path: #{external_upload_stub.key}",
+          ),
+        )
       )
     end
 
@@ -357,7 +359,7 @@ module ExternalUploadHelpers
   end
 
   def debug_upload_error(err, friendly_message)
-    return if !SiteSetting.enable_upload_debug_mode
+    return I18n.t("upload.failed") if !SiteSetting.enable_upload_debug_mode
     Discourse.warn_exception(err, message: "[ExternalUploadError] #{friendly_message}")
 
     if Rails.env.local? || is_api?

--- a/spec/jobs/clean_up_uploads_spec.rb
+++ b/spec/jobs/clean_up_uploads_spec.rb
@@ -404,4 +404,20 @@ RSpec.describe Jobs::CleanUpUploads do
     Jobs::CleanUpUploads.new.execute(nil)
     expect(ExternalUploadStub.pluck(:id)).to contain_exactly(external_stub1.id, external_stub3.id)
   end
+
+  it "does not delete create external upload stubs for 2 days if debug mode is on" do
+    SiteSetting.enable_upload_debug_mode = true
+    external_stub1 =
+      Fabricate(
+        :external_upload_stub,
+        status: ExternalUploadStub.statuses[:created],
+        created_at: 2.hours.ago,
+      )
+    Jobs::CleanUpUploads.new.execute(nil)
+    expect(ExternalUploadStub.pluck(:id)).to contain_exactly(external_stub1.id)
+
+    SiteSetting.enable_upload_debug_mode = false
+    Jobs::CleanUpUploads.new.execute(nil)
+    expect(ExternalUploadStub.pluck(:id)).to be_empty
+  end
 end


### PR DESCRIPTION
* Do not delete created external upload stubs for 2 days
  instead of 1 hour if enable_upload_debug_mode is true,
  this aids with server-side debugging.
* If using an API call, return the detailed error message
  if enable_upload_debug_mode is true. In this case the user
  is not using the UI, so a more detailed message is appropriate.
* Add a prefix to log messages in ExternalUploadHelpers, to
  make it easier to find these in logster.
