### PR TITLE
UX: prevent a focus-visible outline on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu.scss
@@ -7,6 +7,12 @@
     padding-top: 0.25em;
   }
 
+  .dropdown-menu {
+    li a:focus-visible {
+      outline: 0;
+    }
+  }
+
   li > .btn,
   li > a {
     padding: 0.75em 1rem;


### PR DESCRIPTION
On occasion the focus-visible style is activated when opening the list-control menu on mobile. This commit prevents this style from being visible. While it's important to adhere to accessibility guidelines, the focus state on a touch device is of minor importance, since traditionally no keyboard navigation is being used.

![CleanShot 2024-09-10 at 11 54 33](https://github.com/user-attachments/assets/2c8daa90-b277-4797-8cca-e6fbd21f11dc)
