### PR TITLE
DEV: Deprecate `show_in_ui` argument of the `register_stat` API

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/about.js
+++ b/app/assets/javascripts/discourse/app/controllers/about.js
@@ -3,6 +3,17 @@ import { alias, gt } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "discourse-i18n";
 
+// TODO(osama): remove all of these methods when the legacy about page is
+// removed
+const customStats = [];
+export function addLegacyStat(name) {
+  customStats.push(name);
+}
+
+export function clearCustomStats() {
+  customStats.clear();
+}
+
 export default class AboutController extends Controller {
   @gt("siteSettings.faq_url.length", 0) faqOverridden;
 
@@ -33,5 +44,14 @@ export default class AboutController extends Controller {
       total_visitors: all,
       eu_visitors: eu,
     });
+  }
+
+  @discourseComputed("site.displayed_about_plugin_stat_groups")
+  statGroups() {
+    return Array.from(
+      new Set(customStats).union(
+        new Set(this.site.displayed_about_plugin_stat_groups || [])
+      )
+    );
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/about.js
+++ b/app/assets/javascripts/discourse/app/controllers/about.js
@@ -48,10 +48,10 @@ export default class AboutController extends Controller {
 
   @discourseComputed("site.displayed_about_plugin_stat_groups")
   statGroups() {
-    return Array.from(
-      new Set(customStats).union(
-        new Set(this.site.displayed_about_plugin_stat_groups || [])
-      )
-    );
+    const set = new Set(customStats);
+    for (const name of this.site.displayed_about_plugin_stat_groups || []) {
+      set.add(name);
+    }
+    return Array.from(set);
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -46,6 +46,7 @@ import { setDesktopScrollAreaHeight } from "discourse/components/topic-timeline/
 import { addTopicTitleDecorator } from "discourse/components/topic-title";
 import { setNotificationsLimit as setUserMenuNotificationsLimit } from "discourse/components/user-menu/notifications-list";
 import { addUserMenuProfileTabItem } from "discourse/components/user-menu/profile-tab-content";
+import { addLegacyStat as addLegacyAboutPageStat } from "discourse/controllers/about";
 import { addDiscoveryQueryParam } from "discourse/controllers/discovery/list";
 import { registerFullPageSearchType } from "discourse/controllers/full-page-search";
 import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/controllers/topic";
@@ -3278,6 +3279,7 @@ class PluginApi {
    */
   addAboutPageActivity(name, func) {
     addAboutPageActivity(name, func);
+    addLegacyAboutPageStat(name);
   }
 
   #deprecatedHeaderWidgetOverride(widgetName, override) {

--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -162,10 +162,7 @@
                   <td>{{number this.model.stats.likes_30_days}}</td>
                   <td>{{number this.model.stats.likes_count}}</td>
                 </tr>
-                {{#each
-                  this.site.displayed_about_plugin_stat_groups
-                  as |statGroupName|
-                }}
+                {{#each this.statGroups as |statGroupName|}}
                   <tr class={{concat "about-" statGroupName "-count"}}>
                     <td>{{i18n (concat "about." statGroupName "_count")}}</td>
                     <td>{{number

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -29,6 +29,7 @@ import { resetQuickSearchRandomTips } from "discourse/components/search-menu/res
 import { resetOnKeyUpCallbacks } from "discourse/components/search-menu/search-term";
 import { resetTopicTitleDecorators } from "discourse/components/topic-title";
 import { resetUserMenuProfileTabItems } from "discourse/components/user-menu/profile-tab-content";
+import { clearCustomStats as clearLegacyAboutPageStats } from "discourse/controllers/about";
 import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { clearHTMLCache } from "discourse/helpers/custom-html";
 import { resetUsernameDecorators } from "discourse/helpers/decorate-username-selector";
@@ -253,6 +254,7 @@ export function testCleanup(container, app) {
   resetTransformers();
   rollbackAllPrepends();
   clearAboutPageActivities();
+  clearLegacyAboutPageStats();
 }
 
 function cleanupCssGeneratorTags() {

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1122,9 +1122,24 @@ class Plugin::Instance
   # table. Some stats may be needed purely for reporting purposes and thus
   # do not need to be shown in the UI to admins/users.
   #
-  # TODO(osama): deprecate show_in_ui when experimental_redesigned_about_page_groups
-  # is removed
-  def register_stat(name, show_in_ui: false, expose_via_api: false, &block)
+  # TODO(osama): remove show_in_ui when experimental_redesigned_about_page_groups is removed
+  def register_stat(
+    name,
+    show_in_ui: (
+      not_using_deprecated_arg = true
+      false
+    ),
+    expose_via_api: false,
+    &block
+  )
+    if !not_using_deprecated_arg
+      Discourse.deprecate(
+        "`show_in_ui` argument of the `register_stat` API is deprecated. Please use the `addAboutPageActivity` JS API instead if you want your custom stat to be shown on the about page.",
+        since: "3.4.0.beta2",
+        drop_from: "3.5.0.beta1",
+      )
+    end
+
     # We do not want to register and display the same group multiple times.
     return if DiscoursePluginRegistry.stats.any? { |stat| stat.name == name }
 

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -29,11 +29,26 @@ class ChatSetupInit {
     setOwner(this, owner);
     this.appEvents.on("discourse:focus-changed", this, "_handleFocusChanged");
 
-    if (!this.chatService.userCanChat) {
-      return;
-    }
-
     withPluginApi("0.12.1", (api) => {
+      api.addAboutPageActivity("chat_messages", (periods) => {
+        const count = periods["7_days"];
+        if (count) {
+          return {
+            icon: "comment-dots",
+            class: "chat-messages",
+            activityText: I18n.t("about.activities.chat_messages", {
+              count,
+              formatted_number: number(count),
+            }),
+            period: I18n.t("about.activities.periods.last_7_days"),
+          };
+        }
+      });
+
+      if (!this.chatService.userCanChat) {
+        return;
+      }
+
       api.onPageChange((path) => {
         const route = this.router.recognize(path);
         if (route.name.startsWith("chat.")) {
@@ -156,21 +171,6 @@ class ChatSetupInit {
         component: chatStyleguide,
         category: "organisms",
         id: "chat",
-      });
-
-      api.addAboutPageActivity("chat_messages", (periods) => {
-        const count = periods["7_days"];
-        if (count) {
-          return {
-            icon: "comment-dots",
-            class: "chat-messages",
-            activityText: I18n.t("about.activities.chat_messages", {
-              count,
-              formatted_number: number(count),
-            }),
-            period: I18n.t("about.activities.periods.last_7_days"),
-          };
-        }
       });
     });
   }

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -500,9 +500,7 @@ after_initialize do
 
   register_email_unsubscriber("chat_summary", EmailControllerHelper::ChatSummaryUnsubscriber)
 
-  register_stat("chat_messages", show_in_ui: true, expose_via_api: true) do
-    Chat::Statistics.about_messages
-  end
+  register_stat("chat_messages", expose_via_api: true) { Chat::Statistics.about_messages }
   register_stat("chat_users", expose_via_api: true) { Chat::Statistics.about_users }
   register_stat("chat_channels", expose_via_api: true) { Chat::Statistics.about_channels }
 


### PR DESCRIPTION
We need to start printing deprecation notices when the `show_in_ui` argument is used because it works only for the old about page which will be removed soon. For the new about page, we've introduced a new API `addAboutPageActivity` which is more flexible than a true/false argument on the server side.

Internal topic: t/136551.