### PR TITLE
DEV: Remove old problem check system - Part 1

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -179,7 +179,6 @@ class GroupsController < ApplicationController
       if params[:update_existing_users] == "true"
         update_existing_users(group.group_users, notification_level, categories, tags)
       end
-      AdminDashboardData.clear_found_problem("group_#{group.id}_email_credentials")
 
       # Redirect user to groups index page if they can no longer see the group
       return redirect_with_client_support groups_path if !guardian.can_see?(group)

--- a/app/jobs/scheduled/run_problem_checks.rb
+++ b/app/jobs/scheduled/run_problem_checks.rb
@@ -10,10 +10,6 @@ module Jobs
     every 10.minutes
 
     def execute(_args)
-      # This way if the problems have been solved in the meantime, then they will
-      # not be re-added by the relevant checker, and will be cleared.
-      AdminDashboardData.clear_found_scheduled_check_problems
-
       scheduled_checks =
         ProblemCheckTracker.all.filter_map do |tracker|
           tracker.check if tracker.check.scheduled? && tracker.ready_to_run?

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -31,7 +31,6 @@ class AdminDashboardData
     end
     problems.concat(ProblemCheck.realtime.flat_map { |c| c.call(@opts).map(&:to_h) })
 
-    problems += self.class.load_found_scheduled_check_problems
     problems.compact!
 
     if problems.empty?
@@ -48,46 +47,6 @@ class AdminDashboardData
       "`AdminDashboardData#add_problem_check` is deprecated. Implement a class that inherits `ProblemCheck` instead.",
       drop_from: "3.3",
     )
-  end
-
-  def self.add_found_scheduled_check_problem(problem)
-    problems = load_found_scheduled_check_problems
-    if problem.identifier.present?
-      return if problems.find { |p| p.identifier == problem.identifier }
-    end
-    set_found_scheduled_check_problem(problem)
-  end
-
-  def self.set_found_scheduled_check_problem(problem)
-    Discourse.redis.rpush(SCHEDULED_PROBLEM_STORAGE_KEY, JSON.dump(problem.to_h))
-  end
-
-  def self.clear_found_scheduled_check_problems
-    Discourse.redis.del(SCHEDULED_PROBLEM_STORAGE_KEY)
-  end
-
-  def self.clear_found_problem(identifier)
-    problems = load_found_scheduled_check_problems
-    problem = problems.find { |p| p.identifier == identifier }
-    Discourse.redis.lrem(SCHEDULED_PROBLEM_STORAGE_KEY, 1, JSON.dump(problem.to_h))
-  end
-
-  def self.load_found_scheduled_check_problems
-    found_problems = Discourse.redis.lrange(SCHEDULED_PROBLEM_STORAGE_KEY, 0, -1)
-
-    return [] if found_problems.blank?
-
-    found_problems.filter_map do |problem|
-      begin
-        ProblemCheck::Problem.from_h(JSON.parse(problem))
-      rescue JSON::ParserError => err
-        Discourse.warn_exception(
-          err,
-          message: "Error parsing found problem JSON in admin dashboard: #{problem}",
-        )
-        nil
-      end
-    end
   end
 
   ##

--- a/spec/jobs/run_problem_check_spec.rb
+++ b/spec/jobs/run_problem_check_spec.rb
@@ -97,27 +97,4 @@ RSpec.describe Jobs::RunProblemCheck do
       end
     end
   end
-
-  context "when the check unexpectedly errors out" do
-    around do |example|
-      ProblemCheck::TestCheck =
-        Class.new(ProblemCheck) do
-          self.max_retries = 1
-
-          def call
-            raise StandardError.new("Something went wrong")
-          end
-        end
-
-      stub_const(ProblemCheck, "CORE_PROBLEM_CHECKS", [ProblemCheck::TestCheck], &example)
-
-      ProblemCheck.send(:remove_const, "TestCheck")
-    end
-
-    it "does not add a problem to the Redis array" do
-      described_class.new.execute(check_identifier: :test_check)
-
-      expect(AdminDashboardData.load_found_scheduled_check_problems).to be_empty
-    end
-  end
 end

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -6,37 +6,6 @@ RSpec.describe AdminDashboardData do
     Discourse.redis.flushdb
   end
 
-  describe "adding scheduled checks" do
-    it "does not add duplicate problems with the same identifier" do
-      prob1 = ProblemCheck::Problem.new("test problem", identifier: "test")
-      prob2 = ProblemCheck::Problem.new("test problem 2", identifier: "test")
-      AdminDashboardData.add_found_scheduled_check_problem(prob1)
-      AdminDashboardData.add_found_scheduled_check_problem(prob2)
-      expect(AdminDashboardData.load_found_scheduled_check_problems.map(&:to_s)).to eq(
-        ["test problem"],
-      )
-    end
-
-    it "does not error when loading malformed problems saved in redis" do
-      Discourse.redis.rpush(AdminDashboardData::SCHEDULED_PROBLEM_STORAGE_KEY, "{ 'badjson")
-      expect(AdminDashboardData.load_found_scheduled_check_problems).to eq([])
-    end
-
-    it "clears a specific problem by identifier" do
-      prob1 = ProblemCheck::Problem.new("test problem 1", identifier: "test")
-      AdminDashboardData.add_found_scheduled_check_problem(prob1)
-      AdminDashboardData.clear_found_problem("test")
-      expect(AdminDashboardData.load_found_scheduled_check_problems).to eq([])
-    end
-
-    it "defaults to low priority, and uses low priority if an invalid priority is passed" do
-      prob1 = ProblemCheck::Problem.new("test problem 1")
-      prob2 = ProblemCheck::Problem.new("test problem 2", priority: "superbad")
-      expect(prob1.priority).to eq("low")
-      expect(prob2.priority).to eq("low")
-    end
-  end
-
   describe "stats cache" do
     include_examples "stats cacheable"
   end


### PR DESCRIPTION
### What is this change?

We're now using the new, database-backed problem check system. This PR removes parts of the old, Redis-backed system that is now defunct.

### Verification

- [x] A search through both our public and private repos show no more usages of these methods.