### PR TITLE
DEV: Add debug logging for automation recurring trigger

### DIFF
--- a/plugins/automation/config/settings.yml
+++ b/plugins/automation/config/settings.yml
@@ -2,3 +2,6 @@ plugins:
   discourse_automation_enabled:
     default: false
     client: true
+  discourse_automation_enable_recurring_debug:
+    default: false
+    hidden: true

--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -32,6 +32,16 @@ module DiscourseAutomation
              previous_frequency != frequency
           automation.pending_automations.destroy_all
         elsif automation.pending_automations.present?
+          log_debugging_info(
+            id: automation.id,
+            start_date:,
+            interval:,
+            frequency:,
+            previous_start_date:,
+            previous_interval:,
+            previous_frequency:,
+            now: Time.zone.now,
+          )
           return
         end
 
@@ -87,7 +97,29 @@ module DiscourseAutomation
 
         if next_trigger_date && next_trigger_date > Time.zone.now
           automation.pending_automations.create!(execute_at: next_trigger_date)
+        else
+          log_debugging_info(
+            id: automation.id,
+            start_date:,
+            interval:,
+            frequency:,
+            previous_start_date:,
+            previous_interval:,
+            previous_frequency:,
+            byday:,
+            interval_end:,
+            next_trigger_date:,
+            now: Time.zone.now,
+          )
+          nil
         end
+      end
+
+      def self.log_debugging_info(context)
+        return if !SiteSetting.discourse_automation_enable_recurring_debug
+        str = "[automation] scheduling recurring automation debug: "
+        str += context.map { |k, v| "#{k}=#{v.inspect}" }.join(", ")
+        Rails.logger.warn(str)
       end
     end
   end


### PR DESCRIPTION
We're seeing a problem where some recurring automations end up in a state where they don't have any `pending_automations` records scheduled which effectively makes the recurring automation dead. We need to add some debugging to figure out what might be causing this problem.

Internal topic: t/138045.