### PR TITLE
PERF: Cache serialized voters at topic view level

### DIFF
--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -25,6 +25,7 @@ class Poll < ActiveRecord::Base
 
   attr_writer :voters_count
   attr_accessor :has_voted
+  attr_accessor :serialized_voters_cache
 
   after_initialize { @has_voted = {} }
 

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -184,6 +184,7 @@ after_initialize do
         if post_with_polls.present?
           all_polls = Poll.includes(:poll_options).where(post_id: post_with_polls)
           Poll.preload!(all_polls, user_id: @user&.id)
+          DiscoursePoll::Poll.preload_serialized_voters!(all_polls)
           all_polls.each do |p|
             polls[p.post_id] ||= []
             polls[p.post_id] << p

--- a/plugins/poll/spec/requests/topics_controller_spec.rb
+++ b/plugins/poll/spec/requests/topics_controller_spec.rb
@@ -47,10 +47,8 @@ RSpec.describe PostsController do
         #
         # - all queries listed for "when not logged in"
         # - query to find out if the user has voted in each poll
-        # - queries to get "serialized voters" (NOT TRACKED)
-        # - voters for poll in post5
-        # - voters for poll in post6
-        # - voters for poll in post7
+        # - queries to get "serialized voters"
+        # - voters for poll in post5, post6, post7
         expect(poll_queries.size).to eq(8)
       end
     end

--- a/plugins/poll/spec/requests/topics_controller_spec.rb
+++ b/plugins/poll/spec/requests/topics_controller_spec.rb
@@ -45,11 +45,9 @@ RSpec.describe PostsController do
 
         # Expected queries:
         #
-        # - all queries listed for "when not logged in"
+        # - all queries listed for "when not logged in" (except it loads voters for polls in post5, post6 and post7)
         # - query to find out if the user has voted in each poll
-        # - queries to get "serialized voters"
-        # - voters for poll in post5, post6, post7
-        expect(poll_queries.size).to eq(8)
+        expect(poll_queries.size).to eq(6)
       end
     end
   end


### PR DESCRIPTION
Topics with multiple polls will generate N+1 queries to load the IDs of the users who voted and the details of these users.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->