### PR TITLE
DEV: adds topic_url/topic_title placeholders

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -230,6 +230,10 @@ module DiscourseAutomation
             "topic" => topic,
             "removed_tags" => removed_tags,
             "added_tags" => added_tags,
+            "placeholders" => {
+              "topic_url" => topic.relative_url,
+              "topic_title" => topic.title,
+            },
           )
         end
     end

--- a/plugins/automation/lib/discourse_automation/triggers/topic_tags_changed.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/topic_tags_changed.rb
@@ -3,4 +3,7 @@
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED) do
   field :watching_categories, component: :categories
   field :watching_tags, component: :tags
+
+  placeholder :topic_url
+  placeholder :topic_title
 end

--- a/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
+++ b/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
@@ -32,6 +32,19 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
       automation.reload
     end
 
+    it "fills placeholders correctly" do
+      topic_0 = Fabricate(:topic, user: user, tags: [], category: category)
+
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(topic_0, Guardian.new(user), [cool_tag.name])
+        end
+
+      expect(list[0]["placeholders"]).to eq(
+        { "topic_title" => topic_0.title, "topic_url" => topic_0.relative_url },
+      )
+    end
+
     it "should fire the trigger if the tag is added" do
       topic_0 = Fabricate(:topic, user: user, tags: [], category: category)
 


### PR DESCRIPTION
`topic_tags_changed` trigger now fills the {{topic_url}} and {{topic_title}} placeholders. `topic_url` is the relative URL.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
