### PR TITLE
DEV: Skip babel for ace-builds and json-editor

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -233,6 +233,12 @@ module.exports = function (defaults) {
       {
         package: "sinon",
       },
+      {
+        package: "@json-editor/json-editor",
+      },
+      {
+        package: "ace-builds",
+      },
     ],
   });
 


### PR DESCRIPTION
This will avoid warnings: "The code generator has deoptimised the styling of {path} as it exceeds the max of 500KB."

Should also provide a tiny improvement in build times

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
