### PR TITLE
FIX: Error when moving the group default notification state

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
@@ -19,7 +19,7 @@
 
     <TagChooser
       @tags={{this.model.watching_tags}}
-      @blacklist={{this.selectedTags}}
+      @blockedTags={{this.selectedTags}}
       @everyTag={{true}}
       @unlimitedTagCount={{true}}
       @options={{hash allowAny=false}}
@@ -36,7 +36,7 @@
 
     <TagChooser
       @tags={{this.model.tracking_tags}}
-      @blacklist={{this.selectedTags}}
+      @blockedTags={{this.selectedTags}}
       @everyTag={{true}}
       @unlimitedTagCount={{true}}
       @options={{hash allowAny=false}}
@@ -53,7 +53,7 @@
 
     <TagChooser
       @tags={{this.model.watching_first_post_tags}}
-      @blacklist={{this.selectedTags}}
+      @blockedTags={{this.selectedTags}}
       @everyTag={{true}}
       @unlimitedTagCount={{true}}
       @options={{hash allowAny=false}}
@@ -70,7 +70,7 @@
 
     <TagChooser
       @tags={{this.model.regular_tags}}
-      @blacklist={{this.selectedTags}}
+      @blockedTags={{this.selectedTags}}
       @everyTag={{true}}
       @unlimitedTagCount={{true}}
       @options={{hash allowAny=false}}
@@ -87,7 +87,7 @@
 
     <TagChooser
       @tags={{this.model.muted_tags}}
-      @blacklist={{this.selectedTags}}
+      @blockedTags={{this.selectedTags}}
       @everyTag={{true}}
       @unlimitedTagCount={{true}}
       @options={{hash allowAny=false}}

--- a/app/models/group_tag_notification_default.rb
+++ b/app/models/group_tag_notification_default.rb
@@ -34,9 +34,14 @@ class GroupTagNotificationDefault < ActiveRecord::Base
       changed = true
     end
 
-    (tag_ids - old_ids).each do |id|
-      self.create!(group: group, tag_id: id, notification_level: notification_levels[level])
-      changed = true
+    new_records_attrs =
+      (tag_ids - old_ids).map do |tag_id|
+        { group_id: group.id, tag_id: tag_id, notification_level: notification_levels[level] }
+      end
+
+    unless new_records_attrs.empty?
+      result = GroupTagNotificationDefault.insert_all(new_records_attrs)
+      changed = true if result.rows.length > 0
     end
 
     changed

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1380,6 +1380,24 @@ RSpec.describe Group do
       expect(GroupTagNotificationDefault.lookup(group, :watching)).to be_empty
     end
 
+    it "can change the notification level for a tag" do
+      GroupTagNotificationDefault.create!(
+        group: group,
+        tag: tag1,
+        notification_level: GroupTagNotificationDefault.notification_levels[:watching],
+      )
+
+      group.watching_tags = [tag1.name]
+      group.save!
+      expect(GroupTagNotificationDefault.lookup(group, :watching).pluck(:tag_id)).to eq([tag1.id])
+
+      group.watching_tags = []
+      group.tracking_tags = [tag1.name]
+      group.save!
+      expect(GroupTagNotificationDefault.lookup(group, :watching)).to be_empty
+      expect(GroupTagNotificationDefault.lookup(group, :tracking).pluck(:tag_id)).to eq([tag1.id])
+    end
+
     it "can apply default notifications for admins group" do
       group = Group.find(Group::AUTO_GROUPS[:admins])
       group.tracking_category_ids = [category1.id]


### PR DESCRIPTION
An error will pop up when switching the default tag notification state for a group. This also happened if you attempted to set the same tag to two notification levels at a time. The UI no longer allows this