### PR TITLE
FIX: Mini-profiler CSP nonce when in report-only mode

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -90,7 +90,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
 
   Rack::MiniProfiler.config.content_security_policy_nonce =
     Proc.new do |env, headers|
-      if csp = headers["Content-Security-Policy"]
+      if csp = headers["Content-Security-Policy"] || headers["Content-Security-Policy-Report-Only"]
         csp[/script-src[^;]+'nonce-([^']+)'/, 1]
       end
     end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
