### PR TITLE
UX: Hide 'other' and 'crawler' site traffic on report page

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -391,7 +391,7 @@ export default class AdminReport extends Component {
             Report.groupingForDatapoints(report.chartData.length),
         })
       );
-    } else if (mode === "stacked-chart") {
+    } else if (mode === "stacked-chart" || mode === "stacked_chart") {
       return this.get("reportOptions.stackedChart") || {};
     }
   }

--- a/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
@@ -16,6 +16,12 @@ export default class AdminReportsShowController extends Controller {
       options.table.limit = 10;
     }
 
+    if (type === "site_traffic") {
+      options.stackedChart = {
+        hiddenLabels: ["page_view_other", "page_view_crawler"],
+      };
+    }
+
     options.chartGrouping = this.chart_grouping;
 
     return options;


### PR DESCRIPTION
Followup 14b436923c5b582cea454b69441a28e16f2f191e

On the standalone Site Traffic report page, we also need
to hide the 'other' and 'crawler' pageviews by default
like we do on the admin dashboard.

![image](https://github.com/user-attachments/assets/ec2ec996-b690-4b9a-9588-324b527489bc)
