### PR TITLE
DEV: Remove `register_color_scheme` api

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -49,7 +49,6 @@ class Plugin::Instance
   # Memoized array readers
   %i[
     assets
-    color_schemes
     initializers
     javascripts
     locales
@@ -593,12 +592,6 @@ class Plugin::Instance
   end
 
   def notify_after_initialize
-    color_schemes.each do |c|
-      unless ColorScheme.where(name: c[:name]).exists?
-        ColorScheme.create_from_base(name: c[:name], colors: c[:colors])
-      end
-    end
-
     initializers.each do |callback|
       begin
         callback.call(self)
@@ -730,10 +723,6 @@ class Plugin::Instance
 
   def register_service_worker(file, opts = nil)
     service_workers << [File.join(File.dirname(path), "assets", file), opts]
-  end
-
-  def register_color_scheme(name, colors)
-    color_schemes << { name: name, colors: colors }
   end
 
   def register_seed_data(key, value)

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -444,26 +444,6 @@ TEXT
     end
   end
 
-  describe "#register_color_scheme" do
-    it "can add a color scheme for the first time" do
-      plugin = Plugin::Instance.new nil, "/tmp/test.rb"
-      expect {
-        plugin.register_color_scheme("Purple", primary: "EEE0E5")
-        plugin.notify_after_initialize
-      }.to change { ColorScheme.count }.by(1)
-      expect(ColorScheme.where(name: "Purple")).to be_present
-    end
-
-    it "doesn't add the same color scheme twice" do
-      Fabricate(:color_scheme, name: "Halloween")
-      plugin = Plugin::Instance.new nil, "/tmp/test.rb"
-      expect {
-        plugin.register_color_scheme("Halloween", primary: "EEE0E5")
-        plugin.notify_after_initialize
-      }.to_not change { ColorScheme.count }
-    end
-  end
-
   describe ".register_seedfu_fixtures" do
     it "should add the new path to SeedFu's fixtures path" do
       plugin = Plugin::Instance.new nil, "/tmp/test.rb"


### PR DESCRIPTION
This was added 10 years ago, but currently there's not a single use in our public and private plugins and no reference in third-party plugins on github

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
