### PR TITLE
FIX: Show topic admin menu if can_split_merge_topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -77,7 +77,8 @@ export default class TopicAdminMenu extends Component {
     return (
       this.currentUser?.canManageTopic ||
       this.details?.can_archive_topic ||
-      this.details?.can_close_topic
+      this.details?.can_close_topic ||
+      this.details?.can_split_merge_topic
     );
   }
 


### PR DESCRIPTION
Show the topic admin button is the `can_split_merge_topic` permission is present, without the user needing full `can_manage_topic` permissions.
