### PR TITLE
DEV: Forces custom search filter matchers to be case insensitive

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -903,8 +903,11 @@ class Search
         found = false
 
         Search.advanced_filters.each do |matcher, block|
+          case_insensitive_matcher =
+            Regexp.new(matcher.source, matcher.options | Regexp::IGNORECASE)
+
           cleaned = word.gsub(/["']/, "")
-          if cleaned =~ matcher
+          if cleaned =~ case_insensitive_matcher
             (@filters ||= []) << [block, $1]
             found = true
           end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2832,6 +2832,18 @@ RSpec.describe Search do
       Search.advanced_filters.delete(/^min_chars:(\d+)$/)
     end
 
+    it "forces custom filters matchers to be case insensitive" do
+      expect(Search.new("advanced").execute.posts).to eq([post1, post0])
+
+      Search.advanced_filter(/^MIN_CHARS:(\d+)$/) do |posts, match|
+        posts.where("(SELECT LENGTH(p2.raw) FROM posts p2 WHERE p2.id = posts.id) >= ?", match.to_i)
+      end
+
+      expect(Search.new("advanced Min_Chars:50").execute.posts).to eq([post0])
+    ensure
+      Search.advanced_filters.delete(/^MIN_CHARS:(\d+)$/)
+    end
+
     it "allows to define custom order" do
       expect(Search.new("advanced").execute.posts).to eq([post1, post0])
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
