### PR TITLE
UX: remove btn-default class from chat thread tracking dropdown

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread-tracking-dropdown.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread-tracking-dropdown.js
@@ -11,6 +11,7 @@ import { threadNotificationButtonLevels } from "discourse/plugins/chat/discourse
   i18nPrefix: "chat.thread.notifications",
   showFullTitle: false,
   btnCustomClasses: "btn-flat",
+  customStyle: true,
 })
 @pluginApiIdentifiers("thread-notifications-button")
 export default class ChatThreadTrackingDropdown extends NotificationsButtonComponent {


### PR DESCRIPTION
The bell dropdown here:

![image](https://github.com/user-attachments/assets/b0417c1d-3d2e-4474-aa6a-9ecd4301f51c)

gets the `.btn-default` class from select-kit, but it's not styled like a default button like this:

![image](https://github.com/user-attachments/assets/496e2c42-81d2-4507-9f64-90e425982b52)


so that class only serves to get in the way of theming and should be removed — fortunately that's what `customStyle` does 