### PR TITLE
UX: chat composer style tweaks

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer-button.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer-button.scss
@@ -21,10 +21,10 @@
   }
 
   .d-icon {
-    color: var(--primary-low-mid);
+    color: var(--primary-medium);
 
     &:hover {
-      color: var(--primary-low-mid);
+      color: var(--primary-medium);
     }
 
     .is-focused & {
@@ -32,6 +32,7 @@
     }
 
     .is-disabled & {
+      color: var(--primary-low-mid);
       cursor: not-allowed;
     }
   }

--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -48,12 +48,12 @@
     flex-direction: row;
     border: 1px solid var(--primary-low);
     border-radius: var(--d-border-radius-large);
-    background: var(--primary-very-low);
+    background: rgba(var(--primary-very-low-rgb), 0.5);
     min-height: 50px;
     overflow: hidden;
 
     .chat-composer.is-focused & {
-      box-shadow: 0 0 2px 0 rgba(var(--tertiary-rgb), 0.95);
+      box-shadow: 0 0 1px 0 var(--tertiary);
     }
 
     .chat-composer.is-disabled & {


### PR DESCRIPTION
Some minor follow up tweaks for the chat composer:

- more subtle hover state
- lighter background

## Before
<img width="750" alt="CleanShot 2024-09-17 at 10 57 00@2x" src="https://github.com/user-attachments/assets/83101704-6f9f-45ec-9c83-e48ea845e47f">

## After
<img width="754" alt="CleanShot 2024-09-17 at 10 56 41@2x" src="https://github.com/user-attachments/assets/be940c44-af80-4190-b793-914f9252b241">
