### PR TITLE
FIX: ensures global notices are destroyed on post created

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -330,7 +330,7 @@ module DiscourseAutomation
           next if categories && !categories.include?(post.topic.category_id)
 
           tags = fields.dig("tags", "value")
-          next if tags && (tags & post.topic.tags.map(&:name)).empty?
+          next if tags&.any? && (tags & post.topic.tags.map(&:name)).empty?
 
           DiscourseAutomation::UserGlobalNotice
             .where(identifier: automation.id)

--- a/plugins/automation/spec/fabricators/user_global_notice_fabricator.rb
+++ b/plugins/automation/spec/fabricators/user_global_notice_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator(:user_global_notice, from: DiscourseAutomation::UserGlobalNotice) do
+  user_id { Fabricate(:user).id }
+  notice "This is an important notice"
+  level "info"
+  identifier "foo"
+end

--- a/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
+++ b/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe DiscourseAutomation::EventHandlers do
+  describe "#handle_stalled_topic" do
+    context "when tags are empty" do
+      fab!(:automation) do
+        Fabricate(:automation, trigger: DiscourseAutomation::Triggers::STALLED_TOPIC, enabled: true)
+      end
+      fab!(:user)
+      fab!(:post) { Fabricate(:post, user: user) }
+
+      before do
+        automation.upsert_field!("tags", "tags", { value: [] }, target: "trigger")
+        Fabricate(:user_global_notice, identifier: automation.id, user_id: user.id)
+      end
+
+      it "destroys notices" do
+        expect { subject.handle_stalled_topic(post) }.to change {
+          DiscourseAutomation::UserGlobalNotice.count
+        }.by(-1)
+      end
+    end
+  end
+end

--- a/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
+++ b/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
@@ -15,7 +15,7 @@ describe DiscourseAutomation::EventHandlers do
       end
 
       it "destroys notices" do
-        expect { subject.handle_stalled_topic(post) }.to change {
+        expect { DiscourseAutomation::EventHandlers.handle_stalled_topic(post) }.to change {
           DiscourseAutomation::UserGlobalNotice.count
         }.by(-1)
       end


### PR DESCRIPTION
Prior to this fix we could exit early if tags was `[]` as `tags && (tags & post.topic.tags.map(&:name)).empty?` would have returned true. This commit ensures it's not the case anymore and adds a test for it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
