### PR TITLE
FEATURE: Add setting to exclude groups from /about page

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2699,6 +2699,7 @@ en:
 
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
+    about_page_hidden_groups: "Do not show members of specific groups on the /about page."
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
     experimental_flags_admin_page_enabled_groups: "EXPERIMENTAL: Remove the Moderation Flags link from the admin sidebar."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -410,6 +410,9 @@ basic:
   show_user_menu_avatars:
     client: true
     default: false
+  about_page_hidden_groups:
+    default: ""
+    type: group_list
   extended_site_description:
     default: ""
     max: 10_000


### PR DESCRIPTION
This PR adds a new `about_page_hidden_groups` setting to exclude members of specific groups from the admin and moderator lists on the /about page.

Internal topic: t/137717.