### PR TITLE
PREF: sets default notification level in batches

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -465,7 +465,7 @@ class Group < ActiveRecord::Base
   end
 
   def set_message_default_notification_levels!(topic, ignore_existing: false)
-    group_users.in_batches(of: 1000) do |batch|
+    group_users.in_batches do |batch|
       batch
         .pluck(:user_id, :notification_level)
         .each do |user_id, notification_level|


### PR DESCRIPTION
The code was doings `group_users.each`, which means that for a very large group of users it can end up loading in memory a very large array. The code was already aware of this by doing pluck and loading only the necessary fields, but I suspect the batch might help the most pathological cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
