### PR TITLE
Update admin-report-chart.gjs

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-chart.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-report-chart.gjs
@@ -10,8 +10,8 @@ export default class AdminReportChart extends Component {
 
     const chartData = Report.collapse(
       model,
-      makeArray(model.chartData || model.data, "weekly"),
-      options.chartGrouping
+      makeArray(model.chartData || model.data),
+      options.chartGrouping || "daily"
     );
     const prevChartData = makeArray(model.prevChartData || model.prev_data);
     const labels = chartData.map((d) => d.x);


### PR DESCRIPTION
1. `makeArray` expects one argument, but provided two.

2. `options.chartGrouping || "weekly"` makes more sense in given context. Defaulting `weekly` to `daily` probably makes even more sense considering to [`Report.collapse`](https://github.com/discourse/discourse/blob/7b89fdead98606d4f47ceb0a1d240d0f6e5f589e/app/assets/javascripts/admin/addon/models/report.js#L58-L126)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
