### PR TITLE
DEV: Use blob URL to install discourse/squoosh fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pikaday": "1.8.2",
     "prettier": "^2.8.8",
     "puppeteer-core": "^23.2.1",
-    "squoosh": "discourse/squoosh#dc9649d",
+    "squoosh": "https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d",
     "terser": "^5.31.6",
     "typescript": "^5.5.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
         specifier: ^23.2.1
         version: 23.2.1
       squoosh:
-        specifier: discourse/squoosh#dc9649d
+        specifier: https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d
         version: https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d
       terser:
         specifier: ^5.31.6


### PR DESCRIPTION
Workaround for https://github.com/dependabot/dependabot-core/issues/10124

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
