### PR TITLE
UX: Adjustments for the about page banner image

### DIFF
--- a/app/assets/stylesheets/common/base/about.scss
+++ b/app/assets/stylesheets/common/base/about.scss
@@ -6,6 +6,10 @@
     max-width: 1100px;
   }
 
+  &__header {
+    max-width: 1100px;
+  }
+
   &__left-side {
     flex: 1 1 650px;
   }
@@ -42,8 +46,9 @@
 
   &__banner {
     margin-bottom: 1em;
-    min-height: 300px;
     max-height: 300px;
+    max-width: 100%;
+    object-fit: contain;
   }
 
   &__activities-item {

--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -7,7 +7,7 @@
     max-width: unset;
     section:not(.admins):not(.moderators):not(.category-moderators):not(
         .about__admins
-      ):not(.about__moderators) {
+      ):not(.about__moderators):not(.about__header) {
       max-width: 700px;
     }
     .about.category-moderators {


### PR DESCRIPTION
Before:

<img src="https://github.com/user-attachments/assets/5f57fd2f-4b43-4eb4-b8b8-4ae2b41f1a1a" width=500>
<img src="https://github.com/user-attachments/assets/97c0e74e-d4a9-481e-9fa5-ae90c1e86576" width=300>

After:

<img src="https://github.com/user-attachments/assets/92a8f660-170b-480b-9338-daa9c8cef073" width=500>
<img src="https://github.com/user-attachments/assets/2241161a-c343-41a4-8bed-758de19ac0dd" width=300>