### PR TITLE
PERF: Use insertText more efficiently in `replaceText`

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -149,16 +149,21 @@ export default Mixin.create({
     });
 
     if (opts.index && opts.regex) {
-      let i = -1;
-      const newValue = val.replace(opts.regex, (match) => {
-        i++;
-        return i === opts.index ? newVal : match;
-      });
+      if (!opts.regex.global) {
+        throw new Error("Regex must be global");
+      }
 
-      this._insertAt(0, val.length, newValue);
+      const regex = new RegExp(opts.regex);
+      let match;
+      for (let i = 0; i <= opts.index; i++) {
+        match = regex.exec(val);
+      }
+
+      if (match) {
+        this._insertAt(match.index, match.index + match[0].length, newVal);
+      }
     } else {
-      const replacedValue = val.replace(oldVal, newVal);
-      this._insertAt(0, val.length, replacedValue);
+      this._insertAt(needleStart, needleStart + oldVal.length, newVal);
     }
 
     if (


### PR DESCRIPTION
Followup to e25578d702791bac80b431acd450cc53b6c39a3c

Using execCommand to replace the entire contents of the textarea is very slow for larger posts (it seems the browser does a reflow after every 'virtual keypress'.

This commit updates the `replaceText` function to be more surgical with its `insertAt` calls. Now it only selects & replaces the characters which are actually being replaced.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->