### PR TITLE
FIX: reset cache after flags are seed

### DIFF
--- a/db/fixtures/003_flags.rb
+++ b/db/fixtures/003_flags.rb
@@ -74,3 +74,5 @@ Flag.unscoped.seed do |s|
   s.applies_to = %w[Post]
   s.skip_reset_flag_callback = true
 end
+
+Flag.reset_flag_settings!


### PR DESCRIPTION
There was a bug report on meta that after deployment, some topics were not loaded properly for 24 hours - https://meta.discourse.org/t/endless-spinner-on-some-posts/323031/17

In this PR we moved the `like` post action type to the database - https://github.com/discourse/discourse/pull/28362

However, flags are cached for performance reasons https://github.com/discourse/discourse/blob/main/app/serializers/site_serializer.rb#L113

After seed, we should ensure that the cache is reset so the site has access to all post-action types.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
