### PR TITLE
DEV: Use recorded runtime log for plugin specs

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -193,7 +193,7 @@ def spec(plugin, parallel: false, argv: nil)
 
   # reject system specs as they are slow and need dedicated setup
   files =
-    Dir.glob("./plugins/#{plugin}/spec/**/*_spec.rb").reject { |f| f.include?("spec/system/") }.sort
+    Dir.glob("plugins/#{plugin}/spec/**/*_spec.rb").reject { |f| f.include?("spec/system/") }.sort
 
   if files.length > 0
     cmd = parallel ? "bin/turbo_rspec" : "bin/rspec"


### PR DESCRIPTION
The recorded runtime log was specified when running the plugin specs, but it failed to match the entries from the runtime log and the passed as command line arguments because the runtime log entries were not prefixed with `./`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
