### PR TITLE
FIX: Import script didn't set `public` attribute of polls

### DIFF
--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -955,7 +955,7 @@ class BulkImport::Generic < BulkImport::Base
     min = row["min"]
     max = row["max"]
     step = row["step"]
-    visibility = ::Poll.visibilities.key(row["visibility"])
+    visibility = row["visibility"]
     chart_type = ::Poll.chart_types.key(row["chart_type"])
     groups = row["groups"]
     auto_close = to_datetime(row["close_at"])


### PR DESCRIPTION
This prevented users from editing imported posts when they contained polls.