### PR TITLE
FIX: Use `.login-right-side` instead of `.has-alt-auth`

### DIFF
--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -151,7 +151,7 @@
 /* end shared styles */
 
 .d-modal.create-account {
-  &:not(:has(.has-alt-auth)) .d-modal__container {
+  &:not(:has(.login-right-side)) .d-modal__container {
     max-width: 500px;
   }
 


### PR DESCRIPTION
The class `login-right-side` is more reliable since it's in the template itself instead of being injected.