### PR TITLE
UX: Add links to getting started check list

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -6,12 +6,12 @@ Discourse is a powerful and flexible platform with many options for customizatio
 
 To get started, we recommend you follow the sections below for each of the following:
 
-- [ ] Test your email configuration
-- [ ] Complete the setup wizard
-- [ ] Invite a few people to join you
-- [ ] Discuss ideas with your community
+- [ ] [Test your email configuration](/admin/email)
+- [ ] [Complete the setup wizard](/wizard)
+- [ ] [Invite a few people to join you](/my/invited)
+- [ ] [Discuss ideas with your community](/new-topic)
+- [ ] [Adjust other customizations](/admin/site_settings/category/all_results?filter=font)
 - [ ] Update your welcome topic and guidelines
-- [ ] Adjust other customizations
 - [ ] Repeat!
 - [ ] Launch your community
 

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -7,10 +7,10 @@ Discourse is a powerful and flexible platform with many options for customizatio
 To get started, we recommend you follow the sections below for each of the following:
 
 - [ ] [Test your email configuration](/admin/email)
-- [ ] [Complete the setup wizard](/wizard)
+- [ ] [Complete the setup wizard](wizard/steps/branding)
 - [ ] [Invite a few people to join you](/my/invited)
 - [ ] [Discuss ideas with your community](/new-topic)
-- [ ] [Adjust other customizations](/admin/site_settings/category/all_results?filter=font)
+- [ ] [Adjust other customizations](/admin/site_settings/category/required)
 - [ ] Update your welcome topic and guidelines
 - [ ] Repeat!
 - [ ] Launch your community


### PR DESCRIPTION
This PR adds links to the checklist in the new quick start guide an admin will see when launching Discourse for the first time.