### PR TITLE
FIX: Don't show move topic for private messages for TL4

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -875,8 +875,6 @@ class TopicsController < ApplicationController
     params.permit(:chronological_order)
     params.permit(:archetype)
 
-    raise Discourse::InvalidAccess if params[:archetype] == "private_message" && !guardian.is_staff?
-
     topic = Topic.with_deleted.find_by(id: topic_id)
     guardian.ensure_can_move_posts!(topic)
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -355,7 +355,9 @@ module TopicGuardian
 
   def can_move_posts?(topic)
     return false if is_silenced?
-    can_perform_action_available_to_group_moderators?(topic)
+    return false unless can_perform_action_available_to_group_moderators?(topic)
+    return false if topic.archetype == "private_message" && !is_staff?
+    true
   end
 
   def affected_by_slow_mode?(topic)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2288,6 +2288,27 @@ RSpec.describe Guardian do
         expect(Guardian.new(admin).can_move_posts?(topic)).to be_truthy
       end
     end
+
+    context "with a private message topic" do
+      fab!(:pm) { Fabricate(:private_message_topic) }
+
+      it "returns false when not logged in" do
+        expect(Guardian.new.can_move_posts?(pm)).to be_falsey
+      end
+
+      it "returns false when not a moderator" do
+        expect(Guardian.new(user).can_move_posts?(pm)).to be_falsey
+        expect(Guardian.new(trust_level_4).can_move_posts?(pm)).to be_falsey
+      end
+
+      it "returns true when a moderator" do
+        expect(Guardian.new(moderator).can_move_posts?(pm)).to be_truthy
+      end
+
+      it "returns true when an admin" do
+        expect(Guardian.new(admin).can_move_posts?(pm)).to be_truthy
+      end
+    end
   end
 
   describe "#can_delete?" do


### PR DESCRIPTION
In TopicController, in addition to ensure_can_move_posts!, we also checked if the topic is private message in this line:

```ruby
raise Discourse::InvalidAccess if params[:archetype] == "private_message" && !guardian.is_staff?
```

However, this was not present in `guardian.can_move_posts?`. As a result, the frontend topic view got an incorrect serialized result, thinking that TL4 could move the private message post. In fact, once they tried to move it, they got the `InvalidAccess` error message.

This commit fixes that TL4 will no longer sees the "move to" option in the "select post" panel for a private message.

ref=/t/133860

Screenshot:

![image](https://github.com/user-attachments/assets/66833732-8b86-4aa5-903b-4a1c903b4f36)


<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->