### PR TITLE
UX: Fix admin report filter stacking

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_report.scss
+++ b/app/assets/stylesheets/common/admin/admin_report.scss
@@ -78,7 +78,7 @@
 
   .body {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
   }
 
   .main {


### PR DESCRIPTION
Followup 5a8e7c5f29b21fe3465dd0db48026075e6c4b274

The admin report results need to be side by side
with the filter for the report, which sits on the
right. The previous commit made it stacked.

![image](https://github.com/user-attachments/assets/a701f807-576e-4b18-91c9-962620dd2089)
