### PR TITLE
DEV: Remove corepack config for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lint-progress": "pnpm lttf:output && npx html-pages ./lint-progress --no-cache",
     "ember": "pnpm --dir=app/assets/javascripts/discourse ember"
   },
-  "packageManager": "pnpm@9.9.0",
   "engines": {
     "node": ">= 18",
     "npm": "please-use-pnpm",


### PR DESCRIPTION
For people with corepack enabled, this causes problems when trying to `yarn install` in plugin directories.

Perhaps that can be improved in future by adding `packageManager` config in each plugin's own `package.json`, but that won't happen overnight. Removing the config for now to stop the bleeding.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
