### PR TITLE
DEV: Reduce number of parallel processes for frontend tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Core QUnit
         working-directory: ./app/assets/javascripts/discourse
         run: |
-          pnpm ember exam --path /tmp/emberbuild --load-balance --parallel=$(($(nproc) / 2 + 1)) --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
+          pnpm ember exam --path /tmp/emberbuild --load-balance --parallel=$(($(nproc) / 2)) --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
         timeout-minutes: 15
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Seeing errors like the following which is normally due to us running
too many processes.

```
not ok 292 Firefox - [undefined ms] - error
    ---
        message: >
            Error: Browser timeout exceeded: 10s
            Error while executing test: Acceptance: Uppy Composer Attachment - Multiple Upload Errors: should show a consolidated message for multiple failed uploads
            Stderr:
             *** You are running in headless mode.

            Stdout:
             [GFX1-]: glxtest: libpci missing
            [GFX1-]: glxtest: Unable to open a connection to the X server
            [GFX1-]: No GPUs detected via PCI

            [GFX1-]: RenderCompositorSWGL failed mapping default framebuffer, no dt
```
