### PR TITLE
FIX: flaky system admin flags specs

### DIFF
--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -134,7 +134,7 @@ describe "Admin Flags Page", type: :system do
     # delete
     admin_flags_page.visit.click_delete_flag("custom_tasteless").confirm_delete
 
-    expect(admin_flags_page).to have_no_flag("tasteless")
+    expect(admin_flags_page).to have_no_flag("custom_tasteless")
 
     expect(admin_flags_page).to have_add_flag_button_enabled
 
@@ -157,6 +157,16 @@ describe "Admin Flags Page", type: :system do
       .select_applies_to("Post")
       .click_save
 
+    expect(admin_flags_page).to have_flags(
+      "Send @%{username} a message",
+      "Off-Topic",
+      "Inappropriate",
+      "Spam",
+      "Illegal",
+      "Something Else",
+      "Inappropriate",
+    )
+
     topic_page.visit_topic(post.topic).open_flag_topic_modal
 
     expect(flag_modal).to have_choices(
@@ -166,7 +176,7 @@ describe "Admin Flags Page", type: :system do
       "Inappropriate",
     )
 
-    Flag.system.where(name: "illegal").update!(enabled: true)
+    Flag.system.where(name: "inappropriate").update!(enabled: true)
     admin_flags_page.visit.click_delete_flag("custom_inappropriate").confirm_delete
   end
 


### PR DESCRIPTION
Recently `custom_` prefix was added for flags https://github.com/discourse/discourse/pull/28839

When we wait to ensure that `Tasteless` flag is deleted, we need to use new prefix as well.