### PR TITLE
DEV: pnpm ember-template-lint should not use run command

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,7 +29,7 @@ pre-commit:
     ember-template-lint:
       glob: "*.hbs"
       include: "app/assets/javascripts|plugins/.+?/assets/javascripts"
-      run: pnpm run ember-template-lint {staged_files}
+      run: pnpm ember-template-lint {staged_files}
     yaml-syntax:
       glob: "*.{yaml,yml}"
       # database.yml is an erb file not a yaml file
@@ -66,7 +66,7 @@ lints:
     eslint:
       run: pnpm eslint -f compact --quiet --ext .js .
     ember-template-lint:
-      run: pnpm run ember-template-lint .
+      run: pnpm ember-template-lint .
     yaml-syntax:
       glob: "*.{yaml,yml}"
       # database.yml is an erb file not a yaml file


### PR DESCRIPTION
On pre-commit, various people were getting an error like this:

> ERR_PNPM_NO_SCRIPT Missing script: ember-template-lint

This was because in our lefthook config we were doing
`pnpm run ember-template-lint` rather than the correct
`pnpm ember-template-lint`
