### PR TITLE
FIX: Exclude inactive and silenced users from /about page stats

### DIFF
--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -70,11 +70,15 @@ class Statistics
   end
 
   def self.users
+    query = User.real.not_silenced.activated
+
+    query = query.where(approved: true) if SiteSetting.must_approve_users
+
     {
-      last_day: User.real.where("created_at > ?", 1.day.ago).count,
-      "7_days": User.real.where("created_at > ?", 7.days.ago).count,
-      "30_days": User.real.where("created_at > ?", 30.days.ago).count,
-      count: User.real.count,
+      last_day: query.where("created_at > ?", 1.day.ago).count,
+      "7_days": query.where("created_at > ?", 7.days.ago).count,
+      "30_days": query.where("created_at > ?", 30.days.ago).count,
+      count: query.count,
     }
   end
 


### PR DESCRIPTION
The user directory (`/u`) excludes inactive and silenced users from the list, so for the sake parity, it makes sense to also exclude those users from the /about page stats.

Internal topic: t/70928.