### PR TITLE
DEV: Fix app-cache key not considering number of parallel database

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,7 +182,8 @@ jobs:
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
             ${{ hashFiles('config/environments/test.rb') }}-
-            ${{ env.USES_PARALLEL_DATABASES }}
+            ${{ env.USES_PARALLEL_DATABASES }}-
+            ${{ env.PARALLEL_TEST_PROCESSORS }}-
 
       - name: Restore database from cache
         if: steps.app-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
This is a follow-up to 8adc484804f67672cbed82dcdf4f2615e8831af9
