### PR TITLE
FIX: Fix incorrect check for required custom fields (stable)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1867,7 +1867,7 @@ class User < ActiveRecord::Base
 
   def populated_required_custom_fields?
     UserField
-      .required
+      .for_all_users
       .pluck(:id)
       .all? { |field_id| custom_fields["#{User::USER_FIELD_PREFIX}#{field_id}"].present? }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3569,7 +3569,10 @@ RSpec.describe User do
   end
 
   describe "#populated_required_fields?" do
-    let!(:required_field) { Fabricate(:user_field, name: "hairstyle") }
+    let!(:required_field) do
+      Fabricate(:user_field, name: "hairstyle", requirement: "for_all_users")
+    end
+    let!(:signup_field) { Fabricate(:user_field, name: "haircolor", requirement: "on_signup") }
     let!(:optional_field) { Fabricate(:user_field, name: "haircolor", requirement: "optional") }
 
     context "when all required fields are populated" do


### PR DESCRIPTION
### What is this change?

Back port of #28541 to stable.

This check was checking the wrong scope, causing problems in certain edge conditions, for example:

1. Admin adds an "on signup" field that isn't editable after signup.
2. Admin adds a "for all users" field.
3. User goes and fills up the "for all users" field from 2.
4. User is now stuck on the required fields page without any fields showing.

With this change, we only consider "for all users" fields when asking if required custom fields are filled in.