### PR TITLE
DEV: add below-sidebar-sections to sidebar dropdown mode

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -73,6 +73,7 @@ export default class SidebarHamburgerDropdown extends Component {
                     @collapsableSections={{this.collapsableSections}}
                   />
                 {{/if}}
+                <PluginOutlet @name="after-sidebar-sections" />
                 <Footer />
               </div>
             </DeferredRender>


### PR DESCRIPTION
This adds a below-sidebar-sections plugin outlet to the dropdown version of the sidebar, to match the outlet in the default sidebar (in sidebar.hbs)