### PR TITLE
DEV: Automatically add `--ignore-workspace` when pnpm used in plugins

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -17,8 +17,14 @@ if (fs.existsSync(`${discourseRoot}/node_modules/.yarn-integrity`)) {
   console.log("cleanup done");
 }
 
+const pluginBase = `${discourseRoot}/plugins/`;
+const pluginName =
+  process.cwd().startsWith(pluginBase) &&
+  process.cwd().replace(pluginBase, "").split("/", 2)[0];
+
 if (
-  process.cwd().startsWith(`${discourseRoot}/plugins/`) &&
+  pluginName &&
+  fs.existsSync(`${discourseRoot}/plugins/${pluginName}/package.json`) &&
   !process.argv.includes("--ignore-workspace")
 ) {
   console.log(

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -17,7 +17,10 @@ if (fs.existsSync(`${discourseRoot}/node_modules/.yarn-integrity`)) {
   console.log("cleanup done");
 }
 
-if (process.cwd().startsWith(`${discourseRoot}/plugins/`)) {
+if (
+  process.cwd().startsWith(`${discourseRoot}/plugins/`) &&
+  !process.argv.includes("--ignore-workspace")
+) {
   console.log(
     "> pnpm was run inside a plugin directory. Re-executing with --ignore-workspace..."
   );

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,7 +1,9 @@
 const fs = require("fs");
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 
-if (fs.existsSync("node_modules/.yarn-integrity")) {
+const discourseRoot = __dirname;
+
+if (fs.existsSync(`${discourseRoot}/node_modules/.yarn-integrity`)) {
   console.log(
     "Detected yarn-managed node_modules. Performing one-time cleanup..."
   );
@@ -9,8 +11,31 @@ if (fs.existsSync("node_modules/.yarn-integrity")) {
   // Delete entire contents of all node_modules directories
   // But keep the directories themselves, in case they are volume mounts (e.g. in devcontainer)
   execSync(
-    "find ./node_modules ./app/assets/javascripts/*/node_modules -mindepth 1 -maxdepth 1 -exec rm -rf {} +"
+    `find ${discourseRoot}/node_modules ${discourseRoot}/app/assets/javascripts/*/node_modules -mindepth 1 -maxdepth 1 -exec rm -rf {} +`
   );
 
   console.log("cleanup done");
+}
+
+if (process.cwd().startsWith(`${discourseRoot}/plugins/`)) {
+  console.log(
+    "> pnpm was run inside a plugin directory. Re-executing with --ignore-workspace..."
+  );
+
+  try {
+    execFileSync(
+      process.argv[0],
+      [...process.argv.slice(1), "--ignore-workspace"],
+      {
+        stdio: "inherit",
+      }
+    );
+  } catch (e) {
+    if (e.status) {
+      process.exit(e.status);
+    }
+    throw e;
+  }
+
+  process.exit(0);
 }

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -18,9 +18,9 @@ if (fs.existsSync(`${discourseRoot}/node_modules/.yarn-integrity`)) {
 }
 
 const pluginBase = `${discourseRoot}/plugins/`;
+const cwd = process.cwd();
 const pluginName =
-  process.cwd().startsWith(pluginBase) &&
-  process.cwd().replace(pluginBase, "").split("/", 2)[0];
+  cwd.startsWith(pluginBase) && cwd.replace(pluginBase, "").split("/", 2)[0];
 
 if (
   pluginName &&


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->