### PR TITLE
DEV: Remove dynamic inclusions from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -286,7 +286,4 @@ group :migrations, optional: true do
 
   # CLI
   gem "ruby-progressbar"
-
-  # additional Gemfiles from converters
-  Dir[File.expand_path("migrations/**/Gemfile", __dir__)].each { |path| eval_gemfile(path) }
 end


### PR DESCRIPTION
Added in 7c3a29c, broke Dependabot parsing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
