### PR TITLE
DEV: Include a basic oauth faraday formatter in core for usage in managed authenticators

### DIFF
--- a/lib/auth/oauth_faraday_formatter.rb
+++ b/lib/auth/oauth_faraday_formatter.rb
@@ -20,7 +20,7 @@ class Auth::OauthFaradayFormatter < Faraday::Logging::Formatter
       From #{env.method.upcase} #{env.url}
 
       Headers:
-      #{env.request_headers}
+      #{env.response_headers}
 
       Body:
       #{env[:body]}


### PR DESCRIPTION
We currently have [some](https://github.com/search?type=code&q=org%3Adiscourse+Faraday%3A%3ALogging%3A%3AFormatter) occurrences of ____FaradayFormatter for OAuth logs. This PR creates a generic formatter so that any new authenticators can use it.