### PR TITLE
DEV: Fix another report flaky

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -224,6 +224,11 @@ class Report
     singleton_class.instance_eval { define_method("report_#{name}", &block) }
   end
 
+  # Only used for testing.
+  def Report.remove_report(name)
+    singleton_class.instance_eval { remove_method("report_#{name}") }
+  end
+
   def self._get(type, opts = nil)
     opts ||= {}
 

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -358,6 +358,8 @@ TEXT
   end
 
   describe "#add_report" do
+    after { Report.remove_report("readers") }
+
     it "adds a report" do
       plugin = Plugin::Instance.new nil, "/tmp/test.rb"
       plugin.add_report("readers") {}


### PR DESCRIPTION
Followup 0323b366f3023843468d1024135bbb1c7c6f0483

This was happening because another spec was adding a
report using the plugin API, but there was nothing
resetting that, so later in the reports controller
when we did Report.singleton_methods, we ended up
with another report with no translation, causing another
error.
