### PR TITLE
UX: update stying of chat composer focused state

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -3,7 +3,6 @@
     display: flex;
     flex-direction: column;
     z-index: 3;
-    background-color: var(--primary-very-low);
     padding: 0.5rem 0 env(safe-area-inset-bottom) 0;
 
     .keyboard-visible & {
@@ -49,13 +48,12 @@
     flex-direction: row;
     border: 1px solid var(--primary-low);
     border-radius: var(--d-border-radius-large);
-    background-color: var(--secondary);
+    background: var(--primary-very-low);
     min-height: 50px;
     overflow: hidden;
 
     .chat-composer.is-focused & {
-      border-color: var(--primary-low-mid);
-      box-shadow: 0px 0px 4px 1px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 0 2px 0 rgba(var(--tertiary-rgb), 0.95);
     }
 
     .chat-composer.is-disabled & {

--- a/plugins/chat/assets/stylesheets/mobile/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-composer.scss
@@ -17,10 +17,6 @@
   &__inner-container {
     align-self: stretch;
     min-height: unset;
-    .chat-composer.is-focused & {
-      border-color: var(--primary-low);
-      box-shadow: 0 0 2px 0 rgba(var(--tertiary-rgb), 0.95);
-    }
   }
   &__input-container {
     padding: 0.15em 0.5em;


### PR DESCRIPTION
The chat composer focus state on mobile and desktop had diverted. This commit updates the desktop focus state to fall in line. It's  less harsh than before and no longer relies on box-shadow, which doesn't work well in dark mode anyway. Additionally, it incorporates the `tertiary` colour, which is used elsewhere too to indicate focus.

| Before | After |
|--------|--------|
| <img width="756" alt="CleanShot 2024-09-13 at 14 15 26@2x" src="https://github.com/user-attachments/assets/2eac76bd-e31e-4d01-92d2-dd8be2294807"> | <img width="756" alt="CleanShot 2024-09-13 at 14 14 29@2x" src="https://github.com/user-attachments/assets/92b80cc5-80b5-4b00-aade-f860dd7e8b5c"> | 
| <img width="756" alt="CleanShot 2024-09-13 at 14 15 09@2x" src="https://github.com/user-attachments/assets/ddbbf7d5-cccb-4503-a68a-c471a6a6d894"> | <img width="756" alt="CleanShot 2024-09-13 at 14 14 54@2x" src="https://github.com/user-attachments/assets/0d1ddab0-3e17-4fb8-b912-6f0f2ba8dc45"> | 