### PR TITLE
DEV: Change qunit_parallel to 2 for frontend themes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,11 @@ jobs:
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'
         run: |
-          echo "QUNIT_PARALLEL=$(($(nproc) / 2))" >> $GITHUB_ENV
+          if [ "${{ matrix.target }}" = "themes" ]; then
+            echo "QUNIT_PARALLEL=2" >> $GITHUB_ENV
+          else
+            echo "QUNIT_PARALLEL=$(($(nproc) / 2))" >> $GITHUB_ENV
+          fi
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This seems to mitigate the flaky timeouts we've been seeing recently, while not affecting the speed in any meaningful way.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
