### PR TITLE
FIX: prevent chat channel not found ajax error

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -148,7 +148,9 @@ export default class ChatNotificationManager extends Service {
 
   @action
   async fetchChannel(channelId) {
-    return await this.chatChannelsManager.find(channelId);
+    return await this.chatChannelsManager.find(channelId, {
+      fetchIfNotFound: false,
+    });
   }
 
   @bind
@@ -159,7 +161,10 @@ export default class ChatNotificationManager extends Service {
 
     if (this.site.desktopView) {
       const channel = await this.fetchChannel(data.channel_id);
-      data.isDirectMessageChannel = channel.isDirectMessageChannel ?? false;
+
+      if (channel) {
+        data.isDirectMessageChannel = channel.isDirectMessageChannel ?? false;
+      }
 
       return onDesktopNotification(
         data,


### PR DESCRIPTION
On occasion we get an error popup on desktop due to the channel not being found.

This change means that we only check the cached channels in ChatChannelsManager for the matching channel id, but we skip doing manual lookup which results in ajax popup when it fails.