### PR TITLE
UX: fix double li-element in mobile list control

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
@@ -51,14 +51,13 @@ export default class NavigationBarComponent extends Component {
             <:content>
               <DropdownMenu {{on "click" this.dMenu.close}} as |dropdown|>
                 {{#each @navItems as |navItem|}}
-                  <dropdown.item>
-                    <NavigationItem
-                      @content={{navItem}}
-                      @filterMode={{@filterMode}}
-                      @category={{@category}}
-                      class={{concat "nav-item_" navItem.name}}
-                    />
-                  </dropdown.item>
+                  <NavigationItem
+                    @content={{navItem}}
+                    @filterMode={{@filterMode}}
+                    @category={{@category}}
+                    class={{concat "nav-item_" navItem.name}}
+                  />
+
                 {{/each}}
                 <dropdown.item>
                   <PluginOutlet

--- a/app/assets/stylesheets/mobile/list-controls.scss
+++ b/app/assets/stylesheets/mobile/list-controls.scss
@@ -71,15 +71,13 @@
     display: flex;
     flex-direction: column;
 
-    &__item {
-      a {
-        display: block;
-        color: var(--primary);
+    a {
+      display: block;
+      color: var(--primary);
 
-        &.active {
-          background: var(--d-selected);
-          font-weight: bold;
-        }
+      &.active {
+        background: var(--d-selected);
+        font-weight: bold;
       }
     }
   }


### PR DESCRIPTION
This commit fixes the double li-element present in the list-control DMenu, introduced by #28324

