### PR TITLE
FIX: Notify mailing list subscribers on category change

### DIFF
--- a/app/jobs/regular/notify_category_change.rb
+++ b/app/jobs/regular/notify_category_change.rb
@@ -13,6 +13,7 @@ module Jobs
           include_tag_watchers: false,
         )
         post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
+        ::Jobs.enqueue(:notify_mailing_list_subscribers, post_id: post.id)
       end
     end
   end

--- a/spec/jobs/notify_category_change_spec.rb
+++ b/spec/jobs/notify_category_change_spec.rb
@@ -19,4 +19,18 @@ RSpec.describe ::Jobs::NotifyCategoryChange do
       Notification.count
     }
   end
+
+  context "when mailing list mode is enabled" do
+    before { SiteSetting.disable_mailing_list_mode = false }
+    before { regular_user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 1) }
+    before { Jobs.run_immediately! }
+
+    it "notifies mailing list subscribers" do
+      post.topic.update!(category: category)
+
+      expected_args = { "post_id" => post.id, "current_site_id" => "default" }
+      Jobs::NotifyMailingListSubscribers.any_instance.expects(:execute).with(expected_args).once
+      described_class.new.execute(post_id: post.id, notified_user_ids: [])
+    end
+  end
 end


### PR DESCRIPTION
Fixes: [Email notifications don’t get sent on category change for mailing list mode users](https://meta.discourse.org/t/email-notifications-dont-get-sent-on-category-change-for-mailing-list-mode-users/308096)

Previously, when category was changed, emails for mailing list subscribers were never triggered. It turns out this case was [never accounted for](https://meta.discourse.org/t/email-notifications-dont-get-sent-on-category-change-for-mailing-list-mode-users/308096/3). This PR triggers email notification for mailing list subscribers as well 