### PR TITLE
DEV: Generic bulk chat import support

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -110,7 +110,17 @@ class BulkImport::Base
     ActiveSupport::Inflector.transliterate("test")
   end
 
-  MAPPING_TYPES = Enum.new(upload: 1, badge: 2, poll: 3, poll_option: 4)
+  MAPPING_TYPES =
+    Enum.new(
+      upload: 1,
+      badge: 2,
+      poll: 3,
+      poll_option: 4,
+      direct_message_channel: 5,
+      chat_channel: 6,
+      chat_thread: 7,
+      chat_message: 8,
+    )
 
   def create_migration_mappings_table
     puts "Creating migration mappings table..."
@@ -286,6 +296,19 @@ class BulkImport::Base
     @poll_option_mapping = load_index(MAPPING_TYPES[:poll_option])
     @last_poll_id = last_id(Poll)
     @last_poll_option_id = last_id(PollOption)
+
+    puts "Loading chat indexes..."
+    @chat_direct_message_channel_mapping = load_index(MAPPING_TYPES[:direct_message_channel])
+    @last_chat_direct_message_channel_id = last_id(Chat::DirectMessage)
+
+    @chat_channel_mapping = load_index(MAPPING_TYPES[:chat_channel])
+    @last_chat_channel_id = last_id(Chat::Channel)
+
+    @chat_thread_mapping = load_index(MAPPING_TYPES[:chat_thread])
+    @last_chat_thread_id = last_id(Chat::Thread)
+
+    @chat_message_mapping = load_index(MAPPING_TYPES[:chat_message])
+    @last_chat_message_id = last_id(Chat::Message)
   end
 
   def use_bbcode_to_md?
@@ -346,6 +369,26 @@ class BulkImport::Base
     end
     if @last_poll_option_id > 0
       @raw_connection.exec("SELECT setval('#{PollOption.sequence_name}', #{@last_poll_option_id})")
+    end
+    if @last_chat_direct_message_channel_id > 0
+      @raw_connection.exec(
+        "SELECT setval('#{Chat::DirectMessage.sequence_name}', #{@last_chat_direct_message_channel_id})",
+      )
+    end
+    if @last_chat_channel_id > 0
+      @raw_connection.exec(
+        "SELECT setval('#{Chat::Channel.sequence_name}', #{@last_chat_channel_id})",
+      )
+    end
+    if @last_chat_thread_id > 0
+      @raw_connection.exec(
+        "SELECT setval('#{Chat::Thread.sequence_name}', #{@last_chat_thread_id})",
+      )
+    end
+    if @last_chat_message_id > 0
+      @raw_connection.exec(
+        "SELECT setval('#{Chat::Message.sequence_name}', #{@last_chat_message_id})",
+      )
     end
   end
 
@@ -414,6 +457,22 @@ class BulkImport::Base
 
   def poll_option_id_from_original_id(id)
     @poll_option_mapping[id.to_s]&.to_i
+  end
+
+  def chat_channel_id_from_original_id(id)
+    @chat_channel_mapping[id.to_s]&.to_i
+  end
+
+  def chat_direct_message_channel_id_from_original_id(id)
+    @chat_direct_message_channel_mapping[id.to_s]&.to_i
+  end
+
+  def chat_thread_id_from_original_id(id)
+    @chat_thread_mapping[id.to_s]&.to_i
+  end
+
+  def chat_message_id_from_original_id(id)
+    @chat_message_mapping[id.to_s]&.to_i
   end
 
   GROUP_COLUMNS ||= %i[
@@ -785,6 +844,82 @@ class BulkImport::Base
     updated_at
   ]
 
+  CHAT_DIRECT_MESSAGE_CHANNEL_COLUMNS ||= %i[id group created_at updated_at]
+
+  CHAT_CHANNEL_COLUMNS ||= %i[
+    id
+    name
+    description
+    slug
+    status
+    chatable_id
+    chatable_type
+    user_count
+    messages_count
+    type
+    created_at
+    updated_at
+    allow_channel_wide_mentions
+    auto_join_users
+    threading_enabled
+  ]
+
+  USER_CHAT_CHANNEL_MEMBERSHIP_COLUMNS ||= %i[
+    chat_channel_id
+    user_id
+    created_at
+    updated_at
+    following
+    muted
+    desktop_notification_level
+    mobile_notification_level
+    last_read_message_id
+    join_mode
+    last_viewed_at
+  ]
+
+  DIRECT_MESSAGE_USER_COLUMNS ||= %i[direct_message_channel_id user_id created_at updated_at]
+
+  CHAT_THREAD_COLUMNS ||= %i[
+    id
+    channel_id
+    original_message_id
+    original_message_user_id
+    status
+    title
+    created_at
+    updated_at
+    replies_count
+  ]
+
+  USER_CHAT_THREAD_MEMBERSHIP_COLUMNS ||= %i[
+    user_id
+    thread_id
+    notification_level
+    created_at
+    updated_at
+  ]
+
+  CHAT_MESSAGE_COLUMNS ||= %i[
+    id
+    chat_channel_id
+    user_id
+    created_at
+    updated_at
+    deleted_at
+    deleted_by_id
+    in_reply_to_id
+    message
+    cooked
+    cooked_version
+    last_editor_id
+    thread_id
+  ]
+
+  CHAT_MESSAGE_REACTION_COLUMNS ||= %i[chat_message_id user_id emoji created_at updated_at]
+
+  CHAT_MENTION_COLUMNS ||= %i[chat_message_id target_id type created_at updated_at]
+
   def create_groups(rows, &block)
     create_records(rows, "group", GROUP_COLUMNS, &block)
   end
@@ -965,6 +1100,52 @@ class BulkImport::Base
 
   def create_permalinks(rows, &block)
     create_records(rows, "permalink", PERMALINK_COLUMNS, &block)
+  end
+
+  def create_chat_channels(rows, &block)
+    create_records_with_mapping(rows, "chat_channel", CHAT_CHANNEL_COLUMNS, &block)
+  end
+
+  def create_chat_direct_message(rows, &block)
+    create_records_with_mapping(
+      rows,
+      "direct_message_channel",
+      CHAT_DIRECT_MESSAGE_CHANNEL_COLUMNS,
+      &block
+    )
+  end
+
+  def create_user_chat_channel_memberships(rows, &block)
+    create_records(
+      rows,
+      "user_chat_channel_membership",
+      USER_CHAT_CHANNEL_MEMBERSHIP_COLUMNS,
+      &block
+    )
+  end
+
+  def create_direct_message_users(rows, &block)
+    create_records(rows, "direct_message_user", DIRECT_MESSAGE_USER_COLUMNS, &block)
+  end
+
+  def create_chat_threads(rows, &block)
+    create_records_with_mapping(rows, "chat_thread", CHAT_THREAD_COLUMNS, &block)
+  end
+
+  def create_thread_users(rows, &block)
+    create_records(rows, "user_chat_thread_membership", USER_CHAT_THREAD_MEMBERSHIP_COLUMNS, &block)
+  end
+
+  def create_chat_messages(rows, &block)
+    create_records_with_mapping(rows, "chat_message", CHAT_MESSAGE_COLUMNS, &block)
+  end
+
+  def create_chat_message_reactions(rows, &block)
+    create_records(rows, "chat_message_reaction", CHAT_MESSAGE_REACTION_COLUMNS, &block)
+  end
+
+  def create_chat_mentions(rows, &block)
+    create_records(rows, "chat_mention", CHAT_MENTION_COLUMNS, &block)
   end
 
   def process_group(group)
@@ -1632,6 +1813,136 @@ class BulkImport::Base
     permalink[:created_at] ||= NOW
     permalink[:updated_at] ||= NOW
     permalink
+  end
+
+  def process_direct_message_channel(chat_channel)
+    chat_channel[:id] = @last_chat_direct_message_channel_id += 1
+    chat_channel[:group] = false if chat_channel[:group].nil?
+    chat_channel[:created_at] ||= NOW
+    chat_channel[:updated_at] ||= NOW
+
+    @imported_records[chat_channel[:original_id].to_s] = chat_channel[:id]
+    @chat_direct_message_channel_mapping[chat_channel[:original_id].to_s] = chat_channel[:id]
+
+    chat_channel
+  end
+
+  def process_chat_channel(chat_channel)
+    chat_channel[:id] = @last_chat_channel_id += 1
+
+    if chat_channel[:name].present?
+      chat_channel[:name] = chat_channel[:name][0..SiteSetting.max_topic_title_length]
+        .scrub
+        .strip
+        .presence
+      chat_channel[:slug] ||= Slug.ascii_generator(chat_channel[:name])
+    end
+
+    chat_channel[:description] = chat_channel[:description][0..500].scrub.strip if chat_channel[
+      :description
+    ].present?
+    chat_channel[:slug] = chat_channel[:slug][0..100] if chat_channel[:slug].present?
+    chat_channel[:allow_channel_wide_mentions] ||= true if chat_channel[
+      :allow_channel_wide_mentions
+    ].nil?
+    chat_channel[:auto_join_users] ||= false if chat_channel[:auto_join_users].nil?
+    chat_channel[:threading_enabled] ||= false if chat_channel[:threading_enabled].nil?
+    chat_channel[:user_count] ||= 0
+    chat_channel[:messages_count] ||= 0
+    chat_channel[:status] ||= 0
+    chat_channel[:created_at] ||= NOW
+    chat_channel[:updated_at] ||= NOW
+
+    @imported_records[chat_channel[:original_id].to_s] = chat_channel[:id]
+    @chat_channel_mapping[chat_channel[:original_id].to_s] = chat_channel[:id]
+
+    chat_channel
+  end
+
+  def process_user_chat_channel_membership(membership)
+    membership[:created_at] ||= NOW
+    membership[:updated_at] ||= NOW
+    membership[:last_viewed_at] ||= NOW
+    membership[:following] = false if membership[:following].nil?
+    membership[:muted] = false if membership[:muted].nil?
+    membership[
+      :desktop_notification_level
+    ] ||= Chat::UserChatChannelMembership.desktop_notification_levels[:mention]
+    membership[
+      :mobile_notification_level
+    ] ||= Chat::UserChatChannelMembership.mobile_notification_levels[:mention]
+    membership[:join_mode] ||= Chat::UserChatChannelMembership.join_modes[:manual]
+
+    membership
+  end
+
+  def process_direct_message_user(user)
+    user[:created_at] ||= NOW
+    user[:updated_at] ||= NOW
+
+    user
+  end
+
+  def process_chat_thread(thread)
+    thread[:id] = @last_chat_thread_id += 1
+    thread[:created_at] ||= NOW
+    thread[:updated_at] ||= NOW
+
+    @imported_records[thread[:original_id].to_s] = thread[:id]
+    @chat_thread_mapping[thread[:original_id].to_s] = thread[:id]
+
+    thread
+  end
+
+  def process_user_chat_thread_membership(membership)
+    membership[:created_at] ||= NOW
+    membership[:updated_at] ||= NOW
+    membership[:notification_level] ||= Chat::UserChatThreadMembership.notification_levels[
+      :tracking
+    ]
+    membership[:thread_title_prompt_seen] = false if membership[:thread_title_prompt_seen].nil?
+
+    membership
+  end
+
+  def process_chat_message(message)
+    message[:id] = @last_chat_message_id += 1
+    message[:user_id] ||= Discourse::SYSTEM_USER_ID
+    message[:last_editor_id] ||= message[:user_id]
+    message[:message] = (message[:message] || "").scrub.strip.presence || "<Empty imported message>"
+    message[:message] = normalize_text(message[:message])
+    message[:cooked] = pre_cook(message[:message])
+    message[:created_at] ||= NOW
+    message[:updated_at] ||= NOW
+
+    @imported_records[message[:original_id].to_s] = message[:id]
+    @chat_message_mapping[message[:original_id].to_s] = message[:id]
+
+    if message[:message].bytes.include?(0)
+      STDERR.puts "Skipping chat message with original ID #{message[:original_id]} because `message` contains null bytes"
+      message[:skip] = true
+    end
+
+    if message[:cooked].bytes.include?(0)
+      STDERR.puts "Skipping chat message with original ID #{message[:original_id]} because `cooked` contains null bytes"
+      message[:skip] = true
+    end
+
+    message
+  end
+
+  def process_chat_message_reaction(reaction)
+    reaction[:created_at] ||= NOW
+    reaction[:updated_at] ||= NOW
+
+    reaction
+  end
+
+  def process_chat_mention(mention)
+    mention[:created_at] ||= NOW
+    mention[:updated_at] ||= NOW
+
+    mention
   end
 
   def create_records(all_rows, name, columns, &block)

--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -1862,7 +1862,6 @@ class BulkImport::Base
   def process_user_chat_channel_membership(membership)
     membership[:created_at] ||= NOW
     membership[:updated_at] ||= NOW
-    membership[:last_viewed_at] ||= NOW
     membership[:following] = false if membership[:following].nil?
     membership[:muted] = false if membership[:muted].nil?
     membership[

--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -1911,7 +1911,8 @@ class BulkImport::Base
     message[:last_editor_id] ||= message[:user_id]
     message[:message] = (message[:message] || "").scrub.strip.presence || "<Empty imported message>"
     message[:message] = normalize_text(message[:message])
-    message[:cooked] = pre_cook(message[:message])
+    message[:cooked] = ::Chat::Message.cook(message[:message], user_id: message[:last_editor_id])
+    message[:cooked_version] = ::Chat::Message::BAKED_VERSION
     message[:created_at] ||= NOW
     message[:updated_at] ||= NOW
 

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -45,7 +45,14 @@ class BulkImport::Generic < BulkImport::Base
 
     import_uploads
 
-    if false
+    if ENV["CHAT_ONLY"] == "1"
+      # TODO: Test data. Remove
+      @categories[140] = 4
+      @users[100] = 1 # selase
+      @users[101] = 47 # foster
+      @users[102] = 23 # vance
+      @users[103] = 19 # cristopher.yundt
+    else
       # needs to happen before users, because keeping group names is more important than usernames
       import_groups
 
@@ -110,13 +117,6 @@ class BulkImport::Generic < BulkImport::Base
       import_permalink_normalizations
       import_permalinks
     end
-
-    # TODO: Test data. Remove
-    @categories[140] = 4
-    @users[100] = 1 # selase
-    @users[101] = 47 # foster
-    @users[102] = 23 # vance
-    @users[103] = 19 # cristopher.yundt
 
     import_chat_direct_messages
     import_chat_channels
@@ -2462,6 +2462,12 @@ class BulkImport::Generic < BulkImport::Base
     end
 
     puts "", "Importing chat channels..."
+
+    # Ideally, we’d like these to be set in `import_site_settings`,
+    # but since there’s no way to enforce that, we're defaulting to keeping all chats
+    # indefinitely for now
+    SiteSetting.chat_channel_retention_days = 0
+    SiteSetting.chat_dm_retention_days = 0
 
     channels = query(<<~SQL)
       SELECT *

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2706,7 +2706,8 @@ class BulkImport::Generic < BulkImport::Base
       ORDER BY chat_message_id
     SQL
 
-    existing_reactions = Chat::MessageReaction.distinct.pluck(:chat_message_id, :user_id).to_set
+    existing_reactions =
+      Chat::MessageReaction.distinct.pluck(:chat_message_id, :user_id, :emoji).to_set
 
     create_chat_message_reactions(reactions) do |row|
       next if row["emoji"].blank?
@@ -2715,7 +2716,7 @@ class BulkImport::Generic < BulkImport::Base
       user_id = user_id_from_imported_id(row["user_id"])
 
       next if message_id.blank? || user_id.blank?
-      next unless existing_reactions.add?([message_id, user_id])
+      next unless existing_reactions.add?([message_id, user_id, row["emoji"]])
 
       # TODO: Validate emoji
 


### PR DESCRIPTION
This first iteration implements bulk import for:

* direct_messages
* chat_channels
* user_chat_channel_memberships
* chat_threads
* user_chat_thread_memberships
* chat_messages
* chat_reactions
* chat_mentions

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
