### PR TITLE
UX: small colour change to chat composer insert button

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer-dropdown.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer-dropdown.scss
@@ -3,7 +3,7 @@
     .chat-composer-dropdown__trigger-btn:hover {
       cursor: default;
       .d-icon {
-        color: var(--primary-low-mid);
+        color: var(--primary-high);
       }
     }
   }
@@ -16,7 +16,7 @@
   .d-icon {
     padding: 5px;
     transition: transform 0.1s ease-in-out;
-    background: var(--secondary-very-high);
+    background: var(--primary-low);
     border-radius: 100%;
   }
 


### PR DESCRIPTION
Mini follow up for https://github.com/discourse/discourse/pull/28900

## Before
<img width="255" alt="CleanShot 2024-09-13 at 17 02 30@2x" src="https://github.com/user-attachments/assets/022c081a-4f10-4af4-afcb-60e7ea282ca1">

## After
<img width="277" alt="CleanShot 2024-09-13 at 17 02 01@2x" src="https://github.com/user-attachments/assets/054d083d-6997-4b32-a1b9-82f4dcb8b3ff">
