### PR TITLE
PERF: Preload user options when status is enabled

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -752,8 +752,9 @@ class TopicView
         usernames.flatten!
         usernames.uniq!
 
-        users =
-          User.where(username_lower: usernames).includes(:user_status).index_by(&:username_lower)
+        users = User.where(username_lower: usernames)
+        users = users.includes(:user_option, :user_status) if SiteSetting.enable_user_status
+        users = users.index_by(&:username_lower)
 
         mentions.reduce({}) do |hash, (post_id, post_mentioned_usernames)|
           hash[post_id] = post_mentioned_usernames.map { |username| users[username] }.compact


### PR DESCRIPTION
The user option 'hide_profile_and_presence' is necessary to figure out
if the user status has to be displayed or not. In order to avoid N+1s
generated by `include_status?` method, both `user_status` and
`user_option` relations have to be included.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->