### PR TITLE
DEV: Approved Post Webhook Event Category Update

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -40,6 +40,7 @@ class WebHook < ActiveRecord::Base
         WebHookEventType::TYPES[:post_edited],
         WebHookEventType::TYPES[:post_destroyed],
         WebHookEventType::TYPES[:post_recovered],
+        WebHookEventType::TYPES[:category_experts_approved],
       ],
     )
   end

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -17,7 +17,6 @@ class WebHookEventType < ActiveRecord::Base
   USER_PROMOTED = 16
   TOPIC_VOTING = 17
   CHAT_MESSAGE = 18
-  CATEGORY_EXPERTS = 19
 
   enum group: {
          topic: 0,
@@ -36,7 +35,6 @@ class WebHookEventType < ActiveRecord::Base
          user_promoted: 13,
          voting: 14,
          chat: 15,
-         category_experts: 16,
        },
        _scopes: false
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5409,6 +5409,7 @@ en:
           post_edited: "Post is updated"
           post_destroyed: "Post is deleted"
           post_recovered: "Post is recovered"
+          category_experts_approved: "Post is approved by category experts"
         group_event:
           group_name: "Group Events"
           group_created: "Group is created"

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -233,5 +233,5 @@ end
 WebHookEventType.seed do |b|
   b.id = WebHookEventType::TYPES[:category_experts_approved]
   b.name = "category_experts_approved"
-  b.group = WebHookEventType.groups[:category_experts]
+  b.group = WebHookEventType.groups[:post]
 end


### PR DESCRIPTION
### Changes

'Post approved by category experts' is moved to the post category:

<img width="993" alt="Screenshot 2024-09-04 at 1 06 22 PM" src="https://github.com/user-attachments/assets/939c484a-f1d3-4ea6-b90e-b1eec844cbb0">