### PR TITLE
PERF: Update migration to drop index concurrently.

### DIFF
--- a/db/migrate/20240912061806_drop_trgm_indexes_on_users.rb
+++ b/db/migrate/20240912061806_drop_trgm_indexes_on_users.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 class DropTrgmIndexesOnUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   def up
     execute <<~SQL
-      DROP INDEX IF EXISTS index_users_on_username_lower_trgm;
-      DROP INDEX IF EXISTS index_users_on_name_trgm;
+      DROP INDEX CONCURRENTLY IF EXISTS index_users_on_username_lower_trgm;
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS index_users_on_name_trgm;
     SQL
   end
 


### PR DESCRIPTION
This avoids locking the index's table
