### PR TITLE
DEV: Fix some js deprecations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/ace-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/ace-editor.gjs
@@ -94,7 +94,7 @@ export default class AceEditor extends Component {
     this.appEvents.on("ace:resize", this.resize);
     window.addEventListener("resize", this.resize);
     this._darkModeListener = window.matchMedia("(prefers-color-scheme: dark)");
-    this._darkModeListener.addListener(this.setAceTheme);
+    this._darkModeListener.addEventListener("change", this.setAceTheme);
   }
 
   willDestroy() {
@@ -102,7 +102,7 @@ export default class AceEditor extends Component {
 
     this.editor?.destroy();
 
-    this._darkModeListener?.removeListener(this.setAceTheme);
+    this._darkModeListener?.removeEventListener("change", this.setAceTheme);
     window.removeEventListener("resize", this.resize);
     this.appEvents.off("ace:resize", this.resize);
   }

--- a/app/assets/javascripts/discourse/app/instance-initializers/hashtag-css-generator.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/hashtag-css-generator.js
@@ -12,11 +12,8 @@ export default {
    * with the hashtag type via api.registerHashtagType. The default
    * ones in core are CategoryHashtagType and TagHashtagType.
    */
-  initialize(owner) {
-    this.site = owner.lookup("service:site");
-
+  initialize() {
     const cssTag = document.createElement("style");
-    cssTag.type = "text/css";
     cssTag.id = "hashtag-css-generator";
     cssTag.innerHTML = Object.values(getHashtagTypeClasses())
       .map((hashtagType) => hashtagType.generatePreloadedCssClasses())

--- a/app/assets/javascripts/discourse/app/instance-initializers/webview-background.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/webview-background.js
@@ -10,10 +10,17 @@ export default {
     if (caps.isAppWebview) {
       window
         .matchMedia("(prefers-color-scheme: dark)")
-        .addListener(this.updateAppBackground);
+        .addEventListener("change", this.updateAppBackground);
       this.updateAppBackground();
     }
   },
+
+  teardown() {
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .removeEventListener("change", this.updateAppBackground);
+  },
+
   updateAppBackground() {
     discourseLater(() => {
       const header = document.querySelector(".d-header-wrap .d-header");


### PR DESCRIPTION
1. `MediaQueryList.addListener` is deprecated in favor of `addEventListener`
2. `HTMLStyleElement.type` is deprecated with no replacement

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->