### PR TITLE
FIX: Chat emoji picker positioning

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-message-emoji-picker.gjs
@@ -13,10 +13,6 @@ export default class ChatChannelMessageEmojiPicker extends Component {
   context = "chat-channel-message";
 
   listenToBodyScroll = modifier(() => {
-    if (!this.site.mobileView) {
-      return;
-    }
-
     const handler = () => {
       this.chatEmojiPickerManager.close();
     };
@@ -47,6 +43,10 @@ export default class ChatChannelMessageEmojiPicker extends Component {
       {
         placement: "top",
         modifiers: [
+          {
+            name: "eventListeners",
+            options: { scroll: false, resize: false },
+          },
           {
             name: "flip",
             options: { padding: { top: headerOffset() } },

--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -215,7 +215,7 @@ export default class ChatEmojiPicker extends Component {
   @action
   focusFilter(target) {
     schedule("afterRender", () => {
-      target?.focus();
+      target?.focus({ preventScroll: true });
     });
   }
 


### PR DESCRIPTION
Removes chat-specific changes from dfc947a97dd37d5ec58e1c971a9a2285429dd98d, and adds `preventScroll: true` to prevent timing issues between the emoji picker being brought into the viewport and being focussed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
