### PR TITLE
FIX: Don't let static pages overflow on some devices

### DIFF
--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -1,6 +1,5 @@
 .body-page {
   /* covers /about, /faq, /guidelines, /tos, /privacy, and login-required */
-  width: 100%;
   max-width: 700px;
   background: var(--d-content-background);
   .about-page & {


### PR DESCRIPTION
Static pages such as /about, /faqs, /tos etc. currently overflow horizontally on some Android devices (reproducible on Samsung Galaxy A11). It seems like the `width: 100%` property on `.body-page` is what causing the problem, and removing it doesn't seem to break anything on the various devices that I've tested (desktop, iOS, Android).

Before:

<img src="https://github.com/user-attachments/assets/3edd9ba1-51ff-4361-a756-508b1b0e593d" width=300>

After:

<img src="https://github.com/user-attachments/assets/1158d8a8-ecd1-4c88-908f-263575f28a76" width=300>