### PR TITLE
FIX: ensures message field is rendering placeholders

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-message-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-message-field.gjs
@@ -24,8 +24,8 @@ export default class MessageField extends BaseField {
             {{#if this.displayPlaceholders}}
               <PlaceholdersList
                 @currentValue={{@field.metadata.value}}
-                @placeholders={{@placeholder}}
-                @onCopy={{this.test}}
+                @placeholders={{@placeholders}}
+                @onCopy={{this.mutValue}}
               />
             {{/if}}
           </div>

--- a/plugins/automation/test/javascripts/integration/components/da-message-field-test.js
+++ b/plugins/automation/test/javascripts/integration/components/da-message-field-test.js
@@ -24,4 +24,17 @@ module("Integration | Component | da-message-field", function (hooks) {
 
     assert.strictEqual(this.field.metadata.value, "Hello World");
   });
+
+  test("render placeholders", async function (assert) {
+    this.field = new AutomationFabricators(getOwner(this)).field({
+      component: "message",
+    });
+    this.automation.placeholders = ["foo", "bar"];
+
+    await render(
+      hbs`<AutomationField @automation={{this.automation}} @field={{this.field}}  />`
+    );
+
+    assert.dom(".placeholders-list").hasText("foo bar");
+  });
 });


### PR DESCRIPTION
A previous commit had broken this codepath, this commit ensures it's fixed and is adding a test. It's not testing the copy/paste behavior as fairly complex to test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
