### PR TITLE
FIX: ensure About#stats uses the cache

### DIFF
--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -81,7 +81,7 @@ class About
   end
 
   def stats
-    @stats ||= About.fetch_stats
+    @stats ||= About.fetch_cached_stats
   end
 
   def category_moderators

--- a/app/models/concerns/stats_cacheable.rb
+++ b/app/models/concerns/stats_cacheable.rb
@@ -30,6 +30,10 @@ module StatsCacheable
       stats
     end
 
+    def clear_stats_cache
+      Discourse.redis.del(stats_cache_key)
+    end
+
     private
 
     def set_cache(stats)

--- a/app/models/concerns/stats_cacheable.rb
+++ b/app/models/concerns/stats_cacheable.rb
@@ -30,10 +30,6 @@ module StatsCacheable
       stats
     end
 
-    def clear_stats_cache
-      Discourse.redis.del(stats_cache_key)
-    end
-
     private
 
     def set_cache(stats)

--- a/spec/models/about_spec.rb
+++ b/spec/models/about_spec.rb
@@ -31,16 +31,10 @@ RSpec.describe About do
     end
 
     it "uses the cache" do
-      ActiveRecord::Base.connection.query_cache.clear
-      ActiveRecord::Base.connection.enable_query_cache!
-      described_class.new.stats
-      expect(ActiveRecord::Base.connection.query_cache.length).not_to eq(0)
+      cold_cache_count = track_sql_queries { described_class.new.stats }.count
+      hot_cache_count = track_sql_queries { described_class.new.stats }.count
 
-      ActiveRecord::Base.connection.query_cache.clear
-      described_class.new.stats
-      expect(ActiveRecord::Base.connection.query_cache.length).to eq(0)
-    ensure
-      ActiveRecord::Base.connection.disable_query_cache!
+      expect(cold_cache_count + hot_cache_count).to eq(cold_cache_count)
     end
 
     it "does not add plugin stats to the output if they are missing one of the required keys" do

--- a/spec/models/about_spec.rb
+++ b/spec/models/about_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe About do
     )
   end
 
-  after do
-    About.clear_stats_cache
-    DiscoursePluginRegistry.reset!
-  end
+  after { DiscoursePluginRegistry.reset! }
 
   describe "#stats" do
+    use_redis_snapshotting
+
     it "adds plugin stats to the output" do
       stats = { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
       register_stat("some_group", Proc.new { stats })


### PR DESCRIPTION
Prior to this fix we were calling `fetch_stats` which is never checking if we have a cache entry. This call is making a lot of SQL calls, so it's better to use the cache.

This commit also adds a spec and a way to clear the cache of a model using `stats_cacheable`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
