### PR TITLE
UX: fix spacing of emoji in chat channel title

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -10,6 +10,7 @@
     display: flex;
     align-items: center;
     white-space: nowrap;
+    gap: 0.5rem;
   }
 
   .emoji {
@@ -25,7 +26,6 @@
     justify-content: center;
     width: 8px;
     height: 8px;
-    margin-left: 0.75em;
 
     &.-urgent {
       width: auto;


### PR DESCRIPTION
Fixes a small spacing bug with emoji in channel titles, this is a recent regression from #28731

### Before

<img width="390" alt="Screenshot 2024-09-05 at 4 31 50 PM" src="https://github.com/user-attachments/assets/b1f19966-febb-4271-9589-1504d2d9e761">


### After

<img width="389" alt="Screenshot 2024-09-05 at 4 32 10 PM" src="https://github.com/user-attachments/assets/6c56e33b-9251-468f-b023-78caed8e9ccc">

With unread indicator:

<img width="386" alt="Screenshot 2024-09-05 at 4 34 27 PM" src="https://github.com/user-attachments/assets/2b31de48-da4b-4e7f-8747-9531368537c2">
