### PR TITLE
DEV: Track SQL queries from MiniSql

### DIFF
--- a/lib/mini_sql_multisite_connection.rb
+++ b/lib/mini_sql_multisite_connection.rb
@@ -99,6 +99,16 @@ class MiniSqlMultisiteConnection < MiniSql::ActiveRecordPostgres::Connection
     CustomBuilder.new(self, sql)
   end
 
+  def run(sql, params)
+    ActiveSupport::Notifications.instrument(
+      "sql.mini_sql",
+      sql: sql_fragment(sql, *params),
+      name: "MiniSql",
+    )
+
+    super
+  end
+
   def sql_fragment(query, *args)
     if args.length > 0
       param_encoder.encode(query, *args)

--- a/plugins/poll/spec/requests/topics_controller_spec.rb
+++ b/plugins/poll/spec/requests/topics_controller_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe PostsController do
   fab!(:post2) { Fabricate(:post, topic:, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]") }
   fab!(:post3) { Fabricate(:post, topic:, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]") }
   fab!(:post4) { Fabricate(:post, topic:, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]") }
-  fab!(:post5) { Fabricate(:post, topic:, raw: "[poll results=staff_only]\n- A\n- B\n[/poll]") }
-  fab!(:post6) { Fabricate(:post, topic:, raw: "[poll results=staff_only]\n- A\n- B\n[/poll]") }
-  fab!(:post7) { Fabricate(:post, topic:, raw: "[poll visibility=]\n- A\n- B\n[/poll]") }
+  fab!(:post5) do
+    Fabricate(:post, topic:, raw: "[poll public=true results=staff_only]\n- A\n- B\n[/poll]")
+  end
+  fab!(:post6) do
+    Fabricate(:post, topic:, raw: "[poll public=true results=staff_only]\n- A\n- B\n[/poll]")
+  end
+  fab!(:post7) { Fabricate(:post, topic:, raw: "[poll public=true]\n- A\n- B\n[/poll]") }
 
   describe "#show" do
     context "when not logged in" do
@@ -26,7 +30,8 @@ RSpec.describe PostsController do
         # - load all options
         # - count votes for each poll
         # - count votes for each option
-        expect(poll_queries.size).to eq(4)
+        # - voters for poll in post7
+        expect(poll_queries.size).to eq(5)
       end
     end
 
@@ -43,7 +48,10 @@ RSpec.describe PostsController do
         # - all queries listed for "when not logged in"
         # - query to find out if the user has voted in each poll
         # - queries to get "serialized voters" (NOT TRACKED)
-        expect(poll_queries.size).to eq(5)
+        # - voters for poll in post5
+        # - voters for poll in post6
+        # - voters for poll in post7
+        expect(poll_queries.size).to eq(8)
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -209,7 +209,9 @@ module Helpers
       queries << payload.fetch(:sql) if %w[CACHE SCHEMA].exclude?(payload.fetch(:name))
     end
 
-    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      ActiveSupport::Notifications.subscribed(callback, "sql.mini_sql") { yield }
+    end
 
     queries
   end


### PR DESCRIPTION
`track_sql_queries` only returned queries that were executed by
ActiveRecord. All queries executed through DB.exec, DB.query and others
were not returned.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->