### PR TITLE
DEV: update runners to debian-12

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   triage:
     if: github.actor != 'discourse-translator-bot'
-    runs-on: ubuntu-latest
+    runs-on: debian-12
 
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: run
-    runs-on: ubuntu-latest
+    runs-on: debian-12
     container: discourse/discourse_test:slim
     timeout-minutes: 10
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: run
-    runs-on: ubuntu-latest
+    runs-on: debian-12
     container: discourse/discourse_test:slim
     timeout-minutes: 30
 

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -24,7 +24,7 @@ jobs:
   tests:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: Tests with Ruby ${{ matrix.ruby }}
-    runs-on: 'ubuntu-latest'
+    runs-on: debian-12
     container: discourse/discourse_test:slim
     timeout-minutes: 20
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build:
     name: run
-    runs-on: ubuntu-latest
+    runs-on: debian-12
     container: discourse/discourse_test:slim
     timeout-minutes: 10
     env:

--- a/.github/workflows/stale-pr-closer.yml
+++ b/.github/workflows/stale-pr-closer.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: debian-12
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }} # Update fetch-job-id step if changing this
-    runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || 'ubuntu-22.04-8core' }}
+    runs-on: debian-12
     container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
     timeout-minutes: 20
 
@@ -358,7 +358,7 @@ jobs:
   core_frontend_tests:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: core frontend (${{ matrix.browser }})
-    runs-on: ubuntu-22.04-8core
+    runs-on: debian-12
     container:
       image: discourse/discourse_test:slim-browsers
       options: --user discourse


### PR DESCRIPTION
The self-hosted Github runners have been provisioned, and we can switch to using them for evaluation.

To prefer Github-hosted runners, you can safely revert this commit.

See: t/123181.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->