### PR TITLE
DEV: adds post_created_edited suport to chat

### DIFF
--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -138,12 +138,18 @@ en:
               label: Topic ID
         post_created_edited:
           fields:
+            original_post_only:
+              label: Original post only
+              description: Will trigger only if the post is the original post in the topic
             action_type:
               label: Action type
               description: "Optional, limit triggering to only created or edited events"
             valid_trust_levels:
               label: Valid trust levels
               description: Will trigger only if post is created by user in these trust levels, defaults to any trust level
+            restricted_tags:
+              label: Tags
+              description: Optional, will trigger only if the post has any of these tags
             restricted_category:
               label: Category
               description: Optional, will trigger only if the post's topic is in this category

--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -12,6 +12,11 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
+          original_post_only = automation.trigger_field("original_post_only")
+          if original_post_only["value"]
+            next if topic.posts_count > 1
+          end
+
           first_post_only = automation.trigger_field("first_post_only")
           if first_post_only["value"]
             next if post.user.user_stat.post_count != 1
@@ -44,6 +49,11 @@ module DiscourseAutomation
             next if !category_ids.include?(restricted_category["value"])
           end
 
+          restricted_tags = automation.trigger_field("restricted_tags")
+          if restricted_tags["value"]
+            next if (restricted_tags["value"] & topic.tags.map(&:name)).empty?
+          end
+
           restricted_group_id = automation.trigger_field("restricted_group")["value"]
           if restricted_group_id.present?
             next if !topic.private_message?
@@ -66,7 +76,15 @@ module DiscourseAutomation
             next if selected_action == :edited && action != :edit
           end
 
-          automation.trigger!("kind" => name, "action" => action, "post" => post)
+          automation.trigger!(
+            "kind" => name,
+            "action" => action,
+            "post" => post,
+            "placeholders" => {
+              "topic_url" => topic.relative_url,
+              "topic_title" => topic.title,
+            },
+          )
         end
     end
 

--- a/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
@@ -13,11 +13,16 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::POST_CREATED
           ],
         }
   field :restricted_category, component: :category
+  field :restricted_tags, component: :tags
   field :restricted_group, component: :group
   field :ignore_automated, component: :boolean
   field :ignore_group_members, component: :boolean
   field :valid_trust_levels, component: :"trust-levels"
+  field :original_post_only, component: :boolean
   field :first_post_only, component: :boolean
   field :first_topic_only, component: :boolean
   field :skip_via_email, component: :boolean
+
+  placeholder :topic_url
+  placeholder :topic_title
 end

--- a/plugins/automation/spec/triggers/post_created_edited_spec.rb
+++ b/plugins/automation/spec/triggers/post_created_edited_spec.rb
@@ -302,6 +302,66 @@ describe "PostCreatedEdited" do
       end
     end
 
+    context "with original_post_only" do
+      before do
+        automation.upsert_field!(
+          "original_post_only",
+          "boolean",
+          { value: true },
+          target: "trigger",
+        )
+      end
+
+      it "fires the trigger only for OP" do
+        list = capture_contexts { PostCreator.create(user, basic_topic_params) }
+
+        expect(list.length).to eq(1)
+
+        list =
+          capture_contexts do
+            PostCreator.create(
+              user,
+              basic_topic_params.merge({ topic_id: list[0]["post"].topic_id }),
+            )
+          end
+
+        expect(list.length).to eq(0)
+      end
+    end
+
+    context "when tags is restricted" do
+      fab!(:tag_1) { Fabricate(:tag) }
+
+      before do
+        automation.upsert_field!(
+          "restricted_tags",
+          "tags",
+          { value: [tag_1.name] },
+          target: "trigger",
+        )
+      end
+
+      context "when tag is allowed" do
+        it "fires the trigger" do
+          list =
+            capture_contexts do
+              PostCreator.create(user, basic_topic_params.merge({ tags: [tag_1.name] }))
+            end
+
+          expect(list.length).to eq(1)
+          expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+      end
+
+      context "when tag is not allowed" do
+        it "fires the trigger" do
+          list = capture_contexts { PostCreator.create(user, basic_topic_params.merge()) }
+
+          expect(list.length).to eq(0)
+        end
+      end
+    end
+
     context "when category is restricted" do
       before do
         automation.upsert_field!(

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -459,7 +459,7 @@ after_initialize do
 
     placeholder :channel_name
 
-    triggerables %i[recurring topic_tags_changed]
+    triggerables %i[recurring topic_tags_changed post_created_edited]
 
     script do |context, fields, automation|
       sender = User.find_by(username: fields.dig("sender", "value")) || Discourse.system_user


### PR DESCRIPTION
On top of this the following changes have also been made:
- adds a new `original_post_only` option, to trigger only on OP
- adds a new `restricted_tags` option, to trigger only when these tags are present
- adds `topic_url` and `topic_title` placeholders to the trigger

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
