### PR TITLE
FIX: Check existing custom flags before creating a flag id

### DIFF
--- a/db/migrate/20240829155635_update_custom_flag_sequence.rb
+++ b/db/migrate/20240829155635_update_custom_flag_sequence.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class UpdateCustomFlagSequence < ActiveRecord::Migration[7.1]
+  def up
+    # Update flags to consider the sequence when manual ids were added
+    max_id = DB.query_single("SELECT MAX(id) from flags").first
+    DB.exec("SELECT setval('flags_id_seq', #{max_id + 1}, FALSE);")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20240829155635_update_custom_flag_sequence.rb
+++ b/db/migrate/20240829155635_update_custom_flag_sequence.rb
@@ -2,7 +2,7 @@
 class UpdateCustomFlagSequence < ActiveRecord::Migration[7.1]
   def up
     # Update flags to consider the sequence when manual ids were added
-    max_id = DB.query_single("SELECT MAX(id) from flags").first
+    max_id = DB.query_single("SELECT MAX(id) from flags").first || Flag::MAX_SYSTEM_FLAG_ID
     DB.exec("SELECT setval('flags_id_seq', #{max_id + 1}, FALSE);")
   end
 


### PR DESCRIPTION
- This migration aims to amend the case where flag IDs are inserted manually. Considering such cases, we should get the highest custom flag ID in the DB and start counting from there.