### PR TITLE
DEV: Remove unneeded dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -271,10 +271,6 @@ gem "cgi", ">= 0.3.6", require: false
 gem "tzinfo-data"
 gem "csv", require: false
 
-# TODO: Can be removed once we upgrade to Rails 7.1
-gem "mutex_m"
-gem "drb"
-
 # dependencies for the automation plugin
 gem "iso8601"
 gem "rrule"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -621,7 +621,6 @@ DEPENDENCIES
   discourse-fonts
   discourse-seed-fu
   discourse_dev_assets
-  drb
   email_reply_trimmer
   excon
   execjs
@@ -660,7 +659,6 @@ DEPENDENCIES
   mocha
   multi_json
   mustache
-  mutex_m
   net-http
   net-imap
   net-pop


### PR DESCRIPTION
Now that we’re using Rails 7.1, we don’t need to have the `mutex_m` and `drb` gems explicitly listed in our Gemfile.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
