### PR TITLE
FIX: prevents PM to large groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -468,7 +468,7 @@ class Group < ActiveRecord::Base
   end
 
   def set_message_default_notification_levels!(topic, ignore_existing: false)
-    if user_count >= SiteSetting.group_pm_user_limit
+    if user_count > SiteSetting.group_pm_user_limit
       raise GroupPmUserLimitExceededError,
             I18n.t(
               "groups.errors.default_notification_level_users_limit",

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -464,7 +464,19 @@ class Group < ActiveRecord::Base
     Group.auto_groups_between(:trust_level_0, :trust_level_4).to_a
   end
 
+  class GroupPmUserLimitExceededError < StandardError
+  end
+
   def set_message_default_notification_levels!(topic, ignore_existing: false)
+    if user_count >= SiteSetting.group_pm_user_limit
+      raise GroupPmUserLimitExceededError,
+            I18n.t(
+              "groups.errors.default_notification_level_users_limit",
+              count: SiteSetting.group_pm_user_limit,
+              group_name: name,
+            )
+    end
+
     group_users
       .pluck(:user_id, :notification_level)
       .each do |user_id, notification_level|

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -612,7 +612,9 @@ en:
         one: "%{count} user has been added to the group."
         other: "%{count} users have been added to the group."
     errors:
-      default_notification_level_users_limit: "Default notification level can't be set on groups larger than %{count} users. Incorrect group: %{group_name}"
+      default_notification_level_users_limit:
+        one: "Default notification level can't be set on groups larger than %{count} user. Incorrect group: %{group_name}"
+        other: "Default notification level can't be set on groups larger than %{count} users. Incorrect group: %{group_name}"
       grant_trust_level_not_valid: "'%{trust_level}' is not a valid trust level."
       can_not_modify_automatic: "You cannot modify an automatic group"
       member_already_exist:
@@ -755,7 +757,7 @@ en:
               reply_by_email_disabled: "Reply by email has been disabled."
               send_to_email_disabled: "Sorry, you cannot send personal messages to email."
               target_user_not_found: "One of the users you are sending this message to could not be found."
-              too_large_group: "The group: %{group_name}, has too many users to receive a message."
+              too_large_group: "The group: %{group_name}, has too many users to receive a message. Limit is %{limit}."
               unable_to_update: "There was an error updating that topic."
               unable_to_tag: "There was an error tagging the topic."
               unable_to_unlist: "Sorry, you cannot create an unlisted topic."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -612,6 +612,7 @@ en:
         one: "%{count} user has been added to the group."
         other: "%{count} users have been added to the group."
     errors:
+      default_notification_level_users_limit: "Default notification level can't be set on groups larger than %{count} users. Incorrect group: %{group_name}"
       grant_trust_level_not_valid: "'%{trust_level}' is not a valid trust level."
       can_not_modify_automatic: "You cannot modify an automatic group"
       member_already_exist:
@@ -754,6 +755,7 @@ en:
               reply_by_email_disabled: "Reply by email has been disabled."
               send_to_email_disabled: "Sorry, you cannot send personal messages to email."
               target_user_not_found: "One of the users you are sending this message to could not be found."
+              too_large_group: "The group: %{group_name}, has too many users to receive a message."
               unable_to_update: "There was an error updating that topic."
               unable_to_tag: "There was an error tagging the topic."
               unable_to_unlist: "Sorry, you cannot create an unlisted topic."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1227,6 +1227,11 @@ posting:
   max_form_template_content_length:
     default: 5000
     max: 150000
+  group_pm_user_limit:
+    default: 1000
+    type: integer
+    min: 1
+    hidden: true
 
 email:
   email_time_window_mins:

--- a/lib/has_errors.rb
+++ b/lib/has_errors.rb
@@ -15,14 +15,14 @@ module HasErrors
     false
   end
 
-  def rollback_with!(obj, error)
-    obj.errors.add(:base, error)
+  def rollback_with!(obj, error, **kwargs)
+    obj.errors.add(:base, error, **kwargs)
     rollback_from_errors!(obj)
   end
 
   def rollback_from_errors!(obj)
     add_errors_from(obj)
-    raise ActiveRecord::Rollback.new
+    raise ActiveRecord::Rollback.new, obj.errors.full_messages.join("\n")
   end
 
   def add_error(msg)

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -109,7 +109,13 @@ class TopicCreator
     end
 
     topic.reload.topic_allowed_groups.each do |topic_allowed_group|
-      topic_allowed_group.group.set_message_default_notification_levels!(topic)
+      group = topic_allowed_group.group
+
+      begin
+        group.set_message_default_notification_levels!(topic)
+      rescue Group::GroupPmUserLimitExceededError => e
+        rollback_with!(topic, :too_large_group, group_name: group.name)
+      end
     end
   end
 

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -114,7 +114,12 @@ class TopicCreator
       begin
         group.set_message_default_notification_levels!(topic)
       rescue Group::GroupPmUserLimitExceededError => e
-        rollback_with!(topic, :too_large_group, group_name: group.name)
+        rollback_with!(
+          topic,
+          :too_large_group,
+          group_name: group.name,
+          limit: SiteSetting.group_pm_user_limit,
+        )
       end
     end
   end

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -579,7 +579,7 @@ RSpec.describe TopicCreator do
             ActiveRecord::Rollback,
             I18n.t(
               "activerecord.errors.models.topic.attributes.base.too_large_group",
-              count: SiteSetting.group_pm_user_limit,
+              limit: SiteSetting.group_pm_user_limit,
               group_name: group.name,
             ),
           )

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -563,6 +563,29 @@ RSpec.describe TopicCreator do
         end
       end
 
+      context "with too many users in a group" do
+        fab!(:group) { Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]) }
+
+        before do
+          SiteSetting.group_pm_user_limit = 1
+          Fabricate.times(2, :user).each { |user| group.add(user) }
+          pm_valid_attrs[:target_group_names] = group.name
+        end
+
+        it "fails with an error" do
+          expect do
+            TopicCreator.create(user, Guardian.new(admin), pm_valid_attrs)
+          end.to raise_error(
+            ActiveRecord::Rollback,
+            I18n.t(
+              "groups.errors.default_notification_level_users_limit",
+              count: SiteSetting.group_pm_user_limit,
+              group_name: group.name,
+            ),
+          )
+        end
+      end
+
       context "with to emails" do
         it "works for staff" do
           SiteSetting.send_email_messages_allowed_groups = "1|3"

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -578,7 +578,7 @@ RSpec.describe TopicCreator do
           end.to raise_error(
             ActiveRecord::Rollback,
             I18n.t(
-              "groups.errors.default_notification_level_users_limit",
+              "activerecord.errors.models.topic.attributes.base.too_large_group",
               count: SiteSetting.group_pm_user_limit,
               group_name: group.name,
             ),

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -94,6 +94,31 @@ RSpec.describe Group do
     end
   end
 
+  describe "#set_message_default_notification_levels!" do
+    context "with too many users in a group" do
+      fab!(:topic)
+      fab!(:large_group) { Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]) }
+
+      before do
+        SiteSetting.group_pm_user_limit = 1
+        Fabricate.times(2, :user).each { |user| large_group.add(user) }
+      end
+
+      it "raises a GroupPmUserLimitExceededError error" do
+        expect do
+          large_group.reload.set_message_default_notification_levels!(topic)
+        end.to raise_error(
+          Group::GroupPmUserLimitExceededError,
+          I18n.t(
+            "groups.errors.default_notification_level_users_limit",
+            count: SiteSetting.group_pm_user_limit,
+            group_name: large_group.name,
+          ),
+        )
+      end
+    end
+  end
+
   describe "#builtin" do
     context "when verifying enum sequence" do
       before { @builtin = Group.builtin }


### PR DESCRIPTION
This commit introduces a new hidden site setting: `group_pm_user_limit`, default to `1000` which will raise an error when attempting to create a PM target a large group.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
