### PR TITLE
FIX: correctly pass updateGroupings to the modal

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/edit-badge-groupings.hbs
+++ b/app/assets/javascripts/admin/addon/components/modal/edit-badge-groupings.hbs
@@ -37,13 +37,17 @@
         {{/each}}
       </ul>
     </div>
-    <DButton @action={{this.add}} @label="admin.badges.new" />
+    <DButton
+      @action={{this.add}}
+      class="badge-groupings__add-grouping"
+      @label="admin.badges.new"
+    />
   </:body>
   <:footer>
     <DButton
       @action={{this.saveAll}}
       @label="admin.badges.save"
-      class="btn-primary"
+      class="btn-primary badge-groupings__save"
       @disabled={{this.submitDisabled}}
     />
     <DButton

--- a/app/assets/javascripts/admin/addon/routes/admin-badges.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges.js
@@ -29,6 +29,11 @@ export default class AdminBadgesRoute extends DiscourseRoute {
     });
   }
 
+  @action
+  updateGroupings(groupings) {
+    this.controllerFor("admin-badges").set("badgeGroupings", groupings);
+  }
+
   setupController(controller, model) {
     const json = this._json;
     const badgeTriggers = [];

--- a/app/assets/javascripts/admin/addon/routes/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges/show.js
@@ -1,4 +1,4 @@
-import { action, get } from "@ember/object";
+import { get } from "@ember/object";
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
 import Badge from "discourse/models/badge";
@@ -27,10 +27,5 @@ export default class AdminBadgesShowRoute extends Route {
     super.setupController(...arguments);
 
     controller.setup();
-  }
-
-  @action
-  updateGroupings(groupings) {
-    this.controllerFor("admin-badges").set("badgeGroupings", groupings);
   }
 }

--- a/app/assets/javascripts/admin/addon/templates/admin-badges.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges.hbs
@@ -14,7 +14,7 @@
         @action={{route-action "editGroupings"}}
         @translatedLabel="Group settings"
         @icon="cog"
-        @class="btn-default"
+        @class="btn-default edit-groupings-btn"
       />
 
       <LinkTo @route="adminBadges.show" @model="new" class="btn btn-primary">

--- a/spec/system/admin_badges_grouping_modal_spec.rb
+++ b/spec/system/admin_badges_grouping_modal_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe "Admin Badges Grouping Modal", type: :system do
+  before { SiteSetting.enable_badges = true }
+
+  fab!(:current_user) { Fabricate(:admin) }
+
+  let(:badges_page) { PageObjects::Pages::AdminBadges.new }
+  let(:badges_groupings_page) { PageObjects::Pages::AdminBadgesGroupings.new }
+
+  before { sign_in(current_user) }
+
+  context "when adding a new grouping" do
+    it "saves it" do
+      badges_page.visit_page(Badge::Autobiographer).edit_groupings
+      badges_groupings_page.add_grouping("a new grouping")
+
+      try_until_success { BadgeGrouping.exists?(name: "a new grouping") }
+    end
+  end
+end

--- a/spec/system/page_objects/admin_badges.rb
+++ b/spec/system/page_objects/admin_badges.rb
@@ -56,6 +56,11 @@ module PageObjects
         self
       end
 
+      def edit_groupings
+        page.find(".edit-groupings-btn").click
+        self
+      end
+
       def form
         @form ||= PageObjects::Components::FormKit.new("form")
       end

--- a/spec/system/page_objects/admin_badges_groupings.rb
+++ b/spec/system/page_objects/admin_badges_groupings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminBadgesGroupings < PageObjects::Pages::Base
+      def add_grouping(name)
+        within(modal) do
+          find(".badge-groupings__add-grouping").click
+          find(".badge-grouping-name-input").fill_in(with: name)
+        end
+
+        save
+
+        self
+      end
+
+      def save
+        page.find(".badge-groupings__save").click
+        expect(self).to be_closed
+        self
+      end
+
+      def modal
+        page.find(".badge-groupings-modal")
+      end
+
+      def closed?
+        page.has_no_css?(".badge-groupings-modal")
+      end
+    end
+  end
+end


### PR DESCRIPTION
A previous refactor has moved this function in the controller instead of the route making it inaccessible to the modal.

This commit is fixing this and also adding a spec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
