### PR TITLE
FEATURE: increasing name length in automation

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -31,7 +31,7 @@ module DiscourseAutomation
     end
 
     MIN_NAME_LENGTH = 5
-    MAX_NAME_LENGTH = 30
+    MAX_NAME_LENGTH = 100
     validates :name, length: { in: MIN_NAME_LENGTH..MAX_NAME_LENGTH }
 
     def add_id_to_custom_field(target, custom_field_key)

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -180,4 +180,19 @@ describe DiscourseAutomation::Automation do
       expect(user.custom_fields).to eq({ automation2.new_user_custom_field_name => "1" })
     end
   end
+
+  context "when creating a new automation" do
+    it "validates the name length" do
+      automation = Fabricate.build(:automation, name: "a" * 101)
+      expect(automation).not_to be_valid
+      expect(automation.errors[:name]).to eq(["is too long (maximum is 100 characters)"])
+
+      automation = Fabricate.build(:automation, name: "b" * 4)
+      expect(automation).not_to be_valid
+      expect(automation.errors[:name]).to eq(["is too short (minimum is 5 characters)"])
+
+      automation = Fabricate.build(:automation, name: "c" * 50)
+      expect(automation).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Updates from 30 to 100 the maximum length of the name of an automation.

And adds tests for validating the maximum length of the name of an automation.
