### PR TITLE
FIX: creating an automation without script should error

### DIFF
--- a/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
@@ -27,7 +27,8 @@ module DiscourseAutomation
         DiscourseAutomation::Automation.new(
           automation_params.merge(last_updated_by_id: current_user.id),
         )
-      if automation.scriptable.forced_triggerable
+
+      if automation.scriptable&.forced_triggerable
         automation.trigger = scriptable.forced_triggerable[:triggerable].to_s
       end
 

--- a/plugins/automation/spec/system/new_automation_spec.rb
+++ b/plugins/automation/spec/system/new_automation_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe "DiscourseAutomation | New automation", type: :system, js: true do
+  fab!(:admin)
+
+  before do
+    SiteSetting.discourse_automation_enabled = true
+    sign_in(admin)
+  end
+
+  let(:new_automation_page) { PageObjects::Pages::NewAutomation.new }
+
+  context "when the script is not selected" do
+    it "shows an error" do
+      new_automation_page.visit.fill_name("aaaaa").create
+
+      expect(new_automation_page).to have_error(I18n.t("errors.messages.blank"))
+    end
+  end
+end

--- a/plugins/automation/spec/system/page_objects/discourse_automation/new_automation.rb
+++ b/plugins/automation/spec/system/page_objects/discourse_automation/new_automation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class NewAutomation < PageObjects::Pages::Base
+      def visit
+        super("/admin/plugins/discourse-automation/new")
+        self
+      end
+
+      def fill_name(name)
+        find_field("automation-name").fill_in(with: name)
+        self
+      end
+
+      def create
+        find(".create-automation").click
+        self
+      end
+
+      def has_error?(message)
+        find(".form-errors").has_text?(message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit ensure we are properly showing an error to the end user and not just a vague 500.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
