### PR TITLE
UX: Add learn more URL for admin flags page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/config-flags.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-flags.hbs
@@ -1,6 +1,7 @@
 <AdminPageHeader
   @titleLabel="admin.config_areas.flags.header"
   @descriptionLabel="admin.config_areas.flags.subheader"
+  @learnMoreUrl="https://meta.discourse.org/t/moderation-flags/325589"
   @hideTabs={{this.hideTabs}}
 >
   <:breadcrumbs>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b4fe6b32-e289-4865-80be-c718882d73ab)


Docs are published now at https://meta.discourse.org/t/moderation-flags/325589
