### PR TITLE
FIX: prevents user status selection in mentions

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1098,6 +1098,10 @@ a.mention,
 a.mention-group {
   // linked
   @include mention;
+
+  .user-status-message {
+    user-select: none;
+  }
 }
 
 .mention .emoji {


### PR DESCRIPTION
Prior to this fix copy/pasting a text with mentions containing user status would paste the emoji name.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->