### PR TITLE
FIX: don't use post ID as timeline collapse delay

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -104,7 +104,7 @@ export default class TopicNavigation extends Component {
     this._checkSize();
   }
 
-  _collapseFullscreen(delay = 500) {
+  _collapseFullscreen(postId, delay = 500) {
     if (this.get("info.topicProgressExpanded")) {
       $(".timeline-fullscreen").removeClass("show");
       discourseLater(() => {
@@ -180,7 +180,7 @@ export default class TopicNavigation extends Component {
           duration: durationMs,
           fill: "forwards",
         })
-        .finished.then(() => this._collapseFullscreen(0));
+        .finished.then(() => this._collapseFullscreen(null, 0));
     } else {
       const distancePx = this.pxClosed;
       durationMs = this._swipeEvents.getMaxAnimationTimeMs(


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/timeline-bug-on-mobile-video-attached/323633

This regards the expanded timeline on mobile. When the timeline is dragged and the post changes, the timeline doesn't fully auto-close

![image](https://github.com/user-attachments/assets/30d1077b-33de-4f60-ab62-523543949b93)


What seems to happen, is that the postId is passed in from the topic controller like this:

`this.appEvents.trigger("topic:jump-to-post", postId);`

and in topic-navigation, the id is mistakenly used as the delay... so in cases like Meta where post ids are high the delay is very long (20+ minutes) and the expanded timeline appears stuck open

this avoids the issue by setting up a separate postId param 