### PR TITLE
FIX: ensures default required validator handles 0

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
@@ -1,3 +1,4 @@
+import { isBlank } from "@ember/utils";
 import I18n from "discourse-i18n";
 
 export default class Validator {
@@ -114,7 +115,7 @@ export default class Validator {
         }
         break;
       default:
-        if (!value) {
+        if (isBlank(value)) {
           error = true;
         }
     }

--- a/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
@@ -267,5 +267,10 @@ module("Unit | Lib | FormKit | Validator", function (hooks) {
       [I18n.t("form_kit.errors.required")],
       "it returns an error when the value is undefined"
     );
+
+    errors = await new Validator(0, {
+      required: {},
+    }).validate("xxx");
+    assert.deepEqual(errors, [], "it returns no error when the value is 0");
   });
 });


### PR DESCRIPTION
Prior to this fix `0` would be required as non-existing and would raise the required error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
