### PR TITLE
FIX: Support date field in FormKit page object

### DIFF
--- a/spec/system/page_objects/components/form_kit.rb
+++ b/spec/system/page_objects/components/form_kit.rb
@@ -84,7 +84,7 @@ module PageObjects
 
       def fill_in(value)
         case control_type
-        when "input-text", "password"
+        when "input-text", "password", "input-date"
           component.find("input").fill_in(with: value)
         when "textarea", "composer"
           component.find("textarea").fill_in(with: value, visible: :all)


### PR DESCRIPTION
Adds support for `input-date` field when calling
`fill_in` on a FormKit field. Capybara supports passing
a Date object to `fill_in(with: value)` for date inputs,
so there is nothing fancy that needs to be done to support this.
