### PR TITLE
FIX: Add traffic info footer to the new /about page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -170,6 +170,13 @@ export default class AboutPage extends Component {
     }
   }
 
+  get trafficInfoFooter() {
+    return I18n.messageFormat("about.traffic_info_footer_MF", {
+      total_visitors: this.args.model.stats.visitors_30_days,
+      eu_visitors: this.args.model.stats.eu_visitors_30_days,
+    });
+  }
+
   siteActivitiesFromPlugins() {
     const stats = this.args.model.stats;
     const statKeys = Object.keys(stats);
@@ -283,6 +290,10 @@ export default class AboutPage extends Component {
             </div>
           {{/each}}
         </div>
+        {{#if this.siteSettings.display_eu_visitor_stats}}
+          <p class="about traffic-info-footer"><small
+            >{{this.trafficInfoFooter}}</small></p>
+        {{/if}}
       </div>
     </div>
   </template>

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -202,6 +202,24 @@ describe "About page", type: :system do
           expect(about_page.site_activities.likes).to have_all_time_period
         end
       end
+
+      describe "traffic info footer" do
+        it "is displayed when the display_eu_visitor_stats setting is true" do
+          SiteSetting.display_eu_visitor_stats = true
+
+          about_page.visit
+
+          expect(about_page).to have_traffic_info_footer
+        end
+
+        it "is not displayed when the display_eu_visitor_stats setting is false" do
+          SiteSetting.display_eu_visitor_stats = false
+
+          about_page.visit
+
+          expect(about_page).to have_no_traffic_info_footer
+        end
+      end
     end
 
     describe "our admins section" do

--- a/spec/system/page_objects/pages/about.rb
+++ b/spec/system/page_objects/pages/about.rb
@@ -62,6 +62,14 @@ module PageObjects
         has_no_css?(".edit-about-page")
       end
 
+      def has_traffic_info_footer?
+        has_css?(".traffic-info-footer")
+      end
+
+      def has_no_traffic_info_footer?
+        has_no_css?(".traffic-info-footer")
+      end
+
       def site_activities
         PageObjects::Components::AboutPageSiteActivity.new(find(".about__activities"))
       end


### PR DESCRIPTION
This PR adds the footer that currently exists on the old /about page to the new one.

<img src="https://github.com/user-attachments/assets/fa033556-c6b7-4235-9d7e-b071d98a9da8" width=300>