### PR TITLE
feat: Added Elestio as one-click deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ If you want to set up a Discourse forum for production use, see our [**Discourse
 
 If you're looking for official hosting, see [discourse.org/pricing](https://www.discourse.org/pricing/).
 
+## Self-Hosting Options
+
+### Elestio
+
+You can deploy Discourse on Elestio using one-click deployment.
+
+[![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/discourse)
+
 ## Requirements
 
 Discourse is built for the *next* 10 years of the Internet, so our requirements are high.


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing Discourse application as shown [here](https://elest.io/open-source/discourse). I think it would be a great idea if we can add it to official readme/documentation here.
🔔 In addition to this, if you are interested we provide partnership opportunities with tools we support by **revenue share** upon addition of this method in docs. If you would like to collaborate, just shoot me an email at [kaiwalya@elest.io](mailto:kaiwalya@elest.io) :)