### PR TITLE
UX: Apply the admin page header component

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import i18n from "discourse-common/helpers/i18n";
 import AdminConfigAreaCard from "admin/components/admin-config-area-card";
 import AdminConfigAreasAboutContactInformation from "admin/components/admin-config-area-cards/about/contact-information";
 import AdminConfigAreasAboutGeneralSettings from "admin/components/admin-config-area-cards/about/general-settings";

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
@@ -50,7 +50,6 @@ export default class AdminConfigAreasAbout extends Component {
 
   <template>
     <div class="admin-config-area">
-      <h2>{{i18n "admin.config_areas.about.header"}}</h2>
       <div class="admin-config-area__primary-content">
         <AdminConfigAreaCard
           @heading="admin.config_areas.about.general_settings"

--- a/app/assets/javascripts/admin/addon/templates/config-about.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-about.hbs
@@ -1,1 +1,15 @@
-<AdminConfigAreas::About @data={{this.model.site_settings}} />
+<AdminPageHeader
+  @titleLabel="admin.config_areas.about.header"
+  @hideTabs={{true}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem
+      @path="/admin/config/about"
+      @label={{i18n "admin.config_areas.about.header"}}
+    />
+  </:breadcrumbs>
+</AdminPageHeader>
+
+<div class="admin-container admin-config-page__main-area">
+  <AdminConfigAreas::About @data={{this.model.site_settings}} />
+</div>


### PR DESCRIPTION
This commit updates the about config page to use the `AdminPageHeader` component, and includes the breadcrumbs.

### Before
<img src="https://github.com/user-attachments/assets/2504c3c0-2d5f-40b8-97cd-d59bbbed04e7" alt="drawing" width="300"/>

### After
<img src="https://github.com/user-attachments/assets/93243c3c-3bd9-40fe-a205-8dfa7434132a" alt="drawing" width="300"/>
