### PR TITLE
FIX: change `eq` to `match_array` in `topic_tags_changed_spec.rb` to solve flaky test

### DIFF
--- a/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
+++ b/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
@@ -149,7 +149,7 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
 
       expect(list.length).to eq(1)
       expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED)
-      expect(list[0]["added_tags"]).to eq([bad_tag.name, another_tag.name])
+      expect(list[0]["added_tags"]).to match_array([bad_tag.name, another_tag.name])
       expect(list[0]["removed_tags"]).to eq([cool_tag.name])
     end
 


### PR DESCRIPTION
The following test is flakey. We don't care about the order because we check if the tags are being sent.

```
Failure/Error: measurement = Benchmark.measure { example.run }

  expected: ["tag4", "tag5"]
       got: ["tag5", "tag4"]

  (compared using ==)
  
  ```