### PR TITLE
DEV: attempt a mini_racer upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer"
+gem "mini_racer", "0.17.0.pre3"
 
 gem "highline", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,10 +206,10 @@ GEM
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.3)
-    libv8-node (18.19.0.0-aarch64-linux)
-    libv8-node (18.19.0.0-arm64-darwin)
-    libv8-node (18.19.0.0-x86_64-darwin)
-    libv8-node (18.19.0.0-x86_64-linux)
+    libv8-node (22.7.0.4)
+    libv8-node (22.7.0.4-aarch64-linux)
+    libv8-node (22.7.0.4-x86_64-darwin)
+    libv8-node (22.7.0.4-x86_64-linux)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -241,8 +241,8 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.14.1)
-      libv8-node (~> 18.19.0.0)
+    mini_racer (0.17.0.pre3)
+      libv8-node (~> 22.7.0.4)
     mini_scheduler (0.17.0)
       sidekiq (>= 4.2.3, < 7.0)
     mini_sql (1.6.0)
@@ -654,7 +654,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer
+  mini_racer (= 0.17.0.pre3)
   mini_scheduler
   mini_sql
   mini_suffix


### PR DESCRIPTION
This is attempt 4 or 5. This time we compiled libv8-node using clang vs gcc.

The working theory is that something may be off with the gcc compile.
