### PR TITLE
FIX: Deprecated Collumns not able to drop because of triggers

### DIFF
--- a/db/post_migrate/20240212034010_drop_deprecated_columns.rb
+++ b/db/post_migrate/20240212034010_drop_deprecated_columns.rb
@@ -19,6 +19,11 @@ class DropDeprecatedColumns < ActiveRecord::Migration[7.0]
   }
 
   def up
+    execute <<~SQL
+    DROP TRIGGER IF EXISTS invites_user_id_readonly ON invites;
+    DROP TRIGGER IF EXISTS invites_redeemed_at_readonly ON invites;
+    DROP TRIGGER IF EXISTS user_api_keys_scopes_readonly ON user_api_keys;
+    SQL
     DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
   end
 


### PR DESCRIPTION
When updating from v3.2.0 to v3.3.0 there are some triggers that needs to be dropped before dropping columns.

I explained the issue in this post https://meta.discourse.org/t/discourse-upgrade-from-3-2-0-to-3-3-0-postgress-issue/323034
