### PR TITLE
UX: Change organization alert type from error to info

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/your-organization.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/your-organization.gjs
@@ -68,7 +68,7 @@ export default class AdminConfigAreasAboutYourOrganization extends Component {
           }}
         />
       </form.Field>
-      <form.Alert @type="error">
+      <form.Alert @type="info">
         {{i18n "admin.config_areas.about.company_name_warning"}}
       </form.Alert>
 


### PR DESCRIPTION
Updated to an info alert for clarity, as the message is informational, not critical.

### Before
<img width="478" alt="image" src="https://github.com/user-attachments/assets/5ca361db-af8c-4097-a94e-f949050250e4">


### After
<img width="485" alt="image" src="https://github.com/user-attachments/assets/29d9671d-3ef5-42ff-a0b2-2255a7fcbef9">
