### PR TITLE
DEV: Cap QUnit tests parallel count at 8

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -86,6 +86,11 @@ def system_tests_parallel_tests_processors_env
   "PARALLEL_TEST_PROCESSORS=#{number_of_processors / 2}"
 end
 
+def qunit_parallel_count
+  # Capped at a maximum of 8 parallel tests to avoid saturating the ember-cli server
+  [number_of_processors / 2, 8].min
+end
+
 # Environment Variables (specific to this rake task)
 # => INSTALL_OFFICIAL_PLUGINS  set to 1 to install all official plugins
 # => UPDATE_ALL_PLUGINS        set to 1 to update all plugins
@@ -298,7 +303,7 @@ task "docker:test" do
         unless ENV["SKIP_CORE"]
           @good &&=
             run_or_fail(
-              "cd app/assets/javascripts/discourse && CI=1 yarn ember exam --load-balance --parallel=#{number_of_processors / 2} --random",
+              "cd app/assets/javascripts/discourse && CI=1 yarn ember exam --load-balance --parallel=#{qunit_parallel_count} --random",
             )
         end
 
@@ -311,7 +316,7 @@ task "docker:test" do
           else
             @good &&=
               run_or_fail(
-                "QUNIT_PARALLEL=#{number_of_processors / 2}  CI=1 bundle exec rake plugin:qunit['*','#{js_timeout}']",
+                "QUNIT_PARALLEL=#{qunit_parallel_count} CI=1 bundle exec rake plugin:qunit['*','#{js_timeout}']",
               )
           end
         end


### PR DESCRIPTION
We are seeing tests being more flaky when running at higher parallel
counts. Hypothesis is that we are saturating the ember-cli server. Cap
the maximum parallel count at 8 for now.
