### PR TITLE
FEATURE: Add 'Edit this page' link at the top of the new /about page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import AboutPageUsers from "discourse/components/about-page-users";
@@ -22,6 +23,7 @@ export function clearAboutPageActivities() {
 
 export default class AboutPage extends Component {
   @service siteSettings;
+  @service currentUser;
 
   get moderatorsCount() {
     return this.args.model.moderators.length;
@@ -196,6 +198,14 @@ export default class AboutPage extends Component {
   }
 
   <template>
+    {{#if this.currentUser.admin}}
+      <p>
+        <LinkTo class="edit-about-page" @route="adminConfig.about">
+          {{dIcon "pencil-alt"}}
+          <span>{{i18n "about.edit"}}</span>
+        </LinkTo>
+      </p>
+    {{/if}}
     <section class="about__header">
       {{#if @model.banner_image}}
         <img class="about__banner" src={{@model.banner_image}} />

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -328,6 +328,7 @@ en:
       pm_title: "Suggested Messages"
 
     about:
+      edit: "Edit this page"
       simple_title: "About"
       title: "About %{title}"
       stats: "Site Statistics"

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -2,10 +2,10 @@
 
 describe "About page", type: :system do
   fab!(:current_user) { Fabricate(:user) }
-  fab!(:group) { Fabricate(:group, users: [current_user]) }
   fab!(:image_upload)
   fab!(:admin) { Fabricate(:admin, last_seen_at: 1.hour.ago) }
   fab!(:moderator) { Fabricate(:moderator, last_seen_at: 1.hour.ago) }
+  fab!(:group) { Fabricate(:group, users: [current_user, admin, moderator]) }
 
   before do
     SiteSetting.title = "title for my forum"
@@ -383,6 +383,31 @@ describe "About page", type: :system do
 
         about_page.moderators_list.users.last[:node].click
         expect(about_page).to have_css("#user-card")
+      end
+    end
+
+    describe "the edit link" do
+      it "appears for admins" do
+        sign_in(admin)
+
+        about_page.visit
+        expect(about_page).to have_edit_link
+
+        about_page.edit_link.click
+
+        try_until_success { expect(current_url).to end_with("/admin/config/about") }
+      end
+
+      it "doesn't appear for moderators" do
+        sign_in(moderator)
+
+        about_page.visit
+        expect(about_page).to have_no_edit_link
+      end
+
+      it "doesn't appear for normal users" do
+        about_page.visit
+        expect(about_page).to have_no_edit_link
       end
     end
   end

--- a/spec/system/page_objects/pages/about.rb
+++ b/spec/system/page_objects/pages/about.rb
@@ -50,6 +50,18 @@ module PageObjects
         site_age_stat_element.has_text?(I18n.t("js.about.site_age.year", count: years))
       end
 
+      def edit_link
+        find(".edit-about-page")
+      end
+
+      def has_edit_link?
+        has_css?(".edit-about-page")
+      end
+
+      def has_no_edit_link?
+        has_no_css?(".edit-about-page")
+      end
+
       def site_activities
         PageObjects::Components::AboutPageSiteActivity.new(find(".about__activities"))
       end


### PR DESCRIPTION
This PR adds a link to the top of the new /about page, shown to admins only, to allow them to easily navigate to `/admin/config/about` where they can edit the /about page.

Screenshot:

<img src="https://github.com/user-attachments/assets/7c89ddb0-f212-4e5a-9883-015f961c5add" width=500>

Internal topic: t/137546.