### PR TITLE
DEV: Stop using sprockets for 'use ember cli' stylesheet

### DIFF
--- a/app/views/layouts/ember_cli.html.erb
+++ b/app/views/layouts/ember_cli.html.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title><%= content_for?(:title) ? yield(:title) : SiteSetting.title %></title>
 
-  <%= stylesheet_link_tag(:ember_cli) %>
+  <%= discourse_stylesheet_link_tag(:ember_cli) %>
 
 </head>
 <body class="requires-ember-cli">


### PR DESCRIPTION
This was throwing the "Discourse does not support compiling scss/sass files via Sprockets" error if the file was not cached

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
