### PR TITLE
FIX: Form template limit validation

### DIFF
--- a/app/controllers/admin/form_templates_controller.rb
+++ b/app/controllers/admin/form_templates_controller.rb
@@ -2,7 +2,6 @@
 
 class Admin::FormTemplatesController < Admin::StaffController
   before_action :ensure_form_templates_enabled
-  before_action :extra_validations, only: %i[create update]
 
   def index
     form_templates = FormTemplate.all.order(:id)
@@ -74,30 +73,5 @@ class Admin::FormTemplatesController < Admin::StaffController
 
   def ensure_form_templates_enabled
     raise Discourse::InvalidAccess.new unless SiteSetting.experimental_form_templates
-  end
-
-  # Since these validations are based on site settings that may change, we do these
-  # validations in the controller instead of the model so a reload is not required.
-  def extra_validations
-    max_title_length = SiteSetting.max_form_template_title_length
-    max_template_length = SiteSetting.max_form_template_content_length
-
-    errors = []
-    if params[:name].length > max_title_length
-      errors << I18n.t(
-        "form_templates.errors.too_long",
-        type: "title",
-        max_length: max_title_length,
-      )
-    end
-    if params[:template].length > max_template_length
-      errors << I18n.t(
-        "form_templates.errors.too_long",
-        type: "template",
-        max_length: max_template_length,
-      )
-    end
-
-    render_json_error(errors.join(", "), status: :unprocessable_entity) && return if errors.any?
   end
 end

--- a/app/models/form_template.rb
+++ b/app/models/form_template.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 class FormTemplate < ActiveRecord::Base
-  validates :name, presence: true, uniqueness: true
-  validates :template, presence: true
-  validates_with FormTemplateYamlValidator
+  validates :name,
+            presence: true,
+            uniqueness: true,
+            length: {
+              maximum: -> { SiteSetting.max_form_template_title_length },
+            }
+  validates :template,
+            presence: true,
+            length: {
+              maximum: -> { SiteSetting.max_form_template_content_length },
+            }
+  validates_with FormTemplateYamlValidator, if: ->(ft) { ft.template }
 
   has_many :category_form_templates, dependent: :destroy
   has_many :categories, through: :category_form_templates

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5708,4 +5708,3 @@ en:
       duplicate_ids: "has duplicate ids"
       reserved_id: "has a reserved keyword as id: %{id}"
       unsafe_description: "has an unsafe HTML description"
-      too_long: "%{type} exceeds the maxium allowed length of %{max_length} characters"

--- a/spec/models/form_template_spec.rb
+++ b/spec/models/form_template_spec.rb
@@ -11,6 +11,48 @@ RSpec.describe FormTemplate, type: :model do
     expect(described_class.count).to eq(1)
   end
 
+  context "when length validations set in SiteSetting" do
+    before do
+      SiteSetting.max_form_template_content_length = 50
+      SiteSetting.max_form_template_title_length = 5
+    end
+
+    it "can't exceed max title length" do
+      t = Fabricate.build(:form_template, name: "Bug Report", template: "- type: input\n  id: name")
+      expect(t.save).to eq(false)
+      expect(t.errors.full_messages.first).to include(
+        "Name #{I18n.t("errors.messages.too_long", count: SiteSetting.max_form_template_title_length)}",
+      )
+    end
+
+    it "can't exceed max content length" do
+      t =
+        Fabricate.build(
+          :form_template,
+          name: "Bug",
+          template: "- type: input\n  id: name-that-is-really-long-to-make-the-template-longer",
+        )
+      expect(t.save).to eq(false)
+      expect(t.errors.full_messages.first).to include(
+        "Template #{I18n.t("errors.messages.too_long", count: SiteSetting.max_form_template_content_length)}",
+      )
+    end
+
+    it "should update validation limits when the site setting has been changed" do
+      SiteSetting.max_form_template_content_length = 100
+      SiteSetting.max_form_template_title_length = 100
+
+      t =
+        Fabricate.build(
+          :form_template,
+          name: "Bug Report",
+          template: "- type: input\n  id: name-that-is-really-long-to-make-the-template-longer",
+        )
+
+      expect(t.save).to eq(true)
+    end
+  end
+
   it "can't have an invalid yaml template" do
     template = "- type: checkbox\nattributes; bad"
     t = Fabricate.build(:form_template, name: "Feature Request", template: template)

--- a/spec/requests/admin/form_templates_controller_spec.rb
+++ b/spec/requests/admin/form_templates_controller_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe Admin::FormTemplatesController do
   fab!(:user)
   fab!(:form_template)
 
-  before do
-    SiteSetting.experimental_form_templates = true
-    SiteSetting.max_form_template_title_length = 100
-    SiteSetting.max_form_template_content_length = 3000
-  end
+  before { SiteSetting.experimental_form_templates = true }
 
   describe "#index" do
     context "when logged in as an admin" do
@@ -80,47 +76,6 @@ RSpec.describe Admin::FormTemplatesController do
 
           expect(response.status).to eq(200)
         }.to change(FormTemplate, :count).by(1)
-      end
-
-      it "returns an error if the title is too long" do
-        SiteSetting.max_form_template_title_length = 12
-        SiteSetting.max_form_template_content_length = 3000
-
-        post "/admin/customize/form-templates.json",
-             params: {
-               name: "This is a very very long title that is too long for the database",
-               template: "- type: input\n  id: name",
-             }
-
-        expect(response.status).to eq(422)
-        expect(response.parsed_body["errors"]).to include(
-          I18n.t(
-            "form_templates.errors.too_long",
-            type: "title",
-            max_length: SiteSetting.max_form_template_title_length,
-          ),
-        )
-      end
-
-      it "returns an error if the template content is too long" do
-        SiteSetting.max_form_template_title_length = 100
-        SiteSetting.max_form_template_content_length = 50
-
-        post "/admin/customize/form-templates.json",
-             params: {
-               name: "Bug",
-               template:
-                 "- type: input\n  id: website\n  attributes:\n    label: Website or apps\n    description: |\n      Which website or app were you using when the bug happened, please tell me because I need to know this information?\n    placeholder: |\n      e.g. website URL, name of the app\n    validations:\n      required: true",
-             }
-
-        expect(response.status).to eq(422)
-        expect(response.parsed_body["errors"]).to include(
-          I18n.t(
-            "form_templates.errors.too_long",
-            type: "template",
-            max_length: SiteSetting.max_form_template_content_length,
-          ),
-        )
       end
     end
 


### PR DESCRIPTION
This PR fixes a bug where form template content length validation does not work properly. Previously we were setting the limit validations on the Active Record model. However, because it was dependant on a `SiteSetting`, the validation would not reflect the correct number if that setting had been changed without a rebuild. This PR updates the validation in the model to be a dynamic one so that it would be called on every request.

Previously we had also set a `limit` on the database column for the content length. However, this was being ignored since it was a type `text` which does not support the `limit` property. As a result this PR also removes those limits in a new migration.