### PR TITLE
UX: avoid flashing error when loading form template

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -276,11 +276,7 @@ export default class DEditor extends Component.extend(
   @discourseComputed("formTemplateIds", "replyingToTopic", "editingPost")
   showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
     // TODO(@keegan): Remove !editingPost once we add edit/draft support for form templates
-    if (formTemplateIds?.length > 0 && !replyingToTopic && !editingPost) {
-      return true;
-    }
-
-    return false;
+    return formTemplateIds?.length > 0 && !replyingToTopic && !editingPost;
   }
 
   @discourseComputed("placeholder")

--- a/app/assets/javascripts/discourse/app/components/form-template-field/wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/form-template-field/wrapper.gjs
@@ -87,7 +87,7 @@ export default class FormTemplateFieldWrapper extends Component {
           />
         {{/each}}
       </div>
-    {{else}}
+    {{else if this.error}}
       <div class="alert alert-error">
         {{this.error}}
       </div>


### PR DESCRIPTION
Avoid the flashing red bar when loading a form template.

![Kapture 2024-08-26 at 16 31 14](https://github.com/user-attachments/assets/e1d51c0c-71ff-41ed-bbf3-52a43ddec0c9)

The ajax call to retrieve the form template yaml and then load it into fields could be made sooner, but that can be handled separately.