### PR TITLE
DEV: remove CSS for consolidated DM notifications

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -30,15 +30,3 @@
 .user-main .collapsed-info .details .controls ul {
   flex-direction: row;
 }
-
-// TODO (davidb): remove once consolidated chat notifications is complete
-.user-stream .large-notifications .item {
-  &:has(.chat-message) {
-    display: none;
-  }
-}
-
-// TODO (davidb): remove once consolidated chat notifications is complete
-.user-menu .quick-access-panel .chat-message {
-  display: none;
-}


### PR DESCRIPTION
Removes unused CSS that was a temporary fix for a new notification type that was later reverted.