### PR TITLE
DEV: update mini_racer to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer"
+gem "mini_racer", "0.17.0.pre2"
 
 gem "highline", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,10 +205,10 @@ GEM
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.3)
-    libv8-node (18.19.0.0-aarch64-linux)
-    libv8-node (18.19.0.0-arm64-darwin)
-    libv8-node (18.19.0.0-x86_64-darwin)
-    libv8-node (18.19.0.0-x86_64-linux)
+    libv8-node (22.7.0.3)
+    libv8-node (22.7.0.3-aarch64-linux)
+    libv8-node (22.7.0.3-arm64-darwin)
+    libv8-node (22.7.0.3-x86_64-linux)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -240,8 +240,8 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.14.1)
-      libv8-node (~> 18.19.0.0)
+    mini_racer (0.17.0.pre2)
+      libv8-node (~> 22.7.0.3)
     mini_scheduler (0.17.0)
       sidekiq (>= 4.2.3, < 7.0)
     mini_sql (1.6.0)
@@ -651,7 +651,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer
+  mini_racer (= 0.17.0.pre2)
   mini_scheduler
   mini_sql
   mini_suffix


### PR DESCRIPTION
The latest node 22.7.0 based release of mini_racer disabled
Maglev (https://v8.dev/blog/maglev) based optimisations

From previous segfaults it appears the failures happened in the maglev code
paths.

Node release of v8 lags latest release of v8 so, whatever is happening, may
be resolved in latest.
