### PR TITLE
DEV: Refactor complex initializers into classes

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/logout.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/logout.js
@@ -1,3 +1,5 @@
+import { setOwner } from "@ember/owner";
+import { service } from "@ember/service";
 import logout from "discourse/lib/logout";
 import { bind } from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
@@ -5,13 +7,13 @@ import I18n from "discourse-i18n";
 let _showingLogout = false;
 
 // Subscribe to "logout" change events via the Message Bus
-export default {
-  after: "message-bus",
+class LogoutInit {
+  @service messageBus;
+  @service dialog;
+  @service currentUser;
 
-  initialize(owner) {
-    this.messageBus = owner.lookup("service:message-bus");
-    this.dialog = owner.lookup("service:dialog");
-    this.currentUser = owner.lookup("service:current-user");
+  constructor(owner) {
+    setOwner(this, owner);
 
     if (this.currentUser) {
       this.messageBus.subscribe(
@@ -19,7 +21,7 @@ export default {
         this.onMessage
       );
     }
-  },
+  }
 
   teardown() {
     if (this.currentUser) {
@@ -28,7 +30,7 @@ export default {
         this.onMessage
       );
     }
-  },
+  }
 
   @bind
   onMessage() {
@@ -45,5 +47,18 @@ export default {
       didCancel: logout,
       shouldDisplayCancel: false,
     });
+  }
+}
+
+export default {
+  after: "message-bus",
+
+  initialize(owner) {
+    this.instance = new LogoutInit(owner);
+  },
+
+  teardown() {
+    this.instance.teardown();
+    this.instance = null;
   },
 };

--- a/app/assets/javascripts/discourse/app/instance-initializers/read-only.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/read-only.js
@@ -1,22 +1,37 @@
+import { setOwner } from "@ember/owner";
+import { service } from "@ember/service";
 import { bind } from "discourse-common/utils/decorators";
 
 // Subscribe to "read-only" status change events via the Message Bus
-export default {
-  after: "message-bus",
+class ReadOnlyInit {
+  @service messageBus;
+  @service site;
 
-  initialize(owner) {
-    this.messageBus = owner.lookup("service:message-bus");
-    this.site = owner.lookup("service:site");
+  constructor(owner) {
+    setOwner(this, owner);
 
     this.messageBus.subscribe("/site/read-only", this.onMessage);
-  },
+  }
 
   teardown() {
     this.messageBus.unsubscribe("/site/read-only", this.onMessage);
-  },
+  }
 
   @bind
   onMessage(enabled) {
     this.site.set("isReadOnly", enabled);
+  }
+}
+
+export default {
+  after: "message-bus",
+
+  initialize(owner) {
+    this.instance = new ReadOnlyInit(owner);
+  },
+
+  teardown() {
+    this.instance.teardown();
+    this.instance = null;
   },
 };

--- a/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -1,4 +1,6 @@
 // Subscribes to user events on the message bus
+import { setOwner } from "@ember/owner";
+import { service } from "@ember/service";
 import {
   alertChannel,
   disable as disableDesktopNotifications,
@@ -14,23 +16,21 @@ import Notification from "discourse/models/notification";
 import { isTesting } from "discourse-common/config/environment";
 import { bind } from "discourse-common/utils/decorators";
 
-export default {
-  after: "message-bus",
+class SubscribeUserNotificationsInit {
+  @service currentUser;
+  @service messageBus;
+  @service store;
+  @service appEvents;
+  @service siteSettings;
+  @service site;
+  @service router;
 
-  initialize(owner) {
-    this.currentUser = owner.lookup("service:current-user");
+  constructor(owner) {
+    setOwner(this, owner);
 
     if (!this.currentUser) {
       return;
     }
-
-    this.messageBus = owner.lookup("service:message-bus");
-    this.store = owner.lookup("service:store");
-    this.messageBus = owner.lookup("service:message-bus");
-    this.appEvents = owner.lookup("service:app-events");
-    this.siteSettings = owner.lookup("service:site-settings");
-    this.site = owner.lookup("service:site");
-    this.router = owner.lookup("service:router");
 
     this.reviewableCountsChannel = `/reviewable_counts/${this.currentUser.id}`;
 
@@ -82,7 +82,7 @@ export default {
         unsubscribePushNotifications(this.currentUser);
       }
     }
-  },
+  }
 
   teardown() {
     if (!this.currentUser) {
@@ -116,7 +116,7 @@ export default {
     this.messageBus.unsubscribe("/client_settings", this.onClientSettings);
 
     this.messageBus.unsubscribe(alertChannel(this.currentUser), this.onAlert);
-  },
+  }
 
   @bind
   onReviewableCounts(data) {
@@ -128,7 +128,7 @@ export default {
       "unseen_reviewable_count",
       data.unseen_reviewable_count
     );
-  },
+  }
 
   @bind
   onNotification(data) {
@@ -210,22 +210,22 @@ export default {
 
       stale.results.set("content", newNotifications);
     }
-  },
+  }
 
   @bind
   onUserDrafts(data) {
     this.currentUser.updateDraftProperties(data);
-  },
+  }
 
   @bind
   onDoNotDisturb(data) {
     this.currentUser.updateDoNotDisturbStatus(data.ends_at);
-  },
+  }
 
   @bind
   onUserStatus(data) {
     this.appEvents.trigger("user-status:changed", data);
-  },
+  }
 
   @bind
   onCategories(data) {
@@ -251,12 +251,12 @@ export default {
     (data.deleted_categories || []).forEach((id) =>
       this.site.removeCategory(id)
     );
-  },
+  }
 
   @bind
   onClientSettings(data) {
     this.siteSettings[data.name] = data.value;
-  },
+  }
 
   @bind
   onAlert(data) {
@@ -268,5 +268,16 @@ export default {
         this.appEvents
       );
     }
+  }
+}
+
+export default {
+  after: "message-bus",
+  initialize(owner) {
+    this.instance = new SubscribeUserNotificationsInit(owner);
+  },
+  teardown() {
+    this.instance.teardown();
+    this.instance = null;
   },
 };


### PR DESCRIPTION
We're working to remove all decorators from object-literal-properties. This commit refactors all initializers which were using these decorators into classes, where decorators are allowed. Also adds cleanup logic to the local-dates initializer, which was previously missing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
