### PR TITLE
DEV: Add 'multiple' class to login-buttons when there are multiple btns

### DIFF
--- a/app/assets/javascripts/discourse/app/components/login-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/login-buttons.js
@@ -4,7 +4,7 @@ import { isWebauthnSupported } from "discourse/lib/webauthn";
 import { findAll } from "discourse/models/login-method";
 import discourseComputed from "discourse-common/utils/decorators";
 
-@classNameBindings("hidden")
+@classNameBindings("hidden", "multiple")
 export default class LoginButtons extends Component {
   elementId = "login-buttons";
 
@@ -15,6 +15,11 @@ export default class LoginButtons extends Component {
   )
   hidden(buttonsCount, showLoginWithEmailLink, showPasskeysButton) {
     return buttonsCount === 0 && !showLoginWithEmailLink && !showPasskeysButton;
+  }
+
+  @discourseComputed("buttons.length")
+  multiple(buttonsCount) {
+    return buttonsCount > 1;
   }
 
   @discourseComputed


### PR DESCRIPTION
This adds a `multiple` class when there is more than one login method. This is needed in a plugin for styling.

<img width="1562" alt="Screenshot 2024-08-29 at 3 15 25 PM" src="https://github.com/user-attachments/assets/86ba2715-7312-438a-bc47-15e228f6dcdd">
