### PR TITLE
DEV: Add `PluginOutlet`s from the old /about page to the new one

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -230,13 +230,11 @@ export default class AboutPage extends Component {
             <AboutPageUsers @users={{@model.admins}} @truncateAt={{6}} />
           </section>
         {{/if}}
-        <span>
-          <PluginOutlet
-            @name="about-after-admins"
-            @connectorTagName="section"
-            @outletArgs={{hash model=@model}}
-          />
-        </span>
+        <PluginOutlet
+          @name="about-after-admins"
+          @connectorTagName="section"
+          @outletArgs={{hash model=@model}}
+        />
 
         {{#if @model.moderators.length}}
           <section class="about__moderators">
@@ -244,13 +242,11 @@ export default class AboutPage extends Component {
             <AboutPageUsers @users={{@model.moderators}} @truncateAt={{6}} />
           </section>
         {{/if}}
-        <span>
-          <PluginOutlet
-            @name="about-after-moderators"
-            @connectorTagName="section"
-            @outletArgs={{hash model=@model}}
-          />
-        </span>
+        <PluginOutlet
+          @name="about-after-moderators"
+          @connectorTagName="section"
+          @outletArgs={{hash model=@model}}
+        />
       </div>
 
       <div class="about__right-side">

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -205,7 +205,7 @@ export default class AboutPage extends Component {
       <PluginOutlet
         @name="about-after-description"
         @connectorTagName="section"
-        @outletArgs={{hash model=this.model}}
+        @outletArgs={{hash model=@model}}
       />
     </section>
     <div class="about__main-content">
@@ -230,6 +230,13 @@ export default class AboutPage extends Component {
             <AboutPageUsers @users={{@model.admins}} @truncateAt={{6}} />
           </section>
         {{/if}}
+        <span>
+          <PluginOutlet
+            @name="about-after-admins"
+            @connectorTagName="section"
+            @outletArgs={{hash model=@model}}
+          />
+        </span>
 
         {{#if @model.moderators.length}}
           <section class="about__moderators">
@@ -237,7 +244,15 @@ export default class AboutPage extends Component {
             <AboutPageUsers @users={{@model.moderators}} @truncateAt={{6}} />
           </section>
         {{/if}}
+        <span>
+          <PluginOutlet
+            @name="about-after-moderators"
+            @connectorTagName="section"
+            @outletArgs={{hash model=@model}}
+          />
+        </span>
       </div>
+
       <div class="about__right-side">
         <h3>{{i18n "about.contact"}}</h3>
         {{#if this.contactInfo}}


### PR DESCRIPTION
The old /about page has 3 plugin outlets: one after the description, one after the admins list, and one after the mods list. These outlets translate cleanly to the new /about page, so we should add them to it to make plugins/themes compatible with the new page.