### PR TITLE
DEV: Update test-prof from 1.4.1 to 1.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,7 +545,7 @@ GEM
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     syntax_tree-disable_ternary (1.0.0)
-    test-prof (1.4.1)
+    test-prof (1.4.2)
     thor (1.3.2)
     timeout (0.4.1)
     trilogy (2.8.1)


### PR DESCRIPTION
The update introduced a small regression in d-data-explorer that was handled in https://github.com/discourse/discourse-data-explorer/pull/326

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
