### PR TITLE
DEV: Remove deprecated respect_plugin_enabled positional argument

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -140,18 +140,10 @@ class Plugin::Instance
   def add_to_serializer(
     serializer,
     attr,
-    deprecated_respect_plugin_enabled = nil,
     respect_plugin_enabled: true,
     include_condition: nil,
     &block
   )
-    if !deprecated_respect_plugin_enabled.nil?
-      Discourse.deprecate(
-        "add_to_serializer's respect_plugin_enabled argument should be passed as a keyword argument",
-      )
-      respect_plugin_enabled = deprecated_respect_plugin_enabled
-    end
-
     if attr.to_s.starts_with?("include_")
       Discourse.deprecate(
         "add_to_serializer should not be used to directly override include_*? methods. Use the include_condition keyword argument instead",


### PR DESCRIPTION
### What is this change?

In April last year we deprecated the positional version of this argument in favour of the keyword version. This change removes the deprecated one.

### Verification

- [x] Plugin tests are passing. (They would fail to load if they are still using the positional argument.)