### PR TITLE
FIX: replace shield-blank with shield-halved for Font Awesome

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -207,7 +207,7 @@ module SvgSprite
         rotate
         scroll
         share
-        shield-blank
+        shield-halved
         shuffle
         signal
         sliders


### PR DESCRIPTION
I think this is a typo in the font awesome documentation, they list `shield-blank` but it should be either `shield` or `shield-halved` in the FA6 renames 

follow-up to 7d8974d