### PR TITLE
FIX: Support getters in hbr `#each` context

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars-helpers.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars-helpers.js
@@ -44,11 +44,12 @@ export function registerRawHelpers(hbs, handlebarsClass, owner) {
       }
       let list = get(this, contextName);
       let output = [];
-      let innerContext = { ...options.contexts[0] };
+      let innerContext = options.contexts[0];
       for (let i = 0; i < list.length; i++) {
         innerContext[localName] = list[i];
         output.push(options.fn(innerContext));
       }
+      delete innerContext[localName];
       return output.join("");
     }
   );

--- a/app/assets/javascripts/discourse/tests/integration/helpers/raw-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/raw-test.gjs
@@ -8,6 +8,7 @@ import raw from "discourse/helpers/raw";
 import rawRenderGlimmer from "discourse/lib/raw-render-glimmer";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { compile } from "discourse-common/lib/raw-handlebars";
+import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
 import {
   addRawTemplate,
   removeRawTemplate,
@@ -120,5 +121,27 @@ module("Integration | Helper | raw", function (hooks) {
     </template>);
 
     assert.dom("span").hasText("foo 1 foo 2");
+  });
+
+  test("#each helper handles getters", async function (assert) {
+    const template = `
+      {{#each items as |item|}}
+        {{string}} {{item}}
+      {{/each}}
+    `;
+    const compiledTemplate = compile(template);
+
+    class Test {
+      items = [1, 2];
+
+      get string() {
+        return "foo";
+      }
+    }
+
+    const object = new Test();
+
+    const output = compiledTemplate(object, RUNTIME_OPTIONS);
+    assert.true(/\s*foo 1\s*foo 2\s*/.test(output));
   });
 });


### PR DESCRIPTION
There is a risk of overriding and then deleting a prop for the context in case of a naming clash between localName and that prop, e.g.

```js
class Test {
  item = "foo";
  items = [1, 2];
}

const template = `
  {{#each items as |item|}}
    {{item}}
  {{/each}}
`;
const compiledTemplate = compile(template);

const object = new Test();
// object.item === "foo"
const output = compiledTemplate(object, RUNTIME_OPTIONS);
// object.item === undefined
```

…but I think we can accept this risk and just be careful.`#each` isn't widely used in hbr anyway (as proven by the other long-standing and recently fixed bug) and hbr is on its way out anyway.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->